### PR TITLE
refactor(channels): reframe INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER as model's own protocol

### DIFF
--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -14,7 +14,7 @@ from aios.models.channel_bindings import ChannelBinding
 from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX, Connection
 from aios.models.events import Event
 
-MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE: "
+MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: "
 
 # Key under a switch_channel tool_result's ``data["metadata"]`` that
 # records the target and outcome — ``{"target": str | None, "success": bool}``.

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -125,11 +125,10 @@ def build_focal_paradigm_block(bindings: list[ChannelBinding]) -> str:
         "When focused on a channel, the connector's response tools "
         "(e.g. `signal_send`, `signal_react`) operate on your focal "
         "channel implicitly — no channel/chat-id argument required. "
-        "Bare assistant text is NOT delivered to any channel; it is "
-        f"internal thinking and will be prefixed with "
-        f"{MONOLOGUE_PREFIX.strip()!r} in your history as a reminder "
-        "that no human saw it. This is the teaching mechanism; do not "
-        "strip it on replay.\n"
+        "Bare assistant text is NOT delivered to any channel — it is "
+        "private thinking no human sees. Prefix any such thinking with "
+        f"{MONOLOGUE_PREFIX.strip()!r} so it is unambiguous in your "
+        "history that you understood it was internal.\n"
         "\n"
         "### Timing\n"
         "\n"
@@ -339,9 +338,10 @@ def _prefix_text(s: str) -> str:
 def apply_monologue_prefix(assistant_msg: dict[str, Any]) -> dict[str, Any]:
     """Prefix every text segment of an assistant message's content.
 
-    The prefix is persisted in the event log — the model seeing its
-    own prefix on every subsequent step IS the teaching mechanism.
-    Do not strip on replay.
+    Safety net: the paradigm prose instructs the model to prefix its own
+    bare text; this fills in the prefix when it forgets, so the log is
+    uniform from the model's perspective on replay. Idempotent — see
+    :func:`_prefix_text`.
     """
     content = assistant_msg.get("content")
     if not content:

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -346,12 +346,15 @@ class TestApplyMonologuePrefix:
     def test_string_content_prefixed(self) -> None:
         msg: dict[str, Any] = {"role": "assistant", "content": "thinking out loud"}
         out = apply_monologue_prefix(msg)
-        assert out["content"] == "INTERNAL_MONOLOGUE: thinking out loud"
+        assert out["content"] == "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: thinking out loud"
 
     def test_already_prefixed_string_unchanged(self) -> None:
-        msg: dict[str, Any] = {"role": "assistant", "content": "INTERNAL_MONOLOGUE: hi"}
+        msg: dict[str, Any] = {
+            "role": "assistant",
+            "content": "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: hi",
+        }
         out = apply_monologue_prefix(msg)
-        assert out["content"] == "INTERNAL_MONOLOGUE: hi"
+        assert out["content"] == "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: hi"
 
     def test_empty_string_left_alone(self) -> None:
         msg: dict[str, Any] = {"role": "assistant", "content": ""}
@@ -384,9 +387,9 @@ class TestApplyMonologuePrefix:
         }
         out = apply_monologue_prefix(msg)
         blocks = out["content"]
-        assert blocks[0] == {"type": "text", "text": "INTERNAL_MONOLOGUE: first"}
+        assert blocks[0] == {"type": "text", "text": "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: first"}
         assert blocks[1] == {"type": "tool_use", "id": "x", "name": "y", "input": {}}
-        assert blocks[2] == {"type": "text", "text": "INTERNAL_MONOLOGUE: second"}
+        assert blocks[2] == {"type": "text", "text": "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: second"}
 
     def test_list_content_tool_use_only_left_alone(self) -> None:
         msg: dict[str, Any] = {
@@ -401,13 +404,13 @@ class TestApplyMonologuePrefix:
         msg: dict[str, Any] = {
             "role": "assistant",
             "content": [
-                {"type": "text", "text": "INTERNAL_MONOLOGUE: first"},
+                {"type": "text", "text": "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: first"},
                 {"type": "text", "text": "second"},
             ],
         }
         out = apply_monologue_prefix(msg)
-        assert out["content"][0]["text"] == "INTERNAL_MONOLOGUE: first"
-        assert out["content"][1]["text"] == "INTERNAL_MONOLOGUE: second"
+        assert out["content"][0]["text"] == "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: first"
+        assert out["content"][1]["text"] == "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: second"
 
     def test_returns_new_dict_preserving_other_fields(self) -> None:
         msg: dict[str, Any] = {


### PR DESCRIPTION
## Summary

- Paradigm prose previously told the model we prefix its bare text with `INTERNAL_MONOLOGUE:` on its behalf ("will be prefixed...", "this is the teaching mechanism"). Invert the framing: instruct the model to prefix its own thinking.
- `apply_monologue_prefix` becomes an invisible safety net when the model forgets — already idempotent via `_prefix_text`, so no behavior change.
- From the model's perspective, the prefix is always its own.

## Context

Alternative considered in #62: add a `no_response(reason)` built-in tool (ported from Jarvis's `NoResponse`). Decided against — INTERNAL_MONOLOGUE already covers the "agent thought and chose silence" case with richer content (the actual thinking) than a reason string. Jarvis needed `NoResponse` because its Stop-hook enforcement requires a tool call to unblock a turn; aios has no such constraint. See #62 for the full comparison; this PR is the lighter-touch alternative.

## Test plan

- [x] `uv run pytest tests/unit -q` — all 628 pass
- [x] `uv run ruff check src tests && uv run ruff format --check src tests`
- [x] `uv run mypy src`
- [x] Idempotency of `_prefix_text` verified via existing `test_applies_prefix_to_string_content` / `test_does_not_double_prefix` cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)