### PR TITLE
feat(connections): block archival while active bindings exist

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1807,6 +1807,26 @@ async def archive_connection(conn: asyncpg.Connection[Any], connection_id: str) 
     return _row_to_connection(row)
 
 
+async def count_active_bindings_for_connection(
+    conn: asyncpg.Connection[Any], *, connector: str, account: str
+) -> int:
+    """Count active channel bindings whose address is scoped to this
+    (connector, account). Used to block connection archival while sessions
+    are still reachable via those bindings — archiving the connection would
+    silently drop the connection-provided MCP tools from any live session.
+
+    Uses ``starts_with`` (literal prefix match) rather than ``LIKE`` so
+    accounts containing ``%`` or ``_`` don't expand into wildcard matches.
+    """
+    prefix = f"{connector}/{account}/"
+    val: int = await conn.fetchval(
+        "SELECT COUNT(*) FROM channel_bindings "
+        "WHERE starts_with(address, $1) AND archived_at IS NULL",
+        prefix,
+    )
+    return val
+
+
 # ─── channel bindings ───────────────────────────────────────────────────────
 
 

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -1,9 +1,10 @@
 """Business logic for connection resources.
 
-Thin wrapper over :mod:`aios.db.queries` — connections themselves carry
-no business rules at this phase. The actual routing logic lives in
-:mod:`aios.services.channels`; the inbound-message endpoint composes
-this service with that one.
+Thin wrapper over :mod:`aios.db.queries`. The only business rule lives
+in :func:`archive_connection`, which refuses to archive a connection
+while channel bindings under its ``(connector, account)`` prefix are
+still active — archiving would silently drop the connection-provided
+MCP tools from any live session bound to those channels.
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from typing import Any
 import asyncpg
 
 from aios.db import queries
+from aios.errors import ConflictError
 from aios.models.connections import Connection
 
 
@@ -68,4 +70,24 @@ async def update_connection(
 
 async def archive_connection(pool: asyncpg.Pool[Any], connection_id: str) -> Connection:
     async with pool.acquire() as conn:
+        connection = await queries.get_connection(conn, connection_id)
+        if connection.archived_at is not None:
+            # Let the query raise its canonical "already archived" error.
+            return await queries.archive_connection(conn, connection_id)
+        active = await queries.count_active_bindings_for_connection(
+            conn, connector=connection.connector, account=connection.account
+        )
+        if active > 0:
+            raise ConflictError(
+                f"connection {connection_id} has {active} active channel binding"
+                f"{'s' if active != 1 else ''} under {connection.connector}/"
+                f"{connection.account}; archive the bindings first to avoid "
+                f"silently dropping MCP tools from live sessions",
+                detail={
+                    "id": connection_id,
+                    "active_bindings": active,
+                    "connector": connection.connector,
+                    "account": connection.account,
+                },
+            )
         return await queries.archive_connection(conn, connection_id)

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -158,6 +158,95 @@ class TestConnectionCRUD:
             metadata={},
         )
 
+    async def test_archive_blocked_by_active_bindings(
+        self, pool: Any, agent_id: str, env_id: str, vault_id: str
+    ) -> None:
+        """A connection with an active binding can't be archived silently —
+        doing so would drop MCP tools from any live session bound to
+        channels under that ``(connector, account)`` prefix.
+        """
+        from aios.services import channels as ch_svc
+        from aios.services import connections as svc
+        from aios.services import sessions as sess_svc
+
+        account = f"archblock-{_uniq()}"
+        c = await svc.create_connection(
+            pool,
+            connector="signal",
+            account=account,
+            mcp_url="https://m",
+            vault_id=vault_id,
+            metadata={},
+        )
+        session = await sess_svc.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+        )
+        binding = await ch_svc.create_binding(
+            pool,
+            address=f"signal/{account}/chat-1",
+            session_id=session.id,
+        )
+
+        with pytest.raises(ConflictError) as exc:
+            await svc.archive_connection(pool, c.id)
+        assert "active channel binding" in str(exc.value)
+        assert exc.value.detail["active_bindings"] == 1
+        assert exc.value.detail["connector"] == "signal"
+        assert exc.value.detail["account"] == account
+
+        # After archiving the binding, connection archival succeeds.
+        await ch_svc.archive_binding(pool, binding.id)
+        archived = await svc.archive_connection(pool, c.id)
+        assert archived.archived_at is not None
+
+    async def test_archive_ignores_bindings_on_other_accounts(
+        self, pool: Any, agent_id: str, env_id: str, vault_id: str
+    ) -> None:
+        """A binding scoped to a different ``(connector, account)`` doesn't
+        block archival — the prefix match is literal, not wildcard.
+        """
+        from aios.services import channels as ch_svc
+        from aios.services import connections as svc
+        from aios.services import sessions as sess_svc
+
+        account_a = f"archigna-{_uniq()}"
+        account_b = f"archignb-{_uniq()}"
+        c_a = await svc.create_connection(
+            pool,
+            connector="signal",
+            account=account_a,
+            mcp_url="https://a",
+            vault_id=vault_id,
+            metadata={},
+        )
+        await svc.create_connection(
+            pool,
+            connector="signal",
+            account=account_b,
+            mcp_url="https://b",
+            vault_id=vault_id,
+            metadata={},
+        )
+        session = await sess_svc.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+        )
+        # Binding lives under account_b; account_a should archive cleanly.
+        await ch_svc.create_binding(
+            pool,
+            address=f"signal/{account_b}/chat-1",
+            session_id=session.id,
+        )
+        archived = await svc.archive_connection(pool, c_a.id)
+        assert archived.archived_at is not None
+
     async def test_unknown_vault(self, pool: Any) -> None:
         from aios.services import connections as svc
 


### PR DESCRIPTION
## Summary

Archiving a connection with live channel bindings under its `(connector, account)` prefix used to silently break every session using those bindings — MCP discovery would quietly drop the connector's tools from the session's tool list, with no feedback to the operator or the agent.

This PR makes `archive_connection` check for active bindings first and raise `ConflictError` (409) if any exist, forcing the operator to archive the bindings explicitly.

## Policy chosen

**Block delete if active bindings exist.** Alternatives I considered (from #35 Phase 4):
- *Cascade archive bindings* — too destructive; sessions would become un-routable silently.
- *Warn + allow* — the status-quo bug. Rejected.

Block-delete mirrors SQL FK semantics: archival is an explicit operator action that has to be made explicit against downstream references.

## Prefix matching

Uses Postgres `starts_with(address, $1)` with `$1 = "<connector>/<account>/"`. Literal, not `LIKE`, so accounts containing `%` or `_` don't expand into wildcards.

## Tests

Two new e2e tests in `TestConnectionCRUD`:

- `test_archive_blocked_by_active_bindings` — creates a connection + session + binding; `archive_connection` raises `ConflictError` with the binding count in `detail`; archiving the binding then unblocks archival.
- `test_archive_ignores_bindings_on_other_accounts` — two connections under different accounts, binding on only one; the other archives cleanly. Guards against the literal-prefix logic accidentally matching across accounts.

All 62 `tests/e2e/test_routing.py` tests green. No behaviour change to any other path.

Implements one of the Phase 4 items tracked in #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)