### PR TITLE
fix(channels): drop monologue from switch_channel recap

### DIFF
--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -24,7 +24,6 @@ from typing import Any
 from aios.db import queries
 from aios.harness import runtime
 from aios.harness.channels import (
-    MONOLOGUE_PREFIX,
     SWITCH_CHANNEL_METADATA_KEY,
     derive_unread_counts,
 )
@@ -43,9 +42,11 @@ SWITCH_CHANNEL_DESCRIPTION = (
     "notification markers in your context. Call switch_channel(target=<address>) "
     "to focus on a bound channel, or switch_channel(target=null) to clear "
     "focal (no channel focused; all inbound renders as notifications). "
-    "On a real switch the tool result includes a recap block quoting "
-    "recent messages on the target channel (both peer and your own) so "
-    "you can pick up where the conversation left off. A call whose "
+    "On a real switch the tool result includes a recap block: peer "
+    "inbound messages on the target channel plus the tool_calls you "
+    "made while focused there (which is where your outbound sends live "
+    "— e.g. signal_send arguments). Your bare assistant text is "
+    "internal monologue and is dropped from recaps. A call whose "
     "target already equals your current focal is a no-op — no recap, "
     "no re-emit."
 )
@@ -239,10 +240,17 @@ def _render_recap_event(event: Event) -> str:
     (we want headers and full bodies inside the recap, never truncated
     notification markers).
 
-    Assistant events render their text content with the
-    ``INTERNAL_MONOLOGUE:`` prefix stripped — the prefix is a teaching
-    signal for the author on replay, not useful framing when recapping
-    "what was said on this channel."
+    Assistant events drop their text content entirely and render only
+    their tool_calls — ``[you called: name(args), ...]`` (second
+    person, addressing the agent reading the recap).  The text portion
+    of a connector-aware session's assistant turn is always internal
+    monologue (see ``MONOLOGUE_PREFIX``) — private thinking the peer
+    never saw, so noise in a "catch up on this chat" view.  Any
+    load-bearing outbound content (what the agent actually said into
+    the channel) lives in the ``signal_send``-style connector tool
+    calls that follow, so rendering the tool_calls is sufficient to
+    surface it.  Assistant events with no tool_calls render as empty
+    and are dropped upstream.
 
     Tool events render as the tool output body, tagged with the tool
     call id so the agent can tie it back to its requesting assistant
@@ -256,9 +264,8 @@ def _render_recap_event(event: Event) -> str:
         return content if isinstance(content, str) else ""
 
     if role == "assistant":
-        text = _assistant_text(event.data)
-        text = _strip_monologue_prefix(text)
-        return f"[assistant] {text}".rstrip() if text else ""
+        calls = _render_tool_calls(event.data.get("tool_calls") or [])
+        return f"[you called: {calls}]" if calls else ""
 
     if role == "tool":
         content = event.data.get("content")
@@ -270,31 +277,25 @@ def _render_recap_event(event: Event) -> str:
     return ""
 
 
-def _assistant_text(data: dict[str, Any]) -> str:
-    """Extract the human-readable text from an assistant message.
+def _render_tool_calls(tool_calls: list[dict[str, Any]]) -> str:
+    """Render an assistant's ``tool_calls`` list as ``name(args), ...``.
 
-    Assistant content may be a plain string or a list of typed blocks
-    (``{"type": "text", "text": "..."}``).  Concatenate text blocks;
-    ignore non-text blocks (tool_calls live on a sibling field, and
-    reasoning blocks aren't useful in a recap).
+    Arguments are emitted verbatim from the OpenAI chat-completions
+    tool_call shape (``function.arguments`` — a JSON string).  No
+    per-tool classification or argument extraction: the recap shows
+    every invocation's raw shape and lets the agent pick out what
+    matters (the ``text`` arg of a ``signal_send`` call, the
+    ``command`` arg of a ``bash`` call, etc.).
     """
-    content = data.get("content")
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[str] = []
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text")
-                if isinstance(text, str):
-                    parts.append(text)
-        return "".join(parts)
-    return ""
-
-
-def _strip_monologue_prefix(text: str) -> str:
-    """Drop the ``INTERNAL_MONOLOGUE:`` prefix from assistant recap text."""
-    return text[len(MONOLOGUE_PREFIX) :] if text.startswith(MONOLOGUE_PREFIX) else text
+    parts: list[str] = []
+    for tc in tool_calls:
+        fn = tc.get("function") or {}
+        name = fn.get("name") or "?"
+        args = fn.get("arguments")
+        if not isinstance(args, str):
+            args = ""
+        parts.append(f"{name}({args})" if args else f"{name}()")
+    return ", ".join(parts)
 
 
 def _blockquote(text: str) -> str:

--- a/tests/unit/test_switch_channel.py
+++ b/tests/unit/test_switch_channel.py
@@ -172,29 +172,44 @@ class TestRecapFiltering:
         assert "hello" in out
         assert "Alice" in out
 
-    def test_includes_agent_replies(self) -> None:
-        """Assistant event with focal=target (i.e. channel=target) lands
-        in the target's recap — this is the one-sided-filter fix.
+    def test_includes_agent_tool_calls(self) -> None:
+        """An assistant turn on the target channel surfaces via its
+        tool_calls — that's where the load-bearing content (what got
+        sent to the peer) lives.  Bare assistant text is monologue and
+        is dropped.
         """
         events: list[Event] = [
             _user(1, channel=CHAN_A, content="peer message"),
-            _assistant(2, focal=CHAN_A, text="agent reply"),
+            _assistant_with_tool_call(
+                2,
+                focal=CHAN_A,
+                tool_call_id="call_send",
+                name="signal_send",
+                arguments={"text": "on it"},
+            ),
         ]
         out = render_reorient_block(events, CHAN_A)
         assert "peer message" in out
-        assert "agent reply" in out
+        assert "signal_send" in out
+        assert '"text": "on it"' in out
 
-    def test_excludes_other_channel_monologues(self) -> None:
+    def test_excludes_other_channel_tool_calls(self) -> None:
         """Assistant events emitted while focal=B must NOT appear in A's
         recap — cross-channel-leakage guard.
         """
         events: list[Event] = [
             _user(1, channel=CHAN_A, content="peer on A"),
-            _assistant(2, focal=CHAN_B, text="monologue about B"),
+            _assistant_with_tool_call(
+                2,
+                focal=CHAN_B,
+                tool_call_id="call_other",
+                name="signal_send",
+                arguments={"text": "reply on B"},
+            ),
         ]
         out = render_reorient_block(events, CHAN_A)
         assert "peer on A" in out
-        assert "monologue about B" not in out
+        assert "reply on B" not in out
 
     def test_excludes_phone_down_assistant_events(self) -> None:
         """Assistant events emitted while focal=None (channel=None) have
@@ -202,11 +217,17 @@ class TestRecapFiltering:
         """
         events: list[Event] = [
             _user(1, channel=CHAN_A, content="peer"),
-            _assistant(2, focal=None, text="phone-down thought"),
+            _assistant_with_tool_call(
+                2,
+                focal=None,
+                tool_call_id="call_pd",
+                name="signal_send",
+                arguments={"text": "phone-down send"},
+            ),
         ]
         out = render_reorient_block(events, CHAN_A)
         assert "peer" in out
-        assert "phone-down thought" not in out
+        assert "phone-down send" not in out
 
     def test_includes_tool_results_via_parent_focal(self) -> None:
         """A tool result whose parent assistant had focal=target belongs
@@ -252,11 +273,106 @@ class TestRecapFiltering:
 
 
 class TestRecapRendering:
-    def test_strips_monologue_prefix_from_assistant_text(self) -> None:
+    def test_drops_pure_text_assistant_events(self) -> None:
+        """Assistant events with no tool_calls are dropped entirely —
+        they're pure internal monologue that the peer never saw.  When
+        no events carry channel-bearing content, the recap falls back
+        to the empty-channel line.
+        """
         events = [_assistant(1, focal=CHAN_A, text="hello world")]
         out = render_reorient_block(events, CHAN_A)
         assert MONOLOGUE_PREFIX not in out
-        assert "hello world" in out
+        assert "hello world" not in out
+        assert "no prior messages on this channel" in out
+
+    def test_drops_assistant_text_even_when_tool_calls_present(self) -> None:
+        """An assistant turn that both monologues AND invokes tool_calls
+        renders only the tool_calls.  The text is monologue regardless
+        of whether a send also happened.
+        """
+        events: list[Event] = [
+            _user(1, channel=CHAN_A, content="peer"),
+            _assistant_with_tool_call(
+                2,
+                focal=CHAN_A,
+                tool_call_id="call_send",
+                name="signal_send",
+                arguments={"text": "real reply"},
+            ),
+        ]
+        # Splice in text alongside the tool_calls to simulate a turn
+        # that both monologues and sends.
+        events[1].data["content"] = MONOLOGUE_PREFIX + "thinking out loud"
+        out = render_reorient_block(events, CHAN_A)
+        assert "thinking out loud" not in out
+        assert MONOLOGUE_PREFIX not in out
+        assert '"text": "real reply"' in out
+
+    def test_tool_call_arguments_are_rendered_verbatim(self) -> None:
+        """The tool_call's ``function.arguments`` JSON string is emitted
+        as-is so the agent can read any sent content (e.g. signal_send's
+        ``text`` arg) directly without per-tool classification.  Uses
+        second-person framing (``[you called: ...]``) because the recap
+        is rendered back to the agent that made the calls.
+        """
+        events: list[Event] = [
+            _assistant_with_tool_call(
+                1,
+                focal=CHAN_A,
+                tool_call_id="call_1",
+                name="signal_send",
+                arguments={"text": "hello peer", "quote_id": "abc"},
+            ),
+        ]
+        out = render_reorient_block(events, CHAN_A)
+        assert "[you called: signal_send(" in out
+        assert '"text": "hello peer"' in out
+        assert '"quote_id": "abc"' in out
+
+    def test_multiple_tool_calls_in_one_turn_are_joined(self) -> None:
+        """A single assistant event carrying multiple tool_calls renders
+        them comma-separated inside a single ``[you called: ...]`` line.
+        """
+        import json as _json
+
+        asst = _assistant(
+            1,
+            focal=CHAN_A,
+            text="",
+            with_monologue_prefix=False,
+            tool_calls=[
+                {
+                    "id": "call_a",
+                    "type": "function",
+                    "function": {
+                        "name": "signal_send",
+                        "arguments": _json.dumps({"text": "first"}),
+                    },
+                },
+                {
+                    "id": "call_b",
+                    "type": "function",
+                    "function": {
+                        "name": "signal_send",
+                        "arguments": _json.dumps({"text": "second"}),
+                    },
+                },
+                {
+                    "id": "call_c",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": _json.dumps({"command": "ls"})},
+                },
+            ],
+        )
+        out = render_reorient_block([asst], CHAN_A)
+        # All three calls appear in the recap.
+        assert '"text": "first"' in out
+        assert '"text": "second"' in out
+        assert '"command": "ls"' in out
+        # They share a single [you called: ...] wrapper, comma-joined.
+        assert out.count("[you called:") == 1
+        assert "signal_send(" in out
+        assert "bash(" in out
 
     def test_fences_top_and_bottom(self) -> None:
         events = [_user(1, channel=CHAN_A, content="msg")]


### PR DESCRIPTION
## Summary

Live-agent follow-up to #67: a DM switch-back recap was dominated by hours-old internal-monologue assistant turns that had `focal=DM` at the time — technically channel-members, but private thoughts the peer never saw. The agent actually wants (a) peer inbounds and (b) what it itself sent into the channel (which lives inside `signal_send`-style connector tool calls).

The recap renderer now:

- **Drops all assistant text content unconditionally** — bare text in a connector-aware session is always `MONOLOGUE_PREFIX`-prefixed monologue, whether or not the same turn also invoked tool_calls.
- **Renders assistant events as `[you called: name(args), ...]`** — multiple tool_calls from a single turn are joined comma-separated inside one wrapper. Arguments are emitted verbatim from the chat-completions `function.arguments` JSON, so the agent can read any sent content (signal_send's `text`, etc.) without the recap needing per-tool classification or key extraction.
- **Drops assistant events with no tool_calls entirely** — pure monologue with nothing to surface.

Tool results continue to render as before.

## Test plan

- [x] New unit tests in `tests/unit/test_switch_channel.py`:
  - `test_drops_pure_text_assistant_events` — text-only assistant events are filtered out
  - `test_drops_assistant_text_even_when_tool_calls_present` — monologue is dropped even alongside operative tool_calls
  - `test_tool_call_arguments_are_rendered_verbatim` — `signal_send` args appear exactly in the recap
  - `test_multiple_tool_calls_in_one_turn_are_joined` — a single assistant event with multiple tool_calls produces a single `[you called: ...]` wrapper
  - `test_includes_agent_tool_calls`, `test_excludes_other_channel_tool_calls`, `test_excludes_phone_down_assistant_events` — updated for the new predicate shape
- [x] `uv run mypy src`, `uv run ruff check`, `uv run ruff format --check`
- [x] `uv run pytest tests/unit -q` — 628 pass
- [x] `DOCKER_HOST=... uv run pytest tests/e2e/test_focal_channel.py -q` — 27 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)