### PR TITLE
test(context): fill integration gaps for separate_adjacent_user_messages

### DIFF
--- a/tests/e2e/test_step_separator.py
+++ b/tests/e2e/test_step_separator.py
@@ -1,39 +1,11 @@
-"""E2E coverage for the adjacent-user-message separator at the LiteLLM boundary.
-
-PR #69 inserts ``{"role": "assistant", "content": ""}`` between any two
-consecutive user-role messages in ``run_session_step`` so LiteLLM's
-Anthropic translator doesn't merge them into one multi-content turn.
-These tests exercise the full pipeline through ``run_session_step`` and
-assert on ``harness.model_calls`` (captured kwargs at the
-``litellm.acompletion`` boundary) to pin down that the fix actually
-reaches the wire.
-"""
+"""E2E coverage for the adjacent-user-message separator at the LiteLLM boundary."""
 
 from __future__ import annotations
 
-from typing import Any
-
 from tests.conftest import needs_docker
-from tests.e2e.harness import Harness, assistant
+from tests.e2e.harness import Harness, assistant, msg_text
 
 _TAIL_HEADER = "━━━ Channels ━━━"
-
-
-def _msg_text(msg: dict[str, Any]) -> str:
-    """Flatten a chat-completions message's content to a string.
-
-    LiteLLM's Anthropic adapter wraps cache-eligible content as
-    ``[{"type": "text", "text": "...", "cache_control": ...}]`` blocks
-    before the request leaves the boundary, so tests that read
-    ``harness.model_calls[...]['messages']`` must handle both the plain
-    string shape and the multi-block shape.
-    """
-    c = msg.get("content", "")
-    if isinstance(c, str):
-        return c
-    if isinstance(c, list):
-        return "".join(str(block.get("text", "")) for block in c if isinstance(block, dict))
-    return ""
 
 
 @needs_docker
@@ -63,25 +35,16 @@ class TestSeparatorAtLiteLLMBoundary:
             (
                 i
                 for i, m in enumerate(msgs)
-                if m.get("role") == "user" and _TAIL_HEADER in _msg_text(m)
+                if m.get("role") == "user" and _TAIL_HEADER in msg_text(m)
             ),
             None,
         )
         assert tail_idx is not None, f"tail block not found in messages: {msgs!r}"
         assert tail_idx > 0, "tail block should not be first — there's an inbound before it"
 
-        # The message immediately before the tail block must defeat the
-        # Anthropic merge: either a role transition (non-user) or
-        # explicitly the empty-assistant separator the fix inserts.
         prev = msgs[tail_idx - 1]
-        assert prev.get("role") != "user" or prev == {"role": "assistant", "content": ""}, (
-            f"user/user adjacency survived to litellm boundary: prev={prev!r}, tail={msgs[tail_idx]!r}"
-        )
-
-        # Stronger: in this specific setup (one inbound + tail block) the
-        # preceding message should be the empty-assistant separator.
         assert prev == {"role": "assistant", "content": ""}, (
-            f"expected empty-assistant separator before tail, got {prev!r}"
+            f"expected empty-assistant separator before tail, got prev={prev!r}, tail={msgs[tail_idx]!r}"
         )
 
     async def test_no_separator_when_tail_block_absent(self, harness: Harness) -> None:

--- a/tests/e2e/test_step_separator.py
+++ b/tests/e2e/test_step_separator.py
@@ -1,0 +1,101 @@
+"""E2E coverage for the adjacent-user-message separator at the LiteLLM boundary.
+
+PR #69 inserts ``{"role": "assistant", "content": ""}`` between any two
+consecutive user-role messages in ``run_session_step`` so LiteLLM's
+Anthropic translator doesn't merge them into one multi-content turn.
+These tests exercise the full pipeline through ``run_session_step`` and
+assert on ``harness.model_calls`` (captured kwargs at the
+``litellm.acompletion`` boundary) to pin down that the fix actually
+reaches the wire.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness, assistant
+
+_TAIL_HEADER = "━━━ Channels ━━━"
+
+
+def _msg_text(msg: dict[str, Any]) -> str:
+    """Flatten a chat-completions message's content to a string.
+
+    LiteLLM's Anthropic adapter wraps cache-eligible content as
+    ``[{"type": "text", "text": "...", "cache_control": ...}]`` blocks
+    before the request leaves the boundary, so tests that read
+    ``harness.model_calls[...]['messages']`` must handle both the plain
+    string shape and the multi-block shape.
+    """
+    c = msg.get("content", "")
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        return "".join(str(block.get("text", "")) for block in c if isinstance(block, dict))
+    return ""
+
+
+@needs_docker
+class TestSeparatorAtLiteLLMBoundary:
+    async def test_adjacent_user_messages_reach_litellm_separated(self, harness: Harness) -> None:
+        """When a session has channel bindings, ``build_channels_tail_block``
+        appends a user-role message.  Paired with the user's inbound, this
+        is the exact adjacency PR #69 targets.  Assert that by the time
+        the message list reaches ``litellm.acompletion``, the separator is
+        in place immediately before the tail block."""
+        from aios.services import channels as ch_svc
+
+        harness.script_model([assistant("ok")])
+        session = await harness.start("hello")
+        await ch_svc.create_binding(harness._pool, address="signal/test/1", session_id=session.id)
+        await harness.run_until_idle(session.id)
+
+        assert len(harness.model_calls) == 1, (
+            "expected exactly one model call — no tool round-trip in this flow"
+        )
+        msgs = harness.model_calls[0]["messages"]
+
+        # Locate the channels tail block by its content header.  Content
+        # may be a plain string or a cache-wrapped block list — flatten
+        # before matching.
+        tail_idx = next(
+            (
+                i
+                for i, m in enumerate(msgs)
+                if m.get("role") == "user" and _TAIL_HEADER in _msg_text(m)
+            ),
+            None,
+        )
+        assert tail_idx is not None, f"tail block not found in messages: {msgs!r}"
+        assert tail_idx > 0, "tail block should not be first — there's an inbound before it"
+
+        # The message immediately before the tail block must defeat the
+        # Anthropic merge: either a role transition (non-user) or
+        # explicitly the empty-assistant separator the fix inserts.
+        prev = msgs[tail_idx - 1]
+        assert prev.get("role") != "user" or prev == {"role": "assistant", "content": ""}, (
+            f"user/user adjacency survived to litellm boundary: prev={prev!r}, tail={msgs[tail_idx]!r}"
+        )
+
+        # Stronger: in this specific setup (one inbound + tail block) the
+        # preceding message should be the empty-assistant separator.
+        assert prev == {"role": "assistant", "content": ""}, (
+            f"expected empty-assistant separator before tail, got {prev!r}"
+        )
+
+    async def test_no_separator_when_tail_block_absent(self, harness: Harness) -> None:
+        """Without channel bindings, ``build_channels_tail_block`` returns
+        ``None`` and no adjacency arises.  Assert the separator is NOT
+        inserted — guards against a future change that always inserts an
+        empty assistant turn."""
+        harness.script_model([assistant("ok")])
+        session = await harness.start("hello")
+        # No binding created → tail block is None → no user/user adjacency.
+        await harness.run_until_idle(session.id)
+
+        assert len(harness.model_calls) == 1
+        msgs = harness.model_calls[0]["messages"]
+        assert not any(m == {"role": "assistant", "content": ""} for m in msgs), (
+            f"gratuitous empty-assistant separator in messages: {msgs!r}"
+        )

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -9,12 +9,27 @@ import json
 from datetime import UTC, datetime
 from typing import Any
 
+from aios.harness.channels import build_channels_tail_block
 from aios.harness.context import (
     build_messages,
     separate_adjacent_user_messages,
     should_call_model,
 )
+from aios.models.channel_bindings import ChannelBinding
 from aios.models.events import Event
+
+
+def _binding(address: str, session_id: str = "sess_01TEST") -> ChannelBinding:
+    """Minimal ChannelBinding for tail-block construction."""
+    now = datetime(2026, 4, 17, tzinfo=UTC)
+    return ChannelBinding(
+        id=f"cbnd_{abs(hash(address)) & 0xFFFF:04x}",
+        address=address,
+        session_id=session_id,
+        created_at=now,
+        updated_at=now,
+        notification_mode="focal_candidate",
+    )
 
 
 def _evt(
@@ -546,6 +561,54 @@ class TestMonotonicity:
         _assert_prefix(ctx1, ctx2)
         _assert_prefix(ctx2, ctx3)
 
+    def test_separator_insertion_preserves_monotonicity(self) -> None:
+        """Running the full loop.py pipeline (build_messages → tail-block
+        append → separate_adjacent_user_messages) must keep the prefix-
+        stability invariant: output(L1) is a prefix of output(L2) when
+        L1 ⊂ L2.  Pins the PR's "insertions only happen at the volatile
+        suffix" claim — a future refactor that started inserting
+        separators earlier in the message list would bust the cache and
+        this test."""
+        addr = "signal/test/1"
+        bindings = [_binding(addr)]
+
+        def _full(events: list[Event]) -> list[dict]:
+            ctx = build_messages(events, system_prompt=None)
+            tail = build_channels_tail_block(bindings, events, None)
+            if tail is not None:
+                ctx.messages.append(tail)
+            return separate_adjacent_user_messages(ctx.messages)
+
+        l1 = [
+            _evt(1, "user", content="do A"),
+            _evt(2, "assistant", content="done A"),
+        ]
+        l2 = [*l1, _evt(3, "user", content="do B")]
+        l3 = [*l2, _evt(4, "assistant", content="done B")]
+
+        out1, out2, out3 = _full(l1), _full(l2), _full(l3)
+
+        # The tail block lives at the end and mutates per step, so the
+        # cache-stable prefix is everything up to (but not including) the
+        # tail block.  Compare those prefixes across appends.
+        def _strip_tail(msgs: list[dict]) -> list[dict]:
+            # Tail block is the last user message whose content starts
+            # with the channels header.  Drop it + any separator the
+            # pipeline inserted immediately before it.
+            for i in range(len(msgs) - 1, -1, -1):
+                m = msgs[i]
+                if m.get("role") == "user" and str(m.get("content", "")).startswith(
+                    "━━━ Channels ━━━"
+                ):
+                    stop = i
+                    if i > 0 and msgs[i - 1] == {"role": "assistant", "content": ""}:
+                        stop = i - 1
+                    return msgs[:stop]
+            return msgs
+
+        _assert_prefix(_strip_tail(out1), _strip_tail(out2))
+        _assert_prefix(_strip_tail(out2), _strip_tail(out3))
+
     def test_reacting_to_includes_inline_injection_seq(self) -> None:
         """ContextResult.reacting_to must account for the seq of blind-spot
         tool results that are injected inline."""
@@ -1008,3 +1071,89 @@ class TestSeparateAdjacentUserMessages:
             {"role": "assistant", "content": ""},
             {"role": "user", "content": "two"},
         ]
+
+
+class TestSeparateAdjacentUserMessagesPipeline:
+    """Compose the real pipeline (``build_messages`` → tail-block append →
+    ``separate_adjacent_user_messages``) and assert the separator fires
+    exactly where adjacency actually arises from realistic event shapes.
+
+    The per-function unit tests above use synthetic message dicts; these
+    exercise the composition against ``build_messages`` output so a
+    refactor that changes that output's role sequence can't silently
+    break the fix."""
+
+    @staticmethod
+    def _pipeline(
+        events: list[Event],
+        bindings: list[ChannelBinding],
+        focal_channel: str | None = None,
+    ) -> list[dict[str, Any]]:
+        ctx = build_messages(events, system_prompt=None)
+        tail = build_channels_tail_block(bindings, events, focal_channel)
+        if tail is not None:
+            ctx.messages.append(tail)
+        return separate_adjacent_user_messages(ctx.messages)
+
+    def test_inbound_then_tail_block_gets_separator(self) -> None:
+        """A user inbound followed by the channels tail block (also
+        user-role) must have an empty-assistant separator inserted
+        between them."""
+        addr = "signal/test/1"
+        events = [_evt(1, "user", content="hello")]
+        msgs = self._pipeline(events, [_binding(addr)])
+
+        # build_messages emits one user; tail block is a second user.
+        # Separator lands between them.
+        assert [m["role"] for m in msgs] == ["user", "assistant", "user"]
+        assert msgs[1] == {"role": "assistant", "content": ""}
+        assert msgs[2]["content"].startswith("━━━ Channels ━━━")
+
+    def test_blind_spot_injection_adjacent_user_gets_separator(self) -> None:
+        """``build_messages`` inlines a blind-spot tool result as a
+        synthetic user message right after the horizon-setter.  When
+        the real log also has a subsequent user event, the two land
+        back-to-back in the output and need separating."""
+        events = [
+            _evt(1, "user", content="run it"),
+            _evt(2, "assistant", tool_calls=[_tc("t1")]),
+            _evt(3, "tool", tool_call_id="t1", content="RESULT"),
+            _evt(4, "assistant", content="checking..."),
+            _evt(5, "user", content="anything else?"),
+            _evt(6, "assistant", content="nope"),
+        ]
+        events[1].data["reacting_to"] = 1
+        events[3].data["reacting_to"] = 1  # blind to tool at seq=3
+        events[5].data["reacting_to"] = 5
+
+        msgs = self._pipeline(events, bindings=[])
+
+        # Pre-fix role sequence (from TestMonotonicity.test_inline_injection_position):
+        #   [user, assistant, tool, assistant, user(injection), user(follow-up), assistant]
+        # Post-fix: an empty-assistant separator lands between the two user msgs.
+        roles_and_contents = [(m["role"], m.get("content", "")) for m in msgs]
+        # Find the injection (carries "RESULT" text) and assert the next
+        # message is the empty-assistant separator.
+        injection_idx = next(
+            i for i, (role, c) in enumerate(roles_and_contents) if role == "user" and "RESULT" in c
+        )
+        assert msgs[injection_idx + 1] == {"role": "assistant", "content": ""}
+        assert msgs[injection_idx + 2]["role"] == "user"
+        assert msgs[injection_idx + 2]["content"] == "anything else?"
+
+    def test_alternating_events_no_tail_block_no_separator(self) -> None:
+        """Alternating user/assistant events with no tail block must
+        produce no empty-assistant insertions — guards against a buggy
+        future change that inserts gratuitously."""
+        events = [
+            _evt(1, "user", content="hi"),
+            _evt(2, "assistant", content="hello"),
+            _evt(3, "user", content="bye"),
+            _evt(4, "assistant", content="later"),
+        ]
+        msgs = self._pipeline(events, bindings=[])
+
+        # No tail block (bindings=[] → build_channels_tail_block returns None),
+        # so the output is just build_messages' alternating sequence.
+        assert [m["role"] for m in msgs] == ["user", "assistant", "user", "assistant"]
+        assert not any(m == {"role": "assistant", "content": ""} for m in msgs)

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -32,6 +32,21 @@ def _binding(address: str, session_id: str = "sess_01TEST") -> ChannelBinding:
     )
 
 
+def _full_pipeline(
+    events: list[Event],
+    bindings: list[ChannelBinding],
+    focal_channel: str | None = None,
+) -> list[dict[str, Any]]:
+    """Compose ``build_messages`` → tail-block append → separator — the
+    same sequence ``loop.py:run_session_step`` runs before handing the
+    message list to LiteLLM."""
+    ctx = build_messages(events, system_prompt=None)
+    tail = build_channels_tail_block(bindings, events, focal_channel)
+    if tail is not None:
+        ctx.messages.append(tail)
+    return separate_adjacent_user_messages(ctx.messages)
+
+
 def _evt(
     seq: int,
     role: str,
@@ -562,22 +577,12 @@ class TestMonotonicity:
         _assert_prefix(ctx2, ctx3)
 
     def test_separator_insertion_preserves_monotonicity(self) -> None:
-        """Running the full loop.py pipeline (build_messages → tail-block
-        append → separate_adjacent_user_messages) must keep the prefix-
-        stability invariant: output(L1) is a prefix of output(L2) when
-        L1 ⊂ L2.  Pins the PR's "insertions only happen at the volatile
-        suffix" claim — a future refactor that started inserting
-        separators earlier in the message list would bust the cache and
-        this test."""
-        addr = "signal/test/1"
-        bindings = [_binding(addr)]
-
-        def _full(events: list[Event]) -> list[dict]:
-            ctx = build_messages(events, system_prompt=None)
-            tail = build_channels_tail_block(bindings, events, None)
-            if tail is not None:
-                ctx.messages.append(tail)
-            return separate_adjacent_user_messages(ctx.messages)
+        """Full pipeline (build_messages → tail-block → separator) must
+        keep the prefix-stability invariant: output(L1) is a prefix of
+        output(L2) when L1 ⊂ L2.  Pins the "insertions only at the
+        volatile suffix" claim — a refactor that inserted separators
+        into the cache-stable prefix would fail this."""
+        bindings = [_binding("signal/test/1")]
 
         l1 = [
             _evt(1, "user", content="do A"),
@@ -586,15 +591,13 @@ class TestMonotonicity:
         l2 = [*l1, _evt(3, "user", content="do B")]
         l3 = [*l2, _evt(4, "assistant", content="done B")]
 
-        out1, out2, out3 = _full(l1), _full(l2), _full(l3)
+        out1 = _full_pipeline(l1, bindings)
+        out2 = _full_pipeline(l2, bindings)
+        out3 = _full_pipeline(l3, bindings)
 
-        # The tail block lives at the end and mutates per step, so the
-        # cache-stable prefix is everything up to (but not including) the
-        # tail block.  Compare those prefixes across appends.
+        # The tail block mutates per step, so compare prefixes only up
+        # to (but not including) the tail and any separator before it.
         def _strip_tail(msgs: list[dict]) -> list[dict]:
-            # Tail block is the last user message whose content starts
-            # with the channels header.  Drop it + any separator the
-            # pipeline inserted immediately before it.
             for i in range(len(msgs) - 1, -1, -1):
                 m = msgs[i]
                 if m.get("role") == "user" and str(m.get("content", "")).startswith(
@@ -1074,37 +1077,14 @@ class TestSeparateAdjacentUserMessages:
 
 
 class TestSeparateAdjacentUserMessagesPipeline:
-    """Compose the real pipeline (``build_messages`` → tail-block append →
-    ``separate_adjacent_user_messages``) and assert the separator fires
-    exactly where adjacency actually arises from realistic event shapes.
-
-    The per-function unit tests above use synthetic message dicts; these
-    exercise the composition against ``build_messages`` output so a
-    refactor that changes that output's role sequence can't silently
-    break the fix."""
-
-    @staticmethod
-    def _pipeline(
-        events: list[Event],
-        bindings: list[ChannelBinding],
-        focal_channel: str | None = None,
-    ) -> list[dict[str, Any]]:
-        ctx = build_messages(events, system_prompt=None)
-        tail = build_channels_tail_block(bindings, events, focal_channel)
-        if tail is not None:
-            ctx.messages.append(tail)
-        return separate_adjacent_user_messages(ctx.messages)
+    """Exercise the separator against realistic ``build_messages`` output
+    (rather than synthetic dicts) so a refactor that changes the output's
+    role sequence can't silently break the fix."""
 
     def test_inbound_then_tail_block_gets_separator(self) -> None:
-        """A user inbound followed by the channels tail block (also
-        user-role) must have an empty-assistant separator inserted
-        between them."""
-        addr = "signal/test/1"
         events = [_evt(1, "user", content="hello")]
-        msgs = self._pipeline(events, [_binding(addr)])
+        msgs = _full_pipeline(events, [_binding("signal/test/1")])
 
-        # build_messages emits one user; tail block is a second user.
-        # Separator lands between them.
         assert [m["role"] for m in msgs] == ["user", "assistant", "user"]
         assert msgs[1] == {"role": "assistant", "content": ""}
         assert msgs[2]["content"].startswith("━━━ Channels ━━━")
@@ -1112,8 +1092,8 @@ class TestSeparateAdjacentUserMessagesPipeline:
     def test_blind_spot_injection_adjacent_user_gets_separator(self) -> None:
         """``build_messages`` inlines a blind-spot tool result as a
         synthetic user message right after the horizon-setter.  When
-        the real log also has a subsequent user event, the two land
-        back-to-back in the output and need separating."""
+        a real user event follows, the two land back-to-back and need
+        separating."""
         events = [
             _evt(1, "user", content="run it"),
             _evt(2, "assistant", tool_calls=[_tc("t1")]),
@@ -1126,34 +1106,27 @@ class TestSeparateAdjacentUserMessagesPipeline:
         events[3].data["reacting_to"] = 1  # blind to tool at seq=3
         events[5].data["reacting_to"] = 5
 
-        msgs = self._pipeline(events, bindings=[])
+        msgs = _full_pipeline(events, bindings=[])
 
-        # Pre-fix role sequence (from TestMonotonicity.test_inline_injection_position):
-        #   [user, assistant, tool, assistant, user(injection), user(follow-up), assistant]
-        # Post-fix: an empty-assistant separator lands between the two user msgs.
-        roles_and_contents = [(m["role"], m.get("content", "")) for m in msgs]
-        # Find the injection (carries "RESULT" text) and assert the next
-        # message is the empty-assistant separator.
         injection_idx = next(
-            i for i, (role, c) in enumerate(roles_and_contents) if role == "user" and "RESULT" in c
+            i
+            for i, m in enumerate(msgs)
+            if m["role"] == "user" and "RESULT" in str(m.get("content", ""))
         )
         assert msgs[injection_idx + 1] == {"role": "assistant", "content": ""}
         assert msgs[injection_idx + 2]["role"] == "user"
         assert msgs[injection_idx + 2]["content"] == "anything else?"
 
     def test_alternating_events_no_tail_block_no_separator(self) -> None:
-        """Alternating user/assistant events with no tail block must
-        produce no empty-assistant insertions — guards against a buggy
-        future change that inserts gratuitously."""
+        """Guards against a future change that inserts a separator when
+        no adjacency exists (empty bindings → tail block is ``None``)."""
         events = [
             _evt(1, "user", content="hi"),
             _evt(2, "assistant", content="hello"),
             _evt(3, "user", content="bye"),
             _evt(4, "assistant", content="later"),
         ]
-        msgs = self._pipeline(events, bindings=[])
+        msgs = _full_pipeline(events, bindings=[])
 
-        # No tail block (bindings=[] → build_channels_tail_block returns None),
-        # so the output is just build_messages' alternating sequence.
         assert [m["role"] for m in msgs] == ["user", "assistant", "user", "assistant"]
         assert not any(m == {"role": "assistant", "content": ""} for m in msgs)


### PR DESCRIPTION
## Summary

Stacked on top of #69 (role-alternation fix for LiteLLM/Anthropic adjacent-user merge). Fills four integration gaps the original six unit tests didn't reach:

1. **Realistic pipeline composition.** New `TestSeparateAdjacentUserMessagesPipeline` runs the full `build_messages` → tail-block append → separator chain against `Event` logs that actually produce adjacent-user pairs (inbound + tail block, blind-spot injection + follow-up user), not synthetic dicts.
2. **Monotonicity preservation.** New `test_separator_insertion_preserves_monotonicity` extends `TestMonotonicity` to pin the "insertions only at the volatile suffix" claim. A future refactor that starts inserting separators into the cache-stable prefix fails this.
3. **Call-site wiring.** New `tests/e2e/test_step_separator.py` drives `run_session_step` end-to-end and reads `harness.model_calls[0]["messages"]` at the `litellm.acompletion` boundary. **Regression-verified:** locally removing the `loop.py:166` call makes this test fail with the exact user/user adjacency diagnostic.
4. **No-op guarantee.** Second e2e test confirms no empty-assistant is inserted when bindings are absent (tail block returns `None`) — guards against a future over-insertion bug.

## Out of scope

- **Post-translation verification.** LiteLLM 1.83.4 exposes no pure chat-completions → Anthropic translator, so asserting "two distinct user turns post-translation" would need VCR cassettes or a real API key. `harness.model_calls` capture at the `acompletion` boundary is the closest test without new infra.
- **Assistant-role adjacency.** Whether LiteLLM merges consecutive `assistant` messages is a separate design question; current fix + test scope is user/user.

## Incidental finding

At the LiteLLM boundary, cache-eligible content is wrapped as `[{"type": "text", "text": "...", "cache_control": {"type": "ephemeral"}}]` blocks, not plain strings. The new e2e helper `_msg_text` flattens both shapes with a docstring for future readers.

## Base

Base is `wt/ancient-jingling-summit` (PR #69). GitHub will auto-retarget to `master` when #69 merges; the diff then shows only the test additions.

## Status

Draft — expecting further direction on this branch.

## Test plan

- [x] `uv run mypy src` clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` clean
- [x] `uv run pytest tests/unit -q` — 638 pass (up from 634)
- [x] `DOCKER_HOST=... uv run pytest tests/e2e/test_step_separator.py -q` — 2 pass
- [x] Regression-checked: disabling `loop.py:166` makes the e2e wiring test fail with the expected diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)