### PR TITLE
feat(context): inline channel metadata into user message content

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -26,9 +26,77 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 from aios.models.events import Event
+
+
+def _format_channel_header(metadata: dict[str, Any]) -> str:
+    """Render a one-line header describing the origin of an inbound message.
+
+    When a user message carries channel metadata, the raw fields are
+    whitelisted out of the chat-completions message before the model ever
+    sees them (see ``_ALLOWED_FIELDS``).  That leaves the model with no way
+    to know the sender or timestamp — values the connector tools need as
+    arguments.  Inline the salient fields into the visible ``content`` so
+    the model can read them natively.
+    """
+    if not isinstance(metadata, dict) or "channel" not in metadata:
+        return ""
+    parts: list[str] = [f"channel={metadata['channel']}"]
+    chat_type = metadata.get("chat_type")
+    if isinstance(chat_type, str) and chat_type:
+        parts.append(f"chat_type={chat_type}")
+    chat_name = metadata.get("chat_name")
+    if isinstance(chat_name, str) and chat_name:
+        parts.append(f"chat_name={chat_name!r}")
+    sender_name = metadata.get("sender_name")
+    if isinstance(sender_name, str) and sender_name:
+        parts.append(f"from={sender_name}")
+    sender_uuid = metadata.get("sender_uuid")
+    if isinstance(sender_uuid, str) and sender_uuid:
+        parts.append(f"sender_uuid={sender_uuid}")
+    timestamp_ms = metadata.get("timestamp_ms")
+    if isinstance(timestamp_ms, int):
+        iso = datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).isoformat(timespec="milliseconds")
+        parts.append(f"timestamp_ms={timestamp_ms} ({iso})")
+    header = "[" + " · ".join(parts) + "]"
+    # Surface platform-native reactions (emoji tap-backs) that come through
+    # as message events with empty content. Without this line the agent sees
+    # the user event as a blank message.
+    reaction = metadata.get("reaction")
+    if isinstance(reaction, dict):
+        emoji = reaction.get("emoji") or "?"
+        r_parts: list[str] = [f"reaction={emoji!r}"]
+        target_author = reaction.get("target_author_uuid")
+        if isinstance(target_author, str) and target_author:
+            r_parts.append(f"target_author_uuid={target_author}")
+        target_ts = reaction.get("target_timestamp_ms")
+        if isinstance(target_ts, int):
+            r_parts.append(f"target_timestamp_ms={target_ts}")
+        header += "\n[" + " · ".join(r_parts) + "]"
+    # Surface a quoted-reply summary when present so the model can see
+    # which message the user is responding to via the platform's native
+    # reply feature.
+    reply_to = metadata.get("reply_to")
+    if isinstance(reply_to, dict):
+        quoted = (reply_to.get("text") or "").replace("\n", " ").strip()
+        quote_parts: list[str] = []
+        author = reply_to.get("author_uuid")
+        if isinstance(author, str) and author:
+            quote_parts.append(f"author_uuid={author}")
+        ts = reply_to.get("timestamp_ms")
+        if isinstance(ts, int):
+            quote_parts.append(f"timestamp_ms={ts}")
+        quote_meta = " · ".join(quote_parts) if quote_parts else "?"
+        if quoted:
+            snippet = quoted if len(quoted) <= 200 else quoted[:200] + "…"
+            header += f"\n[reply_to: {quote_meta}] > {snippet}"
+        else:
+            header += f"\n[reply_to: {quote_meta}]"
+    return header
+
 
 # Chat-completions spec fields per role.  Only these are emitted in the
 # context; provider-specific extensions (reasoning_content, etc.) stay
@@ -237,6 +305,12 @@ def build_messages(
 
         if role == "user":
             msg = {k: v for k, v in e.data.items() if k != "metadata"}
+            metadata = e.data.get("metadata")
+            if isinstance(metadata, dict):
+                header = _format_channel_header(metadata)
+                if header:
+                    existing = msg.get("content") or ""
+                    msg["content"] = f"{header}\n{existing}" if existing else header
             messages.append(msg)
             max_stimulus_seq = max(max_stimulus_seq, e.seq)
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -20,6 +20,7 @@ def _evt(
     tool_calls: list[dict[str, Any]] | None = None,
     tool_call_id: str | None = None,
     content: str = "",
+    metadata: dict[str, Any] | None = None,
 ) -> Event:
     """Build a minimal message Event for testing."""
     data: dict[str, Any] = {"role": role, "content": content}
@@ -27,6 +28,8 @@ def _evt(
         data["tool_calls"] = tool_calls
     if tool_call_id is not None:
         data["tool_call_id"] = tool_call_id
+    if metadata is not None:
+        data["metadata"] = metadata
     return Event(
         id=f"evt_{seq}",
         session_id="sess_01TEST",
@@ -744,3 +747,115 @@ class TestToolCallSanitization:
         ]
         build_messages(events, system_prompt=None)
         assert events[1].data["tool_calls"][0]["function"]["arguments"] == bad_args
+
+
+# ─── channel header inlining ────────────────────────────────────────────────
+
+
+class TestChannelHeader:
+    """Inbound messages stamped with connector metadata get a header line
+    inlined into their ``content`` so the model can natively read the
+    channel, sender, timestamp, reply-to, and reaction fields.
+
+    Metadata is whitelisted out of the chat-completions message by
+    :func:`_strip_to_spec`; the header is the agent-visible projection.
+    """
+
+    def test_no_metadata_leaves_content_untouched(self) -> None:
+        events = [_evt(1, "user", content="hello")]
+        msgs = build_messages(events, system_prompt=None).messages
+        assert msgs[0]["content"] == "hello"
+
+    def test_non_dict_metadata_leaves_content_untouched(self) -> None:
+        # metadata field exists but isn't a dict — defensive: no crash, no header.
+        events = [_evt(1, "user", content="hello", metadata={})]
+        msgs = build_messages(events, system_prompt=None).messages
+        # empty dict has no "channel" key → no header
+        assert msgs[0]["content"] == "hello"
+
+    def test_basic_channel_header(self) -> None:
+        md = {
+            "channel": "signal/bot-uuid/peer-uuid",
+            "sender_uuid": "peer-uuid",
+            "timestamp_ms": 1776401210703,
+        }
+        events = [_evt(1, "user", content="hi", metadata=md)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert content.startswith("[channel=signal/bot-uuid/peer-uuid")
+        assert "sender_uuid=peer-uuid" in content
+        assert "timestamp_ms=1776401210703" in content
+        assert content.endswith("\nhi")
+
+    def test_header_includes_chat_type_and_name(self) -> None:
+        md = {
+            "channel": "signal/bot/group-id",
+            "chat_type": "group",
+            "chat_name": "QA",
+            "sender_uuid": "u1",
+            "sender_name": "Tom",
+            "timestamp_ms": 1776401210703,
+        }
+        events = [_evt(1, "user", content="yo", metadata=md)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "chat_type=group" in content
+        assert "chat_name='QA'" in content
+        assert "from=Tom" in content
+
+    def test_header_surfaces_reply_to(self) -> None:
+        md = {
+            "channel": "signal/bot/peer",
+            "reply_to": {
+                "author_uuid": "bot",
+                "timestamp_ms": 1776400000000,
+                "text": "what I said before",
+            },
+        }
+        events = [_evt(1, "user", content="reacting to that", metadata=md)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        # Second line is the reply block with quoted text preview.
+        assert "\n[reply_to: author_uuid=bot · timestamp_ms=1776400000000]" in content
+        assert "> what I said before" in content
+        assert content.endswith("\nreacting to that")
+
+    def test_header_surfaces_reaction(self) -> None:
+        """Reactions arrive as user events with empty content; the header
+        makes the agent see them as a reaction rather than a blank message.
+        """
+        md = {
+            "channel": "signal/bot/peer",
+            "reaction": {
+                "emoji": "👍",
+                "target_author_uuid": "bot",
+                "target_timestamp_ms": 1776400000000,
+            },
+        }
+        events = [_evt(1, "user", content="", metadata=md)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "[reaction='👍'" in content
+        assert "target_author_uuid=bot" in content
+        assert "target_timestamp_ms=1776400000000" in content
+
+    def test_metadata_stripped_from_wire_message(self) -> None:
+        """The chat-completions message only has spec fields (role, content,
+        name). ``metadata`` must never appear.
+        """
+        md = {"channel": "signal/bot/peer", "sender_uuid": "u1"}
+        events = [_evt(1, "user", content="hi", metadata=md)]
+        msg = build_messages(events, system_prompt=None).messages[0]
+        assert "metadata" not in msg
+        assert set(msg.keys()) <= {"role", "content", "name"}
+
+    def test_timestamp_ms_gets_iso_alongside_raw(self) -> None:
+        """Model sees both the raw ms integer (for tool args) and a
+        human-readable ISO form (for reading).
+        """
+        md = {
+            "channel": "signal/bot/peer",
+            "timestamp_ms": 1776401210703,
+        }
+        events = [_evt(1, "user", content="hi", metadata=md)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        # Raw integer appears for tool args.
+        assert "timestamp_ms=1776401210703" in content
+        # ISO rendering (UTC, millisecond precision) appears parenthesized.
+        assert "(2026-04-17T" in content


### PR DESCRIPTION
## Summary

When a connector stamps metadata on an inbound event (`channel`, `sender_uuid`, `timestamp_ms`, `chat_type`, `chat_name`, `reply_to`, `reaction`), the raw fields are whitelisted out of the chat-completions wire message by `_ALLOWED_FIELDS` — the model never sees them.

This left connector tools with arguments like `target_author_uuid` / `target_timestamp_ms` that the model couldn't source. The Signal smoke test hit this path and produced a 10-step retry spiral where the model mutated base64 variants of the wrong UUID while the real timestamp sat in metadata it couldn't see.

This PR projects the salient metadata into the visible `content` as a header line computed at context-build time:

```
[channel=signal/bot/peer · chat_type=dm · chat_name='QA' · from=Tom · sender_uuid=6c21718f-... · timestamp_ms=1776401210703 (2026-04-17T04:46:50.703+00:00)]
hello darkness my old friend
```

## What lands in the header

| Field | When present | Notes |
|---|---|---|
| `channel` | always (gate) | full path |
| `chat_type` | when stamped | `dm` / `group` / etc. |
| `chat_name` | for groups | repr-quoted |
| `from` | when `sender_name` is known | display name |
| `sender_uuid` | always if stamped | for react/receipt tool args |
| `timestamp_ms` | always if stamped | raw int + ISO rendering |
| `[reply_to: ...]` line | if replying | separate line with quoted preview |
| `[reaction='👍' ...]` line | if reaction event | separate line — makes empty-content reactions visible |

## Design choices

- **Per-build, not stored**: event log stays unchanged. Rebuilding yields the same prefix (monotonicity holds).
- **In `content`, not a new field**: `_strip_to_spec` keeps only spec fields. Using `content` reaches every provider unchanged.
- **Human-readable key=value**: the model references fields by name in monologue and tool args without prompting tricks.
- **Separate lines for reply_to and reaction**: keeps the main header compact.

## Live validation (Signal smoke test)

Before: `target_timestamp_ms: 1776391345000` (rounded, fabricated) — reactions landed on nothing.  
After: `target_timestamp_ms: 1776394349388` (exact match with the real inbound) — reactions landed correctly.

Tested with minimax, Gemma 4, and Opus 4.7 — all three read the fields correctly.

## Tests

Eight new `TestChannelHeader` cases in `tests/unit/test_context.py`. All 561 unit tests pass. ruff / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)