### PR TITLE
feat(harness): pre-inference triage gate for group-chat scenarios

### DIFF
--- a/migrations/versions/0018_agent_triage.py
+++ b/migrations/versions/0018_agent_triage.py
@@ -1,0 +1,34 @@
+"""Agent triage gate: optional cheap-model gate before main inference.
+
+Adds a nullable ``triage`` jsonb column to both ``agents`` (current) and
+``agent_versions`` (history). A NULL value means "no triage — always
+respond," preserving prior behavior.
+
+The JSON shape is ``{"model": str, "system": str}``; validation happens
+in the Pydantic layer, not in the DB.
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-04-19
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0018"
+down_revision: str = "0017"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE agents ADD COLUMN triage jsonb;")
+    op.execute("ALTER TABLE agent_versions ADD COLUMN triage jsonb;")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agent_versions DROP COLUMN IF EXISTS triage;")
+    op.execute("ALTER TABLE agents DROP COLUMN IF EXISTS triage;")

--- a/src/aios/api/routers/agents.py
+++ b/src/aios/api/routers/agents.py
@@ -26,6 +26,7 @@ async def create(body: AgentCreate, pool: PoolDep, _auth: AuthDep) -> Agent:
         metadata=body.metadata,
         window_min=body.window_min,
         window_max=body.window_max,
+        triage=body.triage,
     )
 
 
@@ -65,6 +66,7 @@ async def update(agent_id: str, body: AgentUpdate, pool: PoolDep, _auth: AuthDep
         metadata=body.metadata,
         window_min=body.window_min,
         window_max=body.window_max,
+        triage=body.triage,
     )
 
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -34,7 +34,7 @@ from aios.ids import (
     VAULT_CREDENTIAL,
     make_id,
 )
-from aios.models.agents import Agent, AgentVersion, McpServerSpec, ToolSpec
+from aios.models.agents import Agent, AgentVersion, McpServerSpec, ToolSpec, TriageConfig
 from aios.models.channel_bindings import ChannelBinding
 from aios.models.connections import Connection
 from aios.models.environments import Environment, EnvironmentConfig
@@ -179,6 +179,13 @@ def _parse_jsonb(raw: Any) -> Any:
     return json.loads(raw) if isinstance(raw, str) else raw
 
 
+def _parse_triage(row: asyncpg.Record) -> TriageConfig | None:
+    raw = row.get("triage") if hasattr(row, "get") else row["triage"]
+    if raw is None:
+        return None
+    return TriageConfig.model_validate(_parse_jsonb(raw))
+
+
 def _row_to_agent(row: asyncpg.Record) -> Agent:
     tools_data = _parse_jsonb(row["tools"])
     skills_data = _parse_jsonb(row["skills"])
@@ -197,6 +204,7 @@ def _row_to_agent(row: asyncpg.Record) -> Agent:
         metadata=metadata,
         window_min=row["window_min"],
         window_max=row["window_max"],
+        triage=_parse_triage(row),
         created_at=row["created_at"],
         updated_at=row["updated_at"],
         archived_at=row["archived_at"],
@@ -217,6 +225,7 @@ def _row_to_agent_version(row: asyncpg.Record) -> AgentVersion:
         mcp_servers=[McpServerSpec.model_validate(s) for s in (mcp_data or [])],
         window_min=row["window_min"],
         window_max=row["window_max"],
+        triage=_parse_triage(row),
         created_at=row["created_at"],
     )
 
@@ -234,21 +243,23 @@ async def insert_agent(
     metadata: dict[str, Any],
     window_min: int,
     window_max: int,
+    triage: TriageConfig | None = None,
 ) -> Agent:
     new_id = make_id(AGENT)
     tools_json = json.dumps([t.model_dump() for t in tools])
     mcp_json = json.dumps([s.model_dump() for s in mcp_servers])
     metadata_json = json.dumps(metadata)
+    triage_json = json.dumps(triage.model_dump()) if triage is not None else None
     try:
         async with conn.transaction():
             row = await conn.fetchrow(
                 """
                 INSERT INTO agents (
                     id, name, model, system, tools, skills, mcp_servers,
-                    description, metadata, window_min, window_max, version
+                    description, metadata, window_min, window_max, triage, version
                 )
                 VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb,
-                        $8, $9::jsonb, $10, $11, 1)
+                        $8, $9::jsonb, $10, $11, $12::jsonb, 1)
                 RETURNING *
                 """,
                 new_id,
@@ -262,6 +273,7 @@ async def insert_agent(
                 metadata_json,
                 window_min,
                 window_max,
+                triage_json,
             )
             assert row is not None
             # Snapshot version 1 into agent_versions.
@@ -269,9 +281,9 @@ async def insert_agent(
                 """
                 INSERT INTO agent_versions (
                     agent_id, version, model, system, tools, skills, mcp_servers,
-                    window_min, window_max
+                    window_min, window_max, triage
                 )
-                VALUES ($1, 1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7, $8)
+                VALUES ($1, 1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7, $8, $9::jsonb)
                 """,
                 new_id,
                 model,
@@ -281,6 +293,7 @@ async def insert_agent(
                 mcp_json,
                 window_min,
                 window_max,
+                triage_json,
             )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
@@ -338,6 +351,7 @@ async def update_agent(
     metadata: dict[str, Any] | None = None,
     window_min: int | None = None,
     window_max: int | None = None,
+    triage: TriageConfig | None = None,
 ) -> Agent:
     """Update an agent, creating a new version.
 
@@ -369,6 +383,7 @@ async def update_agent(
     new_meta = metadata if metadata is not None else current.metadata
     new_wmin = window_min if window_min is not None else current.window_min
     new_wmax = window_max if window_max is not None else current.window_max
+    new_triage = triage if triage is not None else current.triage
 
     # No-op detection.
     if (
@@ -382,6 +397,7 @@ async def update_agent(
         and new_meta == current.metadata
         and new_wmin == current.window_min
         and new_wmax == current.window_max
+        and new_triage == current.triage
     ):
         return current
 
@@ -389,6 +405,7 @@ async def update_agent(
     tools_json = json.dumps([t.model_dump() for t in new_tools])
     mcp_json = json.dumps([s.model_dump() for s in new_mcp])
     meta_json = json.dumps(new_meta)
+    triage_json = json.dumps(new_triage.model_dump()) if new_triage is not None else None
 
     async with conn.transaction():
         row = await conn.fetchrow(
@@ -398,6 +415,7 @@ async def update_agent(
                    tools = $6::jsonb, skills = $7::jsonb, mcp_servers = $8::jsonb,
                    description = $9, metadata = $10::jsonb,
                    window_min = $11, window_max = $12,
+                   triage = $13::jsonb,
                    updated_at = now()
              WHERE id = $1
             RETURNING *
@@ -414,15 +432,16 @@ async def update_agent(
             meta_json,
             new_wmin,
             new_wmax,
+            triage_json,
         )
         assert row is not None
         await conn.execute(
             """
             INSERT INTO agent_versions (
                 agent_id, version, model, system, tools, skills, mcp_servers,
-                window_min, window_max
+                window_min, window_max, triage
             )
-            VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8, $9)
+            VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8, $9, $10::jsonb)
             """,
             agent_id,
             new_version,
@@ -433,6 +452,7 @@ async def update_agent(
             mcp_json,
             new_wmin,
             new_wmax,
+            triage_json,
         )
     return _row_to_agent(row)
 

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -243,6 +243,18 @@ def _strip_to_spec(msg: dict[str, Any]) -> dict[str, Any]:
 # ─── should_call_model ──────────────────────────────────────────────────────
 
 
+def _is_triage_decision(e: Event) -> bool:
+    """True if *e* is a ``triage_decision`` lifecycle event.
+
+    Triage-decision events carry a ``reacting_to`` watermark just like
+    assistant messages; both count as "reactions" for the gating logic
+    in :func:`should_call_model`. Without this, a triage-ignored turn
+    would never advance the watermark and the worker would re-fire on
+    the same user message forever.
+    """
+    return e.kind == "lifecycle" and e.data.get("event") == "triage_decision"
+
+
 def should_call_model(events: list[Event]) -> bool:
     """Decide whether this wake should produce an inference call.
 
@@ -254,29 +266,37 @@ def should_call_model(events: list[Event]) -> bool:
 
     ``reacting_to`` is the seq of the latest user/tool event in the
     context the model was given. Events after ``reacting_to`` (excluding
-    the assistant message itself) are "new." This handles the race where
+    the reaction event itself) are "new." This handles the race where
     a tool result arrives during inference — the result has a seq after
     ``reacting_to`` and triggers a follow-up step.
+
+    Both assistant messages and ``triage_decision`` lifecycle events are
+    treated as reactions — a triage-ignored turn advances the watermark
+    via its own ``reacting_to``, so re-wakes on the same stimulus early
+    out here.
     """
     if not events:
         return False
 
-    # Find the most recent assistant message.
-    last_asst: Event | None = None
+    # Find the most recent reaction: assistant message or triage decision.
+    last_reaction: Event | None = None
     for e in reversed(events):
         if e.kind == "message" and e.data.get("role") == "assistant":
-            last_asst = e
+            last_reaction = e
+            break
+        if _is_triage_decision(e):
+            last_reaction = e
             break
 
-    if last_asst is None:
-        return True  # first turn — no assistant response yet
+    if last_reaction is None:
+        return True  # first turn — no reaction yet
 
-    # Use reacting_to if available; fall back to the assistant's own seq
+    # Use reacting_to if available; fall back to the reaction's own seq
     # (backward compat with events written before this field existed).
-    reacting_to: int = last_asst.data.get("reacting_to", last_asst.seq)
+    reacting_to: int = last_reaction.data.get("reacting_to", last_reaction.seq)
 
     # "New" = events the model hasn't reacted to.
-    new_events = [e for e in events if e.seq > reacting_to and e.seq != last_asst.seq]
+    new_events = [e for e in events if e.seq > reacting_to and e.seq != last_reaction.seq]
     if not new_events:
         return False  # duplicate / stale wake
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -28,8 +28,10 @@ from aios.harness.completion import stream_litellm
 from aios.harness.context import build_messages
 from aios.harness.sweep import find_sessions_needing_inference
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
+from aios.harness.triage import run_triage
 from aios.logging import get_logger
 from aios.models.agents import ToolSpec
+from aios.models.events import Event
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
 from aios.tools.registry import to_openai_tools
@@ -79,6 +81,18 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
     events = await sessions_service.read_windowed_events(
         pool, session_id, window_min=agent.window_min, window_max=agent.window_max
     )
+
+    # Triage gate (optional). If configured and there's a fresh user
+    # message to decide on, run a cheap classifier first and short-circuit
+    # on an "ignore" verdict. We do this BEFORE MCP discovery, skill
+    # resolution, and system-prompt augmentation so ignored messages
+    # incur only the gate call's latency.
+    if (
+        agent.triage is not None
+        and _has_new_user_stimulus(events)
+        and await _run_triage_gate(pool, session_id, agent, events)
+    ):
+        return
 
     # Check for confirmed-but-undispatched tool calls (always_ask → allow).
     # The sweep's case (c) ensures we passed the guard above.
@@ -615,3 +629,94 @@ async def _append_lifecycle(
         "lifecycle",
         {"event": event, "status": status, "stop_reason": stop_reason},
     )
+
+
+# ─── triage gate ─────────────────────────────────────────────────────────────
+
+
+def _has_new_user_stimulus(events: list[Event]) -> bool:
+    """True when there's an un-reacted user message in the log.
+
+    The triage gate only runs on new user messages. Tool-chain
+    continuations (a batch completing while the model's already
+    mid-turn) must always proceed to inference so the agent can act on
+    the result — never gate those.
+
+    A "reaction" is either an assistant message or a previously-emitted
+    ``triage_decision`` lifecycle event (both carry a ``reacting_to``
+    watermark; see :func:`aios.harness.context.should_call_model`).
+    """
+    last_reacting_to: int = 0
+    for e in reversed(events):
+        is_assistant = e.kind == "message" and e.data.get("role") == "assistant"
+        is_triage = e.kind == "lifecycle" and e.data.get("event") == "triage_decision"
+        if is_assistant or is_triage:
+            last_reacting_to = e.data.get("reacting_to", e.seq)
+            break
+    for e in events:
+        if e.seq <= last_reacting_to:
+            continue
+        if e.kind == "message" and e.data.get("role") == "user":
+            return True
+    return False
+
+
+async def _run_triage_gate(
+    pool: Any,
+    session_id: str,
+    agent: Any,
+    events: list[Event],
+) -> bool:
+    """Run the triage gate and persist the decision.
+
+    Returns ``True`` when the step should short-circuit (verdict =
+    ``ignore``), ``False`` when the main inference should proceed.
+
+    Both verdicts persist a ``triage_decision`` lifecycle event so the
+    watermark advances and the session's audit trail records every gate
+    fire. On ``ignore``, the session transitions to ``idle`` and a
+    ``turn_ended`` lifecycle event is appended — mirroring the shape of
+    a normal ``end_turn`` so SSE consumers and UIs don't need special
+    handling.
+    """
+    triage_ctx = build_messages(events, system_prompt=None)
+    verdict = await run_triage(
+        config=agent.triage,
+        messages=triage_ctx.messages,
+    )
+
+    await sessions_service.append_event(
+        pool,
+        session_id,
+        "lifecycle",
+        {
+            "event": "triage_decision",
+            "decision": verdict.decision,
+            "reason": verdict.reason,
+            "reacting_to": triage_ctx.reacting_to,
+        },
+    )
+
+    if verdict.decision == "ignore":
+        await sessions_service.set_session_status(
+            pool,
+            session_id,
+            "idle",
+            stop_reason={"type": "triage_skipped", "reason": verdict.reason},
+        )
+        await _append_lifecycle(pool, session_id, "turn_ended", "idle", "triage_skipped")
+        log.info(
+            "step.triage_skipped",
+            session_id=session_id,
+            reason=verdict.reason,
+            reacting_to=triage_ctx.reacting_to,
+        )
+        return True
+
+    log.info(
+        "step.triage_admitted",
+        session_id=session_id,
+        reason=verdict.reason,
+        reacting_to=triage_ctx.reacting_to,
+    )
+    return False

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -248,6 +248,16 @@ async def find_sessions_needing_inference(
     scope_clause = "AND s.id = $1" if session_id else ""
     scope_params: list[Any] = [session_id] if session_id else []
 
+    # A "reaction" is either an assistant message or a triage_decision
+    # lifecycle event — both carry a ``reacting_to`` watermark. Without
+    # counting triage decisions, a triage-ignored user message would
+    # remain an unreacted candidate and the sweep would re-wake it
+    # forever.
+    reaction_predicate = (
+        "((a.kind = 'message' AND a.data->>'role' = 'assistant') "
+        "OR (a.kind = 'lifecycle' AND a.data->>'event' = 'triage_decision'))"
+    )
+
     async with pool.acquire() as conn:
         candidate_rows = await conn.fetch(
             f"""
@@ -261,16 +271,14 @@ async def find_sessions_needing_inference(
                    NOT EXISTS (
                        SELECT 1 FROM events a
                         WHERE a.session_id = e.session_id
-                          AND a.kind = 'message'
-                          AND a.data->>'role' = 'assistant'
+                          AND {reaction_predicate}
                    )
                    OR
                    e.seq > COALESCE(
                        (SELECT MAX(COALESCE((a.data->>'reacting_to')::bigint, a.seq))
                           FROM events a
                          WHERE a.session_id = e.session_id
-                           AND a.kind = 'message'
-                           AND a.data->>'role' = 'assistant'),
+                           AND {reaction_predicate}),
                        0
                    )
                )
@@ -324,6 +332,8 @@ async def _filter_incomplete_batches(
     session_list = list(candidates)
 
     async with pool.acquire() as conn:
+        # Same reaction predicate as find_sessions_needing_inference —
+        # triage_decision lifecycle events count as reactions.
         unreacted_rows = await conn.fetch(
             """
             SELECT e.session_id, e.data
@@ -335,8 +345,9 @@ async def _filter_incomplete_batches(
                    (SELECT MAX(COALESCE((a.data->>'reacting_to')::bigint, a.seq))
                       FROM events a
                      WHERE a.session_id = e.session_id
-                       AND a.kind = 'message'
-                       AND a.data->>'role' = 'assistant'),
+                       AND ((a.kind = 'message' AND a.data->>'role' = 'assistant')
+                            OR (a.kind = 'lifecycle'
+                                AND a.data->>'event' = 'triage_decision'))),
                    0)
             """,
             session_list,

--- a/src/aios/harness/triage.py
+++ b/src/aios/harness/triage.py
@@ -1,0 +1,152 @@
+"""Pre-inference triage gate.
+
+When an agent is configured with :class:`~aios.models.agents.TriageConfig`,
+:func:`run_triage` is invoked once per step before the main model call to
+decide whether the agent should respond to the current stimulus. The gate
+is intended for group-chat scenarios where most inbound messages are not
+addressed to the agent.
+
+The gate runs a single non-streaming LiteLLM call with a JSON-object
+response format. The returned verdict has shape::
+
+    {"decision": "respond" | "ignore", "reason": "<short free text>"}
+
+Failures are **fail-open**: if the gate model errors, times out, or
+returns unparseable output, the verdict defaults to ``"respond"``. Making
+the agent go silent on a broken gate is worse than the occasional
+unnecessary reply.
+
+The gate call is ephemeral — no tool list, no streaming, no SSE
+delivery, no event logging from this module. The caller
+(:mod:`aios.harness.loop`) is responsible for persisting the resulting
+``triage_decision`` lifecycle event with its ``reacting_to`` watermark.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+import litellm
+from pydantic import BaseModel, Field, ValidationError
+
+from aios.logging import get_logger
+from aios.models.agents import TriageConfig
+
+log = get_logger("aios.harness.triage")
+
+TriageDecision = Literal["respond", "ignore"]
+
+# The triage call is a one-shot classification — cap output tightly so a
+# chatty model can't burn tokens or latency here.
+_TRIAGE_MAX_TOKENS = 200
+
+
+class TriageVerdict(BaseModel):
+    """Structured verdict returned by the gate model."""
+
+    decision: TriageDecision
+    reason: str = Field(default="", max_length=500)
+
+
+_DEFAULT_GATE_INSTRUCTIONS = (
+    "You are a gate for a chat assistant. Examine the conversation and decide "
+    "whether the assistant should respond to the most recent inbound message(s). "
+    'Respond with a single JSON object: {"decision": "respond" | "ignore", '
+    '"reason": "<one short sentence>"}. '
+    "Choose 'respond' when the assistant is addressed, named, mentioned, asked a "
+    "direct question, or when the message clearly continues a prior exchange with "
+    "the assistant. Choose 'ignore' for side conversation between other "
+    "participants, acknowledgements not directed at the assistant, or noise."
+)
+
+
+def _compose_system_prompt(agent_system: str) -> str:
+    """Join the agent-supplied triage system prompt with the default gate rubric.
+
+    Having a default rubric means operators can set ``triage.system`` to
+    something narrow (e.g. "only respond when user says 'hey bot'") without
+    having to re-derive the JSON response contract.
+    """
+    if agent_system:
+        return f"{agent_system}\n\n{_DEFAULT_GATE_INSTRUCTIONS}"
+    return _DEFAULT_GATE_INSTRUCTIONS
+
+
+async def run_triage(
+    *,
+    config: TriageConfig,
+    messages: list[dict[str, Any]],
+) -> TriageVerdict:
+    """Call the gate model and return its verdict.
+
+    ``messages`` is the chat-completions message list built by
+    :func:`aios.harness.context.build_messages` — the same context the
+    main inference would see, minus tool declarations. The system
+    message (if any) is replaced with the triage-specific prompt so the
+    gate model's priors aren't polluted by the main agent persona.
+
+    Fail-open: any exception or parse failure yields a ``respond``
+    verdict with ``reason`` describing the failure. The verdict is still
+    a genuine :class:`TriageVerdict`, so callers never need to handle
+    ``None``.
+    """
+    gate_messages = _build_gate_messages(config, messages)
+    try:
+        response = await litellm.acompletion(
+            model=config.model,
+            messages=gate_messages,
+            response_format={"type": "json_object"},
+            max_tokens=_TRIAGE_MAX_TOKENS,
+            stream=False,
+        )
+    except Exception as exc:
+        log.warning("triage.model_call_failed", error=str(exc))
+        return TriageVerdict(decision="respond", reason=f"gate_error: {exc}")
+
+    content = _extract_content(response)
+    if not content:
+        log.warning("triage.empty_response")
+        return TriageVerdict(decision="respond", reason="gate_returned_empty")
+
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        log.warning("triage.invalid_json", content=content[:200])
+        return TriageVerdict(decision="respond", reason="gate_invalid_json")
+
+    try:
+        verdict = TriageVerdict.model_validate(data)
+    except ValidationError as exc:
+        log.warning("triage.schema_mismatch", error=str(exc), content=content[:200])
+        return TriageVerdict(decision="respond", reason="gate_schema_mismatch")
+
+    log.info("triage.verdict", decision=verdict.decision, reason=verdict.reason)
+    return verdict
+
+
+def _build_gate_messages(
+    config: TriageConfig, messages: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Return a fresh message list with the gate's system prompt on top.
+
+    Drops the main agent's system message (if present) so the gate model
+    classifies based on the gate's own rubric rather than the agent
+    persona. The conversation history is preserved verbatim.
+    """
+    body = [m for m in messages if m.get("role") != "system"]
+    return [{"role": "system", "content": _compose_system_prompt(config.system)}, *body]
+
+
+def _extract_content(response: Any) -> str:
+    """Pull the text content out of a LiteLLM ModelResponse.
+
+    LiteLLM normalizes providers to the OpenAI shape, so we can rely on
+    ``choices[0].message.content`` being a string (or None). Keeping the
+    extraction isolated means a provider quirk only needs fixing here.
+    """
+    try:
+        content = response.choices[0].message.content
+    except (AttributeError, IndexError):
+        return ""
+    return content or ""

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -34,6 +34,42 @@ BuiltinToolType = Literal[
 PermissionPolicy = Literal["always_allow", "always_ask"]
 
 
+# ── Triage gate config ────────────────────────────────────────────────────────
+
+
+class TriageConfig(BaseModel):
+    """Pre-inference gate that decides whether the agent should respond.
+
+    When present, the harness runs one cheap model call before the main
+    inference to classify the latest stimulus as ``respond`` or
+    ``ignore``. On ``ignore`` the step emits a ``triage_decision``
+    lifecycle event (carrying a ``reacting_to`` watermark) and returns
+    without calling the main model. The user message itself is still
+    appended to the log unconditionally by the API — the gate only
+    controls the reply, not recording.
+
+    Intended for group-chat scenarios where many messages arrive but
+    few are addressed to the agent.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: str = Field(
+        min_length=1,
+        description=(
+            "LiteLLM model string for the triage call. Use a small, fast model "
+            "(e.g. 'ollama_chat/llama3.2:1b', 'openrouter/anthropic/claude-haiku-4-5')."
+        ),
+    )
+    system: str = Field(
+        default="",
+        description=(
+            "System prompt for the triage classifier. Should instruct the model "
+            'to emit a JSON object {"decision": "respond"|"ignore", "reason": "..."}.'
+        ),
+    )
+
+
 # ── MCP server declaration ────────────────────────────────────────────────────
 
 
@@ -160,6 +196,7 @@ class AgentCreate(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     window_min: int = Field(default=50_000, ge=1)
     window_max: int = Field(default=150_000, ge=1)
+    triage: TriageConfig | None = None
 
 
 class AgentUpdate(BaseModel):
@@ -184,6 +221,7 @@ class AgentUpdate(BaseModel):
     metadata: dict[str, Any] | None = None
     window_min: int | None = Field(default=None, ge=1)
     window_max: int | None = Field(default=None, ge=1)
+    triage: TriageConfig | None = None
 
 
 class Agent(BaseModel):
@@ -201,6 +239,7 @@ class Agent(BaseModel):
     metadata: dict[str, Any]
     window_min: int
     window_max: int
+    triage: TriageConfig | None = None
     created_at: datetime
     updated_at: datetime
     archived_at: datetime | None = None
@@ -218,4 +257,5 @@ class AgentVersion(BaseModel):
     mcp_servers: list[McpServerSpec]
     window_min: int
     window_max: int
+    triage: TriageConfig | None = None
     created_at: datetime

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -12,7 +12,7 @@ from typing import Any
 import asyncpg
 
 from aios.db import queries
-from aios.models.agents import Agent, AgentVersion, McpServerSpec, ToolSpec
+from aios.models.agents import Agent, AgentVersion, McpServerSpec, ToolSpec, TriageConfig
 from aios.models.skills import AgentSkillRef
 from aios.services import skills as skills_service
 
@@ -30,6 +30,7 @@ async def create_agent(
     metadata: dict[str, Any],
     window_min: int,
     window_max: int,
+    triage: TriageConfig | None = None,
 ) -> Agent:
     if window_min >= window_max:
         from aios.errors import ValidationError
@@ -54,6 +55,7 @@ async def create_agent(
             metadata=metadata,
             window_min=window_min,
             window_max=window_max,
+            triage=triage,
         )
 
 
@@ -89,6 +91,7 @@ async def update_agent(
     metadata: dict[str, Any] | None = None,
     window_min: int | None = None,
     window_max: int | None = None,
+    triage: TriageConfig | None = None,
 ) -> Agent:
     skills_json_str: str | None = None
     if skills is not None:
@@ -109,6 +112,7 @@ async def update_agent(
             metadata=metadata,
             window_min=window_min,
             window_max=window_max,
+            triage=triage,
         )
 
 

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -185,3 +185,49 @@ def test_migration_0017_focal_channel_cycle(postgres: object) -> None:
     re_upgraded = _run_alembic(["upgrade", "head"], db_url)
     assert re_upgraded.returncode == 0, f"re-upgrade failed:\n{re_upgraded.stderr}"
     asyncio.run(assert_columns(True))
+
+
+_MIGRATION_0018_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("agents", "triage"),
+    ("agent_versions", "triage"),
+)
+
+
+@needs_docker
+@pytest.mark.integration
+def test_migration_0018_agent_triage_cycle(postgres: object) -> None:
+    """Exercise migration 0018's up/down/up cycle for the triage column.
+
+    The triage gate is a nullable JSONB field on both the current agent
+    row and each historical version, so a downgrade has to drop both.
+    A broken downgrade would leave the ``agents`` table diverged from
+    ``agent_versions`` — subtle and easy to miss without an explicit cycle.
+    """
+    db_url = _alembic_url(postgres)
+
+    upgraded = _run_alembic(["upgrade", "head"], db_url)
+    assert upgraded.returncode == 0, f"initial upgrade failed:\n{upgraded.stderr}"
+
+    import asyncio
+
+    async def assert_columns(expected: bool) -> None:
+        conn = await asyncpg.connect(db_url)
+        try:
+            for table, column in _MIGRATION_0018_COLUMNS:
+                exists = await _column_exists(conn, table, column)
+                if expected:
+                    assert exists, f"{table}.{column} missing after upgrade"
+                else:
+                    assert not exists, f"{table}.{column} still present after downgrade"
+        finally:
+            await conn.close()
+
+    asyncio.run(assert_columns(True))
+
+    downgraded = _run_alembic(["downgrade", "-1"], db_url)
+    assert downgraded.returncode == 0, f"downgrade -1 failed:\n{downgraded.stderr}"
+    asyncio.run(assert_columns(False))
+
+    re_upgraded = _run_alembic(["upgrade", "head"], db_url)
+    assert re_upgraded.returncode == 0, f"re-upgrade failed:\n{re_upgraded.stderr}"
+    asyncio.run(assert_columns(True))

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -13,6 +13,31 @@ from aios.harness.context import build_messages, should_call_model
 from aios.models.events import Event
 
 
+def _triage_evt(
+    seq: int, *, decision: str = "ignore", reacting_to: int = 0, reason: str = ""
+) -> Event:
+    """Build a ``triage_decision`` lifecycle Event for testing.
+
+    Mirrors the shape written by ``aios.harness.loop._run_triage_gate``
+    so ``should_call_model`` tests exercise the real predicate.
+    """
+    return Event(
+        id=f"evt_{seq}",
+        session_id="sess_01TEST",
+        seq=seq,
+        kind="lifecycle",
+        data={
+            "event": "triage_decision",
+            "decision": decision,
+            "reason": reason,
+            "reacting_to": reacting_to,
+        },
+        created_at=datetime.now(tz=UTC),
+        orig_channel=None,
+        focal_channel_at_arrival=None,
+    )
+
+
 def _evt(
     seq: int,
     role: str,
@@ -138,6 +163,49 @@ class TestShouldCallModel:
             _evt(6, "tool", tool_call_id="y1", content="done"),
         ]
         assert should_call_model(events) is True
+
+    def test_triage_ignore_advances_watermark(self) -> None:
+        """After a triage_decision:ignore, re-wakes on the same user stimulus
+        must NOT retrigger inference. Without this, the group-chat gate would
+        re-fire on every sweep tick for messages it already dismissed."""
+        events = [
+            _evt(1, "user", content="unrelated side chat"),
+            _triage_evt(2, decision="ignore", reacting_to=1),
+        ]
+        assert should_call_model(events) is False
+
+    def test_triage_ignore_then_new_user_returns_true(self) -> None:
+        """A user message arriving after a triage-ignore is fresh stimulus.
+        The watermark from the prior decision (reacting_to=1) is below the
+        new user seq, so the gate should re-evaluate."""
+        events = [
+            _evt(1, "user", content="unrelated side chat"),
+            _triage_evt(2, decision="ignore", reacting_to=1),
+            _evt(3, "user", content="hey bot, are you there?"),
+        ]
+        assert should_call_model(events) is True
+
+    def test_triage_respond_then_assistant_reacts(self) -> None:
+        """Normal flow when triage admits: a triage_decision:respond is
+        followed by the assistant message. Both count as reactions; the
+        reverse walk picks the assistant first (lower in the log isn't
+        special — the most recent reaction is the assistant). No re-wake."""
+        events = [
+            _evt(1, "user", content="hey bot"),
+            _triage_evt(2, decision="respond", reacting_to=1),
+            _evt(3, "assistant", content="yes?"),
+        ]
+        assert should_call_model(events) is False
+
+    def test_first_turn_with_only_triage_ignore(self) -> None:
+        """A session that's never had an assistant message but has a
+        triage_decision event is still 'has reacted' — the gate's verdict
+        counts. Without this, the session would loop on first-turn logic."""
+        events = [
+            _evt(1, "user", content="not for me"),
+            _triage_evt(2, decision="ignore", reacting_to=1),
+        ]
+        assert should_call_model(events) is False
 
 
 # ─── build_messages ──────────────────────────────────────────────────────────

--- a/tests/unit/test_triage.py
+++ b/tests/unit/test_triage.py
@@ -1,0 +1,254 @@
+"""Unit tests for the pre-inference triage gate.
+
+Covers the two halves of the feature:
+
+* :func:`aios.harness.triage.run_triage` — LiteLLM call + parse, with
+  fail-open guarantees for broken gates.
+* :func:`aios.harness.loop._has_new_user_stimulus` — the stimulus
+  predicate that decides whether triage is eligible to run at all.
+
+LiteLLM is patched at the module boundary (``aios.harness.triage.litellm``)
+so these tests don't touch the network.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aios.harness.loop import _has_new_user_stimulus
+from aios.harness.triage import TriageVerdict, run_triage
+from aios.models.agents import TriageConfig
+from aios.models.events import Event
+
+
+def _user(seq: int, content: str = "hi") -> Event:
+    return Event(
+        id=f"evt_{seq}",
+        session_id="sess_01TEST",
+        seq=seq,
+        kind="message",
+        data={"role": "user", "content": content},
+        created_at=datetime.now(tz=UTC),
+    )
+
+
+def _assistant(seq: int, reacting_to: int) -> Event:
+    return Event(
+        id=f"evt_{seq}",
+        session_id="sess_01TEST",
+        seq=seq,
+        kind="message",
+        data={"role": "assistant", "content": "ok", "reacting_to": reacting_to},
+        created_at=datetime.now(tz=UTC),
+    )
+
+
+def _triage(seq: int, reacting_to: int, decision: str = "ignore") -> Event:
+    return Event(
+        id=f"evt_{seq}",
+        session_id="sess_01TEST",
+        seq=seq,
+        kind="lifecycle",
+        data={
+            "event": "triage_decision",
+            "decision": decision,
+            "reason": "test",
+            "reacting_to": reacting_to,
+        },
+        created_at=datetime.now(tz=UTC),
+    )
+
+
+def _tool_result(seq: int, tool_call_id: str) -> Event:
+    return Event(
+        id=f"evt_{seq}",
+        session_id="sess_01TEST",
+        seq=seq,
+        kind="message",
+        data={"role": "tool", "tool_call_id": tool_call_id, "content": "done"},
+        created_at=datetime.now(tz=UTC),
+    )
+
+
+def _mock_litellm_response(content: str) -> Any:
+    """Shape a minimal object that matches what ``run_triage`` reads.
+
+    LiteLLM returns a ``ModelResponse`` with ``.choices[0].message.content``;
+    we build a structurally-compatible stand-in so we don't depend on
+    LiteLLM internals in tests.
+    """
+
+    class _Msg:
+        def __init__(self, c: str) -> None:
+            self.content = c
+
+    class _Choice:
+        def __init__(self, c: str) -> None:
+            self.message = _Msg(c)
+
+    class _Resp:
+        def __init__(self, c: str) -> None:
+            self.choices = [_Choice(c)]
+
+    return _Resp(content)
+
+
+# ─── run_triage ─────────────────────────────────────────────────────────────
+
+
+class TestRunTriage:
+    async def test_valid_respond_verdict(self) -> None:
+        config = TriageConfig(model="openrouter/fake", system="")
+        messages = [{"role": "user", "content": "hey bot"}]
+        fake = _mock_litellm_response('{"decision": "respond", "reason": "addressed"}')
+        with patch("aios.harness.triage.litellm.acompletion", AsyncMock(return_value=fake)) as m:
+            verdict = await run_triage(config=config, messages=messages)
+        assert verdict == TriageVerdict(decision="respond", reason="addressed")
+        # The agent persona shouldn't leak into the gate call — the
+        # system message the gate sees is built from config.system plus
+        # the default rubric, not whatever system_prompt the main flow
+        # would use.
+        call_kwargs = m.call_args.kwargs
+        assert call_kwargs["model"] == "openrouter/fake"
+        assert call_kwargs["messages"][0]["role"] == "system"
+        assert call_kwargs["stream"] is False
+
+    async def test_valid_ignore_verdict(self) -> None:
+        config = TriageConfig(model="openrouter/fake")
+        fake = _mock_litellm_response('{"decision": "ignore", "reason": "noise"}')
+        with patch("aios.harness.triage.litellm.acompletion", AsyncMock(return_value=fake)):
+            verdict = await run_triage(config=config, messages=[])
+        assert verdict.decision == "ignore"
+        assert verdict.reason == "noise"
+
+    async def test_invalid_json_fails_open_to_respond(self) -> None:
+        """Fail-open: a broken gate returning unparseable text must not
+        silence the agent. Going silent on gate bugs is worse than the
+        occasional unneeded reply."""
+        config = TriageConfig(model="openrouter/fake")
+        fake = _mock_litellm_response("not json at all")
+        with patch("aios.harness.triage.litellm.acompletion", AsyncMock(return_value=fake)):
+            verdict = await run_triage(config=config, messages=[])
+        assert verdict.decision == "respond"
+        assert "invalid_json" in verdict.reason
+
+    async def test_schema_mismatch_fails_open(self) -> None:
+        config = TriageConfig(model="openrouter/fake")
+        fake = _mock_litellm_response('{"decision": "maybe", "reason": "hmm"}')
+        with patch("aios.harness.triage.litellm.acompletion", AsyncMock(return_value=fake)):
+            verdict = await run_triage(config=config, messages=[])
+        assert verdict.decision == "respond"
+        assert "schema_mismatch" in verdict.reason
+
+    async def test_provider_exception_fails_open(self) -> None:
+        config = TriageConfig(model="openrouter/fake")
+        with patch(
+            "aios.harness.triage.litellm.acompletion",
+            AsyncMock(side_effect=RuntimeError("503 from provider")),
+        ):
+            verdict = await run_triage(config=config, messages=[])
+        assert verdict.decision == "respond"
+        assert "gate_error" in verdict.reason
+
+    async def test_empty_response_fails_open(self) -> None:
+        config = TriageConfig(model="openrouter/fake")
+        fake = _mock_litellm_response("")
+        with patch("aios.harness.triage.litellm.acompletion", AsyncMock(return_value=fake)):
+            verdict = await run_triage(config=config, messages=[])
+        assert verdict.decision == "respond"
+        assert "empty" in verdict.reason
+
+    async def test_drops_main_system_message(self) -> None:
+        """The agent's main system prompt must not reach the gate —
+        otherwise the gate inherits the agent persona and its priors are
+        skewed. The gate only sees its own rubric."""
+        config = TriageConfig(model="openrouter/fake", system="be strict")
+        messages = [
+            {"role": "system", "content": "you are Bot, a helpful assistant"},
+            {"role": "user", "content": "hey"},
+        ]
+        fake = _mock_litellm_response('{"decision": "ignore", "reason": "x"}')
+        with patch("aios.harness.triage.litellm.acompletion", AsyncMock(return_value=fake)) as m:
+            await run_triage(config=config, messages=messages)
+        sent = m.call_args.kwargs["messages"]
+        # Exactly one system message (the gate's), and it includes the
+        # operator-supplied override.
+        assert sum(1 for msg in sent if msg["role"] == "system") == 1
+        assert "be strict" in sent[0]["content"]
+        # The agent persona did NOT survive.
+        assert "you are Bot" not in sent[0]["content"]
+
+
+# ─── _has_new_user_stimulus ──────────────────────────────────────────────────
+
+
+class TestHasNewUserStimulus:
+    def test_fresh_user_returns_true(self) -> None:
+        assert _has_new_user_stimulus([_user(1, "hi")]) is True
+
+    def test_no_events_returns_false(self) -> None:
+        assert _has_new_user_stimulus([]) is False
+
+    def test_only_tool_result_returns_false(self) -> None:
+        """Mid-chain tool completions must always proceed to inference —
+        the gate is for new stimuli, not for continuing the agent's own
+        multi-step work. Gating a tool-result would break tool chains."""
+        events = [
+            _user(1, "run task"),
+            _assistant(2, reacting_to=1),
+            _tool_result(3, "tc_a"),
+        ]
+        assert _has_new_user_stimulus(events) is False
+
+    def test_user_after_triage_ignore_returns_true(self) -> None:
+        events = [
+            _user(1, "side chat"),
+            _triage(2, reacting_to=1, decision="ignore"),
+            _user(3, "hey bot"),
+        ]
+        assert _has_new_user_stimulus(events) is True
+
+    def test_user_before_last_assistant_returns_false(self) -> None:
+        """A user message already reacted to by a prior assistant must
+        not re-trigger triage — the watermark has moved past it."""
+        events = [
+            _user(1, "hi"),
+            _assistant(2, reacting_to=1),
+        ]
+        assert _has_new_user_stimulus(events) is False
+
+    def test_user_during_tool_chain_returns_true(self) -> None:
+        """If a user message interrupts a running tool chain, the next
+        step should triage that message even though a tool result also
+        arrived in the meantime."""
+        events = [
+            _user(1, "run task"),
+            _assistant(2, reacting_to=1),
+            _user(3, "actually wait"),
+            _tool_result(4, "tc_a"),
+        ]
+        assert _has_new_user_stimulus(events) is True
+
+
+# ─── TriageConfig model ──────────────────────────────────────────────────────
+
+
+class TestTriageConfigModel:
+    def test_defaults(self) -> None:
+        c = TriageConfig(model="ollama_chat/llama3.2:1b")
+        assert c.model == "ollama_chat/llama3.2:1b"
+        assert c.system == ""
+
+    def test_rejects_empty_model(self) -> None:
+        with pytest.raises(ValueError):
+            TriageConfig(model="")
+
+    def test_rejects_unknown_fields(self) -> None:
+        """``extra='forbid'`` prevents typos from silently shipping —
+        e.g. ``prompt=...`` instead of ``system=...``."""
+        with pytest.raises(ValueError):
+            TriageConfig.model_validate({"model": "x", "prompt": "wrong field"})


### PR DESCRIPTION
## Summary

Optional **cheap-model gate** that runs before the main inference and decides whether the agent should respond at all. Motivated by group-chat deployments where most inbound messages are not addressed to the agent — paying for full context assembly + main-model call on every message is wasteful.

When ``agent.triage`` is set, ``run_session_step`` runs one non-streaming LiteLLM call with a JSON-object response format and either short-circuits to ``idle`` on ``ignore`` or falls through to the main flow on ``respond``. Both verdicts persist a ``triage_decision`` lifecycle event carrying a ``reacting_to`` watermark, so same-stimulus re-wakes early-out without a second gate call.

## Wire shape

\`\`\`jsonc
POST /v1/agents
{
  "name": "group-chat-bot",
  "model": "openrouter/anthropic/claude-sonnet-4-6",
  "system": "...",
  "triage": {
    "model": "ollama_chat/llama3.2:1b",
    "system": "Only respond when directly addressed as 'bot' or replied to."
  },
  "tools": [ ... ]
}
\`\`\`

NULL (the default) preserves the prior always-respond behaviour, so existing deployments are unaffected.

## Design choices

- **Watermark via lifecycle event, not fake assistant message.** ``triage_decision`` events don't enter ``build_messages`` output (``kind != 'message'``), so context monotonicity and prompt-cache stability are preserved. ``should_call_model`` and the sweep SQL both learned to treat triage decisions as reactions alongside assistant messages — without this, a triage-ignored user would re-trigger the sweep forever.
- **Gate runs before skills / MCP discovery / system-prompt augmentation.** Ignored messages pay only the gate-model latency, not the full session prep cost.
- **Only fires on new user stimuli** (``_has_new_user_stimulus``). Mid-chain tool completions always proceed — gating them would break multi-step tool work.
- **Fail-open.** Parse failures, schema mismatches, and provider exceptions all yield a ``respond`` verdict with the error captured in ``reason``. Going silent on a broken gate is worse than the occasional extra reply.
- **Gate system prompt replaces the agent persona** so the classifier's priors aren't skewed by whatever role the main agent plays.
- **Conversation still recorded** — the API appends user messages before deferring wakes, so a triage-ignored message is still durably logged. When triage later admits, the main model sees the full history including previously-ignored chatter.

## Files

- ``migrations/versions/0018_agent_triage.py`` — nullable ``triage`` JSONB on ``agents`` + ``agent_versions``
- ``src/aios/models/agents.py`` — ``TriageConfig`` Pydantic model; wired into ``AgentCreate``/``Update``/``Agent``/``AgentVersion``
- ``src/aios/db/queries.py``, ``services/agents.py``, ``api/routers/agents.py`` — persist + plumb through the new field
- ``src/aios/harness/triage.py`` (new) — one-shot LiteLLM call with fail-open JSON parse
- ``src/aios/harness/loop.py`` — triage phase + ``_has_new_user_stimulus`` + ``_run_triage_gate`` helper
- ``src/aios/harness/context.py`` — ``should_call_model`` recognizes triage decisions as reactions
- ``src/aios/harness/sweep.py`` — SQL reaction predicate extended with triage lifecycle events

## Test plan

- [x] Unit: gate verdict happy paths (respond / ignore)
- [x] Unit: all fail-open paths (invalid JSON, schema mismatch, provider exception, empty response)
- [x] Unit: agent persona does NOT leak into gate call
- [x] Unit: ``should_call_model`` respects triage decisions as reactions (4 new cases)
- [x] Unit: ``_has_new_user_stimulus`` (6 cases, incl. tool-chain interaction)
- [x] Unit: ``TriageConfig`` model validation (extra=forbid, empty model rejected)
- [x] Integration: migration 0018 up/down/up cycle on both tables
- [ ] Integration / e2e against live Postgres + real cheap model — left for maintainers; no recorded-model infra in this change

Full pre-commit gate clean: mypy strict, ruff (check + format), 617/617 unit tests pass (the 6 pre-existing ``test_task_registry`` failures on Python 3.14 are unrelated to this change).

## Out of scope / follow-ups

- Per-channel-binding overrides (a triage policy that varies by channel). Cleaner once we have a concrete use case.
- Triage cost / latency metrics on the span stream. Easy addition — drop a ``model_request_start``/``end`` pair around the gate call if operators want it visible in SSE.
- Surfacing triage verdicts on ``GET /v1/sessions/:id/events`` filters. Currently visible as ordinary lifecycle events; no special view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)