### PR TITLE
feat(channels): label channel identifiers as channel_id everywhere

### DIFF
--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -99,7 +99,8 @@ def build_focal_paradigm_block(bindings: list[ChannelBinding]) -> str:
         "render in full in your context; inbound on other bound "
         "channels render as short notification markers (🔔 ...). "
         "The listing at the tail of your context shows the current "
-        "state:\n"
+        "state, with each channel's `channel_id=<id>` explicitly "
+        "labelled:\n"
         "\n"
         "* ▸ — your focal channel.\n"
         "* ○ — another bound channel, with unread count + preview.\n"
@@ -107,14 +108,17 @@ def build_focal_paradigm_block(bindings: list[ChannelBinding]) -> str:
         "\n"
         "### Shifting focus\n"
         "\n"
-        "Call `switch_channel(target=<address>)` to focus on a "
-        "different bound channel. Its result is a re-orient block "
+        "Call `switch_channel(channel_id=<id>)` to focus on a "
+        "different bound channel — copy the `channel_id` value from "
+        "the tail block listing or from the `channel_id=<id>` field "
+        "of a notification marker.  Its result is a re-orient block "
         "quoting recent messages on that channel so you can pick up "
-        "the conversation in context. Call `switch_channel(target=null)` "
-        "to put your phone down — every inbound renders as a "
-        "notification, connector response tools disappear from your "
-        "tool list. Switching repeatedly is cheap but not free: each "
-        "switch's re-orient block appends tokens to your context.\n"
+        "the conversation in context.  Call "
+        "`switch_channel(channel_id=null)` to put your phone down — "
+        "every inbound renders as a notification, connector response "
+        "tools disappear from your tool list.  Switching repeatedly "
+        "is cheap but not free: each switch's re-orient block appends "
+        "tokens to your context.\n"
         "\n"
         "### Responding\n"
         "\n"
@@ -184,11 +188,11 @@ def build_channels_tail_block(
         addr = b.address
         muted = b.notification_mode == "silent"
         if addr == focal_channel:
-            lines.append(f"▸ {addr} (focal)")
+            lines.append(f"▸ channel_id={addr} (focal)")
             continue
         count = unread.get(addr, 0)
         if muted:
-            lines.append(f"◌ {addr} (muted) — {count} unread")
+            lines.append(f"◌ channel_id={addr} (muted) — {count} unread")
             continue
         if count > 0:
             preview = last_content.get(addr, "")
@@ -196,9 +200,9 @@ def build_channels_tail_block(
             if len(preview) > 60:
                 preview = preview[:60] + "…"
             preview_clause = f': "{preview}"' if preview else ""
-            lines.append(f"○ {addr} — {count} unread{preview_clause}")
+            lines.append(f"○ channel_id={addr} — {count} unread{preview_clause}")
         else:
-            lines.append(f"○ {addr} — 0 unread")
+            lines.append(f"○ channel_id={addr} — 0 unread")
     return {"role": "user", "content": "\n".join(lines)}
 
 

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -137,13 +137,16 @@ def _format_notification_marker(
 
     Shape::
 
-        🔔 <orig_channel> · from=<sender_name> · <preview>
+        🔔 channel_id=<orig_channel> · from=<sender_name> · <preview>
+        (to respond, call switch_channel(channel_id=<orig_channel>) first)
 
     The ``from`` clause is omitted when ``sender_name`` is absent from
     metadata.  The preview clause is omitted when content is empty and
-    there's no reaction to surface.
+    there's no reaction to surface.  The trailing hint line is always
+    emitted — it tells the reader how to turn this notification into
+    full-content context.
     """
-    parts = [f"🔔 {orig_channel}"]
+    parts = [f"🔔 channel_id={orig_channel}"]
     if isinstance(metadata, dict):
         sender_name = metadata.get("sender_name")
         if isinstance(sender_name, str) and sender_name:
@@ -151,7 +154,9 @@ def _format_notification_marker(
     preview = _notification_preview(content, metadata)
     if preview:
         parts.append(preview)
-    return " · ".join(parts)
+    header = " · ".join(parts)
+    hint = f"(to respond, call switch_channel(channel_id={orig_channel!r}) first)"
+    return f"{header}\n{hint}"
 
 
 def render_user_event(

--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -46,30 +46,34 @@ SWITCH_CHANNEL_DESCRIPTION = (
     "Shift your attention to a different bound channel, or put your phone "
     "down entirely. When focused on a channel, inbound messages on that "
     "channel render in full; inbound on other channels show up as short "
-    "notification markers in your context. Call switch_channel(target=<address>) "
-    "to focus on a bound channel, or switch_channel(target=null) to clear "
+    "notification markers in your context. Call "
+    "switch_channel(channel_id=<id>) to focus on a bound channel — use one "
+    "of the channel_ids listed in the channels tail block or named in a "
+    "notification marker. Call switch_channel(channel_id=null) to clear "
     "focal (no channel focused; all inbound renders as notifications). "
     "On a real switch the tool result includes a recap block: peer "
     "inbound messages on the target channel plus the tool_calls you "
     "made while focused there (which is where your outbound sends live "
     "— e.g. signal_send arguments). Your bare assistant text is "
     "internal monologue and is dropped from recaps. A call whose "
-    "target already equals your current focal is a no-op — no recap, "
-    "no re-emit."
+    "channel_id already equals your current focal is a no-op — no "
+    "recap, no re-emit."
 )
 
 SWITCH_CHANNEL_PARAMETERS_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "target": {
+        "channel_id": {
             "type": ["string", "null"],
             "description": (
-                "The channel address to focus on (must be a bound channel "
-                "on this session), or null to clear focal."
+                "The channel_id to focus on (must be a bound channel on "
+                "this session — look it up from the channels tail block "
+                "or the most recent notification marker), or null to "
+                "clear focal."
             ),
         },
     },
-    "required": ["target"],
+    "required": ["channel_id"],
     "additionalProperties": False,
 }
 
@@ -83,10 +87,10 @@ async def switch_channel_handler(session_id: str, arguments: dict[str, Any]) -> 
     current focal) return a terse ack with empty metadata — they didn't
     actually change the agent's attention and shouldn't anchor anything.
     """
-    target = arguments.get("target")
+    target = arguments.get("channel_id")
     if target is not None and not isinstance(target, str):
         return ToolResult(
-            content=("Invalid target: must be a channel address string or null."),
+            content=("Invalid channel_id: must be a channel_id string or null."),
             metadata={
                 SWITCH_CHANNEL_METADATA_KEY: {"target": None, "success": False},
             },

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -318,7 +318,7 @@ class TestSwitchChannelHandler:
         connection = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
         session_id, _e, address = await _post_inbound(runtime_pool, connection, "chat-1")
 
-        result = await switch_channel_handler(session_id, {"target": address})
+        result = await switch_channel_handler(session_id, {"channel_id": address})
 
         assert result.is_error is False
         assert await _get_session_focal(runtime_pool, session_id) == address
@@ -339,7 +339,7 @@ class TestSwitchChannelHandler:
         session_id, _e, address = await _post_inbound(runtime_pool, connection, "chat-1")
         await _set_focal(runtime_pool, session_id, address)
 
-        result = await switch_channel_handler(session_id, {"target": None})
+        result = await switch_channel_handler(session_id, {"channel_id": None})
 
         assert result.is_error is False
         assert await _get_session_focal(runtime_pool, session_id) is None
@@ -360,7 +360,7 @@ class TestSwitchChannelHandler:
         session_id, _e, address = await _post_inbound(runtime_pool, connection, "chat-1")
         await _set_focal(runtime_pool, session_id, address)  # focus on A
 
-        result = await switch_channel_handler(session_id, {"target": "signal/other/fake"})
+        result = await switch_channel_handler(session_id, {"channel_id": "signal/other/fake"})
 
         assert result.is_error is True
         # Focal is unchanged after an invalid switch.
@@ -386,7 +386,7 @@ class TestSwitchChannelHandler:
         for i in range(3):
             await _post_inbound(runtime_pool, connection, "chat-1", content=f"msg-{i}")
 
-        result = await switch_channel_handler(session_id, {"target": address})
+        result = await switch_channel_handler(session_id, {"channel_id": address})
 
         content = result.content
         assert isinstance(content, str)
@@ -417,7 +417,7 @@ class TestSwitchChannelHandler:
         )
         await _post_inbound(runtime_pool, connection, "chat-1", content="only-two")
 
-        result = await switch_channel_handler(session_id, {"target": address})
+        result = await switch_channel_handler(session_id, {"channel_id": address})
         content = result.content
         assert isinstance(content, str)
         assert "only-one" in content
@@ -449,7 +449,7 @@ class TestSwitchChannelHandler:
                 runtime_pool, connection, "chat-1", content=f"unread-{i:02d} {body}"
             )
 
-        result = await switch_channel_handler(session_id, {"target": address})
+        result = await switch_channel_handler(session_id, {"channel_id": address})
         content = result.content
         assert isinstance(content, str)
         # Every unread message body should appear in the re-orient block.
@@ -480,7 +480,7 @@ class TestSwitchChannelHandler:
         # Sanity check session exists.
         await sess_svc.get_session(runtime_pool, session_id)
 
-        result = await switch_channel_handler(session_id, {"target": unused_address})
+        result = await switch_channel_handler(session_id, {"channel_id": unused_address})
         content = result.content
         assert isinstance(content, str)
         assert "no prior messages on this channel" in content
@@ -508,7 +508,7 @@ class TestSwitchChannelNoOp:
         session_id, _e, address = await _post_inbound(runtime_pool, connection, "chat-1")
         await _set_focal(runtime_pool, session_id, address)
 
-        result = await switch_channel_handler(session_id, {"target": address})
+        result = await switch_channel_handler(session_id, {"channel_id": address})
 
         assert result.is_error is False
         assert result.content == f"Focal channel is already {address}."
@@ -534,7 +534,7 @@ class TestSwitchChannelNoOp:
         # _post_inbound leaves focal = None (phone down) by default.
         assert await _get_session_focal(runtime_pool, session_id) is None
 
-        result = await switch_channel_handler(session_id, {"target": None})
+        result = await switch_channel_handler(session_id, {"channel_id": None})
 
         assert result.is_error is False
         assert result.content == "Focal channel is already None."
@@ -565,7 +565,7 @@ class TestSwitchChannelNoOp:
         session_id, _e, address = await _post_inbound(runtime_pool, connection, "chat-1")
         await _set_focal(runtime_pool, session_id, address)
 
-        result = await switch_channel_handler(session_id, {"target": address})
+        result = await switch_channel_handler(session_id, {"channel_id": address})
         assert result.metadata == {}
 
         # The dispatch path stores ``ToolResult.metadata`` under the
@@ -778,7 +778,7 @@ class TestSwitchChannelAsEvent:
                             "type": "function",
                             "function": {
                                 "name": "switch_channel",
-                                "arguments": json.dumps({"target": address}),
+                                "arguments": json.dumps({"channel_id": address}),
                             },
                         }
                     ],
@@ -793,7 +793,7 @@ class TestSwitchChannelAsEvent:
                     "type": "function",
                     "function": {
                         "name": "switch_channel",
-                        "arguments": json.dumps({"target": address}),
+                        "arguments": json.dumps({"channel_id": address}),
                     },
                 }
             ],
@@ -1027,7 +1027,7 @@ class TestOraSmokeTestRegression:
 
         # Agent switches back to the DM.  Re-orient block must include
         # BOTH the "I'm Ora" seed and the "you sure" follow-up.
-        result = await switch_channel_handler(session_id, {"target": dm_address})
+        result = await switch_channel_handler(session_id, {"channel_id": dm_address})
         content = result.content
         assert isinstance(content, str)
         assert "I'm Ora" in content, f"missing referent in re-orient block:\n{content}"
@@ -1100,7 +1100,7 @@ class TestTailBlockInStep:
         content = msg_text(messages[-1])
         assert "━━━ Channels ━━━" in content
         # NULL focal at this point → no ▸ marker, the one binding appears as ○.
-        assert f"○ {address}" in content
+        assert f"○ channel_id={address}" in content
         assert "▸" not in content
 
     async def test_tail_block_reflects_focal_and_unread_changes(
@@ -1167,8 +1167,8 @@ class TestTailBlockInStep:
         messages = harness.model_calls[-1]["messages"]
         assert messages[-1]["role"] == "user"
         content_step1 = msg_text(messages[-1])
-        assert f"▸ {address_a} (focal)" in content_step1
-        assert f"○ {address_b} — 2 unread" in content_step1
+        assert f"▸ channel_id={address_a} (focal)" in content_step1
+        assert f"○ channel_id={address_b} — 2 unread" in content_step1
         assert "msg-b2" in content_step1  # preview of latest unread
 
         # Step 2: change focal to B and run again.  Tail block reflects.
@@ -1182,7 +1182,7 @@ class TestTailBlockInStep:
         harness.script_model([assistant("noted")])
         await harness.run_step(session_id)
         content_step2 = msg_text(harness.model_calls[-1]["messages"][-1])
-        assert f"▸ {address_b} (focal)" in content_step2
+        assert f"▸ channel_id={address_b} (focal)" in content_step2
         # A is now non-focal; no unread for A yet since we never switched
         # away after its last focal-stamp, but the listing should show it.
-        assert f"○ {address_a}" in content_step2
+        assert f"○ channel_id={address_a}" in content_step2

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -261,7 +261,7 @@ class TestBuildChannelsTailBlock:
         block = build_channels_tail_block([_binding(self._ALICE)], [], focal_channel=self._ALICE)
         assert block is not None
         content = block["content"]
-        assert "▸ signal/bot/alice (focal)" in content
+        assert "▸ channel_id=signal/bot/alice (focal)" in content
         # Focal line must not advertise an unread count — you ARE in it.
         # Check that no digit appears on the focal line.
         focal_line = next(ln for ln in content.splitlines() if "▸" in ln)
@@ -279,7 +279,7 @@ class TestBuildChannelsTailBlock:
         )
         assert block is not None
         content = block["content"]
-        assert "○ signal/bot/family — 2 unread" in content
+        assert "○ channel_id=signal/bot/family — 2 unread" in content
 
     def test_non_focal_preview_truncated(self) -> None:
         long = "x" * 200
@@ -313,7 +313,7 @@ class TestBuildChannelsTailBlock:
         )
         assert block is not None
         content = block["content"]
-        assert f"◌ {self._ANNOUNCEMENTS} (muted) — 1 unread" in content
+        assert f"◌ channel_id={self._ANNOUNCEMENTS} (muted) — 1 unread" in content
         # No preview (no quoted content).
         assert "system noise" not in content
 
@@ -343,7 +343,7 @@ class TestBuildChannelsTailBlock:
         )
         assert block is not None
         content = block["content"]
-        assert f"○ {self._FAMILY} — 0 unread" in content
+        assert f"○ channel_id={self._FAMILY} — 0 unread" in content
 
 
 # ── apply_monologue_prefix ─────────────────────────────────────────────────

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -950,7 +950,7 @@ class TestFocalRendering:
             )
         ]
         content = build_messages(events, system_prompt=None).messages[0]["content"]
-        assert content.startswith(f"🔔 {self._CHAN_B}")
+        assert content.startswith(f"🔔 channel_id={self._CHAN_B}")
         assert "from=Bob" in content
         assert "hey there" in content
 
@@ -959,17 +959,33 @@ class TestFocalRendering:
         md = {"channel": self._CHAN_B, "sender_name": "Bob"}
         events = [_evt(1, "user", content="hey", metadata=md, focal_channel_at_arrival=None)]
         content = build_messages(events, system_prompt=None).messages[0]["content"]
-        assert content.startswith(f"🔔 {self._CHAN_B}")
+        assert content.startswith(f"🔔 channel_id={self._CHAN_B}")
 
     def test_notification_omits_sender_when_absent(self) -> None:
-        """No sender_name → no ``from=`` clause, just channel + preview."""
+        """No sender_name → no ``from=`` clause, just channel + preview
+        on the header line.  Hint line follows unconditionally.
+        """
         md = {"channel": self._CHAN_B}
         events = [
             _evt(1, "user", content="hey", metadata=md, focal_channel_at_arrival=self._CHAN_A)
         ]
         content = build_messages(events, system_prompt=None).messages[0]["content"]
         assert "from=" not in content
-        assert content == f"🔔 {self._CHAN_B} · hey"
+        header, hint = content.split("\n", 1)
+        assert header == f"🔔 channel_id={self._CHAN_B} · hey"
+        assert hint.startswith("(to respond, call switch_channel(channel_id=")
+
+    def test_notification_hint_names_the_channel_id(self) -> None:
+        """The ``to respond...`` hint line includes the same channel_id
+        as the marker, so weaker models can copy-paste it directly into
+        a ``switch_channel`` call.
+        """
+        md = {"channel": self._CHAN_B, "sender_name": "Bob"}
+        events = [
+            _evt(1, "user", content="hey", metadata=md, focal_channel_at_arrival=self._CHAN_A)
+        ]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert f"switch_channel(channel_id='{self._CHAN_B}')" in content
 
     def test_notification_truncation_at_80_chars(self) -> None:
         long = "x" * 200
@@ -1015,7 +1031,7 @@ class TestFocalRendering:
             focal_channel_at_arrival=self._CHAN_A,
         )
         msgs = build_messages([ev_early, ev_late], system_prompt=None).messages
-        assert msgs[0]["content"].startswith(f"🔔 {self._CHAN_B}")
+        assert msgs[0]["content"].startswith(f"🔔 channel_id={self._CHAN_B}")
         assert msgs[1]["content"].startswith(f"[channel={self._CHAN_A}")
 
 


### PR DESCRIPTION
## Summary

Live-observed failure mode on weaker models (minimax m2.7, kimi k2.6): ``switch_channel`` called with an opaque path they can't connect to the notification that prompted the call.  The paradigm asks them to do four inference hops — ``"come in here"`` → match the preview against tail-block entries → extract the opaque UUID → pass it as ``target=``.  Stronger models (Opus, Qwen 3.6-plus, GLM-5.1) do it; weaker ones don't.

Collapse the four hops into a pattern-match by using one label name, ``channel_id``, in all three places the model sees channel identifiers.

## What changed

- **Tool parameter**: ``switch_channel(target=...)`` → ``switch_channel(channel_id=...)``.  Schema property renamed; handler looks up ``arguments.get("channel_id")``; tool description and paradigm prose updated.
- **Tail block listing**: each channel entry now prefixes its path with ``channel_id=``:
  ```
  ▸ channel_id=signal/37bdbafc.../xyz (focal)
  ○ channel_id=signal/37bdbafc.../abc — 3 unread: "latest preview..."
  ◌ channel_id=signal/37bdbafc.../def (muted) — 5 unread
  ```
- **Notification marker**: now renders as
  ```
  🔔 channel_id=signal/37bdbafc.../xyz · from=Tom · "hey come in here"
  (to respond, call switch_channel(channel_id='signal/37bdbafc.../xyz') first)
  ```
  The hint line names the exact id the model should pass — load-bearing for a weak model's copy-paste path.

## What's explicitly unchanged

The ``switch_channel`` tool_result marker metadata still carries ``{"target": X, "success": Y}``.  That's persisted on historical events and read by ``_switch_marker`` for watermark derivation.  Renaming would need a data migration for no visible benefit — only the user-facing surface renames.

## Live-validated

- **Minimax** on the new schema (no historical ``target=`` precedent in the live log): first ``switch_channel`` call used ``channel_id`` correctly.
- **Sonnet 4.6**, **Qwen 3.6-plus**, **GLM-5.1**, **Opus 4.7**: all transparently used ``channel_id`` on first attempt.
- When a model DOES slip back into ``target=...``, the concurrent tool-schema validation work (#82) surfaces a clear ``'channel_id' is a required property`` + ``'target' was unexpected`` error.  Same paradigm that was hot-looping on silent no-ops now self-corrects on the next step.

## Cost

Per-step tokens: ~ ``channel_id=`` (13 chars) × N bindings + the hint line on non-focal notifications.  For a typical 4-channel session with 1 notification per step, ~100 extra tokens.  Negligible for any session that's not already at the window cap.

## Test plan

- [x] ``tests/unit/test_channels_helpers.py`` — tail-block listing assertions updated to ``channel_id=`` format for focal/unread/muted/zero-unread cases
- [x] ``tests/unit/test_context.py`` — notification marker assertions updated; new ``test_notification_hint_names_the_channel_id`` asserts the hint line carries the id inline
- [x] ``uv run pytest tests/unit -q`` — 677 pass
- [x] ``uv run mypy src``, ``uv run ruff check``, ``uv run ruff format --check`` — all clean
- [x] Live validated on JN via Signal smoke test across 5 models tonight

## Related

- #82 — tool-schema validation.  Complements this PR: even with the new vocabulary, a misbehaving model's ``target=...`` slip now produces a surfaced error rather than a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)