### PR TITLE
feat: search_events built-in tool

### DIFF
--- a/migrations/versions/0010_events_search_view.py
+++ b/migrations/versions/0010_events_search_view.py
@@ -1,0 +1,53 @@
+"""Events search view for the search_events built-in tool.
+
+Creates a ``events_search`` view that exposes the event log in a
+model-friendly shape, scoped to the current session via
+``current_setting('app.session_id')``. The tool handler sets
+``SET LOCAL app.session_id = <id>`` inside a read-only transaction
+so the agent can only see its own events.
+
+Columns:
+- ``id`` (text): event ID
+- ``seq`` (bigint): gapless sequence number within the session
+- ``kind`` (text): event kind (message, lifecycle, span, interrupt)
+- ``role`` (text): message role (user, assistant, tool) — NULL for
+  non-message events
+- ``created_at`` (timestamptz): when the event was appended
+- ``content_text`` (text): human-readable content; extracts
+  ``data->>'content'`` for messages, falls back to ``data::text``
+  for other event kinds
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-04-13
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0010"
+down_revision: str = "0009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE OR REPLACE VIEW events_search AS
+        SELECT
+            id,
+            seq,
+            kind,
+            data->>'role' AS role,
+            created_at,
+            COALESCE(data->>'content', data::text) AS content_text
+        FROM events
+        WHERE session_id = current_setting('app.session_id', true)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS events_search")

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -17,7 +17,16 @@ from aios.models.skills import AgentSkillRef
 
 # Built-in tool types. Custom tools use type="custom" with extra fields.
 BuiltinToolType = Literal[
-    "bash", "read", "write", "edit", "glob", "grep", "web_fetch", "web_search", "cancel"
+    "bash",
+    "read",
+    "write",
+    "edit",
+    "glob",
+    "grep",
+    "web_fetch",
+    "web_search",
+    "search_events",
+    "cancel",
 ]
 
 # Permission policy for built-in tools. Custom tools are always client-controlled

--- a/src/aios/tools/__init__.py
+++ b/src/aios/tools/__init__.py
@@ -25,6 +25,7 @@ from aios.tools import edit as _edit  # noqa: F401
 from aios.tools import glob as _glob  # noqa: F401
 from aios.tools import grep as _grep  # noqa: F401
 from aios.tools import read as _read  # noqa: F401
+from aios.tools import search_events as _search_events  # noqa: F401
 from aios.tools import web_fetch as _web_fetch  # noqa: F401
 from aios.tools import web_search as _web_search  # noqa: F401
 from aios.tools import write as _write  # noqa: F401

--- a/src/aios/tools/search_events.py
+++ b/src/aios/tools/search_events.py
@@ -1,0 +1,210 @@
+"""The search_events tool — read-only SQL access to the session event log.
+
+Gives agents the ability to search their own conversation history via SQL
+queries against the ``events_search`` view. The view is scoped per-session
+using ``SET LOCAL app.session_id``, so the agent can only see its own events.
+
+Safety:
+- Only SELECT queries are accepted (validated before execution).
+- Queries run inside a READ ONLY transaction.
+- A 10-second statement_timeout prevents runaway queries.
+- Results are capped at 200 rows.
+
+Return shape: {"result": "<formatted text table>"}
+On error: {"error": "..."}
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import asyncpg
+
+from aios.harness import runtime
+from aios.logging import get_logger
+from aios.tools.registry import registry
+
+log = get_logger("aios.tools.search_events")
+
+MAX_ROWS = 200
+QUERY_TIMEOUT_MS = 10_000
+
+_FORBIDDEN_KEYWORDS = re.compile(
+    r"\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|EXECUTE|COPY|GRANT|REVOKE|SET_CONFIG|CALL)\b",
+    re.IGNORECASE,
+)
+
+
+def _validate_sql(sql: str) -> str | None:
+    """Validate SQL is a safe SELECT query. Returns an error string or None."""
+    stripped = sql.strip()
+    if not stripped.upper().startswith("SELECT"):
+        return "Only SELECT queries are allowed"
+    if ";" in stripped:
+        return "Multiple statements (semicolons) are not allowed"
+    m = _FORBIDDEN_KEYWORDS.search(stripped)
+    if m:
+        return f"Forbidden keyword '{m.group()}' is not allowed in queries"
+    return None
+
+
+def _format_results(rows: list[asyncpg.Record], columns: list[str], truncated: bool) -> str:
+    """Format query result rows as a readable text table."""
+    if not rows:
+        return "No results."
+    header = " | ".join(columns)
+    divider = "-" * len(header)
+    data_lines = [
+        " | ".join(str(v) if v is not None else "NULL" for v in row.values()) for row in rows
+    ]
+    lines = [header, divider, *data_lines]
+    result = "\n".join(lines)
+    if truncated:
+        result += f"\n\n(Results truncated to {MAX_ROWS} rows)"
+    return result
+
+
+async def _execute_query(
+    pool: asyncpg.Pool[Any],
+    session_id: str,
+    sql: str,
+) -> tuple[list[asyncpg.Record], list[str]]:
+    """Execute a read-only SQL query scoped to session_id.
+
+    Acquires a connection from the pool, starts a READ ONLY transaction,
+    sets the session scope and statement timeout, wraps the user query
+    in a LIMIT to enforce the row cap, and returns the results.
+    """
+    async with pool.acquire() as conn:
+        await conn.execute("BEGIN READ ONLY")
+        try:
+            await conn.execute(f"SET LOCAL statement_timeout = '{QUERY_TIMEOUT_MS}ms'")
+            # Use set_config() instead of SET LOCAL so the session_id
+            # goes through as a parameter, not string interpolation.
+            await conn.execute("SELECT set_config('app.session_id', $1, true)", session_id)
+
+            # Wrap user query to enforce row limit (fetch MAX_ROWS+1 to detect
+            # truncation). Using text interpolation is safe here because `sql`
+            # has already been validated as a SELECT-only query without
+            # semicolons, and the LIMIT value is a constant integer.
+            wrapped = f"SELECT * FROM ({sql}) _q LIMIT {MAX_ROWS + 1}"
+            rows = await conn.fetch(wrapped)
+            columns = list(rows[0].keys()) if rows else []
+        finally:
+            await conn.execute("ROLLBACK")
+
+    return rows, columns
+
+
+SEARCH_EVENTS_DESCRIPTION = (
+    "Query this session's event log using SQL. Use this tool to search past "
+    "conversation history — especially useful when earlier messages have fallen "
+    "out of the context window.\n\n"
+    "Schema — events_search view columns:\n"
+    "- id (text): unique event ID\n"
+    "- seq (integer): sequence number (chronological order within the session)\n"
+    "- kind (text): 'message', 'lifecycle', 'span', or 'interrupt'\n"
+    "- role (text): 'user', 'assistant', or 'tool' (NULL for non-message events)\n"
+    "- created_at (timestamptz): when the event was created\n"
+    "- content_text (text): the message content (or full JSON for non-message events)\n\n"
+    "Limits: results capped at 200 rows. Only SELECT queries allowed.\n\n"
+    "Common patterns:\n\n"
+    "Keyword search (case-insensitive):\n"
+    "  SELECT seq, role, created_at, substr(content_text, 1, 200) AS preview\n"
+    "  FROM events_search\n"
+    "  WHERE content_text ILIKE '%docker%'\n"
+    "  ORDER BY seq DESC LIMIT 20\n\n"
+    "Find user messages about a topic:\n"
+    "  SELECT seq, created_at, substr(content_text, 1, 300) AS preview\n"
+    "  FROM events_search\n"
+    "  WHERE role = 'user' AND content_text ILIKE '%deploy%'\n"
+    "  ORDER BY seq DESC LIMIT 10\n\n"
+    "Time-range filter (last 7 days):\n"
+    "  SELECT * FROM events_search\n"
+    "  WHERE created_at > now() - interval '7 days'\n"
+    "  ORDER BY seq\n\n"
+    "Count messages by role:\n"
+    "  SELECT role, count(*) AS n\n"
+    "  FROM events_search\n"
+    "  WHERE kind = 'message'\n"
+    "  GROUP BY role\n\n"
+    "Most recent messages:\n"
+    "  SELECT seq, role, created_at, substr(content_text, 1, 100) AS preview\n"
+    "  FROM events_search\n"
+    "  WHERE kind = 'message'\n"
+    "  ORDER BY seq DESC LIMIT 10\n\n"
+    "Exact date range:\n"
+    "  SELECT * FROM events_search\n"
+    "  WHERE created_at >= '2026-03-01'\n"
+    "    AND created_at < '2026-03-08'\n"
+    "  ORDER BY seq\n\n"
+    "Tips:\n"
+    "- ORDER BY seq for chronological output (seq is the canonical ordering)\n"
+    "- Use LIMIT to control result size (hard cap is 200 rows)\n"
+    "- Use substr(content_text, 1, N) for content previews to keep output compact\n"
+    "- ILIKE '%term%' is case-insensitive; use multiple ILIKE clauses for OR searches\n"
+    "- Filter by kind = 'message' to exclude lifecycle/span events\n"
+    "- Filter by role = 'user'/'assistant'/'tool' to narrow to specific speakers"
+)
+
+SEARCH_EVENTS_PARAMETERS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": (
+                "SQL SELECT query against the events_search view.\n"
+                "Available columns: id (text), seq (integer), kind (text), "
+                "role (text), created_at (timestamptz), content_text (text).\n\n"
+                "Examples:\n"
+                "  SELECT * FROM events_search WHERE content_text ILIKE '%keyword%' LIMIT 20\n"
+                "  SELECT role, count(*) FROM events_search WHERE kind = 'message' GROUP BY role\n"
+                "  SELECT * FROM events_search "
+                "WHERE created_at > now() - interval '7 days' ORDER BY seq"
+            ),
+        },
+    },
+    "required": ["query"],
+    "additionalProperties": False,
+}
+
+
+async def search_events_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Handler for the search_events tool."""
+    query = arguments.get("query")
+    if not isinstance(query, str) or not query.strip():
+        return {"error": "search_events requires a non-empty 'query' string"}
+
+    err = _validate_sql(query)
+    if err:
+        return {"error": f"SQL validation: {err}"}
+
+    pool = runtime.require_pool()
+
+    try:
+        rows, columns = await _execute_query(pool, session_id, query)
+    except asyncpg.exceptions.QueryCanceledError:
+        return {"error": f"Query timed out after {QUERY_TIMEOUT_MS}ms"}
+    except Exception as exc:
+        log.warning("search_events.query_failed", error=str(exc))
+        return {"error": f"Query failed: {exc}"}
+
+    truncated = len(rows) > MAX_ROWS
+    if truncated:
+        rows = rows[:MAX_ROWS]
+
+    text = _format_results(rows, columns, truncated)
+    return {"result": text}
+
+
+def _register() -> None:
+    registry.register(
+        name="search_events",
+        description=SEARCH_EVENTS_DESCRIPTION,
+        parameters_schema=SEARCH_EVENTS_PARAMETERS_SCHEMA,
+        handler=search_events_handler,
+    )
+
+
+_register()

--- a/src/aios/tools/search_events.py
+++ b/src/aios/tools/search_events.py
@@ -25,7 +25,7 @@ from aios.harness import runtime
 from aios.logging import get_logger
 from aios.tools.registry import registry
 
-log = get_logger("aios.tools.search_events")
+log = get_logger(__name__)
 
 MAX_ROWS = 200
 QUERY_TIMEOUT_MS = 10_000
@@ -49,10 +49,11 @@ def _validate_sql(sql: str) -> str | None:
     return None
 
 
-def _format_results(rows: list[asyncpg.Record], columns: list[str], truncated: bool) -> str:
+def _format_results(rows: list[asyncpg.Record], truncated: bool) -> str:
     """Format query result rows as a readable text table."""
     if not rows:
         return "No results."
+    columns = list(rows[0].keys())
     header = " | ".join(columns)
     divider = "-" * len(header)
     data_lines = [
@@ -69,32 +70,23 @@ async def _execute_query(
     pool: asyncpg.Pool[Any],
     session_id: str,
     sql: str,
-) -> tuple[list[asyncpg.Record], list[str]]:
+) -> tuple[list[asyncpg.Record], bool]:
     """Execute a read-only SQL query scoped to session_id.
 
-    Acquires a connection from the pool, starts a READ ONLY transaction,
-    sets the session scope and statement timeout, wraps the user query
-    in a LIMIT to enforce the row cap, and returns the results.
+    Returns (rows, truncated). Rows are capped at MAX_ROWS; truncated
+    is True when the query produced more rows than the cap.
     """
-    async with pool.acquire() as conn:
-        await conn.execute("BEGIN READ ONLY")
-        try:
-            await conn.execute(f"SET LOCAL statement_timeout = '{QUERY_TIMEOUT_MS}ms'")
-            # Use set_config() instead of SET LOCAL so the session_id
-            # goes through as a parameter, not string interpolation.
-            await conn.execute("SELECT set_config('app.session_id', $1, true)", session_id)
+    async with pool.acquire() as conn, conn.transaction(readonly=True):
+        await conn.execute(f"SET LOCAL statement_timeout = '{QUERY_TIMEOUT_MS}ms'")
+        # set_config() accepts session_id as a parameter, avoiding interpolation.
+        await conn.execute("SELECT set_config('app.session_id', $1, true)", session_id)
+        wrapped = f"SELECT * FROM ({sql}) _q LIMIT {MAX_ROWS + 1}"
+        rows = await conn.fetch(wrapped)
 
-            # Wrap user query to enforce row limit (fetch MAX_ROWS+1 to detect
-            # truncation). Using text interpolation is safe here because `sql`
-            # has already been validated as a SELECT-only query without
-            # semicolons, and the LIMIT value is a constant integer.
-            wrapped = f"SELECT * FROM ({sql}) _q LIMIT {MAX_ROWS + 1}"
-            rows = await conn.fetch(wrapped)
-            columns = list(rows[0].keys()) if rows else []
-        finally:
-            await conn.execute("ROLLBACK")
-
-    return rows, columns
+    truncated = len(rows) > MAX_ROWS
+    if truncated:
+        rows = rows[:MAX_ROWS]
+    return rows, truncated
 
 
 SEARCH_EVENTS_DESCRIPTION = (
@@ -183,18 +175,14 @@ async def search_events_handler(session_id: str, arguments: dict[str, Any]) -> d
     pool = runtime.require_pool()
 
     try:
-        rows, columns = await _execute_query(pool, session_id, query)
+        rows, truncated = await _execute_query(pool, session_id, query)
     except asyncpg.exceptions.QueryCanceledError:
         return {"error": f"Query timed out after {QUERY_TIMEOUT_MS}ms"}
     except Exception as exc:
         log.warning("search_events.query_failed", error=str(exc))
         return {"error": f"Query failed: {exc}"}
 
-    truncated = len(rows) > MAX_ROWS
-    if truncated:
-        rows = rows[:MAX_ROWS]
-
-    text = _format_results(rows, columns, truncated)
+    text = _format_results(rows, truncated)
     return {"result": text}
 
 

--- a/tests/e2e/test_search_events.py
+++ b/tests/e2e/test_search_events.py
@@ -1,0 +1,177 @@
+"""E2E tests for the search_events built-in tool.
+
+Exercises the full stack: real Postgres (testcontainer), the events_search
+view created by migration 0010, and the search_events tool handler querying
+against real event data. Verifies session scoping, result formatting, SQL
+validation, and read-only enforcement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.tools.search_events import search_events_handler
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness, assistant
+
+
+@needs_docker
+class TestSearchEvents:
+    """search_events tool against real Postgres with real event data."""
+
+    async def _setup_session(self, harness: Harness) -> str:
+        """Create a session with a user message and an assistant reply."""
+        harness.script_model([assistant("I can help with Docker!")])
+        session = await harness.start(
+            "Tell me about Docker",
+            tools=["search_events"],
+        )
+        await harness.run_until_idle(session.id)
+        return session.id
+
+    async def test_basic_keyword_search(self, harness: Harness) -> None:
+        """Search for a keyword that appears in the conversation."""
+        session_id = await self._setup_session(harness)
+
+        result = await search_events_handler(
+            session_id,
+            {
+                "query": (
+                    "SELECT seq, role, substr(content_text, 1, 100) AS preview "
+                    "FROM events_search "
+                    "WHERE content_text ILIKE '%docker%' "
+                    "ORDER BY seq"
+                ),
+            },
+        )
+
+        assert "result" in result
+        assert "docker" in result["result"].lower()
+
+    async def test_count_by_role(self, harness: Harness) -> None:
+        """Aggregate query: count events by role."""
+        session_id = await self._setup_session(harness)
+
+        result = await search_events_handler(
+            session_id,
+            {
+                "query": (
+                    "SELECT role, count(*) AS n "
+                    "FROM events_search "
+                    "WHERE kind = 'message' AND role IS NOT NULL "
+                    "GROUP BY role "
+                    "ORDER BY role"
+                ),
+            },
+        )
+
+        assert "result" in result
+        text = result["result"]
+        # Should have at least user and assistant rows
+        assert "user" in text
+        assert "assistant" in text
+
+    async def test_session_scoping(self, harness: Harness) -> None:
+        """Events from one session must not appear in another session's query."""
+        # Create two independent sessions
+        session_id_a = await self._setup_session(harness)
+
+        harness.script_model([assistant("Kubernetes is great!")])
+        session_b = await harness.start(
+            "Tell me about Kubernetes",
+            tools=["search_events"],
+        )
+        await harness.run_until_idle(session_b.id)
+
+        # Session A should NOT see "Kubernetes"
+        result_a = await search_events_handler(
+            session_id_a,
+            {
+                "query": ("SELECT * FROM events_search WHERE content_text ILIKE '%kubernetes%'"),
+            },
+        )
+        assert result_a["result"] == "No results."
+
+        # Session B should NOT see "Docker"
+        result_b = await search_events_handler(
+            session_b.id,
+            {
+                "query": ("SELECT * FROM events_search WHERE content_text ILIKE '%docker%'"),
+            },
+        )
+        assert result_b["result"] == "No results."
+
+    async def test_select_star(self, harness: Harness) -> None:
+        """SELECT * returns all expected columns."""
+        session_id = await self._setup_session(harness)
+
+        result = await search_events_handler(
+            session_id,
+            {
+                "query": (
+                    "SELECT * FROM events_search WHERE kind = 'message' ORDER BY seq LIMIT 1"
+                ),
+            },
+        )
+
+        text = result["result"]
+        # Header line should contain all view columns
+        header = text.split("\n")[0]
+        for col in ("id", "seq", "kind", "role", "created_at", "content_text"):
+            assert col in header
+
+    async def test_sql_validation_rejects_insert(self, harness: Harness) -> None:
+        """DML queries are rejected before hitting the database."""
+        session_id = await self._setup_session(harness)
+
+        result = await search_events_handler(
+            session_id,
+            {
+                "query": "INSERT INTO events (id) VALUES ('evil')",
+            },
+        )
+
+        assert "error" in result
+        assert "SELECT" in result["error"]
+
+    async def test_read_only_enforcement(self, harness: Harness) -> None:
+        """The READ ONLY transaction used by _execute_query blocks writes.
+
+        Verifies the defense-in-depth layer: even if SQL validation were
+        bypassed, Postgres itself rejects mutations.
+        """
+        import asyncpg.exceptions
+
+        from aios.harness import runtime
+
+        session_id = await self._setup_session(harness)
+        pool = runtime.require_pool()
+
+        # Simulate what _execute_query does: BEGIN READ ONLY, then attempt
+        # a write — Postgres must reject it.
+        async with pool.acquire() as conn:
+            await conn.execute("BEGIN READ ONLY")
+            try:
+                with pytest.raises(asyncpg.exceptions.ReadOnlySQLTransactionError):
+                    await conn.execute(
+                        "INSERT INTO events (id, session_id, seq, kind, data) "
+                        "VALUES ('evil', $1, 999999, 'message', '{}'::jsonb)",
+                        session_id,
+                    )
+            finally:
+                await conn.execute("ROLLBACK")
+
+    async def test_no_results_query(self, harness: Harness) -> None:
+        """Query that matches nothing returns 'No results.'"""
+        session_id = await self._setup_session(harness)
+
+        result = await search_events_handler(
+            session_id,
+            {
+                "query": (
+                    "SELECT * FROM events_search WHERE content_text ILIKE '%zzz_nonexistent_zzz%'"
+                ),
+            },
+        )
+
+        assert result["result"] == "No results."

--- a/tests/unit/test_search_events_handler.py
+++ b/tests/unit/test_search_events_handler.py
@@ -112,13 +112,12 @@ class TestFormatResults:
     """Tests for _format_results pure function."""
 
     def test_empty_rows(self) -> None:
-        result = _format_results([], [], False)
+        result = _format_results([], False)
         assert result == "No results."
 
     def test_single_row(self) -> None:
         rows = [_FakeRecord({"id": "evt_01", "role": "assistant", "content_text": "Hello"})]
-        cols = ["id", "role", "content_text"]
-        result = _format_results(rows, cols, False)  # type: ignore[arg-type]
+        result = _format_results(rows, False)  # type: ignore[arg-type]
         assert "id" in result
         assert "role" in result
         assert "assistant" in result
@@ -129,34 +128,29 @@ class TestFormatResults:
             _FakeRecord({"seq": 1, "role": "user"}),
             _FakeRecord({"seq": 2, "role": "assistant"}),
         ]
-        cols = ["seq", "role"]
-        result = _format_results(rows, cols, False)  # type: ignore[arg-type]
+        result = _format_results(rows, False)  # type: ignore[arg-type]
         lines = result.strip().split("\n")
         assert len(lines) == 4  # header + divider + 2 data rows
 
     def test_truncated_notice(self) -> None:
         rows = [_FakeRecord({"id": "evt_01"})]
-        cols = ["id"]
-        result = _format_results(rows, cols, truncated=True)  # type: ignore[arg-type]
+        result = _format_results(rows, truncated=True)  # type: ignore[arg-type]
         assert "truncat" in result.lower()
         assert str(MAX_ROWS) in result
 
     def test_not_truncated_no_notice(self) -> None:
         rows = [_FakeRecord({"id": "evt_01"})]
-        cols = ["id"]
-        result = _format_results(rows, cols, truncated=False)  # type: ignore[arg-type]
+        result = _format_results(rows, truncated=False)  # type: ignore[arg-type]
         assert "truncat" not in result.lower()
 
     def test_null_values(self) -> None:
         rows = [_FakeRecord({"id": "evt_01", "role": None, "content_text": "text"})]
-        cols = ["id", "role", "content_text"]
-        result = _format_results(rows, cols, False)  # type: ignore[arg-type]
+        result = _format_results(rows, False)  # type: ignore[arg-type]
         assert "NULL" in result
 
     def test_header_divider_format(self) -> None:
         rows = [_FakeRecord({"a": 1, "b": 2})]
-        cols = ["a", "b"]
-        result = _format_results(rows, cols, False)  # type: ignore[arg-type]
+        result = _format_results(rows, False)  # type: ignore[arg-type]
         lines = result.split("\n")
         assert lines[0] == "a | b"
         assert lines[1] == "-" * len("a | b")
@@ -166,26 +160,20 @@ class TestFormatResults:
 
 
 def _mock_execute(
-    return_value: Any = ([], []),
+    return_value: Any = ([], False),
     side_effect: Any = None,
 ) -> Any:
     """Context manager that mocks both _execute_query and runtime.require_pool."""
-    from contextlib import contextmanager
+    return patch(
+        "aios.tools.search_events._execute_query",
+        new_callable=AsyncMock,
+        return_value=return_value,
+        side_effect=side_effect,
+    )
 
-    @contextmanager
-    def _ctx() -> Any:
-        with (
-            patch(
-                "aios.tools.search_events._execute_query",
-                new_callable=AsyncMock,
-                return_value=return_value,
-                side_effect=side_effect,
-            ) as mock_exec,
-            patch("aios.tools.search_events.runtime.require_pool"),
-        ):
-            yield mock_exec
 
-    return _ctx()
+def _mock_pool() -> Any:
+    return patch("aios.tools.search_events.runtime.require_pool")
 
 
 class TestSearchEventsHandler:
@@ -193,8 +181,7 @@ class TestSearchEventsHandler:
 
     async def test_success_returns_formatted_results(self) -> None:
         rows = [_FakeRecord({"role": "assistant", "content_text": "Hello"})]
-        columns = ["role", "content_text"]
-        with _mock_execute(return_value=(rows, columns)):
+        with _mock_execute(return_value=(rows, False)), _mock_pool():
             result = await search_events_handler(
                 "sess_01TEST", {"query": "SELECT * FROM events_search"}
             )
@@ -221,7 +208,7 @@ class TestSearchEventsHandler:
         assert "error" in result
 
     async def test_db_error_returns_error(self) -> None:
-        with _mock_execute(side_effect=Exception("connection refused")):
+        with _mock_execute(side_effect=Exception("connection refused")), _mock_pool():
             result = await search_events_handler(
                 "sess_01TEST", {"query": "SELECT * FROM events_search"}
             )
@@ -231,8 +218,9 @@ class TestSearchEventsHandler:
     async def test_timeout_returns_error(self) -> None:
         import asyncpg.exceptions
 
-        with _mock_execute(
-            side_effect=asyncpg.exceptions.QueryCanceledError(),
+        with (
+            _mock_execute(side_effect=asyncpg.exceptions.QueryCanceledError()),
+            _mock_pool(),
         ):
             result = await search_events_handler(
                 "sess_01TEST", {"query": "SELECT * FROM events_search"}
@@ -242,24 +230,22 @@ class TestSearchEventsHandler:
 
     async def test_row_limit_exact_max_no_truncation(self) -> None:
         rows = [_FakeRecord({"id": f"evt_{i}"}) for i in range(MAX_ROWS)]
-        columns = ["id"]
-        with _mock_execute(return_value=(rows, columns)):
+        with _mock_execute(return_value=(rows, False)), _mock_pool():
             result = await search_events_handler(
                 "sess_01TEST", {"query": "SELECT * FROM events_search"}
             )
         assert "truncat" not in result["result"].lower()
 
     async def test_row_limit_truncation(self) -> None:
-        rows = [_FakeRecord({"id": f"evt_{i}"}) for i in range(MAX_ROWS + 1)]
-        columns = ["id"]
-        with _mock_execute(return_value=(rows, columns)):
+        rows = [_FakeRecord({"id": f"evt_{i}"}) for i in range(MAX_ROWS)]
+        with _mock_execute(return_value=(rows, True)), _mock_pool():
             result = await search_events_handler(
                 "sess_01TEST", {"query": "SELECT * FROM events_search"}
             )
         assert "truncat" in result["result"].lower()
 
     async def test_no_results(self) -> None:
-        with _mock_execute(return_value=([], [])):
+        with _mock_execute(return_value=([], False)), _mock_pool():
             result = await search_events_handler(
                 "sess_01TEST", {"query": "SELECT * FROM events_search"}
             )

--- a/tests/unit/test_search_events_handler.py
+++ b/tests/unit/test_search_events_handler.py
@@ -1,0 +1,266 @@
+"""Unit tests for the search_events tool handler."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from aios.tools.search_events import (
+    MAX_ROWS,
+    _format_results,
+    _validate_sql,
+    search_events_handler,
+)
+
+# ─── SQL Validation ──────────────────────────────────────────────────────────
+
+
+class TestValidateSql:
+    """Tests for _validate_sql pure function."""
+
+    def test_valid_select(self) -> None:
+        assert _validate_sql("SELECT * FROM events_search") is None
+
+    def test_valid_select_count(self) -> None:
+        assert _validate_sql("SELECT COUNT(*) FROM events_search") is None
+
+    def test_valid_select_with_where(self) -> None:
+        assert _validate_sql("SELECT id FROM events_search WHERE role = 'user' LIMIT 10") is None
+
+    def test_valid_select_with_subquery(self) -> None:
+        assert _validate_sql("SELECT * FROM (SELECT id FROM events_search) sub") is None
+
+    def test_valid_select_ilike(self) -> None:
+        assert (
+            _validate_sql("SELECT * FROM events_search WHERE content_text ILIKE '%hello%'") is None
+        )
+
+    def test_valid_select_case_insensitive_keyword(self) -> None:
+        assert _validate_sql("select * from events_search") is None
+
+    def test_rejects_insert(self) -> None:
+        err = _validate_sql("INSERT INTO foo VALUES (1)")
+        assert err is not None
+        assert "SELECT" in err
+
+    def test_rejects_update(self) -> None:
+        err = _validate_sql("UPDATE foo SET x = 1")
+        assert err is not None
+
+    def test_rejects_delete(self) -> None:
+        err = _validate_sql("DELETE FROM foo")
+        assert err is not None
+
+    def test_rejects_drop_in_subquery(self) -> None:
+        err = _validate_sql("SELECT * FROM events_search WHERE id IN (DROP TABLE events)")
+        assert err is not None
+
+    def test_rejects_create(self) -> None:
+        err = _validate_sql("SELECT * FROM events_search; CREATE TABLE evil (id int)")
+        assert err is not None
+        # Caught by semicolon check first
+        assert "semicolon" in err.lower() or "multiple" in err.lower()
+
+    def test_rejects_truncate(self) -> None:
+        err = _validate_sql("SELECT * FROM events_search WHERE TRUNCATE = 1")
+        assert err is not None
+        assert "TRUNCATE" in err
+
+    def test_rejects_semicolon(self) -> None:
+        err = _validate_sql("SELECT 1; DROP TABLE events")
+        assert err is not None
+        assert "semicolon" in err.lower() or "multiple" in err.lower()
+
+    def test_rejects_semicolon_case_insensitive(self) -> None:
+        err = _validate_sql("select * from events_search; delete from x")
+        assert err is not None
+
+    def test_rejects_non_select_start(self) -> None:
+        err = _validate_sql("WITH cte AS (DELETE FROM events) SELECT 1")
+        assert err is not None
+        assert "SELECT" in err
+
+    def test_rejects_empty_string(self) -> None:
+        err = _validate_sql("")
+        assert err is not None
+
+    def test_rejects_whitespace_only(self) -> None:
+        err = _validate_sql("   ")
+        assert err is not None
+
+    def test_allows_leading_whitespace(self) -> None:
+        assert _validate_sql("  SELECT 1") is None
+
+
+# ─── Format Results ──────────────────────────────────────────────────────────
+
+
+class _FakeRecord:
+    """Minimal stand-in for asyncpg.Record for unit tests."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def values(self) -> Any:
+        return self._data.values()
+
+    def keys(self) -> Any:
+        return self._data.keys()
+
+
+class TestFormatResults:
+    """Tests for _format_results pure function."""
+
+    def test_empty_rows(self) -> None:
+        result = _format_results([], [], False)
+        assert result == "No results."
+
+    def test_single_row(self) -> None:
+        rows = [_FakeRecord({"id": "evt_01", "role": "assistant", "content_text": "Hello"})]
+        cols = ["id", "role", "content_text"]
+        result = _format_results(rows, cols, False)  # type: ignore[arg-type]
+        assert "id" in result
+        assert "role" in result
+        assert "assistant" in result
+        assert "Hello" in result
+
+    def test_multiple_rows(self) -> None:
+        rows = [
+            _FakeRecord({"seq": 1, "role": "user"}),
+            _FakeRecord({"seq": 2, "role": "assistant"}),
+        ]
+        cols = ["seq", "role"]
+        result = _format_results(rows, cols, False)  # type: ignore[arg-type]
+        lines = result.strip().split("\n")
+        assert len(lines) == 4  # header + divider + 2 data rows
+
+    def test_truncated_notice(self) -> None:
+        rows = [_FakeRecord({"id": "evt_01"})]
+        cols = ["id"]
+        result = _format_results(rows, cols, truncated=True)  # type: ignore[arg-type]
+        assert "truncat" in result.lower()
+        assert str(MAX_ROWS) in result
+
+    def test_not_truncated_no_notice(self) -> None:
+        rows = [_FakeRecord({"id": "evt_01"})]
+        cols = ["id"]
+        result = _format_results(rows, cols, truncated=False)  # type: ignore[arg-type]
+        assert "truncat" not in result.lower()
+
+    def test_null_values(self) -> None:
+        rows = [_FakeRecord({"id": "evt_01", "role": None, "content_text": "text"})]
+        cols = ["id", "role", "content_text"]
+        result = _format_results(rows, cols, False)  # type: ignore[arg-type]
+        assert "NULL" in result
+
+    def test_header_divider_format(self) -> None:
+        rows = [_FakeRecord({"a": 1, "b": 2})]
+        cols = ["a", "b"]
+        result = _format_results(rows, cols, False)  # type: ignore[arg-type]
+        lines = result.split("\n")
+        assert lines[0] == "a | b"
+        assert lines[1] == "-" * len("a | b")
+
+
+# ─── Handler Behavior ────────────────────────────────────────────────────────
+
+
+def _mock_execute(
+    return_value: Any = ([], []),
+    side_effect: Any = None,
+) -> Any:
+    """Context manager that mocks both _execute_query and runtime.require_pool."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _ctx() -> Any:
+        with (
+            patch(
+                "aios.tools.search_events._execute_query",
+                new_callable=AsyncMock,
+                return_value=return_value,
+                side_effect=side_effect,
+            ) as mock_exec,
+            patch("aios.tools.search_events.runtime.require_pool"),
+        ):
+            yield mock_exec
+
+    return _ctx()
+
+
+class TestSearchEventsHandler:
+    """Tests for the handler with mocked _execute_query."""
+
+    async def test_success_returns_formatted_results(self) -> None:
+        rows = [_FakeRecord({"role": "assistant", "content_text": "Hello"})]
+        columns = ["role", "content_text"]
+        with _mock_execute(return_value=(rows, columns)):
+            result = await search_events_handler(
+                "sess_01TEST", {"query": "SELECT * FROM events_search"}
+            )
+        assert "result" in result
+        assert "assistant" in result["result"]
+        assert "Hello" in result["result"]
+
+    async def test_sql_validation_error(self) -> None:
+        with _mock_execute() as mock_exec:
+            result = await search_events_handler(
+                "sess_01TEST", {"query": "INSERT INTO foo VALUES (1)"}
+            )
+            mock_exec.assert_not_called()
+        assert "error" in result
+        assert "SELECT" in result["error"]
+
+    async def test_missing_query(self) -> None:
+        result = await search_events_handler("sess_01TEST", {})
+        assert "error" in result
+        assert "query" in result["error"].lower()
+
+    async def test_empty_query(self) -> None:
+        result = await search_events_handler("sess_01TEST", {"query": ""})
+        assert "error" in result
+
+    async def test_db_error_returns_error(self) -> None:
+        with _mock_execute(side_effect=Exception("connection refused")):
+            result = await search_events_handler(
+                "sess_01TEST", {"query": "SELECT * FROM events_search"}
+            )
+        assert "error" in result
+        assert "failed" in result["error"].lower()
+
+    async def test_timeout_returns_error(self) -> None:
+        import asyncpg.exceptions
+
+        with _mock_execute(
+            side_effect=asyncpg.exceptions.QueryCanceledError(),
+        ):
+            result = await search_events_handler(
+                "sess_01TEST", {"query": "SELECT * FROM events_search"}
+            )
+        assert "error" in result
+        assert "timed out" in result["error"].lower()
+
+    async def test_row_limit_exact_max_no_truncation(self) -> None:
+        rows = [_FakeRecord({"id": f"evt_{i}"}) for i in range(MAX_ROWS)]
+        columns = ["id"]
+        with _mock_execute(return_value=(rows, columns)):
+            result = await search_events_handler(
+                "sess_01TEST", {"query": "SELECT * FROM events_search"}
+            )
+        assert "truncat" not in result["result"].lower()
+
+    async def test_row_limit_truncation(self) -> None:
+        rows = [_FakeRecord({"id": f"evt_{i}"}) for i in range(MAX_ROWS + 1)]
+        columns = ["id"]
+        with _mock_execute(return_value=(rows, columns)):
+            result = await search_events_handler(
+                "sess_01TEST", {"query": "SELECT * FROM events_search"}
+            )
+        assert "truncat" in result["result"].lower()
+
+    async def test_no_results(self) -> None:
+        with _mock_execute(return_value=([], [])):
+            result = await search_events_handler(
+                "sess_01TEST", {"query": "SELECT * FROM events_search"}
+            )
+        assert result["result"] == "No results."


### PR DESCRIPTION
## Summary

- Add `search_events` built-in tool giving agents read-only SQL access to their own session's event log via an `events_search` Postgres view
- Three-layer security: SQL validation (SELECT-only, forbidden keywords, no semicolons), `BEGIN READ ONLY` transaction, and session-scoped view via `set_config('app.session_id', $1, true)`
- aios-original feature — lets long-lived agents search past conversation history that has fallen out of the context window

## What's included

| File | Purpose |
|------|---------|
| `migrations/versions/0010_events_search_view.py` | View with id, seq, kind, role, created_at, content_text columns |
| `src/aios/tools/search_events.py` | Tool handler: validation, read-only execution, 200-row cap, 10s timeout, text table formatting |
| `src/aios/models/agents.py` | `"search_events"` added to `BuiltinToolType` |
| `src/aios/tools/__init__.py` | Registration import |
| `tests/unit/test_search_events_handler.py` | 34 unit tests (SQL validation, formatting, handler) |
| `tests/e2e/test_search_events.py` | 7 e2e tests (keyword search, aggregation, session scoping, read-only enforcement) |

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 358 passed
- [x] `uv run pytest tests/e2e -q` — 86 passed, 1 pre-existing failure (networking/iptables unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)