### PR TITLE
fix: handle tool_calls: null from LiteLLM providers

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -22,6 +22,18 @@ if TYPE_CHECKING:
     import asyncpg
 
 
+def _normalize_message(msg: dict[str, Any]) -> dict[str, Any]:
+    """Strip null-valued fields that break downstream JSONB queries.
+
+    Some LiteLLM providers (e.g. openrouter/moonshotai/kimi-k2.5) return
+    ``tool_calls: null`` instead of omitting the key.  Stored verbatim,
+    this becomes JSONB ``null`` which ``jsonb_array_length`` rejects.
+    """
+    if "tool_calls" in msg and msg["tool_calls"] is None:
+        del msg["tool_calls"]
+    return msg
+
+
 def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
     """Map LiteLLM's usage field names to our canonical names.
 
@@ -73,9 +85,9 @@ async def call_litellm(
     # litellm returns a Message object that supports model_dump()
     if hasattr(message, "model_dump"):
         result: dict[str, Any] = message.model_dump()
-        return result, usage
+        return _normalize_message(result), usage
     if isinstance(message, dict):
-        return message, usage
+        return _normalize_message(message), usage
     raise TypeError(f"unexpected message type from litellm.acompletion: {type(message).__name__}")
 
 
@@ -123,9 +135,9 @@ async def stream_litellm(
     message = assembled["choices"][0]["message"]
     if hasattr(message, "model_dump"):
         result: dict[str, Any] = message.model_dump()
-        return result, usage
+        return _normalize_message(result), usage
     if isinstance(message, dict):
-        return message, usage
+        return _normalize_message(message), usage
     raise TypeError(f"unexpected message type from stream_chunk_builder: {type(message).__name__}")
 
 

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -71,7 +71,7 @@ async def find_and_repair_ghosts(
              WHERE s.archived_at IS NULL
                AND e.kind = 'message'
                AND e.data->>'role' = 'assistant'
-               AND jsonb_array_length(COALESCE(e.data->'tool_calls', '[]'::jsonb)) > 0
+               AND jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls', 'null'::jsonb), '[]'::jsonb)) > 0
                {scope_clause}
             """,
             *scope_params,
@@ -360,7 +360,7 @@ async def _filter_incomplete_batches(
              WHERE e.session_id = ANY($1::text[])
                AND e.kind = 'message'
                AND e.data->>'role' = 'assistant'
-               AND jsonb_array_length(COALESCE(e.data->'tool_calls', '[]'::jsonb)) > 0
+               AND jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls', 'null'::jsonb), '[]'::jsonb)) > 0
             """,
             session_list,
         )

--- a/tests/e2e/test_sweep.py
+++ b/tests/e2e/test_sweep.py
@@ -320,6 +320,41 @@ class TestGhostExclusions:
         repaired = await harness.run_ghost_repair(session.id)
         assert len(repaired) == 0
 
+    async def test_tool_calls_null_not_ghost(self, harness: Harness) -> None:
+        """Assistant message with tool_calls: null (JSON null) doesn't crash sweep.
+
+        Some LiteLLM providers return tool_calls: null instead of omitting
+        the key. Stored as JSONB null, this used to crash the ghost sweep's
+        jsonb_array_length query. The message has no tool calls, so ghost
+        repair should return nothing and the inference query should not crash.
+        """
+        harness.script_model([])
+        session = await harness.start("hi", tools=[])
+
+        # Manually append an assistant message with tool_calls: null.
+        # This simulates what reaches the DB from providers like kimi-k2.5
+        # (the ingestion fix strips it, but existing rows may have it).
+        await sessions_service.append_event(
+            harness._pool,
+            session.id,
+            "message",
+            {
+                "role": "assistant",
+                "content": "I have no tools to call.",
+                "tool_calls": None,
+                "reacting_to": 1,
+            },
+        )
+
+        # Ghost repair must not crash and must find no ghosts.
+        repaired = await harness.run_ghost_repair(session.id)
+        assert len(repaired) == 0
+
+        # Inference detection must not crash either (exercises
+        # _filter_incomplete_batches which has the same query pattern).
+        needs = await harness.sessions_needing_inference(session.id)
+        assert session.id not in needs
+
     async def test_custom_tool_not_ghost(self, harness: Harness) -> None:
         """Custom (client-executed) tool waiting for result is NOT a ghost."""
         harness.script_model(

--- a/tests/unit/test_completion_sanitize.py
+++ b/tests/unit/test_completion_sanitize.py
@@ -1,0 +1,48 @@
+"""Unit tests for assistant message normalization in completion.py."""
+
+from __future__ import annotations
+
+from aios.harness.completion import _normalize_message
+
+
+class TestNormalizeMessage:
+    """Tests for _normalize_message which strips provider quirks."""
+
+    def test_tool_calls_null_stripped(self) -> None:
+        """tool_calls: None (from providers like kimi-k2.5) is removed."""
+        msg: dict[str, object] = {
+            "role": "assistant",
+            "content": "hello",
+            "tool_calls": None,
+        }
+        result = _normalize_message(msg)
+        assert "tool_calls" not in result
+        assert result["content"] == "hello"
+
+    def test_tool_calls_empty_list_preserved(self) -> None:
+        """tool_calls: [] is a valid (if unusual) value — keep it."""
+        msg: dict[str, object] = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [],
+        }
+        result = _normalize_message(msg)
+        assert result["tool_calls"] == []
+
+    def test_tool_calls_with_calls_preserved(self) -> None:
+        """Normal tool_calls list passes through unchanged."""
+        tc = {"id": "call_1", "type": "function", "function": {"name": "bash", "arguments": "{}"}}
+        msg: dict[str, object] = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [tc],
+        }
+        result = _normalize_message(msg)
+        assert result["tool_calls"] == [tc]
+
+    def test_tool_calls_absent_unchanged(self) -> None:
+        """Message without tool_calls key is not modified."""
+        msg: dict[str, object] = {"role": "assistant", "content": "just text"}
+        result = _normalize_message(msg)
+        assert result == {"role": "assistant", "content": "just text"}
+        assert "tool_calls" not in result


### PR DESCRIPTION
## Summary

- **Ingestion fix**: `_normalize_message()` in `completion.py` strips `tool_calls: None` from assistant message dicts before they reach the event log, preventing JSON null from being stored in Postgres
- **Query hardening**: `NULLIF(data->'tool_calls', 'null'::jsonb)` in both sweep queries (`sweep.py:74`, `sweep.py:363`) converts JSON null → SQL NULL so `COALESCE` triggers correctly, protecting against existing bad rows
- **Tests**: 4 unit tests for the message normalization + 1 E2E test that inserts `tool_calls: null` directly into Postgres and exercises both vulnerable sweep queries

## Context

Observed with `openrouter/moonshotai/kimi-k2.5` — the provider returns `tool_calls: null` instead of omitting the field. LiteLLM's `model_dump()` preserves this. Stored as JSONB, the ghost sweep crashes with `InvalidParameterValueError: cannot get array length of a scalar` because `COALESCE(data->'tool_calls', '[]')` doesn't convert JSON null to SQL NULL.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 381 passed
- [ ] `uv run pytest tests/e2e/test_sweep.py::TestGhostExclusions::test_tool_calls_null_not_ghost -xvs` (requires Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)