### PR TITLE
fix: use model_dump() for LiteLLM usage serialization

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -68,7 +68,8 @@ async def call_litellm(
         kwargs.update(extra)
 
     response = await litellm.acompletion(**kwargs)
-    usage = _normalize_usage(dict(response.get("usage") or {}))
+    usage_obj = response.get("usage")
+    usage = _normalize_usage(usage_obj.model_dump() if usage_obj else {})
     message = response["choices"][0]["message"]
     # litellm returns a Message object that supports model_dump()
     if hasattr(message, "model_dump"):
@@ -119,7 +120,8 @@ async def stream_litellm(
             await _notify_delta(pool, session_id, content)
 
     assembled: Any = litellm.stream_chunk_builder(chunks=chunks)
-    usage = _normalize_usage(dict(assembled.get("usage") or {}))
+    usage_obj = assembled.get("usage")
+    usage = _normalize_usage(usage_obj.model_dump() if usage_obj else {})
     message = assembled["choices"][0]["message"]
     if hasattr(message, "model_dump"):
         result: dict[str, Any] = message.model_dump()

--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -69,7 +69,9 @@ async def call_litellm(
 
     response = await litellm.acompletion(**kwargs)
     usage_obj = response.get("usage")
-    usage = _normalize_usage(usage_obj.model_dump() if usage_obj else {})
+    usage = _normalize_usage(
+        usage_obj.model_dump() if hasattr(usage_obj, "model_dump") else usage_obj or {}
+    )
     message = response["choices"][0]["message"]
     # litellm returns a Message object that supports model_dump()
     if hasattr(message, "model_dump"):
@@ -121,7 +123,9 @@ async def stream_litellm(
 
     assembled: Any = litellm.stream_chunk_builder(chunks=chunks)
     usage_obj = assembled.get("usage")
-    usage = _normalize_usage(usage_obj.model_dump() if usage_obj else {})
+    usage = _normalize_usage(
+        usage_obj.model_dump() if hasattr(usage_obj, "model_dump") else usage_obj or {}
+    )
     message = assembled["choices"][0]["message"]
     if hasattr(message, "model_dump"):
         result: dict[str, Any] = message.model_dump()

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -85,6 +85,27 @@ class TestNormalizeUsage:
             "cache_creation_input_tokens": 0,
         }
 
+    def test_model_dump_flattened_prompt_tokens_details(self) -> None:
+        """model_dump() flattens Pydantic objects; verify dict form still works.
+
+        Regression test: LiteLLM can return a PromptTokensDetailsWrapper
+        Pydantic object for prompt_tokens_details.  After model_dump() at the
+        call site, it arrives here as a dict with extra keys (audio_tokens,
+        etc.).  Verify we still extract cached_tokens correctly.
+        """
+        raw = {
+            "prompt_tokens": 400,
+            "completion_tokens": 120,
+            "prompt_tokens_details": {"cached_tokens": 200, "audio_tokens": None},
+        }
+        result = _normalize_usage(raw)
+        assert result == {
+            "input_tokens": 400,
+            "output_tokens": 120,
+            "cache_read_input_tokens": 200,
+            "cache_creation_input_tokens": 0,
+        }
+
     def test_zero_values_preserved(self) -> None:
         raw = {
             "prompt_tokens": 0,

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -86,13 +86,7 @@ class TestNormalizeUsage:
         }
 
     def test_model_dump_flattened_prompt_tokens_details(self) -> None:
-        """model_dump() flattens Pydantic objects; verify dict form still works.
-
-        Regression test: LiteLLM can return a PromptTokensDetailsWrapper
-        Pydantic object for prompt_tokens_details.  After model_dump() at the
-        call site, it arrives here as a dict with extra keys (audio_tokens,
-        etc.).  Verify we still extract cached_tokens correctly.
-        """
+        """Regression: model_dump() flattens Pydantic objects to dicts with extra keys."""
         raw = {
             "prompt_tokens": 400,
             "completion_tokens": 120,


### PR DESCRIPTION
## Summary

- `dict()` on LiteLLM's Pydantic `Usage` object only flattens the top level — nested `prompt_tokens_details` stays as a `PromptTokensDetailsWrapper` object, causing `AttributeError` when `_normalize_usage` calls `.get("cached_tokens")` on it
- Replaced `dict()` with `model_dump()` at both call sites in `completion.py` — the standard Pydantic v2 recursive serialization method, and what LiteLLM itself uses internally
- Added regression test covering `model_dump()`-flattened output with extra keys

## Test plan

- [x] `uv run mypy src` — passes
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — passes
- [x] `uv run pytest tests/unit -q` — 378 passed
- [ ] Manual: use a model via OpenRouter that returns structured usage data (e.g. `openrouter/moonshotai/kimi-k2.5`) and verify no crash in `stream_litellm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)