### PR TITLE
fix(harness): exponential backoff for transient model errors (closes #54)

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -38,20 +38,11 @@ from aios.tools.registry import to_openai_tools
 log = get_logger("aios.harness.loop")
 
 
-# Exponential backoff for transient model-call failures.  The index into
-# this table is the number of consecutive ``rescheduling`` lifecycle
-# events already in the log (see ``_count_consecutive_rescheduling``).
-# Once the index runs off the end, the retry budget is exhausted and the
-# step gives up with ``stop_reason={"type": "error"}``.
 _RETRY_BACKOFF_SECONDS: list[float] = [2, 8, 30, 120]
 
 
 def _retry_delay_for_attempt(attempt: int) -> float | None:
-    """Return the backoff delay for the given 0-indexed attempt, or ``None``.
-
-    ``attempt`` is the number of consecutive rescheduling lifecycle
-    events already logged; ``None`` signals the caller to give up.
-    """
+    """Return the backoff delay for ``attempt``, or ``None`` if the budget is spent."""
     if attempt >= len(_RETRY_BACKOFF_SECONDS):
         return None
     return _RETRY_BACKOFF_SECONDS[attempt]
@@ -219,10 +210,6 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
             },
         )
 
-        # Exponential backoff — index is the number of consecutive
-        # rescheduling lifecycle events already in the log.  A successful
-        # turn between failures clears the streak so the next failure
-        # starts fresh at the smallest delay.
         attempt = await _count_consecutive_rescheduling(pool, session_id)
         delay = _retry_delay_for_attempt(attempt)
         if delay is not None:
@@ -232,13 +219,12 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
             await _append_lifecycle(pool, session_id, "turn_ended", "rescheduling", "rescheduling")
             await defer_retry_wake(session_id, delay_seconds=delay)
             return
-        else:
-            # Retry budget exhausted — surface the error.
-            await sessions_service.set_session_status(
-                pool, session_id, "idle", stop_reason={"type": "error"}
-            )
-            await _append_lifecycle(pool, session_id, "turn_ended", "idle", "error")
-            raise
+
+        await sessions_service.set_session_status(
+            pool, session_id, "idle", stop_reason={"type": "error"}
+        )
+        await _append_lifecycle(pool, session_id, "turn_ended", "idle", "error")
+        raise
 
     # Emit span end with per-request token usage.
     await sessions_service.append_event(

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -28,6 +28,7 @@ from aios.harness.completion import stream_litellm
 from aios.harness.context import build_messages
 from aios.harness.sweep import find_sessions_needing_inference
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
+from aios.harness.wake import defer_retry_wake
 from aios.logging import get_logger
 from aios.models.agents import ToolSpec
 from aios.services import agents as agents_service
@@ -35,6 +36,25 @@ from aios.services import sessions as sessions_service
 from aios.tools.registry import to_openai_tools
 
 log = get_logger("aios.harness.loop")
+
+
+# Exponential backoff for transient model-call failures.  The index into
+# this table is the number of consecutive ``rescheduling`` lifecycle
+# events already in the log (see ``_count_consecutive_rescheduling``).
+# Once the index runs off the end, the retry budget is exhausted and the
+# step gives up with ``stop_reason={"type": "error"}``.
+_RETRY_BACKOFF_SECONDS: list[float] = [2, 8, 30, 120]
+
+
+def _retry_delay_for_attempt(attempt: int) -> float | None:
+    """Return the backoff delay for the given 0-indexed attempt, or ``None``.
+
+    ``attempt`` is the number of consecutive rescheduling lifecycle
+    events already logged; ``None`` signals the caller to give up.
+    """
+    if attempt >= len(_RETRY_BACKOFF_SECONDS):
+        return None
+    return _RETRY_BACKOFF_SECONDS[attempt]
 
 
 async def run_session_step(session_id: str, *, cause: str = "message") -> None:
@@ -199,28 +219,21 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
             },
         )
 
-        # Count consecutive rescheduling lifecycle events to decide
-        # whether to retry or give up.
-        consecutive = await _count_consecutive_rescheduling(pool, session_id)
-        if consecutive < 2:
-            # Retry: set status to rescheduling and defer a delayed wake.
+        # Exponential backoff — index is the number of consecutive
+        # rescheduling lifecycle events already in the log.  A successful
+        # turn between failures clears the streak so the next failure
+        # starts fresh at the smallest delay.
+        attempt = await _count_consecutive_rescheduling(pool, session_id)
+        delay = _retry_delay_for_attempt(attempt)
+        if delay is not None:
             await sessions_service.set_session_status(
                 pool, session_id, "rescheduling", stop_reason={"type": "rescheduling"}
             )
             await _append_lifecycle(pool, session_id, "turn_ended", "rescheduling", "rescheduling")
-            from aios.harness.procrastinate_app import app as procrastinate_app
-
-            try:
-                await procrastinate_app.configure_task("harness.wake_session").defer_async(
-                    session_id=session_id,
-                    cause="reschedule",
-                    schedule_in={"seconds": 5},
-                )
-            except Exception:
-                log.exception("step.reschedule_defer_failed", session_id=session_id)
+            await defer_retry_wake(session_id, delay_seconds=delay)
             return
         else:
-            # 3rd consecutive error — give up.
+            # Retry budget exhausted — surface the error.
             await sessions_service.set_session_status(
                 pool, session_id, "idle", stop_reason={"type": "error"}
             )

--- a/src/aios/harness/wake.py
+++ b/src/aios/harness/wake.py
@@ -30,3 +30,28 @@ async def defer_wake(session_id: str, *, cause: str = "message") -> None:
         )
     except procrastinate_exceptions.AlreadyEnqueued:
         log.debug("wake.already_enqueued", session_id=session_id, cause=cause)
+
+
+async def defer_retry_wake(session_id: str, *, delay_seconds: float) -> None:
+    """Enqueue a delayed ``wake_session`` job for retry after a transient error.
+
+    Mirrors :func:`defer_wake` but schedules the job ``delay_seconds``
+    in the future via procrastinate's ``schedule_in``.  An already-queued
+    wake for the same session dedups this retry via ``queueing_lock``;
+    that's benign — the queued wake will run, hit the same error, and
+    the handler will defer a fresh retry.
+    """
+    from aios.harness.procrastinate_app import app
+
+    try:
+        await app.configure_task("harness.wake_session").defer_async(
+            session_id=session_id,
+            cause="reschedule",
+            schedule_in={"seconds": delay_seconds},
+        )
+    except procrastinate_exceptions.AlreadyEnqueued:
+        log.debug(
+            "wake.retry_already_enqueued",
+            session_id=session_id,
+            delay_seconds=delay_seconds,
+        )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -72,10 +72,14 @@ async def harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     async def _noop_defer_wake(session_id: str, *, cause: str = "message") -> None:
         pass
 
+    async def _noop_defer_retry_wake(session_id: str, *, delay_seconds: float) -> None:
+        pass
+
     with (
         mock.patch("aios.harness.completion.litellm.acompletion", _fake_acompletion),
         mock.patch("aios.harness.completion.litellm.stream_chunk_builder", _fake_chunk_builder),
         mock.patch("aios.harness.wake.defer_wake", _noop_defer_wake),
+        mock.patch("aios.harness.loop.defer_retry_wake", _noop_defer_retry_wake),
     ):
         yield h
 
@@ -137,10 +141,14 @@ async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     async def _noop_defer_wake(session_id: str, *, cause: str = "message") -> None:
         pass
 
+    async def _noop_defer_retry_wake(session_id: str, *, delay_seconds: float) -> None:
+        pass
+
     with (
         mock.patch("aios.harness.completion.litellm.acompletion", _fake_acompletion),
         mock.patch("aios.harness.completion.litellm.stream_chunk_builder", _fake_chunk_builder),
         mock.patch("aios.harness.wake.defer_wake", _noop_defer_wake),
+        mock.patch("aios.harness.loop.defer_retry_wake", _noop_defer_retry_wake),
     ):
         yield h
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -23,6 +23,14 @@ import pytest
 from tests.e2e.harness import Harness
 
 
+async def _noop_defer_wake(session_id: str, *, cause: str = "message") -> None:
+    pass
+
+
+async def _noop_defer_retry_wake(session_id: str, *, delay_seconds: float) -> None:
+    pass
+
+
 @pytest.fixture
 async def harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     """Function-scoped harness: real Postgres, scripted model, no Docker."""
@@ -68,12 +76,6 @@ async def harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
 
     def _fake_chunk_builder(*args: Any, **kwargs: Any) -> dict[str, Any]:
         return h._build_chunk_response(*args, **kwargs)
-
-    async def _noop_defer_wake(session_id: str, *, cause: str = "message") -> None:
-        pass
-
-    async def _noop_defer_retry_wake(session_id: str, *, delay_seconds: float) -> None:
-        pass
 
     with (
         mock.patch("aios.harness.completion.litellm.acompletion", _fake_acompletion),
@@ -137,12 +139,6 @@ async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
 
     def _fake_chunk_builder(*args: Any, **kwargs: Any) -> dict[str, Any]:
         return h._build_chunk_response(*args, **kwargs)
-
-    async def _noop_defer_wake(session_id: str, *, cause: str = "message") -> None:
-        pass
-
-    async def _noop_defer_retry_wake(session_id: str, *, delay_seconds: float) -> None:
-        pass
 
     with (
         mock.patch("aios.harness.completion.litellm.acompletion", _fake_acompletion),

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -1,0 +1,247 @@
+"""Unit tests for transient-model-error retry logic in ``run_session_step``.
+
+Covers three layers:
+
+1. Pure backoff table lookup (``_retry_delay_for_attempt``).
+2. The consecutive-rescheduling counter (``_count_consecutive_rescheduling``)
+   that drives the attempt index.
+3. The exception handler's state-machine — retry with the right delay on
+   early attempts, give up and re-raise once the budget is exhausted.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestRetryDelayForAttempt:
+    """Pure lookup into the backoff table."""
+
+    def test_retry_delay_attempt_0_returns_2s(self) -> None:
+        from aios.harness.loop import _retry_delay_for_attempt
+
+        assert _retry_delay_for_attempt(0) == 2
+
+    def test_retry_delay_attempt_1_returns_8s(self) -> None:
+        from aios.harness.loop import _retry_delay_for_attempt
+
+        assert _retry_delay_for_attempt(1) == 8
+
+    def test_retry_delay_attempt_2_returns_30s(self) -> None:
+        from aios.harness.loop import _retry_delay_for_attempt
+
+        assert _retry_delay_for_attempt(2) == 30
+
+    def test_retry_delay_attempt_3_returns_120s(self) -> None:
+        from aios.harness.loop import _retry_delay_for_attempt
+
+        assert _retry_delay_for_attempt(3) == 120
+
+    def test_retry_delay_attempt_4_returns_none(self) -> None:
+        """After 4 consecutive reschedules, the budget is exhausted."""
+        from aios.harness.loop import _retry_delay_for_attempt
+
+        assert _retry_delay_for_attempt(4) is None
+
+
+class TestCountConsecutiveRescheduling:
+    """Streak counter that resets on any non-rescheduling lifecycle event."""
+
+    async def test_count_consecutive_rescheduling_empty_log_returns_zero(self) -> None:
+        from aios.harness.loop import _count_consecutive_rescheduling
+
+        pool = MagicMock()
+        with patch(
+            "aios.harness.loop.sessions_service.read_events",
+            AsyncMock(return_value=[]),
+        ):
+            assert await _count_consecutive_rescheduling(pool, "sess_x") == 0
+
+    async def test_count_consecutive_rescheduling_resets_on_non_rescheduling_tail(
+        self,
+    ) -> None:
+        """A successful turn between failures wipes the retry budget.
+
+        Regression guard: a long-ago rescheduling streak followed by a
+        clean turn_ended must not count toward the current failure's
+        attempt number.
+        """
+        from aios.harness.loop import _count_consecutive_rescheduling
+
+        events = [
+            SimpleNamespace(data={"event": "turn_ended", "stop_reason": "rescheduling"}),
+            SimpleNamespace(data={"event": "turn_ended", "stop_reason": "rescheduling"}),
+            SimpleNamespace(data={"event": "turn_ended", "stop_reason": "end_turn"}),
+            SimpleNamespace(data={"event": "turn_ended", "stop_reason": "rescheduling"}),
+        ]
+        pool = MagicMock()
+        with patch(
+            "aios.harness.loop.sessions_service.read_events",
+            AsyncMock(return_value=events),
+        ):
+            # Only the trailing single rescheduling counts.
+            assert await _count_consecutive_rescheduling(pool, "sess_x") == 1
+
+
+# ─── exception handler tests ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_step_dependencies() -> Any:
+    """Mock everything ``run_session_step`` touches before the model call.
+
+    The exception handler is deep inside ``run_session_step``; to reach
+    it we have to let the function walk past all the setup work: sweep
+    early-out, session/agent loading, MCP discovery, context build,
+    span append, and the model call (which we make raise).
+    """
+    session = SimpleNamespace(
+        id="sess_x",
+        agent_id="agt_x",
+        agent_version=None,
+        focal_channel=None,
+    )
+    agent = SimpleNamespace(
+        model="openrouter/x",
+        tools=[],
+        mcp_servers=[],
+        skills=[],
+        system="sys",
+        window_min=1000,
+        window_max=10000,
+    )
+    start_event = SimpleNamespace(id="ev_start")
+
+    with (
+        patch(
+            "aios.harness.loop.runtime.require_pool",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "aios.harness.loop.runtime.require_task_registry",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "aios.harness.loop.find_sessions_needing_inference",
+            AsyncMock(return_value={"sess_x"}),
+        ),
+        patch(
+            "aios.harness.loop.sessions_service.get_session",
+            AsyncMock(return_value=session),
+        ),
+        patch(
+            "aios.harness.loop.agents_service.get_agent",
+            AsyncMock(return_value=agent),
+        ),
+        # Channels helpers are imported lazily inside run_session_step —
+        # patch them at their source module rather than on loop.
+        patch(
+            "aios.harness.channels.list_bindings_and_connections",
+            AsyncMock(return_value=([], [])),
+        ),
+        patch(
+            "aios.harness.channels.augment_with_connector_instructions",
+            return_value="sys",
+        ),
+        patch(
+            "aios.harness.channels.augment_with_focal_paradigm",
+            return_value="sys",
+        ),
+        patch(
+            "aios.harness.channels.build_channels_tail_block",
+            return_value=None,
+        ),
+        patch(
+            "aios.harness.skills.augment_system_prompt",
+            return_value="sys",
+        ),
+        patch(
+            "aios.services.skills.resolve_skill_refs",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "aios.harness.loop.sessions_service.read_windowed_events",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "aios.harness.loop._dispatch_confirmed_tools",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "aios.harness.loop.to_openai_tools",
+            return_value=[],
+        ),
+        patch(
+            "aios.harness.loop.build_messages",
+            return_value=SimpleNamespace(messages=[], reacting_to=0),
+        ),
+        patch(
+            "aios.harness.loop.sessions_service.set_session_status",
+            AsyncMock(),
+        ) as set_status,
+        patch(
+            "aios.harness.loop.sessions_service.append_event",
+            AsyncMock(return_value=start_event),
+        ) as append_event,
+        patch(
+            "aios.harness.loop.stream_litellm",
+            AsyncMock(side_effect=RuntimeError("provider boom")),
+        ),
+        patch(
+            "aios.harness.loop.defer_retry_wake",
+            AsyncMock(),
+        ) as defer_retry,
+    ):
+        yield SimpleNamespace(
+            set_status=set_status,
+            append_event=append_event,
+            defer_retry=defer_retry,
+        )
+
+
+class TestRunSessionStepOnModelError:
+    """End-to-end behavior of the exception handler's state machine."""
+
+    async def test_first_attempt_defers_retry_with_2s(self, mock_step_dependencies: Any) -> None:
+        """On the first transient failure, schedule a retry at 2 seconds."""
+        from aios.harness.loop import run_session_step
+
+        with patch(
+            "aios.harness.loop._count_consecutive_rescheduling",
+            AsyncMock(return_value=0),
+        ):
+            await run_session_step("sess_x")
+
+        mock_step_dependencies.defer_retry.assert_awaited_once_with("sess_x", delay_seconds=2)
+        # Status transitions to rescheduling, not idle/error.
+        status_calls = [call.args[2] for call in mock_step_dependencies.set_status.call_args_list]
+        assert "rescheduling" in status_calls
+        assert "idle" not in status_calls
+
+    async def test_exhausted_budget_raises_and_sets_idle_error(
+        self, mock_step_dependencies: Any
+    ) -> None:
+        """After 4 consecutive reschedules, give up: idle/error + re-raise."""
+        from aios.harness.loop import run_session_step
+
+        with (
+            patch(
+                "aios.harness.loop._count_consecutive_rescheduling",
+                AsyncMock(return_value=4),
+            ),
+            pytest.raises(RuntimeError, match="provider boom"),
+        ):
+            await run_session_step("sess_x")
+
+        mock_step_dependencies.defer_retry.assert_not_awaited()
+        # Final status is idle with error stop_reason.
+        idle_call = next(
+            call
+            for call in mock_step_dependencies.set_status.call_args_list
+            if call.args[2] == "idle"
+        )
+        assert idle_call.kwargs["stop_reason"] == {"type": "error"}

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -17,43 +17,32 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aios.harness.loop import (
+    _count_consecutive_rescheduling,
+    _retry_delay_for_attempt,
+    run_session_step,
+)
+
 
 class TestRetryDelayForAttempt:
-    """Pure lookup into the backoff table."""
-
     def test_retry_delay_attempt_0_returns_2s(self) -> None:
-        from aios.harness.loop import _retry_delay_for_attempt
-
         assert _retry_delay_for_attempt(0) == 2
 
     def test_retry_delay_attempt_1_returns_8s(self) -> None:
-        from aios.harness.loop import _retry_delay_for_attempt
-
         assert _retry_delay_for_attempt(1) == 8
 
     def test_retry_delay_attempt_2_returns_30s(self) -> None:
-        from aios.harness.loop import _retry_delay_for_attempt
-
         assert _retry_delay_for_attempt(2) == 30
 
     def test_retry_delay_attempt_3_returns_120s(self) -> None:
-        from aios.harness.loop import _retry_delay_for_attempt
-
         assert _retry_delay_for_attempt(3) == 120
 
     def test_retry_delay_attempt_4_returns_none(self) -> None:
-        """After 4 consecutive reschedules, the budget is exhausted."""
-        from aios.harness.loop import _retry_delay_for_attempt
-
         assert _retry_delay_for_attempt(4) is None
 
 
 class TestCountConsecutiveRescheduling:
-    """Streak counter that resets on any non-rescheduling lifecycle event."""
-
     async def test_count_consecutive_rescheduling_empty_log_returns_zero(self) -> None:
-        from aios.harness.loop import _count_consecutive_rescheduling
-
         pool = MagicMock()
         with patch(
             "aios.harness.loop.sessions_service.read_events",
@@ -64,14 +53,7 @@ class TestCountConsecutiveRescheduling:
     async def test_count_consecutive_rescheduling_resets_on_non_rescheduling_tail(
         self,
     ) -> None:
-        """A successful turn between failures wipes the retry budget.
-
-        Regression guard: a long-ago rescheduling streak followed by a
-        clean turn_ended must not count toward the current failure's
-        attempt number.
-        """
-        from aios.harness.loop import _count_consecutive_rescheduling
-
+        """Regression: a clean turn_ended breaks the streak even if reschedulings preceded it."""
         events = [
             SimpleNamespace(data={"event": "turn_ended", "stop_reason": "rescheduling"}),
             SimpleNamespace(data={"event": "turn_ended", "stop_reason": "rescheduling"}),
@@ -207,9 +189,6 @@ class TestRunSessionStepOnModelError:
     """End-to-end behavior of the exception handler's state machine."""
 
     async def test_first_attempt_defers_retry_with_2s(self, mock_step_dependencies: Any) -> None:
-        """On the first transient failure, schedule a retry at 2 seconds."""
-        from aios.harness.loop import run_session_step
-
         with patch(
             "aios.harness.loop._count_consecutive_rescheduling",
             AsyncMock(return_value=0),
@@ -217,7 +196,6 @@ class TestRunSessionStepOnModelError:
             await run_session_step("sess_x")
 
         mock_step_dependencies.defer_retry.assert_awaited_once_with("sess_x", delay_seconds=2)
-        # Status transitions to rescheduling, not idle/error.
         status_calls = [call.args[2] for call in mock_step_dependencies.set_status.call_args_list]
         assert "rescheduling" in status_calls
         assert "idle" not in status_calls
@@ -225,9 +203,6 @@ class TestRunSessionStepOnModelError:
     async def test_exhausted_budget_raises_and_sets_idle_error(
         self, mock_step_dependencies: Any
     ) -> None:
-        """After 4 consecutive reschedules, give up: idle/error + re-raise."""
-        from aios.harness.loop import run_session_step
-
         with (
             patch(
                 "aios.harness.loop._count_consecutive_rescheduling",
@@ -238,7 +213,6 @@ class TestRunSessionStepOnModelError:
             await run_session_step("sess_x")
 
         mock_step_dependencies.defer_retry.assert_not_awaited()
-        # Final status is idle with error stop_reason.
         idle_call = next(
             call
             for call in mock_step_dependencies.set_status.call_args_list


### PR DESCRIPTION
## Summary

- Replaces the fixed-5s / 2-attempt retry logic in ``run_session_step``'s exception handler with exponential backoff ``[2, 8, 30, 120]`` seconds over 4 attempts before giving up
- Extracts the delayed-wake defer into a new ``wake.defer_retry_wake`` helper symmetric to the existing ``defer_wake``, so it can be mocked in tests the same way and narrows the over-broad ``except Exception`` swallow to just ``AlreadyEnqueued``
- No exception classification — per CLAUDE.md's "extreme simplicity" mandate, any exception from ``stream_litellm`` is treated as transient and gets the same retry budget

## Why

Live smoke test on session ``sess_01KPCX6P484PAHSQ53AHBTB498`` showed ~35 seconds of dead air after an OpenRouter stream abort: the step deferred a single 5s retry, but that retry collided with an in-flight sweep-queued wake (swallowed as ``AlreadyEnqueued``), leaving the session to wait on the 30s periodic sweep. The 2-attempt budget also gives up in just 15s of wall time — tight for real provider hiccups. See #54 for the observation and fix sketch.

## Design

- ``loop._retry_delay_for_attempt(attempt)`` — pure lookup into the backoff table, returns ``None`` when the budget is exhausted so the caller surfaces the error instead of retrying
- ``wake.defer_retry_wake(session_id, *, delay_seconds)`` — thin wrapper around ``configure_task(...).defer_async(schedule_in=...)``, swallows only ``AlreadyEnqueued``. A dedup-rejected retry is benign: the queued wake will fire, hit the same error, and the handler defers a fresh retry
- Reuses ``_count_consecutive_rescheduling``'s existing "reset streak on non-rescheduling tail" semantic — a successful turn between failures wipes the budget so the next failure starts fresh at 2s

Invariants from CLAUDE.md "Key invariants" list are preserved: gapless seq, monotonic context, ``reacting_to``, tool-always-appends-result, procrastinate locks, NOTIFY-after-commit.

## Scope notes

- **``AlreadyEnqueued`` collisions**: still possible when the sweep races a retry defer. Approximate-backoff is acceptable for the first iteration since the sweep wake re-enters the handler anyway.
- **Rate-limit ``Retry-After`` honoring**: punted. The 4-attempt budget caps 429 thrash at ~2.5 minutes.
- **``ContextWindowExceededError``**: will exhaust the budget rather than fast-fail. Wastes ~2.5 minutes but no worse than the current 15s × ∞ windowing issue — proper fix is dynamic windowing, out of scope.

## Test plan

TDD: 9 new unit tests in ``tests/unit/test_loop_retry.py``.

- [x] 5 pure-function tests for ``_retry_delay_for_attempt`` (attempts 0–3 return 2/8/30/120, attempt 4 returns ``None``)
- [x] 2 tests for ``_count_consecutive_rescheduling`` (empty log + streak-reset regression)
- [x] 2 tests for the full exception handler: first-attempt defers with 2s; exhausted-budget raises and idles with ``stop_reason={"type": "error"}``
- [x] ``uv run pytest tests/unit -q`` — 637 passed in ~3s (was 628)
- [x] ``uv run mypy src`` — clean
- [x] ``uv run ruff check src tests && ruff format --check`` — clean
- [ ] E2E tier (Docker) — not run locally; ``tests/e2e/conftest.py`` now mocks ``defer_retry_wake`` so existing flows are unaffected
- [ ] Manual smoke: simulate a provider outage with ``OPENROUTER_API_KEY`` set to garbage for 10s; observe lifecycle events at 2s / 8s intervals rather than the 30s periodic-sweep cadence

🤖 Generated with [Claude Code](https://claude.com/claude-code)