### PR TITLE
feat: enforce environment networking config

### DIFF
--- a/docker/Dockerfile.sandbox
+++ b/docker/Dockerfile.sandbox
@@ -24,12 +24,16 @@ FROM python:3.13-slim-bookworm
 
 # Install standard tools. Keep this list small; aios is opinionated about
 # what lives in the sandbox.
+# iptables is required for environments with "limited" networking mode.
+# If you customize the sandbox image and only use unrestricted networking,
+# you can omit it.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         ca-certificates \
         coreutils \
         curl \
         git \
+        iptables \
         ripgrep \
  && rm -rf /var/lib/apt/lists/*
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -136,6 +136,25 @@ async def update_environment(
     return _row_to_environment(row)
 
 
+async def get_environment_config_for_session(
+    conn: asyncpg.Connection[Any], session_id: str
+) -> EnvironmentConfig | None:
+    """Return the environment config for a session, or None if not found."""
+    row = await conn.fetchrow(
+        """
+        SELECT e.config FROM environments e
+        JOIN sessions s ON s.environment_id = e.id
+        WHERE s.id = $1
+        """,
+        session_id,
+    )
+    if row is None:
+        return None
+    raw_config = row["config"]
+    config_data = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+    return EnvironmentConfig.model_validate(config_data)
+
+
 # ─── agents ───────────────────────────────────────────────────────────────────
 
 

--- a/src/aios/models/environments.py
+++ b/src/aios/models/environments.py
@@ -25,7 +25,9 @@ from pydantic import (
 
 # Hostname: RFC 952 / RFC 1123 labels joined by dots.  Only characters that
 # are safe to embed in a shell script (no metacharacters, no slashes).
-_HOSTNAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9\-\.]*[a-zA-Z0-9])?$")
+_HOSTNAME_RE = re.compile(
+    r"^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)*$"
+)
 
 
 class UnrestrictedNetworking(BaseModel):

--- a/src/aios/models/environments.py
+++ b/src/aios/models/environments.py
@@ -7,10 +7,80 @@ packages, network access rules, and (later) custom base images. The
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
-from typing import Any
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Discriminator,
+    Field,
+    Tag,
+    field_validator,
+    model_validator,
+)
+
+# ── networking config ─────────────────────────────────────────────────────────
+
+# Hostname: RFC 952 / RFC 1123 labels joined by dots.  Only characters that
+# are safe to embed in a shell script (no metacharacters, no slashes).
+_HOSTNAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9\-\.]*[a-zA-Z0-9])?$")
+
+
+class UnrestrictedNetworking(BaseModel):
+    """Full outbound network access (default)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["unrestricted"] = "unrestricted"
+
+
+class LimitedNetworking(BaseModel):
+    """Deny-all with domain allowlist.
+
+    Outbound HTTP/HTTPS is restricted to ``allowed_hosts`` plus any hosts
+    implied by the boolean flags.  DNS (port 53) remains open so tools
+    like ``curl`` can resolve names.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["limited"]
+    allowed_hosts: list[str] = Field(default_factory=list)
+    allow_package_managers: bool = False
+    # TODO: resolve MCP server hosts when MCP config is available
+    allow_mcp_servers: bool = False
+
+    @field_validator("allowed_hosts", mode="after")
+    @classmethod
+    def _validate_hosts(cls, v: list[str]) -> list[str]:
+        for host in v:
+            if not host:
+                raise ValueError("allowed_hosts entries must not be empty")
+            if len(host) > 253:
+                raise ValueError(f"hostname too long ({len(host)} > 253): {host!r}")
+            if not _HOSTNAME_RE.match(host):
+                raise ValueError(
+                    f"invalid hostname {host!r}: only alphanumerics, hyphens, and dots allowed"
+                )
+        return v
+
+
+def _networking_discriminator(v: Any) -> str:
+    if isinstance(v, dict):
+        return str(v.get("type", "unrestricted"))
+    return str(getattr(v, "type", "unrestricted"))
+
+
+NetworkingConfig = Annotated[
+    Annotated[UnrestrictedNetworking, Tag("unrestricted")]
+    | Annotated[LimitedNetworking, Tag("limited")],
+    Discriminator(_networking_discriminator),
+]
+
+
+# ── environment config ────────────────────────────────────────────────────────
 
 
 class EnvironmentConfig(BaseModel):
@@ -22,10 +92,21 @@ class EnvironmentConfig(BaseModel):
         default=None,
         description='Package manager → package list, e.g. {"pip": ["pandas"], "npm": ["express"]}.',
     )
-    networking: dict[str, Any] | None = Field(
+    networking: NetworkingConfig | None = Field(
         default=None,
-        description='Network access rules, e.g. {"type": "unrestricted"}.',
+        description=(
+            'Network access rules.  None or {"type": "unrestricted"} for full '
+            'access; {"type": "limited", "allowed_hosts": [...]} to restrict.'
+        ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_networking(cls, data: Any) -> Any:
+        """Treat ``networking: {}`` from legacy DB rows as None (unrestricted)."""
+        if isinstance(data, dict) and data.get("networking") == {}:
+            data = {**data, "networking": None}
+        return data
 
 
 class EnvironmentCreate(BaseModel):

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -22,10 +22,9 @@ CLI.
 from __future__ import annotations
 
 import asyncio
-import json
-from typing import Any
 
 from aios.config import get_settings
+from aios.db import queries
 from aios.logging import get_logger
 from aios.models.environments import EnvironmentConfig, LimitedNetworking
 from aios.sandbox.container import ContainerError, ContainerHandle
@@ -97,20 +96,7 @@ async def _load_environment_config(session_id: str) -> EnvironmentConfig | None:
 
     pool = runtime.require_pool()
     async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            """
-            SELECT e.config FROM environments e
-            JOIN sessions s ON s.environment_id = e.id
-            WHERE s.id = $1
-            """,
-            session_id,
-        )
-    if row is None:
-        return None
-
-    raw_config: Any = row["config"]
-    config_data = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
-    return EnvironmentConfig.model_validate(config_data)
+        return await queries.get_environment_config_for_session(conn, session_id)
 
 
 async def provision_for_session(session_id: str) -> ContainerHandle:
@@ -178,8 +164,7 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
     await _install_packages(handle, env_config, session_id)
 
     # Apply iptables lockdown after packages are installed.
-    if needs_lockdown:
-        assert isinstance(networking, LimitedNetworking)
+    if needs_lockdown and isinstance(networking, LimitedNetworking):
         await _apply_network_lockdown(handle, networking, session_id)
 
     log.info(

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -22,9 +22,12 @@ CLI.
 from __future__ import annotations
 
 import asyncio
+import json
+from typing import Any
 
 from aios.config import get_settings
 from aios.logging import get_logger
+from aios.models.environments import EnvironmentConfig, LimitedNetworking
 from aios.sandbox.container import ContainerError, ContainerHandle
 from aios.sandbox.volumes import ensure_workspace_dir
 
@@ -36,6 +39,32 @@ log = get_logger("aios.sandbox.provisioner")
 MANAGED_LABEL_KEY = "aios.managed"
 MANAGED_LABEL_VALUE = "true"
 SESSION_LABEL_KEY = "aios.session_id"
+
+# Well-known hosts for public package registries.  Added to the iptables
+# allowlist when ``allow_package_managers`` is True in limited networking.
+PACKAGE_REGISTRY_HOSTS: frozenset[str] = frozenset(
+    {
+        # Python (pip)
+        "pypi.org",
+        "files.pythonhosted.org",
+        # Node (npm)
+        "registry.npmjs.org",
+        # Rust (cargo)
+        "crates.io",
+        "static.crates.io",
+        # Ruby (gem)
+        "rubygems.org",
+        # Go
+        "proxy.golang.org",
+        "sum.golang.org",
+        # Debian/Ubuntu (apt)
+        "deb.debian.org",
+        "security.debian.org",
+        # Common CDN used by package managers
+        "github.com",
+        "objects.githubusercontent.com",
+    }
+)
 
 
 async def _run_docker(argv: list[str]) -> tuple[int, bytes, bytes]:
@@ -58,6 +87,32 @@ async def _run_docker(argv: list[str]) -> tuple[int, bytes, bytes]:
     return proc.returncode or 0, stdout_bytes, stderr_bytes
 
 
+async def _load_environment_config(session_id: str) -> EnvironmentConfig | None:
+    """Load the environment config for a session from the DB.
+
+    Returns ``None`` if the session or environment doesn't exist (shouldn't
+    happen in normal flow, but callers handle it gracefully).
+    """
+    from aios.harness import runtime
+
+    pool = runtime.require_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT e.config FROM environments e
+            JOIN sessions s ON s.environment_id = e.id
+            WHERE s.id = $1
+            """,
+            session_id,
+        )
+    if row is None:
+        return None
+
+    raw_config: Any = row["config"]
+    config_data = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+    return EnvironmentConfig.model_validate(config_data)
+
+
 async def provision_for_session(session_id: str) -> ContainerHandle:
     """Create a fresh container for ``session_id`` and return a handle.
 
@@ -71,6 +126,11 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
     """
     settings = get_settings()
     workspace_path = ensure_workspace_dir(session_id)
+    env_config = await _load_environment_config(session_id)
+
+    # Determine if the environment uses limited networking.
+    networking = env_config.networking if env_config else None
+    needs_lockdown = isinstance(networking, LimitedNetworking)
 
     argv = [
         "docker",
@@ -89,8 +149,13 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
         settings.sandbox_network_mode,
         # Keep stdin open so the container doesn't exit on empty stdin.
         "--interactive",
-        settings.docker_image,
     ]
+
+    # Limited networking needs NET_ADMIN to apply iptables rules.
+    if needs_lockdown:
+        argv.extend(["--cap-add", "NET_ADMIN"])
+
+    argv.append(settings.docker_image)
 
     rc, stdout_bytes, stderr_bytes = await _run_docker(argv)
     if rc != 0:
@@ -109,48 +174,39 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
         workspace_path=workspace_path,
     )
 
-    # Install packages from the session's environment config (if any).
-    await _install_packages(handle, session_id)
+    # Install packages while the network is still open.
+    await _install_packages(handle, env_config, session_id)
+
+    # Apply iptables lockdown after packages are installed.
+    if needs_lockdown:
+        assert isinstance(networking, LimitedNetworking)
+        await _apply_network_lockdown(handle, networking, session_id)
 
     log.info(
         "sandbox.provisioned",
         session_id=session_id,
         container_id=container_id[:12],
         workspace_path=str(workspace_path),
+        networking=networking.type if networking else "unrestricted",
     )
 
     return handle
 
 
-async def _install_packages(handle: ContainerHandle, session_id: str) -> None:
-    """Install packages from the session's environment config.
+async def _install_packages(
+    handle: ContainerHandle,
+    env_config: EnvironmentConfig | None,
+    session_id: str,
+) -> None:
+    """Install packages from the environment config.
 
-    Looks up the session → environment → config.packages. If no packages
-    are configured, returns immediately. Failures are logged but don't
-    prevent container use — the model can retry or work around.
+    Failures are logged but don't prevent container use — the model can
+    retry or work around missing packages.
     """
-    from aios.harness import runtime
-
-    pool = runtime.require_pool()
-    async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            """
-            SELECT e.config FROM environments e
-            JOIN sessions s ON s.environment_id = e.id
-            WHERE s.id = $1
-            """,
-            session_id,
-        )
-    if row is None:
+    if env_config is None or not env_config.packages:
         return
 
-    import json
-
-    raw_config = row["config"]
-    config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
-    packages = config.get("packages")
-    if not packages:
-        return
+    packages = env_config.packages
 
     install_cmds = {
         "apt": "apt-get update -qq && apt-get install -y -qq {}",
@@ -161,12 +217,12 @@ async def _install_packages(handle: ContainerHandle, session_id: str) -> None:
         "go": "go install {}",
     }
 
+    settings = get_settings()
     for manager, cmd_template in install_cmds.items():
         pkg_list = packages.get(manager)
         if not pkg_list:
             continue
         cmd = cmd_template.format(" ".join(pkg_list))
-        settings = get_settings()
         result = await handle.run_command(
             cmd, timeout_seconds=120, max_output_bytes=settings.bash_max_output_bytes
         )
@@ -178,6 +234,90 @@ async def _install_packages(handle: ContainerHandle, session_id: str) -> None:
                 exit_code=result.exit_code,
                 stderr=result.stderr[:500],
             )
+
+
+# ── network lockdown ──────────────────────────────────────────────────────────
+
+
+def build_iptables_script(allowed_hosts: set[str]) -> str:
+    """Build a shell script that restricts outbound traffic via iptables.
+
+    The script allows: loopback, established connections, DNS (port 53),
+    and HTTP/HTTPS (ports 80/443) to the resolved IPs of each allowed
+    host. Everything else is dropped.
+
+    Hostnames are validated at the model layer (alphanumerics, dots, hyphens
+    only) so embedding them in the script is safe.
+    """
+    lines = [
+        "set -e",
+        "",
+        "# Flush existing OUTPUT rules",
+        "iptables -F OUTPUT",
+        "",
+        "# Allow loopback",
+        "iptables -A OUTPUT -o lo -j ACCEPT",
+        "",
+        "# Allow established/related connections",
+        "iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT",
+        "",
+        "# Allow DNS (UDP and TCP port 53)",
+        "iptables -A OUTPUT -p udp --dport 53 -j ACCEPT",
+        "iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT",
+    ]
+
+    for host in sorted(allowed_hosts):
+        lines.append("")
+        lines.append(f"# Allow {host}")
+        lines.append(
+            f"for ip in $(getent ahosts {host} 2>/dev/null | awk '{{print $1}}' | sort -u); do"
+        )
+        lines.append('  iptables -A OUTPUT -d "$ip" -p tcp --dport 80 -j ACCEPT')
+        lines.append('  iptables -A OUTPUT -d "$ip" -p tcp --dport 443 -j ACCEPT')
+        lines.append("done")
+
+    lines.append("")
+    lines.append("# Drop everything else")
+    lines.append("iptables -P OUTPUT DROP")
+
+    return "\n".join(lines)
+
+
+async def _apply_network_lockdown(
+    handle: ContainerHandle,
+    networking: LimitedNetworking,
+    session_id: str,
+) -> None:
+    """Apply iptables rules to restrict outbound traffic.
+
+    Called after package installation so that ``pip install`` etc. can
+    reach registries before the lockdown takes effect.  Failures are
+    logged as warnings — the container is still usable, but the model
+    will see connection errors if it tries to reach blocked hosts.
+    """
+    allowed: set[str] = set(networking.allowed_hosts)
+    if networking.allow_package_managers:
+        allowed |= PACKAGE_REGISTRY_HOSTS
+
+    script = build_iptables_script(allowed)
+    settings = get_settings()
+    result = await handle.run_command(
+        script, timeout_seconds=30, max_output_bytes=settings.bash_max_output_bytes
+    )
+
+    if result.exit_code != 0:
+        log.warning(
+            "sandbox.network_lockdown_failed",
+            session_id=session_id,
+            exit_code=result.exit_code,
+            stderr=result.stderr[:500],
+        )
+    else:
+        log.info(
+            "sandbox.network_lockdown_applied",
+            session_id=session_id,
+            allowed_host_count=len(allowed),
+        )
 
 
 async def release(handle: ContainerHandle) -> None:

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -224,20 +224,34 @@ class Harness:
         tools: list[str] | None = None,
         tool_specs: list[Any] | None = None,
         system: str = "You are a test assistant.",
+        environment_config: Any | None = None,
     ) -> Session:
         """Create an agent + session and append the initial user message.
 
         Pass ``tools=["bash", "read"]`` for simple built-in lists, or
         ``tool_specs=[ToolSpec(...)]`` for full control (e.g. permission
         policies). Only one of the two should be provided.
-        """
-        if self._env_id is None:
-            from aios.ids import make_id
 
+        Pass ``environment_config`` to create a fresh environment with
+        that config (e.g. for networking tests). When omitted, a shared
+        default environment is reused across calls.
+        """
+        from aios.ids import make_id
+
+        if environment_config is not None:
             env = await environments_service.create_environment(
-                self._pool, name=f"test-env-{make_id('env')[-8:]}"
+                self._pool,
+                name=f"test-env-{make_id('env')[-8:]}",
+                config=environment_config,
             )
-            self._env_id = env.id
+            env_id = env.id
+        else:
+            if self._env_id is None:
+                env = await environments_service.create_environment(
+                    self._pool, name=f"test-env-{make_id('env')[-8:]}"
+                )
+                self._env_id = env.id
+            env_id = self._env_id
 
         from aios.models.agents import ToolSpec
 
@@ -259,7 +273,7 @@ class Harness:
         session = await sessions_service.create_session(
             self._pool,
             agent_id=agent.id,
-            environment_id=self._env_id,
+            environment_id=env_id,
             title="e2e-test",
             metadata={},
         )

--- a/tests/e2e/test_networking.py
+++ b/tests/e2e/test_networking.py
@@ -7,46 +7,8 @@ rules actually block/allow outbound traffic.
 from __future__ import annotations
 
 from aios.models.environments import EnvironmentConfig, LimitedNetworking, UnrestrictedNetworking
-from aios.services import agents as agents_service
-from aios.services import environments as environments_service
-from aios.services import sessions as sessions_service
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness, assistant, bash
-
-
-async def _start_session_with_networking(
-    harness: Harness,
-    networking: LimitedNetworking | UnrestrictedNetworking,
-) -> str:
-    """Create an environment with the given networking config and return a session id."""
-    from aios.ids import make_id
-    from aios.models.agents import ToolSpec
-
-    env = await environments_service.create_environment(
-        harness._pool,
-        name=f"net-test-{make_id('env')[-8:]}",
-        config=EnvironmentConfig(networking=networking),
-    )
-    agent = await agents_service.create_agent(
-        harness._pool,
-        name=f"net-test-{make_id('agent')[-8:]}",
-        model="fake/test",
-        system="You are a test assistant.",
-        tools=[ToolSpec(type="bash")],
-        description=None,
-        metadata={},
-        window_min=50_000,
-        window_max=150_000,
-    )
-    session = await sessions_service.create_session(
-        harness._pool,
-        agent_id=agent.id,
-        environment_id=env.id,
-        title="networking-e2e",
-        metadata={},
-    )
-    await sessions_service.append_user_message(harness._pool, session.id, "test")
-    return session.id
 
 
 @needs_docker
@@ -55,12 +17,6 @@ class TestNetworkingEnforcement:
 
     async def test_limited_blocks_unlisted_host(self, docker_harness: Harness) -> None:
         """A limited environment should block curl to a host NOT in allowed_hosts."""
-        session_id = await _start_session_with_networking(
-            docker_harness,
-            LimitedNetworking(type="limited", allowed_hosts=["example.com"]),
-        )
-        # Script the model to curl a host that is NOT allowed.
-        # --connect-timeout 5 so the test doesn't hang.
         docker_harness.script_model(
             [
                 assistant(
@@ -69,9 +25,16 @@ class TestNetworkingEnforcement:
                 assistant("Done."),
             ]
         )
-        await docker_harness.run_until_idle(session_id)
+        session = await docker_harness.start(
+            "test",
+            tools=["bash"],
+            environment_config=EnvironmentConfig(
+                networking=LimitedNetworking(type="limited", allowed_hosts=["example.com"]),
+            ),
+        )
+        await docker_harness.run_until_idle(session.id)
 
-        events = await docker_harness.events(session_id)
+        events = await docker_harness.events(session.id)
         # The curl should fail — connection refused or timed out.
         tool_result = next(
             e for e in events if e.kind == "message" and e.data.get("role") == "tool"
@@ -86,10 +49,6 @@ class TestNetworkingEnforcement:
 
     async def test_limited_allows_listed_host(self, docker_harness: Harness) -> None:
         """A limited environment should allow curl to a host in allowed_hosts."""
-        session_id = await _start_session_with_networking(
-            docker_harness,
-            LimitedNetworking(type="limited", allowed_hosts=["example.com"]),
-        )
         docker_harness.script_model(
             [
                 assistant(
@@ -98,9 +57,16 @@ class TestNetworkingEnforcement:
                 assistant("Done."),
             ]
         )
-        await docker_harness.run_until_idle(session_id)
+        session = await docker_harness.start(
+            "test",
+            tools=["bash"],
+            environment_config=EnvironmentConfig(
+                networking=LimitedNetworking(type="limited", allowed_hosts=["example.com"]),
+            ),
+        )
+        await docker_harness.run_until_idle(session.id)
 
-        events = await docker_harness.events(session_id)
+        events = await docker_harness.events(session.id)
         tool_result = next(
             e for e in events if e.kind == "message" and e.data.get("role") == "tool"
         )
@@ -110,10 +76,6 @@ class TestNetworkingEnforcement:
 
     async def test_unrestricted_allows_all(self, docker_harness: Harness) -> None:
         """An unrestricted environment should allow curl to any host."""
-        session_id = await _start_session_with_networking(
-            docker_harness,
-            UnrestrictedNetworking(),
-        )
         docker_harness.script_model(
             [
                 assistant(
@@ -122,9 +84,16 @@ class TestNetworkingEnforcement:
                 assistant("Done."),
             ]
         )
-        await docker_harness.run_until_idle(session_id)
+        session = await docker_harness.start(
+            "test",
+            tools=["bash"],
+            environment_config=EnvironmentConfig(
+                networking=UnrestrictedNetworking(),
+            ),
+        )
+        await docker_harness.run_until_idle(session.id)
 
-        events = await docker_harness.events(session_id)
+        events = await docker_harness.events(session.id)
         tool_result = next(
             e for e in events if e.kind == "message" and e.data.get("role") == "tool"
         )

--- a/tests/e2e/test_networking.py
+++ b/tests/e2e/test_networking.py
@@ -1,0 +1,132 @@
+"""E2E tests for networking enforcement.
+
+Requires Docker: provisions real containers and verifies that iptables
+rules actually block/allow outbound traffic.
+"""
+
+from __future__ import annotations
+
+from aios.models.environments import EnvironmentConfig, LimitedNetworking, UnrestrictedNetworking
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness, assistant, bash
+
+
+async def _start_session_with_networking(
+    harness: Harness,
+    networking: LimitedNetworking | UnrestrictedNetworking,
+) -> str:
+    """Create an environment with the given networking config and return a session id."""
+    from aios.ids import make_id
+    from aios.models.agents import ToolSpec
+
+    env = await environments_service.create_environment(
+        harness._pool,
+        name=f"net-test-{make_id('env')[-8:]}",
+        config=EnvironmentConfig(networking=networking),
+    )
+    agent = await agents_service.create_agent(
+        harness._pool,
+        name=f"net-test-{make_id('agent')[-8:]}",
+        model="fake/test",
+        system="You are a test assistant.",
+        tools=[ToolSpec(type="bash")],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    session = await sessions_service.create_session(
+        harness._pool,
+        agent_id=agent.id,
+        environment_id=env.id,
+        title="networking-e2e",
+        metadata={},
+    )
+    await sessions_service.append_user_message(harness._pool, session.id, "test")
+    return session.id
+
+
+@needs_docker
+class TestNetworkingEnforcement:
+    """Verify that iptables lockdown actually blocks/allows traffic."""
+
+    async def test_limited_blocks_unlisted_host(self, docker_harness: Harness) -> None:
+        """A limited environment should block curl to a host NOT in allowed_hosts."""
+        session_id = await _start_session_with_networking(
+            docker_harness,
+            LimitedNetworking(type="limited", allowed_hosts=["example.com"]),
+        )
+        # Script the model to curl a host that is NOT allowed.
+        # --connect-timeout 5 so the test doesn't hang.
+        docker_harness.script_model(
+            [
+                assistant(
+                    tool_calls=[bash("curl -s --connect-timeout 5 http://httpbin.org/get")],
+                ),
+                assistant("Done."),
+            ]
+        )
+        await docker_harness.run_until_idle(session_id)
+
+        events = await docker_harness.events(session_id)
+        # The curl should fail — connection refused or timed out.
+        tool_result = next(
+            e for e in events if e.kind == "message" and e.data.get("role") == "tool"
+        )
+        content = tool_result.data.get("content", "")
+        # iptables DROP causes a timeout or connection error, not an HTTP response.
+        assert (
+            "httpbin" not in content.lower()
+            or "timed out" in content.lower()
+            or (tool_result.data.get("exit_code", 0) != 0)
+        )
+
+    async def test_limited_allows_listed_host(self, docker_harness: Harness) -> None:
+        """A limited environment should allow curl to a host in allowed_hosts."""
+        session_id = await _start_session_with_networking(
+            docker_harness,
+            LimitedNetworking(type="limited", allowed_hosts=["example.com"]),
+        )
+        docker_harness.script_model(
+            [
+                assistant(
+                    tool_calls=[bash("curl -s --connect-timeout 10 https://example.com")],
+                ),
+                assistant("Done."),
+            ]
+        )
+        await docker_harness.run_until_idle(session_id)
+
+        events = await docker_harness.events(session_id)
+        tool_result = next(
+            e for e in events if e.kind == "message" and e.data.get("role") == "tool"
+        )
+        content = tool_result.data.get("content", "")
+        # example.com returns a simple HTML page with "Example Domain"
+        assert "Example Domain" in content
+
+    async def test_unrestricted_allows_all(self, docker_harness: Harness) -> None:
+        """An unrestricted environment should allow curl to any host."""
+        session_id = await _start_session_with_networking(
+            docker_harness,
+            UnrestrictedNetworking(),
+        )
+        docker_harness.script_model(
+            [
+                assistant(
+                    tool_calls=[bash("curl -s --connect-timeout 10 https://example.com")],
+                ),
+                assistant("Done."),
+            ]
+        )
+        await docker_harness.run_until_idle(session_id)
+
+        events = await docker_harness.events(session_id)
+        tool_result = next(
+            e for e in events if e.kind == "message" and e.data.get("role") == "tool"
+        )
+        content = tool_result.data.get("content", "")
+        assert "Example Domain" in content

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -1,0 +1,327 @@
+"""Unit tests for networking model validation and provisioner logic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aios.models.environments import (
+    EnvironmentConfig,
+    LimitedNetworking,
+    UnrestrictedNetworking,
+)
+from aios.sandbox.container import CommandResult, ContainerHandle
+from aios.sandbox.provisioner import PACKAGE_REGISTRY_HOSTS, build_iptables_script
+
+# ── model validation ──────────────────────────────────────────────────────────
+
+
+class TestUnrestrictedNetworking:
+    def test_round_trip(self) -> None:
+        n = UnrestrictedNetworking()
+        assert n.type == "unrestricted"
+        assert n.model_dump() == {"type": "unrestricted"}
+
+    def test_from_dict(self) -> None:
+        n = UnrestrictedNetworking.model_validate({"type": "unrestricted"})
+        assert n.type == "unrestricted"
+
+
+class TestLimitedNetworking:
+    def test_round_trip(self) -> None:
+        n = LimitedNetworking(
+            type="limited",
+            allowed_hosts=["api.example.com", "cdn.example.com"],
+            allow_package_managers=True,
+            allow_mcp_servers=False,
+        )
+        assert n.type == "limited"
+        assert n.allowed_hosts == ["api.example.com", "cdn.example.com"]
+        assert n.allow_package_managers is True
+        assert n.allow_mcp_servers is False
+
+    def test_defaults(self) -> None:
+        n = LimitedNetworking(type="limited")
+        assert n.allowed_hosts == []
+        assert n.allow_package_managers is False
+        assert n.allow_mcp_servers is False
+
+    def test_rejects_empty_hostname(self) -> None:
+        with pytest.raises(ValueError, match="must not be empty"):
+            LimitedNetworking(type="limited", allowed_hosts=[""])
+
+    def test_rejects_hostname_with_protocol(self) -> None:
+        with pytest.raises(ValueError, match="invalid hostname"):
+            LimitedNetworking(type="limited", allowed_hosts=["https://example.com"])
+
+    def test_rejects_hostname_with_shell_metacharacters(self) -> None:
+        with pytest.raises(ValueError, match="invalid hostname"):
+            LimitedNetworking(type="limited", allowed_hosts=["example.com; rm -rf /"])
+
+    def test_rejects_hostname_with_path(self) -> None:
+        with pytest.raises(ValueError, match="invalid hostname"):
+            LimitedNetworking(type="limited", allowed_hosts=["example.com/path"])
+
+    def test_rejects_hostname_too_long(self) -> None:
+        with pytest.raises(ValueError, match="hostname too long"):
+            LimitedNetworking(type="limited", allowed_hosts=["a" * 254])
+
+    def test_accepts_valid_hostnames(self) -> None:
+        hosts = ["example.com", "sub.domain.co.uk", "a-b-c.example.org", "123.45.67.89"]
+        n = LimitedNetworking(type="limited", allowed_hosts=hosts)
+        assert n.allowed_hosts == hosts
+
+
+class TestEnvironmentConfigNetworking:
+    def test_defaults_to_none(self) -> None:
+        config = EnvironmentConfig()
+        assert config.networking is None
+
+    def test_unrestricted(self) -> None:
+        config = EnvironmentConfig.model_validate({"networking": {"type": "unrestricted"}})
+        assert isinstance(config.networking, UnrestrictedNetworking)
+
+    def test_limited(self) -> None:
+        config = EnvironmentConfig.model_validate(
+            {"networking": {"type": "limited", "allowed_hosts": ["api.example.com"]}}
+        )
+        assert isinstance(config.networking, LimitedNetworking)
+        assert config.networking.allowed_hosts == ["api.example.com"]
+
+    def test_null_networking_is_none(self) -> None:
+        config = EnvironmentConfig.model_validate({"networking": None})
+        assert config.networking is None
+
+    def test_empty_dict_networking_normalized_to_none(self) -> None:
+        """Backward compat: existing DB rows may have networking: {}."""
+        config = EnvironmentConfig.model_validate({"networking": {}})
+        assert config.networking is None
+
+    def test_missing_networking_key(self) -> None:
+        """Backward compat: existing DB rows may have no networking key."""
+        config = EnvironmentConfig.model_validate({"packages": {"pip": ["pandas"]}})
+        assert config.networking is None
+
+    def test_rejects_bogus_type(self) -> None:
+        with pytest.raises(ValueError):
+            EnvironmentConfig.model_validate({"networking": {"type": "bogus"}})
+
+
+# ── build_iptables_script ─────────────────────────────────────────────────────
+
+
+class TestBuildIptablesScript:
+    def test_empty_hosts(self) -> None:
+        script = build_iptables_script(set())
+        assert "iptables -F OUTPUT" in script
+        assert "iptables -P OUTPUT DROP" in script
+        # No host-specific rules
+        assert "getent" not in script
+
+    def test_single_host(self) -> None:
+        script = build_iptables_script({"api.example.com"})
+        assert "getent ahosts api.example.com" in script
+        assert "--dport 80" in script
+        assert "--dport 443" in script
+
+    def test_multiple_hosts_sorted(self) -> None:
+        script = build_iptables_script({"z.example.com", "a.example.com"})
+        z_pos = script.index("z.example.com")
+        a_pos = script.index("a.example.com")
+        assert a_pos < z_pos, "hosts should be sorted alphabetically"
+
+    def test_allows_dns(self) -> None:
+        script = build_iptables_script({"example.com"})
+        assert "--dport 53" in script
+
+    def test_allows_loopback(self) -> None:
+        script = build_iptables_script({"example.com"})
+        assert "-o lo -j ACCEPT" in script
+
+    def test_allows_established(self) -> None:
+        script = build_iptables_script({"example.com"})
+        assert "ESTABLISHED,RELATED" in script
+
+    def test_package_registry_hosts_integration(self) -> None:
+        """Verify PACKAGE_REGISTRY_HOSTS can be passed directly."""
+        script = build_iptables_script(PACKAGE_REGISTRY_HOSTS)
+        assert "pypi.org" in script
+        assert "registry.npmjs.org" in script
+
+
+# ── provisioner docker args ───────────────────────────────────────────────────
+
+
+def _make_handle(session_id: str = "sess_01TEST") -> ContainerHandle:
+    handle = ContainerHandle(
+        session_id=session_id,
+        container_id="abc123",
+        workspace_path=Path("/tmp/ws"),
+    )
+    handle.run_command = AsyncMock(  # type: ignore[method-assign]
+        return_value=CommandResult(
+            exit_code=0, stdout="", stderr="", timed_out=False, truncated=False
+        )
+    )
+    return handle
+
+
+class TestProvisionerDockerArgs:
+    """Test that provision_for_session passes the right docker args."""
+
+    @pytest.mark.asyncio
+    async def test_limited_adds_cap_net_admin(self) -> None:
+        limited_config = EnvironmentConfig(
+            networking=LimitedNetworking(type="limited", allowed_hosts=["example.com"])
+        )
+        captured_argv: list[list[str]] = []
+
+        async def fake_run_docker(argv: list[str]) -> tuple[int, bytes, bytes]:
+            captured_argv.append(argv)
+            # Return a container id for docker run
+            return 0, b"container_abc123\n", b""
+
+        with (
+            patch(
+                "aios.sandbox.provisioner._load_environment_config",
+                AsyncMock(return_value=limited_config),
+            ),
+            patch("aios.sandbox.provisioner._run_docker", fake_run_docker),
+            patch("aios.sandbox.provisioner.ensure_workspace_dir", return_value=Path("/tmp/ws")),
+            patch(
+                "aios.sandbox.provisioner._install_packages",
+                AsyncMock(),
+            ) as mock_install,
+            patch(
+                "aios.sandbox.provisioner._apply_network_lockdown",
+                AsyncMock(),
+            ) as mock_lockdown,
+        ):
+            from aios.sandbox.provisioner import provision_for_session
+
+            await provision_for_session("sess_01TEST")
+
+        # docker run argv should contain --cap-add NET_ADMIN
+        run_argv = captured_argv[0]
+        assert "--cap-add" in run_argv
+        cap_idx = run_argv.index("--cap-add")
+        assert run_argv[cap_idx + 1] == "NET_ADMIN"
+
+        # install should be called before lockdown
+        mock_install.assert_called_once()
+        mock_lockdown.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unrestricted_no_cap_net_admin(self) -> None:
+        unrestricted_config = EnvironmentConfig(networking=UnrestrictedNetworking())
+        captured_argv: list[list[str]] = []
+
+        async def fake_run_docker(argv: list[str]) -> tuple[int, bytes, bytes]:
+            captured_argv.append(argv)
+            return 0, b"container_abc123\n", b""
+
+        with (
+            patch(
+                "aios.sandbox.provisioner._load_environment_config",
+                AsyncMock(return_value=unrestricted_config),
+            ),
+            patch("aios.sandbox.provisioner._run_docker", fake_run_docker),
+            patch("aios.sandbox.provisioner.ensure_workspace_dir", return_value=Path("/tmp/ws")),
+            patch("aios.sandbox.provisioner._install_packages", AsyncMock()),
+            patch(
+                "aios.sandbox.provisioner._apply_network_lockdown",
+                AsyncMock(),
+            ) as mock_lockdown,
+        ):
+            from aios.sandbox.provisioner import provision_for_session
+
+            await provision_for_session("sess_01TEST")
+
+        run_argv = captured_argv[0]
+        assert "--cap-add" not in run_argv
+        mock_lockdown.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_none_config_no_lockdown(self) -> None:
+        """No environment config at all — should work like unrestricted."""
+        captured_argv: list[list[str]] = []
+
+        async def fake_run_docker(argv: list[str]) -> tuple[int, bytes, bytes]:
+            captured_argv.append(argv)
+            return 0, b"container_abc123\n", b""
+
+        with (
+            patch(
+                "aios.sandbox.provisioner._load_environment_config",
+                AsyncMock(return_value=None),
+            ),
+            patch("aios.sandbox.provisioner._run_docker", fake_run_docker),
+            patch("aios.sandbox.provisioner.ensure_workspace_dir", return_value=Path("/tmp/ws")),
+            patch("aios.sandbox.provisioner._install_packages", AsyncMock()),
+            patch(
+                "aios.sandbox.provisioner._apply_network_lockdown",
+                AsyncMock(),
+            ) as mock_lockdown,
+        ):
+            from aios.sandbox.provisioner import provision_for_session
+
+            await provision_for_session("sess_01TEST")
+
+        run_argv = captured_argv[0]
+        assert "--cap-add" not in run_argv
+        mock_lockdown.assert_not_called()
+
+
+class TestApplyNetworkLockdown:
+    """Test _apply_network_lockdown builds and executes the right script."""
+
+    @pytest.mark.asyncio
+    async def test_calls_run_command_with_script(self) -> None:
+        from aios.sandbox.provisioner import _apply_network_lockdown
+
+        handle = _make_handle()
+        networking = LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
+
+        await _apply_network_lockdown(handle, networking, "sess_01TEST")
+
+        handle.run_command.assert_called_once()  # type: ignore[union-attr]
+        script = handle.run_command.call_args[0][0]  # type: ignore[union-attr]
+        assert "iptables -P OUTPUT DROP" in script
+        assert "getent ahosts api.example.com" in script
+
+    @pytest.mark.asyncio
+    async def test_includes_package_registries_when_enabled(self) -> None:
+        from aios.sandbox.provisioner import _apply_network_lockdown
+
+        handle = _make_handle()
+        networking = LimitedNetworking(
+            type="limited",
+            allowed_hosts=["api.example.com"],
+            allow_package_managers=True,
+        )
+
+        await _apply_network_lockdown(handle, networking, "sess_01TEST")
+
+        script = handle.run_command.call_args[0][0]  # type: ignore[union-attr]
+        assert "pypi.org" in script
+        assert "registry.npmjs.org" in script
+        assert "api.example.com" in script
+
+    @pytest.mark.asyncio
+    async def test_no_package_registries_when_disabled(self) -> None:
+        from aios.sandbox.provisioner import _apply_network_lockdown
+
+        handle = _make_handle()
+        networking = LimitedNetworking(
+            type="limited",
+            allowed_hosts=["api.example.com"],
+            allow_package_managers=False,
+        )
+
+        await _apply_network_lockdown(handle, networking, "sess_01TEST")
+
+        script = handle.run_command.call_args[0][0]  # type: ignore[union-attr]
+        assert "pypi.org" not in script
+        assert "api.example.com" in script


### PR DESCRIPTION
## Summary

- **Structured networking model**: Replaces untyped `dict[str, Any]` with Pydantic discriminated union (`UnrestrictedNetworking | LimitedNetworking`). Hostname validation prevents shell injection. Backward-compatible with existing DB rows (`null`, `{}`, missing key).
- **iptables enforcement**: Limited networking containers get `--cap-add=NET_ADMIN` and iptables rules applied after package installation. Outbound HTTP/HTTPS restricted to resolved IPs of `allowed_hosts`. DNS (port 53) stays open.
- **Package registry allowlist**: `allow_package_managers: true` adds well-known hosts (pypi.org, registry.npmjs.org, crates.io, etc.) to the iptables allowlist.
- **Dockerfile**: Adds `iptables` to sandbox image. Documented as optional for unrestricted-only deployments.

### Provisioning order
1. `docker run --network bridge` (+ `--cap-add NET_ADMIN` if limited)
2. `_install_packages()` — while network is still open
3. `_apply_network_lockdown()` — iptables restricts outbound

### Deferred
`allow_mcp_servers` field is validated and stored but enforcement is deferred until MCP server URLs are available on the environment model.

## Files changed
| File | Change |
|------|--------|
| `src/aios/models/environments.py` | Discriminated union networking model |
| `src/aios/sandbox/provisioner.py` | Config loading, cap-add, iptables lockdown |
| `docker/Dockerfile.sandbox` | Add iptables |
| `tests/unit/test_networking.py` | 30 unit tests |
| `tests/e2e/test_networking.py` | 3 Docker e2e tests |

## Test plan

- [x] `uv run mypy src` — 66 files, no issues
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — all clean
- [x] `uv run pytest tests/unit -q` — 245 passed (215 existing + 30 new)
- [ ] Rebuild sandbox image: `docker build -t aios-sandbox:latest -f docker/Dockerfile.sandbox docker/`
- [ ] `uv run pytest tests/e2e/test_networking.py -xvs` — limited blocks unlisted hosts, allows listed hosts, unrestricted allows all

🤖 Generated with [Claude Code](https://claude.com/claude-code)