### PR TITLE
fix: cross-model session breakage from null content and provider fields

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -23,14 +23,17 @@ if TYPE_CHECKING:
 
 
 def _normalize_message(msg: dict[str, Any]) -> dict[str, Any]:
-    """Strip null-valued fields that break downstream JSONB queries.
+    """Normalize provider quirks that break downstream consumers.
 
-    Some LiteLLM providers (e.g. openrouter/moonshotai/kimi-k2.5) return
-    ``tool_calls: null`` instead of omitting the key.  Stored verbatim,
-    this becomes JSONB ``null`` which ``jsonb_array_length`` rejects.
+    Some LiteLLM providers return ``tool_calls: null`` instead of omitting
+    the key (breaks ``jsonb_array_length``), and ``content: null`` instead
+    of ``content: ""`` (breaks providers like MiniMax and Gemma when the
+    message is replayed in a cross-model session).
     """
     if "tool_calls" in msg and msg["tool_calls"] is None:
         del msg["tool_calls"]
+    if msg.get("content") is None:
+        msg["content"] = ""
     return msg
 
 

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -30,6 +30,23 @@ from typing import Any
 
 from aios.models.events import Event
 
+# Chat-completions spec fields per role.  Only these are emitted in the
+# context; provider-specific extensions (reasoning_content, etc.) stay
+# in the event log but are excluded from the message list.
+_ALLOWED_FIELDS: dict[str, frozenset[str]] = {
+    "assistant": frozenset({"role", "content", "tool_calls"}),
+    "tool": frozenset({"role", "tool_call_id", "content", "name"}),
+    "user": frozenset({"role", "content", "name"}),
+    "system": frozenset({"role", "content", "name"}),
+}
+
+
+def _strip_to_spec(msg: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *msg* with only chat-completions spec fields."""
+    allowed = _ALLOWED_FIELDS.get(msg.get("role", ""), frozenset())
+    return {k: v for k, v in msg.items() if k in allowed}
+
+
 # ─── should_call_model ──────────────────────────────────────────────────────
 
 
@@ -242,7 +259,10 @@ def build_messages(
     if system_prompt:
         messages.insert(0, {"role": "system", "content": system_prompt})
 
-    return ContextResult(messages=messages, reacting_to=max_stimulus_seq)
+    return ContextResult(
+        messages=[_strip_to_spec(m) for m in messages],
+        reacting_to=max_stimulus_seq,
+    )
 
 
 # ─── helpers ─────────────────────────────────────────────────────────────────

--- a/tests/unit/test_completion_sanitize.py
+++ b/tests/unit/test_completion_sanitize.py
@@ -46,3 +46,32 @@ class TestNormalizeMessage:
         result = _normalize_message(msg)
         assert result == {"role": "assistant", "content": "just text"}
         assert "tool_calls" not in result
+
+    def test_content_null_becomes_empty_string(self) -> None:
+        """content: None (from providers like GPT-5.4-mini) becomes ""."""
+        msg: dict[str, object] = {"role": "assistant", "content": None}
+        result = _normalize_message(msg)
+        assert result["content"] == ""
+
+    def test_content_absent_becomes_empty_string(self) -> None:
+        """Message missing content key entirely gets content: ""."""
+        msg: dict[str, object] = {"role": "assistant"}
+        result = _normalize_message(msg)
+        assert result["content"] == ""
+
+    def test_content_nonempty_preserved(self) -> None:
+        """Non-null content passes through unchanged."""
+        msg: dict[str, object] = {"role": "assistant", "content": "hello"}
+        result = _normalize_message(msg)
+        assert result["content"] == "hello"
+
+    def test_content_null_with_tool_calls_null_both_fixed(self) -> None:
+        """Both null content and null tool_calls are normalized together."""
+        msg: dict[str, object] = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": None,
+        }
+        result = _normalize_message(msg)
+        assert result["content"] == ""
+        assert "tool_calls" not in result

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -529,3 +529,90 @@ class TestMonotonicity:
 
         ctx = build_messages(events, system_prompt=None)
         assert ctx.reacting_to >= 3
+
+
+# ─── field stripping ────────────────────────────────────────────────────────
+
+
+class TestFieldStripping:
+    """build_messages strips provider-specific fields from the output,
+    keeping only chat-completions spec fields per role."""
+
+    def test_assistant_reasoning_content_stripped(self) -> None:
+        """Provider-specific reasoning_content is excluded from context."""
+        events = [
+            _evt(1, "user", content="hello"),
+            _evt(2, "assistant", content="hi"),
+        ]
+        events[1].data["reasoning_content"] = "I think the user wants..."
+        msgs = build_messages(events, system_prompt=None).messages
+        assert msgs[1]["content"] == "hi"
+        assert "reasoning_content" not in msgs[1]
+
+    def test_assistant_reacting_to_stripped(self) -> None:
+        """Internal reacting_to field is excluded from context output."""
+        events = [
+            _evt(1, "user", content="hello"),
+            _evt(2, "assistant", content="hi"),
+        ]
+        events[1].data["reacting_to"] = 1
+        msgs = build_messages(events, system_prompt=None).messages
+        assert "reacting_to" not in msgs[1]
+
+    def test_assistant_tool_calls_preserved(self) -> None:
+        """tool_calls is a spec field and must survive stripping."""
+        events = [
+            _evt(1, "user", content="do it"),
+            _evt(2, "assistant", tool_calls=[_tc("a")]),
+            _evt(3, "tool", tool_call_id="a", content="done"),
+        ]
+        msgs = build_messages(events, system_prompt=None).messages
+        assert msgs[1]["tool_calls"] == [_tc("a")]
+
+    def test_tool_message_extra_fields_stripped(self) -> None:
+        """Unknown fields on tool messages are excluded."""
+        events = [
+            _evt(1, "user", content="go"),
+            _evt(2, "assistant", tool_calls=[_tc("a")]),
+            _evt(3, "tool", tool_call_id="a", content="done"),
+        ]
+        events[2].data["provider_metadata"] = {"some": "thing"}
+        msgs = build_messages(events, system_prompt=None).messages
+        tool_msg = next(m for m in msgs if m.get("role") == "tool")
+        assert "provider_metadata" not in tool_msg
+        assert tool_msg["tool_call_id"] == "a"
+        assert tool_msg["content"] == "done"
+
+    def test_multiple_provider_fields_all_stripped(self) -> None:
+        """All provider-specific fields are excluded, only spec fields remain."""
+        events = [
+            _evt(1, "user", content="think hard"),
+            _evt(2, "assistant", content="here's my answer"),
+        ]
+        events[1].data.update(
+            {
+                "reasoning_content": "deep thoughts...",
+                "reasoning": "step by step...",
+                "reasoning_details": [{"type": "thinking", "content": "hmm"}],
+                "reacting_to": 1,
+                "provider_specific_id": "abc123",
+            }
+        )
+        msgs = build_messages(events, system_prompt=None).messages
+        assert set(msgs[1].keys()) == {"role", "content"}
+
+    def test_system_prompt_clean(self) -> None:
+        """System prompt message contains only spec fields."""
+        events = [_evt(1, "user", content="hi")]
+        msgs = build_messages(events, system_prompt="You are helpful.").messages
+        assert msgs[0] == {"role": "system", "content": "You are helpful."}
+
+    def test_stripping_does_not_mutate_event_data(self) -> None:
+        """Stripping produces new dicts; original event data is unchanged."""
+        events = [
+            _evt(1, "user", content="hello"),
+            _evt(2, "assistant", content="hi"),
+        ]
+        events[1].data["reasoning_content"] = "thoughts"
+        build_messages(events, system_prompt=None)
+        assert "reasoning_content" in events[1].data


### PR DESCRIPTION
## Summary

- **`content: null` normalization**: `_normalize_message()` now converts `content: null` to `""` at storage time, same pattern as the existing `tool_calls: null` fix. Prevents MiniMax, Gemma, and other providers from rejecting replayed messages.
- **Allowlist-based field stripping**: `build_messages()` strips messages to chat-completions spec fields (`role`, `content`, `tool_calls`, `tool_call_id`, `name`) before returning. Provider-specific fields like `reasoning_content`, `reasoning`, and `reasoning_details` stay in the event log for observability but never reach downstream models.

The allowlist approach is provider-agnostic — no blocklist to maintain, no provider-specific shims.

Closes #25

## Test plan

- [ ] 4 new tests for `content: null` normalization in `test_completion_sanitize.py`
- [ ] 7 new tests for field stripping in `test_context.py` (including mutation safety)
- [ ] All 403 unit tests pass, mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)