### PR TITLE
fix: place cache_control on content blocks, not message dicts

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -37,6 +37,20 @@ def _normalize_message(msg: dict[str, Any]) -> dict[str, Any]:
 _CACHE_CONTROL = {"type": "ephemeral"}
 
 
+def _set_content_block_cache(msg: dict[str, Any]) -> None:
+    """Place ``cache_control`` on the last content block of a message.
+
+    Anthropic requires ``cache_control`` on content blocks, not on the
+    message dict itself.  If ``content`` is a plain string, it is converted
+    to content-block format so the marker has somewhere to live.
+    """
+    content = msg.get("content")
+    if isinstance(content, str):
+        msg["content"] = [{"type": "text", "text": content, "cache_control": _CACHE_CONTROL}]
+    elif isinstance(content, list) and content:
+        content[-1]["cache_control"] = _CACHE_CONTROL
+
+
 def inject_cache_breakpoints(
     messages: list[dict[str, Any]],
     tools: list[dict[str, Any]] | None,
@@ -44,8 +58,9 @@ def inject_cache_breakpoints(
     """Annotate messages and tools with ``cache_control`` breakpoints.
 
     Anthropic's prompt caching requires explicit ``cache_control`` markers
-    to create cache entries.  LiteLLM strips them for providers that don't
-    support them (e.g. OpenAI), so this is safe to apply unconditionally.
+    on **content blocks** (not on message dicts) to create cache entries.
+    LiteLLM strips them for providers that don't support them (e.g. OpenAI),
+    so this is safe to apply unconditionally.
 
     Places breakpoints on the system message, last tool definition, and
     last conversation message (3 of Anthropic's max 4).
@@ -54,14 +69,14 @@ def inject_cache_breakpoints(
         return
 
     if messages[0].get("role") == "system":
-        messages[0]["cache_control"] = _CACHE_CONTROL
+        _set_content_block_cache(messages[0])
 
     if tools:
         tools[-1]["cache_control"] = _CACHE_CONTROL
 
     last = messages[-1]
     if last.get("role") != "system":
-        last["cache_control"] = _CACHE_CONTROL
+        _set_content_block_cache(last)
 
 
 def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -168,6 +168,16 @@ def last_assistant_content(events: list[Event]) -> str:
     raise AssertionError("no assistant message found in events")
 
 
+def msg_text(msg: dict[str, Any]) -> str:
+    """Extract plain text from a message's content (string or content blocks)."""
+    content = msg.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(b.get("text", "") for b in content if isinstance(b, dict))
+    return str(content)
+
+
 # ─── the harness ─────────────────────────────────────────────────────────────
 
 

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -21,6 +21,7 @@ from tests.e2e.harness import (
     cancel,
     first_tool_result,
     last_assistant_content,
+    msg_text,
     tool_call,
     tool_results,
 )
@@ -299,7 +300,7 @@ class TestPendingResultSynthesis:
             for m in step2_messages
             if m.get("role") == "tool" and m.get("tool_call_id") == "call_slow_1"
         )
-        assert "pending" in tool_msg["content"]
+        assert "pending" in msg_text(tool_msg)
 
         # Let tool complete, finish up
         tool_proceed.set()
@@ -331,8 +332,9 @@ class TestPendingResultSynthesis:
             for m in step2_messages
             if m.get("role") == "tool" and m.get("tool_call_id") == "call_f1"
         )
-        assert "pending" not in tool_msg["content"]
-        assert "42" in tool_msg["content"]
+        tool_text = msg_text(tool_msg)
+        assert "pending" not in tool_text
+        assert "42" in tool_text
 
 
 @needs_docker
@@ -901,7 +903,7 @@ class TestSessionVersionBinding:
         assert len(harness.model_calls) == 2
         step2_messages = harness.model_calls[1]["messages"]
         system_msg = next(m for m in step2_messages if m["role"] == "system")
-        assert system_msg["content"] == "updated"
+        assert msg_text(system_msg) == "updated"
 
     async def test_pinned_session_ignores_agent_update(self, harness: Harness) -> None:
         """Pinned session keeps using the old version after agent update."""
@@ -932,7 +934,7 @@ class TestSessionVersionBinding:
 
         step2_messages = harness.model_calls[1]["messages"]
         system_msg = next(m for m in step2_messages if m["role"] == "system")
-        assert system_msg["content"] == "original"  # v1, not v2
+        assert msg_text(system_msg) == "original"  # v1, not v2
 
     async def test_session_update_changes_agent(self, harness: Harness) -> None:
         """Sessions can be updated to point at a different agent."""
@@ -972,7 +974,7 @@ class TestSessionVersionBinding:
 
         step2_messages = harness.model_calls[1]["messages"]
         system_msg = next(m for m in step2_messages if m["role"] == "system")
-        assert system_msg["content"] == "agent-two"
+        assert msg_text(system_msg) == "agent-two"
 
 
 # ─── custom tools ───────────────────────────────────────────────────────────

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -142,7 +142,9 @@ class TestInjectCacheBreakpoints:
     def test_system_message_annotated(self) -> None:
         msgs = [_msg("system", "you are helpful"), _msg("user", "hi")]
         inject_cache_breakpoints(msgs, None)
-        assert msgs[0]["cache_control"] == _CACHE_CONTROL
+        assert msgs[0]["content"] == [
+            {"type": "text", "text": "you are helpful", "cache_control": _CACHE_CONTROL}
+        ]
 
     def test_last_tool_annotated(self) -> None:
         msgs = [_msg("system", "sys"), _msg("user", "hi")]
@@ -154,20 +156,25 @@ class TestInjectCacheBreakpoints:
     def test_last_conversation_message_annotated(self) -> None:
         msgs = [_msg("system", "sys"), _msg("user", "hi")]
         inject_cache_breakpoints(msgs, None)
-        assert msgs[1]["cache_control"] == _CACHE_CONTROL
+        assert msgs[1]["content"] == [
+            {"type": "text", "text": "hi", "cache_control": _CACHE_CONTROL}
+        ]
 
     def test_no_system_message(self) -> None:
+        """First non-system message is not annotated; only last is."""
         msgs = [_msg("user", "hi"), _msg("assistant", "hello")]
         inject_cache_breakpoints(msgs, None)
-        assert "cache_control" not in msgs[0]
-        assert msgs[1]["cache_control"] == _CACHE_CONTROL
+        assert msgs[0]["content"] == "hi"  # untouched
+        assert msgs[1]["content"] == [
+            {"type": "text", "text": "hello", "cache_control": _CACHE_CONTROL}
+        ]
 
     def test_no_tools(self) -> None:
         msgs = [_msg("system", "sys"), _msg("user", "hi")]
         inject_cache_breakpoints(msgs, None)
-        # No crash; system and last message still annotated.
-        assert msgs[0]["cache_control"] == _CACHE_CONTROL
-        assert msgs[1]["cache_control"] == _CACHE_CONTROL
+        # No crash; system and last message still annotated via content blocks.
+        assert msgs[0]["content"][0]["cache_control"] == _CACHE_CONTROL
+        assert msgs[1]["content"][0]["cache_control"] == _CACHE_CONTROL
 
     def test_empty_messages(self) -> None:
         inject_cache_breakpoints([], None)  # no crash
@@ -178,7 +185,9 @@ class TestInjectCacheBreakpoints:
         skips it to avoid redundancy."""
         msgs = [_msg("system", "sys")]
         inject_cache_breakpoints(msgs, None)
-        assert msgs[0]["cache_control"] == _CACHE_CONTROL
+        assert msgs[0]["content"] == [
+            {"type": "text", "text": "sys", "cache_control": _CACHE_CONTROL}
+        ]
 
     def test_tool_result_as_last_message(self) -> None:
         msgs = [
@@ -188,12 +197,30 @@ class TestInjectCacheBreakpoints:
             {"role": "tool", "tool_call_id": "a", "content": "done"},
         ]
         inject_cache_breakpoints(msgs, None)
-        assert msgs[3]["cache_control"] == _CACHE_CONTROL
+        assert msgs[3]["content"] == [
+            {"type": "text", "text": "done", "cache_control": _CACHE_CONTROL}
+        ]
 
     def test_all_three_breakpoints(self) -> None:
         msgs = [_msg("system", "sys"), _msg("user", "hi")]
         tools = [_tool_def("bash")]
         inject_cache_breakpoints(msgs, tools)
-        assert msgs[0]["cache_control"] == _CACHE_CONTROL
+        assert msgs[0]["content"][0]["cache_control"] == _CACHE_CONTROL
         assert tools[0]["cache_control"] == _CACHE_CONTROL
-        assert msgs[1]["cache_control"] == _CACHE_CONTROL
+        assert msgs[1]["content"][0]["cache_control"] == _CACHE_CONTROL
+
+    def test_content_already_list(self) -> None:
+        """When content is already a list of blocks, annotate the last block."""
+        msgs = [
+            _msg("system", "sys"),
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "part 1"},
+                    {"type": "text", "text": "part 2"},
+                ],
+            },
+        ]
+        inject_cache_breakpoints(msgs, None)
+        assert "cache_control" not in msgs[1]["content"][0]
+        assert msgs[1]["content"][1]["cache_control"] == _CACHE_CONTROL


### PR DESCRIPTION
## Summary

- Place `cache_control` markers on **content blocks** within messages instead of on message dicts, matching Anthropic's API spec
- String content is wrapped into content-block format (`[{"type": "text", "text": ..., "cache_control": ...}]`) so the marker has a valid home
- Content already in list format gets `cache_control` on the last block
- Tool-level `cache_control` unchanged (Anthropic's tool schema supports it natively)

## Test plan

- [x] All 392 unit tests pass (including updated + new cache breakpoint tests)
- [x] mypy, ruff clean
- [x] Verified cache creation/read against Anthropic direct via LiteLLM with 4096+ token prompt
- [ ] Verify cache hits through OpenRouter with a caching-enabled key

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)