### PR TITLE
feat(channels): focal-channel attention model (closes #49)

### DIFF
--- a/connectors/signal/src/aios_signal/mcp.py
+++ b/connectors/signal/src/aios_signal/mcp.py
@@ -46,7 +46,7 @@ log = structlog.get_logger(__name__)
 _FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
 
-def _focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> str:
+def focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> str:
     """Extract the Signal ``chat_id`` from an MCP request's ``_meta``.
 
     aios injects ``aios.focal_channel_path`` for connection-provided
@@ -69,7 +69,7 @@ def _focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> str:
     return path
 
 
-def _build_send_params(chat_id: str, text: str) -> dict[str, Any]:
+def build_send_params(chat_id: str, text: str) -> dict[str, Any]:
     """Translate ``(chat_id, text)`` into signal-cli ``send`` params.
 
     Pure function: decodes the URL-safe chat_id, applies Signal's
@@ -88,7 +88,7 @@ def _build_send_params(chat_id: str, text: str) -> dict[str, Any]:
     return params
 
 
-def _build_react_params(
+def build_react_params(
     chat_id: str,
     target_author_uuid: str,
     target_timestamp_ms: int,
@@ -152,8 +152,8 @@ def build_mcp_server(*, rpc: RpcClient) -> FastMCP:
         Args:
             text: Message body. Markdown is converted to Signal text styles.
         """
-        chat_id = _focal_chat_id_from_meta(ctx.request_context.meta)
-        params = _build_send_params(chat_id, text)
+        chat_id = focal_chat_id_from_meta(ctx.request_context.meta)
+        params = build_send_params(chat_id, text)
         result = await rpc.call("send", params)
         return {"sent_at_ms": _extract_timestamp(result)}
 
@@ -174,8 +174,8 @@ def build_mcp_server(*, rpc: RpcClient) -> FastMCP:
             target_timestamp_ms: Timestamp of the target message (from inbound metadata).
             emoji: The reaction emoji.
         """
-        chat_id = _focal_chat_id_from_meta(ctx.request_context.meta)
-        params = _build_react_params(chat_id, target_author_uuid, target_timestamp_ms, emoji)
+        chat_id = focal_chat_id_from_meta(ctx.request_context.meta)
+        params = build_react_params(chat_id, target_author_uuid, target_timestamp_ms, emoji)
         await rpc.call("sendReaction", params)
         return {"status": "ok"}
 

--- a/connectors/signal/src/aios_signal/mcp.py
+++ b/connectors/signal/src/aios_signal/mcp.py
@@ -22,7 +22,8 @@ from typing import Any
 
 import structlog
 import uvicorn
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import RequestParams
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -33,6 +34,78 @@ from .prompts import SIGNAL_SERVER_INSTRUCTIONS
 from .rpc import RpcClient
 
 log = structlog.get_logger(__name__)
+
+
+# Key under a JSON-RPC tool-call request's ``_meta`` populated by the
+# aios worker when dispatching a connection-provided tool.  Its value
+# is the focal-channel path suffix — for Signal's 3-segment address
+# ``signal/<bot>/<chat>``, the suffix is just ``<chat>`` and can be
+# decoded directly as the Signal chat id.  See the aios focal-channel
+# plan + ``aios.harness.channels.FOCAL_CHANNEL_META_KEY`` for the
+# client-side contract.
+_FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
+
+
+def _focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> str:
+    """Extract the Signal ``chat_id`` from an MCP request's ``_meta``.
+
+    aios injects ``aios.focal_channel_path`` for connection-provided
+    tool calls; its value is the full focal-channel suffix (stripped
+    of ``<connector>/<account>``), which for a 3-segment Signal
+    address equals the chat id verbatim.  Missing / malformed meta
+    raises — the agent shouldn't be able to reach these tools without
+    a focal channel set (aios filters them out of the tool list when
+    focal is NULL), so any absence here is a real error to surface.
+    """
+    path: Any = None
+    if meta is not None:
+        extra = getattr(meta, "model_extra", None) or {}
+        path = extra.get(_FOCAL_CHANNEL_META_KEY)
+    if not isinstance(path, str) or not path:
+        raise ValueError(
+            "signal tools require a focal channel — aios should inject "
+            f"{_FOCAL_CHANNEL_META_KEY!r} in _meta when focal is set"
+        )
+    return path
+
+
+def _build_send_params(chat_id: str, text: str) -> dict[str, Any]:
+    """Translate ``(chat_id, text)`` into signal-cli ``send`` params.
+
+    Pure function: decodes the URL-safe chat_id, applies Signal's
+    markdown-to-textStyles transformation, and attaches either
+    ``recipient`` (DM) or ``groupId`` (group) per the decoded kind.
+    """
+    chat_type, raw_id = decode_chat_id(chat_id)
+    stripped, styles = convert_markdown_to_signal_styles(text)
+    params: dict[str, Any] = {"message": stripped}
+    if styles:
+        params["textStyles"] = styles
+    if chat_type == "group":
+        params["groupId"] = raw_id
+    else:
+        params["recipient"] = [raw_id]
+    return params
+
+
+def _build_react_params(
+    chat_id: str,
+    target_author_uuid: str,
+    target_timestamp_ms: int,
+    emoji: str,
+) -> dict[str, Any]:
+    """Translate a react request into signal-cli ``sendReaction`` params."""
+    chat_type, raw_id = decode_chat_id(chat_id)
+    params: dict[str, Any] = {
+        "emoji": emoji,
+        "targetAuthor": target_author_uuid,
+        "targetTimestamp": target_timestamp_ms,
+    }
+    if chat_type == "group":
+        params["groupId"] = raw_id
+    else:
+        params["recipient"] = [raw_id]
+    return params
 
 
 class BearerAuthMiddleware:
@@ -69,50 +142,40 @@ def build_mcp_server(*, rpc: RpcClient) -> FastMCP:
     )
 
     @mcp.tool()
-    async def signal_send(chat_id: str, text: str) -> dict[str, Any]:
-        """Send a text message to a Signal chat.
+    async def signal_send(text: str, ctx: Context[Any, Any, Any]) -> dict[str, Any]:
+        """Send a text message to your focal Signal chat.
+
+        The chat id is taken implicitly from your focal channel —
+        aios injects it via the JSON-RPC ``_meta`` field on each call.
+        Set focal with the built-in ``switch_channel`` tool.
 
         Args:
-            chat_id: URL-safe chat ID (DM UUID or URL-safe-base64 group ID).
             text: Message body. Markdown is converted to Signal text styles.
         """
-        chat_type, raw_id = decode_chat_id(chat_id)
-        stripped, styles = convert_markdown_to_signal_styles(text)
-        params: dict[str, Any] = {"message": stripped}
-        if styles:
-            params["textStyles"] = styles
-        if chat_type == "group":
-            params["groupId"] = raw_id
-        else:
-            params["recipient"] = [raw_id]
+        chat_id = _focal_chat_id_from_meta(ctx.request_context.meta)
+        params = _build_send_params(chat_id, text)
         result = await rpc.call("send", params)
         return {"sent_at_ms": _extract_timestamp(result)}
 
     @mcp.tool()
     async def signal_react(
-        chat_id: str,
         target_author_uuid: str,
         target_timestamp_ms: int,
         emoji: str,
+        ctx: Context[Any, Any, Any],
     ) -> dict[str, Any]:
-        """React to a Signal message with an emoji.
+        """React to a message in your focal Signal chat with an emoji.
+
+        The chat id is taken implicitly from your focal channel —
+        aios injects it via the JSON-RPC ``_meta`` field on each call.
 
         Args:
-            chat_id: URL-safe chat ID where the target message lives.
             target_author_uuid: ACI UUID of the message's author.
             target_timestamp_ms: Timestamp of the target message (from inbound metadata).
             emoji: The reaction emoji.
         """
-        chat_type, raw_id = decode_chat_id(chat_id)
-        params: dict[str, Any] = {
-            "emoji": emoji,
-            "targetAuthor": target_author_uuid,
-            "targetTimestamp": target_timestamp_ms,
-        }
-        if chat_type == "group":
-            params["groupId"] = raw_id
-        else:
-            params["recipient"] = [raw_id]
+        chat_id = _focal_chat_id_from_meta(ctx.request_context.meta)
+        params = _build_react_params(chat_id, target_author_uuid, target_timestamp_ms, emoji)
         await rpc.call("sendReaction", params)
         return {"status": "ok"}
 

--- a/connectors/signal/tests/test_mcp.py
+++ b/connectors/signal/tests/test_mcp.py
@@ -3,20 +3,42 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from mcp.server.fastmcp import Context
+from mcp.shared.context import RequestContext
+from mcp.types import RequestParams
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 
 from aios_signal.mcp import (
     BearerAuthMiddleware,
+    _build_react_params,
+    _build_send_params,
     _extract_timestamp,
+    _focal_chat_id_from_meta,
     build_mcp_app,
     build_mcp_server,
     parse_bind,
 )
+
+
+def _ctx_with_focal(chat_id: str | None) -> Context[Any, Any, Any]:
+    """Build a Context carrying an ``aios.focal_channel_path`` in ``_meta``.
+
+    The ToolManager.call_tool path accepts an explicit Context; this
+    lets us simulate what aios sends without going through a full
+    ClientSession round-trip.
+    """
+    rc = MagicMock(spec=RequestContext)
+    if chat_id is None:
+        rc.meta = None
+    else:
+        rc.meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": chat_id})
+    return Context(request_context=rc)
 
 
 class FakeRpc:
@@ -31,9 +53,25 @@ class FakeRpc:
         return self._results.get(method, {})
 
 
-async def _call_tool(rpc: FakeRpc, name: str, args: dict[str, Any]) -> dict[str, Any]:
+async def _call_tool(
+    rpc: FakeRpc,
+    name: str,
+    args: dict[str, Any],
+    *,
+    focal_chat_id: str | None = None,
+) -> dict[str, Any]:
+    """Invoke a Signal MCP tool with an aios-style focal-channel meta.
+
+    Goes through ``FastMCP.tool_manager.call_tool`` so the tool handler's
+    ``ctx: Context`` dependency is filled in with the constructed meta.
+    """
     mcp = build_mcp_server(rpc=rpc)  # type: ignore[arg-type]
-    result = await mcp.call_tool(name, args)
+    result = await mcp._tool_manager.call_tool(
+        name,
+        args,
+        _ctx_with_focal(focal_chat_id),
+        convert_result=True,
+    )
     # call_tool returns (content_blocks, structured_result) when the tool
     # has an output_schema (ours do — typed dict returns).
     assert isinstance(result, tuple)
@@ -42,62 +80,119 @@ async def _call_tool(rpc: FakeRpc, name: str, args: dict[str, Any]) -> dict[str,
     return structured
 
 
-async def test_signal_send_dm() -> None:
+# ─── unit: pure helpers ─────────────────────────────────────────────────────
+
+
+class TestFocalChatIdFromMeta:
+    def test_returns_path_when_present(self) -> None:
+        meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "chat-abc"})
+        assert _focal_chat_id_from_meta(meta) == "chat-abc"
+
+    def test_none_meta_raises(self) -> None:
+        with pytest.raises(ValueError, match="focal channel"):
+            _focal_chat_id_from_meta(None)
+
+    def test_missing_key_raises(self) -> None:
+        meta = RequestParams.Meta.model_validate({"other_key": "x"})
+        with pytest.raises(ValueError, match="focal channel"):
+            _focal_chat_id_from_meta(meta)
+
+    def test_empty_string_raises(self) -> None:
+        meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": ""})
+        with pytest.raises(ValueError, match="focal channel"):
+            _focal_chat_id_from_meta(meta)
+
+
+class TestBuildSendParams:
+    def test_dm_uuid(self) -> None:
+        params = _build_send_params("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "hi")
+        assert params == {
+            "message": "hi",
+            "recipient": ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"],
+        }
+
+    def test_group_urlsafe_base64_decoded(self) -> None:
+        params = _build_send_params("abc-def_xyz==", "hi")
+        assert params["groupId"] == "abc+def/xyz=="
+        assert "recipient" not in params
+
+    def test_markdown_produces_text_styles(self) -> None:
+        params = _build_send_params("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "**bold** now")
+        assert params["message"] == "bold now"
+        assert any("BOLD" in s for s in params["textStyles"])
+
+
+class TestBuildReactParams:
+    def test_dm_shape(self) -> None:
+        params = _build_react_params(
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "cccccccc-dddd-eeee-ffff-000000000000",
+            987654,
+            "👍",
+        )
+        assert params == {
+            "emoji": "👍",
+            "targetAuthor": "cccccccc-dddd-eeee-ffff-000000000000",
+            "targetTimestamp": 987654,
+            "recipient": ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"],
+        }
+
+    def test_group_shape(self) -> None:
+        params = _build_react_params(
+            "abc-def_xyz==",
+            "cccccccc-dddd-eeee-ffff-000000000000",
+            987654,
+            "👍",
+        )
+        assert params["groupId"] == "abc+def/xyz=="
+        assert "recipient" not in params
+
+
+# ─── integration: tool handlers consume _meta ──────────────────────────────
+
+
+async def test_signal_send_reads_focal_from_meta() -> None:
     rpc = FakeRpc(results={"send": {"timestamp": 123456}})
     result = await _call_tool(
         rpc,
         "signal_send",
-        {"chat_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "text": "hello"},
+        {"text": "hello"},
+        focal_chat_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
     )
     assert result == {"sent_at_ms": 123456}
     method, params = rpc.calls[0]
     assert method == "send"
-    assert params is not None
     assert params == {
         "message": "hello",
         "recipient": ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"],
     }
 
 
-async def test_signal_send_group() -> None:
-    rpc = FakeRpc(results={"send": {"timestamp": 99}})
-    # URL-safe group id — decode should reverse `-` to `+` and `_` to `/`.
-    urlsafe_group = "abc-def_xyz=="
-    await _call_tool(rpc, "signal_send", {"chat_id": urlsafe_group, "text": "hi"})
-    method, params = rpc.calls[0]
-    assert method == "send"
-    assert params is not None
-    assert params["groupId"] == "abc+def/xyz=="
-    assert "recipient" not in params
-    assert params["message"] == "hi"
+async def test_signal_send_errors_without_meta() -> None:
+    rpc = FakeRpc()
+    mcp = build_mcp_server(rpc=rpc)  # type: ignore[arg-type]
+    # No focal — aios should have filtered this tool out, but defend.
+    ctx_no_meta = _ctx_with_focal(None)
+    with pytest.raises(Exception, match="focal channel"):
+        await mcp._tool_manager.call_tool(
+            "signal_send",
+            {"text": "hi"},
+            ctx_no_meta,
+            convert_result=True,
+        )
 
 
-async def test_signal_send_with_markdown_emits_text_styles() -> None:
-    rpc = FakeRpc(results={"send": {"timestamp": 1}})
-    await _call_tool(
-        rpc,
-        "signal_send",
-        {"chat_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "text": "**bold** now"},
-    )
-    _method, params = rpc.calls[0]
-    assert params is not None
-    # Markdown stripped from message body.
-    assert params["message"] == "bold now"
-    # textStyles (plural) set with a BOLD span.
-    assert any("BOLD" in s for s in params["textStyles"])
-
-
-async def test_signal_react_dm() -> None:
+async def test_signal_react_reads_focal_from_meta() -> None:
     rpc = FakeRpc()
     await _call_tool(
         rpc,
         "signal_react",
         {
-            "chat_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "target_author_uuid": "cccccccc-dddd-eeee-ffff-000000000000",
             "target_timestamp_ms": 987654,
             "emoji": "👍",
         },
+        focal_chat_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
     )
     method, params = rpc.calls[0]
     assert method == "sendReaction"
@@ -107,6 +202,29 @@ async def test_signal_react_dm() -> None:
         "targetTimestamp": 987654,
         "recipient": ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"],
     }
+
+
+async def test_signal_send_group_via_meta() -> None:
+    rpc = FakeRpc(results={"send": {"timestamp": 99}})
+    await _call_tool(rpc, "signal_send", {"text": "hi"}, focal_chat_id="abc-def_xyz==")
+    _method, params = rpc.calls[0]
+    assert params is not None
+    assert params["groupId"] == "abc+def/xyz=="
+    assert "recipient" not in params
+
+
+async def test_signal_send_markdown_via_meta() -> None:
+    rpc = FakeRpc(results={"send": {"timestamp": 1}})
+    await _call_tool(
+        rpc,
+        "signal_send",
+        {"text": "**bold** now"},
+        focal_chat_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    )
+    _method, params = rpc.calls[0]
+    assert params is not None
+    assert params["message"] == "bold now"
+    assert any("BOLD" in s for s in params["textStyles"])
 
 
 async def test_signal_read_receipt() -> None:

--- a/connectors/signal/tests/test_mcp.py
+++ b/connectors/signal/tests/test_mcp.py
@@ -16,12 +16,12 @@ from starlette.routing import Route
 
 from aios_signal.mcp import (
     BearerAuthMiddleware,
-    _build_react_params,
-    _build_send_params,
     _extract_timestamp,
-    _focal_chat_id_from_meta,
     build_mcp_app,
     build_mcp_server,
+    build_react_params,
+    build_send_params,
+    focal_chat_id_from_meta,
     parse_bind,
 )
 
@@ -86,45 +86,45 @@ async def _call_tool(
 class TestFocalChatIdFromMeta:
     def test_returns_path_when_present(self) -> None:
         meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "chat-abc"})
-        assert _focal_chat_id_from_meta(meta) == "chat-abc"
+        assert focal_chat_id_from_meta(meta) == "chat-abc"
 
     def test_none_meta_raises(self) -> None:
         with pytest.raises(ValueError, match="focal channel"):
-            _focal_chat_id_from_meta(None)
+            focal_chat_id_from_meta(None)
 
     def test_missing_key_raises(self) -> None:
         meta = RequestParams.Meta.model_validate({"other_key": "x"})
         with pytest.raises(ValueError, match="focal channel"):
-            _focal_chat_id_from_meta(meta)
+            focal_chat_id_from_meta(meta)
 
     def test_empty_string_raises(self) -> None:
         meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": ""})
         with pytest.raises(ValueError, match="focal channel"):
-            _focal_chat_id_from_meta(meta)
+            focal_chat_id_from_meta(meta)
 
 
 class TestBuildSendParams:
     def test_dm_uuid(self) -> None:
-        params = _build_send_params("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "hi")
+        params = build_send_params("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "hi")
         assert params == {
             "message": "hi",
             "recipient": ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"],
         }
 
     def test_group_urlsafe_base64_decoded(self) -> None:
-        params = _build_send_params("abc-def_xyz==", "hi")
+        params = build_send_params("abc-def_xyz==", "hi")
         assert params["groupId"] == "abc+def/xyz=="
         assert "recipient" not in params
 
     def test_markdown_produces_text_styles(self) -> None:
-        params = _build_send_params("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "**bold** now")
+        params = build_send_params("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "**bold** now")
         assert params["message"] == "bold now"
         assert any("BOLD" in s for s in params["textStyles"])
 
 
 class TestBuildReactParams:
     def test_dm_shape(self) -> None:
-        params = _build_react_params(
+        params = build_react_params(
             "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "cccccccc-dddd-eeee-ffff-000000000000",
             987654,
@@ -138,7 +138,7 @@ class TestBuildReactParams:
         }
 
     def test_group_shape(self) -> None:
-        params = _build_react_params(
+        params = build_react_params(
             "abc-def_xyz==",
             "cccccccc-dddd-eeee-ffff-000000000000",
             987654,

--- a/migrations/versions/0017_focal_channel.py
+++ b/migrations/versions/0017_focal_channel.py
@@ -1,0 +1,47 @@
+"""Focal-channel attention model.
+
+Adds state + per-event stamps for the focal-channel redesign of
+connector-aware sessions (issue #29, focal-channel plan):
+
+* ``sessions.focal_channel`` — the bound channel the agent's attention
+  is currently directed at. NULL is a valid "phone down" state.
+* ``events.orig_channel`` — the channel a user event originated from
+  (derived from ``metadata["channel"]`` at append time).
+* ``events.focal_channel_at_arrival`` — the session's focal channel at
+  the moment the event was appended. Rendering (full vs notification)
+  is a deterministic function of ``(orig_channel, focal_channel_at_arrival)``.
+* ``channel_bindings.notification_mode`` — per-binding noisy/silent flag.
+  Silent bindings don't produce inline notification markers and are
+  rendered quieter in the ephemeral tail block.
+
+Revision ID: 0017
+Revises: 0016
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0017"
+down_revision: str = "0016"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE sessions ADD COLUMN focal_channel text")
+    op.execute("ALTER TABLE events ADD COLUMN orig_channel text")
+    op.execute("ALTER TABLE events ADD COLUMN focal_channel_at_arrival text")
+    op.execute(
+        "ALTER TABLE channel_bindings "
+        "ADD COLUMN notification_mode text NOT NULL DEFAULT 'focal_candidate'"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE channel_bindings DROP COLUMN IF EXISTS notification_mode")
+    op.execute("ALTER TABLE events DROP COLUMN IF EXISTS focal_channel_at_arrival")
+    op.execute("ALTER TABLE events DROP COLUMN IF EXISTS orig_channel")
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS focal_channel")

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -505,6 +505,7 @@ def _row_to_session(row: asyncpg.Record) -> Session:
         created_at=row["created_at"],
         updated_at=row["updated_at"],
         archived_at=row["archived_at"],
+        focal_channel=row["focal_channel"],
     )
 
 
@@ -769,6 +770,8 @@ def _row_to_event(row: asyncpg.Record) -> Event:
         data=data,
         cumulative_tokens=row["cumulative_tokens"],
         created_at=row["created_at"],
+        orig_channel=row["orig_channel"],
+        focal_channel_at_arrival=row["focal_channel_at_arrival"],
     )
 
 
@@ -790,6 +793,7 @@ async def append_event(
     session_id: str,
     kind: EventKind,
     data: dict[str, Any],
+    orig_channel: str | None = None,
 ) -> Event:
     """Append an event to ``session_id`` with gapless seq allocation.
 
@@ -802,7 +806,16 @@ async def append_event(
     running total of approximate token counts through this event.  The
     previous cumulative value is fetched inside the same transaction (under
     the session row lock), so there is no race with concurrent appenders.
+
+    Focal-channel stamping (issue #29 redesign): the session's current
+    ``focal_channel`` is read from the same UPDATE that allocates the seq
+    (via its RETURNING clause) and written to ``focal_channel_at_arrival``
+    on the new event row.  Pairing it with the caller-supplied
+    ``orig_channel`` (stamped for user events via ``append_user_message``)
+    lets the context builder render each event deterministically at arrival
+    time without ever needing to re-project past events.
     """
+    from aios.harness.context import render_user_event
     from aios.harness.tokens import approx_tokens
 
     new_id = make_id(EVENT)
@@ -811,28 +824,40 @@ async def append_event(
     async with conn.transaction():
         seq_row = await conn.fetchrow(
             "UPDATE sessions SET last_event_seq = last_event_seq + 1 "
-            "WHERE id = $1 RETURNING last_event_seq",
+            "WHERE id = $1 RETURNING last_event_seq, focal_channel",
             session_id,
         )
         if seq_row is None:
             raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
         seq = seq_row["last_event_seq"]
+        focal_at_arrival: str | None = seq_row["focal_channel"]
 
-        # Compute cumulative_tokens for message events.
+        # Compute cumulative_tokens for message events against the
+        # as-rendered form so the column stays honest for non-focal
+        # notification markers (which occupy far fewer tokens than their
+        # full-content counterparts).
         cum_tokens: int | None = None
         if kind == "message":
             prev = await _latest_cumulative_tokens(conn, session_id)
-            cum_tokens = (prev or 0) + approx_tokens(data)
+            if data.get("role") == "user" and orig_channel is not None:
+                rendered = render_user_event(data, orig_channel, focal_at_arrival)
+                cum_tokens = (prev or 0) + approx_tokens(rendered)
+            else:
+                cum_tokens = (prev or 0) + approx_tokens(data)
 
         row = await conn.fetchrow(
-            "INSERT INTO events (id, session_id, seq, kind, data, cumulative_tokens) "
-            "VALUES ($1, $2, $3, $4, $5::jsonb, $6) RETURNING *",
+            "INSERT INTO events "
+            "(id, session_id, seq, kind, data, cumulative_tokens, "
+            " orig_channel, focal_channel_at_arrival) "
+            "VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8) RETURNING *",
             new_id,
             session_id,
             seq,
             kind,
             data_json,
             cum_tokens,
+            orig_channel,
+            focal_at_arrival,
         )
         assert row is not None
 
@@ -1838,6 +1863,7 @@ def _row_to_channel_binding(row: asyncpg.Record) -> ChannelBinding:
         created_at=row["created_at"],
         updated_at=row["updated_at"],
         archived_at=row["archived_at"],
+        notification_mode=row["notification_mode"],
     )
 
 

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -1,9 +1,10 @@
-"""Channel helpers: prompt augmentation, monologue prefix, and the
-bindings → connections translation.
+"""Channel helpers: prompt augmentation, monologue prefix, bindings →
+connections translation, and focal-channel unread derivation.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 import asyncpg
@@ -11,8 +12,45 @@ import asyncpg
 from aios.db import queries
 from aios.models.channel_bindings import ChannelBinding
 from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX, Connection
+from aios.models.events import Event
 
 MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE: "
+
+# Key under a switch_channel tool_result's ``data["metadata"]`` that
+# records the target and outcome.  Set by the switch_channel handler
+# (slice 5), consumed by :func:`derive_last_seen` /
+# :func:`derive_unread_counts` here.  Its value is a dict with
+# ``{"target": str | None, "success": bool}`` shape.
+SWITCH_CHANNEL_METADATA_KEY = "switch_channel"
+
+# Top-level key inside the ``_meta`` field sent on JSON-RPC tool-call
+# requests to connection-provided MCP servers.  The value is the
+# focal-channel suffix (the focal channel address with its first two
+# ``<connector>/<account>`` segments stripped, since the connector
+# already knows its own connection identity).  The connector splits
+# this on ``/`` to recover its own per-chat identifiers.
+FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
+
+
+def focal_channel_path(focal: str | None) -> str | None:
+    """Return the connector-specific suffix of a focal address.
+
+    The ``<connector>/<account>`` prefix is information the MCP server
+    already has (it was invoked *by* that connection), so sending it
+    would be redundant; we strip it.  For a 3-segment address like
+    ``signal/<bot>/<chat>`` the suffix is just ``<chat>``.  For
+    ``telegram/<bot>/<chat>/<thread>`` it's ``<chat>/<thread>``.
+
+    Returns ``None`` if ``focal`` is ``None`` or malformed (fewer than
+    three segments) — neither should reach the dispatch path, but
+    degrading gracefully avoids leaking garbled metadata to connectors.
+    """
+    if not focal:
+        return None
+    parts = focal.split("/", 2)
+    if len(parts) < 3 or not parts[2]:
+        return None
+    return parts[2]
 
 
 def connection_server_name(c: Connection) -> str:
@@ -37,8 +75,15 @@ async def list_bindings_and_connections(
     return bindings, connections
 
 
-def build_channels_system_block(bindings: list[ChannelBinding]) -> str:
-    """Generic, connector-agnostic prose introducing the channels paradigm.
+def build_focal_paradigm_block(bindings: list[ChannelBinding]) -> str:
+    """Generic, connector-agnostic prose introducing the focal-channel paradigm.
+
+    Cache-stable: the block's text does not vary across steps, so the
+    prompt prefix stays hot.  Per-channel state (unread counts, recent
+    previews) lives in the ephemeral tail block — see
+    :func:`build_channels_tail_block` — which is rebuilt each step and
+    appended AFTER ``build_messages`` so its mutations don't bust the
+    prefix cache.
 
     Per-platform specifics (Signal markdown subset, mention syntax,
     response idioms) live in each connector and travel through the MCP
@@ -47,43 +92,120 @@ def build_channels_system_block(bindings: list[ChannelBinding]) -> str:
     """
     if not bindings:
         return ""
-    lines = ["You are bound to the following channels:"]
-    for b in bindings:
-        lines.append(f"  - {b.address}")
-    lines.append("")
-    lines.append(
-        "A channel is a conversation reachable through a connector "
-        "(Signal, Slack, etc.). Each address is path-shaped: "
-        "connector/account/chat-id."
+    return (
+        "## Channels & focal attention\n"
+        "\n"
+        "You operate across one or more connector channels (Signal, "
+        "Slack, etc.). A channel address is path-shaped: "
+        "`connector/account/chat-id`.\n"
+        "\n"
+        "At any moment you have exactly one focal channel, or none "
+        '("phone down"). Inbound messages on your focal channel '
+        "render in full in your context; inbound on other bound "
+        "channels render as short notification markers (🔔 ...). "
+        "The listing at the tail of your context shows the current "
+        "state:\n"
+        "\n"
+        "* ▸ — your focal channel.\n"
+        "* ○ — another bound channel, with unread count + preview.\n"
+        "* ◌ — a muted bound channel (counts only, no preview).\n"
+        "\n"
+        "### Shifting focus\n"
+        "\n"
+        "Call `switch_channel(target=<address>)` to focus on a "
+        "different bound channel. Its result is a re-orient block "
+        "quoting recent messages on that channel so you can pick up "
+        "the conversation in context. Call `switch_channel(target=null)` "
+        "to put your phone down — every inbound renders as a "
+        "notification, connector response tools disappear from your "
+        "tool list. Switching repeatedly is cheap but not free: each "
+        "switch's re-orient block appends tokens to your context.\n"
+        "\n"
+        "### Responding\n"
+        "\n"
+        "When focused on a channel, the connector's response tools "
+        "(e.g. `signal_send`, `signal_react`) operate on your focal "
+        "channel implicitly — no channel/chat-id argument required. "
+        "Bare assistant text is NOT delivered to any channel; it is "
+        f"internal thinking and will be prefixed with "
+        f"{MONOLOGUE_PREFIX.strip()!r} in your history as a reminder "
+        "that no human saw it. This is the teaching mechanism; do not "
+        "strip it on replay.\n"
+        "\n"
+        "### Timing\n"
+        "\n"
+        "Tools run asynchronously — new user messages can arrive while "
+        "a tool is in flight, and you will see them on your next step. "
+        "There is no obligation to respond on every step; silence is "
+        "the right choice when there is nothing new requiring a reply."
     )
-    lines.append("")
-    lines.append(
-        "To respond to a channel you must call the connector's response "
-        "tool; each connector describes its own tools in the "
-        "per-connector sections below. Bare assistant text is NOT "
-        "delivered to any channel; it is internal thinking and will be "
-        f"prefixed with {MONOLOGUE_PREFIX.strip()!r} in your "
-        "conversation history as a reminder that no human will see it."
-    )
-    lines.append("")
-    lines.append(
-        "You may take any number of tool calls before responding (web "
-        "fetches, file edits, sandbox commands). Tools run "
-        "asynchronously — new user messages can arrive while a tool is "
-        "in flight, and you will see them on your next step. There is "
-        "no obligation to respond on every step; silence is the right "
-        "choice when there is nothing new requiring a reply."
-    )
-    return "\n".join(lines)
 
 
-def augment_with_channels(base_system: str, bindings: list[ChannelBinding]) -> str:
-    block = build_channels_system_block(bindings)
+def augment_with_focal_paradigm(base_system: str, bindings: list[ChannelBinding]) -> str:
+    block = build_focal_paradigm_block(bindings)
     if not block:
         return base_system
     if base_system:
         return base_system + "\n\n" + block
     return block
+
+
+def build_channels_tail_block(
+    bindings: list[ChannelBinding],
+    events: list[Event],
+    focal_channel: str | None,
+) -> dict[str, Any] | None:
+    """Ephemeral per-step listing of bound channels with unread counts.
+
+    Rebuilt at each step from the monotonic event log; appended after
+    :func:`~aios.harness.context.build_messages` as the last user-role
+    message so per-step mutations don't bust the prompt prefix cache.
+    Pure data — the paradigm prose (what the symbols mean, how
+    switch_channel works) lives in the cache-stable
+    :func:`build_focal_paradigm_block`.
+
+    Returns ``None`` when the session has no active bindings (no
+    listing to render and the paradigm block is also omitted).
+    """
+    if not bindings:
+        return None
+
+    addresses = [b.address for b in bindings]
+    unread = derive_unread_counts(events, addresses)
+
+    # Index last inbound per channel for the preview clause.
+    last_content: dict[str, str] = {}
+    for e in events:
+        if e.kind != "message" or e.data.get("role") != "user":
+            continue
+        orig = e.orig_channel
+        if not isinstance(orig, str):
+            continue
+        content = e.data.get("content") or ""
+        if isinstance(content, str):
+            last_content[orig] = content
+
+    lines = ["━━━ Channels ━━━"]
+    for b in bindings:
+        addr = b.address
+        muted = b.notification_mode == "silent"
+        if addr == focal_channel:
+            lines.append(f"▸ {addr} (focal)")
+            continue
+        count = unread.get(addr, 0)
+        if muted:
+            lines.append(f"◌ {addr} (muted) — {count} unread")
+            continue
+        if count > 0:
+            preview = last_content.get(addr, "")
+            preview = preview.replace("\n", " ").strip()
+            if len(preview) > 60:
+                preview = preview[:60] + "…"
+            preview_clause = f': "{preview}"' if preview else ""
+            lines.append(f"○ {addr} — {count} unread{preview_clause}")
+        else:
+            lines.append(f"○ {addr} — 0 unread")
+    return {"role": "user", "content": "\n".join(lines)}
 
 
 def build_connector_instructions_block(
@@ -122,6 +244,84 @@ def augment_with_connector_instructions(
     if base_system:
         return base_system + "\n\n" + block
     return block
+
+
+def _switch_marker(e: Event) -> dict[str, Any] | None:
+    """Return the switch_channel marker on a tool_result event, if present.
+
+    Shape: ``{"target": str | None, "success": bool}``.  Any deviation
+    (missing keys, wrong types) returns None so malformed markers are
+    ignored by downstream derivation.
+    """
+    if e.kind != "message":
+        return None
+    data = e.data
+    if data.get("role") != "tool":
+        return None
+    metadata = data.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    marker = metadata.get(SWITCH_CHANNEL_METADATA_KEY)
+    if not isinstance(marker, dict):
+        return None
+    if not isinstance(marker.get("success"), bool):
+        return None
+    target = marker.get("target")
+    if target is not None and not isinstance(target, str):
+        return None
+    return marker
+
+
+def derive_last_seen(events: Iterable[Event], channel: str) -> int:
+    """Compute ``last_seen_in_X`` per the focal-channel plan.
+
+    ``last_seen_in_channel = max(
+        max(seq) over events where focal_channel_at_arrival == channel,
+        max(seq) over successful switch_channel tool_results targeting channel,
+    )``
+
+    Both terms naturally yield ``0`` when no matching event exists
+    (empty log, channel never focused, never switched to).  Failed
+    switches and ``switch_channel(target=None)`` do not anchor.
+    """
+    last = 0
+    for e in events:
+        if e.focal_channel_at_arrival == channel and e.seq > last:
+            last = e.seq
+        marker = _switch_marker(e)
+        if (
+            marker is not None
+            and marker["success"]
+            and marker["target"] == channel
+            and e.seq > last
+        ):
+            last = e.seq
+    return last
+
+
+def derive_unread_counts(events: Iterable[Event], channels: Iterable[str]) -> dict[str, int]:
+    """Compute per-channel unread counts.
+
+    ``unread_in_channel = count of events where orig_channel == channel
+    AND seq > last_seen_in_channel``.
+
+    Implementation walks the events once: first pass builds per-channel
+    last_seen via the same rules as :func:`derive_last_seen`, second
+    pass counts qualifying user events against those watermarks.  The
+    input is fully materialised into a list so both passes see the
+    same data even if the caller passes a one-shot iterator.
+    """
+    channel_list = list(channels)
+    events_list = list(events)
+    last_seen = {ch: derive_last_seen(events_list, ch) for ch in channel_list}
+    counts = dict.fromkeys(channel_list, 0)
+    for e in events_list:
+        orig = e.orig_channel
+        if orig is None or orig not in counts:
+            continue
+        if e.seq > last_seen[orig]:
+            counts[orig] += 1
+    return counts
 
 
 def _prefix_text(s: str) -> str:

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -17,10 +17,9 @@ from aios.models.events import Event
 MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE: "
 
 # Key under a switch_channel tool_result's ``data["metadata"]`` that
-# records the target and outcome.  Set by the switch_channel handler
-# (slice 5), consumed by :func:`derive_last_seen` /
-# :func:`derive_unread_counts` here.  Its value is a dict with
-# ``{"target": str | None, "success": bool}`` shape.
+# records the target and outcome — ``{"target": str | None, "success": bool}``.
+# :func:`derive_last_seen` / :func:`derive_unread_counts` anchor the
+# per-channel ``last_seen`` watermark off successful switches.
 SWITCH_CHANNEL_METADATA_KEY = "switch_channel"
 
 # Top-level key inside the ``_meta`` field sent on JSON-RPC tool-call
@@ -305,21 +304,30 @@ def derive_unread_counts(events: Iterable[Event], channels: Iterable[str]) -> di
     ``unread_in_channel = count of events where orig_channel == channel
     AND seq > last_seen_in_channel``.
 
-    Implementation walks the events once: first pass builds per-channel
-    last_seen via the same rules as :func:`derive_last_seen`, second
-    pass counts qualifying user events against those watermarks.  The
-    input is fully materialised into a list so both passes see the
-    same data even if the caller passes a one-shot iterator.
+    Single pass: build every channel's ``last_seen`` watermark and
+    collect candidate events in one walk, then count candidates whose
+    seq exceeds their channel's watermark.  O(N + C) where N is events
+    and C is candidates — versus the naïve per-channel derivation
+    which is O(K*N).
     """
-    channel_list = list(channels)
-    events_list = list(events)
-    last_seen = {ch: derive_last_seen(events_list, ch) for ch in channel_list}
-    counts = dict.fromkeys(channel_list, 0)
-    for e in events_list:
+    channel_set = set(channels)
+    last_seen = dict.fromkeys(channel_set, 0)
+    candidates: list[tuple[str, int]] = []
+    for e in events:
+        focal = e.focal_channel_at_arrival
+        if focal in last_seen and e.seq > last_seen[focal]:
+            last_seen[focal] = e.seq
+        marker = _switch_marker(e)
+        if marker is not None and marker["success"]:
+            target = marker["target"]
+            if target in last_seen and e.seq > last_seen[target]:
+                last_seen[target] = e.seq
         orig = e.orig_channel
-        if orig is None or orig not in counts:
-            continue
-        if e.seq > last_seen[orig]:
+        if isinstance(orig, str) and orig in last_seen:
+            candidates.append((orig, e.seq))
+    counts = dict.fromkeys(channel_set, 0)
+    for orig, seq in candidates:
+        if seq > last_seen[orig]:
             counts[orig] += 1
     return counts
 

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -51,10 +51,6 @@ _NOTIFICATION_PREVIEW_CHARS = 80
 def _format_channel_header(metadata: dict[str, Any]) -> str:
     """Render a one-line header describing the origin of an inbound message.
 
-    Lifted from PR #46 — folded into slice 4 so the focal-channel
-    rendering owns the single source of truth for inbound-event
-    presentation.
-
     When a user message carries channel metadata, the raw fields are
     whitelisted out of the chat-completions message before the model
     ever sees them (see ``_ALLOWED_FIELDS``).  That leaves the model
@@ -165,21 +161,19 @@ def render_user_event(
 ) -> dict[str, Any]:
     """Render a user event into its chat-completions message form.
 
-    Slice 4 of the focal-channel redesign (issue #29): rendering is a
-    deterministic function of the event's stamped ``orig_channel`` and
-    ``focal_channel_at_arrival``.  Callers (``build_messages`` and the
-    append-time token counter in ``queries.append_event``) share this
-    helper so the context and the ``cumulative_tokens`` column stay in
-    lock-step.
+    Rendering is a deterministic function of the event's stamped
+    ``orig_channel`` and ``focal_channel_at_arrival``.  ``build_messages``
+    and the append-time token counter in ``queries.append_event`` share
+    this helper so the context and the ``cumulative_tokens`` column
+    stay in lock-step.
 
     Branches:
 
-    * ``orig_channel`` is ``None`` → legacy / non-connector event,
-      rendered as Phase 2 did (metadata stripped, no header, no
-      notification).  Covers direct ``POST /sessions/{id}/messages``
-      traffic and pre-migration rows.
-    * ``orig == focal_at_arrival`` (non-NULL) → full content with the
-      #46 metadata header inlined.
+    * ``orig_channel`` is ``None`` → legacy / non-connector event;
+      metadata stripped, no header, no notification.  Covers direct
+      ``POST /sessions/{id}/messages`` traffic and pre-migration rows.
+    * ``orig == focal_at_arrival`` (non-NULL) → full content with a
+      metadata header inlined.
     * Otherwise (focal is NULL, or focal differs from orig) →
       notification marker: a short, emoji-prefixed one-liner surfacing
       the origin channel, sender, and a truncated content preview.

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 from aios.models.events import Event
@@ -39,6 +40,170 @@ _ALLOWED_FIELDS: dict[str, frozenset[str]] = {
     "user": frozenset({"role", "content", "name"}),
     "system": frozenset({"role", "content", "name"}),
 }
+
+# Notification markers truncate the source content to this many chars
+# (plus an ellipsis when truncated) so a busy non-focal channel
+# contributes O(tens-of-tokens) per inbound to the context — cheap
+# enough to keep in-log at its seq position for episodic chronology.
+_NOTIFICATION_PREVIEW_CHARS = 80
+
+
+def _format_channel_header(metadata: dict[str, Any]) -> str:
+    """Render a one-line header describing the origin of an inbound message.
+
+    Lifted from PR #46 — folded into slice 4 so the focal-channel
+    rendering owns the single source of truth for inbound-event
+    presentation.
+
+    When a user message carries channel metadata, the raw fields are
+    whitelisted out of the chat-completions message before the model
+    ever sees them (see ``_ALLOWED_FIELDS``).  That leaves the model
+    with no way to know the sender or timestamp — values the connector
+    tools need as arguments.  Inline the salient fields into the
+    visible ``content`` so the model can read them natively.
+    """
+    if not isinstance(metadata, dict) or "channel" not in metadata:
+        return ""
+    parts: list[str] = [f"channel={metadata['channel']}"]
+    chat_type = metadata.get("chat_type")
+    if isinstance(chat_type, str) and chat_type:
+        parts.append(f"chat_type={chat_type}")
+    chat_name = metadata.get("chat_name")
+    if isinstance(chat_name, str) and chat_name:
+        parts.append(f"chat_name={chat_name!r}")
+    sender_name = metadata.get("sender_name")
+    if isinstance(sender_name, str) and sender_name:
+        parts.append(f"from={sender_name}")
+    sender_uuid = metadata.get("sender_uuid")
+    if isinstance(sender_uuid, str) and sender_uuid:
+        parts.append(f"sender_uuid={sender_uuid}")
+    timestamp_ms = metadata.get("timestamp_ms")
+    if isinstance(timestamp_ms, int):
+        iso = datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).isoformat(timespec="milliseconds")
+        parts.append(f"timestamp_ms={timestamp_ms} ({iso})")
+    header = "[" + " · ".join(parts) + "]"
+    reaction = metadata.get("reaction")
+    if isinstance(reaction, dict):
+        emoji = reaction.get("emoji") or "?"
+        r_parts: list[str] = [f"reaction={emoji!r}"]
+        target_author = reaction.get("target_author_uuid")
+        if isinstance(target_author, str) and target_author:
+            r_parts.append(f"target_author_uuid={target_author}")
+        target_ts = reaction.get("target_timestamp_ms")
+        if isinstance(target_ts, int):
+            r_parts.append(f"target_timestamp_ms={target_ts}")
+        header += "\n[" + " · ".join(r_parts) + "]"
+    reply_to = metadata.get("reply_to")
+    if isinstance(reply_to, dict):
+        quoted = (reply_to.get("text") or "").replace("\n", " ").strip()
+        quote_parts: list[str] = []
+        author = reply_to.get("author_uuid")
+        if isinstance(author, str) and author:
+            quote_parts.append(f"author_uuid={author}")
+        ts = reply_to.get("timestamp_ms")
+        if isinstance(ts, int):
+            quote_parts.append(f"timestamp_ms={ts}")
+        quote_meta = " · ".join(quote_parts) if quote_parts else "?"
+        if quoted:
+            snippet = quoted if len(quoted) <= 200 else quoted[:200] + "…"
+            header += f"\n[reply_to: {quote_meta}] > {snippet}"
+        else:
+            header += f"\n[reply_to: {quote_meta}]"
+    return header
+
+
+def _notification_preview(content: str, metadata: dict[str, Any] | None) -> str:
+    """Short preview string for a notification marker.
+
+    Prefers truncated text content.  Falls back to the reaction emoji
+    for reaction events (which arrive with empty content — without the
+    fallback the marker would be blank).
+    """
+    if isinstance(content, str) and content:
+        if len(content) <= _NOTIFICATION_PREVIEW_CHARS:
+            return content
+        return content[:_NOTIFICATION_PREVIEW_CHARS] + "…"
+    if isinstance(metadata, dict):
+        reaction = metadata.get("reaction")
+        if isinstance(reaction, dict):
+            emoji = reaction.get("emoji")
+            if isinstance(emoji, str) and emoji:
+                return f"reacted {emoji}"
+    return ""
+
+
+def _format_notification_marker(
+    orig_channel: str,
+    metadata: dict[str, Any] | None,
+    content: str,
+) -> str:
+    """Render a concise, non-focal-channel notification marker.
+
+    Shape::
+
+        🔔 <orig_channel> · from=<sender_name> · <preview>
+
+    The ``from`` clause is omitted when ``sender_name`` is absent from
+    metadata.  The preview clause is omitted when content is empty and
+    there's no reaction to surface.
+    """
+    parts = [f"🔔 {orig_channel}"]
+    if isinstance(metadata, dict):
+        sender_name = metadata.get("sender_name")
+        if isinstance(sender_name, str) and sender_name:
+            parts.append(f"from={sender_name}")
+    preview = _notification_preview(content, metadata)
+    if preview:
+        parts.append(preview)
+    return " · ".join(parts)
+
+
+def render_user_event(
+    event_data: dict[str, Any],
+    orig_channel: str | None,
+    focal_channel_at_arrival: str | None,
+) -> dict[str, Any]:
+    """Render a user event into its chat-completions message form.
+
+    Slice 4 of the focal-channel redesign (issue #29): rendering is a
+    deterministic function of the event's stamped ``orig_channel`` and
+    ``focal_channel_at_arrival``.  Callers (``build_messages`` and the
+    append-time token counter in ``queries.append_event``) share this
+    helper so the context and the ``cumulative_tokens`` column stay in
+    lock-step.
+
+    Branches:
+
+    * ``orig_channel`` is ``None`` → legacy / non-connector event,
+      rendered as Phase 2 did (metadata stripped, no header, no
+      notification).  Covers direct ``POST /sessions/{id}/messages``
+      traffic and pre-migration rows.
+    * ``orig == focal_at_arrival`` (non-NULL) → full content with the
+      #46 metadata header inlined.
+    * Otherwise (focal is NULL, or focal differs from orig) →
+      notification marker: a short, emoji-prefixed one-liner surfacing
+      the origin channel, sender, and a truncated content preview.
+    """
+    msg = {k: v for k, v in event_data.items() if k != "metadata"}
+    metadata = event_data.get("metadata")
+    metadata = metadata if isinstance(metadata, dict) else None
+
+    if orig_channel is None:
+        return msg
+
+    if orig_channel == focal_channel_at_arrival:
+        if metadata:
+            header = _format_channel_header(metadata)
+            if header:
+                existing = msg.get("content") or ""
+                msg["content"] = f"{header}\n{existing}" if existing else header
+        return msg
+
+    content = event_data.get("content", "")
+    if not isinstance(content, str):
+        content = ""
+    marker = _format_notification_marker(orig_channel, metadata, content)
+    return {"role": "user", "content": marker}
 
 
 def _sanitize_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -236,7 +401,7 @@ def build_messages(
         role = e.data.get("role")
 
         if role == "user":
-            msg = {k: v for k, v in e.data.items() if k != "metadata"}
+            msg = render_user_event(e.data, e.orig_channel, e.focal_channel_at_arrival)
             messages.append(msg)
             max_stimulus_seq = max(max_stimulus_seq, e.seq)
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -152,11 +152,10 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
         system_prompt=system_prompt,
     )
 
-    # Append the ephemeral channels tail block (slice 7).  Rebuilt from
-    # the monotonic event log each step so unread counts refresh
-    # without busting the prefix cache.  Lives at the tail of the
-    # user-visible context; the paradigm prose explaining the symbols
-    # is in the cache-stable system prompt above.
+    # The tail block lives *after* build_messages so its per-step
+    # mutations (unread counts, previews) don't bust the prefix cache.
+    # Paradigm prose (symbol meanings, switch_channel semantics) stays
+    # in the cache-stable system prompt above.
     tail = build_channels_tail_block(bindings, events, session.focal_channel)
     if tail is not None:
         ctx.messages.append(tail)
@@ -375,19 +374,19 @@ def _switch_channel_tool_spec() -> dict[str, Any]:
 def _hide_conn_tools_when_phone_down(
     mcp_tools: list[dict[str, Any]], focal_channel: str | None
 ) -> list[dict[str, Any]]:
-    """Filter ``mcp__conn_*`` tools out of the list when focal is NULL.
+    """Filter connection-provided MCP tools out when focal is NULL.
 
-    The agent should not see connection-provided tools in the "phone
-    down" state — those tools require a focal channel to resolve their
-    ``chat_id`` (injected into ``_meta`` at dispatch time), and the
-    model shouldn't be asked to choose which channel to send to.
-    Agent-declared MCP tools are untouched.
+    Those tools resolve their ``chat_id`` from focal (injected into
+    ``_meta`` at dispatch time); a "phone down" state has no focal to
+    inject, so the model shouldn't be offered them.  Agent-declared
+    MCP tools are untouched.
     """
+    from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
+
     if focal_channel is not None:
         return mcp_tools
-    return [
-        t for t in mcp_tools if not t.get("function", {}).get("name", "").startswith("mcp__conn_")
-    ]
+    prefix = f"mcp__{CONNECTION_SERVER_NAME_PREFIX}"
+    return [t for t in mcp_tools if not t.get("function", {}).get("name", "").startswith(prefix)]
 
 
 def _tc_name(tc: dict[str, Any]) -> str:

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -89,7 +89,13 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
         if pending_builtin:
             launch_tool_calls(pool, session_id, pending_builtin)
         if pending_mcp:
-            launch_mcp_tool_calls(pool, session_id, pending_mcp, mcp_server_map)
+            launch_mcp_tool_calls(
+                pool,
+                session_id,
+                pending_mcp,
+                mcp_server_map,
+                focal_channel=session.focal_channel,
+            )
         log.info(
             "step.confirmed_tools_dispatched",
             session_id=session_id,
@@ -100,15 +106,31 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
     # Discovery runs before prompt assembly because each MCP server's
     # instructions feed the per-connector affordance block.
     tools = to_openai_tools(agent.tools)
+    # Inject the built-in switch_channel tool when the session has any
+    # active bindings — it's the only way the agent can mutate its
+    # focal attention, so expose it whenever focal-aware rendering is
+    # relevant.  Agents don't need to opt in via ``agent.tools``; the
+    # focal machinery is session-state-level, not agent-level.
+    if bindings:
+        tools.append(_switch_channel_tool_spec())
     mcp_instructions: dict[str, str] = {}
     if agent.mcp_servers or connections:
         mcp_tools, mcp_instructions = await discover_session_mcp_tools(
             pool, session_id, agent, connections
         )
+        # Hide connection-provided MCP tools when the agent is in the
+        # "phone down" state (focal_channel is NULL).  You can't type in
+        # a chat app unless you're in a chat — the agent must call
+        # switch_channel first if it wants to send.
+        mcp_tools = _hide_conn_tools_when_phone_down(mcp_tools, session.focal_channel)
         tools.extend(mcp_tools)
 
     # Resolve skills and augment system prompt.
-    from aios.harness.channels import augment_with_channels, augment_with_connector_instructions
+    from aios.harness.channels import (
+        augment_with_connector_instructions,
+        augment_with_focal_paradigm,
+        build_channels_tail_block,
+    )
     from aios.harness.skills import augment_system_prompt, provision_skill_files
     from aios.services import skills as skills_service
 
@@ -116,7 +138,7 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
         await skills_service.resolve_skill_refs(pool, agent.skills) if agent.skills else []
     )
     system_prompt = augment_system_prompt(agent.system, skill_versions)
-    system_prompt = augment_with_channels(system_prompt, bindings)
+    system_prompt = augment_with_focal_paradigm(system_prompt, bindings)
     system_prompt = augment_with_connector_instructions(
         system_prompt, mcp_instructions, connections
     )
@@ -129,6 +151,15 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
         events,
         system_prompt=system_prompt,
     )
+
+    # Append the ephemeral channels tail block (slice 7).  Rebuilt from
+    # the monotonic event log each step so unread counts refresh
+    # without busting the prefix cache.  Lives at the tail of the
+    # user-visible context; the paradigm prose explaining the symbols
+    # is in the cache-stable system prompt above.
+    tail = build_channels_tail_block(bindings, events, session.focal_channel)
+    if tail is not None:
+        ctx.messages.append(tail)
 
     # Mark session as running.
     await sessions_service.set_session_status(pool, session_id, "running")
@@ -270,7 +301,13 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
             )
 
         if mcp_immediate:
-            launch_mcp_tool_calls(pool, session_id, mcp_immediate, mcp_server_map)
+            launch_mcp_tool_calls(
+                pool,
+                session_id,
+                mcp_immediate,
+                mcp_server_map,
+                focal_channel=session.focal_channel,
+            )
             log.info(
                 "step.mcp_tools_launched",
                 session_id=session_id,
@@ -312,6 +349,45 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
         )
         await _append_lifecycle(pool, session_id, "turn_ended", "idle", "end_turn")
         log.info("step.turn_ended", session_id=session_id, cause=cause)
+
+
+def _switch_channel_tool_spec() -> dict[str, Any]:
+    """Build the chat-completions tool entry for the ``switch_channel`` built-in.
+
+    Injected unconditionally into the tool list when the session has
+    any active bindings (see ``run_session_step``).  Agents don't need
+    to list it in their ``tools`` declaration — it's focal-machinery
+    scope, not agent scope.
+    """
+    from aios.tools.registry import registry as tool_registry
+
+    tool = tool_registry.get("switch_channel")
+    return {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.parameters_schema,
+        },
+    }
+
+
+def _hide_conn_tools_when_phone_down(
+    mcp_tools: list[dict[str, Any]], focal_channel: str | None
+) -> list[dict[str, Any]]:
+    """Filter ``mcp__conn_*`` tools out of the list when focal is NULL.
+
+    The agent should not see connection-provided tools in the "phone
+    down" state — those tools require a focal channel to resolve their
+    ``chat_id`` (injected into ``_meta`` at dispatch time), and the
+    model shouldn't be asked to choose which channel to send to.
+    Agent-declared MCP tools are untouched.
+    """
+    if focal_channel is not None:
+        return mcp_tools
+    return [
+        t for t in mcp_tools if not t.get("function", {}).get("name", "").startswith("mcp__conn_")
+    ]
 
 
 def _tc_name(tc: dict[str, Any]) -> str:

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -30,7 +30,7 @@ import asyncpg
 from aios.harness import runtime
 from aios.logging import get_logger
 from aios.services import sessions as sessions_service
-from aios.tools.registry import ToolNotFoundError, registry
+from aios.tools.registry import ToolNotFoundError, ToolResult, registry
 
 log = get_logger("aios.harness.tool_dispatch")
 
@@ -103,15 +103,32 @@ async def _execute_tool_async(
             await _append_tool_result(pool, session_id, call_id, name, error=err.message)
             return
 
-        # Invoke handler.
+        # Invoke handler.  Handlers return either a plain dict (JSON-
+        # encoded into the tool message's content) or a ToolResult
+        # (carries per-event metadata and/or a plain-string content).
         result = await tool.handler(session_id, arguments)
-        content_str = json.dumps(result, ensure_ascii=False)
+        event_data: dict[str, Any] = {
+            "role": "tool",
+            "tool_call_id": call_id,
+            "name": name,
+        }
+        if isinstance(result, ToolResult):
+            if isinstance(result.content, str):
+                event_data["content"] = result.content
+            else:
+                event_data["content"] = json.dumps(result.content, ensure_ascii=False)
+            if result.metadata:
+                event_data["metadata"] = result.metadata
+            if result.is_error:
+                event_data["is_error"] = True
+        else:
+            event_data["content"] = json.dumps(result, ensure_ascii=False)
         bound_log.info("tool.completed")
         await sessions_service.append_event(
             pool,
             session_id,
             "message",
-            {"role": "tool", "tool_call_id": call_id, "name": name, "content": content_str},
+            event_data,
         )
 
     except asyncio.CancelledError:
@@ -197,12 +214,23 @@ def launch_mcp_tool_calls(
     session_id: str,
     tool_calls: list[dict[str, Any]],
     mcp_server_map: dict[str, str],
+    *,
+    focal_channel: str | None = None,
 ) -> None:
-    """Launch MCP tool calls as asyncio tasks. Returns immediately."""
+    """Launch MCP tool calls as asyncio tasks. Returns immediately.
+
+    ``focal_channel`` is the session's focal at the moment these calls
+    were emitted (captured at step top in ``run_session_step`` so a
+    concurrent ``switch_channel`` in the same batch cannot race the
+    ``chat_id`` injection).  Passed through to each task so
+    connection-provided tools can stamp ``_meta`` with the suffix.
+    """
     _launch_tasks(
         session_id,
         tool_calls,
-        lambda call: _execute_mcp_tool_async(pool, session_id, call, mcp_server_map),
+        lambda call: _execute_mcp_tool_async(
+            pool, session_id, call, mcp_server_map, focal_channel=focal_channel
+        ),
         prefix="mcp_tool",
     )
 
@@ -223,8 +251,21 @@ async def _execute_mcp_tool_async(
     session_id: str,
     call: dict[str, Any],
     mcp_server_map: dict[str, str],
+    *,
+    focal_channel: str | None = None,
 ) -> None:
-    """Execute one MCP tool call: connect, invoke, append result, defer wake."""
+    """Execute one MCP tool call: connect, invoke, append result, defer wake.
+
+    For connection-provided servers (name in the reserved ``conn_``
+    namespace), the focal-channel suffix is stamped into the JSON-RPC
+    request's ``_meta`` so the connector can resolve its
+    connector-specific chat identifiers without the model having to
+    pass them explicitly.  The ``focal_channel`` snapshot is emission-
+    time — a concurrent ``switch_channel`` in the same assistant batch
+    does not race this injection.
+    """
+    from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
+
     call_id = call.get("id") or "unknown"
     function = call.get("function") or {}
     name: str = function.get("name") or ""
@@ -250,11 +291,33 @@ async def _execute_mcp_tool_async(
             )
             return
 
+        from aios.harness.channels import FOCAL_CHANNEL_META_KEY, focal_channel_path
         from aios.mcp.client import call_mcp_tool, resolve_auth_for_url
+
+        meta: dict[str, Any] | None = None
+        if server_name.startswith(CONNECTION_SERVER_NAME_PREFIX):
+            suffix = focal_channel_path(focal_channel)
+            if suffix is None:
+                # The model shouldn't be able to call a conn_* tool while
+                # focal is NULL — loop.py filters them out of the tool
+                # list in that state — but defend in depth if it slips
+                # through (stale tool_calls, etc.).
+                await _append_tool_result(
+                    pool,
+                    session_id,
+                    call_id,
+                    name,
+                    error=(
+                        "connection-provided tools require a focal channel; "
+                        "call switch_channel first"
+                    ),
+                )
+                return
+            meta = {FOCAL_CHANNEL_META_KEY: suffix}
 
         crypto_box = runtime.require_crypto_box()
         headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
-        result = await call_mcp_tool(url, headers, tool_name, arguments)
+        result = await call_mcp_tool(url, headers, tool_name, arguments, meta=meta)
 
         content_str = json.dumps(result, ensure_ascii=False)
         is_error = "error" in result

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -199,12 +199,17 @@ async def call_mcp_tool(
     headers: dict[str, str],
     tool_name: str,
     arguments: dict[str, Any],
+    *,
+    meta: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Connect to an MCP server and invoke a tool.
 
     ``tool_name`` is the raw MCP tool name (without the ``mcp__`` prefix).
-    Returns a result dict with either ``content`` (success) or ``error``
-    (failure).
+    ``meta`` is an optional per-request metadata dict forwarded as the
+    JSON-RPC request's ``_meta`` field — used by the focal-channel
+    redesign to pass ``aios.focal_channel_path`` to connection-provided
+    MCP servers without stuffing it into arguments.  Returns a result
+    dict with either ``content`` (success) or ``error`` (failure).
     """
     try:
         from aios.harness import runtime
@@ -214,15 +219,15 @@ async def call_mcp_tool(
         if _pool is not None:
             try:
                 session, _ = await _pool.get_or_connect(url, headers)
-                result = await session.call_tool(tool_name, arguments)
+                result = await session.call_tool(tool_name, arguments, meta=meta)
             except Exception:
                 _pool.evict(url, headers)
                 session, _ = await _pool.get_or_connect(url, headers)
-                result = await session.call_tool(tool_name, arguments)
+                result = await session.call_tool(tool_name, arguments, meta=meta)
         else:
             async with AsyncExitStack() as stack:
                 session, _ = await _open_session(url, headers, stack)
-                result = await session.call_tool(tool_name, arguments)
+                result = await session.call_tool(tool_name, arguments, meta=meta)
 
         # Concatenate text content from the result.
         parts: list[str] = []

--- a/src/aios/models/channel_bindings.py
+++ b/src/aios/models/channel_bindings.py
@@ -9,8 +9,11 @@ a new one (or rely on a routing rule).
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+
+NotificationMode = Literal["focal_candidate", "silent"]
 
 
 class ChannelBindingCreate(BaseModel):
@@ -31,3 +34,4 @@ class ChannelBinding(BaseModel):
     created_at: datetime
     updated_at: datetime
     archived_at: datetime | None = None
+    notification_mode: NotificationMode = "focal_candidate"

--- a/src/aios/models/events.py
+++ b/src/aios/models/events.py
@@ -36,3 +36,5 @@ class Event(BaseModel):
     data: dict[str, Any]
     cumulative_tokens: int | None = Field(default=None, exclude=True)
     created_at: datetime
+    orig_channel: str | None = Field(default=None, exclude=True)
+    focal_channel_at_arrival: str | None = Field(default=None, exclude=True)

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -115,6 +115,7 @@ class Session(BaseModel):
     created_at: datetime
     updated_at: datetime
     archived_at: datetime | None = None
+    focal_channel: str | None = None
 
 
 class SessionUserMessage(BaseModel):

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -85,16 +85,28 @@ async def append_user_message(
     content: str,
     metadata: dict[str, Any] | None = None,
 ) -> Event:
-    """Append a `role: user` message event to the session log."""
+    """Append a `role: user` message event to the session log.
+
+    When the inbound path stamps ``metadata["channel"]`` (the connector's
+    full channel address), we lift it into the event's ``orig_channel``
+    column so the context builder and unread-derivation helpers can key
+    off it directly — without re-parsing a JSONB blob on every read.
+    """
     data: dict[str, Any] = {"role": "user", "content": content}
     if metadata:
         data["metadata"] = metadata
+    orig_channel: str | None = None
+    if metadata is not None:
+        channel = metadata.get("channel")
+        if isinstance(channel, str):
+            orig_channel = channel
     async with pool.acquire() as conn:
         return await queries.append_event(
             conn,
             session_id=session_id,
             kind="message",
             data=data,
+            orig_channel=orig_channel,
         )
 
 

--- a/src/aios/tools/__init__.py
+++ b/src/aios/tools/__init__.py
@@ -26,6 +26,7 @@ from aios.tools import glob as _glob  # noqa: F401
 from aios.tools import grep as _grep  # noqa: F401
 from aios.tools import read as _read  # noqa: F401
 from aios.tools import search_events as _search_events  # noqa: F401
+from aios.tools import switch_channel as _switch_channel  # noqa: F401
 from aios.tools import web_fetch as _web_fetch  # noqa: F401
 from aios.tools import web_search as _web_search  # noqa: F401
 from aios.tools import write as _write  # noqa: F401

--- a/src/aios/tools/registry.py
+++ b/src/aios/tools/registry.py
@@ -44,11 +44,35 @@ class DuplicateToolError(AiosError):
     status_code = 500
 
 
-# Handler signature: async (session_id, arguments) -> result dict.
-# The result dict is appended verbatim as the ``content`` or ``error`` of
-# a tool-role message. Handlers do NOT call append_event themselves —
+@dataclass(slots=True, frozen=True)
+class ToolResult:
+    """Rich return from a tool handler.
+
+    Most handlers just return a result ``dict`` and :mod:`aios.harness.tool_dispatch`
+    serialises it as JSON into the tool-role message's ``content``.
+    Handlers that need to attach structured metadata or a plain-string
+    content to the resulting event — notably ``switch_channel`` which
+    stamps a marker consumed by the unread-derivation helpers — return
+    ``ToolResult`` instead.
+
+    * ``content`` — ``str``: used verbatim.  ``dict``: JSON-encoded.
+    * ``metadata`` — merged into the event's ``data.metadata`` (stripped
+      from the chat-completions wire shape by ``_strip_to_spec``).
+    * ``is_error`` — records a handler-level error (separate from
+      dispatch-level exceptions, which raise).
+    """
+
+    content: str | dict[str, Any]
+    metadata: dict[str, Any] | None = None
+    is_error: bool = False
+
+
+# Handler signature: async (session_id, arguments) -> result dict | ToolResult.
+# Plain dict → serialised as JSON into the tool message's ``content``.
+# :class:`ToolResult` → richer shape with optional per-event metadata.
+# Handlers do NOT call append_event themselves —
 # :mod:`aios.harness.tool_dispatch` does that.
-ToolHandler = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]]
+ToolHandler = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any] | ToolResult]]
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -1,0 +1,189 @@
+"""The switch_channel tool — shift the agent's focal attention.
+
+Slice 5 of the focal-channel redesign (issue #29). A many-to-one
+connector-aware session has at most one *focal* channel at any given
+time.  Inbound events on the focal channel render in full; inbound on
+non-focal channels render as truncated notification markers.  The
+agent shifts its attention by calling ``switch_channel`` — the only
+way ``sessions.focal_channel`` changes post-session-creation.
+
+The tool's tool_result event carries a ``metadata.switch_channel``
+marker (``{target, success}``) that the unread-derivation helpers in
+:mod:`aios.harness.channels` key off.  Successful switches anchor
+``last_seen_in_<target>``; failed switches do not.
+
+Re-orient block (non-NULL target):
+
+    Switched to <target>. Recent messages:
+
+    <last max(unread_in_target, FLOOR_N) events on target, rendered
+     with full metadata header, newest last>
+
+Phone down (``target=None``):
+
+    Focal cleared.
+
+Unknown-target (not a bound channel on this session):
+
+    Cannot switch to <target>: not a bound channel on this session.
+
+Errors do not mutate ``focal_channel``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.db import queries
+from aios.harness import runtime
+from aios.harness.channels import (
+    SWITCH_CHANNEL_METADATA_KEY,
+    derive_unread_counts,
+)
+from aios.harness.context import render_user_event
+from aios.tools.registry import ToolResult, registry
+
+# Floor on the number of events included in the re-orient block so a
+# switch into a quiet channel still gives the agent a screen's worth of
+# context to reorient on — matches how phone messaging apps show the
+# last N messages when you tap into a conversation, regardless of
+# whether any are "new."
+RE_ORIENT_FLOOR_N = 10
+
+
+SWITCH_CHANNEL_DESCRIPTION = (
+    "Shift your attention to a different bound channel, or put your phone "
+    "down entirely. When focused on a channel, inbound messages on that "
+    "channel render in full; inbound on other channels show up as short "
+    "notification markers in your context. Call switch_channel(target=<address>) "
+    "to focus on a bound channel, or switch_channel(target=null) to clear "
+    "focal (no channel focused; all inbound renders as notifications). "
+    "The tool result includes a re-orient block quoting recent messages on "
+    "the target channel so you can pick up the conversation in context."
+)
+
+SWITCH_CHANNEL_PARAMETERS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "target": {
+            "type": ["string", "null"],
+            "description": (
+                "The channel address to focus on (must be a bound channel "
+                "on this session), or null to clear focal."
+            ),
+        },
+    },
+    "required": ["target"],
+    "additionalProperties": False,
+}
+
+
+async def switch_channel_handler(session_id: str, arguments: dict[str, Any]) -> ToolResult:
+    """Mutate ``sessions.focal_channel`` and build the re-orient block.
+
+    Returns a :class:`ToolResult` carrying a ``switch_channel`` marker
+    under ``metadata`` so the unread-derivation helpers can recognise
+    successful switches as anchors.
+    """
+    target = arguments.get("target")
+    if target is not None and not isinstance(target, str):
+        return ToolResult(
+            content=("Invalid target: must be a channel address string or null."),
+            metadata={
+                SWITCH_CHANNEL_METADATA_KEY: {"target": None, "success": False},
+            },
+            is_error=True,
+        )
+
+    pool = runtime.require_pool()
+
+    if target is None:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE sessions SET focal_channel = NULL WHERE id = $1",
+                session_id,
+            )
+        return ToolResult(
+            content="Focal cleared.",
+            metadata={
+                SWITCH_CHANNEL_METADATA_KEY: {"target": None, "success": True},
+            },
+        )
+
+    # Validate target against the session's active bindings.
+    async with pool.acquire() as conn:
+        bindings = await queries.list_session_bindings(conn, session_id)
+    valid_targets = {b.address for b in bindings if b.archived_at is None}
+    if target not in valid_targets:
+        return ToolResult(
+            content=(
+                f"Cannot switch to {target!r}: not a bound channel on this session. "
+                f"Bound channels: {sorted(valid_targets) if valid_targets else '(none)'}."
+            ),
+            metadata={
+                SWITCH_CHANNEL_METADATA_KEY: {"target": target, "success": False},
+            },
+            is_error=True,
+        )
+
+    # Atomically flip the focal pointer.  The UPDATE serialises against
+    # append_event's row lock, so concurrent inbound stamping sees
+    # either the pre-switch or post-switch focal, never a torn read.
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE sessions SET focal_channel = $1 WHERE id = $2",
+            target,
+            session_id,
+        )
+
+    content = await _build_reorient_block(pool, session_id, target)
+    return ToolResult(
+        content=content,
+        metadata={
+            SWITCH_CHANNEL_METADATA_KEY: {"target": target, "success": True},
+        },
+    )
+
+
+async def _build_reorient_block(pool: Any, session_id: str, target: str) -> str:
+    """Pull recent events from ``target`` and render chronologically.
+
+    Size is ``max(unread_in_target, RE_ORIENT_FLOOR_N)``: the floor
+    gives a quiet-channel context refresher, the unread-count term
+    ensures no unread message gets silently skipped on switch-in.
+    """
+    async with pool.acquire() as conn:
+        all_events = await queries.read_message_events(conn, session_id)
+
+    target_events = [e for e in all_events if e.orig_channel == target]
+    if not target_events:
+        return f"Switched to {target}. (no prior messages on this channel)"
+
+    unread = derive_unread_counts(all_events, [target]).get(target, 0)
+    n = max(unread, RE_ORIENT_FLOOR_N)
+    recent = target_events[-n:] if n < len(target_events) else target_events
+
+    lines = [f"Switched to {target}. Recent messages:", ""]
+    for e in recent:
+        # Render each quoted event as full content + metadata header
+        # (as if orig==focal), regardless of its stamped focal_at_arrival.
+        # The re-orient block is the "you've opened the app" view of
+        # the channel's own chronology.
+        rendered = render_user_event(e.data, e.orig_channel, e.orig_channel)
+        content = rendered.get("content", "")
+        if isinstance(content, str) and content:
+            lines.append(content)
+            lines.append("")
+    return "\n".join(lines).rstrip("\n")
+
+
+def _register() -> None:
+    registry.register(
+        name="switch_channel",
+        description=SWITCH_CHANNEL_DESCRIPTION,
+        parameters_schema=SWITCH_CHANNEL_PARAMETERS_SCHEMA,
+        handler=switch_channel_handler,
+    )
+
+
+_register()

--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -1,31 +1,16 @@
 """The switch_channel tool — shift the agent's focal attention.
 
-Slice 5 of the focal-channel redesign (issue #29). A many-to-one
-connector-aware session has at most one *focal* channel at any given
-time.  Inbound events on the focal channel render in full; inbound on
-non-focal channels render as truncated notification markers.  The
-agent shifts its attention by calling ``switch_channel`` — the only
-way ``sessions.focal_channel`` changes post-session-creation.
+A many-to-one connector-aware session has at most one *focal* channel
+at any given time.  Inbound events on the focal channel render in
+full; inbound on non-focal channels render as truncated notification
+markers.  The agent shifts its attention by calling ``switch_channel``
+— the only way ``sessions.focal_channel`` changes after the session
+exists.
 
 The tool's tool_result event carries a ``metadata.switch_channel``
 marker (``{target, success}``) that the unread-derivation helpers in
 :mod:`aios.harness.channels` key off.  Successful switches anchor
 ``last_seen_in_<target>``; failed switches do not.
-
-Re-orient block (non-NULL target):
-
-    Switched to <target>. Recent messages:
-
-    <last max(unread_in_target, FLOOR_N) events on target, rendered
-     with full metadata header, newest last>
-
-Phone down (``target=None``):
-
-    Focal cleared.
-
-Unknown-target (not a bound channel on this session):
-
-    Cannot switch to <target>: not a bound channel on this session.
 
 Errors do not mutate ``focal_channel``.
 """
@@ -43,11 +28,6 @@ from aios.harness.channels import (
 from aios.harness.context import render_user_event
 from aios.tools.registry import ToolResult, registry
 
-# Floor on the number of events included in the re-orient block so a
-# switch into a quiet channel still gives the agent a screen's worth of
-# context to reorient on — matches how phone messaging apps show the
-# last N messages when you tap into a conversation, regardless of
-# whether any are "new."
 RE_ORIENT_FLOOR_N = 10
 
 
@@ -126,9 +106,6 @@ async def switch_channel_handler(session_id: str, arguments: dict[str, Any]) -> 
             is_error=True,
         )
 
-    # Atomically flip the focal pointer.  The UPDATE serialises against
-    # append_event's row lock, so concurrent inbound stamping sees
-    # either the pre-switch or post-switch focal, never a torn read.
     async with pool.acquire() as conn:
         await conn.execute(
             "UPDATE sessions SET focal_channel = $1 WHERE id = $2",
@@ -165,10 +142,6 @@ async def _build_reorient_block(pool: Any, session_id: str, target: str) -> str:
 
     lines = [f"Switched to {target}. Recent messages:", ""]
     for e in recent:
-        # Render each quoted event as full content + metadata header
-        # (as if orig==focal), regardless of its stamped focal_at_arrival.
-        # The re-orient block is the "you've opened the app" view of
-        # the channel's own chronology.
         rendered = render_user_event(e.data, e.orig_channel, e.orig_channel)
         content = rendered.get("content", "")
         if isinstance(content, str) and content:

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -17,6 +17,7 @@ from unittest import mock
 import pytest
 
 from aios.models.routing_rules import SessionParams
+from tests.e2e.harness import msg_text
 
 
 def _uniq() -> str:
@@ -771,28 +772,6 @@ class TestOraSmokeTestRegression:
         assert await _get_session_focal(runtime_pool, session_id) == dm_address
 
 
-def _msg_text(msg: dict[str, Any]) -> str:
-    """Extract plain text from a chat-completions message.
-
-    Messages can carry ``content`` as a plain string or a list of
-    content blocks (Anthropic-style) — LiteLLM's cache-breakpoint
-    injection turns the system-prompt string into a list-of-blocks
-    shape.  Collapse both to plain text for substring assertions.
-    """
-    content = msg.get("content")
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[str] = []
-        for b in content:
-            if isinstance(b, dict):
-                t = b.get("text")
-                if isinstance(t, str):
-                    parts.append(t)
-        return "\n".join(parts)
-    return ""
-
-
 class TestTailBlockInStep:
     """Slice 7: the ephemeral channels tail block appears as the last
     user-role message on the chat-completions list, and its unread
@@ -854,7 +833,7 @@ class TestTailBlockInStep:
         messages = calls[-1]["messages"]
         # Tail block is the last user message in the payload.
         assert messages[-1]["role"] == "user"
-        content = _msg_text(messages[-1])
+        content = msg_text(messages[-1])
         assert "━━━ Channels ━━━" in content
         # NULL focal at this point → no ▸ marker, the one binding appears as ○.
         assert f"○ {address}" in content
@@ -925,7 +904,7 @@ class TestTailBlockInStep:
         await harness.run_step(session_id)
         messages = harness.model_calls[-1]["messages"]
         assert messages[-1]["role"] == "user"
-        content_step1 = _msg_text(messages[-1])
+        content_step1 = msg_text(messages[-1])
         assert f"▸ {address_a} (focal)" in content_step1
         assert f"○ {address_b} — 2 unread" in content_step1
         assert "msg-b2" in content_step1  # preview of latest unread
@@ -940,7 +919,7 @@ class TestTailBlockInStep:
         )
         harness.script_model([assistant("noted")])
         await harness.run_step(session_id)
-        content_step2 = _msg_text(harness.model_calls[-1]["messages"][-1])
+        content_step2 = msg_text(harness.model_calls[-1]["messages"][-1])
         assert f"▸ {address_b} (focal)" in content_step2
         # A is now non-focal; no unread for A yet since we never switched
         # away after its last focal-stamp, but the listing should show it.

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -1,0 +1,947 @@
+"""E2E tests for the focal-channel attention model (issue #29 redesign).
+
+Covers event stamping (``orig_channel`` + ``focal_channel_at_arrival``)
+at append time, the ``switch_channel`` built-in tool, and (in later
+slices) MCP ``_meta`` injection + paradigm/tail blocks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from aios.models.routing_rules import SessionParams
+
+
+def _uniq() -> str:
+    return secrets.token_hex(4)
+
+
+# ─── shared fixtures (mirrors the test_routing.py pattern) ──────────────────
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def env_id(pool: Any) -> str:
+    from aios.db import queries
+
+    async with pool.acquire() as conn:
+        env = await queries.insert_environment(conn, name=f"focal-test-{_uniq()}")
+    return env.id
+
+
+@pytest.fixture
+async def agent_id(pool: Any) -> str:
+    from aios.services import agents as svc
+
+    a = await svc.create_agent(
+        pool,
+        name=f"focal-agent-{_uniq()}",
+        model="openai/gpt-4o-mini",
+        system="",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    return a.id
+
+
+@pytest.fixture
+async def vault_id(pool: Any) -> str:
+    from aios.services import vaults as svc
+
+    v = await svc.create_vault(pool, display_name="focal-vault", metadata={})
+    return v.id
+
+
+# ─── helpers ────────────────────────────────────────────────────────────────
+
+
+async def _set_focal(pool: Any, session_id: str, focal: str | None) -> None:
+    """Direct DB update until the switch_channel tool (slice 5) lands."""
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE sessions SET focal_channel = $1 WHERE id = $2",
+            focal,
+            session_id,
+        )
+
+
+async def _setup_inbound(pool: Any, agent_id: str, env_id: str, vault_id: str) -> tuple[str, str]:
+    """Create a connection + routing rule, return (connection_id, prefix)."""
+    from aios.services import channels as ch_svc
+    from aios.services import connections as conn_svc
+
+    account = f"focal-{_uniq()}"
+    connection = await conn_svc.create_connection(
+        pool,
+        connector="signal",
+        account=account,
+        mcp_url="https://m",
+        vault_id=vault_id,
+        metadata={},
+    )
+    await ch_svc.create_routing_rule(
+        pool,
+        prefix=f"signal/{account}",
+        target=f"agent:{agent_id}",
+        session_params=SessionParams(environment_id=env_id),
+    )
+    return connection.id, f"signal/{account}"
+
+
+async def _post_inbound(
+    pool: Any, prefix: str, path: str, content: str = "hi"
+) -> tuple[str, str, str]:
+    """Resolve + append a user inbound message.
+
+    Returns ``(session_id, event_id, address)``. Bypasses the HTTP layer
+    and defer_wake so the test is DB-focused.
+    """
+    from aios.services import channels as ch_svc
+    from aios.services import sessions as sess_svc
+
+    address = f"{prefix}/{path}"
+    with mock.patch("aios.harness.wake.defer_wake"):
+        resolution = await ch_svc.resolve_channel(pool, address)
+        event = await sess_svc.append_user_message(
+            pool,
+            resolution.session_id,
+            content,
+            metadata={"channel": address},
+        )
+    return resolution.session_id, event.id, address
+
+
+# ─── slice 2: stamping tests ────────────────────────────────────────────────
+
+
+class TestEventStampingFromInbound:
+    async def test_inbound_stamps_orig_channel(
+        self, pool: Any, agent_id: str, env_id: str, vault_id: str
+    ) -> None:
+        from aios.db import queries
+
+        _connection_id, prefix = await _setup_inbound(pool, agent_id, env_id, vault_id)
+        session_id, _event_id, address = await _post_inbound(pool, prefix, "chat-1")
+
+        async with pool.acquire() as conn:
+            events = await queries.read_message_events(conn, session_id)
+
+        msg = events[-1]
+        assert msg.orig_channel == address
+
+    async def test_inbound_stamps_focal_at_arrival_null_when_phone_down(
+        self, pool: Any, agent_id: str, env_id: str, vault_id: str
+    ) -> None:
+        from aios.db import queries
+
+        _connection_id, prefix = await _setup_inbound(pool, agent_id, env_id, vault_id)
+        session_id, _event_id, _address = await _post_inbound(pool, prefix, "chat-1")
+
+        # Session was auto-created with focal_channel NULL (phone down).
+        async with pool.acquire() as conn:
+            events = await queries.read_message_events(conn, session_id)
+        msg = events[-1]
+        assert msg.focal_channel_at_arrival is None
+
+    async def test_inbound_stamps_focal_at_arrival_when_focused(
+        self, pool: Any, agent_id: str, env_id: str, vault_id: str
+    ) -> None:
+        from aios.db import queries
+
+        _connection_id, prefix = await _setup_inbound(pool, agent_id, env_id, vault_id)
+        # First message auto-creates the session.
+        session_id, _e1, address = await _post_inbound(pool, prefix, "chat-1")
+        # Focus the agent on this channel.
+        await _set_focal(pool, session_id, address)
+
+        # Second inbound on the same channel — focal matches orig.
+        _sid, _e2, _addr = await _post_inbound(pool, prefix, "chat-1", content="still here")
+
+        async with pool.acquire() as conn:
+            events = await queries.read_message_events(conn, session_id)
+        msg = events[-1]
+        assert msg.orig_channel == address
+        assert msg.focal_channel_at_arrival == address
+
+    async def test_inbound_stamps_focal_when_orig_differs(
+        self, pool: Any, agent_id: str, env_id: str, vault_id: str
+    ) -> None:
+        """Focal=A, inbound on B → stamp orig=B, focal_at_arrival=A."""
+        from aios.db import queries
+        from aios.services import channels as ch_svc
+
+        _connection_id, prefix = await _setup_inbound(pool, agent_id, env_id, vault_id)
+        # First message on chat-A auto-creates the session.
+        session_a_id, _e1, address_a = await _post_inbound(pool, prefix, "chat-A")
+        # Focus on A.
+        await _set_focal(pool, session_a_id, address_a)
+        # Bind chat-B to the same session so a POST to B doesn't create a new session.
+        address_b = f"{prefix}/chat-B"
+        await ch_svc.create_binding(pool, address=address_b, session_id=session_a_id)
+        # Inbound on B while focal is A.
+        _sid_b, _e2, _addr_b = await _post_inbound(pool, prefix, "chat-B", content="hi from B")
+
+        async with pool.acquire() as conn:
+            events = await queries.read_message_events(conn, session_a_id)
+        msg = events[-1]
+        assert msg.orig_channel == address_b
+        assert msg.focal_channel_at_arrival == address_a
+
+    async def test_stamping_reflects_latest_focal_across_serial_appends(
+        self,
+        pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        """append_event reads focal inside the same txn that allocates seq.
+
+        We can't cleanly race asyncio transactions without adding test-
+        internal plumbing, but we can verify that the focal column's
+        value at append time is the value stamped on the event, across
+        multiple serial updates.  Because the UPDATE used for seq
+        allocation also reads focal_channel (RETURNING clause), the read
+        is serialized against any concurrent focal mutation.
+        """
+        from aios.db import queries
+
+        _connection_id, prefix = await _setup_inbound(pool, agent_id, env_id, vault_id)
+        session_id, _e1, address_a = await _post_inbound(pool, prefix, "chat-A")
+
+        # Flip focal repeatedly, appending between each flip, and assert
+        # each event carries the focal that was in effect at its append.
+        expected_stamps: list[str | None] = []
+        for focal in (None, address_a, None, address_a):
+            await _set_focal(pool, session_id, focal)
+            _sid, _eid, _addr = await _post_inbound(pool, prefix, "chat-A", content="tick")
+            expected_stamps.append(focal)
+
+        async with pool.acquire() as conn:
+            events = await queries.read_message_events(conn, session_id)
+        # The first event (auto-created) is before our loop — drop it.
+        observed = [e.focal_channel_at_arrival for e in events[-len(expected_stamps) :]]
+        assert observed == expected_stamps
+
+    async def test_concurrent_appends_stamp_focal_consistently(
+        self, pool: Any, agent_id: str, env_id: str, vault_id: str
+    ) -> None:
+        """Concurrent appends serialize through the session row lock.
+
+        If two inbounds arrive simultaneously while focal is A, both
+        should stamp focal_at_arrival=A (not NULL, not each other's
+        scrap).  This pins down that the focal read lives inside the
+        same transaction that allocates the seq.
+        """
+        from aios.db import queries
+
+        _connection_id, prefix = await _setup_inbound(pool, agent_id, env_id, vault_id)
+        session_id, _e1, address = await _post_inbound(pool, prefix, "chat-C")
+        await _set_focal(pool, session_id, address)
+
+        async def _fire() -> None:
+            await _post_inbound(pool, prefix, "chat-C", content=f"msg-{_uniq()}")
+
+        await asyncio.gather(*(_fire() for _ in range(5)))
+
+        async with pool.acquire() as conn:
+            events = await queries.read_message_events(conn, session_id)
+        # All 5 concurrent user events plus the setup one — each has focal=address.
+        user_events = [
+            e
+            for e in events
+            if e.data.get("role") == "user" and e.data.get("metadata", {}).get("channel") == address
+        ]
+        # The first user event was appended before focal was set; the
+        # remaining 5 were after.  All "after" events must stamp focal.
+        focal_stamps = [e.focal_channel_at_arrival for e in user_events[1:]]
+        assert len(focal_stamps) == 5
+        assert all(s == address for s in focal_stamps), focal_stamps
+
+
+# ─── slice 5: switch_channel tool ───────────────────────────────────────────
+
+
+@pytest.fixture
+async def runtime_pool(pool: Any) -> AsyncIterator[Any]:
+    """Install ``runtime.pool`` so tool handlers can use it directly.
+
+    Unit-style direct-handler tests exercise
+    ``switch_channel_handler(session_id, arguments)`` without running
+    the full step function; the handler calls ``runtime.require_pool()``
+    which needs ``runtime.pool`` populated.
+    """
+    import aios.tools  # noqa: F401 — trigger registry population
+    from aios.harness import runtime
+
+    prev = runtime.pool
+    runtime.pool = pool
+    yield pool
+    runtime.pool = prev
+
+
+async def _get_session_focal(pool: Any, session_id: str) -> str | None:
+    async with pool.acquire() as conn:
+        return await conn.fetchval("SELECT focal_channel FROM sessions WHERE id = $1", session_id)
+
+
+class TestSwitchChannelHandler:
+    async def test_switch_to_target_updates_session_focal(
+        self,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        from aios.tools.switch_channel import switch_channel_handler
+
+        _conn_id, prefix = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+        session_id, _e, address = await _post_inbound(runtime_pool, prefix, "chat-1")
+
+        result = await switch_channel_handler(session_id, {"target": address})
+
+        assert result.is_error is False
+        assert await _get_session_focal(runtime_pool, session_id) == address
+        assert result.metadata is not None
+        marker = result.metadata["switch_channel"]
+        assert marker == {"target": address, "success": True}
+
+    async def test_switch_to_none_clears_focal(
+        self,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        from aios.tools.switch_channel import switch_channel_handler
+
+        _conn_id, prefix = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+        session_id, _e, address = await _post_inbound(runtime_pool, prefix, "chat-1")
+        await _set_focal(runtime_pool, session_id, address)
+
+        result = await switch_channel_handler(session_id, {"target": None})
+
+        assert result.is_error is False
+        assert await _get_session_focal(runtime_pool, session_id) is None
+        assert result.content == "Focal cleared."
+        assert result.metadata is not None
+        assert result.metadata["switch_channel"] == {"target": None, "success": True}
+
+    async def test_switch_to_unknown_target_errors_and_keeps_focal(
+        self,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        from aios.tools.switch_channel import switch_channel_handler
+
+        _conn_id, prefix = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+        session_id, _e, address = await _post_inbound(runtime_pool, prefix, "chat-1")
+        await _set_focal(runtime_pool, session_id, address)  # focus on A
+
+        result = await switch_channel_handler(session_id, {"target": "signal/other/fake"})
+
+        assert result.is_error is True
+        # Focal is unchanged after an invalid switch.
+        assert await _get_session_focal(runtime_pool, session_id) == address
+        assert result.metadata is not None
+        marker = result.metadata["switch_channel"]
+        assert marker == {"target": "signal/other/fake", "success": False}
+
+    async def test_reorient_block_renders_recent_events_with_header(
+        self,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        from aios.tools.switch_channel import switch_channel_handler
+
+        _conn_id, prefix = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+        session_id, _e, address = await _post_inbound(
+            runtime_pool, prefix, "chat-1", content="first"
+        )
+        # Add more messages on this channel.
+        for i in range(3):
+            await _post_inbound(runtime_pool, prefix, "chat-1", content=f"msg-{i}")
+
+        result = await switch_channel_handler(session_id, {"target": address})
+
+        content = result.content
+        assert isinstance(content, str)
+        assert content.startswith(f"Switched to {address}. Recent messages:")
+        # All 4 messages should appear (under the FLOOR_N=10 floor).
+        for text in ("first", "msg-0", "msg-1", "msg-2"):
+            assert text in content
+        # The header convention signals focal rendering was used.
+        assert f"[channel={address}" in content
+
+    async def test_reorient_block_respects_floor_on_quiet_channel(
+        self,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        """A switch into a channel with only 2 prior messages still
+        shows those 2 (below the floor — no padding from nowhere)."""
+        from aios.tools.switch_channel import switch_channel_handler
+
+        _conn_id, prefix = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+        session_id, _e, address = await _post_inbound(
+            runtime_pool, prefix, "chat-1", content="only-one"
+        )
+        await _post_inbound(runtime_pool, prefix, "chat-1", content="only-two")
+
+        result = await switch_channel_handler(session_id, {"target": address})
+        content = result.content
+        assert isinstance(content, str)
+        assert "only-one" in content
+        assert "only-two" in content
+
+    async def test_reorient_block_includes_all_unread_when_over_floor(
+        self,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        """Unread > FLOOR_N → all unread included, not clamped."""
+        from aios.tools.switch_channel import RE_ORIENT_FLOOR_N, switch_channel_handler
+
+        _conn_id, prefix = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+        session_id, _e, address = await _post_inbound(runtime_pool, prefix, "chat-1")
+        # Post MANY messages while focal is NULL so they all count as unread.
+        n = RE_ORIENT_FLOOR_N + 5
+        for i in range(n):
+            await _post_inbound(runtime_pool, prefix, "chat-1", content=f"unread-{i:02d}")
+
+        result = await switch_channel_handler(session_id, {"target": address})
+        content = result.content
+        assert isinstance(content, str)
+        # Every unread message body should appear in the re-orient block.
+        for i in range(n):
+            assert f"unread-{i:02d}" in content
+
+    async def test_reorient_block_empty_channel_fallback(
+        self,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        """Switching into a bound channel that has never received a
+        message shows a fallback line, not an empty block.
+        """
+        from aios.services import channels as ch_svc
+        from aios.services import sessions as sess_svc
+        from aios.tools.switch_channel import switch_channel_handler
+
+        _conn_id, prefix = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+        # Create a session + bind an unused channel address to it.
+        session_id, _e, _addr_used = await _post_inbound(
+            runtime_pool, prefix, "chat-used", content="seed"
+        )
+        unused_address = f"{prefix}/chat-never"
+        await ch_svc.create_binding(runtime_pool, address=unused_address, session_id=session_id)
+        # Sanity check session exists.
+        await sess_svc.get_session(runtime_pool, session_id)
+
+        result = await switch_channel_handler(session_id, {"target": unused_address})
+        content = result.content
+        assert isinstance(content, str)
+        assert "no prior messages on this channel" in content
+        assert await _get_session_focal(runtime_pool, session_id) == unused_address
+
+
+class TestSwitchChannelAsEvent:
+    """Switch_channel's tool_result event, as persisted by the dispatch
+    path, must carry the ``metadata.switch_channel`` marker so unread
+    derivation (slice 3) can use it as an anchor.
+    """
+
+    async def test_event_dispatch_persists_marker_metadata(
+        self,
+        harness: Any,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        from aios.db import queries
+        from aios.harness.tool_dispatch import launch_tool_calls
+
+        _conn_id, prefix = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+        session_id, _e, address = await _post_inbound(runtime_pool, prefix, "chat-1")
+
+        # Simulate an assistant message + a switch_channel tool call —
+        # launch_tool_calls will invoke the handler and persist the
+        # tool_result event via the dispatch path (exercising ToolResult).
+        async with runtime_pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_switch_1",
+                            "type": "function",
+                            "function": {
+                                "name": "switch_channel",
+                                "arguments": json.dumps({"target": address}),
+                            },
+                        }
+                    ],
+                },
+            )
+        launch_tool_calls(
+            runtime_pool,
+            session_id,
+            [
+                {
+                    "id": "call_switch_1",
+                    "type": "function",
+                    "function": {
+                        "name": "switch_channel",
+                        "arguments": json.dumps({"target": address}),
+                    },
+                }
+            ],
+        )
+        # Wait for the fire-and-forget tool task to complete.  The task
+        # registry tracks in-flight tasks by session; poll its count
+        # with a small sleep budget.
+        for _ in range(200):
+            if harness._task_registry.in_flight_count(session_id) == 0:
+                break
+            await asyncio.sleep(0.01)
+        assert harness._task_registry.in_flight_count(session_id) == 0
+
+        async with runtime_pool.acquire() as conn:
+            events = await queries.read_message_events(conn, session_id)
+
+        tool_events = [
+            e
+            for e in events
+            if e.data.get("role") == "tool" and e.data.get("name") == "switch_channel"
+        ]
+        assert len(tool_events) == 1
+        ev = tool_events[0]
+        # The marker lands under data.metadata — consumed by
+        # derive_last_seen / derive_unread_counts in slice 3.
+        assert ev.data.get("metadata", {}).get("switch_channel") == {
+            "target": address,
+            "success": True,
+        }
+        # Focal actually got flipped.
+        assert await _get_session_focal(runtime_pool, session_id) == address
+
+
+class TestMcpMetaInjection:
+    """Slice 6: connection-provided MCP tools receive the focal channel
+    path via the JSON-RPC ``_meta`` field, without stuffing it into
+    arguments.  Agent-declared MCP servers don't get the meta stamp.
+    """
+
+    async def test_conn_tool_dispatch_injects_focal_suffix_into_meta(
+        self,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        from aios.crypto.vault import CryptoBox
+        from aios.harness import runtime
+        from aios.harness.tool_dispatch import _execute_mcp_tool_async
+
+        # The dispatch path calls resolve_auth_for_url which uses
+        # runtime.crypto_box.
+        prev_crypto = runtime.crypto_box
+        runtime.crypto_box = CryptoBox(__import__("os").urandom(32))
+        try:
+            _conn_id, prefix = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+            session_id, _e, address = await _post_inbound(runtime_pool, prefix, "chat-1")
+
+            # The connection created by _setup_inbound has id prefix `conn_`.
+            from aios.services import connections as conn_svc
+
+            connections = await conn_svc.list_connections(runtime_pool)
+            conn = next(c for c in connections if c.connector == "signal")
+
+            mcp_server_map = {conn.id: conn.mcp_url}
+            tool_call_dict = {
+                "id": "call_send_1",
+                "type": "function",
+                "function": {
+                    "name": f"mcp__{conn.id}__signal_send",
+                    "arguments": json.dumps({"text": "hi there"}),
+                },
+            }
+
+            with (
+                patch(
+                    "aios.mcp.client.resolve_auth_for_url",
+                    new=AsyncMock(return_value={}),
+                ),
+                patch(
+                    "aios.mcp.client.call_mcp_tool",
+                    new=AsyncMock(return_value={"content": "ok"}),
+                ) as mock_call,
+            ):
+                await _execute_mcp_tool_async(
+                    runtime_pool,
+                    session_id,
+                    tool_call_dict,
+                    mcp_server_map,
+                    focal_channel=address,  # focal=A → suffix=chat-1
+                )
+
+            # Verify call_mcp_tool was invoked with the focal suffix meta.
+            _args, kwargs = mock_call.call_args
+            meta = kwargs.get("meta")
+            assert isinstance(meta, dict)
+            assert meta == {"aios.focal_channel_path": "chat-1"}
+        finally:
+            runtime.crypto_box = prev_crypto
+
+    async def test_agent_mcp_tool_dispatch_no_meta_stamped(
+        self,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        """Agent-declared MCP servers (not under the conn_* prefix) don't
+        get focal meta — aios has no business telling an agent-declared
+        MCP server about the session's focal channel.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from aios.crypto.vault import CryptoBox
+        from aios.harness import runtime
+        from aios.harness.tool_dispatch import _execute_mcp_tool_async
+
+        prev_crypto = runtime.crypto_box
+        runtime.crypto_box = CryptoBox(__import__("os").urandom(32))
+        try:
+            _conn_id, prefix = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+            session_id, _e, address = await _post_inbound(runtime_pool, prefix, "chat-1")
+
+            # Agent-declared server: name does NOT start with conn_.
+            agent_server_name = "github"
+            mcp_server_map = {agent_server_name: "https://mcp.github.com"}
+            tool_call_dict = {
+                "id": "call_gh_1",
+                "type": "function",
+                "function": {
+                    "name": f"mcp__{agent_server_name}__create_issue",
+                    "arguments": json.dumps({"title": "bug"}),
+                },
+            }
+
+            with (
+                patch(
+                    "aios.mcp.client.resolve_auth_for_url",
+                    new=AsyncMock(return_value={}),
+                ),
+                patch(
+                    "aios.mcp.client.call_mcp_tool",
+                    new=AsyncMock(return_value={"content": "done"}),
+                ) as mock_call,
+            ):
+                await _execute_mcp_tool_async(
+                    runtime_pool,
+                    session_id,
+                    tool_call_dict,
+                    mcp_server_map,
+                    focal_channel=address,  # non-null focal, but agent server
+                )
+
+            _args, kwargs = mock_call.call_args
+            # No meta for agent-declared MCP.
+            assert kwargs.get("meta") is None
+        finally:
+            runtime.crypto_box = prev_crypto
+
+
+class TestOraSmokeTestRegression:
+    """Regression for the smoke-test bug that motivated this redesign.
+
+    The original failure: in a many-to-one session, a follow-up on a
+    quiet DM was indistinguishable from questions about other channels'
+    noise, because every channel's messages were interleaved.  Under
+    the focal model, switching back to the DM surfaces its last-N
+    messages (including the referent the follow-up points at) in the
+    re-orient block — the agent has the context it needs.
+
+    Design validation:
+    * the re-orient block contains the "I'm Ora" claim (seeded early).
+    * the re-orient block contains the follow-up "you sure about that?"
+      (which arrived while agent was focused elsewhere).
+    * focal_channel is set to the DM afterward, so the next inbound
+      stamps correctly.
+    """
+
+    async def test_switch_back_to_quiet_channel_surfaces_referent(
+        self,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        from aios.services import channels as ch_svc
+        from aios.tools.switch_channel import switch_channel_handler
+
+        _conn_id, prefix = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+
+        # DM with Tom — session seeded here.
+        session_id, _e_seed, dm_address = await _post_inbound(
+            runtime_pool, prefix, "dm-tom", content="hey"
+        )
+        # Agent is focused on dm-tom, claims "I'm Ora".
+        await _set_focal(runtime_pool, session_id, dm_address)
+
+        # Inbound: the assistant self-identifies — in a real system this
+        # is an assistant event, but for regression purposes we seed a
+        # user event carrying the claim so it appears in the re-orient
+        # block later.  (A real assistant message would already live in
+        # the focal-native log and be visible to build_messages.)
+        async with runtime_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE sessions SET focal_channel = $1 WHERE id = $2",
+                dm_address,
+                session_id,
+            )
+        from aios.services import sessions as sess_svc
+
+        await sess_svc.append_user_message(
+            runtime_pool,
+            session_id,
+            "I'm Ora — an AI running on this Signal channel.",
+            metadata={"channel": dm_address, "sender_name": "Ora-claim"},
+        )
+
+        # Now agent switches to a second channel + burst of activity.
+        qa_address = f"{prefix}/qa-group"
+        await ch_svc.create_binding(runtime_pool, address=qa_address, session_id=session_id)
+        await _set_focal(runtime_pool, session_id, qa_address)
+        for i in range(30):
+            await _post_inbound(runtime_pool, prefix, "qa-group", content=f"noise-{i:02d}")
+
+        # Agent puts phone down (focal=None) and user sends the DM
+        # follow-up while attention is elsewhere.
+        await _set_focal(runtime_pool, session_id, None)
+        await _post_inbound(runtime_pool, prefix, "dm-tom", content="you sure about that?")
+
+        # Agent switches back to the DM.  Re-orient block must include
+        # BOTH the "I'm Ora" seed and the "you sure" follow-up.
+        result = await switch_channel_handler(session_id, {"target": dm_address})
+        content = result.content
+        assert isinstance(content, str)
+        assert "I'm Ora" in content, f"missing referent in re-orient block:\n{content}"
+        assert "you sure about that?" in content, (
+            f"missing follow-up in re-orient block:\n{content}"
+        )
+        # Focal is set now; the DM-native view is active.
+        assert await _get_session_focal(runtime_pool, session_id) == dm_address
+
+
+def _msg_text(msg: dict[str, Any]) -> str:
+    """Extract plain text from a chat-completions message.
+
+    Messages can carry ``content`` as a plain string or a list of
+    content blocks (Anthropic-style) — LiteLLM's cache-breakpoint
+    injection turns the system-prompt string into a list-of-blocks
+    shape.  Collapse both to plain text for substring assertions.
+    """
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for b in content:
+            if isinstance(b, dict):
+                t = b.get("text")
+                if isinstance(t, str):
+                    parts.append(t)
+        return "\n".join(parts)
+    return ""
+
+
+class TestTailBlockInStep:
+    """Slice 7: the ephemeral channels tail block appears as the last
+    user-role message on the chat-completions list, and its unread
+    counts update across steps without busting the cache-stable
+    system prompt.
+    """
+
+    async def test_tail_block_appears_as_last_user_message(
+        self,
+        harness: Any,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        from aios.services import channels as ch_svc
+        from aios.services import connections as conn_svc
+        from tests.e2e.harness import assistant
+
+        # Build a session with a routed inbound so bindings exist.
+        account = f"tail-{_uniq()}"
+        connection = await conn_svc.create_connection(
+            runtime_pool,
+            connector="signal",
+            account=account,
+            mcp_url="https://m",
+            vault_id=vault_id,
+            metadata={},
+        )
+        await ch_svc.create_routing_rule(
+            runtime_pool,
+            prefix=f"signal/{account}",
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        prefix = f"signal/{account}"
+
+        # Route one inbound to auto-create a session.
+        address = f"{prefix}/chat-1"
+        with mock.patch("aios.harness.wake.defer_wake"):
+            resolution = await ch_svc.resolve_channel(runtime_pool, address)
+            from aios.services import sessions as sess_svc
+
+            await sess_svc.append_user_message(
+                runtime_pool,
+                resolution.session_id,
+                "hi",
+                metadata={"channel": address},
+            )
+        session_id = resolution.session_id
+        # Ignore the connection — the channel listing pulls from bindings.
+        assert connection.id.startswith("conn_")
+
+        harness.script_model([assistant("ok")])
+        await harness.run_step(session_id)
+
+        calls = harness.model_calls
+        assert calls, "litellm was not called"
+        messages = calls[-1]["messages"]
+        # Tail block is the last user message in the payload.
+        assert messages[-1]["role"] == "user"
+        content = _msg_text(messages[-1])
+        assert "━━━ Channels ━━━" in content
+        # NULL focal at this point → no ▸ marker, the one binding appears as ○.
+        assert f"○ {address}" in content
+        assert "▸" not in content
+
+    async def test_tail_block_reflects_focal_and_unread_changes(
+        self,
+        harness: Any,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        from aios.services import channels as ch_svc
+        from aios.services import connections as conn_svc
+        from tests.e2e.harness import assistant
+
+        account = f"tail2-{_uniq()}"
+        await conn_svc.create_connection(
+            runtime_pool,
+            connector="signal",
+            account=account,
+            mcp_url="https://m",
+            vault_id=vault_id,
+            metadata={},
+        )
+        await ch_svc.create_routing_rule(
+            runtime_pool,
+            prefix=f"signal/{account}",
+            target=f"agent:{agent_id}",
+            session_params=SessionParams(environment_id=env_id),
+        )
+        prefix = f"signal/{account}"
+
+        # Route two channels to the same session.
+        address_a = f"{prefix}/chat-A"
+        address_b = f"{prefix}/chat-B"
+        with mock.patch("aios.harness.wake.defer_wake"):
+            resolution_a = await ch_svc.resolve_channel(runtime_pool, address_a)
+            session_id = resolution_a.session_id
+            await ch_svc.create_binding(runtime_pool, address=address_b, session_id=session_id)
+            # Focus on A and let one message land in A.
+            from aios.services import sessions as sess_svc
+
+            await _set_focal(runtime_pool, session_id, address_a)
+            await sess_svc.append_user_message(
+                runtime_pool,
+                session_id,
+                "hi from A",
+                metadata={"channel": address_a},
+            )
+            # Then two messages on B while focal is A → unread in B.
+            await sess_svc.append_user_message(
+                runtime_pool,
+                session_id,
+                "msg-b1",
+                metadata={"channel": address_b},
+            )
+            await sess_svc.append_user_message(
+                runtime_pool,
+                session_id,
+                "msg-b2",
+                metadata={"channel": address_b},
+            )
+
+        # Step 1: focal=A.  Tail block should mark A as focal, show 2 unread on B.
+        harness.script_model([assistant("processing")])
+        await harness.run_step(session_id)
+        messages = harness.model_calls[-1]["messages"]
+        assert messages[-1]["role"] == "user"
+        content_step1 = _msg_text(messages[-1])
+        assert f"▸ {address_a} (focal)" in content_step1
+        assert f"○ {address_b} — 2 unread" in content_step1
+        assert "msg-b2" in content_step1  # preview of latest unread
+
+        # Step 2: change focal to B and run again.  Tail block reflects.
+        await _set_focal(runtime_pool, session_id, address_b)
+        await sess_svc.append_user_message(
+            runtime_pool,
+            session_id,
+            "more activity",
+            metadata={"channel": address_b},
+        )
+        harness.script_model([assistant("noted")])
+        await harness.run_step(session_id)
+        content_step2 = _msg_text(harness.model_calls[-1]["messages"][-1])
+        assert f"▸ {address_b} (focal)" in content_step2
+        # A is now non-focal; no unread for A yet since we never switched
+        # away after its last focal-stamp, but the listing should show it.
+        assert f"○ {address_a}" in content_step2

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -123,3 +123,65 @@ def test_migration_downgrade_drops_tables(postgres: object) -> None:
             await conn.close()
 
     asyncio.run(check())
+
+
+# Columns added by migration 0017 (focal-channel attention model). Listed
+# as (table, column) pairs used by the cycle test below.
+_MIGRATION_0017_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("sessions", "focal_channel"),
+    ("events", "orig_channel"),
+    ("events", "focal_channel_at_arrival"),
+    ("channel_bindings", "notification_mode"),
+)
+
+
+async def _column_exists(conn: asyncpg.Connection, table: str, column: str) -> bool:
+    row = await conn.fetchrow(
+        "SELECT 1 FROM information_schema.columns "
+        "WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2",
+        table,
+        column,
+    )
+    return row is not None
+
+
+@needs_docker
+@pytest.mark.integration
+def test_migration_0017_focal_channel_cycle(postgres: object) -> None:
+    """Exercise migration 0017's up/down/up cycle.
+
+    Verifies that the focal-channel columns appear at head, are removed
+    on ``downgrade -1`` (back to 0016), and reappear on ``upgrade head``.
+    """
+    db_url = _alembic_url(postgres)
+
+    # Start at head (idempotent regardless of prior test state).
+    upgraded = _run_alembic(["upgrade", "head"], db_url)
+    assert upgraded.returncode == 0, f"initial upgrade failed:\n{upgraded.stderr}"
+
+    import asyncio
+
+    async def assert_columns(expected: bool) -> None:
+        conn = await asyncpg.connect(db_url)
+        try:
+            for table, column in _MIGRATION_0017_COLUMNS:
+                exists = await _column_exists(conn, table, column)
+                if expected:
+                    assert exists, f"{table}.{column} missing after upgrade"
+                else:
+                    assert not exists, f"{table}.{column} still present after downgrade"
+        finally:
+            await conn.close()
+
+    # 1. Columns exist at head.
+    asyncio.run(assert_columns(True))
+
+    # 2. Downgrade one step → back to 0016. Columns gone.
+    downgraded = _run_alembic(["downgrade", "-1"], db_url)
+    assert downgraded.returncode == 0, f"downgrade -1 failed:\n{downgraded.stderr}"
+    asyncio.run(assert_columns(False))
+
+    # 3. Upgrade back to head. Columns reappear.
+    re_upgraded = _run_alembic(["upgrade", "head"], db_url)
+    assert re_upgraded.returncode == 0, f"re-upgrade failed:\n{re_upgraded.stderr}"
+    asyncio.run(assert_columns(True))

--- a/tests/unit/test_channels_focal.py
+++ b/tests/unit/test_channels_focal.py
@@ -1,0 +1,257 @@
+"""Unit tests for focal-channel unread-derivation helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from aios.harness.channels import (
+    SWITCH_CHANNEL_METADATA_KEY,
+    derive_last_seen,
+    derive_unread_counts,
+    focal_channel_path,
+)
+from aios.models.events import Event, EventKind
+
+
+def _evt(
+    seq: int,
+    *,
+    kind: EventKind = "message",
+    role: str | None = "user",
+    orig: str | None = None,
+    focal_at: str | None = None,
+    content: str = "hi",
+    data: dict | None = None,
+) -> Event:
+    if data is None:
+        data = {}
+        if role is not None:
+            data["role"] = role
+        if content is not None and role is not None:
+            data["content"] = content
+    return Event(
+        id=f"evt_{seq:04d}",
+        session_id="sess_test",
+        seq=seq,
+        kind=kind,
+        data=data,
+        cumulative_tokens=None,
+        created_at=datetime(2026, 4, 17, tzinfo=UTC),
+        orig_channel=orig,
+        focal_channel_at_arrival=focal_at,
+    )
+
+
+def _switch_result(
+    seq: int,
+    target: str | None,
+    *,
+    success: bool = True,
+) -> Event:
+    return _evt(
+        seq,
+        kind="message",
+        role=None,
+        orig=None,
+        focal_at=None,
+        data={
+            "role": "tool",
+            "tool_call_id": f"call_{seq}",
+            "content": "switched" if success else "error",
+            "metadata": {
+                SWITCH_CHANNEL_METADATA_KEY: {
+                    "target": target,
+                    "success": success,
+                }
+            },
+        },
+    )
+
+
+class TestDeriveLastSeen:
+    def test_no_events_returns_zero(self) -> None:
+        assert derive_last_seen([], "signal/a/chat") == 0
+
+    def test_no_matching_events_returns_zero(self) -> None:
+        events = [_evt(1, orig="signal/a/other", focal_at=None)]
+        assert derive_last_seen(events, "signal/a/chat") == 0
+
+    def test_events_while_focal_are_seen(self) -> None:
+        """Any user event with focal_at_arrival == X proves the agent was
+        focused on X at that seq; therefore all X-origin events up to
+        that seq have been visible in the focal view.
+        """
+        events = [
+            _evt(1, orig="signal/a/x", focal_at="signal/a/x"),
+            _evt(2, orig="signal/a/x", focal_at="signal/a/x"),
+        ]
+        assert derive_last_seen(events, "signal/a/x") == 2
+
+    def test_peripheral_focal_still_anchors(self) -> None:
+        """Focal=X at arrival, orig=Y — still anchors last_seen_in_X
+        (agent was watching X when Y's notification arrived).
+        """
+        events = [_evt(5, orig="signal/a/y", focal_at="signal/a/x")]
+        assert derive_last_seen(events, "signal/a/x") == 5
+
+    def test_successful_switch_anchors_last_seen(self) -> None:
+        events = [_switch_result(7, target="signal/a/x", success=True)]
+        assert derive_last_seen(events, "signal/a/x") == 7
+
+    def test_failed_switch_not_anchor(self) -> None:
+        events = [_switch_result(7, target="signal/a/x", success=False)]
+        assert derive_last_seen(events, "signal/a/x") == 0
+
+    def test_switch_to_other_channel_not_anchor(self) -> None:
+        events = [_switch_result(7, target="signal/a/other", success=True)]
+        assert derive_last_seen(events, "signal/a/x") == 0
+
+    def test_switch_to_none_does_not_anchor_any(self) -> None:
+        events = [_switch_result(7, target=None, success=True)]
+        assert derive_last_seen(events, "signal/a/x") == 0
+
+    def test_max_of_focal_and_switch_anchors(self) -> None:
+        events = [
+            _evt(3, orig="signal/a/x", focal_at="signal/a/x"),
+            _switch_result(5, target="signal/a/x", success=True),
+            _evt(6, orig="signal/a/y", focal_at="signal/a/y"),
+        ]
+        # Latest anchor for X is the switch at seq 5.
+        assert derive_last_seen(events, "signal/a/x") == 5
+
+    def test_legacy_null_events_ignored(self) -> None:
+        events = [
+            _evt(1, orig=None, focal_at=None),  # pre-migration legacy
+            _evt(2, orig="signal/a/x", focal_at="signal/a/x"),
+        ]
+        assert derive_last_seen(events, "signal/a/x") == 2
+
+
+class TestDeriveUnreadCounts:
+    def test_no_events_all_zero(self) -> None:
+        counts = derive_unread_counts([], ["signal/a/x", "signal/a/y"])
+        assert counts == {"signal/a/x": 0, "signal/a/y": 0}
+
+    def test_events_while_focal_are_not_unread(self) -> None:
+        events = [
+            _evt(1, orig="signal/a/x", focal_at="signal/a/x"),
+            _evt(2, orig="signal/a/x", focal_at="signal/a/x"),
+        ]
+        counts = derive_unread_counts(events, ["signal/a/x"])
+        assert counts == {"signal/a/x": 0}
+
+    def test_unread_from_peripheral_channels_counted(self) -> None:
+        """Events arriving on Y while focal==X count toward unread_in_Y."""
+        events = [
+            _evt(1, orig="signal/a/x", focal_at="signal/a/x"),
+            _evt(2, orig="signal/a/y", focal_at="signal/a/x"),
+            _evt(3, orig="signal/a/y", focal_at="signal/a/x"),
+        ]
+        counts = derive_unread_counts(events, ["signal/a/x", "signal/a/y"])
+        assert counts["signal/a/x"] == 0
+        assert counts["signal/a/y"] == 2
+
+    def test_switch_resets_unread_for_target(self) -> None:
+        """A successful switch to Y is a last_seen anchor for Y — prior
+        Y-origin events are no longer unread.
+        """
+        events = [
+            _evt(1, orig="signal/a/y", focal_at="signal/a/x"),
+            _evt(2, orig="signal/a/y", focal_at="signal/a/x"),
+            _switch_result(3, target="signal/a/y", success=True),
+        ]
+        counts = derive_unread_counts(events, ["signal/a/y"])
+        assert counts == {"signal/a/y": 0}
+
+    def test_unread_after_switch_counted(self) -> None:
+        """New Y-origin events arriving after the switch to Y are seen
+        (focal=Y at arrival) — still not unread.  But Y-origin events
+        arriving with focal != Y after a later switch-away are unread.
+        """
+        events = [
+            _switch_result(1, target="signal/a/y", success=True),
+            _evt(2, orig="signal/a/y", focal_at="signal/a/y"),  # seen focally
+            _switch_result(3, target="signal/a/x", success=True),
+            _evt(4, orig="signal/a/y", focal_at="signal/a/x"),  # unread
+            _evt(5, orig="signal/a/y", focal_at="signal/a/x"),  # unread
+        ]
+        counts = derive_unread_counts(events, ["signal/a/y"])
+        assert counts == {"signal/a/y": 2}
+
+    def test_legacy_null_events_not_counted(self) -> None:
+        events = [
+            _evt(1, orig=None, focal_at=None),
+            _evt(2, orig=None, focal_at=None),
+            _evt(3, orig="signal/a/x", focal_at=None),  # real peripheral
+        ]
+        counts = derive_unread_counts(events, ["signal/a/x"])
+        assert counts == {"signal/a/x": 1}
+
+    def test_failed_switch_does_not_reset_unread(self) -> None:
+        events = [
+            _evt(1, orig="signal/a/y", focal_at="signal/a/x"),
+            _switch_result(2, target="signal/a/y", success=False),
+            _evt(3, orig="signal/a/y", focal_at="signal/a/x"),
+        ]
+        counts = derive_unread_counts(events, ["signal/a/y"])
+        assert counts == {"signal/a/y": 2}
+
+    def test_counts_per_channel_independent(self) -> None:
+        events = [
+            _evt(1, orig="signal/a/x", focal_at="signal/a/z"),
+            _evt(2, orig="signal/a/y", focal_at="signal/a/z"),
+            _evt(3, orig="signal/a/y", focal_at="signal/a/z"),
+        ]
+        counts = derive_unread_counts(events, ["signal/a/x", "signal/a/y", "signal/a/z"])
+        assert counts == {"signal/a/x": 1, "signal/a/y": 2, "signal/a/z": 0}
+
+    def test_non_message_events_not_counted(self) -> None:
+        events = [
+            _evt(1, kind="span", role=None, orig=None, focal_at=None, data={"event": "ping"}),
+            _evt(2, orig="signal/a/x", focal_at=None),
+        ]
+        counts = derive_unread_counts(events, ["signal/a/x"])
+        assert counts == {"signal/a/x": 1}
+
+    def test_assistant_events_not_counted_as_unread(self) -> None:
+        """Assistant-role events don't get orig_channel stamped (per
+        slice 2's contract: orig is derived from inbound metadata).
+        Even if they somehow carried orig=X, they're not user stimuli
+        and shouldn't count toward unread.
+        """
+        events = [
+            _evt(1, role="assistant", orig=None, focal_at=None, data={"role": "assistant"}),
+            _evt(2, orig="signal/a/x", focal_at=None),
+        ]
+        counts = derive_unread_counts(events, ["signal/a/x"])
+        assert counts == {"signal/a/x": 1}
+
+
+class TestFocalChannelPath:
+    """Suffix-extraction helper for MCP _meta injection (slice 6)."""
+
+    def test_three_segment_address(self) -> None:
+        # Signal shape: signal/<bot>/<chat_id>
+        assert focal_channel_path("signal/bot/alice") == "alice"
+
+    def test_four_segment_address_preserves_inner_slashes(self) -> None:
+        # Telegram forum-thread shape: telegram/<bot>/<chat>/<thread>
+        assert focal_channel_path("telegram/bot/chat/thread") == "chat/thread"
+
+    def test_deep_address_preserves_all_tail_segments(self) -> None:
+        # Defensive: connectors may use arbitrarily deep suffixes.
+        assert focal_channel_path("x/y/a/b/c") == "a/b/c"
+
+    def test_none_returns_none(self) -> None:
+        assert focal_channel_path(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert focal_channel_path("") is None
+
+    def test_malformed_two_segments_returns_none(self) -> None:
+        # Missing suffix — should not leak a garbled value.
+        assert focal_channel_path("signal/bot") is None
+
+    def test_trailing_slash_yields_empty_suffix_is_none(self) -> None:
+        # "signal/bot/" → 3 segments but suffix is empty → None.
+        assert focal_channel_path("signal/bot/") is None

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -6,22 +6,29 @@ DB) is covered in tests/e2e.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from aios.harness.channels import (
     apply_monologue_prefix,
-    augment_with_channels,
     augment_with_connector_instructions,
-    build_channels_system_block,
+    augment_with_focal_paradigm,
+    build_channels_tail_block,
     build_connector_instructions_block,
+    build_focal_paradigm_block,
     connection_server_name,
 )
-from aios.models.channel_bindings import ChannelBinding
+from aios.models.channel_bindings import ChannelBinding, NotificationMode
 from aios.models.connections import Connection
+from aios.models.events import Event
 
 
-def _binding(address: str, session_id: str = "sess_x") -> ChannelBinding:
+def _binding(
+    address: str,
+    session_id: str = "sess_x",
+    *,
+    notification_mode: NotificationMode = "focal_candidate",
+) -> ChannelBinding:
     now = datetime(2026, 4, 16)
     return ChannelBinding(
         id=f"cbnd_{hash(address) & 0xFFFF:04x}",
@@ -29,6 +36,27 @@ def _binding(address: str, session_id: str = "sess_x") -> ChannelBinding:
         session_id=session_id,
         created_at=now,
         updated_at=now,
+        notification_mode=notification_mode,
+    )
+
+
+def _user_event(
+    seq: int,
+    *,
+    orig: str | None = None,
+    focal_at: str | None = None,
+    content: str = "hello",
+) -> Event:
+    return Event(
+        id=f"evt_{seq:04d}",
+        session_id="sess_x",
+        seq=seq,
+        kind="message",
+        data={"role": "user", "content": content},
+        cumulative_tokens=None,
+        created_at=datetime(2026, 4, 17, tzinfo=UTC),
+        orig_channel=orig,
+        focal_channel_at_arrival=focal_at,
     )
 
 
@@ -69,33 +97,50 @@ class TestConnectionServerName:
         assert connection_server_name(c) == connection_server_name(c)
 
 
-# ── build_channels_system_block / augment_with_channels ────────────────────
+# ── build_focal_paradigm_block / augment_with_focal_paradigm ───────────────
 
 
-class TestBuildChannelsSystemBlock:
+class TestBuildFocalParadigmBlock:
+    """Slice 7: paradigm prose introducing the focal-channel model.
+
+    Cache-stable: text does not vary with per-channel state (unread
+    counts, previews) — that lives in the ephemeral tail block.
+    """
+
     def test_empty_bindings_returns_empty_string(self) -> None:
-        assert build_channels_system_block([]) == ""
+        assert build_focal_paradigm_block([]) == ""
 
-    def test_single_binding_lists_address(self) -> None:
-        block = build_channels_system_block([_binding("signal/alice/chat-1")])
-        assert "signal/alice/chat-1" in block
+    def test_mentions_focal_and_switch_channel(self) -> None:
+        block = build_focal_paradigm_block([_binding("signal/alice/chat-1")])
+        assert "focal" in block.lower()
+        assert "switch_channel" in block
+
+    def test_describes_tail_symbols(self) -> None:
+        block = build_focal_paradigm_block([_binding("signal/alice/chat-1")])
+        assert "▸" in block
+        assert "○" in block
+        assert "◌" in block
+
+    def test_contains_monologue_reminder(self) -> None:
+        block = build_focal_paradigm_block([_binding("signal/alice/chat-1")])
         assert "INTERNAL_MONOLOGUE" in block
-        assert "bound to the following channels" in block.lower()
 
-    def test_multiple_bindings_all_listed(self) -> None:
-        block = build_channels_system_block(
+    def test_no_per_channel_data_leakage(self) -> None:
+        """The block must not name any specific bound channel — that's
+        the tail block's job.  Paradigm prose stays cache-stable.
+        """
+        block = build_focal_paradigm_block(
             [
                 _binding("signal/alice/chat-1"),
-                _binding("slack/ws/C123/t"),
+                _binding("slack/workspace/channel/thread"),
             ]
         )
-        assert "signal/alice/chat-1" in block
-        assert "slack/ws/C123/t" in block
+        assert "signal/alice/chat-1" not in block
+        assert "slack/workspace/channel/thread" not in block
 
-    def test_generic_paradigm_prose_present(self) -> None:
-        block = build_channels_system_block([_binding("signal/alice/chat-1")])
-        assert "asynchronously" in block
-        assert "silence" in block
+    def test_describes_phone_down_state(self) -> None:
+        block = build_focal_paradigm_block([_binding("signal/alice/chat-1")])
+        assert "phone down" in block.lower() or "target=null" in block
 
 
 # ── build_connector_instructions_block / augment_with_connector_instructions ──
@@ -168,21 +213,130 @@ class TestAugmentWithConnectorInstructions:
         assert not out.startswith("\n")
 
 
-class TestAugmentWithChannels:
+class TestAugmentWithFocalParadigm:
     def test_no_bindings_returns_base_unchanged(self) -> None:
-        assert augment_with_channels("you are a helpful agent", []) == "you are a helpful agent"
+        assert (
+            augment_with_focal_paradigm("you are a helpful agent", []) == "you are a helpful agent"
+        )
 
     def test_appends_block_after_base(self) -> None:
-        result = augment_with_channels("you are helpful", [_binding("signal/a/1")])
+        result = augment_with_focal_paradigm("you are helpful", [_binding("signal/a/1")])
         assert result.startswith("you are helpful")
-        assert "signal/a/1" in result
+        assert "switch_channel" in result
         # Separator between base and appended block (blank line).
         assert "\n\n" in result
 
     def test_empty_base_yields_block_only(self) -> None:
-        result = augment_with_channels("", [_binding("signal/a/1")])
-        assert "signal/a/1" in result
+        result = augment_with_focal_paradigm("", [_binding("signal/a/1")])
+        assert "switch_channel" in result
         assert not result.startswith("\n")
+
+
+# ── build_channels_tail_block ──────────────────────────────────────────────
+
+
+class TestBuildChannelsTailBlock:
+    """Slice 7: the ephemeral per-step listing of bound channels.
+
+    Pure data block — no prose explaining the paradigm (that's the job
+    of :func:`build_focal_paradigm_block`, which is cache-stable and
+    lives in the system prompt).
+    """
+
+    _ALICE = "signal/bot/alice"
+    _FAMILY = "signal/bot/family"
+    _ANNOUNCEMENTS = "signal/bot/announcements"
+
+    def test_no_bindings_returns_none(self) -> None:
+        assert build_channels_tail_block([], [], focal_channel=None) is None
+
+    def test_focal_line_marked_with_triangle_no_unread_count(self) -> None:
+        block = build_channels_tail_block([_binding(self._ALICE)], [], focal_channel=self._ALICE)
+        assert block is not None
+        content = block["content"]
+        assert "▸ signal/bot/alice (focal)" in content
+        # Focal line must not advertise an unread count — you ARE in it.
+        # Check that no digit appears on the focal line.
+        focal_line = next(ln for ln in content.splitlines() if "▸" in ln)
+        assert not any(ch.isdigit() for ch in focal_line), focal_line
+
+    def test_non_focal_channel_shows_unread_count(self) -> None:
+        events = [
+            _user_event(1, orig=self._FAMILY, focal_at=self._ALICE, content="hi from mom"),
+            _user_event(2, orig=self._FAMILY, focal_at=self._ALICE, content="and again"),
+        ]
+        block = build_channels_tail_block(
+            [_binding(self._ALICE), _binding(self._FAMILY)],
+            events,
+            focal_channel=self._ALICE,
+        )
+        assert block is not None
+        content = block["content"]
+        assert "○ signal/bot/family — 2 unread" in content
+
+    def test_non_focal_preview_truncated(self) -> None:
+        long = "x" * 200
+        events = [_user_event(1, orig=self._FAMILY, focal_at=self._ALICE, content=long)]
+        block = build_channels_tail_block(
+            [_binding(self._ALICE), _binding(self._FAMILY)],
+            events,
+            focal_channel=self._ALICE,
+        )
+        assert block is not None
+        content = block["content"]
+        assert "x" * 60 + "…" in content
+        assert "x" * 61 not in content
+
+    def test_muted_channel_shows_count_only_no_preview(self) -> None:
+        events = [
+            _user_event(
+                1,
+                orig=self._ANNOUNCEMENTS,
+                focal_at=self._ALICE,
+                content="system noise",
+            ),
+        ]
+        block = build_channels_tail_block(
+            [
+                _binding(self._ALICE),
+                _binding(self._ANNOUNCEMENTS, notification_mode="silent"),
+            ],
+            events,
+            focal_channel=self._ALICE,
+        )
+        assert block is not None
+        content = block["content"]
+        assert f"◌ {self._ANNOUNCEMENTS} (muted) — 1 unread" in content
+        # No preview (no quoted content).
+        assert "system noise" not in content
+
+    def test_phone_down_shows_no_focal_marker(self) -> None:
+        block = build_channels_tail_block(
+            [_binding(self._ALICE), _binding(self._FAMILY)],
+            [],
+            focal_channel=None,
+        )
+        assert block is not None
+        content = block["content"]
+        assert "▸" not in content
+        assert "(focal)" not in content
+
+    def test_tail_message_shape_is_user_role(self) -> None:
+        block = build_channels_tail_block([_binding(self._ALICE)], [], focal_channel=self._ALICE)
+        assert block is not None
+        assert block["role"] == "user"
+        assert isinstance(block["content"], str)
+        assert set(block.keys()) <= {"role", "content"}
+
+    def test_zero_unread_non_focal_still_listed(self) -> None:
+        block = build_channels_tail_block(
+            [_binding(self._ALICE), _binding(self._FAMILY)],
+            [],
+            focal_channel=self._ALICE,
+        )
+        assert block is not None
+        content = block["content"]
+        assert f"○ {self._FAMILY} — 0 unread" in content
 
 
 # ── apply_monologue_prefix ─────────────────────────────────────────────────

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -20,13 +20,29 @@ def _evt(
     tool_calls: list[dict[str, Any]] | None = None,
     tool_call_id: str | None = None,
     content: str = "",
+    metadata: dict[str, Any] | None = None,
+    orig_channel: str | None = None,
+    focal_channel_at_arrival: str | None = None,
 ) -> Event:
-    """Build a minimal message Event for testing."""
+    """Build a minimal message Event for testing.
+
+    When a user event is constructed with ``metadata["channel"]`` but
+    no explicit ``orig_channel``, the helper auto-stamps it the same
+    way :func:`aios.services.sessions.append_user_message` does at the
+    real append site, so focal-aware rendering kicks in for these
+    events just as it would in production.
+    """
     data: dict[str, Any] = {"role": role, "content": content}
     if tool_calls is not None:
         data["tool_calls"] = tool_calls
     if tool_call_id is not None:
         data["tool_call_id"] = tool_call_id
+    if metadata is not None:
+        data["metadata"] = metadata
+    if orig_channel is None and role == "user" and isinstance(metadata, dict):
+        ch = metadata.get("channel")
+        if isinstance(ch, str):
+            orig_channel = ch
     return Event(
         id=f"evt_{seq}",
         session_id="sess_01TEST",
@@ -34,6 +50,8 @@ def _evt(
         kind="message",
         data=data,
         created_at=datetime.now(tz=UTC),
+        orig_channel=orig_channel,
+        focal_channel_at_arrival=focal_channel_at_arrival,
     )
 
 
@@ -744,3 +762,184 @@ class TestToolCallSanitization:
         ]
         build_messages(events, system_prompt=None)
         assert events[1].data["tool_calls"][0]["function"]["arguments"] == bad_args
+
+
+# ─── focal-channel rendering ────────────────────────────────────────────────
+
+
+class TestFocalRendering:
+    """Slice 4 of the focal-channel redesign (issue #29).
+
+    User events are rendered differently based on ``orig_channel`` vs
+    ``focal_channel_at_arrival``.  Three branches:
+
+    * both NULL (legacy / direct non-connector message) → Phase 2
+      rendering unchanged.
+    * ``orig == focal_at_arrival`` → full content with the #46 metadata
+      header inlined.
+    * ``orig != focal_at_arrival`` OR focal NULL → short notification
+      marker.
+    """
+
+    _CHAN_A = "signal/bot/alice"
+    _CHAN_B = "signal/bot/bob"
+
+    def test_legacy_null_event_phase2_rendering(self) -> None:
+        """orig_channel=None: no header, no marker — same as Phase 2."""
+        events = [_evt(1, "user", content="hi")]
+        msg = build_messages(events, system_prompt=None).messages[0]
+        assert msg["content"] == "hi"
+        assert "metadata" not in msg
+        assert "🔔" not in msg["content"]
+
+    def test_focal_match_renders_full_content_with_header(self) -> None:
+        md = {
+            "channel": self._CHAN_A,
+            "sender_uuid": "peer-uuid",
+            "timestamp_ms": 1776401210703,
+        }
+        events = [_evt(1, "user", content="hi", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
+        msg = build_messages(events, system_prompt=None).messages[0]
+        assert msg["content"].startswith(f"[channel={self._CHAN_A}")
+        assert "sender_uuid=peer-uuid" in msg["content"]
+        assert msg["content"].endswith("\nhi")
+        assert "metadata" not in msg
+
+    def test_focal_match_header_includes_chat_type_name_and_sender(self) -> None:
+        md = {
+            "channel": self._CHAN_A,
+            "chat_type": "group",
+            "chat_name": "QA",
+            "sender_uuid": "u1",
+            "sender_name": "Tom",
+            "timestamp_ms": 1776401210703,
+        }
+        events = [_evt(1, "user", content="yo", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "chat_type=group" in content
+        assert "chat_name='QA'" in content
+        assert "from=Tom" in content
+
+    def test_focal_match_reply_to_surfaced(self) -> None:
+        md = {
+            "channel": self._CHAN_A,
+            "reply_to": {
+                "author_uuid": "bot",
+                "timestamp_ms": 1776400000000,
+                "text": "what I said before",
+            },
+        }
+        events = [
+            _evt(1, "user", content="reacting", metadata=md, focal_channel_at_arrival=self._CHAN_A)
+        ]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "\n[reply_to: author_uuid=bot · timestamp_ms=1776400000000]" in content
+        assert "> what I said before" in content
+
+    def test_focal_match_reaction_surfaced(self) -> None:
+        md = {
+            "channel": self._CHAN_A,
+            "reaction": {
+                "emoji": "👍",
+                "target_author_uuid": "bot",
+                "target_timestamp_ms": 1776400000000,
+            },
+        }
+        events = [_evt(1, "user", content="", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "[reaction='👍'" in content
+        assert "target_author_uuid=bot" in content
+
+    def test_focal_match_iso_timestamp(self) -> None:
+        md = {"channel": self._CHAN_A, "timestamp_ms": 1776401210703}
+        events = [_evt(1, "user", content="hi", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "timestamp_ms=1776401210703" in content
+        assert "(2026-04-17T" in content
+
+    def test_focal_match_metadata_stripped_from_wire_message(self) -> None:
+        md = {"channel": self._CHAN_A, "sender_uuid": "u1"}
+        events = [_evt(1, "user", content="hi", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
+        msg = build_messages(events, system_prompt=None).messages[0]
+        assert "metadata" not in msg
+        assert set(msg.keys()) <= {"role", "content", "name"}
+
+    def test_notification_when_orig_differs_from_focal(self) -> None:
+        md = {"channel": self._CHAN_B, "sender_name": "Bob"}
+        events = [
+            _evt(
+                1,
+                "user",
+                content="hey there",
+                metadata=md,
+                focal_channel_at_arrival=self._CHAN_A,
+            )
+        ]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert content.startswith(f"🔔 {self._CHAN_B}")
+        assert "from=Bob" in content
+        assert "hey there" in content
+
+    def test_notification_when_focal_null(self) -> None:
+        """Phone-down state: all inbound renders as notifications."""
+        md = {"channel": self._CHAN_B, "sender_name": "Bob"}
+        events = [_evt(1, "user", content="hey", metadata=md, focal_channel_at_arrival=None)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert content.startswith(f"🔔 {self._CHAN_B}")
+
+    def test_notification_omits_sender_when_absent(self) -> None:
+        """No sender_name → no ``from=`` clause, just channel + preview."""
+        md = {"channel": self._CHAN_B}
+        events = [
+            _evt(1, "user", content="hey", metadata=md, focal_channel_at_arrival=self._CHAN_A)
+        ]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "from=" not in content
+        assert content == f"🔔 {self._CHAN_B} · hey"
+
+    def test_notification_truncation_at_80_chars(self) -> None:
+        long = "x" * 200
+        md = {"channel": self._CHAN_B, "sender_name": "Bob"}
+        events = [_evt(1, "user", content=long, metadata=md, focal_channel_at_arrival=self._CHAN_A)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        # Exactly 80 x's followed by an ellipsis.
+        assert "x" * 80 + "…" in content
+        assert "x" * 81 not in content  # never more than 80 raw chars
+
+    def test_notification_reaction_fallback_when_content_empty(self) -> None:
+        md = {
+            "channel": self._CHAN_B,
+            "sender_name": "Bob",
+            "reaction": {"emoji": "👍"},
+        }
+        events = [_evt(1, "user", content="", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "reacted 👍" in content
+
+    def test_notification_metadata_stripped_from_wire_message(self) -> None:
+        md = {"channel": self._CHAN_B, "sender_name": "Bob"}
+        events = [_evt(1, "user", content="hi", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
+        msg = build_messages(events, system_prompt=None).messages[0]
+        assert "metadata" not in msg
+        assert set(msg.keys()) <= {"role", "content", "name"}
+
+    def test_switch_channel_does_not_rewrite_past_events(self) -> None:
+        """Monotonicity invariant: past events' rendering is pinned by
+        their own stamped fields, regardless of subsequent focal changes.
+        """
+        md_b = {"channel": self._CHAN_B, "sender_name": "Bob"}
+        # Event arrives on B while focal=A → notification at append time.
+        ev_early = _evt(
+            1, "user", content="early", metadata=md_b, focal_channel_at_arrival=self._CHAN_A
+        )
+        # Later event on A while focal=A (post-switch simulation) → full.
+        ev_late = _evt(
+            2,
+            "user",
+            content="later",
+            metadata={"channel": self._CHAN_A, "sender_name": "Alice"},
+            focal_channel_at_arrival=self._CHAN_A,
+        )
+        msgs = build_messages([ev_early, ev_late], system_prompt=None).messages
+        assert msgs[0]["content"].startswith(f"🔔 {self._CHAN_B}")
+        assert msgs[1]["content"].startswith(f"[channel={self._CHAN_A}")

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -533,6 +533,77 @@ class TestCallMcpTool:
         assert "error" in result
         assert "MCP server error" in result["error"]
 
+    async def test_meta_forwarded_to_session_call_tool(self) -> None:
+        """The ``meta`` kwarg on call_mcp_tool reaches session.call_tool
+        as its ``meta=`` kwarg so it lands in the JSON-RPC request's
+        ``_meta`` field (the transport for slice 6's focal-path
+        injection on connection-provided servers).
+        """
+        mock_content = MagicMock()
+        mock_content.text = "ok"
+        mock_content.type = "text"
+        mock_result = MagicMock()
+        mock_result.content = [mock_content]
+        mock_result.isError = False
+
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value=mock_result)
+
+        meta = {"aios.focal_channel_path": "alice"}
+
+        with (
+            patch("aios.mcp.client.streamable_http_client") as mock_transport,
+            patch("aios.mcp.client.ClientSession") as mock_session_cls,
+        ):
+            mock_transport.return_value.__aenter__ = AsyncMock(
+                return_value=(MagicMock(), MagicMock(), MagicMock())
+            )
+            mock_transport.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await call_mcp_tool(
+                "https://example.com/",
+                {},
+                "signal_send",
+                {"text": "hi"},
+                meta=meta,
+            )
+
+        mock_session.call_tool.assert_awaited_once_with("signal_send", {"text": "hi"}, meta=meta)
+
+    async def test_meta_defaults_to_none(self) -> None:
+        """When meta is omitted, session.call_tool is called with meta=None
+        — important for agent-declared MCP servers that should stay
+        unaware of aios internal context.
+        """
+        mock_content = MagicMock()
+        mock_content.text = "ok"
+        mock_content.type = "text"
+        mock_result = MagicMock()
+        mock_result.content = [mock_content]
+        mock_result.isError = False
+
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("aios.mcp.client.streamable_http_client") as mock_transport,
+            patch("aios.mcp.client.ClientSession") as mock_session_cls,
+        ):
+            mock_transport.return_value.__aenter__ = AsyncMock(
+                return_value=(MagicMock(), MagicMock(), MagicMock())
+            )
+            mock_transport.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await call_mcp_tool("https://example.com/", {}, "tool", {})
+
+        mock_session.call_tool.assert_awaited_once_with("tool", {}, meta=None)
+
     async def test_non_text_content_handled(self) -> None:
         mock_img = MagicMock()
         mock_img.type = "image"

--- a/tests/unit/test_mcp_routing.py
+++ b/tests/unit/test_mcp_routing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from aios.harness.loop import (
+    _hide_conn_tools_when_phone_down,
     _is_mcp_tool,
     _tc_name,
     resolve_mcp_permission,
@@ -154,3 +155,42 @@ class TestToOpenaiToolsSkipsMcpToolset:
         )
         assert len(result) == 1
         assert result[0]["function"]["name"] == "bash"
+
+
+def _tool(name: str) -> dict[str, object]:
+    return {"type": "function", "function": {"name": name}}
+
+
+class TestHideConnToolsWhenPhoneDown:
+    """Slice 6: connection-provided MCP tools disappear from the model's
+    tool list when the session's focal_channel is NULL.  Agent-declared
+    MCP tools and built-ins stay visible.
+    """
+
+    def test_focal_set_keeps_all_tools(self) -> None:
+        tools = [
+            _tool("mcp__conn_abc__signal_send"),
+            _tool("mcp__github__create_issue"),
+            _tool("bash"),
+        ]
+        result = _hide_conn_tools_when_phone_down(tools, "signal/bot/alice")
+        assert result == tools
+
+    def test_focal_null_hides_conn_tools(self) -> None:
+        tools = [
+            _tool("mcp__conn_abc__signal_send"),
+            _tool("mcp__conn_abc__signal_react"),
+            _tool("mcp__github__create_issue"),
+            _tool("bash"),
+        ]
+        result = _hide_conn_tools_when_phone_down(tools, None)
+        names = [t["function"]["name"] for t in result]  # type: ignore[index]
+        assert "mcp__conn_abc__signal_send" not in names
+        assert "mcp__conn_abc__signal_react" not in names
+        # Agent-declared MCP and built-ins survive.
+        assert "mcp__github__create_issue" in names
+        assert "bash" in names
+
+    def test_empty_list(self) -> None:
+        assert _hide_conn_tools_when_phone_down([], None) == []
+        assert _hide_conn_tools_when_phone_down([], "signal/bot/alice") == []

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from aios.harness.context import render_user_event
 from aios.harness.tokens import approx_tokens
 
 
@@ -65,3 +66,36 @@ class TestApproxTokens:
         }
         # "bash" (4) + "{}" (2) + "read" (4) + "{}" (2) = 12 / 4 = 3
         assert approx_tokens(msg) == 3
+
+
+class TestApproxTokensUnderFocalRendering:
+    """The cumulative_tokens column is computed against the as-rendered
+    form of user events.  A non-focal inbound that renders as a short
+    notification marker must cost far fewer tokens than the same inbound
+    rendered with full content + metadata header.  This invariant keeps
+    the chunked-window slicer honest even in busy many-to-one sessions.
+    """
+
+    _CHAN = "signal/bot/alice"
+
+    def test_notification_smaller_than_full(self) -> None:
+        long_text = "this is a moderately long message body " * 10
+        metadata = {
+            "channel": self._CHAN,
+            "sender_uuid": "u1",
+            "sender_name": "Alice",
+            "timestamp_ms": 1776401210703,
+        }
+        data = {"role": "user", "content": long_text, "metadata": metadata}
+
+        focal_render = render_user_event(data, self._CHAN, self._CHAN)
+        notif_render = render_user_event(data, self._CHAN, "signal/bot/other")
+
+        assert approx_tokens(notif_render) < approx_tokens(focal_render)
+
+    def test_legacy_null_matches_raw_data(self) -> None:
+        """orig=None → Phase 2 rendering: tokens match the raw data
+        (minus metadata stripping, which is content-preserving)."""
+        data = {"role": "user", "content": "hello"}
+        rendered = render_user_event(data, None, None)
+        assert approx_tokens(rendered) == approx_tokens(data)


### PR DESCRIPTION
Closes #49. Child of #29. Depends in spirit on #46/#47/#48 (unmerged); #46's `_format_channel_header` is folded directly in rather than relying on its merge, so this PR can land independently.

## Why

Signal smoke test surfaced a cross-channel confusion failure the Phase 2 merged-stream model couldn't avoid: a narrow follow-up in a quiet DM ("you sure about that?") couldn't be distinguished from questions about noise in other channels — the agent saw all channels interleaved. Humans using phone messaging apps don't have this problem because their attention is structurally bound to one chat at a time.

This PR replaces the merged-stream model with a **focal-channel attention model**: one channel focused at a time, notification markers for others, an explicit `switch_channel` tool (with `target=null` "phone down" state) to shift focus. Switching into a channel returns a re-orient block quoting its recent messages — `max(unread, FLOOR_N=10)` events — so the agent picks up in context regardless of read status, fixing the Ora scenario.

See #49 for the full plan and `plans/mellow-jingling-pine.md` (in-tree) for implementation details.

## Summary

- **Schema**: migration `0017_focal_channel` adds `sessions.focal_channel`, `events.{orig_channel,focal_channel_at_arrival}`, `channel_bindings.notification_mode`.
- **Rendering**: user events render in three branches (full + #46 header / notification marker / legacy-NULL fallback), deterministic from stamped fields — monotonicity invariant preserved.
- **`switch_channel` built-in**: auto-injected when bindings exist; `metadata.switch_channel` marker on the tool_result event anchors unread derivation.
- **MCP `_meta` injection**: connection-provided tools get `aios.focal_channel_path` (suffix-only) via native MCP `_meta` — works with pooled sessions from #45. Focal is snapshotted at step top (emission-time), not read per-call.
- **Focal-NULL tool filter**: `conn_*` tools disappear from the tool list in "phone down" state; agent must `switch_channel` first to send.
- **Signal connector**: `signal_send` / `signal_react` drop `chat_id`, read focal from `ctx.request_context.meta`.
- **Prompt blocks**: cache-stable paradigm prose (`build_focal_paradigm_block`) in system prompt + per-step ephemeral tail block (`build_channels_tail_block`) with ▸/○/◌ listing.

Folds PR #46's metadata header into `render_user_event` — a separate merge of #46 is no longer needed.

## Test plan

- [x] `uv run mypy src` — clean (84 files)
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 611 passed
- [x] `DOCKER_HOST=... uv run pytest tests/e2e tests/integration -q` — 194 passed (191 e2e + 3 migration-cycle)
- [x] `cd connectors/signal && uv run pytest -q` — 77 passed
- [x] `uv run alembic upgrade head && downgrade -1 && upgrade head` against a fresh testcontainer — clean cycle
- [x] **Smoke-test regression**: `TestOraSmokeTestRegression::test_switch_back_to_quiet_channel_surfaces_referent` seeds the Ora/DM/QA scenario and verifies the re-orient block after switching back contains both "I'm Ora" and "you sure about that?".

🤖 Generated with [Claude Code](https://claude.com/claude-code)