### PR TITLE
feat: external orchestrator support (#21, #22, #23)

### DIFF
--- a/migrations/versions/0014_session_env.py
+++ b/migrations/versions/0014_session_env.py
@@ -1,0 +1,30 @@
+"""Add per-session environment variables.
+
+External orchestrators need to inject env vars (API URLs, run IDs, etc.)
+into sandbox containers on a per-session basis.  The ``env`` column stores
+a ``dict[str, str]`` as JSONB.  At container provisioning time, these are
+merged with the environment-level ``config.env`` (session wins on key
+collisions) and passed as ``--env`` flags to ``docker run``.
+
+Revision ID: 0014
+Revises: 0013
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0014"
+down_revision: str = "0013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE sessions ADD COLUMN env jsonb NOT NULL DEFAULT '{}'::jsonb")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE sessions DROP COLUMN env")

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -55,6 +55,8 @@ async def create(
         title=body.title,
         metadata=body.metadata,
         vault_ids=body.vault_ids or None,
+        workspace_path=body.workspace_path,
+        env=body.env or None,
     )
     if body.initial_message is not None:
         await service.append_user_message(pool, session.id, body.initial_message)
@@ -125,7 +127,9 @@ async def post_message(
     procrastinate: ProcrastinateDep,
     _auth: AuthDep,
 ) -> Event:
-    event = await service.append_user_message(pool, session_id, body.content)
+    event = await service.append_user_message(
+        pool, session_id, body.content, metadata=body.metadata or None
+    )
     await defer_wake(session_id, cause="message")
     return event
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -548,14 +548,18 @@ async def get_session_workspace_path(conn: asyncpg.Connection[Any], session_id: 
     return val
 
 
-async def get_session_env(conn: asyncpg.Connection[Any], session_id: str) -> dict[str, str]:
-    """Return per-session environment variables from the session row."""
-    val = await conn.fetchval("SELECT env FROM sessions WHERE id = $1", session_id)
-    if val is None:
+async def get_session_provisioning(
+    conn: asyncpg.Connection[Any], session_id: str
+) -> tuple[str, dict[str, str]]:
+    """Return ``(workspace_volume_path, env)`` for provisioning a session's container."""
+    row = await conn.fetchrow(
+        "SELECT workspace_volume_path, env FROM sessions WHERE id = $1", session_id
+    )
+    if row is None:
         raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
-    raw = json.loads(val) if isinstance(val, str) else val
-    result: dict[str, str] = raw
-    return result
+    raw_env = row["env"]
+    env: dict[str, str] = json.loads(raw_env) if isinstance(raw_env, str) else raw_env
+    return row["workspace_volume_path"], env
 
 
 async def list_sessions(

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -20,7 +20,7 @@ import asyncpg
 
 from aios.crypto.vault import EncryptedBlob
 from aios.errors import ConflictError, NotFoundError
-from aios.ids import AGENT, ENVIRONMENT, EVENT, SESSION, SKILL, VAULT, VAULT_CREDENTIAL, make_id
+from aios.ids import AGENT, ENVIRONMENT, EVENT, SKILL, VAULT, VAULT_CREDENTIAL, make_id
 from aios.models.agents import Agent, AgentVersion, McpServerSpec, ToolSpec
 from aios.models.environments import Environment, EnvironmentConfig
 from aios.models.events import Event, EventKind
@@ -490,45 +490,6 @@ def _row_to_session(row: asyncpg.Record) -> Session:
         updated_at=row["updated_at"],
         archived_at=row["archived_at"],
     )
-
-
-async def insert_session(
-    conn: asyncpg.Connection[Any],
-    *,
-    agent_id: str,
-    environment_id: str,
-    agent_version: int | None,
-    title: str | None,
-    metadata: dict[str, Any],
-    workspace_volume_path: str,
-) -> Session:
-    new_id = make_id(SESSION)
-    metadata_json = json.dumps(metadata)
-    try:
-        row = await conn.fetchrow(
-            """
-            INSERT INTO sessions (
-                id, agent_id, environment_id, agent_version, title, metadata,
-                status, workspace_volume_path
-            )
-            VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'idle', $7)
-            RETURNING *
-            """,
-            new_id,
-            agent_id,
-            environment_id,
-            agent_version,
-            title,
-            metadata_json,
-            workspace_volume_path,
-        )
-    except asyncpg.ForeignKeyViolationError as exc:
-        raise NotFoundError(
-            "agent or environment not found",
-            detail={"agent_id": agent_id, "environment_id": environment_id},
-        ) from exc
-    assert row is not None
-    return _row_to_session(row)
 
 
 async def get_session(conn: asyncpg.Connection[Any], session_id: str) -> Session:

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -538,6 +538,26 @@ async def get_session(conn: asyncpg.Connection[Any], session_id: str) -> Session
     return _row_to_session(row)
 
 
+async def get_session_workspace_path(conn: asyncpg.Connection[Any], session_id: str) -> str:
+    """Return the host-side workspace path stored on the session row."""
+    val: str | None = await conn.fetchval(
+        "SELECT workspace_volume_path FROM sessions WHERE id = $1", session_id
+    )
+    if val is None:
+        raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
+    return val
+
+
+async def get_session_env(conn: asyncpg.Connection[Any], session_id: str) -> dict[str, str]:
+    """Return per-session environment variables from the session row."""
+    val = await conn.fetchval("SELECT env FROM sessions WHERE id = $1", session_id)
+    if val is None:
+        raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
+    raw = json.loads(val) if isinstance(val, str) else val
+    result: dict[str, str] = raw
+    return result
+
+
 async def list_sessions(
     conn: asyncpg.Connection[Any],
     *,

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -185,7 +185,8 @@ def build_messages(
         role = e.data.get("role")
 
         if role == "user":
-            messages.append(e.data)
+            msg = {k: v for k, v in e.data.items() if k != "metadata"}
+            messages.append(msg)
             max_stimulus_seq = max(max_stimulus_seq, e.seq)
 
         elif role == "assistant":

--- a/src/aios/harness/skills.py
+++ b/src/aios/harness/skills.py
@@ -19,11 +19,21 @@ model inference call.
 
 from __future__ import annotations
 
+from aios.db import queries
 from aios.logging import get_logger
 from aios.models.skills import SkillVersion
-from aios.sandbox.volumes import ensure_workspace_dir
+from aios.sandbox.volumes import ensure_workspace_path
 
 log = get_logger("aios.harness.skills")
+
+
+async def _load_workspace_path(session_id: str) -> str:
+    """Load the workspace volume path for a session from the DB."""
+    from aios.harness import runtime
+
+    pool = runtime.require_pool()
+    async with pool.acquire() as conn:
+        return await queries.get_session_workspace_path(conn, session_id)
 
 
 # ── system prompt augmentation ─────────────────────────────────────────────
@@ -93,7 +103,8 @@ async def provision_skill_files(
     if not skill_versions:
         return
 
-    workspace = ensure_workspace_dir(session_id)
+    raw_path = await _load_workspace_path(session_id)
+    workspace = ensure_workspace_path(raw_path)
     skills_dir = workspace / "skills"
 
     if skills_dir.exists():

--- a/src/aios/models/environments.py
+++ b/src/aios/models/environments.py
@@ -101,6 +101,13 @@ class EnvironmentConfig(BaseModel):
             'access; {"type": "limited", "allowed_hosts": [...]} to restrict.'
         ),
     )
+    env: dict[str, str] | None = Field(
+        default=None,
+        description=(
+            "Environment variables injected into every session container "
+            "using this environment.  Per-session env overrides these."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -9,9 +9,10 @@ internal — they live in the DB row but are not exposed on the wire shape.
 from __future__ import annotations
 
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 SessionStatus = Literal["running", "idle", "rescheduling", "terminated"]
 
@@ -45,6 +46,19 @@ class SessionCreate(BaseModel):
         default_factory=list,
         description="Vault ids to bind to this session for MCP credential resolution.",
     )
+
+    workspace_path: str | None = Field(
+        default=None,
+        description=(
+            "Absolute host path to use as the session workspace. "
+            "If omitted, defaults to workspace_root/<session_id>. "
+            "The directory must exist; aios will not create it."
+        ),
+    )
+    env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Environment variables injected into the sandbox container.",
+    )
     initial_message: str | None = Field(
         default=None,
         description=(
@@ -53,6 +67,18 @@ class SessionCreate(BaseModel):
             "enqueues a wake job. Equivalent to a follow-up POST /messages."
         ),
     )
+
+    @field_validator("workspace_path")
+    @classmethod
+    def _validate_workspace_path(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        p = Path(v)
+        if not p.is_absolute():
+            raise ValueError("workspace_path must be an absolute path")
+        if not p.is_dir():
+            raise ValueError(f"workspace_path directory does not exist: {v}")
+        return v
 
 
 class SessionUpdate(BaseModel):

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -28,7 +28,6 @@ from aios.db import queries
 from aios.logging import get_logger
 from aios.models.environments import EnvironmentConfig, LimitedNetworking
 from aios.sandbox.container import ContainerError, ContainerHandle
-from aios.sandbox.volumes import ensure_workspace_dir
 
 log = get_logger("aios.sandbox.provisioner")
 
@@ -99,6 +98,24 @@ async def _load_environment_config(session_id: str) -> EnvironmentConfig | None:
         return await queries.get_environment_config_for_session(conn, session_id)
 
 
+async def _load_workspace_path(session_id: str) -> str:
+    """Load the workspace volume path for a session from the DB."""
+    from aios.harness import runtime
+
+    pool = runtime.require_pool()
+    async with pool.acquire() as conn:
+        return await queries.get_session_workspace_path(conn, session_id)
+
+
+async def _load_session_env(session_id: str) -> dict[str, str]:
+    """Load per-session environment variables from the DB."""
+    from aios.harness import runtime
+
+    pool = runtime.require_pool()
+    async with pool.acquire() as conn:
+        return await queries.get_session_env(conn, session_id)
+
+
 async def provision_for_session(session_id: str) -> ContainerHandle:
     """Create a fresh container for ``session_id`` and return a handle.
 
@@ -110,9 +127,19 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
     Raises :class:`ContainerError` if ``docker run`` fails for any reason
     (image missing, daemon unreachable, resource limits, ...).
     """
+    from aios.sandbox.volumes import ensure_workspace_path
+
     settings = get_settings()
-    workspace_path = ensure_workspace_dir(session_id)
+    raw_path = await _load_workspace_path(session_id)
+    workspace_path = ensure_workspace_path(raw_path)
     env_config = await _load_environment_config(session_id)
+    session_env = await _load_session_env(session_id)
+
+    # Merge environment-level and session-level env vars (session wins).
+    merged_env: dict[str, str] = {
+        **(env_config.env if env_config and env_config.env else {}),
+        **session_env,
+    }
 
     # Determine if the environment uses limited networking.
     networking = env_config.networking if env_config else None
@@ -136,6 +163,10 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
         # Keep stdin open so the container doesn't exit on empty stdin.
         "--interactive",
     ]
+
+    # Inject merged environment variables into the container.
+    for key, value in merged_env.items():
+        argv.extend(["--env", f"{key}={value}"])
 
     # Limited networking needs NET_ADMIN to apply iptables rules.
     if needs_lockdown:

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -98,22 +98,13 @@ async def _load_environment_config(session_id: str) -> EnvironmentConfig | None:
         return await queries.get_environment_config_for_session(conn, session_id)
 
 
-async def _load_workspace_path(session_id: str) -> str:
-    """Load the workspace volume path for a session from the DB."""
+async def _load_session_provisioning(session_id: str) -> tuple[str, dict[str, str]]:
+    """Load workspace path and env from the session row in one query."""
     from aios.harness import runtime
 
     pool = runtime.require_pool()
     async with pool.acquire() as conn:
-        return await queries.get_session_workspace_path(conn, session_id)
-
-
-async def _load_session_env(session_id: str) -> dict[str, str]:
-    """Load per-session environment variables from the DB."""
-    from aios.harness import runtime
-
-    pool = runtime.require_pool()
-    async with pool.acquire() as conn:
-        return await queries.get_session_env(conn, session_id)
+        return await queries.get_session_provisioning(conn, session_id)
 
 
 async def provision_for_session(session_id: str) -> ContainerHandle:
@@ -130,10 +121,9 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
     from aios.sandbox.volumes import ensure_workspace_path
 
     settings = get_settings()
-    raw_path = await _load_workspace_path(session_id)
+    raw_path, session_env = await _load_session_provisioning(session_id)
     workspace_path = ensure_workspace_path(raw_path)
     env_config = await _load_environment_config(session_id)
-    session_env = await _load_session_env(session_id)
 
     # Merge environment-level and session-level env vars (session wins).
     merged_env: dict[str, str] = {
@@ -164,7 +154,6 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
         "--interactive",
     ]
 
-    # Inject merged environment variables into the container.
     for key, value in merged_env.items():
         argv.extend(["--env", f"{key}={value}"])
 

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -42,3 +42,15 @@ def ensure_workspace_dir(session_id: str) -> Path:
     path = workspace_dir_for(session_id)
     path.mkdir(parents=True, exist_ok=True)
     return path
+
+
+def ensure_workspace_path(raw_path: str) -> Path:
+    """Resolve ``raw_path`` to an absolute ``Path``, creating it if needed.
+
+    Used by the provisioner when the workspace path is loaded from the
+    session row (which may be a custom path or the default auto-generated
+    one).  ``mkdir`` with ``exist_ok=True`` is safe for both cases.
+    """
+    path = Path(raw_path).resolve()
+    path.mkdir(parents=True, exist_ok=True)
+    return path

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -45,12 +45,7 @@ def ensure_workspace_dir(session_id: str) -> Path:
 
 
 def ensure_workspace_path(raw_path: str) -> Path:
-    """Resolve ``raw_path`` to an absolute ``Path``, creating it if needed.
-
-    Used by the provisioner when the workspace path is loaded from the
-    session row (which may be a custom path or the default auto-generated
-    one).  ``mkdir`` with ``exist_ok=True`` is safe for both cases.
-    """
+    """Resolve ``raw_path`` to an absolute ``Path``, creating it if needed."""
     path = Path(raw_path).resolve()
     path.mkdir(parents=True, exist_ok=True)
     return path

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -19,11 +19,6 @@ from aios.models.events import Event, EventKind
 from aios.models.sessions import Session, SessionStatus
 
 
-def _workspace_path_for(session_id: str) -> str:
-    """Compute the host-side workspace directory for ``session_id``."""
-    return str(get_settings().workspace_root / session_id)
-
-
 async def create_session(
     pool: asyncpg.Pool[Any],
     *,
@@ -46,8 +41,6 @@ async def create_session(
 
         new_id = make_id(SESSION)
         workspace_path = workspace_path or str(get_settings().workspace_root / new_id)
-
-        import json
 
         try:
             row = await conn.fetchrow(

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -1,9 +1,9 @@
 """Business logic for sessions and their event log.
 
-Phase 1 sessions own a workspace directory on the host but no Docker
-container yet — Phase 3 wires the sandbox in. The session creation flow
-allocates the workspace path under ``settings.workspace_root`` and persists
-it on the row so future workers can re-mount the same volume.
+Session creation persists the workspace volume path (caller-supplied or
+defaulting to ``settings.workspace_root / session_id``) and optional
+per-session env vars on the row so workers can mount the correct volume
+and inject environment variables at container provisioning time.
 """
 
 from __future__ import annotations

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -33,6 +33,8 @@ async def create_session(
     title: str | None,
     metadata: dict[str, Any],
     vault_ids: list[str] | None = None,
+    workspace_path: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> Session:
     """Create a session row and return it.
 
@@ -43,7 +45,7 @@ async def create_session(
         from aios.ids import SESSION, make_id
 
         new_id = make_id(SESSION)
-        workspace_path = str(get_settings().workspace_root / new_id)
+        workspace_path = workspace_path or str(get_settings().workspace_root / new_id)
 
         import json
 
@@ -52,9 +54,9 @@ async def create_session(
                 """
                 INSERT INTO sessions (
                     id, agent_id, environment_id, agent_version, title, metadata,
-                    status, workspace_volume_path
+                    status, workspace_volume_path, env
                 )
-                VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'idle', $7)
+                VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'idle', $7, $8::jsonb)
                 RETURNING *
                 """,
                 new_id,
@@ -64,6 +66,7 @@ async def create_session(
                 title,
                 json.dumps(metadata),
                 workspace_path,
+                json.dumps(env or {}),
             )
         except asyncpg.ForeignKeyViolationError as exc:
             from aios.errors import NotFoundError
@@ -107,14 +110,22 @@ async def list_sessions(
         return sessions
 
 
-async def append_user_message(pool: asyncpg.Pool[Any], session_id: str, content: str) -> Event:
+async def append_user_message(
+    pool: asyncpg.Pool[Any],
+    session_id: str,
+    content: str,
+    metadata: dict[str, Any] | None = None,
+) -> Event:
     """Append a `role: user` message event to the session log."""
+    data: dict[str, Any] = {"role": "user", "content": content}
+    if metadata:
+        data["metadata"] = metadata
     async with pool.acquire() as conn:
         return await queries.append_event(
             conn,
             session_id=session_id,
             kind="message",
-            data={"role": "user", "content": content},
+            data=data,
         )
 
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -312,6 +312,14 @@ class TestBuildMessages:
         assert msgs[0]["content"] == "next question"
         assert msgs[1]["role"] == "assistant"
 
+    def test_user_metadata_excluded_from_messages(self) -> None:
+        """Metadata on user message events must not leak into the
+        chat-completions message list sent to the model."""
+        e = _evt(1, "user", content="hello")
+        e.data["metadata"] = {"run_id": "abc123"}
+        msgs = build_messages([e], system_prompt=None).messages
+        assert msgs[0] == {"role": "user", "content": "hello"}
+
     def test_prune_partial_assistant_tool_group(self) -> None:
         """If DB windowing keeps an assistant with tool_calls but dropped
         one of its paired results, the incomplete group should be pruned."""

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -190,10 +190,10 @@ class TestProvisionerDockerArgs:
             ),
             patch("aios.sandbox.provisioner._run_docker", fake_run_docker),
             patch(
-                "aios.sandbox.provisioner._load_workspace_path", AsyncMock(return_value="/tmp/ws")
+                "aios.sandbox.provisioner._load_session_provisioning",
+                AsyncMock(return_value=("/tmp/ws", {})),
             ),
             patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
-            patch("aios.sandbox.provisioner._load_session_env", AsyncMock(return_value={})),
             patch(
                 "aios.sandbox.provisioner._install_packages",
                 AsyncMock(),
@@ -233,10 +233,10 @@ class TestProvisionerDockerArgs:
             ),
             patch("aios.sandbox.provisioner._run_docker", fake_run_docker),
             patch(
-                "aios.sandbox.provisioner._load_workspace_path", AsyncMock(return_value="/tmp/ws")
+                "aios.sandbox.provisioner._load_session_provisioning",
+                AsyncMock(return_value=("/tmp/ws", {})),
             ),
             patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
-            patch("aios.sandbox.provisioner._load_session_env", AsyncMock(return_value={})),
             patch("aios.sandbox.provisioner._install_packages", AsyncMock()),
             patch(
                 "aios.sandbox.provisioner._apply_network_lockdown",
@@ -267,10 +267,10 @@ class TestProvisionerDockerArgs:
             ),
             patch("aios.sandbox.provisioner._run_docker", fake_run_docker),
             patch(
-                "aios.sandbox.provisioner._load_workspace_path", AsyncMock(return_value="/tmp/ws")
+                "aios.sandbox.provisioner._load_session_provisioning",
+                AsyncMock(return_value=("/tmp/ws", {})),
             ),
             patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
-            patch("aios.sandbox.provisioner._load_session_env", AsyncMock(return_value={})),
             patch("aios.sandbox.provisioner._install_packages", AsyncMock()),
             patch(
                 "aios.sandbox.provisioner._apply_network_lockdown",

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -189,7 +189,11 @@ class TestProvisionerDockerArgs:
                 AsyncMock(return_value=limited_config),
             ),
             patch("aios.sandbox.provisioner._run_docker", fake_run_docker),
-            patch("aios.sandbox.provisioner.ensure_workspace_dir", return_value=Path("/tmp/ws")),
+            patch(
+                "aios.sandbox.provisioner._load_workspace_path", AsyncMock(return_value="/tmp/ws")
+            ),
+            patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
+            patch("aios.sandbox.provisioner._load_session_env", AsyncMock(return_value={})),
             patch(
                 "aios.sandbox.provisioner._install_packages",
                 AsyncMock(),
@@ -228,7 +232,11 @@ class TestProvisionerDockerArgs:
                 AsyncMock(return_value=unrestricted_config),
             ),
             patch("aios.sandbox.provisioner._run_docker", fake_run_docker),
-            patch("aios.sandbox.provisioner.ensure_workspace_dir", return_value=Path("/tmp/ws")),
+            patch(
+                "aios.sandbox.provisioner._load_workspace_path", AsyncMock(return_value="/tmp/ws")
+            ),
+            patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
+            patch("aios.sandbox.provisioner._load_session_env", AsyncMock(return_value={})),
             patch("aios.sandbox.provisioner._install_packages", AsyncMock()),
             patch(
                 "aios.sandbox.provisioner._apply_network_lockdown",
@@ -258,7 +266,11 @@ class TestProvisionerDockerArgs:
                 AsyncMock(return_value=None),
             ),
             patch("aios.sandbox.provisioner._run_docker", fake_run_docker),
-            patch("aios.sandbox.provisioner.ensure_workspace_dir", return_value=Path("/tmp/ws")),
+            patch(
+                "aios.sandbox.provisioner._load_workspace_path", AsyncMock(return_value="/tmp/ws")
+            ),
+            patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
+            patch("aios.sandbox.provisioner._load_session_env", AsyncMock(return_value={})),
             patch("aios.sandbox.provisioner._install_packages", AsyncMock()),
             patch(
                 "aios.sandbox.provisioner._apply_network_lockdown",

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -10,7 +10,7 @@ import json
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pydantic
 import pytest
@@ -266,7 +266,13 @@ class TestProvisionSkillFiles:
         )
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir) / "sess_01TEST"
-            with patch("aios.harness.skills.ensure_workspace_dir", return_value=workspace):
+            with (
+                patch(
+                    "aios.harness.skills._load_workspace_path",
+                    AsyncMock(return_value=str(workspace)),
+                ),
+                patch("aios.harness.skills.ensure_workspace_path", return_value=workspace),
+            ):
                 await provision_skill_files("sess_01TEST", [sv])
 
             skill_md = workspace / "skills" / "my-skill" / "SKILL.md"
@@ -284,7 +290,13 @@ class TestProvisionSkillFiles:
             workspace = Path(tmpdir) / "sess_01TEST"
             skills_dir = workspace / "skills"
             skills_dir.mkdir(parents=True)
-            with patch("aios.harness.skills.ensure_workspace_dir", return_value=workspace):
+            with (
+                patch(
+                    "aios.harness.skills._load_workspace_path",
+                    AsyncMock(return_value=str(workspace)),
+                ),
+                patch("aios.harness.skills.ensure_workspace_path", return_value=workspace),
+            ):
                 await provision_skill_files("sess_01TEST", [sv])
 
             assert not (skills_dir / "code-review").exists()


### PR DESCRIPTION
## Summary

Three tightly-scoped changes for embedding aios behind an external control plane (e.g., Paperclip):

- **fix #23** — Thread `SessionUserMessage.metadata` through to event data. The field was accepted by the API but silently discarded. Now persisted in the event's JSONB `data` dict for orchestrator traceability (invisible to the model's chat-completions context).
- **feat #21** — Custom workspace path per session. `SessionCreate` accepts an optional `workspace_path` (must be absolute, directory must exist). The provisioner and skills provisioner now read `workspace_volume_path` from the session DB row instead of recomputing from settings.
- **feat #22** — Per-session environment variables. `SessionCreate.env` and `EnvironmentConfig.env` provide two layers of env var injection. The provisioner merges them (session wins) and passes `--env` flags to `docker run`. Migration 0014 adds the `env` JSONB column to sessions.

## Test plan

- [x] mypy clean (73 source files)
- [x] ruff check + format clean
- [x] 392 unit tests pass
- [ ] E2E: create session with `workspace_path` pointing at existing directory
- [ ] E2E: create session with `env: {"FOO": "bar"}`, verify container sees it
- [ ] E2E: POST message with `metadata: {"run_id": "abc"}`, verify it appears in event data
- [ ] Run migration 0014 against dev Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)