### PR TITLE
fix: restrict events_search view to message events only

### DIFF
--- a/migrations/versions/0013_events_search_messages_only.py
+++ b/migrations/versions/0013_events_search_messages_only.py
@@ -1,0 +1,55 @@
+"""Restrict events_search view to message events only.
+
+The view previously exposed all event kinds (lifecycle, span, interrupt)
+which are harness internals the agent should never see.  Filter to
+``kind = 'message'`` so the agent only searches its own conversation
+history.
+
+The ``kind`` column is dropped from the view since it is now constant.
+
+Revision ID: 0013
+Revises: 0012
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0013"
+down_revision: str = "0012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS events_search")
+    op.execute("""
+        CREATE VIEW events_search AS
+        SELECT
+            id,
+            seq,
+            data->>'role' AS role,
+            created_at,
+            COALESCE(data->>'content', data::text) AS content_text
+        FROM events
+        WHERE session_id = current_setting('app.session_id', true)
+          AND kind = 'message'
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS events_search")
+    op.execute("""
+        CREATE VIEW events_search AS
+        SELECT
+            id,
+            seq,
+            kind,
+            data->>'role' AS role,
+            created_at,
+            COALESCE(data->>'content', data::text) AS content_text
+        FROM events
+        WHERE session_id = current_setting('app.session_id', true)
+    """)

--- a/src/aios/tools/search_events.py
+++ b/src/aios/tools/search_events.py
@@ -90,16 +90,15 @@ async def _execute_query(
 
 
 SEARCH_EVENTS_DESCRIPTION = (
-    "Query this session's event log using SQL. Use this tool to search past "
-    "conversation history — especially useful when earlier messages have fallen "
+    "Query this session's conversation history using SQL. Use this tool to "
+    "search past messages — especially useful when earlier messages have fallen "
     "out of the context window.\n\n"
     "Schema — events_search view columns:\n"
     "- id (text): unique event ID\n"
     "- seq (integer): sequence number (chronological order within the session)\n"
-    "- kind (text): 'message', 'lifecycle', 'span', or 'interrupt'\n"
-    "- role (text): 'user', 'assistant', or 'tool' (NULL for non-message events)\n"
-    "- created_at (timestamptz): when the event was created\n"
-    "- content_text (text): the message content (or full JSON for non-message events)\n\n"
+    "- role (text): 'user', 'assistant', or 'tool'\n"
+    "- created_at (timestamptz): when the message was created\n"
+    "- content_text (text): the message content\n\n"
     "Limits: results capped at 200 rows. Only SELECT queries allowed.\n\n"
     "Common patterns:\n\n"
     "Keyword search (case-insensitive):\n"
@@ -119,12 +118,10 @@ SEARCH_EVENTS_DESCRIPTION = (
     "Count messages by role:\n"
     "  SELECT role, count(*) AS n\n"
     "  FROM events_search\n"
-    "  WHERE kind = 'message'\n"
     "  GROUP BY role\n\n"
     "Most recent messages:\n"
     "  SELECT seq, role, created_at, substr(content_text, 1, 100) AS preview\n"
     "  FROM events_search\n"
-    "  WHERE kind = 'message'\n"
     "  ORDER BY seq DESC LIMIT 10\n\n"
     "Exact date range:\n"
     "  SELECT * FROM events_search\n"
@@ -136,7 +133,6 @@ SEARCH_EVENTS_DESCRIPTION = (
     "- Use LIMIT to control result size (hard cap is 200 rows)\n"
     "- Use substr(content_text, 1, N) for content previews to keep output compact\n"
     "- ILIKE '%term%' is case-insensitive; use multiple ILIKE clauses for OR searches\n"
-    "- Filter by kind = 'message' to exclude lifecycle/span events\n"
     "- Filter by role = 'user'/'assistant'/'tool' to narrow to specific speakers"
 )
 
@@ -147,11 +143,11 @@ SEARCH_EVENTS_PARAMETERS_SCHEMA: dict[str, Any] = {
             "type": "string",
             "description": (
                 "SQL SELECT query against the events_search view.\n"
-                "Available columns: id (text), seq (integer), kind (text), "
+                "Available columns: id (text), seq (integer), "
                 "role (text), created_at (timestamptz), content_text (text).\n\n"
                 "Examples:\n"
                 "  SELECT * FROM events_search WHERE content_text ILIKE '%keyword%' LIMIT 20\n"
-                "  SELECT role, count(*) FROM events_search WHERE kind = 'message' GROUP BY role\n"
+                "  SELECT role, count(*) FROM events_search GROUP BY role\n"
                 "  SELECT * FROM events_search "
                 "WHERE created_at > now() - interval '7 days' ORDER BY seq"
             ),

--- a/tests/e2e/test_search_events.py
+++ b/tests/e2e/test_search_events.py
@@ -58,7 +58,7 @@ class TestSearchEvents:
                 "query": (
                     "SELECT role, count(*) AS n "
                     "FROM events_search "
-                    "WHERE kind = 'message' AND role IS NOT NULL "
+                    "WHERE role IS NOT NULL "
                     "GROUP BY role "
                     "ORDER BY role"
                 ),
@@ -108,17 +108,17 @@ class TestSearchEvents:
         result = await search_events_handler(
             session_id,
             {
-                "query": (
-                    "SELECT * FROM events_search WHERE kind = 'message' ORDER BY seq LIMIT 1"
-                ),
+                "query": ("SELECT * FROM events_search ORDER BY seq LIMIT 1"),
             },
         )
 
         text = result["result"]
         # Header line should contain all view columns
         header = text.split("\n")[0]
-        for col in ("id", "seq", "kind", "role", "created_at", "content_text"):
+        for col in ("id", "seq", "role", "created_at", "content_text"):
             assert col in header
+        # kind column should NOT be present (view is messages-only now)
+        assert "kind" not in header
 
     async def test_sql_validation_rejects_insert(self, harness: Harness) -> None:
         """DML queries are rejected before hitting the database."""
@@ -175,3 +175,31 @@ class TestSearchEvents:
         )
 
         assert result["result"] == "No results."
+
+    async def test_view_excludes_non_message_events(self, harness: Harness) -> None:
+        """The events_search view must only expose message events.
+
+        Lifecycle, span, and interrupt events are harness internals — they
+        should not leak into the agent's search results.  After migration
+        0013 the view filters to ``kind = 'message'`` and drops the ``kind``
+        column entirely.
+        """
+        session_id = await self._setup_session(harness)
+
+        # A normal step produces lifecycle + span events alongside messages.
+        # Verify the raw event log has non-message events…
+        all_events = await harness.all_events(session_id)
+        non_message_kinds = {e.kind for e in all_events if e.kind != "message"}
+        assert non_message_kinds, "test setup: expected lifecycle/span events in the log"
+
+        # …but the search view must not expose them.  Count total rows in the
+        # view vs message events in the raw log — they must match.
+        msg_count = sum(1 for e in all_events if e.kind == "message")
+
+        result = await search_events_handler(
+            session_id,
+            {"query": "SELECT count(*) AS n FROM events_search"},
+        )
+
+        text = result["result"]
+        assert str(msg_count) in text, f"expected {msg_count} rows in view, got: {text}"


### PR DESCRIPTION
## Summary
- The `events_search` Postgres view (backing the `search_events` tool) was exposing all event kinds — lifecycle, span, and interrupt — alongside messages. These are harness internals the agent should never see.
- Migration `0013` drops and recreates the view with `AND kind = 'message'`, removing the now-constant `kind` column.
- Tool description and parameter schema updated to match the new column set.
- Existing E2E tests updated; new `test_view_excludes_non_message_events` test added.

## Test plan
- [x] New E2E test verified failing before the fix (view returned lifecycle + span rows)
- [x] All 8 `test_search_events` E2E tests pass after the fix
- [x] 392 unit tests pass
- [x] mypy + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)