### PR TITLE
feat: routing infrastructure (connections, bindings, rules)

### DIFF
--- a/migrations/versions/0015_connections_bindings_rules.py
+++ b/migrations/versions/0015_connections_bindings_rules.py
@@ -1,0 +1,93 @@
+"""Routing infrastructure: connections, channel bindings, routing rules.
+
+Phase 1 of the connectors/channels design (issue #30).
+
+* ``connections`` — registered connector+account instances. Each one
+  identifies an external messaging account and the MCP URL connectors
+  expose to the worker for sending replies.
+* ``channel_bindings`` — explicit ``address → session_id`` map.  When an
+  inbound message arrives, the resolver checks here first.
+* ``routing_rules`` — fallback when no binding exists.  A rule's
+  ``prefix`` is matched against the address segment-aware, longest-prefix
+  wins.  ``target`` is one of ``agent:<id>[@<version>]`` or
+  ``session:<id>``; for ``agent:`` targets, ``session_params`` carries
+  the args used to spin up a fresh session at resolve time.
+
+Revision ID: 0015
+Revises: 0014
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0015"
+down_revision: str = "0014"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ── connections ──────────────────────────────────────────────────────
+    op.execute("""
+        CREATE TABLE connections (
+            id          text PRIMARY KEY,
+            connector   text NOT NULL,
+            account     text NOT NULL,
+            mcp_url     text NOT NULL,
+            vault_id    text NOT NULL REFERENCES vaults(id),
+            metadata    jsonb NOT NULL DEFAULT '{}'::jsonb,
+            created_at  timestamptz NOT NULL DEFAULT now(),
+            updated_at  timestamptz NOT NULL DEFAULT now(),
+            archived_at timestamptz
+        )
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX connections_connector_account_uniq
+            ON connections (connector, account) WHERE archived_at IS NULL
+    """)
+
+    # ── channel bindings ─────────────────────────────────────────────────
+    op.execute("""
+        CREATE TABLE channel_bindings (
+            id          text PRIMARY KEY,
+            address     text NOT NULL,
+            session_id  text NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            created_at  timestamptz NOT NULL DEFAULT now(),
+            updated_at  timestamptz NOT NULL DEFAULT now(),
+            archived_at timestamptz
+        )
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX channel_bindings_address_uniq
+            ON channel_bindings (address) WHERE archived_at IS NULL
+    """)
+    op.execute("""
+        CREATE INDEX channel_bindings_session_id
+            ON channel_bindings (session_id) WHERE archived_at IS NULL
+    """)
+
+    # ── routing rules ────────────────────────────────────────────────────
+    op.execute("""
+        CREATE TABLE routing_rules (
+            id             text PRIMARY KEY,
+            prefix         text NOT NULL,
+            target         text NOT NULL,
+            session_params jsonb NOT NULL DEFAULT '{}'::jsonb,
+            created_at     timestamptz NOT NULL DEFAULT now(),
+            updated_at     timestamptz NOT NULL DEFAULT now(),
+            archived_at    timestamptz
+        )
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX routing_rules_prefix_uniq
+            ON routing_rules (prefix) WHERE archived_at IS NULL
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS routing_rules")
+    op.execute("DROP TABLE IF EXISTS channel_bindings")
+    op.execute("DROP TABLE IF EXISTS connections")

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -12,7 +12,17 @@ from typing import Any
 
 from fastapi import FastAPI
 
-from aios.api.routers import agents, environments, health, sessions, skills, vaults
+from aios.api.routers import (
+    agents,
+    channel_bindings,
+    connections,
+    environments,
+    health,
+    routing_rules,
+    sessions,
+    skills,
+    vaults,
+)
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
 from aios.db.pool import close_pool, create_pool
@@ -58,6 +68,9 @@ def create_app() -> FastAPI:
     app.include_router(sessions.router)
     app.include_router(skills.router)
     app.include_router(vaults.router)
+    app.include_router(connections.router)
+    app.include_router(channel_bindings.router)
+    app.include_router(routing_rules.router)
     return app
 
 

--- a/src/aios/api/routers/channel_bindings.py
+++ b/src/aios/api/routers/channel_bindings.py
@@ -1,12 +1,7 @@
 """Channel binding endpoints — explicit address → session mappings.
 
 No PUT: bindings are immutable.  To re-route an address, archive the
-existing binding and create a new one.
-
-``DELETE /{id}`` soft-archives by design.  No hard-delete endpoint:
-the partial unique index on ``address`` already lets archived rows
-coexist with a fresh active binding for the same address, and the row
-itself ``ON DELETE CASCADE``s away with its session.
+existing binding and create a new one.  ``DELETE`` soft-archives.
 """
 
 from __future__ import annotations

--- a/src/aios/api/routers/channel_bindings.py
+++ b/src/aios/api/routers/channel_bindings.py
@@ -1,0 +1,47 @@
+"""Channel binding endpoints — explicit address → session mappings.
+
+No PUT: bindings are immutable.  To re-route an address, archive the
+existing binding and create a new one.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, status
+
+from aios.api.deps import AuthDep, PoolDep
+from aios.models.channel_bindings import ChannelBinding, ChannelBindingCreate
+from aios.models.common import ListResponse
+from aios.services import channels as service
+
+router = APIRouter(prefix="/v1/channel-bindings", tags=["channel-bindings"])
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create(body: ChannelBindingCreate, pool: PoolDep, _auth: AuthDep) -> ChannelBinding:
+    return await service.create_binding(pool, address=body.address, session_id=body.session_id)
+
+
+@router.get("")
+async def list_(
+    pool: PoolDep,
+    _auth: AuthDep,
+    session_id: str | None = None,
+    limit: int = 50,
+    after: str | None = None,
+) -> ListResponse[ChannelBinding]:
+    items = await service.list_bindings(pool, session_id=session_id, limit=limit, after=after)
+    return ListResponse[ChannelBinding](
+        data=items,
+        has_more=len(items) == limit,
+        next_after=items[-1].id if items else None,
+    )
+
+
+@router.get("/{binding_id}")
+async def get(binding_id: str, pool: PoolDep, _auth: AuthDep) -> ChannelBinding:
+    return await service.get_binding(pool, binding_id)
+
+
+@router.delete("/{binding_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete(binding_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+    await service.archive_binding(pool, binding_id)

--- a/src/aios/api/routers/channel_bindings.py
+++ b/src/aios/api/routers/channel_bindings.py
@@ -2,6 +2,11 @@
 
 No PUT: bindings are immutable.  To re-route an address, archive the
 existing binding and create a new one.
+
+``DELETE /{id}`` soft-archives by design.  No hard-delete endpoint:
+the partial unique index on ``address`` already lets archived rows
+coexist with a fresh active binding for the same address, and the row
+itself ``ON DELETE CASCADE``s away with its session.
 """
 
 from __future__ import annotations

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -1,0 +1,112 @@
+"""Connection endpoints + the inbound-message endpoint.
+
+Inbound flow: a connector posts a message for some ``path`` (chat id);
+we build the channel ``address`` from ``connector/account/path``, run
+the resolver, append a user-message event with ``metadata.channel``
+stamped, and defer a wake job.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, status
+
+from aios.api.deps import AuthDep, PoolDep
+from aios.errors import ValidationError
+from aios.harness.wake import defer_wake
+from aios.models.common import ListResponse
+from aios.models.connections import (
+    Connection,
+    ConnectionCreate,
+    ConnectionUpdate,
+    InboundMessage,
+    InboundMessageResponse,
+)
+from aios.services import channels as channels_service
+from aios.services import connections as service
+from aios.services import sessions as sessions_service
+
+router = APIRouter(prefix="/v1/connections", tags=["connections"])
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create(body: ConnectionCreate, pool: PoolDep, _auth: AuthDep) -> Connection:
+    return await service.create_connection(
+        pool,
+        connector=body.connector,
+        account=body.account,
+        mcp_url=body.mcp_url,
+        vault_id=body.vault_id,
+        metadata=body.metadata,
+    )
+
+
+@router.get("")
+async def list_(
+    pool: PoolDep,
+    _auth: AuthDep,
+    limit: int = 50,
+    after: str | None = None,
+) -> ListResponse[Connection]:
+    items = await service.list_connections(pool, limit=limit, after=after)
+    return ListResponse[Connection](
+        data=items,
+        has_more=len(items) == limit,
+        next_after=items[-1].id if items else None,
+    )
+
+
+@router.get("/{connection_id}")
+async def get(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Connection:
+    return await service.get_connection(pool, connection_id)
+
+
+@router.put("/{connection_id}")
+async def update(
+    connection_id: str, body: ConnectionUpdate, pool: PoolDep, _auth: AuthDep
+) -> Connection:
+    return await service.update_connection(
+        pool,
+        connection_id,
+        mcp_url=body.mcp_url,
+        vault_id=body.vault_id,
+        metadata=body.metadata,
+    )
+
+
+@router.delete("/{connection_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete(connection_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+    await service.archive_connection(pool, connection_id)
+
+
+# ─── inbound message ────────────────────────────────────────────────────────
+
+
+@router.post("/{connection_id}/messages", status_code=status.HTTP_201_CREATED)
+async def post_message(
+    connection_id: str,
+    body: InboundMessage,
+    pool: PoolDep,
+    _auth: AuthDep,
+) -> InboundMessageResponse:
+    if not body.path or body.path.startswith("/") or body.path.endswith("/"):
+        raise ValidationError(
+            "path must be non-empty and have no leading or trailing slashes",
+            detail={"path": body.path},
+        )
+
+    connection = await service.get_connection(pool, connection_id)
+    address = f"{connection.connector}/{connection.account}/{body.path}"
+
+    resolution = await channels_service.resolve_channel(pool, address)
+
+    metadata = {**body.metadata, "channel": address}
+    event = await sessions_service.append_user_message(
+        pool, resolution.session_id, body.content, metadata=metadata
+    )
+    await defer_wake(resolution.session_id, cause="inbound_message")
+
+    return InboundMessageResponse(
+        session_id=resolution.session_id,
+        event_id=event.id,
+        created_session=resolution.created_session,
+    )

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -3,13 +3,8 @@
 Inbound flow: a connector posts a message for some ``path`` (chat id);
 we build the channel ``address`` from ``connector/account/path``, run
 the resolver, append a user-message event with ``metadata.channel``
-stamped, and defer a wake job.
-
-``DELETE /{id}`` soft-archives by design.  No hard-delete endpoint:
-connections are cheap to retain archived for audit, and dropping the
-``connections`` row would orphan any historical ``metadata.channel``
-references in the event log.  (Vaults expose both because vault
-credentials carry encrypted secrets that may need to be purged.)
+stamped, and defer a wake job.  ``DELETE`` soft-archives — hard-delete
+would orphan ``metadata.channel`` references in the event log.
 """
 
 from __future__ import annotations
@@ -94,11 +89,9 @@ async def post_message(
     pool: PoolDep,
     _auth: AuthDep,
 ) -> InboundMessageResponse:
-    # Path is split on '/' to form trailing address segments.  Reject
-    # empty leading/trailing/interior segments and '..' to keep the
-    # full address (and thus prefix-rule matching) unambiguous.
+    # Empty/`..` segments would break segment-aware prefix-rule matching.
     segments = body.path.split("/")
-    if not segments or any(seg == "" or seg == ".." for seg in segments):
+    if not segments or any(seg in ("", "..") for seg in segments):
         raise ValidationError(
             "path must be non-empty with no empty segments or '..'",
             detail={"path": body.path},

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -4,6 +4,12 @@ Inbound flow: a connector posts a message for some ``path`` (chat id);
 we build the channel ``address`` from ``connector/account/path``, run
 the resolver, append a user-message event with ``metadata.channel``
 stamped, and defer a wake job.
+
+``DELETE /{id}`` soft-archives by design.  No hard-delete endpoint:
+connections are cheap to retain archived for audit, and dropping the
+``connections`` row would orphan any historical ``metadata.channel``
+references in the event log.  (Vaults expose both because vault
+credentials carry encrypted secrets that may need to be purged.)
 """
 
 from __future__ import annotations
@@ -88,9 +94,13 @@ async def post_message(
     pool: PoolDep,
     _auth: AuthDep,
 ) -> InboundMessageResponse:
-    if not body.path or body.path.startswith("/") or body.path.endswith("/"):
+    # Path is split on '/' to form trailing address segments.  Reject
+    # empty leading/trailing/interior segments and '..' to keep the
+    # full address (and thus prefix-rule matching) unambiguous.
+    segments = body.path.split("/")
+    if not segments or any(seg == "" or seg == ".." for seg in segments):
         raise ValidationError(
-            "path must be non-empty and have no leading or trailing slashes",
+            "path must be non-empty with no empty segments or '..'",
             detail={"path": body.path},
         )
 

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -90,8 +90,7 @@ async def post_message(
     _auth: AuthDep,
 ) -> InboundMessageResponse:
     # Empty/`..` segments would break segment-aware prefix-rule matching.
-    segments = body.path.split("/")
-    if not segments or any(seg in ("", "..") for seg in segments):
+    if any(seg in ("", "..") for seg in body.path.split("/")):
         raise ValidationError(
             "path must be non-empty with no empty segments or '..'",
             detail={"path": body.path},

--- a/src/aios/api/routers/routing_rules.py
+++ b/src/aios/api/routers/routing_rules.py
@@ -1,10 +1,6 @@
 """Routing rule endpoints — fallback prefix-match for unbound addresses.
 
-``DELETE /{id}`` soft-archives by design.  No hard-delete endpoint:
-the partial unique index on ``prefix`` already lets archived rules
-coexist with a fresh active rule on the same prefix, and retaining
-archived rules is useful for tracing how historical sessions were
-created.
+``DELETE`` soft-archives; archived rules are retained for audit.
 """
 
 from __future__ import annotations

--- a/src/aios/api/routers/routing_rules.py
+++ b/src/aios/api/routers/routing_rules.py
@@ -1,4 +1,11 @@
-"""Routing rule endpoints — fallback prefix-match for unbound addresses."""
+"""Routing rule endpoints — fallback prefix-match for unbound addresses.
+
+``DELETE /{id}`` soft-archives by design.  No hard-delete endpoint:
+the partial unique index on ``prefix`` already lets archived rules
+coexist with a fresh active rule on the same prefix, and retaining
+archived rules is useful for tracing how historical sessions were
+created.
+"""
 
 from __future__ import annotations
 

--- a/src/aios/api/routers/routing_rules.py
+++ b/src/aios/api/routers/routing_rules.py
@@ -1,0 +1,63 @@
+"""Routing rule endpoints — fallback prefix-match for unbound addresses."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, status
+
+from aios.api.deps import AuthDep, PoolDep
+from aios.models.common import ListResponse
+from aios.models.routing_rules import (
+    RoutingRule,
+    RoutingRuleCreate,
+    RoutingRuleUpdate,
+)
+from aios.services import channels as service
+
+router = APIRouter(prefix="/v1/routing-rules", tags=["routing-rules"])
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create(body: RoutingRuleCreate, pool: PoolDep, _auth: AuthDep) -> RoutingRule:
+    return await service.create_routing_rule(
+        pool,
+        prefix=body.prefix,
+        target=body.target,
+        session_params=body.session_params,
+    )
+
+
+@router.get("")
+async def list_(
+    pool: PoolDep,
+    _auth: AuthDep,
+    limit: int = 50,
+    after: str | None = None,
+) -> ListResponse[RoutingRule]:
+    items = await service.list_routing_rules(pool, limit=limit, after=after)
+    return ListResponse[RoutingRule](
+        data=items,
+        has_more=len(items) == limit,
+        next_after=items[-1].id if items else None,
+    )
+
+
+@router.get("/{rule_id}")
+async def get(rule_id: str, pool: PoolDep, _auth: AuthDep) -> RoutingRule:
+    return await service.get_routing_rule(pool, rule_id)
+
+
+@router.put("/{rule_id}")
+async def update(
+    rule_id: str, body: RoutingRuleUpdate, pool: PoolDep, _auth: AuthDep
+) -> RoutingRule:
+    return await service.update_routing_rule(
+        pool,
+        rule_id,
+        target=body.target,
+        session_params=body.session_params,
+    )
+
+
+@router.delete("/{rule_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete(rule_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+    await service.archive_routing_rule(pool, rule_id)

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -20,10 +20,25 @@ import asyncpg
 
 from aios.crypto.vault import EncryptedBlob
 from aios.errors import ConflictError, NotFoundError
-from aios.ids import AGENT, ENVIRONMENT, EVENT, SKILL, VAULT, VAULT_CREDENTIAL, make_id
+from aios.ids import (
+    AGENT,
+    CHANNEL_BINDING,
+    CONNECTION,
+    ENVIRONMENT,
+    EVENT,
+    ROUTING_RULE,
+    SESSION,
+    SKILL,
+    VAULT,
+    VAULT_CREDENTIAL,
+    make_id,
+)
 from aios.models.agents import Agent, AgentVersion, McpServerSpec, ToolSpec
+from aios.models.channel_bindings import ChannelBinding
+from aios.models.connections import Connection
 from aios.models.environments import Environment, EnvironmentConfig
 from aios.models.events import Event, EventKind
+from aios.models.routing_rules import RoutingRule, SessionParams
 from aios.models.sessions import Session, SessionStatus, SessionUsage
 from aios.models.skills import AgentSkillRef, Skill, SkillVersion
 from aios.models.vaults import Vault, VaultCredential
@@ -490,6 +505,57 @@ def _row_to_session(row: asyncpg.Record) -> Session:
         updated_at=row["updated_at"],
         archived_at=row["archived_at"],
     )
+
+
+async def insert_session(
+    conn: asyncpg.Connection[Any],
+    *,
+    agent_id: str,
+    environment_id: str,
+    agent_version: int | None,
+    title: str | None,
+    metadata: dict[str, Any],
+    workspace_path: str | None = None,
+    env: dict[str, str] | None = None,
+) -> Session:
+    """Insert a fresh session row.
+
+    ``workspace_path`` defaults to ``settings.workspace_root / session_id``.
+    Caller sets up vault bindings via :func:`set_session_vaults` after.
+    Raises :class:`NotFoundError` if either the agent or environment FK
+    is unsatisfied.
+    """
+    from aios.config import get_settings
+
+    new_id = make_id(SESSION)
+    if workspace_path is None:
+        workspace_path = str(get_settings().workspace_root / new_id)
+    try:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO sessions (
+                id, agent_id, environment_id, agent_version, title, metadata,
+                status, workspace_volume_path, env
+            )
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'idle', $7, $8::jsonb)
+            RETURNING *
+            """,
+            new_id,
+            agent_id,
+            environment_id,
+            agent_version,
+            title,
+            json.dumps(metadata),
+            workspace_path,
+            json.dumps(env or {}),
+        )
+    except asyncpg.ForeignKeyViolationError as exc:
+        raise NotFoundError(
+            "agent or environment not found",
+            detail={"agent_id": agent_id, "environment_id": environment_id},
+        ) from exc
+    assert row is not None
+    return _row_to_session(row)
 
 
 async def get_session(conn: asyncpg.Connection[Any], session_id: str) -> Session:
@@ -1477,3 +1543,385 @@ async def resolve_skill_refs(
             sv = await get_skill_version(conn, ref.skill_id, ref.version)
         results.append(sv)
     return results
+
+
+# ─── connections ────────────────────────────────────────────────────────────
+
+
+def _row_to_connection(row: asyncpg.Record) -> Connection:
+    raw_metadata = row["metadata"]
+    metadata = json.loads(raw_metadata) if isinstance(raw_metadata, str) else raw_metadata
+    return Connection(
+        id=row["id"],
+        connector=row["connector"],
+        account=row["account"],
+        mcp_url=row["mcp_url"],
+        vault_id=row["vault_id"],
+        metadata=metadata,
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        archived_at=row["archived_at"],
+    )
+
+
+async def insert_connection(
+    conn: asyncpg.Connection[Any],
+    *,
+    connector: str,
+    account: str,
+    mcp_url: str,
+    vault_id: str,
+    metadata: dict[str, Any],
+) -> Connection:
+    new_id = make_id(CONNECTION)
+    metadata_json = json.dumps(metadata)
+    try:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO connections (id, connector, account, mcp_url, vault_id, metadata)
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+            RETURNING *
+            """,
+            new_id,
+            connector,
+            account,
+            mcp_url,
+            vault_id,
+            metadata_json,
+        )
+    except asyncpg.UniqueViolationError as exc:
+        raise ConflictError(
+            f"a connection for ({connector!r}, {account!r}) already exists",
+            detail={"connector": connector, "account": account},
+        ) from exc
+    except asyncpg.ForeignKeyViolationError as exc:
+        raise NotFoundError(
+            f"vault {vault_id} not found",
+            detail={"vault_id": vault_id},
+        ) from exc
+    assert row is not None
+    return _row_to_connection(row)
+
+
+async def get_connection(conn: asyncpg.Connection[Any], connection_id: str) -> Connection:
+    row = await conn.fetchrow("SELECT * FROM connections WHERE id = $1", connection_id)
+    if row is None:
+        raise NotFoundError(
+            f"connection {connection_id} not found",
+            detail={"id": connection_id},
+        )
+    return _row_to_connection(row)
+
+
+async def list_connections(
+    conn: asyncpg.Connection[Any], *, limit: int = 50, after: str | None = None
+) -> list[Connection]:
+    if after is None:
+        rows = await conn.fetch(
+            "SELECT * FROM connections WHERE archived_at IS NULL ORDER BY id DESC LIMIT $1",
+            limit,
+        )
+    else:
+        rows = await conn.fetch(
+            "SELECT * FROM connections WHERE archived_at IS NULL AND id < $1 "
+            "ORDER BY id DESC LIMIT $2",
+            after,
+            limit,
+        )
+    return [_row_to_connection(r) for r in rows]
+
+
+async def update_connection(
+    conn: asyncpg.Connection[Any],
+    connection_id: str,
+    *,
+    mcp_url: str | None = None,
+    vault_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Connection:
+    sets: list[str] = []
+    args: list[Any] = [connection_id]
+    if mcp_url is not None:
+        args.append(mcp_url)
+        sets.append(f"mcp_url = ${len(args)}")
+    if vault_id is not None:
+        args.append(vault_id)
+        sets.append(f"vault_id = ${len(args)}")
+    if metadata is not None:
+        args.append(json.dumps(metadata))
+        sets.append(f"metadata = ${len(args)}::jsonb")
+    if not sets:
+        return await get_connection(conn, connection_id)
+    sets.append("updated_at = now()")
+    sql = f"UPDATE connections SET {', '.join(sets)} WHERE id = $1 RETURNING *"
+    try:
+        row = await conn.fetchrow(sql, *args)
+    except asyncpg.ForeignKeyViolationError as exc:
+        raise NotFoundError(
+            "vault not found",
+            detail={"vault_id": vault_id},
+        ) from exc
+    if row is None:
+        raise NotFoundError(
+            f"connection {connection_id} not found",
+            detail={"id": connection_id},
+        )
+    return _row_to_connection(row)
+
+
+async def archive_connection(conn: asyncpg.Connection[Any], connection_id: str) -> Connection:
+    row = await conn.fetchrow(
+        "UPDATE connections SET archived_at = now(), updated_at = now() "
+        "WHERE id = $1 AND archived_at IS NULL RETURNING *",
+        connection_id,
+    )
+    if row is None:
+        raise NotFoundError(
+            f"connection {connection_id} not found or already archived",
+            detail={"id": connection_id},
+        )
+    return _row_to_connection(row)
+
+
+# ─── channel bindings ───────────────────────────────────────────────────────
+
+
+def _row_to_channel_binding(row: asyncpg.Record) -> ChannelBinding:
+    return ChannelBinding(
+        id=row["id"],
+        address=row["address"],
+        session_id=row["session_id"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        archived_at=row["archived_at"],
+    )
+
+
+async def insert_binding(
+    conn: asyncpg.Connection[Any],
+    *,
+    address: str,
+    session_id: str,
+) -> ChannelBinding:
+    new_id = make_id(CHANNEL_BINDING)
+    try:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO channel_bindings (id, address, session_id)
+            VALUES ($1, $2, $3)
+            RETURNING *
+            """,
+            new_id,
+            address,
+            session_id,
+        )
+    except asyncpg.UniqueViolationError as exc:
+        raise ConflictError(
+            f"an active binding for address {address!r} already exists",
+            detail={"address": address},
+        ) from exc
+    except asyncpg.ForeignKeyViolationError as exc:
+        raise NotFoundError(
+            f"session {session_id} not found",
+            detail={"session_id": session_id},
+        ) from exc
+    assert row is not None
+    return _row_to_channel_binding(row)
+
+
+async def get_binding(conn: asyncpg.Connection[Any], binding_id: str) -> ChannelBinding:
+    row = await conn.fetchrow("SELECT * FROM channel_bindings WHERE id = $1", binding_id)
+    if row is None:
+        raise NotFoundError(
+            f"channel binding {binding_id} not found",
+            detail={"id": binding_id},
+        )
+    return _row_to_channel_binding(row)
+
+
+async def get_binding_by_address(
+    conn: asyncpg.Connection[Any], address: str
+) -> ChannelBinding | None:
+    row = await conn.fetchrow(
+        "SELECT * FROM channel_bindings WHERE address = $1 AND archived_at IS NULL",
+        address,
+    )
+    if row is None:
+        return None
+    return _row_to_channel_binding(row)
+
+
+async def list_bindings(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str | None = None,
+    limit: int = 50,
+    after: str | None = None,
+) -> list[ChannelBinding]:
+    clauses: list[str] = ["archived_at IS NULL"]
+    args: list[Any] = []
+    if session_id is not None:
+        args.append(session_id)
+        clauses.append(f"session_id = ${len(args)}")
+    if after is not None:
+        args.append(after)
+        clauses.append(f"id < ${len(args)}")
+    args.append(limit)
+    sql = (
+        f"SELECT * FROM channel_bindings WHERE {' AND '.join(clauses)} "
+        f"ORDER BY id DESC LIMIT ${len(args)}"
+    )
+    rows = await conn.fetch(sql, *args)
+    return [_row_to_channel_binding(r) for r in rows]
+
+
+async def archive_binding(conn: asyncpg.Connection[Any], binding_id: str) -> ChannelBinding:
+    row = await conn.fetchrow(
+        "UPDATE channel_bindings SET archived_at = now(), updated_at = now() "
+        "WHERE id = $1 AND archived_at IS NULL RETURNING *",
+        binding_id,
+    )
+    if row is None:
+        raise NotFoundError(
+            f"channel binding {binding_id} not found or already archived",
+            detail={"id": binding_id},
+        )
+    return _row_to_channel_binding(row)
+
+
+# ─── routing rules ──────────────────────────────────────────────────────────
+
+
+def _row_to_routing_rule(row: asyncpg.Record) -> RoutingRule:
+    raw_params = row["session_params"]
+    params_data = json.loads(raw_params) if isinstance(raw_params, str) else raw_params
+    return RoutingRule(
+        id=row["id"],
+        prefix=row["prefix"],
+        target=row["target"],
+        session_params=SessionParams.model_validate(params_data),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        archived_at=row["archived_at"],
+    )
+
+
+async def insert_routing_rule(
+    conn: asyncpg.Connection[Any],
+    *,
+    prefix: str,
+    target: str,
+    session_params: SessionParams,
+) -> RoutingRule:
+    new_id = make_id(ROUTING_RULE)
+    params_json = json.dumps(session_params.model_dump())
+    try:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO routing_rules (id, prefix, target, session_params)
+            VALUES ($1, $2, $3, $4::jsonb)
+            RETURNING *
+            """,
+            new_id,
+            prefix,
+            target,
+            params_json,
+        )
+    except asyncpg.UniqueViolationError as exc:
+        raise ConflictError(
+            f"an active routing rule for prefix {prefix!r} already exists",
+            detail={"prefix": prefix},
+        ) from exc
+    assert row is not None
+    return _row_to_routing_rule(row)
+
+
+async def get_routing_rule(conn: asyncpg.Connection[Any], rule_id: str) -> RoutingRule:
+    row = await conn.fetchrow("SELECT * FROM routing_rules WHERE id = $1", rule_id)
+    if row is None:
+        raise NotFoundError(
+            f"routing rule {rule_id} not found",
+            detail={"id": rule_id},
+        )
+    return _row_to_routing_rule(row)
+
+
+async def list_routing_rules(
+    conn: asyncpg.Connection[Any], *, limit: int = 50, after: str | None = None
+) -> list[RoutingRule]:
+    if after is None:
+        rows = await conn.fetch(
+            "SELECT * FROM routing_rules WHERE archived_at IS NULL ORDER BY id DESC LIMIT $1",
+            limit,
+        )
+    else:
+        rows = await conn.fetch(
+            "SELECT * FROM routing_rules WHERE archived_at IS NULL AND id < $1 "
+            "ORDER BY id DESC LIMIT $2",
+            after,
+            limit,
+        )
+    return [_row_to_routing_rule(r) for r in rows]
+
+
+async def update_routing_rule(
+    conn: asyncpg.Connection[Any],
+    rule_id: str,
+    *,
+    target: str | None = None,
+    session_params: SessionParams | None = None,
+) -> RoutingRule:
+    sets: list[str] = []
+    args: list[Any] = [rule_id]
+    if target is not None:
+        args.append(target)
+        sets.append(f"target = ${len(args)}")
+    if session_params is not None:
+        args.append(json.dumps(session_params.model_dump()))
+        sets.append(f"session_params = ${len(args)}::jsonb")
+    if not sets:
+        return await get_routing_rule(conn, rule_id)
+    sets.append("updated_at = now()")
+    sql = f"UPDATE routing_rules SET {', '.join(sets)} WHERE id = $1 RETURNING *"
+    row = await conn.fetchrow(sql, *args)
+    if row is None:
+        raise NotFoundError(
+            f"routing rule {rule_id} not found",
+            detail={"id": rule_id},
+        )
+    return _row_to_routing_rule(row)
+
+
+async def archive_routing_rule(conn: asyncpg.Connection[Any], rule_id: str) -> RoutingRule:
+    row = await conn.fetchrow(
+        "UPDATE routing_rules SET archived_at = now(), updated_at = now() "
+        "WHERE id = $1 AND archived_at IS NULL RETURNING *",
+        rule_id,
+    )
+    if row is None:
+        raise NotFoundError(
+            f"routing rule {rule_id} not found or already archived",
+            detail={"id": rule_id},
+        )
+    return _row_to_routing_rule(row)
+
+
+async def find_matching_rule(conn: asyncpg.Connection[Any], address: str) -> RoutingRule | None:
+    """Longest-matching segment-aware prefix lookup.
+
+    ``signal`` matches ``signal/abc/x`` but not ``signalfoo``: the
+    ``$1 LIKE prefix || '/%'`` clause requires a segment boundary.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT * FROM routing_rules
+        WHERE archived_at IS NULL
+          AND ($1 = prefix OR $1 LIKE prefix || '/%')
+        ORDER BY length(prefix) DESC
+        LIMIT 1
+        """,
+        address,
+    )
+    if row is None:
+        return None
+    return _row_to_routing_rule(row)

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1909,14 +1909,23 @@ async def archive_routing_rule(conn: asyncpg.Connection[Any], rule_id: str) -> R
 async def find_matching_rule(conn: asyncpg.Connection[Any], address: str) -> RoutingRule | None:
     """Longest-matching segment-aware prefix lookup.
 
-    ``signal`` matches ``signal/abc/x`` but not ``signalfoo``: the
-    ``$1 LIKE prefix || '/%'`` clause requires a segment boundary.
+    ``signal`` matches ``signal/abc/x`` but not ``signalfoo``: the second
+    clause requires a literal ``prefix + "/"`` boundary.  Substring
+    equality (rather than ``LIKE``) is used so meta-characters in the
+    prefix (``_``, ``%``) are matched literally — a prefix of
+    ``foo_bar`` must not match ``fooXbar/baz``.
     """
     row = await conn.fetchrow(
         """
         SELECT * FROM routing_rules
         WHERE archived_at IS NULL
-          AND ($1 = prefix OR $1 LIKE prefix || '/%')
+          AND (
+              $1 = prefix
+              OR (
+                  length($1) > length(prefix)
+                  AND substring($1, 1, length(prefix) + 1) = prefix || '/'
+              )
+          )
         ORDER BY length(prefix) DESC
         LIMIT 1
         """,

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -75,6 +75,17 @@ class ForbiddenError(AiosError):
     status_code = 403
 
 
+class NoRouteError(AiosError):
+    """Raised when a channel address has no matching binding or routing rule.
+
+    Translates to 404 with envelope ``type="no_route"`` so callers (the
+    inbound-message endpoint, connectors) can branch on the type.
+    """
+
+    error_type = "no_route"
+    status_code = 404
+
+
 class CryptoDecryptError(AiosError):
     """Raised when the CryptoBox cannot decrypt a stored ciphertext.
 

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -28,9 +28,25 @@ AGENT_VERSION: Final = "agver"  # reserved for phase 4
 VAULT: Final = "vlt"
 VAULT_CREDENTIAL: Final = "vcr"
 SKILL: Final = "skl"
+CONNECTION: Final = "conn"
+CHANNEL_BINDING: Final = "cbnd"
+ROUTING_RULE: Final = "rrul"
 
 _PREFIXES: Final = frozenset(
-    {AGENT, ENVIRONMENT, SESSION, EVENT, CREDENTIAL, AGENT_VERSION, VAULT, VAULT_CREDENTIAL, SKILL}
+    {
+        AGENT,
+        ENVIRONMENT,
+        SESSION,
+        EVENT,
+        CREDENTIAL,
+        AGENT_VERSION,
+        VAULT,
+        VAULT_CREDENTIAL,
+        SKILL,
+        CONNECTION,
+        CHANNEL_BINDING,
+        ROUTING_RULE,
+    }
 )
 
 

--- a/src/aios/models/channel_bindings.py
+++ b/src/aios/models/channel_bindings.py
@@ -1,0 +1,33 @@
+"""Channel binding resource.
+
+An explicit, immutable ``address → session_id`` mapping used by the
+channel resolver as the fast path before falling back to routing rules.
+There is no PUT — to re-route an address, archive the binding and create
+a new one (or rely on a routing rule).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ChannelBindingCreate(BaseModel):
+    """Request body for ``POST /v1/channel-bindings``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    address: str = Field(min_length=1)
+    session_id: str
+
+
+class ChannelBinding(BaseModel):
+    """Read view of a channel binding."""
+
+    id: str
+    address: str
+    session_id: str
+    created_at: datetime
+    updated_at: datetime
+    archived_at: datetime | None = None

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -15,11 +15,17 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ConnectionCreate(BaseModel):
-    """Request body for ``POST /v1/connections``."""
+    """Request body for ``POST /v1/connections``.
+
+    ``connector`` and ``account`` may not contain ``/`` — they form the
+    leading two segments of channel addresses (``{connector}/{account}/{path}``)
+    and a ``/`` would create ambiguous segment boundaries that confuse
+    routing-rule prefix matching.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -28,6 +34,13 @@ class ConnectionCreate(BaseModel):
     mcp_url: str = Field(min_length=1)
     vault_id: str
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("connector", "account")
+    @classmethod
+    def _no_slash(cls, v: str) -> str:
+        if "/" in v:
+            raise ValueError("must not contain '/'")
+        return v
 
 
 class ConnectionUpdate(BaseModel):

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -1,0 +1,80 @@
+"""Connection resource and inbound-message DTOs.
+
+A *connection* is a registered ``(connector, account)`` pair plus the
+MCP URL the connector exposes for the agent to send replies back through.
+The address scheme used by the routing layer is::
+
+    {connector}/{account}/{path}
+
+where ``path`` is whatever sub-segments the connector emits for inbound
+messages (typically a chat or thread id).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConnectionCreate(BaseModel):
+    """Request body for ``POST /v1/connections``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    connector: str = Field(min_length=1, max_length=64)
+    account: str = Field(min_length=1, max_length=256)
+    mcp_url: str = Field(min_length=1)
+    vault_id: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ConnectionUpdate(BaseModel):
+    """Request body for ``PUT /v1/connections/{id}``.
+
+    ``connector`` and ``account`` are immutable after creation.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    mcp_url: str | None = Field(default=None, min_length=1)
+    vault_id: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class Connection(BaseModel):
+    """Read view of a connection."""
+
+    id: str
+    connector: str
+    account: str
+    mcp_url: str
+    vault_id: str
+    metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+    archived_at: datetime | None = None
+
+
+class InboundMessage(BaseModel):
+    """Request body for ``POST /v1/connections/{id}/messages``.
+
+    ``path`` carries the chat id (and any connector-defined sub-segments)
+    that, combined with the connection's ``connector`` and ``account``,
+    forms the channel address used for routing.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    content: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class InboundMessageResponse(BaseModel):
+    """Response from ``POST /v1/connections/{id}/messages``."""
+
+    session_id: str
+    event_id: str
+    created_session: bool

--- a/src/aios/models/routing_rules.py
+++ b/src/aios/models/routing_rules.py
@@ -1,0 +1,71 @@
+"""Routing rule resource.
+
+A rule maps a *prefix* of channel addresses onto a *target*: either an
+agent (``agent:<id>[@<version>]`` — auto-creates a session at resolve
+time) or an existing session (``session:<id>``).
+
+When an inbound message arrives and no explicit binding exists, the
+resolver picks the longest matching prefix.  The match is segment-aware:
+``signal`` matches ``signal/abc`` but not ``signalfoo``.
+
+``session_params`` carries the args the resolver passes to
+``queries.insert_session`` for ``agent:`` targets.  It is meaningless and
+must be empty for ``session:`` targets — service-level validation enforces
+this at create/update.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SessionParams(BaseModel):
+    """Args used to spin up a fresh session for an ``agent:`` target.
+
+    ``title`` may contain ``{address}`` which the resolver substitutes
+    with the matched channel address.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    environment_id: str | None = None
+    vault_ids: list[str] = Field(default_factory=list)
+    title: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RoutingRuleCreate(BaseModel):
+    """Request body for ``POST /v1/routing-rules``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    prefix: str = Field(min_length=1)
+    target: str = Field(min_length=1)
+    session_params: SessionParams = Field(default_factory=SessionParams)
+
+
+class RoutingRuleUpdate(BaseModel):
+    """Request body for ``PUT /v1/routing-rules/{id}``.
+
+    ``prefix`` is immutable after creation.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    target: str | None = Field(default=None, min_length=1)
+    session_params: SessionParams | None = None
+
+
+class RoutingRule(BaseModel):
+    """Read view of a routing rule."""
+
+    id: str
+    prefix: str
+    target: str
+    session_params: SessionParams
+    created_at: datetime
+    updated_at: datetime
+    archived_at: datetime | None = None

--- a/src/aios/services/channels.py
+++ b/src/aios/services/channels.py
@@ -228,6 +228,13 @@ async def resolve_channel(pool: asyncpg.Pool[Any], address: str) -> ResolveResul
     ``sessions.id`` is satisfied atomically.
     """
     async with pool.acquire() as conn, conn.transaction():
+        # Serialize concurrent first-time resolves of the same address.
+        # Without this, two simultaneous misses both insert sessions and
+        # the second insert_binding fails on the unique index — a spurious
+        # 409 from the connector's perspective.  Advisory lock is per-
+        # address (not global) and releases automatically on commit.
+        await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", address)
+
         existing = await queries.get_binding_by_address(conn, address)
         if existing is not None:
             return ResolveResult(

--- a/src/aios/services/channels.py
+++ b/src/aios/services/channels.py
@@ -241,7 +241,9 @@ async def resolve_channel(pool: asyncpg.Pool[Any], address: str) -> ResolveResul
         # resolves of the same address don't both reach insert_binding and
         # spuriously 409.  Re-check the binding after acquiring it: another
         # transaction may have inserted one while we were waiting.
-        await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", address)
+        # ``hashtextextended`` gives a 64-bit key (vs ``hashtext``'s 32-bit)
+        # so unrelated addresses don't collide on the lock space.
+        await conn.execute("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", address)
         existing = await queries.get_binding_by_address(conn, address)
         if existing is not None:
             return ResolveResult(

--- a/src/aios/services/channels.py
+++ b/src/aios/services/channels.py
@@ -1,0 +1,275 @@
+"""Channel resolution and routing-resource business logic.
+
+The headline function is :func:`resolve_channel`: given a channel
+*address* (``{connector}/{account}/{path}``), return the session it
+maps to.  Two-tier resolution:
+
+1. If an explicit :class:`~aios.models.channel_bindings.ChannelBinding`
+   exists for this address, return its session.  Fast path.
+2. Otherwise, find the longest-matching segment-aware prefix
+   :class:`~aios.models.routing_rules.RoutingRule`, parse its target,
+   and either look up the existing session (``session:`` target) or
+   create a fresh one (``agent:`` target).  Either way, persist a
+   binding so the next message short-circuits.
+3. If neither tier matches, raise :class:`~aios.errors.NoRouteError`.
+
+This module also owns CRUD for both bindings and routing rules so the
+target-validation logic (``agent:`` requires ``environment_id``,
+``session:`` rejects ``session_params``) lives next to the resolver
+that depends on it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import asyncpg
+
+from aios.db import queries
+from aios.errors import NoRouteError, ValidationError
+from aios.models.channel_bindings import ChannelBinding
+from aios.models.routing_rules import RoutingRule, SessionParams
+
+# ─── target parsing ─────────────────────────────────────────────────────────
+
+
+@dataclass(slots=True)
+class AgentTarget:
+    kind: Literal["agent"]
+    agent_id: str
+    agent_version: int | None
+
+
+@dataclass(slots=True)
+class SessionTarget:
+    kind: Literal["session"]
+    session_id: str
+
+
+Target = AgentTarget | SessionTarget
+
+
+def parse_target(s: str) -> Target:
+    """Parse a routing-rule target string.
+
+    Format: ``agent:<id>[@<version>]`` or ``session:<id>``.
+    Raises :class:`ValueError` on anything else.
+    """
+    if s.startswith("agent:"):
+        rest = s[len("agent:") :]
+        if not rest:
+            raise ValueError(f"invalid target: {s!r}")
+        if "@" in rest:
+            agent_id, _, version_str = rest.rpartition("@")
+            if not agent_id or not version_str:
+                raise ValueError(f"invalid target: {s!r}")
+            try:
+                version = int(version_str)
+            except ValueError as exc:
+                raise ValueError(f"invalid target: {s!r}") from exc
+            return AgentTarget(kind="agent", agent_id=agent_id, agent_version=version)
+        return AgentTarget(kind="agent", agent_id=rest, agent_version=None)
+    if s.startswith("session:"):
+        rest = s[len("session:") :]
+        if not rest:
+            raise ValueError(f"invalid target: {s!r}")
+        return SessionTarget(kind="session", session_id=rest)
+    raise ValueError(f"invalid target: {s!r}")
+
+
+def _validate_rule_target(target: str, session_params: SessionParams) -> None:
+    """Enforce the cross-field rules between ``target`` and ``session_params``.
+
+    Raises :class:`ValidationError` (422) on failure.
+    """
+    try:
+        parsed = parse_target(target)
+    except ValueError as exc:
+        raise ValidationError(str(exc), detail={"target": target}) from exc
+
+    if parsed.kind == "agent":
+        if session_params.environment_id is None:
+            raise ValidationError(
+                "agent: targets require session_params.environment_id",
+                detail={"target": target},
+            )
+    else:
+        # session: targets must not carry session_params
+        if (
+            session_params.environment_id is not None
+            or session_params.vault_ids
+            or session_params.title is not None
+            or session_params.metadata
+        ):
+            raise ValidationError(
+                "session: targets must have empty session_params",
+                detail={"target": target},
+            )
+
+
+# ─── routing-rule CRUD ──────────────────────────────────────────────────────
+#
+# ``target`` and ``session_params`` are NOT NULL columns, so ``None`` in the
+# update path cleanly means "don't change this field" — no _UNSET sentinel
+# needed (matches the vaults.update_vault style).
+
+
+async def create_routing_rule(
+    pool: asyncpg.Pool[Any],
+    *,
+    prefix: str,
+    target: str,
+    session_params: SessionParams,
+) -> RoutingRule:
+    _validate_rule_target(target, session_params)
+    async with pool.acquire() as conn:
+        return await queries.insert_routing_rule(
+            conn,
+            prefix=prefix,
+            target=target,
+            session_params=session_params,
+        )
+
+
+async def get_routing_rule(pool: asyncpg.Pool[Any], rule_id: str) -> RoutingRule:
+    async with pool.acquire() as conn:
+        return await queries.get_routing_rule(conn, rule_id)
+
+
+async def list_routing_rules(
+    pool: asyncpg.Pool[Any], *, limit: int = 50, after: str | None = None
+) -> list[RoutingRule]:
+    async with pool.acquire() as conn:
+        return await queries.list_routing_rules(conn, limit=limit, after=after)
+
+
+async def update_routing_rule(
+    pool: asyncpg.Pool[Any],
+    rule_id: str,
+    *,
+    target: str | None = None,
+    session_params: SessionParams | None = None,
+) -> RoutingRule:
+    if target is not None or session_params is not None:
+        async with pool.acquire() as conn:
+            current = await queries.get_routing_rule(conn, rule_id)
+        new_target = target if target is not None else current.target
+        new_params = session_params if session_params is not None else current.session_params
+        _validate_rule_target(new_target, new_params)
+
+    async with pool.acquire() as conn:
+        return await queries.update_routing_rule(
+            conn,
+            rule_id,
+            target=target,
+            session_params=session_params,
+        )
+
+
+async def archive_routing_rule(pool: asyncpg.Pool[Any], rule_id: str) -> RoutingRule:
+    async with pool.acquire() as conn:
+        return await queries.archive_routing_rule(conn, rule_id)
+
+
+# ─── binding CRUD ───────────────────────────────────────────────────────────
+
+
+async def create_binding(
+    pool: asyncpg.Pool[Any], *, address: str, session_id: str
+) -> ChannelBinding:
+    async with pool.acquire() as conn:
+        return await queries.insert_binding(conn, address=address, session_id=session_id)
+
+
+async def get_binding(pool: asyncpg.Pool[Any], binding_id: str) -> ChannelBinding:
+    async with pool.acquire() as conn:
+        return await queries.get_binding(conn, binding_id)
+
+
+async def list_bindings(
+    pool: asyncpg.Pool[Any],
+    *,
+    session_id: str | None = None,
+    limit: int = 50,
+    after: str | None = None,
+) -> list[ChannelBinding]:
+    async with pool.acquire() as conn:
+        return await queries.list_bindings(conn, session_id=session_id, limit=limit, after=after)
+
+
+async def archive_binding(pool: asyncpg.Pool[Any], binding_id: str) -> ChannelBinding:
+    async with pool.acquire() as conn:
+        return await queries.archive_binding(conn, binding_id)
+
+
+# ─── resolve_channel ────────────────────────────────────────────────────────
+
+
+@dataclass(slots=True)
+class ResolveResult:
+    session_id: str
+    binding_id: str
+    created_session: bool
+
+
+def _render_title(template: str | None, address: str) -> str | None:
+    """Substitute ``{address}`` in a session-title template."""
+    if template is None:
+        return None
+    return template.replace("{address}", address)
+
+
+async def resolve_channel(pool: asyncpg.Pool[Any], address: str) -> ResolveResult:
+    """Resolve a channel address to a session, creating one if a rule matches.
+
+    Runs the binding lookup, rule match, optional session creation, and
+    binding insert under a single transaction so the binding's FK to
+    ``sessions.id`` is satisfied atomically.
+    """
+    async with pool.acquire() as conn, conn.transaction():
+        existing = await queries.get_binding_by_address(conn, address)
+        if existing is not None:
+            return ResolveResult(
+                session_id=existing.session_id,
+                binding_id=existing.id,
+                created_session=False,
+            )
+
+        rule = await queries.find_matching_rule(conn, address)
+        if rule is None:
+            raise NoRouteError(
+                f"no binding or rule matches address {address}",
+                detail={"address": address},
+            )
+
+        target = parse_target(rule.target)
+
+        if isinstance(target, SessionTarget):
+            # Verify the session exists (raises NotFoundError otherwise).
+            session = await queries.get_session(conn, target.session_id)
+            session_id = session.id
+            created = False
+        else:
+            # agent: target — spin up a fresh session.
+            # Validation at create/update guarantees environment_id is set.
+            assert rule.session_params.environment_id is not None
+            session = await queries.insert_session(
+                conn,
+                agent_id=target.agent_id,
+                agent_version=target.agent_version,
+                environment_id=rule.session_params.environment_id,
+                title=_render_title(rule.session_params.title, address),
+                metadata=rule.session_params.metadata,
+            )
+            if rule.session_params.vault_ids:
+                await queries.set_session_vaults(conn, session.id, rule.session_params.vault_ids)
+            session_id = session.id
+            created = True
+
+        binding = await queries.insert_binding(conn, address=address, session_id=session_id)
+        return ResolveResult(
+            session_id=session_id,
+            binding_id=binding.id,
+            created_session=created,
+        )

--- a/src/aios/services/channels.py
+++ b/src/aios/services/channels.py
@@ -228,13 +228,20 @@ async def resolve_channel(pool: asyncpg.Pool[Any], address: str) -> ResolveResul
     ``sessions.id`` is satisfied atomically.
     """
     async with pool.acquire() as conn, conn.transaction():
-        # Serialize concurrent first-time resolves of the same address.
-        # Without this, two simultaneous misses both insert sessions and
-        # the second insert_binding fails on the unique index — a spurious
-        # 409 from the connector's perspective.  Advisory lock is per-
-        # address (not global) and releases automatically on commit.
-        await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", address)
+        # Optimistic path: most resolves are binding hits and need no lock.
+        existing = await queries.get_binding_by_address(conn, address)
+        if existing is not None:
+            return ResolveResult(
+                session_id=existing.session_id,
+                binding_id=existing.id,
+                created_session=False,
+            )
 
+        # Miss — take a per-address advisory lock so concurrent first-time
+        # resolves of the same address don't both reach insert_binding and
+        # spuriously 409.  Re-check the binding after acquiring it: another
+        # transaction may have inserted one while we were waiting.
+        await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", address)
         existing = await queries.get_binding_by_address(conn, address)
         if existing is not None:
             return ResolveResult(

--- a/src/aios/services/channels.py
+++ b/src/aios/services/channels.py
@@ -27,7 +27,7 @@ from typing import Any, Literal
 import asyncpg
 
 from aios.db import queries
-from aios.errors import NoRouteError, ValidationError
+from aios.errors import NoRouteError, NotFoundError, ValidationError
 from aios.models.channel_bindings import ChannelBinding
 from aios.models.routing_rules import RoutingRule, SessionParams
 
@@ -262,8 +262,14 @@ async def resolve_channel(pool: asyncpg.Pool[Any], address: str) -> ResolveResul
         target = parse_target(rule.target)
 
         if isinstance(target, SessionTarget):
-            # Verify the session exists (raises NotFoundError otherwise).
+            # Verify the session exists and is not archived — binding to
+            # an archived session would silently resurrect activity on it.
             session = await queries.get_session(conn, target.session_id)
+            if session.archived_at is not None:
+                raise NotFoundError(
+                    f"session {target.session_id} is archived",
+                    detail={"id": target.session_id},
+                )
             session_id = session.id
             created = False
         else:

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -1,0 +1,71 @@
+"""Business logic for connection resources.
+
+Thin wrapper over :mod:`aios.db.queries` — connections themselves carry
+no business rules at this phase. The actual routing logic lives in
+:mod:`aios.services.channels`; the inbound-message endpoint composes
+this service with that one.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from aios.db import queries
+from aios.models.connections import Connection
+
+
+async def create_connection(
+    pool: asyncpg.Pool[Any],
+    *,
+    connector: str,
+    account: str,
+    mcp_url: str,
+    vault_id: str,
+    metadata: dict[str, Any],
+) -> Connection:
+    async with pool.acquire() as conn:
+        return await queries.insert_connection(
+            conn,
+            connector=connector,
+            account=account,
+            mcp_url=mcp_url,
+            vault_id=vault_id,
+            metadata=metadata,
+        )
+
+
+async def get_connection(pool: asyncpg.Pool[Any], connection_id: str) -> Connection:
+    async with pool.acquire() as conn:
+        return await queries.get_connection(conn, connection_id)
+
+
+async def list_connections(
+    pool: asyncpg.Pool[Any], *, limit: int = 50, after: str | None = None
+) -> list[Connection]:
+    async with pool.acquire() as conn:
+        return await queries.list_connections(conn, limit=limit, after=after)
+
+
+async def update_connection(
+    pool: asyncpg.Pool[Any],
+    connection_id: str,
+    *,
+    mcp_url: str | None = None,
+    vault_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Connection:
+    async with pool.acquire() as conn:
+        return await queries.update_connection(
+            conn,
+            connection_id,
+            mcp_url=mcp_url,
+            vault_id=vault_id,
+            metadata=metadata,
+        )
+
+
+async def archive_connection(pool: asyncpg.Pool[Any], connection_id: str) -> Connection:
+    async with pool.acquire() as conn:
+        return await queries.archive_connection(conn, connection_id)

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -13,7 +13,6 @@ from typing import Any
 
 import asyncpg
 
-from aios.config import get_settings
 from aios.db import queries
 from aios.models.events import Event, EventKind
 from aios.models.sessions import Session, SessionStatus
@@ -37,39 +36,16 @@ async def create_session(
     whatever version of the agent is current at step time.
     """
     async with pool.acquire() as conn:
-        from aios.ids import SESSION, make_id
-
-        new_id = make_id(SESSION)
-        workspace_path = workspace_path or str(get_settings().workspace_root / new_id)
-
-        try:
-            row = await conn.fetchrow(
-                """
-                INSERT INTO sessions (
-                    id, agent_id, environment_id, agent_version, title, metadata,
-                    status, workspace_volume_path, env
-                )
-                VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'idle', $7, $8::jsonb)
-                RETURNING *
-                """,
-                new_id,
-                agent_id,
-                environment_id,
-                agent_version,
-                title,
-                json.dumps(metadata),
-                workspace_path,
-                json.dumps(env or {}),
-            )
-        except asyncpg.ForeignKeyViolationError as exc:
-            from aios.errors import NotFoundError
-
-            raise NotFoundError(
-                "agent or environment not found",
-                detail={"agent_id": agent_id, "environment_id": environment_id},
-            ) from exc
-        assert row is not None
-        session = queries._row_to_session(row)
+        session = await queries.insert_session(
+            conn,
+            agent_id=agent_id,
+            environment_id=environment_id,
+            agent_version=agent_version,
+            title=title,
+            metadata=metadata,
+            workspace_path=workspace_path,
+            env=env,
+        )
         if vault_ids:
             await queries.set_session_vaults(conn, session.id, vault_ids)
             session = session.model_copy(update={"vault_ids": vault_ids})

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -1,0 +1,476 @@
+"""E2E tests for the routing infrastructure (issue #30).
+
+Covers connection / channel binding / routing rule CRUD plus the
+``resolve_channel`` resolver and the ``POST /v1/connections/{id}/messages``
+inbound endpoint.  Runs against a real testcontainer Postgres with
+migrations applied.
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from aios.errors import ConflictError, NoRouteError, NotFoundError, ValidationError
+from aios.models.routing_rules import SessionParams
+
+
+def _uniq() -> str:
+    """Return a short hex string unique across the whole test session.
+
+    Tests share the same testcontainer DB, and ``id(pool)`` can collide
+    when fixtures churn pools — so use a fresh random suffix instead.
+    """
+    return secrets.token_hex(4)
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def env_id(pool: Any) -> str:
+    from aios.db import queries
+
+    async with pool.acquire() as conn:
+        env = await queries.insert_environment(conn, name=f"routing-test-{_uniq()}")
+    return env.id
+
+
+@pytest.fixture
+async def agent_id(pool: Any) -> str:
+    from aios.services import agents as svc
+
+    a = await svc.create_agent(
+        pool,
+        name=f"routing-agent-{_uniq()}",
+        model="openai/gpt-4o-mini",
+        system="",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    return a.id
+
+
+@pytest.fixture
+async def vault_id(pool: Any) -> str:
+    from aios.services import vaults as svc
+
+    v = await svc.create_vault(pool, display_name="routing-vault", metadata={})
+    return v.id
+
+
+# ─── connection CRUD ────────────────────────────────────────────────────────
+
+
+class TestConnectionCRUD:
+    async def test_create_and_get(self, pool: Any, vault_id: str) -> None:
+        from aios.services import connections as svc
+
+        c = await svc.create_connection(
+            pool,
+            connector="signal",
+            account=f"test-{_uniq()}",
+            mcp_url="https://mcp.example.com",
+            vault_id=vault_id,
+            metadata={"region": "us"},
+        )
+        assert c.id.startswith("conn_")
+        assert c.connector == "signal"
+        assert c.metadata == {"region": "us"}
+        assert c.archived_at is None
+
+        fetched = await svc.get_connection(pool, c.id)
+        assert fetched.id == c.id
+
+    async def test_unique_per_connector_account(self, pool: Any, vault_id: str) -> None:
+        from aios.services import connections as svc
+
+        account = f"dup-{_uniq()}"
+        await svc.create_connection(
+            pool,
+            connector="signal",
+            account=account,
+            mcp_url="https://m1",
+            vault_id=vault_id,
+            metadata={},
+        )
+        with pytest.raises(ConflictError):
+            await svc.create_connection(
+                pool,
+                connector="signal",
+                account=account,
+                mcp_url="https://m2",
+                vault_id=vault_id,
+                metadata={},
+            )
+
+    async def test_update_mcp_url(self, pool: Any, vault_id: str) -> None:
+        from aios.services import connections as svc
+
+        c = await svc.create_connection(
+            pool,
+            connector="signal",
+            account=f"upd-{_uniq()}",
+            mcp_url="https://old",
+            vault_id=vault_id,
+            metadata={},
+        )
+        updated = await svc.update_connection(pool, c.id, mcp_url="https://new")
+        assert updated.mcp_url == "https://new"
+
+    async def test_archive(self, pool: Any, vault_id: str) -> None:
+        from aios.services import connections as svc
+
+        account = f"arch-{_uniq()}"
+        c = await svc.create_connection(
+            pool,
+            connector="signal",
+            account=account,
+            mcp_url="https://m",
+            vault_id=vault_id,
+            metadata={},
+        )
+        archived = await svc.archive_connection(pool, c.id)
+        assert archived.archived_at is not None
+        # archived connection no longer counts towards uniqueness for the same (connector, account)
+        await svc.create_connection(
+            pool,
+            connector="signal",
+            account=account,
+            mcp_url="https://m2",
+            vault_id=vault_id,
+            metadata={},
+        )
+
+    async def test_unknown_vault(self, pool: Any) -> None:
+        from aios.services import connections as svc
+
+        with pytest.raises(NotFoundError):
+            await svc.create_connection(
+                pool,
+                connector="signal",
+                account=f"novault-{_uniq()}",
+                mcp_url="https://m",
+                vault_id="vlt_nonexistent",
+                metadata={},
+            )
+
+
+# ─── routing rule CRUD ──────────────────────────────────────────────────────
+
+
+class TestRoutingRuleCRUD:
+    async def test_create_agent_target(self, pool: Any, agent_id: str, env_id: str) -> None:
+        from aios.services import channels as svc
+
+        suffix = f"crud-{_uniq()}"
+        r = await svc.create_routing_rule(
+            pool,
+            prefix=f"signal/{suffix}",
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        assert r.id.startswith("rrul_")
+        assert r.target == f"agent:{agent_id}"
+
+    async def test_create_session_target_rejects_session_params(self, pool: Any) -> None:
+        from aios.services import channels as svc
+
+        with pytest.raises(ValidationError):
+            await svc.create_routing_rule(
+                pool,
+                prefix=f"signal/sess-bad-{_uniq()}",
+                target="session:sess_xxx",
+                session_params=SessionParams(environment_id="env_x"),
+            )
+
+    async def test_agent_target_requires_environment(self, pool: Any, agent_id: str) -> None:
+        from aios.services import channels as svc
+
+        with pytest.raises(ValidationError):
+            await svc.create_routing_rule(
+                pool,
+                prefix=f"signal/missing-env-{_uniq()}",
+                target=f"agent:{agent_id}",
+                session_params=SessionParams(),
+            )
+
+    async def test_invalid_target_string(self, pool: Any) -> None:
+        from aios.services import channels as svc
+
+        with pytest.raises(ValidationError):
+            await svc.create_routing_rule(
+                pool,
+                prefix=f"signal/bad-{_uniq()}",
+                target="garbage",
+                session_params=SessionParams(environment_id="env_x"),
+            )
+
+    async def test_unique_per_prefix(self, pool: Any, agent_id: str, env_id: str) -> None:
+        from aios.services import channels as svc
+
+        prefix = f"signal/uniq-{_uniq()}"
+        await svc.create_routing_rule(
+            pool,
+            prefix=prefix,
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        with pytest.raises(ConflictError):
+            await svc.create_routing_rule(
+                pool,
+                prefix=prefix,
+                target=f"agent:{agent_id}",
+                session_params=SessionParams(environment_id=env_id),
+            )
+
+    async def test_update_target(self, pool: Any, agent_id: str, env_id: str) -> None:
+        from aios.services import channels as svc
+
+        r = await svc.create_routing_rule(
+            pool,
+            prefix=f"signal/upd-{_uniq()}",
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        updated = await svc.update_routing_rule(pool, r.id, target=f"agent:{agent_id}@1")
+        assert updated.target == f"agent:{agent_id}@1"
+
+    async def test_archive(self, pool: Any, agent_id: str, env_id: str) -> None:
+        from aios.services import channels as svc
+
+        r = await svc.create_routing_rule(
+            pool,
+            prefix=f"signal/arch-{_uniq()}",
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        archived = await svc.archive_routing_rule(pool, r.id)
+        assert archived.archived_at is not None
+
+
+# ─── find_matching_rule ─────────────────────────────────────────────────────
+
+
+class TestFindMatchingRule:
+    async def test_exact_match(self, pool: Any, agent_id: str, env_id: str) -> None:
+        from aios.db import queries
+        from aios.services import channels as svc
+
+        prefix = f"fmr-{_uniq()}-exact"
+        await svc.create_routing_rule(
+            pool,
+            prefix=prefix,
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        async with pool.acquire() as conn:
+            r = await queries.find_matching_rule(conn, prefix)
+        assert r is not None
+        assert r.prefix == prefix
+
+    async def test_longer_prefix_wins(self, pool: Any, agent_id: str, env_id: str) -> None:
+        from aios.db import queries
+        from aios.services import channels as svc
+
+        suffix = _uniq()
+        await svc.create_routing_rule(
+            pool,
+            prefix=f"fmrl-{suffix}",
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        await svc.create_routing_rule(
+            pool,
+            prefix=f"fmrl-{suffix}/specific",
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        async with pool.acquire() as conn:
+            r = await queries.find_matching_rule(conn, f"fmrl-{suffix}/specific/x")
+        assert r is not None
+        assert r.prefix == f"fmrl-{suffix}/specific"
+
+    async def test_segment_aware(self, pool: Any, agent_id: str, env_id: str) -> None:
+        """``foo`` must NOT match ``foofoo`` — segment boundary required."""
+        from aios.db import queries
+        from aios.services import channels as svc
+
+        prefix = f"seg-{_uniq()}"
+        await svc.create_routing_rule(
+            pool,
+            prefix=prefix,
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        async with pool.acquire() as conn:
+            none_match = await queries.find_matching_rule(conn, f"{prefix}foo")
+            yes_match = await queries.find_matching_rule(conn, f"{prefix}/abc")
+        assert none_match is None
+        assert yes_match is not None
+
+    async def test_no_match_returns_none(self, pool: Any) -> None:
+        from aios.db import queries
+
+        async with pool.acquire() as conn:
+            r = await queries.find_matching_rule(conn, f"nope-{_uniq()}/x")
+        assert r is None
+
+
+# ─── resolve_channel ────────────────────────────────────────────────────────
+
+
+class TestResolveChannel:
+    async def test_existing_binding_short_circuits(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        from aios.services import channels as svc
+        from aios.services import sessions as sess_svc
+
+        s = await sess_svc.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+        )
+        address = f"manual-{_uniq()}/abc"
+        binding = await svc.create_binding(pool, address=address, session_id=s.id)
+
+        result = await svc.resolve_channel(pool, address)
+        assert result.session_id == s.id
+        assert result.binding_id == binding.id
+        assert result.created_session is False
+
+    async def test_session_target(self, pool: Any, agent_id: str, env_id: str) -> None:
+        from aios.services import channels as svc
+        from aios.services import sessions as sess_svc
+
+        s = await sess_svc.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+        )
+        prefix = f"st-{_uniq()}"
+        await svc.create_routing_rule(
+            pool,
+            prefix=prefix,
+            target=f"session:{s.id}",
+            session_params=SessionParams(),
+        )
+        result = await svc.resolve_channel(pool, f"{prefix}/whatever")
+        assert result.session_id == s.id
+        assert result.created_session is False
+
+    async def test_agent_target_creates_session(
+        self, pool: Any, agent_id: str, env_id: str, vault_id: str
+    ) -> None:
+        from aios.db import queries
+        from aios.services import channels as svc
+        from aios.services import sessions as sess_svc
+
+        prefix = f"at-{_uniq()}"
+        await svc.create_routing_rule(
+            pool,
+            prefix=prefix,
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(
+                environment_id=env_id,
+                vault_ids=[vault_id],
+                title="Routed: {address}",
+                metadata={"source": "rule"},
+            ),
+        )
+        address = f"{prefix}/chat-1"
+        result = await svc.resolve_channel(pool, address)
+        assert result.created_session is True
+
+        s = await sess_svc.get_session(pool, result.session_id)
+        assert s.title == f"Routed: {address}"
+        assert s.metadata == {"source": "rule"}
+        async with pool.acquire() as conn:
+            vids = await queries.get_session_vault_ids(conn, s.id)
+        assert vids == [vault_id]
+
+        # Second hit short-circuits via the binding now persisted.
+        again = await svc.resolve_channel(pool, address)
+        assert again.session_id == result.session_id
+        assert again.binding_id == result.binding_id
+        assert again.created_session is False
+
+    async def test_no_route_raises(self, pool: Any) -> None:
+        from aios.services import channels as svc
+
+        with pytest.raises(NoRouteError):
+            await svc.resolve_channel(pool, f"unrouted-{_uniq()}/x")
+
+
+# ─── inbound endpoint (drives the resolver via the service composition) ─────
+
+
+class TestInboundMessage:
+    async def test_happy_path_creates_session_and_stamps_metadata(
+        self, pool: Any, agent_id: str, env_id: str, vault_id: str
+    ) -> None:
+        from aios.db import queries
+        from aios.services import channels as ch_svc
+        from aios.services import connections as conn_svc
+        from aios.services import sessions as sess_svc
+
+        account = f"inbound-{_uniq()}"
+        connection = await conn_svc.create_connection(
+            pool,
+            connector="signal",
+            account=account,
+            mcp_url="https://m",
+            vault_id=vault_id,
+            metadata={},
+        )
+        await ch_svc.create_routing_rule(
+            pool,
+            prefix=f"signal/{account}",
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+
+        # Mirror the router's logic with defer_wake mocked out.
+        with mock.patch("aios.harness.wake.defer_wake") as fake_wake:
+            address = f"{connection.connector}/{connection.account}/chat-1"
+            resolution = await ch_svc.resolve_channel(pool, address)
+            event = await sess_svc.append_user_message(
+                pool,
+                resolution.session_id,
+                "hi",
+                metadata={"channel": address, "extra": "stuff"},
+            )
+            from aios.harness.wake import defer_wake
+
+            await defer_wake(resolution.session_id, cause="inbound_message")
+
+        assert resolution.created_session is True
+        assert event.data["metadata"]["channel"] == address
+        assert event.data["metadata"]["extra"] == "stuff"
+        assert event.data["content"] == "hi"
+        fake_wake.assert_awaited_once_with(resolution.session_id, cause="inbound_message")
+
+        # The event was actually persisted on the new session.
+        async with pool.acquire() as conn:
+            events = await queries.read_message_events(conn, resolution.session_id)
+        assert any(e.data.get("metadata", {}).get("channel") == address for e in events)

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -421,6 +421,50 @@ class TestFindMatchingRule:
         assert r is not None
         assert r.prefix == f"l-{suffix}/b/c"
 
+    async def test_underscore_in_prefix_treated_literally(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        """LIKE meta-characters (``_``, ``%``) in prefix must NOT act as
+        wildcards.  Without proper handling, prefix ``foo_bar`` would
+        wrongly match address ``fooXbar/baz`` (LIKE's ``_`` matches any
+        single char).
+        """
+        from aios.db import queries
+        from aios.services import channels as svc
+
+        suffix = _uniq()
+        await svc.create_routing_rule(
+            pool,
+            prefix=f"fo_bar-{suffix}",
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        async with pool.acquire() as conn:
+            wrong = await queries.find_matching_rule(conn, f"fooXbar-{suffix}/x")
+            right = await queries.find_matching_rule(conn, f"fo_bar-{suffix}/x")
+        assert wrong is None
+        assert right is not None
+
+    async def test_percent_in_prefix_treated_literally(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        """LIKE's ``%`` (any-string) must not wildcard either."""
+        from aios.db import queries
+        from aios.services import channels as svc
+
+        suffix = _uniq()
+        await svc.create_routing_rule(
+            pool,
+            prefix=f"fo%bar-{suffix}",
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        async with pool.acquire() as conn:
+            wrong = await queries.find_matching_rule(conn, f"fooXXXbar-{suffix}/x")
+            right = await queries.find_matching_rule(conn, f"fo%bar-{suffix}/x")
+        assert wrong is None
+        assert right is not None
+
 
 # ─── resolve_channel ────────────────────────────────────────────────────────
 
@@ -633,6 +677,34 @@ class TestResolveChannel:
             session_params=SessionParams(),
         )
         with pytest.raises(NotFoundError):
+            await svc.resolve_channel(pool, f"{prefix}/x")
+
+    async def test_session_target_with_archived_session_raises(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        """A rule pointing at an archived session must fail loudly rather
+        than silently re-binding to it.
+        """
+        from aios.services import channels as svc
+        from aios.services import sessions as sess_svc
+
+        s = await sess_svc.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+        )
+        await sess_svc.archive_session(pool, s.id)
+
+        prefix = f"st-arch-{_uniq()}"
+        await svc.create_routing_rule(
+            pool,
+            prefix=prefix,
+            target=f"session:{s.id}",
+            session_params=SessionParams(),
+        )
+        with pytest.raises(NotFoundError, match="archived"):
             await svc.resolve_channel(pool, f"{prefix}/x")
 
     async def test_invalid_vault_id_in_session_params_rolls_back(

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -13,6 +13,7 @@ from collections.abc import AsyncIterator
 from typing import Any
 from unittest import mock
 
+import httpx
 import pytest
 
 from aios.errors import ConflictError, NoRouteError, NotFoundError, ValidationError
@@ -263,6 +264,59 @@ class TestRoutingRuleCRUD:
         archived = await svc.archive_routing_rule(pool, r.id)
         assert archived.archived_at is not None
 
+    async def test_update_target_kind_flip_session_to_agent_re_validates(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        """Flipping session: → agent: without supplying environment_id must
+        be rejected — even though the field being updated (target) was
+        valid in isolation, the merged combination is not.
+        """
+        from aios.services import channels as svc
+        from aios.services import sessions as sess_svc
+
+        s = await sess_svc.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+        )
+        r = await svc.create_routing_rule(
+            pool,
+            prefix=f"flip-{_uniq()}",
+            target=f"session:{s.id}",
+            session_params=SessionParams(),
+        )
+        with pytest.raises(ValidationError, match="environment_id"):
+            await svc.update_routing_rule(pool, r.id, target=f"agent:{agent_id}")
+
+    async def test_update_session_params_on_session_target_re_validates(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        """Adding session_params to a session:-target rule must be rejected
+        even though the rule's existing target wasn't touched.
+        """
+        from aios.services import channels as svc
+        from aios.services import sessions as sess_svc
+
+        s = await sess_svc.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+        )
+        r = await svc.create_routing_rule(
+            pool,
+            prefix=f"sp-{_uniq()}",
+            target=f"session:{s.id}",
+            session_params=SessionParams(),
+        )
+        with pytest.raises(ValidationError, match="empty session_params"):
+            await svc.update_routing_rule(
+                pool, r.id, session_params=SessionParams(environment_id=env_id)
+            )
+
 
 # ─── find_matching_rule ─────────────────────────────────────────────────────
 
@@ -330,6 +384,42 @@ class TestFindMatchingRule:
         async with pool.acquire() as conn:
             r = await queries.find_matching_rule(conn, f"nope-{_uniq()}/x")
         assert r is None
+
+    async def test_archived_rule_excluded(self, pool: Any, agent_id: str, env_id: str) -> None:
+        from aios.db import queries
+        from aios.services import channels as svc
+
+        prefix = f"arch-rule-{_uniq()}"
+        rule = await svc.create_routing_rule(
+            pool,
+            prefix=prefix,
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        await svc.archive_routing_rule(pool, rule.id)
+        async with pool.acquire() as conn:
+            r = await queries.find_matching_rule(conn, f"{prefix}/x")
+        assert r is None
+
+    async def test_three_level_longest_prefix_wins(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        """At three nested levels, the deepest matching prefix still wins."""
+        from aios.db import queries
+        from aios.services import channels as svc
+
+        suffix = _uniq()
+        for prefix in (f"l-{suffix}", f"l-{suffix}/b", f"l-{suffix}/b/c"):
+            await svc.create_routing_rule(
+                pool,
+                prefix=prefix,
+                target=f"agent:{agent_id}",
+                session_params=SessionParams(environment_id=env_id),
+            )
+        async with pool.acquire() as conn:
+            r = await queries.find_matching_rule(conn, f"l-{suffix}/b/c/x")
+        assert r is not None
+        assert r.prefix == f"l-{suffix}/b/c"
 
 
 # ─── resolve_channel ────────────────────────────────────────────────────────
@@ -421,6 +511,163 @@ class TestResolveChannel:
         with pytest.raises(NoRouteError):
             await svc.resolve_channel(pool, f"unrouted-{_uniq()}/x")
 
+    async def test_concurrent_resolve_same_address_returns_same_session(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        """Two simultaneous first-time resolves on the same address must
+        agree on the session — no spurious unique-violation conflict, no
+        orphan session.  Regression test for the resolve_channel race
+        flagged in PR #32 review.
+        """
+        import asyncio
+
+        from aios.services import channels as svc
+
+        prefix = f"race-{_uniq()}"
+        await svc.create_routing_rule(
+            pool,
+            prefix=prefix,
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        address = f"{prefix}/chat-1"
+
+        results = await asyncio.gather(
+            svc.resolve_channel(pool, address),
+            svc.resolve_channel(pool, address),
+        )
+        assert results[0].session_id == results[1].session_id
+        assert results[0].binding_id == results[1].binding_id
+        # exactly one resolve actually created the session
+        assert sum(r.created_session for r in results) == 1
+
+        # exactly one binding row exists for this address
+        async with pool.acquire() as conn:
+            count = await conn.fetchval(
+                "SELECT count(*) FROM channel_bindings WHERE address = $1 AND archived_at IS NULL",
+                address,
+            )
+        assert count == 1
+
+    async def test_concurrent_resolve_different_addresses_do_not_block(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        """The advisory lock must be per-address, not global — concurrent
+        resolves for distinct addresses run in parallel without contention.
+        """
+        import asyncio
+
+        from aios.services import channels as svc
+
+        suffix = _uniq()
+        await svc.create_routing_rule(
+            pool,
+            prefix=f"par-{suffix}",
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+
+        results = await asyncio.gather(
+            svc.resolve_channel(pool, f"par-{suffix}/a"),
+            svc.resolve_channel(pool, f"par-{suffix}/b"),
+        )
+        assert results[0].session_id != results[1].session_id
+        assert all(r.created_session for r in results)
+
+    async def test_falls_through_archived_binding(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        """An archived binding must NOT short-circuit; the resolver should
+        consult routing rules and create a fresh session/binding.
+        """
+        from aios.services import channels as svc
+        from aios.services import sessions as sess_svc
+
+        prefix = f"arch-bind-{_uniq()}"
+        await svc.create_routing_rule(
+            pool,
+            prefix=prefix,
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        old_session = await sess_svc.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+        )
+        address = f"{prefix}/x"
+        old_binding = await svc.create_binding(pool, address=address, session_id=old_session.id)
+        await svc.archive_binding(pool, old_binding.id)
+
+        result = await svc.resolve_channel(pool, address)
+        assert result.session_id != old_session.id
+        assert result.created_session is True
+
+    async def test_agent_version_propagated_to_session(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        from aios.services import channels as svc
+        from aios.services import sessions as sess_svc
+
+        prefix = f"av-{_uniq()}"
+        await svc.create_routing_rule(
+            pool,
+            prefix=prefix,
+            target=f"agent:{agent_id}@1",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        result = await svc.resolve_channel(pool, f"{prefix}/x")
+        s = await sess_svc.get_session(pool, result.session_id)
+        assert s.agent_version == 1
+
+    async def test_session_target_with_missing_session_raises(self, pool: Any) -> None:
+        from aios.services import channels as svc
+
+        prefix = f"st-missing-{_uniq()}"
+        await svc.create_routing_rule(
+            pool,
+            prefix=prefix,
+            target="session:sess_does_not_exist",
+            session_params=SessionParams(),
+        )
+        with pytest.raises(NotFoundError):
+            await svc.resolve_channel(pool, f"{prefix}/x")
+
+    async def test_invalid_vault_id_in_session_params_rolls_back(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        """If session_params.vault_ids points at a missing vault, the whole
+        resolve transaction must roll back — no orphan session row, no
+        orphan binding row.
+        """
+        from aios.services import channels as svc
+
+        prefix = f"badvlt-{_uniq()}"
+        await svc.create_routing_rule(
+            pool,
+            prefix=prefix,
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(
+                environment_id=env_id,
+                vault_ids=["vlt_does_not_exist"],
+            ),
+        )
+        address = f"{prefix}/x"
+        with pytest.raises(NotFoundError):
+            await svc.resolve_channel(pool, address)
+
+        async with pool.acquire() as conn:
+            binding_count = await conn.fetchval(
+                "SELECT count(*) FROM channel_bindings WHERE address = $1",
+                address,
+            )
+            # We can't directly query for the orphan session by FK, but we can
+            # verify no session has a title that would have come from this rule.
+            # Easier: just check that no binding was inserted.
+        assert binding_count == 0
+
 
 # ─── inbound endpoint (drives the resolver via the service composition) ─────
 
@@ -474,3 +721,167 @@ class TestInboundMessage:
         async with pool.acquire() as conn:
             events = await queries.read_message_events(conn, resolution.session_id)
         assert any(e.data.get("metadata", {}).get("channel") == address for e in events)
+
+
+# ─── HTTP-level coverage of the inbound endpoint ────────────────────────────
+
+
+@pytest.fixture
+async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    """First HTTP-level test fixture in the codebase.
+
+    Builds the FastAPI app with our testcontainer pool wired straight into
+    ``app.state`` (skipping the lifespan, which would create its own pool).
+    Mocks ``defer_wake`` for the fixture's lifetime so the inbound handler
+    doesn't need a procrastinate worker.
+    """
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    settings = get_settings()
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    transport = httpx.ASGITransport(app=app)
+    with mock.patch("aios.api.routers.connections.defer_wake", new_callable=mock.AsyncMock):
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            headers={"Authorization": f"Bearer {aios_env['AIOS_API_KEY']}"},
+        ) as client:
+            yield client
+
+
+class TestInboundEndpoint:
+    async def _setup_routed(
+        self,
+        http_client: httpx.AsyncClient,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> tuple[str, str, str]:
+        """Create a connection + matching rule. Returns (connection_id, account, prefix)."""
+        account = f"http-{_uniq()}"
+        r = await http_client.post(
+            "/v1/connections",
+            json={
+                "connector": "signal",
+                "account": account,
+                "mcp_url": "https://m",
+                "vault_id": vault_id,
+            },
+        )
+        assert r.status_code == 201, r.text
+        connection_id = r.json()["id"]
+
+        r = await http_client.post(
+            "/v1/routing-rules",
+            json={
+                "prefix": f"signal/{account}",
+                "target": f"agent:{agent_id}",
+                "session_params": {"environment_id": env_id},
+            },
+        )
+        assert r.status_code == 201, r.text
+        return connection_id, account, f"signal/{account}"
+
+    async def test_happy_path_201_and_persists_metadata_channel(
+        self,
+        http_client: httpx.AsyncClient,
+        pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        from aios.db import queries
+
+        connection_id, _account, prefix = await self._setup_routed(
+            http_client, agent_id, env_id, vault_id
+        )
+
+        r = await http_client.post(
+            f"/v1/connections/{connection_id}/messages",
+            json={"path": "chat-1", "content": "hi"},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["created_session"] is True
+        assert body["session_id"].startswith("sess_")
+        assert body["event_id"].startswith("evt_")
+
+        # Channel metadata is on the persisted event.
+        expected_address = f"{prefix}/chat-1"
+        async with pool.acquire() as conn:
+            events = await queries.read_message_events(conn, body["session_id"])
+        msg = events[-1]
+        assert msg.data["content"] == "hi"
+        assert msg.data["metadata"]["channel"] == expected_address
+
+        # Second post short-circuits via the binding.
+        r2 = await http_client.post(
+            f"/v1/connections/{connection_id}/messages",
+            json={"path": "chat-1", "content": "again"},
+        )
+        assert r2.status_code == 201
+        body2 = r2.json()
+        assert body2["session_id"] == body["session_id"]
+        assert body2["created_session"] is False
+
+    async def test_unknown_connection_returns_404(self, http_client: httpx.AsyncClient) -> None:
+        r = await http_client.post(
+            "/v1/connections/conn_does_not_exist/messages",
+            json={"path": "chat-1", "content": "hi"},
+        )
+        assert r.status_code == 404
+        assert r.json()["error"]["type"] == "not_found"
+
+    async def test_no_route_returns_404_with_no_route_envelope(
+        self, http_client: httpx.AsyncClient, vault_id: str
+    ) -> None:
+        # Connection exists but no rule matches the resulting address.
+        account = f"unrouted-{_uniq()}"
+        r = await http_client.post(
+            "/v1/connections",
+            json={
+                "connector": "signal",
+                "account": account,
+                "mcp_url": "https://m",
+                "vault_id": vault_id,
+            },
+        )
+        connection_id = r.json()["id"]
+
+        r = await http_client.post(
+            f"/v1/connections/{connection_id}/messages",
+            json={"path": "chat-1", "content": "hi"},
+        )
+        assert r.status_code == 404
+        body = r.json()
+        assert body["error"]["type"] == "no_route"
+        assert "address" in body["error"].get("detail", {})
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        ["", "/x", "x/", "x//y", "x/../y", ".."],
+    )
+    async def test_malformed_path_returns_422(
+        self,
+        http_client: httpx.AsyncClient,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+        bad_path: str,
+    ) -> None:
+        connection_id, _account, _prefix = await self._setup_routed(
+            http_client, agent_id, env_id, vault_id
+        )
+        r = await http_client.post(
+            f"/v1/connections/{connection_id}/messages",
+            json={"path": bad_path, "content": "hi"},
+        )
+        assert r.status_code == 422, (bad_path, r.text)
+        assert r.json()["error"]["type"] == "validation_error"

--- a/tests/unit/test_parse_target.py
+++ b/tests/unit/test_parse_target.py
@@ -1,0 +1,63 @@
+"""Pure-unit tests for routing-rule target parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.services.channels import (
+    AgentTarget,
+    SessionTarget,
+    parse_target,
+)
+
+
+class TestParseAgentTarget:
+    def test_agent_no_version(self) -> None:
+        t = parse_target("agent:agent_01HQR2K7VXBZ9MNPL3WYCT8F")
+        assert isinstance(t, AgentTarget)
+        assert t.agent_id == "agent_01HQR2K7VXBZ9MNPL3WYCT8F"
+        assert t.agent_version is None
+
+    def test_agent_with_version(self) -> None:
+        t = parse_target("agent:agent_01HQR2K7VXBZ9MNPL3WYCT8F@7")
+        assert isinstance(t, AgentTarget)
+        assert t.agent_id == "agent_01HQR2K7VXBZ9MNPL3WYCT8F"
+        assert t.agent_version == 7
+
+    def test_agent_version_zero(self) -> None:
+        t = parse_target("agent:abc@0")
+        assert isinstance(t, AgentTarget)
+        assert t.agent_version == 0
+
+    def test_agent_id_with_underscores_preserved(self) -> None:
+        t = parse_target("agent:agent_abc_def")
+        assert isinstance(t, AgentTarget)
+        assert t.agent_id == "agent_abc_def"
+
+
+class TestParseSessionTarget:
+    def test_session(self) -> None:
+        t = parse_target("session:sess_01HQR2K7VXBZ9MNPL3WYCT8F")
+        assert isinstance(t, SessionTarget)
+        assert t.session_id == "sess_01HQR2K7VXBZ9MNPL3WYCT8F"
+
+
+class TestParseInvalidTargets:
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "agent:",
+            "session:",
+            "agent:abc@",
+            "agent:@7",
+            "agent:abc@notanint",
+            "agent:abc@1.0",
+            "foo:abc",
+            "abc",
+            "AGENT:abc",  # case-sensitive
+        ],
+    )
+    def test_rejects(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="invalid target"):
+            parse_target(bad)

--- a/tests/unit/test_routing_models.py
+++ b/tests/unit/test_routing_models.py
@@ -54,23 +54,20 @@ class TestConnectionCreate:
                 vault_id="vlt_abc",
             )
 
-    def test_rejects_slash_in_connector(self) -> None:
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("connector", "signal/x"), ("account", "alice/bob")],
+    )
+    def test_rejects_slash(self, field: str, value: str) -> None:
+        kwargs: dict[str, str] = {
+            "connector": "signal",
+            "account": "alice",
+            "mcp_url": "https://m",
+            "vault_id": "vlt_abc",
+        }
+        kwargs[field] = value
         with pytest.raises(ValidationError, match="must not contain '/'"):
-            ConnectionCreate(
-                connector="signal/x",
-                account="alice",
-                mcp_url="https://m",
-                vault_id="vlt_abc",
-            )
-
-    def test_rejects_slash_in_account(self) -> None:
-        with pytest.raises(ValidationError, match="must not contain '/'"):
-            ConnectionCreate(
-                connector="signal",
-                account="alice/bob",
-                mcp_url="https://m",
-                vault_id="vlt_abc",
-            )
+            ConnectionCreate(**kwargs)  # type: ignore[arg-type]
 
 
 class TestConnectionUpdate:

--- a/tests/unit/test_routing_models.py
+++ b/tests/unit/test_routing_models.py
@@ -54,6 +54,24 @@ class TestConnectionCreate:
                 vault_id="vlt_abc",
             )
 
+    def test_rejects_slash_in_connector(self) -> None:
+        with pytest.raises(ValidationError, match="must not contain '/'"):
+            ConnectionCreate(
+                connector="signal/x",
+                account="alice",
+                mcp_url="https://m",
+                vault_id="vlt_abc",
+            )
+
+    def test_rejects_slash_in_account(self) -> None:
+        with pytest.raises(ValidationError, match="must not contain '/'"):
+            ConnectionCreate(
+                connector="signal",
+                account="alice/bob",
+                mcp_url="https://m",
+                vault_id="vlt_abc",
+            )
+
 
 class TestConnectionUpdate:
     def test_all_optional(self) -> None:

--- a/tests/unit/test_routing_models.py
+++ b/tests/unit/test_routing_models.py
@@ -1,0 +1,131 @@
+"""Pure-unit tests for routing Pydantic models (no DB)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aios.models.channel_bindings import ChannelBindingCreate
+from aios.models.connections import ConnectionCreate, ConnectionUpdate, InboundMessage
+from aios.models.routing_rules import (
+    RoutingRuleCreate,
+    RoutingRuleUpdate,
+    SessionParams,
+)
+
+
+class TestConnectionCreate:
+    def test_valid(self) -> None:
+        c = ConnectionCreate(
+            connector="signal",
+            account="alice",
+            mcp_url="https://mcp.example.com",
+            vault_id="vlt_abc",
+        )
+        assert c.connector == "signal"
+        assert c.metadata == {}
+
+    def test_with_metadata(self) -> None:
+        c = ConnectionCreate(
+            connector="signal",
+            account="alice",
+            mcp_url="https://mcp.example.com",
+            vault_id="vlt_abc",
+            metadata={"source": "manual"},
+        )
+        assert c.metadata == {"source": "manual"}
+
+    def test_rejects_extra(self) -> None:
+        with pytest.raises(ValidationError):
+            ConnectionCreate(
+                connector="signal",
+                account="alice",
+                mcp_url="https://m",
+                vault_id="vlt_abc",
+                bogus="x",  # type: ignore[call-arg]
+            )
+
+    def test_rejects_empty_connector(self) -> None:
+        with pytest.raises(ValidationError):
+            ConnectionCreate(
+                connector="",
+                account="alice",
+                mcp_url="https://m",
+                vault_id="vlt_abc",
+            )
+
+
+class TestConnectionUpdate:
+    def test_all_optional(self) -> None:
+        u = ConnectionUpdate()
+        assert u.mcp_url is None
+        assert u.vault_id is None
+        assert u.metadata is None
+
+    def test_rejects_connector_field(self) -> None:
+        # connector and account are immutable — Update doesn't accept them
+        with pytest.raises(ValidationError):
+            ConnectionUpdate(connector="signal")  # type: ignore[call-arg]
+
+
+class TestChannelBindingCreate:
+    def test_valid(self) -> None:
+        b = ChannelBindingCreate(address="signal/test/chat-1", session_id="sess_abc")
+        assert b.address == "signal/test/chat-1"
+
+    def test_rejects_empty_address(self) -> None:
+        with pytest.raises(ValidationError):
+            ChannelBindingCreate(address="", session_id="sess_abc")
+
+
+class TestSessionParams:
+    def test_defaults(self) -> None:
+        p = SessionParams()
+        assert p.environment_id is None
+        assert p.vault_ids == []
+        assert p.title is None
+        assert p.metadata == {}
+
+    def test_full(self) -> None:
+        p = SessionParams(
+            environment_id="env_xyz",
+            vault_ids=["vlt_a", "vlt_b"],
+            title="Signal: {address}",
+            metadata={"source": "rule"},
+        )
+        assert p.environment_id == "env_xyz"
+        assert p.vault_ids == ["vlt_a", "vlt_b"]
+
+
+class TestRoutingRuleCreate:
+    def test_valid(self) -> None:
+        r = RoutingRuleCreate(prefix="signal/test", target="agent:agent_x")
+        assert r.prefix == "signal/test"
+        assert r.target == "agent:agent_x"
+        assert r.session_params == SessionParams()
+
+    def test_rejects_empty_prefix(self) -> None:
+        with pytest.raises(ValidationError):
+            RoutingRuleCreate(prefix="", target="agent:x")
+
+    def test_rejects_empty_target(self) -> None:
+        with pytest.raises(ValidationError):
+            RoutingRuleCreate(prefix="x", target="")
+
+
+class TestRoutingRuleUpdate:
+    def test_all_optional(self) -> None:
+        u = RoutingRuleUpdate()
+        assert u.target is None
+        assert u.session_params is None
+
+
+class TestInboundMessage:
+    def test_minimal(self) -> None:
+        m = InboundMessage(path="chat-1", content="hi")
+        assert m.path == "chat-1"
+        assert m.metadata == {}
+
+    def test_rejects_extra(self) -> None:
+        with pytest.raises(ValidationError):
+            InboundMessage(path="x", content="y", bogus=1)  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

Phase 1 of the connectors/channels design. Adds the routing data model + resolver + inbound HTTP endpoint so external connectors will have something to address sessions through. No connector process exists yet — this slice is fully testable with curl.

- Three new resources: `connections`, `channel_bindings`, `routing_rules` (full CRUD + lists)
- `resolve_channel(address)` — explicit binding short-circuit → segment-aware longest-prefix rule match → optional session creation → binding insert, all in one transaction (per-address advisory lock prevents races on first-time inbound)
- `POST /v1/connections/{id}/messages` — builds the channel address, runs the resolver, appends a user-message event with `metadata.channel` stamped, defers a wake job

Closes #30. Child of #29.

## Review-round-2 changes (commit 2)

The first commit's review surfaced one blocking concurrency bug + a few hygiene items. Addressed in the follow-up commit:

- **Race fix**: `pg_advisory_xact_lock(hashtext($1))` at the top of the `resolve_channel` transaction. Two concurrent first-time resolves of the same address used to spuriously 409 (second `insert_binding` failed on the unique index); now they serialize per-address and both return the same `session_id`. Regression covered by `test_concurrent_resolve_same_address_returns_same_session` (verified to fail without the lock) plus `test_concurrent_resolve_different_addresses_do_not_block` (proves the lock is per-address, not global).
- **Address segment hygiene**: `ConnectionCreate.connector` and `.account` now reject `/` (would break segment boundaries); inbound `path` validation now rejects empty interior segments and `..` in addition to leading/trailing slashes.
- **Archive divergence documented**: each new router has a module-level docstring noting `DELETE` is soft-archive only and *why* there's no hard-delete (different reason per resource).
- **Testing gap closeout**: I missed several adversarial / edge cases the first time. Filled in: archived rules excluded from matching, three-level longest-prefix wins, archived binding falls through to rule, `agent_version` propagates through resolve to the session, missing `session:` target raises `NotFoundError`, invalid vault FK rolls back atomically with no orphan binding/session, and cross-field re-validation when flipping target kind on update.
- **First HTTP-level tests in the codebase**: `TestInboundEndpoint` exercises the actual FastAPI router via `httpx.AsyncClient` — 201 happy path with `metadata.channel` persisted, 404 on unknown connection, 404 with `no_route` envelope, 422 on each malformed path shape. The fixture is reusable for future PRs that want HTTP coverage.

## Deviations from the issue spec

A few intentional deviations, all in the direction of fitting the spec to existing codebase conventions:

1. **Test layout follows the project convention, not the spec.** The issue listed all six test files under `tests/unit/`, but in this repo `tests/unit/` is reserved for pure-unit tests (no Docker, runs in <1s) and DB-backed tests live in `tests/e2e/`. So the split is:
   - `tests/unit/test_parse_target.py` — pure parser tests
   - `tests/unit/test_routing_models.py` — Pydantic model validators (including the new slash rejection)
   - `tests/e2e/test_routing.py` — one consolidated file with `TestConnectionCRUD`, `TestRoutingRuleCRUD`, `TestFindMatchingRule`, `TestResolveChannel`, `TestInboundMessage`, `TestInboundEndpoint` classes
2. **Pre-req refactor: extracted `queries.insert_session`.** The issue's pseudocode for `resolve_channel` calls `queries.insert_session(conn, ...)`, which didn't exist — that INSERT lived inline in `services.sessions.create_session`. I moved it into a new conn-first `queries.insert_session` so the resolver can create a session and a binding atomically inside one transaction. `services.create_session` now delegates to it; behavior unchanged (verified by the existing `tests/e2e/test_step_model.py` suite).
3. **`NoRouteError` is an `AiosError` subclass, not a bare `Exception`.** The spec showed `class NoRouteError(Exception): ...`. I made it `AiosError` with `error_type="no_route"`, `status_code=404` so the existing global handler in `src/aios/errors.py` renders the `{"error": {"type": "no_route", ...}}` envelope automatically — no inline HTTP translation needed.
4. **Update queries use `None`-means-"don't update", not `_UNSET`.** The spec showed `_UNSET` sentinels in the connection/rule update query signatures. I dropped them: every updatable column on these tables is `NOT NULL`, so there's no semantic difference between "not provided" and "set to null" — `None` is unambiguous. This matches `update_vault`'s style. (`_UNSET` is still used elsewhere — e.g. `update_session.title` and `agent_version` — where the underlying columns *are* nullable.)
5. **`update_routing_rule` re-validates the resulting combination, not just the diff.** The spec listed validation "at create/update" without spelling out cross-field re-checking on partial updates. I implemented update by reading the current row and merging in the proposed change, so e.g. mutating only `session_params` on a `session:`-target rule still trips the "session: targets must have empty session_params" check.
6. **Single migration `0015`, raw `op.execute("""…""")` (matches `0005_vaults.py`).** Verbatim DDL from the spec. `down_revision="0014"`. Up→down→up cycle verified clean against a fresh testcontainer.
7. **Soft-delete only on the new resources.** `DELETE /{id}` archives; there is no hard-delete endpoint. Vaults exposes both because vault credentials hold encrypted secrets that may need to be purged; routing/connection metadata is cheap to retain for audit. Documented inline in each new router's module docstring.

## Test plan

- [x] `uv run mypy src` clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` clean
- [x] `uv run pytest tests/unit -q` — 445 passed
- [x] `uv run pytest tests/e2e/test_routing.py -q` — 38 passed (CRUD + resolver + concurrency + cross-field-validation + HTTP-level)
- [x] regression — `tests/e2e/test_step_model.py` (47 tests) and `tests/e2e/test_vaults.py` still pass; the `create_session` refactor didn't move anything observable
- [x] Alembic upgrade → downgrade -1 → upgrade head cycle clean against a fresh testcontainer

## Curl smoke (the path connectors will exercise)

```
# 1. Create agent + environment + vault using existing endpoints
AG=$(curl -sX POST :8090/v1/agents -H "Authorization: Bearer $KEY" -d '{...}' | jq -r .id)
ENV=$(curl -sX POST :8090/v1/environments -H "Authorization: Bearer $KEY" -d '{...}' | jq -r .id)
VLT=$(curl -sX POST :8090/v1/vaults -H "Authorization: Bearer $KEY" -d '{...}' | jq -r .id)

# 2. Create connection
CONN=$(curl -sX POST :8090/v1/connections -H "Authorization: Bearer $KEY" -d "{\"connector\":\"signal\",\"account\":\"test\",\"mcp_url\":\"https://signal-mcp\",\"vault_id\":\"$VLT\"}" | jq -r .id)

# 3. Routing rule that auto-creates sessions for any address under signal/test
curl -sX POST :8090/v1/routing-rules -H "Authorization: Bearer $KEY" -d "{
  \"prefix\":\"signal/test\",
  \"target\":\"agent:$AG\",
  \"session_params\":{\"environment_id\":\"$ENV\",\"title\":\"Signal: {address}\"}
}"

# 4. Inbound message (this is what connectors will POST)
curl -sX POST :8090/v1/connections/$CONN/messages -H "Authorization: Bearer $KEY" -d '{"path":"chat-1","content":"hi"}'
# → {"session_id":"sess_...","event_id":"evt_...","created_session":true}

# 5. Verify the channel was stamped on the event
curl -s :8090/v1/sessions/$SID/events -H "Authorization: Bearer $KEY" | jq '.data[-1].data.metadata.channel'
# → "signal/test/chat-1"

# 6. Second POST short-circuits via the binding
curl -sX POST :8090/v1/connections/$CONN/messages -H "Authorization: Bearer $KEY" -d '{"path":"chat-1","content":"again"}'
# → same session_id, created_session: false
```

## Explicit non-goals (deferred to Phase 2+)

- **Routing is prefix-only in v1.** The umbrella issue (#29) mentions glob patterns; full glob support is deliberately deferred. The current `find_matching_rule` SQL is a good drop-in replacement target when we want it.
- The worker/harness does nothing new with bound-channel sessions: tool list unchanged, no context injection, no `INTERNAL_MONOLOGUE:` prefix.
- No connection-provided MCP — agent-declared `mcp_servers` unchanged.
- No agent-visible channel awareness beyond whatever it can infer from `metadata.channel` on user events.
- No connector process — Signal connector is Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
