### PR TITLE
feat: prompt cache breakpoints for Anthropic models

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -34,6 +34,36 @@ def _normalize_message(msg: dict[str, Any]) -> dict[str, Any]:
     return msg
 
 
+_CACHE_CONTROL = {"type": "ephemeral"}
+
+
+def inject_cache_breakpoints(
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+) -> None:
+    """Annotate messages and tools with ``cache_control`` breakpoints.
+
+    Anthropic's prompt caching requires explicit ``cache_control`` markers
+    to create cache entries.  LiteLLM strips them for providers that don't
+    support them (e.g. OpenAI), so this is safe to apply unconditionally.
+
+    Places breakpoints on the system message, last tool definition, and
+    last conversation message (3 of Anthropic's max 4).
+    """
+    if not messages:
+        return
+
+    if messages[0].get("role") == "system":
+        messages[0]["cache_control"] = _CACHE_CONTROL
+
+    if tools:
+        tools[-1]["cache_control"] = _CACHE_CONTROL
+
+    last = messages[-1]
+    if last.get("role") != "system":
+        last["cache_control"] = _CACHE_CONTROL
+
+
 def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
     """Map LiteLLM's usage field names to our canonical names.
 
@@ -68,6 +98,8 @@ async def call_litellm(
     ``thinking_blocks``. The harness stores the message dict opaquely.
     Usage is normalized to our canonical field names.
     """
+    inject_cache_breakpoints(messages, tools)
+
     kwargs: dict[str, Any] = {
         "model": model,
         "messages": messages,
@@ -112,6 +144,8 @@ async def stream_litellm(
     assembled via ``litellm.stream_chunk_builder`` and returned for
     storage as a normal event.
     """
+    inject_cache_breakpoints(messages, tools)
+
     kwargs: dict[str, Any] = {
         "model": model,
         "messages": messages,

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from aios.harness.completion import _normalize_usage, inject_cache_breakpoints
+from aios.harness.completion import (
+    _CACHE_CONTROL,
+    _normalize_usage,
+    inject_cache_breakpoints,
+)
 
 
 class TestNormalizeUsage:
@@ -121,9 +125,6 @@ class TestNormalizeUsage:
 # ─── inject_cache_breakpoints ─────────────────────────────────────────────
 
 
-_CC = {"type": "ephemeral"}
-
-
 def _msg(role: str, content: str = "") -> dict[str, Any]:
     """Build a minimal message dict."""
     return {"role": role, "content": content}
@@ -141,32 +142,32 @@ class TestInjectCacheBreakpoints:
     def test_system_message_annotated(self) -> None:
         msgs = [_msg("system", "you are helpful"), _msg("user", "hi")]
         inject_cache_breakpoints(msgs, None)
-        assert msgs[0]["cache_control"] == _CC
+        assert msgs[0]["cache_control"] == _CACHE_CONTROL
 
     def test_last_tool_annotated(self) -> None:
         msgs = [_msg("system", "sys"), _msg("user", "hi")]
         tools = [_tool_def("bash"), _tool_def("read")]
         inject_cache_breakpoints(msgs, tools)
         assert "cache_control" not in tools[0]
-        assert tools[1]["cache_control"] == _CC
+        assert tools[1]["cache_control"] == _CACHE_CONTROL
 
     def test_last_conversation_message_annotated(self) -> None:
         msgs = [_msg("system", "sys"), _msg("user", "hi")]
         inject_cache_breakpoints(msgs, None)
-        assert msgs[1]["cache_control"] == _CC
+        assert msgs[1]["cache_control"] == _CACHE_CONTROL
 
     def test_no_system_message(self) -> None:
         msgs = [_msg("user", "hi"), _msg("assistant", "hello")]
         inject_cache_breakpoints(msgs, None)
         assert "cache_control" not in msgs[0]
-        assert msgs[1]["cache_control"] == _CC
+        assert msgs[1]["cache_control"] == _CACHE_CONTROL
 
     def test_no_tools(self) -> None:
         msgs = [_msg("system", "sys"), _msg("user", "hi")]
         inject_cache_breakpoints(msgs, None)
         # No crash; system and last message still annotated.
-        assert msgs[0]["cache_control"] == _CC
-        assert msgs[1]["cache_control"] == _CC
+        assert msgs[0]["cache_control"] == _CACHE_CONTROL
+        assert msgs[1]["cache_control"] == _CACHE_CONTROL
 
     def test_empty_messages(self) -> None:
         inject_cache_breakpoints([], None)  # no crash
@@ -177,7 +178,7 @@ class TestInjectCacheBreakpoints:
         skips it to avoid redundancy."""
         msgs = [_msg("system", "sys")]
         inject_cache_breakpoints(msgs, None)
-        assert msgs[0]["cache_control"] == _CC
+        assert msgs[0]["cache_control"] == _CACHE_CONTROL
 
     def test_tool_result_as_last_message(self) -> None:
         msgs = [
@@ -187,12 +188,12 @@ class TestInjectCacheBreakpoints:
             {"role": "tool", "tool_call_id": "a", "content": "done"},
         ]
         inject_cache_breakpoints(msgs, None)
-        assert msgs[3]["cache_control"] == _CC
+        assert msgs[3]["cache_control"] == _CACHE_CONTROL
 
     def test_all_three_breakpoints(self) -> None:
         msgs = [_msg("system", "sys"), _msg("user", "hi")]
         tools = [_tool_def("bash")]
         inject_cache_breakpoints(msgs, tools)
-        assert msgs[0]["cache_control"] == _CC
-        assert tools[0]["cache_control"] == _CC
-        assert msgs[1]["cache_control"] == _CC
+        assert msgs[0]["cache_control"] == _CACHE_CONTROL
+        assert tools[0]["cache_control"] == _CACHE_CONTROL
+        assert msgs[1]["cache_control"] == _CACHE_CONTROL

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -1,8 +1,10 @@
-"""Unit tests for token usage normalization."""
+"""Unit tests for completion.py: usage normalization and cache breakpoints."""
 
 from __future__ import annotations
 
-from aios.harness.completion import _normalize_usage
+from typing import Any
+
+from aios.harness.completion import _normalize_usage, inject_cache_breakpoints
 
 
 class TestNormalizeUsage:
@@ -114,3 +116,83 @@ class TestNormalizeUsage:
             "cache_read_input_tokens": 0,
             "cache_creation_input_tokens": 0,
         }
+
+
+# ─── inject_cache_breakpoints ─────────────────────────────────────────────
+
+
+_CC = {"type": "ephemeral"}
+
+
+def _msg(role: str, content: str = "") -> dict[str, Any]:
+    """Build a minimal message dict."""
+    return {"role": role, "content": content}
+
+
+def _tool_def(name: str) -> dict[str, Any]:
+    """Build a minimal OpenAI-format tool definition."""
+    return {
+        "type": "function",
+        "function": {"name": name, "description": f"{name} tool", "parameters": {}},
+    }
+
+
+class TestInjectCacheBreakpoints:
+    def test_system_message_annotated(self) -> None:
+        msgs = [_msg("system", "you are helpful"), _msg("user", "hi")]
+        inject_cache_breakpoints(msgs, None)
+        assert msgs[0]["cache_control"] == _CC
+
+    def test_last_tool_annotated(self) -> None:
+        msgs = [_msg("system", "sys"), _msg("user", "hi")]
+        tools = [_tool_def("bash"), _tool_def("read")]
+        inject_cache_breakpoints(msgs, tools)
+        assert "cache_control" not in tools[0]
+        assert tools[1]["cache_control"] == _CC
+
+    def test_last_conversation_message_annotated(self) -> None:
+        msgs = [_msg("system", "sys"), _msg("user", "hi")]
+        inject_cache_breakpoints(msgs, None)
+        assert msgs[1]["cache_control"] == _CC
+
+    def test_no_system_message(self) -> None:
+        msgs = [_msg("user", "hi"), _msg("assistant", "hello")]
+        inject_cache_breakpoints(msgs, None)
+        assert "cache_control" not in msgs[0]
+        assert msgs[1]["cache_control"] == _CC
+
+    def test_no_tools(self) -> None:
+        msgs = [_msg("system", "sys"), _msg("user", "hi")]
+        inject_cache_breakpoints(msgs, None)
+        # No crash; system and last message still annotated.
+        assert msgs[0]["cache_control"] == _CC
+        assert msgs[1]["cache_control"] == _CC
+
+    def test_empty_messages(self) -> None:
+        inject_cache_breakpoints([], None)  # no crash
+
+    def test_system_only_no_double_annotate(self) -> None:
+        """When the only message is the system message, it gets one
+        annotation from the system-message rule.  The last-message rule
+        skips it to avoid redundancy."""
+        msgs = [_msg("system", "sys")]
+        inject_cache_breakpoints(msgs, None)
+        assert msgs[0]["cache_control"] == _CC
+
+    def test_tool_result_as_last_message(self) -> None:
+        msgs = [
+            _msg("system", "sys"),
+            _msg("user", "do it"),
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "a"}]},
+            {"role": "tool", "tool_call_id": "a", "content": "done"},
+        ]
+        inject_cache_breakpoints(msgs, None)
+        assert msgs[3]["cache_control"] == _CC
+
+    def test_all_three_breakpoints(self) -> None:
+        msgs = [_msg("system", "sys"), _msg("user", "hi")]
+        tools = [_tool_def("bash")]
+        inject_cache_breakpoints(msgs, tools)
+        assert msgs[0]["cache_control"] == _CC
+        assert tools[0]["cache_control"] == _CC
+        assert msgs[1]["cache_control"] == _CC


### PR DESCRIPTION
## Summary

- Add `inject_cache_breakpoints()` in `completion.py` that annotates messages and tools with `cache_control: {"type": "ephemeral"}` before each LiteLLM call
- Three breakpoints (of Anthropic's max 4): system message, last tool definition, last conversation message
- Applied unconditionally — LiteLLM strips annotations for providers that don't support them (OpenAI/DeepSeek do automatic prefix caching)

**Before**: 0% cache hits, 0 cache creation on every step despite a perfectly stable prefix.
**After**: ~99% of input tokens read from cache on consecutive steps (verified live against Anthropic direct and OpenRouter).

## Test plan

- [x] 9 new unit tests for breakpoint placement (system, tools, last message, edge cases)
- [x] All 386 unit tests pass, mypy clean, ruff clean
- [x] Live verification against `anthropic/claude-haiku-4-5`: 5192-token cache hits
- [x] Live verification against `openrouter/anthropic/claude-haiku-4-5`: 5191-token cache hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)