### PR TITLE
feat: Phase 2 — agent awareness of bound channels

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1298,12 +1298,8 @@ async def resolve_vault_credential(
     vault_id: str,
     mcp_server_url: str,
 ) -> tuple[EncryptedBlob, str] | None:
-    """Look up an MCP credential in a specific vault by URL.
-
-    Targets a single vault directly — no ``session_vaults`` join.  Used by
-    :func:`aios.mcp.client.resolve_auth_for_url` when a URL is owned by a
-    registered connection (whose vault is fixed per-account).
-    """
+    """Look up an MCP credential in a specific vault by URL — no
+    ``session_vaults`` join."""
     row = await conn.fetchrow(
         """
         SELECT ciphertext, nonce, auth_type
@@ -1702,12 +1698,9 @@ async def get_connections_by_pairs(
     conn: asyncpg.Connection[Any],
     pairs: list[tuple[str, str]],
 ) -> list[Connection]:
-    """Batch-look-up active connections by ``(connector, account)`` pairs.
+    """Active connections where ``(connector, account)`` is in ``pairs``.
 
-    Returns connections where ``(connector, account)`` is in ``pairs`` and
-    ``archived_at IS NULL``. Empty ``pairs`` → empty list (no roundtrip).
-    Used by the step function to turn a session's bindings into the set
-    of connection-provided MCP URLs that belong to it.
+    Empty input → no roundtrip.
     """
     if not pairs:
         return []
@@ -1729,21 +1722,13 @@ async def get_connections_by_pairs(
 
 async def get_connection_vault_for_url(
     conn: asyncpg.Connection[Any], mcp_server_url: str
-) -> tuple[str, str] | None:
-    """Return ``(connection_id, vault_id)`` if ``mcp_server_url`` is owned
-    by an active connection, else ``None``.
-
-    Used by :func:`aios.mcp.client.resolve_auth_for_url` to give connection
-    auth precedence: a URL registered on a connection resolves through
-    that connection's vault rather than through ``session_vaults``.
-    """
-    row = await conn.fetchrow(
-        "SELECT id, vault_id FROM connections WHERE mcp_url = $1 AND archived_at IS NULL LIMIT 1",
+) -> str | None:
+    """Vault id of the active connection owning ``mcp_server_url``, else ``None``."""
+    val: str | None = await conn.fetchval(
+        "SELECT vault_id FROM connections WHERE mcp_url = $1 AND archived_at IS NULL LIMIT 1",
         mcp_server_url,
     )
-    if row is None:
-        return None
-    return row["id"], row["vault_id"]
+    return val
 
 
 async def archive_connection(conn: asyncpg.Connection[Any], connection_id: str) -> Connection:
@@ -1855,12 +1840,10 @@ async def list_bindings(
 async def list_session_bindings(
     conn: asyncpg.Connection[Any], session_id: str
 ) -> list[ChannelBinding]:
-    """Return every active binding for ``session_id``, unpaginated.
+    """Every active binding for ``session_id``, unpaginated.
 
-    Used by the step function (Phase 2, #31) to derive connection-provided
-    MCP URLs and to build the bound-channels block in the system prompt.
-    Distinct from :func:`list_bindings` which is paginated-by-id for CRUD
-    list endpoints — the step function wants them all in one shot.
+    Distinct from the paginated :func:`list_bindings` used by the CRUD
+    list endpoint — the step function wants them all in one shot.
     """
     rows = await conn.fetch(
         "SELECT * FROM channel_bindings WHERE session_id = $1 AND archived_at IS NULL ORDER BY id",

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1292,6 +1292,35 @@ async def batch_get_session_vault_ids(
 # ─── MCP credential resolution ───────────────────────────────────────────────
 
 
+async def resolve_vault_credential(
+    conn: asyncpg.Connection[Any],
+    *,
+    vault_id: str,
+    mcp_server_url: str,
+) -> tuple[EncryptedBlob, str] | None:
+    """Look up an MCP credential in a specific vault by URL.
+
+    Targets a single vault directly — no ``session_vaults`` join.  Used by
+    :func:`aios.mcp.client.resolve_auth_for_url` when a URL is owned by a
+    registered connection (whose vault is fixed per-account).
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT ciphertext, nonce, auth_type
+          FROM vault_credentials
+         WHERE vault_id = $1
+           AND mcp_server_url = $2
+           AND archived_at IS NULL
+         LIMIT 1
+        """,
+        vault_id,
+        mcp_server_url,
+    )
+    if row is None:
+        return None
+    return EncryptedBlob(ciphertext=row["ciphertext"], nonce=row["nonce"]), str(row["auth_type"])
+
+
 async def resolve_mcp_credential(
     conn: asyncpg.Connection[Any],
     session_id: str,

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1669,6 +1669,54 @@ async def update_connection(
     return _row_to_connection(row)
 
 
+async def get_connections_by_pairs(
+    conn: asyncpg.Connection[Any],
+    pairs: list[tuple[str, str]],
+) -> list[Connection]:
+    """Batch-look-up active connections by ``(connector, account)`` pairs.
+
+    Returns connections where ``(connector, account)`` is in ``pairs`` and
+    ``archived_at IS NULL``. Empty ``pairs`` → empty list (no roundtrip).
+    Used by the step function to turn a session's bindings into the set
+    of connection-provided MCP URLs that belong to it.
+    """
+    if not pairs:
+        return []
+    connectors = [p[0] for p in pairs]
+    accounts = [p[1] for p in pairs]
+    rows = await conn.fetch(
+        """
+        SELECT c.*
+          FROM connections c
+          JOIN unnest($1::text[], $2::text[]) AS p(connector, account)
+            ON c.connector = p.connector AND c.account = p.account
+         WHERE c.archived_at IS NULL
+        """,
+        connectors,
+        accounts,
+    )
+    return [_row_to_connection(r) for r in rows]
+
+
+async def get_connection_vault_for_url(
+    conn: asyncpg.Connection[Any], mcp_server_url: str
+) -> tuple[str, str] | None:
+    """Return ``(connection_id, vault_id)`` if ``mcp_server_url`` is owned
+    by an active connection, else ``None``.
+
+    Used by :func:`aios.mcp.client.resolve_auth_for_url` to give connection
+    auth precedence: a URL registered on a connection resolves through
+    that connection's vault rather than through ``session_vaults``.
+    """
+    row = await conn.fetchrow(
+        "SELECT id, vault_id FROM connections WHERE mcp_url = $1 AND archived_at IS NULL LIMIT 1",
+        mcp_server_url,
+    )
+    if row is None:
+        return None
+    return row["id"], row["vault_id"]
+
+
 async def archive_connection(conn: asyncpg.Connection[Any], connection_id: str) -> Connection:
     row = await conn.fetchrow(
         "UPDATE connections SET archived_at = now(), updated_at = now() "
@@ -1772,6 +1820,23 @@ async def list_bindings(
         f"ORDER BY id DESC LIMIT ${len(args)}"
     )
     rows = await conn.fetch(sql, *args)
+    return [_row_to_channel_binding(r) for r in rows]
+
+
+async def list_session_bindings(
+    conn: asyncpg.Connection[Any], session_id: str
+) -> list[ChannelBinding]:
+    """Return every active binding for ``session_id``, unpaginated.
+
+    Used by the step function (Phase 2, #31) to derive connection-provided
+    MCP URLs and to build the bound-channels block in the system prompt.
+    Distinct from :func:`list_bindings` which is paginated-by-id for CRUD
+    list endpoints — the step function wants them all in one shot.
+    """
+    rows = await conn.fetch(
+        "SELECT * FROM channel_bindings WHERE session_id = $1 AND archived_at IS NULL ORDER BY id",
+        session_id,
+    )
     return [_row_to_channel_binding(r) for r in rows]
 
 

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -1,8 +1,5 @@
-"""Phase 2 (#31) channel helpers: prompt augmentation, monologue prefix,
-and the bindings → connections translation.
-
-Kept deliberately small; the step function in :mod:`aios.harness.loop`
-composes these into the discovery + augmentation + append pipeline.
+"""Channel helpers: prompt augmentation, monologue prefix, and the
+bindings → connections translation.
 """
 
 from __future__ import annotations
@@ -13,61 +10,31 @@ import asyncpg
 
 from aios.db import queries
 from aios.models.channel_bindings import ChannelBinding
-from aios.models.connections import Connection
+from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX, Connection
 
-_MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE: "
-
-
-# ── connection_server_name ─────────────────────────────────────────────────
+MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE: "
 
 
 def connection_server_name(c: Connection) -> str:
-    """Deterministic, collision-free MCP server name for a connection.
+    return f"{CONNECTION_SERVER_NAME_PREFIX}{c.id}"
 
-    Uses the connection id directly — globally unique by construction,
-    no sanitization needed.  The tool name the model sees
-    (``mcp__conn_conn_01HQ…__send``) is less readable than
-    ``conn_signal_alice`` would be, but tool names are for the model,
-    not humans, and eliminating the connector/account string pair as a
-    collision source removes an entire class of bug by construction.
+
+async def list_bindings_and_connections(
+    pool: asyncpg.Pool[Any], session_id: str
+) -> tuple[list[ChannelBinding], list[Connection]]:
+    """Load the session's bindings and the distinct connections they
+    reference in a single pool acquisition.
     """
-    return f"conn_{c.id}"
-
-
-# ── bindings → connections ─────────────────────────────────────────────────
-
-
-async def connections_for_bindings(
-    pool: asyncpg.Pool[Any], bindings: list[ChannelBinding]
-) -> list[Connection]:
-    """Look up the distinct active connections referenced by a session's
-    bindings.
-
-    A binding address is ``{connector}/{account}/{path}`` — we extract
-    the leading ``(connector, account)`` pair, dedupe, and batch-look
-    them up in the connections table.  Bindings with malformed
-    addresses (fewer than two segments) are silently ignored; this is
-    defensive against bindings created out-of-band.
-    """
-    pairs: set[tuple[str, str]] = set()
-    for b in bindings:
-        parts = b.address.split("/", 2)
-        if len(parts) >= 2:
-            pairs.add((parts[0], parts[1]))
-    if not pairs:
-        return []
     async with pool.acquire() as conn:
-        return await queries.get_connections_by_pairs(conn, list(pairs))
-
-
-# ── system-prompt augmentation ─────────────────────────────────────────────
+        bindings = await queries.list_session_bindings(conn, session_id)
+        pairs = {
+            (parts[0], parts[1]) for b in bindings if len(parts := b.address.split("/", 2)) >= 2
+        }
+        connections = await queries.get_connections_by_pairs(conn, list(pairs)) if pairs else []
+    return bindings, connections
 
 
 def build_channels_system_block(bindings: list[ChannelBinding]) -> str:
-    """Build a natural-language block describing this session's bound
-    channels.  Returns an empty string when the session has no bindings
-    (so ``augment_with_channels`` is a no-op in that case).
-    """
     if not bindings:
         return ""
     lines = ["You are bound to the following channels:"]
@@ -77,18 +44,13 @@ def build_channels_system_block(bindings: list[ChannelBinding]) -> str:
     lines.append(
         "Use the appropriate connector tool to respond to each channel. "
         "Bare assistant text is not sent to any channel — it is internal "
-        "thinking and will be prefixed with 'INTERNAL_MONOLOGUE:' in your "
+        f"thinking and will be prefixed with {MONOLOGUE_PREFIX.strip()!r} in your "
         "conversation history as a reminder that it is not visible to users."
     )
     return "\n".join(lines)
 
 
 def augment_with_channels(base_system: str, bindings: list[ChannelBinding]) -> str:
-    """Append the bound-channels block to the agent's system prompt.
-
-    No-op when ``bindings`` is empty — the Phase-2 invariant is
-    "session with no bindings behaves identically to pre-Phase-2".
-    """
     block = build_channels_system_block(bindings)
     if not block:
         return base_system
@@ -97,38 +59,28 @@ def augment_with_channels(base_system: str, bindings: list[ChannelBinding]) -> s
     return block
 
 
-# ── INTERNAL_MONOLOGUE prefix ──────────────────────────────────────────────
-
-
 def _prefix_text(s: str) -> str:
-    return s if s.startswith(_MONOLOGUE_PREFIX) else _MONOLOGUE_PREFIX + s
+    return s if s.startswith(MONOLOGUE_PREFIX) else MONOLOGUE_PREFIX + s
 
 
 def apply_monologue_prefix(assistant_msg: dict[str, Any]) -> dict[str, Any]:
-    """Prefix every text segment of an assistant message's ``content``
-    with ``INTERNAL_MONOLOGUE:``.
+    """Prefix every text segment of an assistant message's content.
 
-    No-op when ``content`` is missing, ``None``, or empty.  Idempotent
-    on a per-segment basis — already-prefixed text is left as-is.
-    Returns a new dict; the input is not mutated.
-
-    Design intent: the prefix is persisted in the event log and shown
-    to the model on every subsequent step's context build — that IS
-    the teaching mechanism.  Do not strip on replay.
+    The prefix is persisted in the event log — the model seeing its
+    own prefix on every subsequent step IS the teaching mechanism.
+    Do not strip on replay.
     """
-    if "content" not in assistant_msg:
-        return assistant_msg
-    content = assistant_msg["content"]
+    content = assistant_msg.get("content")
     if not content:
         return assistant_msg
     if isinstance(content, str):
         return {**assistant_msg, "content": _prefix_text(content)}
     if isinstance(content, list):
-        new_blocks: list[Any] = []
-        for b in content:
-            if isinstance(b, dict) and b.get("type") == "text":
-                new_blocks.append({**b, "text": _prefix_text(b.get("text", ""))})
-            else:
-                new_blocks.append(b)
+        new_blocks: list[Any] = [
+            {**b, "text": _prefix_text(b.get("text", ""))}
+            if isinstance(b, dict) and b.get("type") == "text"
+            else b
+            for b in content
+        ]
         return {**assistant_msg, "content": new_blocks}
     return assistant_msg

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -1,0 +1,134 @@
+"""Phase 2 (#31) channel helpers: prompt augmentation, monologue prefix,
+and the bindings → connections translation.
+
+Kept deliberately small; the step function in :mod:`aios.harness.loop`
+composes these into the discovery + augmentation + append pipeline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from aios.db import queries
+from aios.models.channel_bindings import ChannelBinding
+from aios.models.connections import Connection
+
+_MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE: "
+
+
+# ── connection_server_name ─────────────────────────────────────────────────
+
+
+def connection_server_name(c: Connection) -> str:
+    """Deterministic, collision-free MCP server name for a connection.
+
+    Uses the connection id directly — globally unique by construction,
+    no sanitization needed.  The tool name the model sees
+    (``mcp__conn_conn_01HQ…__send``) is less readable than
+    ``conn_signal_alice`` would be, but tool names are for the model,
+    not humans, and eliminating the connector/account string pair as a
+    collision source removes an entire class of bug by construction.
+    """
+    return f"conn_{c.id}"
+
+
+# ── bindings → connections ─────────────────────────────────────────────────
+
+
+async def connections_for_bindings(
+    pool: asyncpg.Pool[Any], bindings: list[ChannelBinding]
+) -> list[Connection]:
+    """Look up the distinct active connections referenced by a session's
+    bindings.
+
+    A binding address is ``{connector}/{account}/{path}`` — we extract
+    the leading ``(connector, account)`` pair, dedupe, and batch-look
+    them up in the connections table.  Bindings with malformed
+    addresses (fewer than two segments) are silently ignored; this is
+    defensive against bindings created out-of-band.
+    """
+    pairs: set[tuple[str, str]] = set()
+    for b in bindings:
+        parts = b.address.split("/", 2)
+        if len(parts) >= 2:
+            pairs.add((parts[0], parts[1]))
+    if not pairs:
+        return []
+    async with pool.acquire() as conn:
+        return await queries.get_connections_by_pairs(conn, list(pairs))
+
+
+# ── system-prompt augmentation ─────────────────────────────────────────────
+
+
+def build_channels_system_block(bindings: list[ChannelBinding]) -> str:
+    """Build a natural-language block describing this session's bound
+    channels.  Returns an empty string when the session has no bindings
+    (so ``augment_with_channels`` is a no-op in that case).
+    """
+    if not bindings:
+        return ""
+    lines = ["You are bound to the following channels:"]
+    for b in bindings:
+        lines.append(f"  - {b.address}")
+    lines.append("")
+    lines.append(
+        "Use the appropriate connector tool to respond to each channel. "
+        "Bare assistant text is not sent to any channel — it is internal "
+        "thinking and will be prefixed with 'INTERNAL_MONOLOGUE:' in your "
+        "conversation history as a reminder that it is not visible to users."
+    )
+    return "\n".join(lines)
+
+
+def augment_with_channels(base_system: str, bindings: list[ChannelBinding]) -> str:
+    """Append the bound-channels block to the agent's system prompt.
+
+    No-op when ``bindings`` is empty — the Phase-2 invariant is
+    "session with no bindings behaves identically to pre-Phase-2".
+    """
+    block = build_channels_system_block(bindings)
+    if not block:
+        return base_system
+    if base_system:
+        return base_system + "\n\n" + block
+    return block
+
+
+# ── INTERNAL_MONOLOGUE prefix ──────────────────────────────────────────────
+
+
+def _prefix_text(s: str) -> str:
+    return s if s.startswith(_MONOLOGUE_PREFIX) else _MONOLOGUE_PREFIX + s
+
+
+def apply_monologue_prefix(assistant_msg: dict[str, Any]) -> dict[str, Any]:
+    """Prefix every text segment of an assistant message's ``content``
+    with ``INTERNAL_MONOLOGUE:``.
+
+    No-op when ``content`` is missing, ``None``, or empty.  Idempotent
+    on a per-segment basis — already-prefixed text is left as-is.
+    Returns a new dict; the input is not mutated.
+
+    Design intent: the prefix is persisted in the event log and shown
+    to the model on every subsequent step's context build — that IS
+    the teaching mechanism.  Do not strip on replay.
+    """
+    if "content" not in assistant_msg:
+        return assistant_msg
+    content = assistant_msg["content"]
+    if not content:
+        return assistant_msg
+    if isinstance(content, str):
+        return {**assistant_msg, "content": _prefix_text(content)}
+    if isinstance(content, list):
+        new_blocks: list[Any] = []
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "text":
+                new_blocks.append({**b, "text": _prefix_text(b.get("text", ""))})
+            else:
+                new_blocks.append(b)
+        return {**assistant_msg, "content": new_blocks}
+    return assistant_msg

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -16,7 +16,10 @@ MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE: "
 
 
 def connection_server_name(c: Connection) -> str:
-    return f"{CONNECTION_SERVER_NAME_PREFIX}{c.id}"
+    # c.id is "conn_<ULID>" — the ids.CONNECTION prefix is already the
+    # reserved namespace marker, so use it directly instead of stuttering.
+    assert c.id.startswith(CONNECTION_SERVER_NAME_PREFIX)
+    return c.id
 
 
 async def list_bindings_and_connections(

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -67,21 +67,10 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
     else:
         agent = await agents_service.get_agent(pool, session.agent_id)
 
-    # Load this session's bindings once.  Passed through to everything that
-    # needs it (MCP discovery, prompt augmentation, monologue prefix gate) —
-    # do NOT re-query inside helpers.
-    from aios.db import queries as _queries
-    from aios.harness.channels import connection_server_name, connections_for_bindings
+    from aios.harness.channels import connection_server_name, list_bindings_and_connections
 
-    async with pool.acquire() as _conn:
-        bindings = await _queries.list_session_bindings(_conn, session_id)
-    connections = await connections_for_bindings(pool, bindings)
+    bindings, connections = await list_bindings_and_connections(pool, session_id)
 
-    # Build MCP server map — agent-declared PLUS connection-provided.
-    # Needed for both confirmed-tool dispatch (below) and post-inference
-    # tool-call routing.  Connection-derived names (conn_<id>) cannot
-    # collide with agent-declared names (reserved prefix, enforced in
-    # the agent model).
     mcp_server_map: dict[str, str] = {s.name: s.url for s in agent.mcp_servers}
     for c in connections:
         mcp_server_map[connection_server_name(c)] = c.mcp_url
@@ -117,8 +106,6 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
         await skills_service.resolve_skill_refs(pool, agent.skills) if agent.skills else []
     )
     system_prompt = augment_system_prompt(agent.system, skill_versions)
-    # Appended after the skills block; no-op when the session has no bindings
-    # (preserves the "no bindings ⇒ identical behaviour" Phase-2 invariant).
     system_prompt = augment_with_channels(system_prompt, bindings)
 
     # Provision skill files to workspace (idempotent, host-side writes).
@@ -128,8 +115,6 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
     # Build context with pending-result synthesis.
     tools = to_openai_tools(agent.tools)
 
-    # Discover MCP tools from every source this session sees — agent-declared
-    # plus connection-provided (derived from bindings loaded above).
     if agent.mcp_servers or connections:
         mcp_tools = await discover_session_mcp_tools(pool, session_id, agent, connections)
         tools.extend(mcp_tools)
@@ -224,10 +209,6 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
         cache_creation_input_tokens=usage.get("cache_creation_input_tokens", 0),
     )
 
-    # INTERNAL_MONOLOGUE prefix, gated on the session having bindings.
-    # The prefix is persisted in the event log and shown to the model on
-    # every subsequent step's context build — that IS the teaching
-    # mechanism.  Do not strip on replay.
     if bindings:
         from aios.harness.channels import apply_monologue_prefix
 
@@ -371,32 +352,14 @@ async def discover_session_mcp_tools(
     agent: Any,
     connections: list[Any],
 ) -> list[dict[str, Any]]:
-    """Discover MCP tools from every source this session sees.
-
-    Two sources:
-
-    * **Agent-declared MCP**: entries in ``agent.mcp_servers`` whose
-      ``name`` matches an enabled ``mcp_toolset`` in ``agent.tools``.
-      Unchanged from the pre-Phase-2 behaviour.
-
-    * **Connection-provided MCP**: every :class:`Connection` whose
-      channel is bound to this session, passed in by the caller
-      (derived from ``list_session_bindings`` + ``connections_for_bindings``).
-      The server name uses :func:`aios.harness.channels.connection_server_name`
-      (``conn_<connection_id>``) so collisions with agent-declared names
-      are impossible by construction.
-
-    Auth for each URL is resolved via
-    :func:`aios.mcp.client.resolve_auth_for_url`, which checks the
-    connection-owned vault first and falls back to ``session_vaults``.
-    All discoveries run concurrently.
+    """Discover MCP tools from agent-declared servers (filtered by enabled
+    ``mcp_toolset`` entries) unioned with connection-provided servers.
     """
     import asyncio
 
     from aios.harness.channels import connection_server_name
     from aios.mcp.client import discover_mcp_tools, resolve_auth_for_url
 
-    # Collect (server_name, url) pairs from both sources.
     servers: list[tuple[str, str]] = []
 
     enabled_server_names: set[str] = set()

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -109,6 +109,7 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
         return
 
     # Resolve skills and augment system prompt.
+    from aios.harness.channels import augment_with_channels
     from aios.harness.skills import augment_system_prompt, provision_skill_files
     from aios.services import skills as skills_service
 
@@ -116,6 +117,9 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
         await skills_service.resolve_skill_refs(pool, agent.skills) if agent.skills else []
     )
     system_prompt = augment_system_prompt(agent.system, skill_versions)
+    # Appended after the skills block; no-op when the session has no bindings
+    # (preserves the "no bindings ⇒ identical behaviour" Phase-2 invariant).
+    system_prompt = augment_with_channels(system_prompt, bindings)
 
     # Provision skill files to workspace (idempotent, host-side writes).
     if skill_versions:

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -67,9 +67,24 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
     else:
         agent = await agents_service.get_agent(pool, session.agent_id)
 
-    # Build MCP server map from agent config (needed for confirmed-tool dispatch
-    # and for routing new tool calls after inference).
+    # Load this session's bindings once.  Passed through to everything that
+    # needs it (MCP discovery, prompt augmentation, monologue prefix gate) —
+    # do NOT re-query inside helpers.
+    from aios.db import queries as _queries
+    from aios.harness.channels import connection_server_name, connections_for_bindings
+
+    async with pool.acquire() as _conn:
+        bindings = await _queries.list_session_bindings(_conn, session_id)
+    connections = await connections_for_bindings(pool, bindings)
+
+    # Build MCP server map — agent-declared PLUS connection-provided.
+    # Needed for both confirmed-tool dispatch (below) and post-inference
+    # tool-call routing.  Connection-derived names (conn_<id>) cannot
+    # collide with agent-declared names (reserved prefix, enforced in
+    # the agent model).
     mcp_server_map: dict[str, str] = {s.name: s.url for s in agent.mcp_servers}
+    for c in connections:
+        mcp_server_map[connection_server_name(c)] = c.mcp_url
 
     # Read windowed message events for this session.
     events = await sessions_service.read_windowed_events(
@@ -109,9 +124,10 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
     # Build context with pending-result synthesis.
     tools = to_openai_tools(agent.tools)
 
-    # Discover MCP tools from declared servers.
-    if agent.mcp_servers:
-        mcp_tools = await _discover_mcp_tools(pool, session_id, agent)
+    # Discover MCP tools from every source this session sees — agent-declared
+    # plus connection-provided (derived from bindings loaded above).
+    if agent.mcp_servers or connections:
+        mcp_tools = await discover_session_mcp_tools(pool, session_id, agent, connections)
         tools.extend(mcp_tools)
 
     ctx = build_messages(
@@ -336,37 +352,61 @@ def resolve_mcp_permission(name: str, agent_tools: list[ToolSpec]) -> str | None
     return None
 
 
-async def _discover_mcp_tools(
+async def discover_session_mcp_tools(
     pool: Any,
     session_id: str,
     agent: Any,
+    connections: list[Any],
 ) -> list[dict[str, Any]]:
-    """Discover tools from all declared MCP servers concurrently.
+    """Discover MCP tools from every source this session sees.
 
-    For each server in ``agent.mcp_servers`` that has an enabled
-    ``mcp_toolset`` entry, connects to the server, lists tools, and
-    returns them in OpenAI format with namespaced names.
+    Two sources:
+
+    * **Agent-declared MCP**: entries in ``agent.mcp_servers`` whose
+      ``name`` matches an enabled ``mcp_toolset`` in ``agent.tools``.
+      Unchanged from the pre-Phase-2 behaviour.
+
+    * **Connection-provided MCP**: every :class:`Connection` whose
+      channel is bound to this session, passed in by the caller
+      (derived from ``list_session_bindings`` + ``connections_for_bindings``).
+      The server name uses :func:`aios.harness.channels.connection_server_name`
+      (``conn_<connection_id>``) so collisions with agent-declared names
+      are impossible by construction.
+
+    Auth for each URL is resolved via
+    :func:`aios.mcp.client.resolve_auth_for_url`, which checks the
+    connection-owned vault first and falls back to ``session_vaults``.
+    All discoveries run concurrently.
     """
     import asyncio
 
+    from aios.harness.channels import connection_server_name
     from aios.mcp.client import discover_mcp_tools, resolve_auth_for_url
 
-    crypto_box = runtime.require_crypto_box()
+    # Collect (server_name, url) pairs from both sources.
+    servers: list[tuple[str, str]] = []
 
-    enabled_servers: set[str] = set()
+    enabled_server_names: set[str] = set()
     for spec in agent.tools:
         if spec.type == "mcp_toolset" and spec.enabled and spec.mcp_server_name:
-            enabled_servers.add(spec.mcp_server_name)
+            enabled_server_names.add(spec.mcp_server_name)
+    for s in agent.mcp_servers:
+        if s.name in enabled_server_names:
+            servers.append((s.name, s.url))
 
-    async def _discover_one(url: str, name: str) -> list[dict[str, Any]]:
-        headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
-        return await discover_mcp_tools(url, name, headers)
+    for c in connections:
+        servers.append((connection_server_name(c), c.mcp_url))
 
-    servers = [s for s in agent.mcp_servers if s.name in enabled_servers]
     if not servers:
         return []
 
-    results = await asyncio.gather(*[_discover_one(s.url, s.name) for s in servers])
+    crypto_box = runtime.require_crypto_box()
+
+    async def _discover_one(name: str, url: str) -> list[dict[str, Any]]:
+        headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
+        return await discover_mcp_tools(url, name, headers)
+
+    results = await asyncio.gather(*[_discover_one(n, u) for n, u in servers])
     return [tool for tools in results for tool in tools]
 
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -331,12 +331,21 @@ def resolve_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
 def resolve_mcp_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
     """Look up the permission policy for an MCP tool.
 
-    Finds the ``mcp_toolset`` entry whose ``mcp_server_name`` matches the
-    server portion of the namespaced tool name, then returns the
-    ``default_config.permission_policy.type`` or ``None`` (which callers
-    treat as ``always_ask``).
+    Connection-provided tools (server name in the reserved ``conn_``
+    namespace) default to ``always_allow`` — the session's channel
+    binding is already explicit routing consent; gating every reply on
+    a confirmation prompt would defeat the connector autonomy story.
+
+    For agent-declared servers, finds the ``mcp_toolset`` entry whose
+    ``mcp_server_name`` matches the server portion of the namespaced
+    tool name, then returns the ``default_config.permission_policy.type``
+    or ``None`` (which callers treat as ``always_ask``).
     """
+    from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
+
     server_name = name.split("__", 2)[1]
+    if server_name.startswith(CONNECTION_SERVER_NAME_PREFIX):
+        return "always_allow"
     for spec in agent_tools:
         if spec.type == "mcp_toolset" and spec.mcp_server_name == server_name:
             cfg = spec.default_config

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -349,7 +349,7 @@ async def _discover_mcp_tools(
     """
     import asyncio
 
-    from aios.mcp.client import discover_mcp_tools, resolve_auth_headers
+    from aios.mcp.client import discover_mcp_tools, resolve_auth_for_url
 
     crypto_box = runtime.require_crypto_box()
 
@@ -359,7 +359,7 @@ async def _discover_mcp_tools(
             enabled_servers.add(spec.mcp_server_name)
 
     async def _discover_one(url: str, name: str) -> list[dict[str, Any]]:
-        headers = await resolve_auth_headers(pool, crypto_box, session_id, url)
+        headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
         return await discover_mcp_tools(url, name, headers)
 
     servers = [s for s in agent.mcp_servers if s.name in enabled_servers]

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -224,6 +224,15 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
         cache_creation_input_tokens=usage.get("cache_creation_input_tokens", 0),
     )
 
+    # INTERNAL_MONOLOGUE prefix, gated on the session having bindings.
+    # The prefix is persisted in the event log and shown to the model on
+    # every subsequent step's context build — that IS the teaching
+    # mechanism.  Do not strip on replay.
+    if bindings:
+        from aios.harness.channels import apply_monologue_prefix
+
+        assistant_msg = apply_monologue_prefix(assistant_msg)
+
     # Inject reacting_to so should_call_model knows what this response
     # was based on. This is the seq of the latest user/tool event in the
     # context — events after this seq are "new" on the next wake.

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -250,10 +250,10 @@ async def _execute_mcp_tool_async(
             )
             return
 
-        from aios.mcp.client import call_mcp_tool, resolve_auth_headers
+        from aios.mcp.client import call_mcp_tool, resolve_auth_for_url
 
         crypto_box = runtime.require_crypto_box()
-        headers = await resolve_auth_headers(pool, crypto_box, session_id, url)
+        headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
         result = await call_mcp_tool(url, headers, tool_name, arguments)
 
         content_str = json.dumps(result, ensure_ascii=False)

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -43,25 +43,17 @@ async def _open_session(url: str, headers: dict[str, str], stack: AsyncExitStack
     return session
 
 
-async def resolve_auth_headers(
-    pool: asyncpg.Pool[Any],
+def _headers_from_credential(
     crypto_box: CryptoBox,
-    session_id: str,
-    mcp_server_url: str,
+    blob: Any,
+    auth_type: str,
 ) -> dict[str, str]:
-    """Look up vault credentials for an MCP server and return auth headers.
+    """Decrypt a credential blob and build the auth header dict.
 
-    Searches the session's bound vaults (rank-ordered) for the first
-    credential matching ``mcp_server_url``. Returns an ``Authorization``
-    header dict, or an empty dict if no credential is found.
+    Returns ``{"Authorization": "Bearer <token>"}`` for recognised auth
+    types, or ``{}`` when the credential is missing a token or the auth
+    type is unknown.
     """
-    async with pool.acquire() as conn:
-        result = await queries.resolve_mcp_credential(conn, session_id, mcp_server_url)
-
-    if result is None:
-        return {}
-
-    blob, auth_type = result
     payload = json.loads(crypto_box.decrypt(blob))
 
     if auth_type == "static_bearer":
@@ -76,6 +68,26 @@ async def resolve_auth_headers(
         return {}
 
     return {"Authorization": f"Bearer {token}"}
+
+
+async def resolve_auth_headers(
+    pool: asyncpg.Pool[Any],
+    crypto_box: CryptoBox,
+    session_id: str,
+    mcp_server_url: str,
+) -> dict[str, str]:
+    """Look up vault credentials for an MCP server and return auth headers.
+
+    Searches the session's bound vaults (rank-ordered) for the first
+    credential matching ``mcp_server_url``. Returns an ``Authorization``
+    header dict, or an empty dict if no credential is found.
+    """
+    async with pool.acquire() as conn:
+        result = await queries.resolve_mcp_credential(conn, session_id, mcp_server_url)
+    if result is None:
+        return {}
+    blob, auth_type = result
+    return _headers_from_credential(crypto_box, blob, auth_type)
 
 
 async def discover_mcp_tools(

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -70,20 +70,34 @@ def _headers_from_credential(
     return {"Authorization": f"Bearer {token}"}
 
 
-async def resolve_auth_headers(
+async def resolve_auth_for_url(
     pool: asyncpg.Pool[Any],
     crypto_box: CryptoBox,
     session_id: str,
     mcp_server_url: str,
 ) -> dict[str, str]:
-    """Look up vault credentials for an MCP server and return auth headers.
+    """Resolve MCP auth for ``mcp_server_url`` in the context of a session.
 
-    Searches the session's bound vaults (rank-ordered) for the first
-    credential matching ``mcp_server_url``. Returns an ``Authorization``
-    header dict, or an empty dict if no credential is found.
+    Connection-declared auth takes precedence.  If this URL belongs to a
+    registered connection, the credential in the connection's vault is
+    used — connections own their auth and it's fixed per-account.
+    Otherwise we fall back to the session's bound vaults
+    (``session_vaults``), the existing mechanism for agent-declared MCP.
+
+    Returns an ``Authorization`` header dict, or ``{}`` if no credential
+    is found.  The fallback is NOT consulted when a connection claims
+    the URL but its vault has no matching credential — connection
+    ownership decides the source, end of discussion.
     """
     async with pool.acquire() as conn:
-        result = await queries.resolve_mcp_credential(conn, session_id, mcp_server_url)
+        owner = await queries.get_connection_vault_for_url(conn, mcp_server_url)
+        if owner is not None:
+            _connection_id, vault_id = owner
+            result = await queries.resolve_vault_credential(
+                conn, vault_id=vault_id, mcp_server_url=mcp_server_url
+            )
+        else:
+            result = await queries.resolve_mcp_credential(conn, session_id, mcp_server_url)
     if result is None:
         return {}
     blob, auth_type = result

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -48,12 +48,6 @@ def _headers_from_credential(
     blob: Any,
     auth_type: str,
 ) -> dict[str, str]:
-    """Decrypt a credential blob and build the auth header dict.
-
-    Returns ``{"Authorization": "Bearer <token>"}`` for recognised auth
-    types, or ``{}`` when the credential is missing a token or the auth
-    type is unknown.
-    """
     payload = json.loads(crypto_box.decrypt(blob))
 
     if auth_type == "static_bearer":
@@ -76,25 +70,20 @@ async def resolve_auth_for_url(
     session_id: str,
     mcp_server_url: str,
 ) -> dict[str, str]:
-    """Resolve MCP auth for ``mcp_server_url`` in the context of a session.
+    """Resolve MCP auth headers for ``mcp_server_url``.
 
-    Connection-declared auth takes precedence.  If this URL belongs to a
-    registered connection, the credential in the connection's vault is
-    used — connections own their auth and it's fixed per-account.
-    Otherwise we fall back to the session's bound vaults
-    (``session_vaults``), the existing mechanism for agent-declared MCP.
-
-    Returns an ``Authorization`` header dict, or ``{}`` if no credential
-    is found.  The fallback is NOT consulted when a connection claims
-    the URL but its vault has no matching credential — connection
-    ownership decides the source, end of discussion.
+    Connection-owned URLs resolve through the connection's vault;
+    other URLs fall back to the session's bound vaults.  A connection
+    that owns the URL but has no matching credential returns ``{}``
+    rather than falling back — ownership decides the source, not
+    whether the lookup hits (prevents a misconfigured connection from
+    silently leaking a tenant-level credential).
     """
     async with pool.acquire() as conn:
-        owner = await queries.get_connection_vault_for_url(conn, mcp_server_url)
-        if owner is not None:
-            _connection_id, vault_id = owner
+        connection_vault_id = await queries.get_connection_vault_for_url(conn, mcp_server_url)
+        if connection_vault_id is not None:
             result = await queries.resolve_vault_credential(
-                conn, vault_id=vault_id, mcp_server_url=mcp_server_url
+                conn, vault_id=connection_vault_id, mcp_server_url=mcp_server_url
             )
         else:
             result = await queries.resolve_mcp_credential(conn, session_id, mcp_server_url)

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from aios.models.skills import AgentSkillRef
 
@@ -43,6 +43,11 @@ class McpServerSpec(BaseModel):
     Declares a remote MCP server reachable via streamable HTTP transport.
     The ``name`` is used to cross-reference from ``mcp_toolset`` tool entries
     and to namespace discovered tools as ``mcp__<name>__<tool_name>``.
+
+    The ``conn_`` prefix on ``name`` is reserved — it's used by the
+    Phase-2 (#31) connector/channel mechanism for connection-derived
+    servers (``conn_<connection_id>``).  Reserving the namespace at the
+    model boundary keeps future scheme changes safe.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -50,6 +55,13 @@ class McpServerSpec(BaseModel):
     type: Literal["url"] = "url"
     name: str = Field(min_length=1, max_length=64)
     url: str = Field(min_length=1)
+
+    @field_validator("name")
+    @classmethod
+    def _reject_conn_prefix(cls, v: str) -> str:
+        if v.startswith("conn_"):
+            raise ValueError("mcp_server name prefix 'conn_' is reserved for connections")
+        return v
 
 
 # ── MCP toolset config (permission policies for discovered tools) ──────────

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -43,11 +43,6 @@ class McpServerSpec(BaseModel):
     Declares a remote MCP server reachable via streamable HTTP transport.
     The ``name`` is used to cross-reference from ``mcp_toolset`` tool entries
     and to namespace discovered tools as ``mcp__<name>__<tool_name>``.
-
-    The ``conn_`` prefix on ``name`` is reserved — it's used by the
-    Phase-2 (#31) connector/channel mechanism for connection-derived
-    servers (``conn_<connection_id>``).  Reserving the namespace at the
-    model boundary keeps future scheme changes safe.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -58,9 +53,13 @@ class McpServerSpec(BaseModel):
 
     @field_validator("name")
     @classmethod
-    def _reject_conn_prefix(cls, v: str) -> str:
-        if v.startswith("conn_"):
-            raise ValueError("mcp_server name prefix 'conn_' is reserved for connections")
+    def _reject_reserved_prefix(cls, v: str) -> str:
+        from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
+
+        if v.startswith(CONNECTION_SERVER_NAME_PREFIX):
+            raise ValueError(
+                f"mcp_server name prefix {CONNECTION_SERVER_NAME_PREFIX!r} is reserved"
+            )
         return v
 
 

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -17,6 +17,11 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+# Reserved prefix for MCP server names derived from a connection.  Keeps
+# connection-provided servers disjoint from agent-declared ones in the
+# shared mcp_server_map.
+CONNECTION_SERVER_NAME_PREFIX = "conn_"
+
 
 class ConnectionCreate(BaseModel):
     """Request body for ``POST /v1/connections``.

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -1093,6 +1093,121 @@ class TestGetConnectionsByPairs:
         assert rows == []
 
 
+class TestResolveVaultCredential:
+    """Direct (vault_id, URL) → (blob, auth_type) lookup — no session_vaults
+    join.  The connection-first half of resolve_auth_for_url uses this.
+    """
+
+    async def test_match_returns_blob(self, pool: Any, vault_id: str) -> None:
+        from pydantic import SecretStr
+
+        from aios.config import get_settings
+        from aios.crypto.vault import CryptoBox
+        from aios.db import queries
+        from aios.models.vaults import VaultCredentialCreate
+        from aios.services import vaults as vault_svc
+
+        crypto_box = CryptoBox.from_base64(get_settings().vault_key.get_secret_value())
+        url = f"https://rvc-{_uniq()}.example"
+        await vault_svc.create_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=vault_id,
+            body=VaultCredentialCreate(
+                display_name="t",
+                mcp_server_url=url,
+                auth_type="static_bearer",
+                token=SecretStr("hello"),
+            ),
+        )
+        async with pool.acquire() as conn:
+            hit = await queries.resolve_vault_credential(
+                conn, vault_id=vault_id, mcp_server_url=url
+            )
+        assert hit is not None
+        blob, auth_type = hit
+        assert auth_type == "static_bearer"
+        import json as _json
+
+        assert _json.loads(crypto_box.decrypt(blob))["token"] == "hello"
+
+    async def test_no_match_returns_none(self, pool: Any, vault_id: str) -> None:
+        from aios.db import queries
+
+        async with pool.acquire() as conn:
+            hit = await queries.resolve_vault_credential(
+                conn,
+                vault_id=vault_id,
+                mcp_server_url=f"https://rvc-miss-{_uniq()}.example",
+            )
+        assert hit is None
+
+    async def test_excludes_archived_credential(self, pool: Any, vault_id: str) -> None:
+        from pydantic import SecretStr
+
+        from aios.config import get_settings
+        from aios.crypto.vault import CryptoBox
+        from aios.db import queries
+        from aios.models.vaults import VaultCredentialCreate
+        from aios.services import vaults as vault_svc
+
+        crypto_box = CryptoBox.from_base64(get_settings().vault_key.get_secret_value())
+        url = f"https://rvc-arc-{_uniq()}.example"
+        cred = await vault_svc.create_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=vault_id,
+            body=VaultCredentialCreate(
+                display_name="t",
+                mcp_server_url=url,
+                auth_type="static_bearer",
+                token=SecretStr("hello"),
+            ),
+        )
+        await vault_svc.archive_vault_credential(pool, vault_id, cred.id)
+
+        async with pool.acquire() as conn:
+            hit = await queries.resolve_vault_credential(
+                conn, vault_id=vault_id, mcp_server_url=url
+            )
+        assert hit is None
+
+    async def test_scoped_to_vault_id(self, pool: Any) -> None:
+        """A credential in vault A must not surface when looking up in vault B."""
+        from pydantic import SecretStr
+
+        from aios.config import get_settings
+        from aios.crypto.vault import CryptoBox
+        from aios.db import queries
+        from aios.models.vaults import VaultCredentialCreate
+        from aios.services import vaults as vault_svc
+
+        crypto_box = CryptoBox.from_base64(get_settings().vault_key.get_secret_value())
+        v_a = await vault_svc.create_vault(pool, display_name="rvc-a", metadata={})
+        v_b = await vault_svc.create_vault(pool, display_name="rvc-b", metadata={})
+        url = f"https://rvc-scope-{_uniq()}.example"
+        await vault_svc.create_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=v_a.id,
+            body=VaultCredentialCreate(
+                display_name="t",
+                mcp_server_url=url,
+                auth_type="static_bearer",
+                token=SecretStr("A"),
+            ),
+        )
+        async with pool.acquire() as conn:
+            hit_a = await queries.resolve_vault_credential(
+                conn, vault_id=v_a.id, mcp_server_url=url
+            )
+            hit_b = await queries.resolve_vault_credential(
+                conn, vault_id=v_b.id, mcp_server_url=url
+            )
+        assert hit_a is not None
+        assert hit_b is None
+
+
 class TestGetConnectionVaultForUrl:
     """URL → (connection_id, vault_id) lookup used by resolve_auth_for_url
     to decide whether a URL belongs to a registered connection.

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -957,3 +957,188 @@ class TestInboundEndpoint:
         )
         assert r.status_code == 422, (bad_path, r.text)
         assert r.json()["error"]["type"] == "validation_error"
+
+
+# ─── Phase 2 queries (#31) ──────────────────────────────────────────────────
+
+
+class TestListSessionBindings:
+    """Unpaginated "all active bindings for this session" lookup used by
+    the Phase-2 step to derive connection-provided MCP URLs.
+    """
+
+    async def test_empty_when_no_bindings(self, pool: Any, agent_id: str, env_id: str) -> None:
+        from aios.db import queries
+        from aios.services import sessions as sess_svc
+
+        s = await sess_svc.create_session(
+            pool, agent_id=agent_id, environment_id=env_id, title=None, metadata={}
+        )
+        async with pool.acquire() as conn:
+            bindings = await queries.list_session_bindings(conn, s.id)
+        assert bindings == []
+
+    async def test_returns_all_active_bindings_for_session(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        from aios.db import queries
+        from aios.services import channels as ch_svc
+        from aios.services import sessions as sess_svc
+
+        s = await sess_svc.create_session(
+            pool, agent_id=agent_id, environment_id=env_id, title=None, metadata={}
+        )
+        suffix = _uniq()
+        a1 = await ch_svc.create_binding(pool, address=f"signal/x-{suffix}/1", session_id=s.id)
+        a2 = await ch_svc.create_binding(pool, address=f"signal/x-{suffix}/2", session_id=s.id)
+
+        async with pool.acquire() as conn:
+            bindings = await queries.list_session_bindings(conn, s.id)
+        ids = {b.id for b in bindings}
+        assert ids == {a1.id, a2.id}
+
+    async def test_excludes_archived_bindings(self, pool: Any, agent_id: str, env_id: str) -> None:
+        from aios.db import queries
+        from aios.services import channels as ch_svc
+        from aios.services import sessions as sess_svc
+
+        s = await sess_svc.create_session(
+            pool, agent_id=agent_id, environment_id=env_id, title=None, metadata={}
+        )
+        active = await ch_svc.create_binding(
+            pool, address=f"signal/arc-{_uniq()}/a", session_id=s.id
+        )
+        dead = await ch_svc.create_binding(pool, address=f"signal/arc-{_uniq()}/b", session_id=s.id)
+        await ch_svc.archive_binding(pool, dead.id)
+
+        async with pool.acquire() as conn:
+            bindings = await queries.list_session_bindings(conn, s.id)
+        ids = {b.id for b in bindings}
+        assert ids == {active.id}
+
+    async def test_scoped_to_session(self, pool: Any, agent_id: str, env_id: str) -> None:
+        from aios.db import queries
+        from aios.services import channels as ch_svc
+        from aios.services import sessions as sess_svc
+
+        s1 = await sess_svc.create_session(
+            pool, agent_id=agent_id, environment_id=env_id, title=None, metadata={}
+        )
+        s2 = await sess_svc.create_session(
+            pool, agent_id=agent_id, environment_id=env_id, title=None, metadata={}
+        )
+        await ch_svc.create_binding(pool, address=f"signal/sc-{_uniq()}/s1", session_id=s1.id)
+        await ch_svc.create_binding(pool, address=f"signal/sc-{_uniq()}/s2", session_id=s2.id)
+
+        async with pool.acquire() as conn:
+            s1_bindings = await queries.list_session_bindings(conn, s1.id)
+            s2_bindings = await queries.list_session_bindings(conn, s2.id)
+        assert len(s1_bindings) == 1 and s1_bindings[0].session_id == s1.id
+        assert len(s2_bindings) == 1 and s2_bindings[0].session_id == s2.id
+
+
+class TestGetConnectionsByPairs:
+    """Batch lookup of active connections by (connector, account) pairs,
+    used by the Phase-2 discovery step after collecting bindings.
+    """
+
+    async def test_empty_input_returns_empty(self, pool: Any) -> None:
+        from aios.db import queries
+
+        async with pool.acquire() as conn:
+            rows = await queries.get_connections_by_pairs(conn, [])
+        assert rows == []
+
+    async def test_returns_matching_connections(self, pool: Any, vault_id: str) -> None:
+        from aios.db import queries
+        from aios.services import connections as conn_svc
+
+        a = f"gcp-a-{_uniq()}"
+        b = f"gcp-b-{_uniq()}"
+        c_a = await conn_svc.create_connection(
+            pool,
+            connector="signal",
+            account=a,
+            mcp_url="https://m1",
+            vault_id=vault_id,
+            metadata={},
+        )
+        c_b = await conn_svc.create_connection(
+            pool, connector="slack", account=b, mcp_url="https://m2", vault_id=vault_id, metadata={}
+        )
+
+        async with pool.acquire() as conn:
+            rows = await queries.get_connections_by_pairs(
+                conn, [("signal", a), ("slack", b), ("discord", "nope")]
+            )
+        ids = {c.id for c in rows}
+        assert ids == {c_a.id, c_b.id}
+
+    async def test_excludes_archived(self, pool: Any, vault_id: str) -> None:
+        from aios.db import queries
+        from aios.services import connections as conn_svc
+
+        acct = f"gcp-arc-{_uniq()}"
+        c = await conn_svc.create_connection(
+            pool,
+            connector="signal",
+            account=acct,
+            mcp_url="https://m",
+            vault_id=vault_id,
+            metadata={},
+        )
+        await conn_svc.archive_connection(pool, c.id)
+        async with pool.acquire() as conn:
+            rows = await queries.get_connections_by_pairs(conn, [("signal", acct)])
+        assert rows == []
+
+
+class TestGetConnectionVaultForUrl:
+    """URL → (connection_id, vault_id) lookup used by resolve_auth_for_url
+    to decide whether a URL belongs to a registered connection.
+    """
+
+    async def test_match_returns_connection_and_vault(self, pool: Any, vault_id: str) -> None:
+        from aios.db import queries
+        from aios.services import connections as conn_svc
+
+        url = f"https://mcp-match-{_uniq()}.example"
+        c = await conn_svc.create_connection(
+            pool,
+            connector="signal",
+            account=f"gcvfu-{_uniq()}",
+            mcp_url=url,
+            vault_id=vault_id,
+            metadata={},
+        )
+        async with pool.acquire() as conn:
+            hit = await queries.get_connection_vault_for_url(conn, url)
+        assert hit is not None
+        assert hit == (c.id, vault_id)
+
+    async def test_no_match_returns_none(self, pool: Any) -> None:
+        from aios.db import queries
+
+        async with pool.acquire() as conn:
+            hit = await queries.get_connection_vault_for_url(
+                conn, f"https://unknown-{_uniq()}.example"
+            )
+        assert hit is None
+
+    async def test_excludes_archived(self, pool: Any, vault_id: str) -> None:
+        from aios.db import queries
+        from aios.services import connections as conn_svc
+
+        url = f"https://mcp-arc-{_uniq()}.example"
+        c = await conn_svc.create_connection(
+            pool,
+            connector="signal",
+            account=f"gcvfu-arc-{_uniq()}",
+            mcp_url=url,
+            vault_id=vault_id,
+            metadata={},
+        )
+        await conn_svc.archive_connection(pool, c.id)
+        async with pool.acquire() as conn:
+            hit = await queries.get_connection_vault_for_url(conn, url)
+        assert hit is None

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -959,12 +959,12 @@ class TestInboundEndpoint:
         assert r.json()["error"]["type"] == "validation_error"
 
 
-# ─── Phase 2 queries (#31) ──────────────────────────────────────────────────
+# ─── step-function queries ──────────────────────────────────────────────────
 
 
 class TestListSessionBindings:
     """Unpaginated "all active bindings for this session" lookup used by
-    the Phase-2 step to derive connection-provided MCP URLs.
+    the step function to derive connection-provided MCP URLs.
     """
 
     async def test_empty_when_no_bindings(self, pool: Any, agent_id: str, env_id: str) -> None:
@@ -1039,7 +1039,7 @@ class TestListSessionBindings:
 
 class TestGetConnectionsByPairs:
     """Batch lookup of active connections by (connector, account) pairs,
-    used by the Phase-2 discovery step after collecting bindings.
+    used by discovery after collecting bindings.
     """
 
     async def test_empty_input_returns_empty(self, pool: Any) -> None:
@@ -1094,13 +1094,8 @@ class TestGetConnectionsByPairs:
 
 
 class TestResolveAuthForUrlPrecedence:
-    """Phase 2 (#31) acceptance: connection-declared auth takes precedence
-    over session_vaults when both sources have a credential for the same URL.
-
-    This is the load-bearing invariant of the connection/channel design —
-    a connection 'owns' its MCP URL's auth; session_vaults is the right
-    place for agent-declared MCP credentials but cannot express per-account
-    auth for connections.
+    """Connection-declared auth takes precedence over session_vaults
+    when both sources have a credential for the same URL.
     """
 
     async def test_connection_credential_beats_session_vault(
@@ -1170,8 +1165,7 @@ class TestResolveAuthForUrlPrecedence:
     async def test_session_vault_used_for_non_connection_url(
         self, pool: Any, agent_id: str, env_id: str
     ) -> None:
-        """When the URL isn't owned by any connection, fall back to
-        session_vaults (the pre-Phase-2 behaviour)."""
+        """When the URL isn't owned by any connection, fall back to session_vaults."""
         from pydantic import SecretStr
 
         from aios.config import get_settings
@@ -1384,16 +1378,16 @@ class TestResolveVaultCredential:
 
 
 class TestGetConnectionVaultForUrl:
-    """URL → (connection_id, vault_id) lookup used by resolve_auth_for_url
-    to decide whether a URL belongs to a registered connection.
+    """URL → vault_id lookup used by resolve_auth_for_url to decide
+    whether a URL belongs to a registered connection.
     """
 
-    async def test_match_returns_connection_and_vault(self, pool: Any, vault_id: str) -> None:
+    async def test_match_returns_vault_id(self, pool: Any, vault_id: str) -> None:
         from aios.db import queries
         from aios.services import connections as conn_svc
 
         url = f"https://mcp-match-{_uniq()}.example"
-        c = await conn_svc.create_connection(
+        await conn_svc.create_connection(
             pool,
             connector="signal",
             account=f"gcvfu-{_uniq()}",
@@ -1403,8 +1397,7 @@ class TestGetConnectionVaultForUrl:
         )
         async with pool.acquire() as conn:
             hit = await queries.get_connection_vault_for_url(conn, url)
-        assert hit is not None
-        assert hit == (c.id, vault_id)
+        assert hit == vault_id
 
     async def test_no_match_returns_none(self, pool: Any) -> None:
         from aios.db import queries

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -1093,6 +1093,181 @@ class TestGetConnectionsByPairs:
         assert rows == []
 
 
+class TestResolveAuthForUrlPrecedence:
+    """Phase 2 (#31) acceptance: connection-declared auth takes precedence
+    over session_vaults when both sources have a credential for the same URL.
+
+    This is the load-bearing invariant of the connection/channel design —
+    a connection 'owns' its MCP URL's auth; session_vaults is the right
+    place for agent-declared MCP credentials but cannot express per-account
+    auth for connections.
+    """
+
+    async def test_connection_credential_beats_session_vault(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        from pydantic import SecretStr
+
+        from aios.config import get_settings
+        from aios.crypto.vault import CryptoBox
+        from aios.mcp.client import resolve_auth_for_url
+        from aios.models.vaults import VaultCredentialCreate
+        from aios.services import connections as conn_svc
+        from aios.services import sessions as sess_svc
+        from aios.services import vaults as vault_svc
+
+        crypto_box = CryptoBox.from_base64(get_settings().vault_key.get_secret_value())
+        shared_url = f"https://shared-mcp-{_uniq()}.example"
+
+        v1 = await vault_svc.create_vault(pool, display_name="session-vault", metadata={})
+        await vault_svc.create_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=v1.id,
+            body=VaultCredentialCreate(
+                display_name="session",
+                mcp_server_url=shared_url,
+                auth_type="static_bearer",
+                token=SecretStr("SESSION_TOKEN_V1"),
+            ),
+        )
+
+        v2 = await vault_svc.create_vault(pool, display_name="connection-vault", metadata={})
+        await vault_svc.create_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=v2.id,
+            body=VaultCredentialCreate(
+                display_name="connection",
+                mcp_server_url=shared_url,
+                auth_type="static_bearer",
+                token=SecretStr("CONNECTION_TOKEN_V2"),
+            ),
+        )
+
+        await conn_svc.create_connection(
+            pool,
+            connector="signal",
+            account=f"precedence-{_uniq()}",
+            mcp_url=shared_url,
+            vault_id=v2.id,
+            metadata={},
+        )
+
+        session = await sess_svc.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            vault_ids=[v1.id],
+        )
+
+        headers = await resolve_auth_for_url(pool, crypto_box, session.id, shared_url)
+        # Connection wins even though session_vaults ALSO has a credential.
+        assert headers == {"Authorization": "Bearer CONNECTION_TOKEN_V2"}
+
+    async def test_session_vault_used_for_non_connection_url(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        """When the URL isn't owned by any connection, fall back to
+        session_vaults (the pre-Phase-2 behaviour)."""
+        from pydantic import SecretStr
+
+        from aios.config import get_settings
+        from aios.crypto.vault import CryptoBox
+        from aios.mcp.client import resolve_auth_for_url
+        from aios.models.vaults import VaultCredentialCreate
+        from aios.services import sessions as sess_svc
+        from aios.services import vaults as vault_svc
+
+        crypto_box = CryptoBox.from_base64(get_settings().vault_key.get_secret_value())
+        url = f"https://agent-mcp-{_uniq()}.example"
+
+        v = await vault_svc.create_vault(pool, display_name="agent-vault", metadata={})
+        await vault_svc.create_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=v.id,
+            body=VaultCredentialCreate(
+                display_name="agent",
+                mcp_server_url=url,
+                auth_type="static_bearer",
+                token=SecretStr("AGENT_TOKEN"),
+            ),
+        )
+
+        session = await sess_svc.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            vault_ids=[v.id],
+        )
+
+        headers = await resolve_auth_for_url(pool, crypto_box, session.id, url)
+        assert headers == {"Authorization": "Bearer AGENT_TOKEN"}
+
+    async def test_connection_with_no_matching_credential_returns_empty(
+        self, pool: Any, agent_id: str, env_id: str
+    ) -> None:
+        """Connection ownership decides the source, regardless of hit.  If
+        the connection's vault has no credential for the URL we MUST NOT
+        silently fall back to session_vaults — a misconfigured connection
+        must surface as missing auth, not as a leaked tenant credential.
+        """
+        from pydantic import SecretStr
+
+        from aios.config import get_settings
+        from aios.crypto.vault import CryptoBox
+        from aios.mcp.client import resolve_auth_for_url
+        from aios.models.vaults import VaultCredentialCreate
+        from aios.services import connections as conn_svc
+        from aios.services import sessions as sess_svc
+        from aios.services import vaults as vault_svc
+
+        crypto_box = CryptoBox.from_base64(get_settings().vault_key.get_secret_value())
+        url = f"https://broken-conn-{_uniq()}.example"
+
+        # session_vaults has the credential...
+        v_session = await vault_svc.create_vault(pool, display_name="s", metadata={})
+        await vault_svc.create_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=v_session.id,
+            body=VaultCredentialCreate(
+                display_name="s",
+                mcp_server_url=url,
+                auth_type="static_bearer",
+                token=SecretStr("LEAKED"),
+            ),
+        )
+        # ...but the connection's vault is empty.
+        v_empty = await vault_svc.create_vault(pool, display_name="empty", metadata={})
+        await conn_svc.create_connection(
+            pool,
+            connector="signal",
+            account=f"broken-{_uniq()}",
+            mcp_url=url,
+            vault_id=v_empty.id,
+            metadata={},
+        )
+
+        session = await sess_svc.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            vault_ids=[v_session.id],
+        )
+
+        headers = await resolve_auth_for_url(pool, crypto_box, session.id, url)
+        # Must NOT be "Bearer LEAKED".
+        assert headers == {}
+
+
 class TestResolveVaultCredential:
     """Direct (vault_id, URL) → (blob, auth_type) lookup — no session_vaults
     join.  The connection-first half of resolve_auth_for_url uses this.

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -48,19 +48,18 @@ def _connection(cid: str, connector: str = "signal", account: str = "acct") -> C
 
 
 class TestConnectionServerName:
-    """Use the connection id directly — unambiguous by construction,
-    no sanitization, no collisions.  Readability cost is acceptable
-    because tool names are for the model, not humans.
+    """The connection id already starts with the reserved ``conn_``
+    prefix (via ``ids.CONNECTION``), so it doubles as the server name
+    directly — no stutter, still unambiguous by construction.
     """
 
     def test_uses_id_directly(self) -> None:
         c = _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")
-        assert connection_server_name(c) == "conn_conn_01HQR2K7VXBZ9MNPL3WYCT8F"
+        assert connection_server_name(c) == "conn_01HQR2K7VXBZ9MNPL3WYCT8F"
 
     def test_distinct_connections_produce_distinct_names(self) -> None:
-        """Distinct ids → distinct names, regardless of connector/account."""
-        c1 = _connection("conn_a", connector="signal", account="abc_def")
-        c2 = _connection("conn_b", connector="signal_abc", account="def")
+        c1 = _connection("conn_aaa", connector="signal", account="abc_def")
+        c2 = _connection("conn_bbb", connector="signal_abc", account="def")
         assert connection_server_name(c1) != connection_server_name(c2)
 
     def test_is_stable_for_same_connection(self) -> None:

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -1,4 +1,4 @@
-"""Unit tests for harness/channels.py — the Phase 2 (#31) helper module.
+"""Unit tests for harness/channels.py.
 
 Pure-function coverage.  The connection-lookup helper (async, hits the
 DB) is covered in tests/e2e.

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -1,0 +1,194 @@
+"""Unit tests for harness/channels.py — the Phase 2 (#31) helper module.
+
+Pure-function coverage.  The connection-lookup helper (async, hits the
+DB) is covered in tests/e2e.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from aios.harness.channels import (
+    apply_monologue_prefix,
+    augment_with_channels,
+    build_channels_system_block,
+    connection_server_name,
+)
+from aios.models.channel_bindings import ChannelBinding
+from aios.models.connections import Connection
+
+
+def _binding(address: str, session_id: str = "sess_x") -> ChannelBinding:
+    now = datetime(2026, 4, 16)
+    return ChannelBinding(
+        id=f"cbnd_{hash(address) & 0xFFFF:04x}",
+        address=address,
+        session_id=session_id,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _connection(cid: str, connector: str = "signal", account: str = "acct") -> Connection:
+    now = datetime(2026, 4, 16)
+    return Connection(
+        id=cid,
+        connector=connector,
+        account=account,
+        mcp_url="https://example.com",
+        vault_id="vlt_x",
+        metadata={},
+        created_at=now,
+        updated_at=now,
+    )
+
+
+# ── connection_server_name ─────────────────────────────────────────────────
+
+
+class TestConnectionServerName:
+    """Use the connection id directly — unambiguous by construction,
+    no sanitization, no collisions.  Readability cost is acceptable
+    because tool names are for the model, not humans.
+    """
+
+    def test_uses_id_directly(self) -> None:
+        c = _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")
+        assert connection_server_name(c) == "conn_conn_01HQR2K7VXBZ9MNPL3WYCT8F"
+
+    def test_distinct_connections_produce_distinct_names(self) -> None:
+        """Distinct ids → distinct names, regardless of connector/account."""
+        c1 = _connection("conn_a", connector="signal", account="abc_def")
+        c2 = _connection("conn_b", connector="signal_abc", account="def")
+        assert connection_server_name(c1) != connection_server_name(c2)
+
+    def test_is_stable_for_same_connection(self) -> None:
+        c = _connection("conn_stable")
+        assert connection_server_name(c) == connection_server_name(c)
+
+
+# ── build_channels_system_block / augment_with_channels ────────────────────
+
+
+class TestBuildChannelsSystemBlock:
+    def test_empty_bindings_returns_empty_string(self) -> None:
+        assert build_channels_system_block([]) == ""
+
+    def test_single_binding_lists_address(self) -> None:
+        block = build_channels_system_block([_binding("signal/alice/chat-1")])
+        assert "signal/alice/chat-1" in block
+        assert "INTERNAL_MONOLOGUE" in block
+        assert "bound to the following channels" in block.lower()
+
+    def test_multiple_bindings_all_listed(self) -> None:
+        block = build_channels_system_block(
+            [
+                _binding("signal/alice/chat-1"),
+                _binding("slack/ws/C123/t"),
+            ]
+        )
+        assert "signal/alice/chat-1" in block
+        assert "slack/ws/C123/t" in block
+
+
+class TestAugmentWithChannels:
+    def test_no_bindings_returns_base_unchanged(self) -> None:
+        assert augment_with_channels("you are a helpful agent", []) == "you are a helpful agent"
+
+    def test_appends_block_after_base(self) -> None:
+        result = augment_with_channels("you are helpful", [_binding("signal/a/1")])
+        assert result.startswith("you are helpful")
+        assert "signal/a/1" in result
+        # Separator between base and appended block (blank line).
+        assert "\n\n" in result
+
+    def test_empty_base_yields_block_only(self) -> None:
+        result = augment_with_channels("", [_binding("signal/a/1")])
+        assert "signal/a/1" in result
+        assert not result.startswith("\n")
+
+
+# ── apply_monologue_prefix ─────────────────────────────────────────────────
+
+
+class TestApplyMonologuePrefix:
+    def test_string_content_prefixed(self) -> None:
+        msg: dict[str, Any] = {"role": "assistant", "content": "thinking out loud"}
+        out = apply_monologue_prefix(msg)
+        assert out["content"] == "INTERNAL_MONOLOGUE: thinking out loud"
+
+    def test_already_prefixed_string_unchanged(self) -> None:
+        msg: dict[str, Any] = {"role": "assistant", "content": "INTERNAL_MONOLOGUE: hi"}
+        out = apply_monologue_prefix(msg)
+        assert out["content"] == "INTERNAL_MONOLOGUE: hi"
+
+    def test_empty_string_left_alone(self) -> None:
+        msg: dict[str, Any] = {"role": "assistant", "content": ""}
+        out = apply_monologue_prefix(msg)
+        assert out["content"] == ""
+
+    def test_none_content_left_alone(self) -> None:
+        """A tool-only assistant turn (content=None) has nothing to prefix."""
+        msg: dict[str, Any] = {"role": "assistant", "content": None, "tool_calls": []}
+        out = apply_monologue_prefix(msg)
+        assert out.get("content") is None
+
+    def test_missing_content_left_alone(self) -> None:
+        msg: dict[str, Any] = {"role": "assistant", "tool_calls": []}
+        out = apply_monologue_prefix(msg)
+        assert "content" not in out
+
+    def test_list_content_all_text_blocks_prefixed(self) -> None:
+        """Multi-block content must prefix EVERY text block — not just the
+        first — so providers that interleave text with tool_use don't leave
+        later text segments unmarked.
+        """
+        msg: dict[str, Any] = {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "first"},
+                {"type": "tool_use", "id": "x", "name": "y", "input": {}},
+                {"type": "text", "text": "second"},
+            ],
+        }
+        out = apply_monologue_prefix(msg)
+        blocks = out["content"]
+        assert blocks[0] == {"type": "text", "text": "INTERNAL_MONOLOGUE: first"}
+        assert blocks[1] == {"type": "tool_use", "id": "x", "name": "y", "input": {}}
+        assert blocks[2] == {"type": "text", "text": "INTERNAL_MONOLOGUE: second"}
+
+    def test_list_content_tool_use_only_left_alone(self) -> None:
+        msg: dict[str, Any] = {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "x", "name": "y", "input": {}}],
+        }
+        out = apply_monologue_prefix(msg)
+        assert out["content"] == [{"type": "tool_use", "id": "x", "name": "y", "input": {}}]
+
+    def test_list_content_mixed_already_prefixed(self) -> None:
+        """Idempotent on a per-block basis."""
+        msg: dict[str, Any] = {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "INTERNAL_MONOLOGUE: first"},
+                {"type": "text", "text": "second"},
+            ],
+        }
+        out = apply_monologue_prefix(msg)
+        assert out["content"][0]["text"] == "INTERNAL_MONOLOGUE: first"
+        assert out["content"][1]["text"] == "INTERNAL_MONOLOGUE: second"
+
+    def test_returns_new_dict_preserving_other_fields(self) -> None:
+        msg: dict[str, Any] = {
+            "role": "assistant",
+            "content": "hi",
+            "tool_calls": [{"id": "x"}],
+            "reacting_to": 42,
+        }
+        out = apply_monologue_prefix(msg)
+        assert out["role"] == "assistant"
+        assert out["tool_calls"] == [{"id": "x"}]
+        assert out["reacting_to"] == 42
+        # Input must not be mutated in place.
+        assert msg["content"] == "hi"

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -1,0 +1,197 @@
+"""Unit tests for discover_session_mcp_tools — the Phase 2 (#31)
+unified MCP discovery.
+
+Covers the collect-URLs-then-discover shape: agent-declared MCP
+(filtered by enabled mcp_toolset entries) unioned with
+connection-provided MCP (derived from session bindings → connections).
+The MCP SDK and auth lookup are both mocked; only the orchestration
+is under test here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aios.models.agents import McpServerSpec, ToolSpec
+from aios.models.connections import Connection
+
+
+@pytest.fixture(autouse=True)
+def _mock_crypto_box() -> Any:
+    """Bypass the runtime crypto-box requirement — discovery doesn't
+    actually decrypt anything when resolve_auth_for_url is mocked.
+    """
+    with patch("aios.harness.loop.runtime.require_crypto_box") as m:
+        m.return_value = object()
+        yield m
+
+
+def _connection(cid: str, url: str) -> Connection:
+    now = datetime(2026, 4, 16)
+    return Connection(
+        id=cid,
+        connector="signal",
+        account="acct",
+        mcp_url=url,
+        vault_id="vlt_x",
+        metadata={},
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _agent(
+    mcp_servers: list[McpServerSpec] | None = None,
+    tools: list[ToolSpec] | None = None,
+) -> Any:
+    return SimpleNamespace(
+        mcp_servers=mcp_servers or [],
+        tools=tools or [],
+    )
+
+
+class TestDiscoverSessionMcpTools:
+    async def test_no_sources_returns_empty(self) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+
+        tools = await discover_session_mcp_tools(
+            pool=AsyncMock(),
+            session_id="sess_x",
+            agent=_agent(),
+            connections=[],
+        )
+        assert tools == []
+
+    async def test_agent_only_enabled_server(self) -> None:
+        """Only enabled mcp_toolset entries produce discovery; disabled
+        ones are skipped.
+        """
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[
+                McpServerSpec(name="gh", url="https://mcp.github"),
+                McpServerSpec(name="off", url="https://mcp.off"),
+            ],
+            tools=[
+                ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh"),
+                ToolSpec(type="mcp_toolset", enabled=False, mcp_server_name="off"),
+            ],
+        )
+
+        async def _discover(url: str, name: str, _headers: dict[str, str]) -> list[dict[str, Any]]:
+            return [{"name": f"mcp__{name}__t", "url": url}]
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            tools = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+                connections=[],
+            )
+        names = {t["name"] for t in tools}
+        assert names == {"mcp__gh__t"}
+
+    async def test_connections_only(self) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+
+        connections = [
+            _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1"),
+            _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8G", "https://m2"),
+        ]
+
+        async def _discover(url: str, name: str, _headers: dict[str, str]) -> list[dict[str, Any]]:
+            return [{"name": f"mcp__{name}__t", "url": url}]
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            tools = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=_agent(),
+                connections=connections,
+            )
+        # Each connection contributes one tool, namespaced with its id.
+        urls = {t["url"] for t in tools}
+        assert urls == {"https://m1", "https://m2"}
+        names = {t["name"] for t in tools}
+        assert names == {
+            "mcp__conn_conn_01HQR2K7VXBZ9MNPL3WYCT8F__t",
+            "mcp__conn_conn_01HQR2K7VXBZ9MNPL3WYCT8G__t",
+        }
+
+    async def test_agent_and_connections_combined(self) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
+            tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
+        )
+        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
+
+        async def _discover(url: str, name: str, _headers: dict[str, str]) -> list[dict[str, Any]]:
+            return [{"name": f"mcp__{name}__t", "url": url}]
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            tools = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+                connections=connections,
+            )
+        urls = sorted(t["url"] for t in tools)
+        assert urls == ["https://m1", "https://mcp.github"]
+
+    async def test_auth_resolved_per_url(self) -> None:
+        """Each URL resolves auth independently — goes through
+        resolve_auth_for_url once per server, not once per batch.
+        """
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
+            tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
+        )
+        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
+
+        seen_urls: list[str] = []
+
+        async def _fake_resolve(_pool: Any, _cb: Any, _sid: str, url: str) -> dict[str, str]:
+            seen_urls.append(url)
+            return {"Authorization": f"Bearer token-for-{url}"}
+
+        async def _discover(url: str, name: str, headers: dict[str, str]) -> list[dict[str, Any]]:
+            return [{"name": f"mcp__{name}__t", "auth": headers["Authorization"]}]
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", side_effect=_fake_resolve),
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            tools = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+                connections=connections,
+            )
+        assert sorted(seen_urls) == ["https://m1", "https://mcp.github"]
+        auths = {t["auth"] for t in tools}
+        assert auths == {
+            "Bearer token-for-https://mcp.github",
+            "Bearer token-for-https://m1",
+        }

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -1,5 +1,4 @@
-"""Unit tests for discover_session_mcp_tools — the Phase 2 (#31)
-unified MCP discovery.
+"""Unit tests for discover_session_mcp_tools.
 
 Covers the collect-URLs-then-discover shape: agent-declared MCP
 (filtered by enabled mcp_toolset entries) unioned with

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -127,8 +127,8 @@ class TestDiscoverSessionMcpTools:
         assert urls == {"https://m1", "https://m2"}
         names = {t["name"] for t in tools}
         assert names == {
-            "mcp__conn_conn_01HQR2K7VXBZ9MNPL3WYCT8F__t",
-            "mcp__conn_conn_01HQR2K7VXBZ9MNPL3WYCT8G__t",
+            "mcp__conn_01HQR2K7VXBZ9MNPL3WYCT8F__t",
+            "mcp__conn_01HQR2K7VXBZ9MNPL3WYCT8G__t",
         }
 
     async def test_agent_and_connections_combined(self) -> None:

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -12,59 +12,148 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aios.crypto.vault import CryptoBox
-from aios.mcp.client import call_mcp_tool, discover_mcp_tools, resolve_auth_headers
+from aios.mcp.client import call_mcp_tool, discover_mcp_tools, resolve_auth_for_url
 
-# ── resolve_auth_headers ──────────────────────────────────────────────────────
+# ── resolve_auth_for_url ──────────────────────────────────────────────────────
 
 
-class TestResolveAuthHeaders:
+class TestResolveAuthForUrl:
+    """Connection-declared credentials take precedence over session_vaults.
+
+    If the URL is owned by a registered connection, auth comes from that
+    connection's vault.  Otherwise we fall back to the session's bound
+    vaults (the existing mechanism for agent-declared MCP).
+    """
+
     @pytest.fixture
     def crypto_box(self) -> CryptoBox:
         import os
 
         return CryptoBox(os.urandom(32))
 
-    async def test_no_credential_returns_empty(self, crypto_box: CryptoBox) -> None:
+    async def test_connection_url_uses_connection_vault(self, crypto_box: CryptoBox) -> None:
+        payload = json.dumps({"token": "connection-token"})
+        blob = crypto_box.encrypt(payload)
         pool = MagicMock()
-        with patch("aios.mcp.client.queries.resolve_mcp_credential", new_callable=AsyncMock) as m:
-            m.return_value = None
-            result = await resolve_auth_headers(
+        with (
+            patch(
+                "aios.mcp.client.queries.get_connection_vault_for_url",
+                new_callable=AsyncMock,
+            ) as g,
+            patch(
+                "aios.mcp.client.queries.resolve_vault_credential",
+                new_callable=AsyncMock,
+            ) as v,
+            patch(
+                "aios.mcp.client.queries.resolve_mcp_credential",
+                new_callable=AsyncMock,
+            ) as s,
+        ):
+            g.return_value = ("conn_abc", "vlt_v2")
+            v.return_value = (blob, "static_bearer")
+            result = await resolve_auth_for_url(
+                pool, crypto_box, "sess_123", "https://mcp.example.com"
+            )
+        assert result == {"Authorization": "Bearer connection-token"}
+        # Connection precedence: session_vaults lookup MUST NOT be consulted.
+        s.assert_not_awaited()
+        v.assert_awaited_once()
+
+    async def test_connection_url_missing_credential_returns_empty(
+        self, crypto_box: CryptoBox
+    ) -> None:
+        pool = MagicMock()
+        with (
+            patch(
+                "aios.mcp.client.queries.get_connection_vault_for_url",
+                new_callable=AsyncMock,
+            ) as g,
+            patch(
+                "aios.mcp.client.queries.resolve_vault_credential",
+                new_callable=AsyncMock,
+            ) as v,
+            patch(
+                "aios.mcp.client.queries.resolve_mcp_credential",
+                new_callable=AsyncMock,
+            ) as s,
+        ):
+            g.return_value = ("conn_abc", "vlt_v2")
+            v.return_value = None
+            result = await resolve_auth_for_url(
+                pool, crypto_box, "sess_123", "https://mcp.example.com"
+            )
+        assert result == {}
+        # Still doesn't fall back — connection ownership decided the source.
+        s.assert_not_awaited()
+
+    async def test_non_connection_url_falls_back_to_session_vaults(
+        self, crypto_box: CryptoBox
+    ) -> None:
+        payload = json.dumps({"token": "session-token"})
+        blob = crypto_box.encrypt(payload)
+        pool = MagicMock()
+        with (
+            patch(
+                "aios.mcp.client.queries.get_connection_vault_for_url",
+                new_callable=AsyncMock,
+            ) as g,
+            patch(
+                "aios.mcp.client.queries.resolve_vault_credential",
+                new_callable=AsyncMock,
+            ) as v,
+            patch(
+                "aios.mcp.client.queries.resolve_mcp_credential",
+                new_callable=AsyncMock,
+            ) as s,
+        ):
+            g.return_value = None
+            s.return_value = (blob, "static_bearer")
+            result = await resolve_auth_for_url(
+                pool, crypto_box, "sess_123", "https://mcp.example.com"
+            )
+        assert result == {"Authorization": "Bearer session-token"}
+        v.assert_not_awaited()
+        s.assert_awaited_once()
+
+    async def test_neither_source_returns_empty(self, crypto_box: CryptoBox) -> None:
+        pool = MagicMock()
+        with (
+            patch(
+                "aios.mcp.client.queries.get_connection_vault_for_url",
+                new_callable=AsyncMock,
+            ) as g,
+            patch(
+                "aios.mcp.client.queries.resolve_mcp_credential",
+                new_callable=AsyncMock,
+            ) as s,
+        ):
+            g.return_value = None
+            s.return_value = None
+            result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com"
             )
         assert result == {}
 
-    async def test_static_bearer(self, crypto_box: CryptoBox) -> None:
-        payload = json.dumps({"token": "my-secret-token"})
+    async def test_mcp_oauth_from_connection(self, crypto_box: CryptoBox) -> None:
+        payload = json.dumps({"access_token": "oauth-conn-token"})
         blob = crypto_box.encrypt(payload)
         pool = MagicMock()
-        with patch("aios.mcp.client.queries.resolve_mcp_credential", new_callable=AsyncMock) as m:
-            m.return_value = (blob, "static_bearer")
-            result = await resolve_auth_headers(
+        with (
+            patch(
+                "aios.mcp.client.queries.get_connection_vault_for_url",
+                new_callable=AsyncMock,
+            ) as g,
+            patch(
+                "aios.mcp.client.queries.resolve_vault_credential",
+                new_callable=AsyncMock,
+            ) as v,
+        ):
+            g.return_value = ("conn_abc", "vlt_v2")
+            v.return_value = (blob, "mcp_oauth")
+            result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com"
             )
-        assert result == {"Authorization": "Bearer my-secret-token"}
-
-    async def test_mcp_oauth(self, crypto_box: CryptoBox) -> None:
-        payload = json.dumps({"access_token": "oauth-token-123"})
-        blob = crypto_box.encrypt(payload)
-        pool = MagicMock()
-        with patch("aios.mcp.client.queries.resolve_mcp_credential", new_callable=AsyncMock) as m:
-            m.return_value = (blob, "mcp_oauth")
-            result = await resolve_auth_headers(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
-            )
-        assert result == {"Authorization": "Bearer oauth-token-123"}
-
-    async def test_empty_token_returns_empty(self, crypto_box: CryptoBox) -> None:
-        payload = json.dumps({"token": ""})
-        blob = crypto_box.encrypt(payload)
-        pool = MagicMock()
-        with patch("aios.mcp.client.queries.resolve_mcp_credential", new_callable=AsyncMock) as m:
-            m.return_value = (blob, "static_bearer")
-            result = await resolve_auth_headers(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
-            )
-        assert result == {}
+        assert result == {"Authorization": "Bearer oauth-conn-token"}
 
 
 # ── discover_mcp_tools ────────────────────────────────────────────────────────

--- a/tests/unit/test_mcp_models.py
+++ b/tests/unit/test_mcp_models.py
@@ -53,9 +53,7 @@ class TestMcpServerSpec:
 
     def test_conn_prefix_reserved(self) -> None:
         """The ``conn_`` prefix is reserved for connection-derived MCP server
-        names (Phase 2, #31).  Even though conn_{c.id} is collision-free by
-        construction with the current scheme, we reserve the namespace so
-        future changes remain safe.
+        names — agent-declared names must not collide.
         """
         with pytest.raises(ValueError, match="conn_"):
             McpServerSpec(name="conn_github", url="https://mcp.github.com/")

--- a/tests/unit/test_mcp_models.py
+++ b/tests/unit/test_mcp_models.py
@@ -51,6 +51,36 @@ class TestMcpServerSpec:
         restored = McpServerSpec.model_validate_json(j)
         assert restored.name == "slack"
 
+    def test_conn_prefix_reserved(self) -> None:
+        """The ``conn_`` prefix is reserved for connection-derived MCP server
+        names (Phase 2, #31).  Even though conn_{c.id} is collision-free by
+        construction with the current scheme, we reserve the namespace so
+        future changes remain safe.
+        """
+        with pytest.raises(ValueError, match="conn_"):
+            McpServerSpec(name="conn_github", url="https://mcp.github.com/")
+
+    def test_conn_prefix_reserved_in_agent_create(self) -> None:
+        """Same rejection at the AgentCreate boundary (the HTTP router
+        path — JSON body → ``model_validate`` runs the field validator
+        on every nested mcp_servers entry).
+        """
+        with pytest.raises(ValueError, match="conn_"):
+            AgentCreate.model_validate(
+                {
+                    "name": "bad",
+                    "model": "openai/gpt-4o-mini",
+                    "system": "",
+                    "mcp_servers": [{"type": "url", "name": "conn_foo", "url": "https://m"}],
+                }
+            )
+
+    def test_names_without_conn_prefix_accepted(self) -> None:
+        """Names containing ``conn`` but not starting with ``conn_`` are fine."""
+        assert McpServerSpec(name="connector", url="https://m").name == "connector"
+        assert McpServerSpec(name="my_conn", url="https://m").name == "my_conn"
+        assert McpServerSpec(name="conn", url="https://m").name == "conn"
+
 
 class TestMcpToolsetConfig:
     def test_defaults(self) -> None:

--- a/tests/unit/test_mcp_routing.py
+++ b/tests/unit/test_mcp_routing.py
@@ -101,6 +101,36 @@ class TestResolveMcpPermission:
         ]
         assert resolve_mcp_permission("mcp__github__create_issue", tools) is None
 
+    def test_connection_provided_defaults_to_always_allow(self) -> None:
+        """Tools from connection-provided MCP servers (names with the
+        reserved ``conn_`` prefix) don't require per-call confirmation:
+        the session's channel binding is the explicit routing consent.
+        """
+        # No agent-declared mcp_toolset entry references the connection —
+        # the reserved-prefix validator forbids it — so normally we'd
+        # fall through to None (= always_ask).  Connection servers are
+        # the exception.
+        assert (
+            resolve_mcp_permission("mcp__conn_01HQR2K7VXBZ9MNPL3WYCT8F__send", []) == "always_allow"
+        )
+
+    def test_connection_provided_ignores_agent_overrides(self) -> None:
+        """Even if someone (somehow) had a matching mcp_toolset entry, the
+        connection branch wins — agent-declared tools can't target
+        connection-derived servers by name."""
+        # The validator prevents this from being constructible via API, but
+        # test behaviour directly in case of bypass (e.g., legacy DB rows).
+        tools = [
+            ToolSpec(
+                type="mcp_toolset",
+                mcp_server_name="conn_foo",
+                default_config=McpToolsetConfig(
+                    permission_policy=McpPermissionPolicy(type="always_ask"),
+                ),
+            ),
+        ]
+        assert resolve_mcp_permission("mcp__conn_foo__send", tools) == "always_allow"
+
 
 class TestToOpenaiToolsSkipsMcpToolset:
     def test_mcp_toolset_skipped(self) -> None:


### PR DESCRIPTION
## Summary

Phase 2 of the connectors/channels design (closes #31, child of #29).  Depends on #30 (merged in #32).  Merged in #34 (vault OAuth refresh + cascade).

Wires the harness to surface channel bindings to the agent:

- Tool list includes MCP tools from connections whose channels are bound to the session
- System prompt is augmented with a natural-language list of bound channels
- Assistant text is prefixed with `INTERNAL_MONOLOGUE:` when the session has bindings (persisted — that's the teaching mechanism; do not strip on replay)
- MCP auth is resolved via a single `resolve_auth_for_url` that gives connection-declared credentials precedence over `session_vaults`, with OAuth refresh applied transparently on expiring credentials from either source

No behaviour change for sessions without bindings — the load-bearing invariant the design rests on.

## Key design choices

- **Connection MCP server names are the connection id directly** (`c.id`, which is `conn_<ULID>` via `ids.CONNECTION`).  No stutter, globally unique by construction, no sanitization.  The `conn_` prefix is reserved via the `McpServerSpec` validator.  The constant lives in `src/aios/models/connections.py` (imported by both producer and rejecter).
- **Connection-provided tools default to `always_allow`.**  `resolve_mcp_permission` short-circuits any server name in the reserved `conn_` namespace to `always_allow`, because the session's channel binding is already explicit human consent to route messages there — re-gating each reply on a confirmation prompt is noise, not safety.  Agent-declared MCP keeps its existing opt-in-via-`mcp_toolset` shape.
- **`resolve_auth_for_url` with precedence, not fallback-on-miss.**  If a URL is owned by a connection but that vault has no matching credential, return `{}` — *not* the session-vault credential.  Prevents a misconfigured connection from silently leaking a tenant-level credential across the ownership boundary.  OAuth refresh works for both sources: the re-read after refresh goes through `resolve_vault_credential(vault_id, url)` regardless of origin.
- **Bindings loaded once at step top, passed through.**  Single pool acquire via `list_bindings_and_connections` covers both the bindings fetch and the `(connector, account)` → connections batch lookup.
- **`_headers_from_credential` / `_token_from_payload` extracted** so the session-vaults path and the connection-vault path share the same decrypt/token-extraction logic.
- **`INTERNAL_MONOLOGUE:` prefix handles both string and list-of-blocks content**, idempotent per-segment, applied before append.

## Non-goals / deferred

- **`no_response` tool** — deferred per issue #31; rely on the monologue prefix and system-prompt guidance first.
- **Connector implementation** — Phase 3.
- **Per-connection permission override** — the uniform `always_allow` default is intentional for Phase 2.  If a specific connection ever needs per-call confirmation, that would land as a `permission_policy` field on the Connection resource (migration + API + tests), not as part of this PR.

## Test plan

- [x] `uv run mypy src` — 82 source files, no issues
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 526 passed
- [x] `uv run pytest tests/e2e -q` (Docker) — 170 passed
- [x] Headline precedence test: `TestResolveAuthForUrlPrecedence` asserts V2 (connection vault) wins over V1 (session_vaults) when both carry credentials for the same URL, and verifies a misconfigured connection returns `{}` rather than leaking a session_vaults credential.
- [x] OAuth refresh: `test_oauth_refresh_triggered_when_expiring` (session-vaults path) and `test_oauth_refresh_triggered_on_connection_path` cover refresh on both sources; `test_oauth_refresh_failure_bubbles` confirms no silent fallback.
- [x] Permission: `test_connection_provided_defaults_to_always_allow` pins the new default; `test_connection_provided_ignores_agent_overrides` prevents a bypass even if a legacy `mcp_toolset` entry exists.
- [x] Regression: existing `test_step_model.py` (47 tests) continues to pass, confirming no behaviour change for sessions without bindings.
- [x] Unit coverage for `discover_session_mcp_tools` (agent-only, connections-only, combined, per-URL auth, empty-both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
