### PR TITLE
feat: environment updates, extra package managers, rescheduling status

### DIFF
--- a/migrations/versions/0007_rescheduling_status.py
+++ b/migrations/versions/0007_rescheduling_status.py
@@ -1,0 +1,41 @@
+"""Add rescheduling to session status check constraint.
+
+Anthropic Managed Agents support a ``rescheduling`` session status for
+transient errors that will auto-retry. This migration widens the
+``sessions_status_check`` constraint to allow the new value.
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-04-13
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0007"
+down_revision: str = "0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_status_check;"
+    )
+    op.execute(
+        "ALTER TABLE sessions ADD CONSTRAINT sessions_status_check "
+        "CHECK (status IN ('running', 'idle', 'rescheduling', 'terminated'));"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_status_check;"
+    )
+    op.execute(
+        "ALTER TABLE sessions ADD CONSTRAINT sessions_status_check "
+        "CHECK (status IN ('running', 'idle', 'terminated'));"
+    )

--- a/src/aios/api/routers/environments.py
+++ b/src/aios/api/routers/environments.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, status
 
 from aios.api.deps import AuthDep, PoolDep
 from aios.models.common import ListResponse
-from aios.models.environments import Environment, EnvironmentCreate
+from aios.models.environments import Environment, EnvironmentCreate, EnvironmentUpdate
 from aios.services import environments as service
 
 router = APIRouter(prefix="/v1/environments", tags=["environments"])
@@ -35,6 +35,13 @@ async def list_(
 @router.get("/{env_id}")
 async def get(env_id: str, pool: PoolDep, _auth: AuthDep) -> Environment:
     return await service.get_environment(pool, env_id)
+
+
+@router.put("/{env_id}")
+async def update(
+    env_id: str, body: EnvironmentUpdate, pool: PoolDep, _auth: AuthDep
+) -> Environment:
+    return await service.update_environment(pool, env_id, name=body.name, config=body.config)
 
 
 @router.delete("/{env_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -100,6 +100,42 @@ async def archive_environment(conn: asyncpg.Connection[Any], env_id: str) -> Non
         raise NotFoundError(f"environment {env_id} not found or already archived")
 
 
+async def update_environment(
+    conn: asyncpg.Connection[Any],
+    env_id: str,
+    *,
+    name: str | None = None,
+    config: EnvironmentConfig | None = None,
+) -> Environment:
+    """Update an environment. Omitted fields are preserved."""
+    current = await get_environment(conn, env_id)
+    if current.archived_at is not None:
+        raise ConflictError(f"environment {env_id} is archived", detail={"id": env_id})
+
+    new_name = name if name is not None else current.name
+    new_config = config if config is not None else current.config
+
+    # No-op detection.
+    if new_name == current.name and new_config == current.config:
+        return current
+
+    config_json = json.dumps(new_config.model_dump(exclude_none=True))
+    try:
+        row = await conn.fetchrow(
+            "UPDATE environments SET name = $2, config = $3::jsonb WHERE id = $1 RETURNING *",
+            env_id,
+            new_name,
+            config_json,
+        )
+    except asyncpg.UniqueViolationError as exc:
+        raise ConflictError(
+            f"an environment named {new_name!r} already exists",
+            detail={"name": new_name},
+        ) from exc
+    assert row is not None
+    return _row_to_environment(row)
+
+
 # ─── agents ───────────────────────────────────────────────────────────────────
 
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -122,11 +122,34 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
                 "model_usage": {},
             },
         )
-        await sessions_service.set_session_status(
-            pool, session_id, "idle", stop_reason={"type": "error"}
-        )
-        await _append_lifecycle(pool, session_id, "turn_ended", "idle", "error")
-        raise
+
+        # Count consecutive rescheduling lifecycle events to decide
+        # whether to retry or give up.
+        consecutive = await _count_consecutive_rescheduling(pool, session_id)
+        if consecutive < 2:
+            # Retry: set status to rescheduling and defer a delayed wake.
+            await sessions_service.set_session_status(
+                pool, session_id, "rescheduling", stop_reason={"type": "rescheduling"}
+            )
+            await _append_lifecycle(pool, session_id, "turn_ended", "rescheduling", "rescheduling")
+            from aios.harness.procrastinate_app import app as procrastinate_app
+
+            try:
+                await procrastinate_app.configure_task("harness.wake_session").defer_async(
+                    session_id=session_id,
+                    cause="reschedule",
+                    schedule_in={"seconds": 5},
+                )
+            except Exception:
+                log.exception("step.reschedule_defer_failed", session_id=session_id)
+            return
+        else:
+            # 3rd consecutive error — give up.
+            await sessions_service.set_session_status(
+                pool, session_id, "idle", stop_reason={"type": "error"}
+            )
+            await _append_lifecycle(pool, session_id, "turn_ended", "idle", "error")
+            raise
 
     # Emit span end with per-request token usage.
     await sessions_service.append_event(
@@ -288,6 +311,23 @@ async def _dispatch_confirmed_tools(
         tc for tc in asst_tool_calls if tc.get("id") in confirmed and tc.get("id") not in completed
     ]
     return pending
+
+
+async def _count_consecutive_rescheduling(pool: Any, session_id: str) -> int:
+    """Count consecutive rescheduling lifecycle events at the tail of the log.
+
+    Returns the number of consecutive ``turn_ended`` lifecycle events
+    with ``stop_reason == "rescheduling"`` at the end of the lifecycle
+    event sequence. A non-rescheduling event breaks the streak.
+    """
+    lifecycle_events = await sessions_service.read_events(pool, session_id, kind="lifecycle")
+    count = 0
+    for e in reversed(lifecycle_events):
+        if e.data.get("event") == "turn_ended" and e.data.get("stop_reason") == "rescheduling":
+            count += 1
+        else:
+            break
+    return count
 
 
 async def _append_lifecycle(

--- a/src/aios/models/environments.py
+++ b/src/aios/models/environments.py
@@ -37,6 +37,18 @@ class EnvironmentCreate(BaseModel):
     config: EnvironmentConfig = Field(default_factory=EnvironmentConfig)
 
 
+class EnvironmentUpdate(BaseModel):
+    """Request body for ``PUT /v1/environments/{id}``.
+
+    All fields are optional; omitted fields are preserved.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = Field(default=None, min_length=1, max_length=128)
+    config: EnvironmentConfig | None = None
+
+
 class Environment(BaseModel):
     """Read view of an environment."""
 

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -13,7 +13,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-SessionStatus = Literal["running", "idle", "terminated"]
+SessionStatus = Literal["running", "idle", "rescheduling", "terminated"]
 
 
 class SessionUsage(BaseModel):

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -156,6 +156,9 @@ async def _install_packages(handle: ContainerHandle, session_id: str) -> None:
         "apt": "apt-get update -qq && apt-get install -y -qq {}",
         "pip": "pip install -q {}",
         "npm": "npm install -g --silent {}",
+        "cargo": "cargo install {}",
+        "gem": "gem install {}",
+        "go": "go install {}",
     }
 
     for manager, cmd_template in install_cmds.items():

--- a/src/aios/services/environments.py
+++ b/src/aios/services/environments.py
@@ -32,6 +32,17 @@ async def list_environments(
         return await queries.list_environments(conn, limit=limit, after=after)
 
 
+async def update_environment(
+    pool: asyncpg.Pool[Any],
+    env_id: str,
+    *,
+    name: str | None = None,
+    config: EnvironmentConfig | None = None,
+) -> Environment:
+    async with pool.acquire() as conn:
+        return await queries.update_environment(conn, env_id, name=name, config=config)
+
+
 async def archive_environment(pool: asyncpg.Pool[Any], env_id: str) -> None:
     async with pool.acquire() as conn:
         await queries.archive_environment(conn, env_id)


### PR DESCRIPTION
## Summary
- PUT /v1/environments/:id for partial environment updates
- cargo, gem, go package managers in sandbox provisioner
- "rescheduling" session status with auto-retry (max 3 attempts, 5s delay) for transient LiteLLM errors

## Test plan
- [x] mypy strict clean
- [x] ruff clean
- [x] unit tests pass (215 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)