### PR TITLE
feat: three-layer validation — Claude hooks, git pre-commit, CI

### DIFF
--- a/.claude/hooks/post-tool-use.sh
+++ b/.claude/hooks/post-tool-use.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Claude PostToolUse hook — runs quality checks after Write/Edit/MultiEdit
+#
+# Input: JSON on stdin with tool information
+# Output: Errors to stderr on failure, exit code 2 to block
+
+set -uo pipefail
+
+# Read JSON input from stdin
+JSON=$(cat)
+
+# Extract file path from JSON
+FILE_PATH=$(echo "$JSON" | jq -r '.tool_input.file_path // .tool_input.filePath // ""')
+
+# Only process Python files
+if [[ ! "$FILE_PATH" == *.py ]]; then
+    exit 0
+fi
+
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+cd "$GIT_ROOT"
+
+# Create temp files for capturing output
+RUFF_OUTPUT=$(mktemp)
+MYPY_OUTPUT=$(mktemp)
+PYTEST_OUTPUT=$(mktemp)
+trap "rm -f $RUFF_OUTPUT $MYPY_OUTPUT $PYTEST_OUTPUT" EXIT
+
+RUFF_FAILED=0
+MYPY_FAILED=0
+PYTEST_FAILED=0
+
+# Ruff: check the specific file (fast)
+if ! uv run ruff check "$FILE_PATH" --output-format concise > "$RUFF_OUTPUT" 2>&1; then
+    RUFF_FAILED=1
+fi
+
+# Mypy: check src/ for full type context
+if ! uv run mypy src --no-error-summary > "$MYPY_OUTPUT" 2>&1; then
+    MYPY_FAILED=1
+fi
+
+# Pytest: re-run last-failed tests only (instant when nothing is broken).
+# Exit code 5 = "no tests collected" which is expected when nothing has failed.
+uv run pytest --lf --lfnf=none -x -q --tb=short --no-header > "$PYTEST_OUTPUT" 2>&1
+PYTEST_RC=$?
+if [ $PYTEST_RC -ne 0 ] && [ $PYTEST_RC -ne 5 ]; then
+    PYTEST_FAILED=1
+fi
+
+if [ $RUFF_FAILED -ne 0 ] || [ $MYPY_FAILED -ne 0 ] || [ $PYTEST_FAILED -ne 0 ]; then
+    [ $RUFF_FAILED -ne 0 ] && [ -s "$RUFF_OUTPUT" ] && cat "$RUFF_OUTPUT" >&2
+    [ $MYPY_FAILED -ne 0 ] && [ -s "$MYPY_OUTPUT" ] && cat "$MYPY_OUTPUT" >&2
+    [ $PYTEST_FAILED -ne 0 ] && [ -s "$PYTEST_OUTPUT" ] && cat "$PYTEST_OUTPUT" >&2
+    exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/post-tool-use.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -51,5 +51,8 @@ jobs:
       - name: Unit tests
         run: uv run pytest tests/unit -q
 
+      - name: Build sandbox image
+        run: docker build -t aios-sandbox:latest -f docker/Dockerfile.sandbox docker/
+
       - name: E2E tests
         run: uv run pytest tests/e2e -q

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -1,0 +1,55 @@
+name: Code Validation
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: aios
+          POSTGRES_PASSWORD: aios
+          POSTGRES_DB: aios_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      AIOS_DB_URL: postgresql://aios:aios@localhost:5432/aios_test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Lint (ruff)
+        run: |
+          uv run ruff check src tests
+          uv run ruff format --check src tests
+
+      - name: Type check (mypy)
+        run: uv run mypy src
+
+      - name: Unit tests
+        run: uv run pytest tests/unit -q
+
+      - name: E2E tests
+        run: uv run pytest tests/e2e -q

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -38,7 +38,7 @@ jobs:
         run: uv python install 3.13
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --extra dev
 
       - name: Lint (ruff)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,11 @@ venv/
 *.swo
 
 # Claude Code session state (not related to aios)
-.claude/
+# Use /* so negation patterns work for tracked config
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+!.claude/hooks/**
 
 # aios runtime state
 /var/lib/aios/

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Git pre-commit hook for aios
+# Runs linting, type checking, and unit tests before allowing commits.
+#
+# Install: ln -sf ../../scripts/git-hooks/pre-commit .git/hooks/pre-commit
+
+set -uo pipefail
+
+echo "Running pre-commit checks..."
+echo ""
+
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+
+# Only run if Python files are staged
+STAGED_PY=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$' || true)
+
+if [[ -z "$STAGED_PY" ]]; then
+    echo "No Python files staged — skipping checks."
+    exit 0
+fi
+
+"$GIT_ROOT/scripts/run-checks.sh" --fail-on-autofix
+RESULT=$?
+
+# Re-add any files that ruff auto-formatted
+if [[ $RESULT -eq 0 ]]; then
+    modified=$(git diff --name-only | grep -E '\.py$' || true)
+    if [[ -n "$modified" ]]; then
+        git add $modified 2>/dev/null
+    fi
+fi
+
+exit $RESULT

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Central check runner for aios
+#
+# Usage:
+#   scripts/run-checks.sh                  # run all checks
+#   scripts/run-checks.sh --skip tests     # skip pytest
+#   scripts/run-checks.sh --skip mypy      # skip mypy
+#   scripts/run-checks.sh --fail-on-autofix # fail if ruff auto-formats (for pre-commit)
+#   scripts/run-checks.sh --fail-fast      # stop at first failure
+#
+# Checks: ruff, mypy, tests (unit only — e2e needs Docker)
+
+set -uo pipefail
+
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+cd "$GIT_ROOT"
+
+# ── Parse flags ────────────────────────────────────────────────────────────────
+
+SKIP=""
+FAIL_ON_AUTOFIX=0
+FAIL_FAST=0
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --skip)       SKIP="$2"; shift 2 ;;
+        --fail-on-autofix) FAIL_ON_AUTOFIX=1; shift ;;
+        --fail-fast)  FAIL_FAST=1; shift ;;
+        *)            echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+should_skip() { [[ "$SKIP" == *"$1"* ]]; }
+
+OVERALL=0
+fail() { OVERALL=1; [[ $FAIL_FAST -eq 1 ]] && exit 1; }
+
+# ── Ruff ───────────────────────────────────────────────────────────────────────
+
+if ! should_skip ruff; then
+    echo "── ruff ──"
+
+    if [[ $FAIL_ON_AUTOFIX -eq 1 ]]; then
+        # Check + format, then detect if anything changed
+        uv run ruff check --fix src tests 2>&1
+        uv run ruff format src tests 2>&1
+        if [[ -n "$(git diff --name-only)" ]]; then
+            echo "ruff auto-fixed files — please re-stage:" >&2
+            git diff --name-only >&2
+            fail
+        fi
+    else
+        uv run ruff check src tests || fail
+        uv run ruff format --check src tests || fail
+    fi
+fi
+
+# ── Mypy ───────────────────────────────────────────────────────────────────────
+
+if ! should_skip mypy; then
+    echo "── mypy ──"
+    uv run mypy src || fail
+fi
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+if ! should_skip tests; then
+    echo "── pytest (unit) ──"
+    uv run pytest tests/unit -q || fail
+fi
+
+echo ""
+if [[ $OVERALL -eq 0 ]]; then
+    echo "All checks passed."
+else
+    echo "Some checks failed." >&2
+fi
+exit $OVERALL

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,12 +88,13 @@ def migrated_db_url(db_url: str) -> str:
 
 
 @pytest.fixture
-def aios_env(migrated_db_url: str) -> Iterator[dict[str, str]]:
+def aios_env(migrated_db_url: str, tmp_path: Path) -> Iterator[dict[str, str]]:
     """Set the env vars the FastAPI app needs."""
     env_vars = {
         "AIOS_API_KEY": secrets.token_urlsafe(32),
         "AIOS_VAULT_KEY": base64.b64encode(secrets.token_bytes(32)).decode("ascii"),
         "AIOS_DB_URL": migrated_db_url,
+        "AIOS_WORKSPACE_ROOT": str(tmp_path / "workspaces"),
     }
     with mock.patch.dict(os.environ, env_vars):
         # Reset the cached settings singleton

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -282,7 +282,10 @@ class Harness:
             await sessions_service.confirm_tool_allow(self._pool, session_id, tool_call_id)
         else:
             await sessions_service.confirm_tool_deny(
-                self._pool, session_id, tool_call_id, deny_message or "Denied.",
+                self._pool,
+                session_id,
+                tool_call_id,
+                deny_message or "Denied.",
             )
 
     # ── step execution ───────────────────────────────────────────────────

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -905,7 +905,8 @@ class TestSessionVersionBinding:
 
     async def test_pinned_session_ignores_agent_update(self, harness: Harness) -> None:
         """Pinned session keeps using the old version after agent update."""
-        from aios.services import agents as agents_service, sessions as sessions_service
+        from aios.services import agents as agents_service
+        from aios.services import sessions as sessions_service
 
         harness.script_model(
             [
@@ -935,7 +936,8 @@ class TestSessionVersionBinding:
 
     async def test_session_update_changes_agent(self, harness: Harness) -> None:
         """Sessions can be updated to point at a different agent."""
-        from aios.services import agents as agents_service, sessions as sessions_service
+        from aios.services import agents as agents_service
+        from aios.services import sessions as sessions_service
 
         harness.script_model(
             [
@@ -948,7 +950,6 @@ class TestSessionVersionBinding:
 
         # Create a second agent
         from aios.ids import make_id
-        from aios.models.agents import ToolSpec
 
         agent2 = await agents_service.create_agent(
             harness._pool,
@@ -1015,7 +1016,8 @@ class TestCustomTools:
         )
 
         from aios.ids import make_id
-        from aios.services import environments as env_svc, sessions as sess_svc
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
 
         if harness._env_id is None:
             env = await env_svc.create_environment(
@@ -1078,7 +1080,8 @@ class TestCustomTools:
         )
 
         from aios.ids import make_id
-        from aios.services import environments as env_svc, sessions as sess_svc
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
 
         if harness._env_id is None:
             env = await env_svc.create_environment(
@@ -1160,7 +1163,8 @@ class TestCustomTools:
         )
 
         from aios.ids import make_id
-        from aios.services import environments as env_svc, sessions as sess_svc
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
 
         if harness._env_id is None:
             env = await env_svc.create_environment(

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -1247,9 +1247,13 @@ class TestPermissionPolicies:
 
         self._override_tool("glob", fake_glob)
 
-        harness.script_model([
-            assistant(tool_calls=[tool_call("glob", {"pattern": "*.txt"}, call_id="call_ask1")]),
-        ])
+        harness.script_model(
+            [
+                assistant(
+                    tool_calls=[tool_call("glob", {"pattern": "*.txt"}, call_id="call_ask1")]
+                ),
+            ]
+        )
         session = await harness.start(
             "list files",
             tool_specs=[ToolSpec(type="glob", permission="always_ask")],
@@ -1272,10 +1276,14 @@ class TestPermissionPolicies:
 
         self._override_tool("glob", fake_glob)
 
-        harness.script_model([
-            assistant(tool_calls=[tool_call("glob", {"pattern": "*.txt"}, call_id="call_allow1")]),
-            assistant("Found found.txt"),
-        ])
+        harness.script_model(
+            [
+                assistant(
+                    tool_calls=[tool_call("glob", {"pattern": "*.txt"}, call_id="call_allow1")]
+                ),
+                assistant("Found found.txt"),
+            ]
+        )
         session = await harness.start(
             "list files",
             tool_specs=[ToolSpec(type="glob", permission="always_ask")],
@@ -1313,10 +1321,14 @@ class TestPermissionPolicies:
 
         self._override_tool("glob", fake_glob)
 
-        harness.script_model([
-            assistant(tool_calls=[tool_call("glob", {"pattern": "*.txt"}, call_id="call_deny1")]),
-            assistant("I understand, the tool was denied."),
-        ])
+        harness.script_model(
+            [
+                assistant(
+                    tool_calls=[tool_call("glob", {"pattern": "*.txt"}, call_id="call_deny1")]
+                ),
+                assistant("I understand, the tool was denied."),
+            ]
+        )
         session = await harness.start(
             "list files",
             tool_specs=[ToolSpec(type="glob", permission="always_ask")],
@@ -1326,9 +1338,7 @@ class TestPermissionPolicies:
         await harness.run_step(session.id)
 
         # Deny with message
-        await harness.confirm_tool(
-            session.id, "call_deny1", "deny", deny_message="Too dangerous."
-        )
+        await harness.confirm_tool(session.id, "call_deny1", "deny", deny_message="Too dangerous.")
 
         # Step 2: model sees the denial error and responds
         await harness.run_step(session.id)
@@ -1362,13 +1372,17 @@ class TestPermissionPolicies:
         self._override_tool("glob", fake_glob)
         self._override_tool("grep", fake_grep)
 
-        harness.script_model([
-            assistant(tool_calls=[
-                tool_call("glob", {"pattern": "*.txt"}, call_id="call_fast"),
-                tool_call("grep", {"pattern": "hello"}, call_id="call_slow"),
-            ]),
-            assistant("Both tools done."),
-        ])
+        harness.script_model(
+            [
+                assistant(
+                    tool_calls=[
+                        tool_call("glob", {"pattern": "*.txt"}, call_id="call_fast"),
+                        tool_call("grep", {"pattern": "hello"}, call_id="call_slow"),
+                    ]
+                ),
+                assistant("Both tools done."),
+            ]
+        )
         session = await harness.start(
             "search files",
             tool_specs=[
@@ -1436,15 +1450,18 @@ class TestPermissionPolicies:
 
     async def test_backward_compat_no_policy(self, harness: Harness) -> None:
         """Agent without permission fields → everything executes immediately."""
+
         async def echo_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
             return {"output": arguments.get("text", "")}
 
         harness.register_tool("echo", echo_handler)
 
-        harness.script_model([
-            assistant(tool_calls=[tool_call("echo", {"text": "hi"})]),
-            assistant("Echo said hi."),
-        ])
+        harness.script_model(
+            [
+                assistant(tool_calls=[tool_call("echo", {"text": "hi"})]),
+                assistant("Echo said hi."),
+            ]
+        )
         # Use simple tools= (no permission/enabled set)
         session = await harness.start("echo hi", tools=[])
         await harness.run_until_idle(session.id)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,32 @@
+"""Unit-test fixtures.
+
+Provides dummy environment variables so ``get_settings()`` succeeds without
+a ``.env`` file or real credentials.  Session-scoped and autouse so every
+unit test gets them automatically.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import secrets
+from collections.abc import Iterator
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _unit_env() -> Iterator[None]:
+    """Inject minimal env vars required by ``Settings()``."""
+    env = {
+        "AIOS_API_KEY": secrets.token_urlsafe(16),
+        "AIOS_VAULT_KEY": base64.b64encode(secrets.token_bytes(32)).decode(),
+        "AIOS_DB_URL": "postgresql://test:test@localhost:5432/test",
+    }
+    with mock.patch.dict(os.environ, env):
+        from aios.config import get_settings
+
+        get_settings.cache_clear()
+        yield
+        get_settings.cache_clear()

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -145,7 +145,9 @@ class TestBuildMessages:
             _evt(3, "tool", tool_call_id="a", content="result a"),
             _evt(4, "tool", tool_call_id="b", content="result b"),
         ]
-        msgs = build_messages(events, system_prompt=None, window_min=50_000, window_max=150_000).messages
+        msgs = build_messages(
+            events, system_prompt=None, window_min=50_000, window_max=150_000
+        ).messages
         # Order: user, assistant, tool_a, tool_b
         assert msgs[0]["role"] == "user"
         assert msgs[1]["role"] == "assistant"
@@ -161,7 +163,9 @@ class TestBuildMessages:
             _evt(3, "tool", tool_call_id="a", content="result a"),
             # b is still pending
         ]
-        msgs = build_messages(events, system_prompt=None, window_min=50_000, window_max=150_000).messages
+        msgs = build_messages(
+            events, system_prompt=None, window_min=50_000, window_max=150_000
+        ).messages
         assert msgs[2]["tool_call_id"] == "a"
         assert "result a" in msgs[2]["content"]
         # b should be a synthetic pending result
@@ -177,7 +181,9 @@ class TestBuildMessages:
             _evt(3, "user", content="how goes?"),  # user injection before tool completes
             _evt(4, "tool", tool_call_id="x", content="X done"),
         ]
-        msgs = build_messages(events, system_prompt=None, window_min=50_000, window_max=150_000).messages
+        msgs = build_messages(
+            events, system_prompt=None, window_min=50_000, window_max=150_000
+        ).messages
         # Should be: user, assistant+tool_calls, tool_result_x, user_injection
         assert msgs[0]["role"] == "user"
         assert msgs[0]["content"] == "do X"
@@ -189,7 +195,9 @@ class TestBuildMessages:
 
     def test_no_system_prompt_when_none(self) -> None:
         events = [_evt(1, "user", content="hi")]
-        msgs = build_messages(events, system_prompt=None, window_min=50_000, window_max=150_000).messages
+        msgs = build_messages(
+            events, system_prompt=None, window_min=50_000, window_max=150_000
+        ).messages
         assert msgs[0]["role"] == "user"
 
     def test_monotonic_blind_spot_shows_pending_then_injects_real(self) -> None:
@@ -212,31 +220,35 @@ class TestBuildMessages:
         events[4].data["reacting_to"] = 3  # assistant at seq=5 reacted to user at seq=3
         # (tool result at seq=4 has seq > reacting_to=3, so assistant saw pending)
 
-        msgs = build_messages(events, system_prompt=None, window_min=50_000, window_max=150_000).messages
+        msgs = build_messages(
+            events, system_prompt=None, window_min=50_000, window_max=150_000
+        ).messages
 
         # The paired position for bash_1 should show PENDING (not real)
         # because the assistant at seq=5 saw it as pending
-        paired_tool = next(m for m in msgs if m.get("tool_call_id") == "bash_1" and m["role"] == "tool")
-        assert "pending" in paired_tool["content"], \
+        paired_tool = next(
+            m for m in msgs if m.get("tool_call_id") == "bash_1" and m["role"] == "tool"
+        )
+        assert "pending" in paired_tool["content"], (
             "paired position should show pending (what the assistant actually saw)"
+        )
 
         # The stale assistant should appear coherently after the pending result
         stale_asst = next(m for m in msgs if m.get("content") == "still running")
         assert stale_asst is not None
 
         # The real result should be injected at the END as a user message
-        last_msgs = msgs[-2:]  # last couple messages
         injected = next(
             (m for m in msgs if m["role"] == "user" and "DONE" in m.get("content", "")),
             None,
         )
-        assert injected is not None, \
-            "real tool result should be injected as a user message"
+        assert injected is not None, "real tool result should be injected as a user message"
         # The injected message should come AFTER the stale assistant
         injected_idx = msgs.index(injected)
         stale_idx = msgs.index(stale_asst)
-        assert injected_idx > stale_idx, \
+        assert injected_idx > stale_idx, (
             "injected result should come after the stale assistant response"
+        )
 
     def test_monotonic_no_rewrite_when_result_seen_as_real(self) -> None:
         """When the assistant saw the real result (result.seq <= reacting_to),
@@ -250,7 +262,9 @@ class TestBuildMessages:
         events[1].data["reacting_to"] = 1
         events[3].data["reacting_to"] = 3  # saw tool result at seq=3
 
-        msgs = build_messages(events, system_prompt=None, window_min=50_000, window_max=150_000).messages
+        msgs = build_messages(
+            events, system_prompt=None, window_min=50_000, window_max=150_000
+        ).messages
         # Paired position should show REAL result (not pending)
         paired_tool = next(m for m in msgs if m.get("tool_call_id") == "a")
         assert "done" in paired_tool["content"]
@@ -268,7 +282,9 @@ class TestBuildMessages:
             _evt(5, "tool", tool_call_id="b", content="done b"),
             _evt(6, "assistant", content="all done"),
         ]
-        msgs = build_messages(events, system_prompt=None, window_min=50_000, window_max=150_000).messages
+        msgs = build_messages(
+            events, system_prompt=None, window_min=50_000, window_max=150_000
+        ).messages
         roles = [m["role"] for m in msgs]
         assert roles == ["user", "assistant", "tool", "assistant", "tool", "assistant"]
 
@@ -288,9 +304,7 @@ class TestBuildMessages:
         # With a very small window, the oldest messages get dropped.
         # window_min=20, window_max=60 means the window holds ~60 tokens.
         # The total is ~200+ tokens, so the front gets cut.
-        msgs = build_messages(
-            events, system_prompt=None, window_min=20, window_max=60
-        ).messages
+        msgs = build_messages(events, system_prompt=None, window_min=20, window_max=60).messages
         # The window should NOT start with an orphan tool result.
         # It should start with a user or assistant (no tool_calls) message.
         if msgs:
@@ -301,9 +315,7 @@ class TestBuildMessages:
             # If it starts with assistant, it should not have unmatched tool_calls
             if first_role == "assistant" and msgs[0].get("tool_calls"):
                 tc_ids = {tc["id"] for tc in msgs[0]["tool_calls"]}
-                result_ids = {
-                    m["tool_call_id"] for m in msgs[1:] if m.get("role") == "tool"
-                }
+                result_ids = {m["tool_call_id"] for m in msgs[1:] if m.get("role") == "tool"}
                 assert tc_ids <= result_ids, "leading assistant has unmatched tool_calls"
 
     def test_window_prunes_partial_assistant_tool_group(self) -> None:
@@ -320,9 +332,7 @@ class TestBuildMessages:
         events[0].data["reacting_to"] = 0
         events[4].data["reacting_to"] = 3
         # Tiny window forces the front to be dropped
-        msgs = build_messages(
-            events, system_prompt=None, window_min=10, window_max=30
-        ).messages
+        msgs = build_messages(events, system_prompt=None, window_min=10, window_max=30).messages
         # Should not start with orphan tool results or incomplete assistant groups
         for m in msgs:
             if m.get("role") == "tool":
@@ -330,7 +340,7 @@ class TestBuildMessages:
                 tc_id = m.get("tool_call_id")
                 has_parent = any(
                     tc_id in {tc["id"] for tc in prior.get("tool_calls") or []}
-                    for prior in msgs[:msgs.index(m)]
+                    for prior in msgs[: msgs.index(m)]
                     if prior.get("role") == "assistant"
                 )
                 assert has_parent, f"orphan tool result for {tc_id}"

--- a/tests/unit/test_tool_confirmation.py
+++ b/tests/unit/test_tool_confirmation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from aios.harness.loop import _resolve_permission
@@ -18,7 +18,7 @@ def _event(seq: int, data: dict[str, Any], kind: str = "message") -> Event:
         seq=seq,
         kind=kind,  # type: ignore[arg-type]
         data=data,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
 
 
@@ -26,14 +26,25 @@ class TestFindToolCall:
     def test_finds_existing_call(self) -> None:
         events = [
             _event(1, {"role": "user", "content": "hello"}),
-            _event(2, {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {"id": "call_1", "type": "function", "function": {"name": "bash", "arguments": '{"command": "echo hi"}'}},
-                    {"id": "call_2", "type": "function", "function": {"name": "read", "arguments": '{"file_path": "/tmp/x"}'}},
-                ],
-            }),
+            _event(
+                2,
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": '{"command": "echo hi"}'},
+                        },
+                        {
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "read", "arguments": '{"file_path": "/tmp/x"}'},
+                        },
+                    ],
+                },
+            ),
         ]
         tc = _find_tool_call(events, "call_2")
         assert tc is not None
@@ -50,15 +61,25 @@ class TestFindToolCall:
     def test_searches_in_reverse(self) -> None:
         """If the same call_id appears in multiple messages, the most recent wins."""
         events = [
-            _event(1, {
-                "role": "assistant",
-                "tool_calls": [{"id": "call_x", "function": {"name": "bash", "arguments": "{}"}}],
-            }),
+            _event(
+                1,
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "call_x", "function": {"name": "bash", "arguments": "{}"}}
+                    ],
+                },
+            ),
             _event(2, {"role": "tool", "tool_call_id": "call_x", "content": "done"}),
-            _event(3, {
-                "role": "assistant",
-                "tool_calls": [{"id": "call_x", "function": {"name": "read", "arguments": "{}"}}],
-            }),
+            _event(
+                3,
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "call_x", "function": {"name": "read", "arguments": "{}"}}
+                    ],
+                },
+            ),
         ]
         tc = _find_tool_call(events, "call_x")
         assert tc is not None

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -137,10 +137,12 @@ class TestToOpenaiTools:
         """Tools with enabled=False are not included in the output."""
         import aios.tools  # noqa: F401
 
-        result = to_openai_tools([
-            AgentToolSpec(type="bash"),
-            AgentToolSpec(type="bash", enabled=False),
-        ])
+        result = to_openai_tools(
+            [
+                AgentToolSpec(type="bash"),
+                AgentToolSpec(type="bash", enabled=False),
+            ]
+        )
         # Only 1 entry — the enabled one.
         assert len(result) == 1
         assert result[0]["function"]["name"] == "bash"
@@ -149,33 +151,39 @@ class TestToOpenaiTools:
         """If all tools are disabled, result is empty."""
         import aios.tools  # noqa: F401
 
-        result = to_openai_tools([
-            AgentToolSpec(type="bash", enabled=False),
-        ])
+        result = to_openai_tools(
+            [
+                AgentToolSpec(type="bash", enabled=False),
+            ]
+        )
         assert result == []
 
     def test_disabled_custom_tool_excluded(self) -> None:
         """Custom tools with enabled=False are also excluded."""
-        result = to_openai_tools([
-            AgentToolSpec(
-                type="custom",
-                name="get_weather",
-                description="Get weather",
-                input_schema={"type": "object"},
-                enabled=False,
-            ),
-        ])
+        result = to_openai_tools(
+            [
+                AgentToolSpec(
+                    type="custom",
+                    name="get_weather",
+                    description="Get weather",
+                    input_schema={"type": "object"},
+                    enabled=False,
+                ),
+            ]
+        )
         assert result == []
 
     def test_enabled_custom_tool_included(self) -> None:
         """Custom tools with enabled=True (default) are included."""
-        result = to_openai_tools([
-            AgentToolSpec(
-                type="custom",
-                name="get_weather",
-                description="Get weather",
-                input_schema={"type": "object"},
-            ),
-        ])
+        result = to_openai_tools(
+            [
+                AgentToolSpec(
+                    type="custom",
+                    name="get_weather",
+                    description="Get weather",
+                    input_schema={"type": "object"},
+                ),
+            ]
+        )
         assert len(result) == 1
         assert result[0]["function"]["name"] == "get_weather"

--- a/tests/unit/test_toolspec.py
+++ b/tests/unit/test_toolspec.py
@@ -36,7 +36,7 @@ class TestPermissionField:
         assert spec.permission == "always_ask"
 
     def test_invalid_policy_rejected(self) -> None:
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             ToolSpec(type="bash", permission="always_deny")  # type: ignore[arg-type]
 
 
@@ -81,12 +81,14 @@ class TestBackwardCompat:
         assert spec.permission is None
 
     def test_old_custom_json(self) -> None:
-        old_json = json.dumps({
-            "type": "custom",
-            "name": "foo",
-            "description": "bar",
-            "input_schema": {"type": "object"},
-        })
+        old_json = json.dumps(
+            {
+                "type": "custom",
+                "name": "foo",
+                "description": "bar",
+                "input_schema": {"type": "object"},
+            }
+        )
         spec = ToolSpec.model_validate_json(old_json)
         assert spec.enabled is True
         assert spec.permission is None


### PR DESCRIPTION
## Summary
- **Claude PostToolUse hook** runs ruff, mypy, and pytest (last-failed) after every Python file edit — blocks on failure
- **Git pre-commit hook** runs the full check suite via `scripts/run-checks.sh` with `--fail-on-autofix` — skips when no `.py` files staged
- **GitHub Actions CI** runs ruff, mypy, unit tests, and e2e tests on every PR and push to master with Postgres 17 service container
- Central `scripts/run-checks.sh` runner shared by hooks and manual use, with `--skip`, `--fail-on-autofix`, and `--fail-fast` flags

## Test plan
- [ ] Verify pre-commit hook fires on `git commit` with staged `.py` files
- [ ] Verify pre-commit hook skips when only non-`.py` files staged
- [ ] Verify `scripts/run-checks.sh` runs ruff, mypy, pytest and reports results
- [ ] Verify `scripts/run-checks.sh --skip tests` skips pytest
- [ ] Verify CI workflow runs on PR (this PR itself)
- [ ] Verify `.claude/settings.json` and `.claude/hooks/` are tracked while `.claude/` session state is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)