### PR TITLE
feat: per-connector system prompt via MCP `instructions`

### DIFF
--- a/connectors/signal/src/aios_signal/mcp.py
+++ b/connectors/signal/src/aios_signal/mcp.py
@@ -29,6 +29,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from .addressing import decode_chat_id
 from .markdown import convert_markdown_to_signal_styles
+from .prompts import SIGNAL_SERVER_INSTRUCTIONS
 from .rpc import RpcClient
 
 log = structlog.get_logger(__name__)
@@ -61,7 +62,11 @@ class BearerAuthMiddleware:
 
 
 def build_mcp_server(*, rpc: RpcClient) -> FastMCP:
-    mcp = FastMCP("aios-signal", stateless_http=True)
+    mcp = FastMCP(
+        "aios-signal",
+        instructions=SIGNAL_SERVER_INSTRUCTIONS,
+        stateless_http=True,
+    )
 
     @mcp.tool()
     async def signal_send(chat_id: str, text: str) -> dict[str, Any]:

--- a/connectors/signal/src/aios_signal/prompts.py
+++ b/connectors/signal/src/aios_signal/prompts.py
@@ -1,0 +1,101 @@
+"""Per-connector affordance prose surfaced to the agent via MCP.
+
+Returned in the ``InitializeResult.instructions`` field of the MCP
+``initialize`` response; the aios harness concatenates it into the
+session's system prompt under a ``## Connector: signal/<account>``
+heading.
+
+Covers only the tools this server actually exposes — ``signal_send``,
+``signal_react``, ``signal_read_receipt``.  Telling the model about
+tools that don't exist would be worse than silence.
+"""
+
+from __future__ import annotations
+
+SIGNAL_SERVER_INSTRUCTIONS = """\
+## chat_id
+
+Each Signal channel address is path-shaped: ``signal/<account>/<chat_id>``.
+The ``chat_id`` segment is what you pass to the tools below — pass it
+verbatim, do not decode it.  It already encodes the distinction between
+direct messages (a recipient UUID) and groups (a URL-safe-base64 group
+id) so the tool can route correctly.
+
+## Sending messages — `signal_send`
+
+**Your text responses are NOT sent automatically.** Bare assistant text
+is internal monologue; nobody on Signal sees it.  To deliver a message
+you MUST call:
+
+    signal_send(chat_id="<chat_id>", text="your message here")
+
+If you don't call this tool, no one will see your response.
+
+### Avoid splitting one thought into multiple messages
+
+Before calling `signal_send`, ask: "am I about to do some trivial work
+and then send again?"  If yes, finish the work first and send one
+combined message.  Back-to-back messages without substantial work in
+between feel like a bot narrating its own steps.
+
+Multiple `signal_send` calls are fine when there is genuinely heavy
+work between them (research, file processing, long tasks) and you are
+giving progress updates.  The test is whether the human would be left
+wondering what is happening — if so, send an update.
+
+## Reacting — `signal_react`
+
+Lighter-weight than a full message.  Call when an emoji says enough:
+
+    signal_react(
+        chat_id="<chat_id>",
+        target_author_uuid="<uuid from inbound metadata>",
+        target_timestamp_ms=<timestamp from inbound metadata>,
+        emoji="👍",
+    )
+
+**Common reactions:** 👍 ❤️ 😂 😮 😢 🎉 🔥 ✅
+
+**When to react instead of sending a full message:**
+- Someone addresses you but a full reply would be overkill — a 👍 or
+  ❤️ says "I see you".
+- Something genuinely makes you laugh or smile — 😂 or ❤️.
+- Good news worth celebrating — 🎉 or 🔥.
+- Acknowledging you will handle something — ✅ or 👍.
+- A cute photo or sweet moment — ❤️.
+
+Mundane messages do not need reactions; standout moments do.  Think
+about what a human would naturally react to.
+
+## Read receipts — `signal_read_receipt`
+
+Mark one or more inbound messages as read so the sender's UI shows the
+double check.  Pass the sender's ACI UUID and the timestamps of the
+messages you are acknowledging:
+
+    signal_read_receipt(
+        sender_uuid="<uuid>",
+        timestamp_ms_list=[<ts1>, <ts2>],
+    )
+
+Use sparingly — usually only when you have actually consumed the
+messages and the sender benefits from knowing.
+
+## Markdown subset
+
+Signal supports a subset of markdown.  In `signal_send` text, use only:
+
+- **bold** (`**text**`) and *italic* (`*text*`) — can be nested
+- ~~strikethrough~~ (`~~text~~`)
+- `inline code` and fenced code blocks (triple backticks)
+- ||spoiler|| (`||text||`)
+- Headers (`# text`, `## text`) — rendered as bold
+
+**Do NOT use** markdown that Signal cannot render — it will appear as
+raw characters in the recipient's chat:
+
+- No `[links](url)` — paste URLs directly.
+- No `> blockquotes`.
+- No `- bullet lists` or `1. numbered lists` — use plain line breaks.
+- No tables, images, or horizontal rules.
+"""

--- a/connectors/signal/tests/test_mcp.py
+++ b/connectors/signal/tests/test_mcp.py
@@ -206,3 +206,20 @@ def test_build_mcp_app_returns_starlette() -> None:
     mcp = build_mcp_server(rpc=rpc)  # type: ignore[arg-type]
     app = build_mcp_app(mcp, token="t")
     assert isinstance(app, Starlette)
+
+
+def test_build_mcp_server_passes_signal_instructions() -> None:
+    """The MCP server's ``instructions`` field is the transport for
+    Signal's per-connector affordance prose; aios reads it from the
+    ``InitializeResult`` returned by ``session.initialize()`` and
+    composes it into the agent's system prompt.
+    """
+    from aios_signal.prompts import SIGNAL_SERVER_INSTRUCTIONS
+
+    rpc = FakeRpc()
+    mcp = build_mcp_server(rpc=rpc)  # type: ignore[arg-type]
+    assert mcp.instructions == SIGNAL_SERVER_INSTRUCTIONS
+    # Sanity-check the prose covers the v1 toolset.
+    assert "signal_send" in mcp.instructions
+    assert "signal_react" in mcp.instructions
+    assert "signal_read_receipt" in mcp.instructions

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1758,7 +1758,10 @@ async def get_connections_by_pairs(
 ) -> list[Connection]:
     """Active connections where ``(connector, account)`` is in ``pairs``.
 
-    Empty input → no roundtrip.
+    Empty input → no roundtrip.  Results are ordered by ``c.id`` so the
+    caller can feed them into the system prompt in a stable order — a
+    prerequisite for prompt-cache stability across steps, since the
+    caller-side ``pairs`` are typically built from a set.
     """
     if not pairs:
         return []
@@ -1771,6 +1774,7 @@ async def get_connections_by_pairs(
           JOIN unnest($1::text[], $2::text[]) AS p(connector, account)
             ON c.connector = p.connector AND c.account = p.account
          WHERE c.archived_at IS NULL
+         ORDER BY c.id
         """,
         connectors,
         accounts,

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -38,6 +38,13 @@ async def list_bindings_and_connections(
 
 
 def build_channels_system_block(bindings: list[ChannelBinding]) -> str:
+    """Generic, connector-agnostic prose introducing the channels paradigm.
+
+    Per-platform specifics (Signal markdown subset, mention syntax,
+    response idioms) live in each connector and travel through the MCP
+    ``InitializeResult.instructions`` field — see
+    :func:`build_connector_instructions_block`.
+    """
     if not bindings:
         return ""
     lines = ["You are bound to the following channels:"]
@@ -45,16 +52,72 @@ def build_channels_system_block(bindings: list[ChannelBinding]) -> str:
         lines.append(f"  - {b.address}")
     lines.append("")
     lines.append(
-        "Use the appropriate connector tool to respond to each channel. "
-        "Bare assistant text is not sent to any channel — it is internal "
-        f"thinking and will be prefixed with {MONOLOGUE_PREFIX.strip()!r} in your "
-        "conversation history as a reminder that it is not visible to users."
+        "A channel is a conversation reachable through a connector "
+        "(Signal, Slack, etc.). Each address is path-shaped: "
+        "connector/account/chat-id."
+    )
+    lines.append("")
+    lines.append(
+        "To respond to a channel you must call the connector's response "
+        "tool — for Signal that is `signal_send`; other connectors "
+        "expose their own response tools, described in the per-connector "
+        "sections below. Bare assistant text is NOT delivered to any "
+        f"channel; it is internal thinking and will be prefixed with "
+        f"{MONOLOGUE_PREFIX.strip()!r} in your conversation history as "
+        "a reminder that no human will see it."
+    )
+    lines.append("")
+    lines.append(
+        "You may take any number of tool calls before responding (web "
+        "fetches, file edits, sandbox commands). Tools run "
+        "asynchronously — new user messages can arrive while a tool is "
+        "in flight, and you will see them on your next step. There is "
+        "no obligation to respond on every step; silence is the right "
+        "choice when there is nothing new requiring a reply."
     )
     return "\n".join(lines)
 
 
 def augment_with_channels(base_system: str, bindings: list[ChannelBinding]) -> str:
     block = build_channels_system_block(bindings)
+    if not block:
+        return base_system
+    if base_system:
+        return base_system + "\n\n" + block
+    return block
+
+
+def build_connector_instructions_block(
+    instructions_by_server: dict[str, str],
+    connections: list[Connection],
+) -> str:
+    """Render per-connector affordance prose grouped by connection.
+
+    ``instructions_by_server`` maps server_name (which for connection-
+    provided MCP servers equals ``connection_server_name(c)``) to the
+    server's ``InitializeResult.instructions`` string.  Connections are
+    iterated in the caller-supplied order so the prompt is stable
+    across steps (cache friendly).
+
+    Connections without an entry in the dict are skipped — a connector
+    that supplies no instructions contributes no block.
+    """
+    sections: list[str] = []
+    for c in connections:
+        name = connection_server_name(c)
+        text = instructions_by_server.get(name)
+        if not text:
+            continue
+        sections.append(f"## Connector: {c.connector}/{c.account}\n\n{text}")
+    return "\n\n".join(sections)
+
+
+def augment_with_connector_instructions(
+    base_system: str,
+    instructions_by_server: dict[str, str],
+    connections: list[Connection],
+) -> str:
+    block = build_connector_instructions_block(instructions_by_server, connections)
     if not block:
         return base_system
     if base_system:

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -59,12 +59,11 @@ def build_channels_system_block(bindings: list[ChannelBinding]) -> str:
     lines.append("")
     lines.append(
         "To respond to a channel you must call the connector's response "
-        "tool — for Signal that is `signal_send`; other connectors "
-        "expose their own response tools, described in the per-connector "
-        "sections below. Bare assistant text is NOT delivered to any "
-        f"channel; it is internal thinking and will be prefixed with "
-        f"{MONOLOGUE_PREFIX.strip()!r} in your conversation history as "
-        "a reminder that no human will see it."
+        "tool; each connector describes its own tools in the "
+        "per-connector sections below. Bare assistant text is NOT "
+        "delivered to any channel; it is internal thinking and will be "
+        f"prefixed with {MONOLOGUE_PREFIX.strip()!r} in your "
+        "conversation history as a reminder that no human will see it."
     )
     lines.append("")
     lines.append(

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -97,8 +97,18 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
         )
         return
 
+    # Discovery runs before prompt assembly because each MCP server's
+    # instructions feed the per-connector affordance block.
+    tools = to_openai_tools(agent.tools)
+    mcp_instructions: dict[str, str] = {}
+    if agent.mcp_servers or connections:
+        mcp_tools, mcp_instructions = await discover_session_mcp_tools(
+            pool, session_id, agent, connections
+        )
+        tools.extend(mcp_tools)
+
     # Resolve skills and augment system prompt.
-    from aios.harness.channels import augment_with_channels
+    from aios.harness.channels import augment_with_channels, augment_with_connector_instructions
     from aios.harness.skills import augment_system_prompt, provision_skill_files
     from aios.services import skills as skills_service
 
@@ -107,17 +117,13 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
     )
     system_prompt = augment_system_prompt(agent.system, skill_versions)
     system_prompt = augment_with_channels(system_prompt, bindings)
+    system_prompt = augment_with_connector_instructions(
+        system_prompt, mcp_instructions, connections
+    )
 
     # Provision skill files to workspace (idempotent, host-side writes).
     if skill_versions:
         await provision_skill_files(session_id, skill_versions)
-
-    # Build context with pending-result synthesis.
-    tools = to_openai_tools(agent.tools)
-
-    if agent.mcp_servers or connections:
-        mcp_tools = await discover_session_mcp_tools(pool, session_id, agent, connections)
-        tools.extend(mcp_tools)
 
     ctx = build_messages(
         events,
@@ -360,9 +366,15 @@ async def discover_session_mcp_tools(
     session_id: str,
     agent: Any,
     connections: list[Any],
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], dict[str, str]]:
     """Discover MCP tools from agent-declared servers (filtered by enabled
     ``mcp_toolset`` entries) unioned with connection-provided servers.
+
+    Returns ``(tools, instructions_by_server)`` where the second element
+    maps ``server_name`` → the server's ``InitializeResult.instructions``
+    string.  Servers that supplied no instructions (or ``""``) are
+    omitted from the dict — the harness uses presence in the dict as
+    the trigger for rendering a per-connector affordance block.
     """
     import asyncio
 
@@ -383,16 +395,24 @@ async def discover_session_mcp_tools(
         servers.append((connection_server_name(c), c.mcp_url))
 
     if not servers:
-        return []
+        return [], {}
 
     crypto_box = runtime.require_crypto_box()
 
-    async def _discover_one(name: str, url: str) -> list[dict[str, Any]]:
+    async def _discover_one(name: str, url: str) -> tuple[list[dict[str, Any]], str | None]:
         headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
         return await discover_mcp_tools(url, name, headers)
 
     results = await asyncio.gather(*[_discover_one(n, u) for n, u in servers])
-    return [tool for tools in results for tool in tools]
+    tools: list[dict[str, Any]] = [
+        tool for (tool_list, _instructions) in results for tool in tool_list
+    ]
+    instructions_by_server: dict[str, str] = {
+        name: instructions
+        for (name, _url), (_tools, instructions) in zip(servers, results, strict=True)
+        if instructions
+    }
+    return tools, instructions_by_server
 
 
 async def _dispatch_confirmed_tools(

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -20,6 +20,7 @@ import asyncpg
 import httpx
 from mcp.client.session import ClientSession
 from mcp.client.streamable_http import streamable_http_client
+from mcp.types import InitializeResult
 
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
@@ -31,8 +32,14 @@ log = get_logger("aios.mcp.client")
 MAX_TOOLS_PER_SERVER = 128
 
 
-async def _open_session(url: str, headers: dict[str, str], stack: AsyncExitStack) -> ClientSession:
-    """Open a fully initialized MCP session, registering all contexts on *stack*."""
+async def _open_session(
+    url: str, headers: dict[str, str], stack: AsyncExitStack
+) -> tuple[ClientSession, InitializeResult]:
+    """Open a fully initialized MCP session, registering all contexts on *stack*.
+
+    Returns the session along with the ``InitializeResult`` so callers can
+    read server-supplied metadata (notably ``instructions``).
+    """
     http_client = await stack.enter_async_context(httpx.AsyncClient(headers=headers))
     read_stream, write_stream, _ = await stack.enter_async_context(
         streamable_http_client(url, http_client=http_client)
@@ -40,8 +47,8 @@ async def _open_session(url: str, headers: dict[str, str], stack: AsyncExitStack
     session: ClientSession = await stack.enter_async_context(
         ClientSession(read_stream, write_stream)
     )
-    await session.initialize()
-    return session
+    init_result = await session.initialize()
+    return session, init_result
 
 
 def _token_from_payload(payload: dict[str, Any], auth_type: str) -> str:
@@ -118,16 +125,24 @@ async def discover_mcp_tools(
     url: str,
     server_name: str,
     headers: dict[str, str],
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], str | None]:
     """Connect to an MCP server and discover available tools.
 
-    Returns a list of OpenAI-format tool dicts with namespaced names
-    (``mcp__<server_name>__<tool_name>``). On any error, logs a warning
-    and returns an empty list — the model simply doesn't see those tools.
+    Returns a ``(tools, instructions)`` pair:
+
+    * ``tools`` — OpenAI-format tool dicts with namespaced names
+      (``mcp__<server_name>__<tool_name>``).
+    * ``instructions`` — the server's ``InitializeResult.instructions``
+      string (per the MCP spec), or ``None`` if the server didn't supply
+      any. Used by the harness to compose per-connector affordance prose
+      into the system prompt.
+
+    On any error, logs a warning and returns ``([], None)`` — the model
+    simply doesn't see those tools (or that connector's instructions).
     """
     try:
         async with AsyncExitStack() as stack:
-            session = await _open_session(url, headers, stack)
+            session, init_result = await _open_session(url, headers, stack)
             result = await session.list_tools()
 
         if len(result.tools) > MAX_TOOLS_PER_SERVER:
@@ -150,7 +165,7 @@ async def discover_mcp_tools(
                     },
                 }
             )
-        return tools
+        return tools, init_result.instructions
 
     except Exception:
         log.warning(
@@ -159,7 +174,7 @@ async def discover_mcp_tools(
             url=url,
             exc_info=True,
         )
-        return []
+        return [], None
 
 
 async def call_mcp_tool(
@@ -176,7 +191,7 @@ async def call_mcp_tool(
     """
     try:
         async with AsyncExitStack() as stack:
-            session = await _open_session(url, headers, stack)
+            session, _ = await _open_session(url, headers, stack)
             result = await session.call_tool(tool_name, arguments)
 
         # Concatenate text content from the result.

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -1073,6 +1073,12 @@ class TestGetConnectionsByPairs:
             )
         ids = {c.id for c in rows}
         assert ids == {c_a.id, c_b.id}
+        # Results must be id-ordered so callers can pass them into the
+        # system prompt in a stable order (prompt-cache stability
+        # invariant).  Caller-side inputs are typically set-derived and
+        # therefore have non-deterministic order across processes.
+        returned_ids = [c.id for c in rows]
+        assert returned_ids == sorted(returned_ids)
 
     async def test_excludes_archived(self, pool: Any, vault_id: str) -> None:
         from aios.db import queries

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -12,7 +12,9 @@ from typing import Any
 from aios.harness.channels import (
     apply_monologue_prefix,
     augment_with_channels,
+    augment_with_connector_instructions,
     build_channels_system_block,
+    build_connector_instructions_block,
     connection_server_name,
 )
 from aios.models.channel_bindings import ChannelBinding
@@ -89,6 +91,81 @@ class TestBuildChannelsSystemBlock:
         )
         assert "signal/alice/chat-1" in block
         assert "slack/ws/C123/t" in block
+
+    def test_generic_paradigm_prose_present(self) -> None:
+        block = build_channels_system_block([_binding("signal/alice/chat-1")])
+        assert "asynchronously" in block
+        assert "silence" in block
+
+
+# ── build_connector_instructions_block / augment_with_connector_instructions ──
+
+
+class TestBuildConnectorInstructionsBlock:
+    def test_empty_dict_returns_empty(self) -> None:
+        assert build_connector_instructions_block({}, []) == ""
+
+    def test_no_matching_connection_returns_empty(self) -> None:
+        """Instructions keyed under a server name that no connection
+        matches must NOT be rendered — we only describe the connectors
+        the session is actually bound to.
+        """
+        c = _connection("conn_aaa", connector="signal", account="alice")
+        block = build_connector_instructions_block({"conn_unknown": "stray prose"}, [c])
+        assert block == ""
+
+    def test_single_connection_renders_heading_and_body(self) -> None:
+        c = _connection("conn_aaa", connector="signal", account="alice")
+        block = build_connector_instructions_block({connection_server_name(c): "be brief"}, [c])
+        assert "## Connector: signal/alice" in block
+        assert "be brief" in block
+
+    def test_multiple_connections_rendered_in_input_order(self) -> None:
+        """Ordering is caller-controlled — important for prompt-cache
+        stability across steps.  Test by passing two connections and
+        asserting the output order matches.
+        """
+        c1 = _connection("conn_aaa", connector="signal", account="alice")
+        c2 = _connection("conn_bbb", connector="signal", account="bob")
+        instructions = {
+            connection_server_name(c1): "alice prose",
+            connection_server_name(c2): "bob prose",
+        }
+        block = build_connector_instructions_block(instructions, [c1, c2])
+        assert block.index("alice prose") < block.index("bob prose")
+        # Reverse the connections list — output order flips.
+        block_rev = build_connector_instructions_block(instructions, [c2, c1])
+        assert block_rev.index("bob prose") < block_rev.index("alice prose")
+
+    def test_connection_without_instructions_skipped(self) -> None:
+        c1 = _connection("conn_aaa", connector="signal", account="alice")
+        c2 = _connection("conn_bbb", connector="signal", account="bob")
+        block = build_connector_instructions_block(
+            {connection_server_name(c2): "bob prose"}, [c1, c2]
+        )
+        assert "alice" not in block
+        assert "bob prose" in block
+
+
+class TestAugmentWithConnectorInstructions:
+    def test_no_instructions_returns_base_unchanged(self) -> None:
+        c = _connection("conn_aaa")
+        assert augment_with_connector_instructions("base", {}, [c]) == "base"
+
+    def test_appends_block_after_base(self) -> None:
+        c = _connection("conn_aaa", connector="signal", account="alice")
+        out = augment_with_connector_instructions(
+            "base system", {connection_server_name(c): "prose"}, [c]
+        )
+        assert out.startswith("base system")
+        assert "## Connector: signal/alice" in out
+        assert "\n\n" in out
+
+    def test_empty_base_yields_block_only(self) -> None:
+        c = _connection("conn_aaa", connector="signal", account="alice")
+        out = augment_with_connector_instructions("", {connection_server_name(c): "prose"}, [c])
+        assert out.startswith("## Connector:")
+        assert not out.startswith("\n")
 
 
 class TestAugmentWithChannels:

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -58,13 +58,14 @@ class TestDiscoverSessionMcpTools:
     async def test_no_sources_returns_empty(self) -> None:
         from aios.harness.loop import discover_session_mcp_tools
 
-        tools = await discover_session_mcp_tools(
+        tools, instructions = await discover_session_mcp_tools(
             pool=AsyncMock(),
             session_id="sess_x",
             agent=_agent(),
             connections=[],
         )
         assert tools == []
+        assert instructions == {}
 
     async def test_agent_only_enabled_server(self) -> None:
         """Only enabled mcp_toolset entries produce discovery; disabled
@@ -83,15 +84,17 @@ class TestDiscoverSessionMcpTools:
             ],
         )
 
-        async def _discover(url: str, name: str, _headers: dict[str, str]) -> list[dict[str, Any]]:
-            return [{"name": f"mcp__{name}__t", "url": url}]
+        async def _discover(
+            url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [{"name": f"mcp__{name}__t", "url": url}], None
 
         with (
             patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
             patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
         ):
             resolve.return_value = {}
-            tools = await discover_session_mcp_tools(
+            tools, _instructions = await discover_session_mcp_tools(
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
@@ -108,15 +111,17 @@ class TestDiscoverSessionMcpTools:
             _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8G", "https://m2"),
         ]
 
-        async def _discover(url: str, name: str, _headers: dict[str, str]) -> list[dict[str, Any]]:
-            return [{"name": f"mcp__{name}__t", "url": url}]
+        async def _discover(
+            url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [{"name": f"mcp__{name}__t", "url": url}], None
 
         with (
             patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
             patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
         ):
             resolve.return_value = {}
-            tools = await discover_session_mcp_tools(
+            tools, _instructions = await discover_session_mcp_tools(
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=_agent(),
@@ -140,15 +145,17 @@ class TestDiscoverSessionMcpTools:
         )
         connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
 
-        async def _discover(url: str, name: str, _headers: dict[str, str]) -> list[dict[str, Any]]:
-            return [{"name": f"mcp__{name}__t", "url": url}]
+        async def _discover(
+            url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [{"name": f"mcp__{name}__t", "url": url}], None
 
         with (
             patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
             patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
         ):
             resolve.return_value = {}
-            tools = await discover_session_mcp_tools(
+            tools, _instructions = await discover_session_mcp_tools(
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
@@ -175,14 +182,16 @@ class TestDiscoverSessionMcpTools:
             seen_urls.append(url)
             return {"Authorization": f"Bearer token-for-{url}"}
 
-        async def _discover(url: str, name: str, headers: dict[str, str]) -> list[dict[str, Any]]:
-            return [{"name": f"mcp__{name}__t", "auth": headers["Authorization"]}]
+        async def _discover(
+            url: str, name: str, headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [{"name": f"mcp__{name}__t", "auth": headers["Authorization"]}], None
 
         with (
             patch("aios.mcp.client.resolve_auth_for_url", side_effect=_fake_resolve),
             patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
         ):
-            tools = await discover_session_mcp_tools(
+            tools, _instructions = await discover_session_mcp_tools(
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
@@ -194,3 +203,66 @@ class TestDiscoverSessionMcpTools:
             "Bearer token-for-https://mcp.github",
             "Bearer token-for-https://m1",
         }
+
+    async def test_instructions_keyed_by_server_name(self) -> None:
+        """Each server's ``InitializeResult.instructions`` flows into the
+        returned dict under its server_name key.  Servers that supply no
+        instructions are omitted — the harness uses dict membership as
+        the trigger for rendering a per-connector affordance block.
+        """
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
+            tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
+        )
+        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
+
+        async def _discover(
+            url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            # Agent server supplies nothing; connection server supplies prose.
+            if name == "gh":
+                return [], None
+            return [], "## signal\n\nbe nice"
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            _tools, instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+                connections=connections,
+            )
+        # 'gh' returned None → omitted; connection returned prose → present.
+        assert instructions == {"conn_01HQR2K7VXBZ9MNPL3WYCT8F": "## signal\n\nbe nice"}
+
+    async def test_empty_string_instructions_omitted(self) -> None:
+        """An empty string is treated identically to ``None`` — no
+        affordance block should be rendered for a server that returned
+        ``""``.
+        """
+        from aios.harness.loop import discover_session_mcp_tools
+
+        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
+
+        async def _discover(
+            _url: str, _name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [], ""
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            _tools, instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=_agent(),
+                connections=connections,
+            )
+        assert instructions == {}

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -343,6 +343,18 @@ def _make_mock_tool(name: str, description: str, schema: dict[str, Any]) -> Magi
     return tool
 
 
+def _mock_init_result(instructions: str | None = None) -> MagicMock:
+    """Build an ``InitializeResult``-shaped mock.
+
+    ``MagicMock`` would happily synthesise a sub-mock for ``.instructions``
+    (truthy by default), so tests must set the attribute explicitly to
+    cover the ``None`` path.
+    """
+    result = MagicMock()
+    result.instructions = instructions
+    return result
+
+
 class TestDiscoverMcpTools:
     async def test_discovery_returns_namespaced_tools(self) -> None:
         mock_tool = _make_mock_tool("create_issue", "Create a GitHub issue", {"type": "object"})
@@ -350,7 +362,7 @@ class TestDiscoverMcpTools:
         mock_result.tools = [mock_tool]
 
         mock_session = AsyncMock()
-        mock_session.initialize = AsyncMock()
+        mock_session.initialize = AsyncMock(return_value=_mock_init_result())
         mock_session.list_tools = AsyncMock(return_value=mock_result)
 
         with (
@@ -364,13 +376,14 @@ class TestDiscoverMcpTools:
             mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
             mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            tools = await discover_mcp_tools("https://mcp.github.com/", "github", {})
+            tools, instructions = await discover_mcp_tools("https://mcp.github.com/", "github", {})
 
         assert len(tools) == 1
         assert tools[0]["type"] == "function"
         assert tools[0]["function"]["name"] == "mcp__github__create_issue"
         assert tools[0]["function"]["description"] == "Create a GitHub issue"
         assert tools[0]["function"]["parameters"] == {"type": "object"}
+        assert instructions is None
 
     async def test_discovery_multiple_tools(self) -> None:
         tools_data = [
@@ -381,7 +394,7 @@ class TestDiscoverMcpTools:
         mock_result.tools = tools_data
 
         mock_session = AsyncMock()
-        mock_session.initialize = AsyncMock()
+        mock_session.initialize = AsyncMock(return_value=_mock_init_result())
         mock_session.list_tools = AsyncMock(return_value=mock_result)
 
         with (
@@ -395,7 +408,9 @@ class TestDiscoverMcpTools:
             mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
             mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            tools = await discover_mcp_tools("https://mcp.example.com/", "myserver", {})
+            tools, _instructions = await discover_mcp_tools(
+                "https://mcp.example.com/", "myserver", {}
+            )
 
         assert len(tools) == 2
         assert tools[0]["function"]["name"] == "mcp__myserver__tool_a"
@@ -406,9 +421,41 @@ class TestDiscoverMcpTools:
             mock_transport.return_value.__aenter__ = AsyncMock(side_effect=ConnectionError("down"))
             mock_transport.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            tools = await discover_mcp_tools("https://bad.example.com/", "bad", {})
+            result = await discover_mcp_tools("https://bad.example.com/", "bad", {})
 
-        assert tools == []
+        assert result == ([], None)
+
+    async def test_discovery_propagates_server_instructions(self) -> None:
+        """``InitializeResult.instructions`` is the standard MCP transport
+        for per-server prompt affordance prose.  The harness reads it from
+        ``discover_mcp_tools``'s second return slot to compose the
+        per-connector system-prompt block.
+        """
+        mock_tool = _make_mock_tool("signal_send", "Send a Signal message", {"type": "object"})
+        mock_result = MagicMock()
+        mock_result.tools = [mock_tool]
+
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock(
+            return_value=_mock_init_result("## Signal\n\nUse signal_send to reply.")
+        )
+        mock_session.list_tools = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("aios.mcp.client.streamable_http_client") as mock_transport,
+            patch("aios.mcp.client.ClientSession") as mock_session_cls,
+        ):
+            mock_transport.return_value.__aenter__ = AsyncMock(
+                return_value=(MagicMock(), MagicMock(), MagicMock())
+            )
+            mock_transport.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            tools, instructions = await discover_mcp_tools("https://mcp.signal/", "signal", {})
+
+        assert len(tools) == 1
+        assert instructions == "## Signal\n\nUse signal_send to reply."
 
 
 # ── call_mcp_tool ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Split the connector-aware session's system prompt into two contributions: a generic aios-owned channels block and per-connector affordance prose transported via MCP's standard `InitializeResult.instructions` field.
- Signal connector ships its first affordance (chat_id encoding, `signal_send` / `signal_react` / `signal_read_receipt`, markdown subset).
- Implements Phase 4 item 1 from #35.

## Design notes

- **Generic block** lives in `harness/channels.py:build_channels_system_block` — expanded from a three-line placeholder into paradigm prose (what a channel is, explicit-response tools, async tool execution, silence permitted). Applies to every connector.
- **Per-connector block** travels in each MCP server's `InitializeResult.instructions` — now surfaced by `_open_session` and returned as the second tuple element of `discover_mcp_tools` / `discover_session_mcp_tools`. The harness renders one `## Connector: <connector>/<account>` section per bound connection whose server supplied instructions.
- `run_session_step` now does MCP discovery **before** prompt assembly, since the affordance block is a function of the servers' `instructions` fields. Tool listing already ran at this phase, so no extra stall.
- Fail-soft preserved: a broken MCP server yields `([], None)` and the agent loses that connector's tools *and* its prose, nothing else.
- Signal's initial prose deliberately excludes voice/audio, mentions, reply-quoting, and `no_response` — telling the model about tools that don't exist would be worse than silence. Those land with Phase 4 items 2 and the reactive items.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 538 passed
- [x] `uv --project connectors/signal run pytest connectors/signal/tests -q` — 67 passed
- [ ] E2E (Docker): `DOCKER_HOST=unix:///Users/tom/.docker/run/docker.sock uv run pytest tests/e2e -q`
- [ ] Manual smoke: bind a session to a Signal channel, send an inbound message, confirm the next assistant step's system prompt contains both the expanded generic channels block and a `## Connector: signal/<account>` section with the affordance prose.
- [ ] Cache stability: second turn produces byte-identical system prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)