### PR TITLE
fix(channels): stamp monologue prefix on first text block only

### DIFF
--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -336,12 +336,18 @@ def _prefix_text(s: str) -> str:
 
 
 def apply_monologue_prefix(assistant_msg: dict[str, Any]) -> dict[str, Any]:
-    """Prefix every text segment of an assistant message's content.
+    """Prefix the *start* of an assistant message's text content.
 
-    Safety net: the paradigm prose instructs the model to prefix its own
-    bare text; this fills in the prefix when it forgets, so the log is
-    uniform from the model's perspective on replay. Idempotent — see
-    :func:`_prefix_text`.
+    Safety net: the paradigm prose instructs the model to open its bare
+    text with the prefix; this fills in the prefix when it forgets, so
+    the log is uniform on replay. Idempotent — see :func:`_prefix_text`.
+
+    For list-shaped content (providers that emit a reasoning block first
+    or interleave text with tool_use blocks), the prefix is stamped on
+    the *first* text block only — the message is one logical turn, and
+    stamping every text segment produced double/triple prefixes in the
+    log (observed on Gemma, which emits a ``thought\\n...`` text block
+    followed by the actual response).
     """
     content = assistant_msg.get("content")
     if not content:
@@ -349,11 +355,13 @@ def apply_monologue_prefix(assistant_msg: dict[str, Any]) -> dict[str, Any]:
     if isinstance(content, str):
         return {**assistant_msg, "content": _prefix_text(content)}
     if isinstance(content, list):
-        new_blocks: list[Any] = [
-            {**b, "text": _prefix_text(b.get("text", ""))}
-            if isinstance(b, dict) and b.get("type") == "text"
-            else b
-            for b in content
-        ]
+        new_blocks: list[Any] = []
+        prefixed = False
+        for block in content:
+            if not prefixed and isinstance(block, dict) and block.get("type") == "text":
+                new_blocks.append({**block, "text": _prefix_text(block.get("text", ""))})
+                prefixed = True
+            else:
+                new_blocks.append(block)
         return {**assistant_msg, "content": new_blocks}
     return assistant_msg

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -372,10 +372,11 @@ class TestApplyMonologuePrefix:
         out = apply_monologue_prefix(msg)
         assert "content" not in out
 
-    def test_list_content_all_text_blocks_prefixed(self) -> None:
-        """Multi-block content must prefix EVERY text block — not just the
-        first — so providers that interleave text with tool_use don't leave
-        later text segments unmarked.
+    def test_list_content_only_first_text_block_prefixed(self) -> None:
+        """Multi-block content must prefix ONLY the first text block.  The
+        assistant message is one logical turn; stamping every text segment
+        produced double/triple prefixes on providers (e.g. Gemma) that emit
+        a reasoning block before the actual response.
         """
         msg: dict[str, Any] = {
             "role": "assistant",
@@ -389,7 +390,7 @@ class TestApplyMonologuePrefix:
         blocks = out["content"]
         assert blocks[0] == {"type": "text", "text": "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: first"}
         assert blocks[1] == {"type": "tool_use", "id": "x", "name": "y", "input": {}}
-        assert blocks[2] == {"type": "text", "text": "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: second"}
+        assert blocks[2] == {"type": "text", "text": "second"}
 
     def test_list_content_tool_use_only_left_alone(self) -> None:
         msg: dict[str, Any] = {
@@ -399,8 +400,11 @@ class TestApplyMonologuePrefix:
         out = apply_monologue_prefix(msg)
         assert out["content"] == [{"type": "tool_use", "id": "x", "name": "y", "input": {}}]
 
-    def test_list_content_mixed_already_prefixed(self) -> None:
-        """Idempotent on a per-block basis."""
+    def test_list_content_first_block_already_prefixed_is_idempotent(self) -> None:
+        """When the first text block already carries the prefix, the call
+        is a no-op — no double-prefix, and subsequent blocks still stay
+        un-stamped (see :func:`apply_monologue_prefix`).
+        """
         msg: dict[str, Any] = {
             "role": "assistant",
             "content": [
@@ -410,7 +414,7 @@ class TestApplyMonologuePrefix:
         }
         out = apply_monologue_prefix(msg)
         assert out["content"][0]["text"] == "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: first"
-        assert out["content"][1]["text"] == "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: second"
+        assert out["content"][1]["text"] == "second"
 
     def test_returns_new_dict_preserving_other_fields(self) -> None:
         msg: dict[str, Any] = {


### PR DESCRIPTION
## Summary

``apply_monologue_prefix`` was walking every text block in list-shaped assistant content and prepending the prefix to each.  On providers that emit a reasoning-style first text block (observed: Gemma 4 with a leading ``thought\n...`` followed by the actual response), the result was two (or more) ``INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER:`` prefixes in the log from a single assistant turn — doubling prefix token cost and producing a confusing event log.

Stamp only the first text block.  The assistant message is one logical turn; the prefix marks the *start* of the agent's bare text as internal monologue.  Later text blocks are part of the same logical output and don't need their own prefix.

## Test plan

- [x] ``test_list_content_all_text_blocks_prefixed`` renamed to ``test_list_content_only_first_text_block_prefixed`` — asserts only ``block[0]`` is prefixed; the trailing text block after a ``tool_use`` stays bare
- [x] ``test_list_content_mixed_already_prefixed`` renamed to ``..._first_block_already_prefixed_is_idempotent`` — when ``block[0]`` already carries the prefix, the call is a no-op and ``block[1]`` stays bare
- [x] Existing string-content tests unchanged and still pass
- [x] ``uv run pytest tests/unit -q`` — 647 pass
- [x] ``uv run mypy src``, ``uv run ruff check``, ``uv run ruff format --check`` all clean

## Related

Observed during today's Signal smoke test; one of the low-priority items noted in ``SMOKE_TEST_NOTES.md`` under "Gemma multi-block monologue creates double-prefix."  Not a regression caused by the recent #72 reframe — the same bug existed under the old ``INTERNAL_MONOLOGUE:`` prefix name but has the same shape under the new name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)