### PR TITLE
refactor: remove dead code, deduplicate SQL, hide internal field

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -720,6 +720,18 @@ def _row_to_event(row: asyncpg.Record) -> Event:
     )
 
 
+async def _latest_cumulative_tokens(conn: asyncpg.Connection[Any], session_id: str) -> int | None:
+    """Fetch the cumulative_tokens value of the most recent message event."""
+    val: int | None = await conn.fetchval(
+        "SELECT cumulative_tokens FROM events "
+        "WHERE session_id = $1 AND kind = 'message' "
+        "AND cumulative_tokens IS NOT NULL "
+        "ORDER BY seq DESC LIMIT 1",
+        session_id,
+    )
+    return val
+
+
 async def append_event(
     conn: asyncpg.Connection[Any],
     *,
@@ -757,13 +769,7 @@ async def append_event(
         # Compute cumulative_tokens for message events.
         cum_tokens: int | None = None
         if kind == "message":
-            prev = await conn.fetchval(
-                "SELECT cumulative_tokens FROM events "
-                "WHERE session_id = $1 AND kind = 'message' "
-                "AND cumulative_tokens IS NOT NULL "
-                "ORDER BY seq DESC LIMIT 1",
-                session_id,
-            )
+            prev = await _latest_cumulative_tokens(conn, session_id)
             cum_tokens = (prev or 0) + approx_tokens(data)
 
         row = await conn.fetchrow(
@@ -847,13 +853,7 @@ async def read_windowed_events(
     deploys) or when the entire session fits within ``window_max``.
     """
     # Index seek: total cumulative tokens from the latest message event.
-    total = await conn.fetchval(
-        "SELECT cumulative_tokens FROM events "
-        "WHERE session_id = $1 AND kind = 'message' "
-        "AND cumulative_tokens IS NOT NULL "
-        "ORDER BY seq DESC LIMIT 1",
-        session_id,
-    )
+    total = await _latest_cumulative_tokens(conn, session_id)
 
     # Fallback: no cumulative data yet — load everything.
     if total is None:

--- a/src/aios/harness/tokens.py
+++ b/src/aios/harness/tokens.py
@@ -1,28 +1,16 @@
 """Token counting helpers.
 
-Two estimators live here:
-
 * :func:`approx_tokens` — fast, dependency-free ``len // 4`` estimate
   used by the cumulative-tokens column and context windowing.  Suitable
   for boundary decisions where ±10 % accuracy is fine.
 
-* :func:`token_count_for_event` — precise LiteLLM-backed counter with
-  a process-local LRU cache keyed by event id.
-
-Both are importable from any layer (no internal aios dependencies
-beyond the ``Event`` model type hint).
+* :func:`tokens_to_drop` — snap boundary math shared by the DB-level
+  windowed reader and the pure-function ``select_window``.
 """
 
 from __future__ import annotations
 
-from functools import lru_cache
-from typing import TYPE_CHECKING, Any
-
-import litellm
-
-if TYPE_CHECKING:
-    from aios.models.events import Event
-
+from typing import Any
 
 # ─── cheap estimator (no external deps) ────────────────────────────────────
 
@@ -65,44 +53,3 @@ def tokens_to_drop(total: int, *, window_min: int, window_max: int) -> int:
     chunk = window_max - window_min
     snaps = (overshoot + chunk - 1) // chunk  # ceil division
     return snaps * chunk
-
-
-# ─── precise litellm counter ───────────────────────────────────────────────
-
-
-@lru_cache(maxsize=10_000)
-def _token_count_cached(event_id: str, payload_repr: str, model: str) -> int:
-    """LRU-cached token counter keyed by ``(event_id, payload_repr, model)``.
-
-    The ``payload_repr`` is a hash-stable string representation of the
-    message; we include it in the cache key as a defensive check, even
-    though events are immutable, so a corrupted re-emission can't poison
-    the cache.
-    """
-    # litellm.token_counter accepts a list of messages and returns a token count.
-    return int(litellm.token_counter(model=model, messages=[_payload_from_repr(payload_repr)]))
-
-
-def _payload_from_repr(payload_repr: str) -> dict[str, object]:
-    import json
-
-    result: dict[str, object] = json.loads(payload_repr)
-    return result
-
-
-def token_count_for_event(event: Event, *, model: str) -> int:
-    """Return the token count of a single message-kind event for ``model``.
-
-    Non-message events return 0 — they don't appear in the chat-completions
-    request the harness builds, so they don't consume context budget.
-    """
-    if event.kind != "message":
-        return 0
-
-    import json
-
-    # Stable repr keyed by event id is enough; the payload is included as a
-    # secondary key only to make the cache resilient to bugs in event id
-    # uniqueness, not because we expect events to mutate.
-    payload_repr = json.dumps(event.data, sort_keys=True)
-    return _token_count_cached(event.id, payload_repr, model)

--- a/src/aios/models/events.py
+++ b/src/aios/models/events.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 EventKind = Literal["message", "lifecycle", "span", "interrupt"]
 
@@ -34,5 +34,5 @@ class Event(BaseModel):
     seq: int
     kind: EventKind
     data: dict[str, Any]
-    cumulative_tokens: int | None = None
+    cumulative_tokens: int | None = Field(default=None, exclude=True)
     created_at: datetime


### PR DESCRIPTION
## Summary
- Remove unused `token_count_for_event` and helpers from `tokens.py` (zero callers)
- Extract duplicated "latest cumulative_tokens" SQL into `_latest_cumulative_tokens()` helper in `queries.py`
- Exclude `cumulative_tokens` from API serialization via `Field(exclude=True)` — internal windowing detail

## Test plan
- [x] All 377 unit tests pass
- [x] mypy clean (73 source files)
- [x] ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)