### PR TITLE
feat(completion): surface LiteLLM cost_usd in model_request_end spans (closes #42)

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -2,9 +2,12 @@
 
 Provides two variants:
 
-* :func:`call_litellm` — non-streaming, returns ``(message, usage)``.
+* :func:`call_litellm` — non-streaming, returns ``(message, usage, cost)``.
 * :func:`stream_litellm` — streaming, delivers per-token deltas via
-  ``pg_notify`` and returns ``(message, usage)``.
+  ``pg_notify`` and returns ``(message, usage, cost)``.
+
+``cost`` is the LiteLLM-computed USD cost for the request, or ``None``
+when the provider/model didn't report one.
 
 Model API keys are resolved by LiteLLM from standard environment variables
 (``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``, etc.) based on the model string
@@ -157,6 +160,23 @@ def _is_empty_assistant(msg: dict[str, Any]) -> bool:
     return isinstance(content, list) and not content
 
 
+def _extract_cost(response: Any) -> float | None:
+    """Pull the per-request USD cost LiteLLM computes post-call.
+
+    LiteLLM populates ``response._hidden_params["response_cost"]`` during
+    its logging pipeline. Missing attribute, missing key, or ``None``
+    value all mean the provider didn't report cost — the harness passes
+    ``None`` through rather than guessing.
+    """
+    hidden = getattr(response, "_hidden_params", None)
+    if not hidden:
+        return None
+    cost = hidden.get("response_cost")
+    if cost is None:
+        return None
+    return float(cost)
+
+
 def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
     """Map LiteLLM's usage field names to our canonical names.
 
@@ -183,13 +203,14 @@ async def call_litellm(
     tools: list[dict[str, Any]] | None = None,
     api_base: str | None = None,
     extra: dict[str, Any] | None = None,
-) -> tuple[dict[str, Any], dict[str, int]]:
-    """Call ``litellm.acompletion`` and return ``(message, usage)``.
+) -> tuple[dict[str, Any], dict[str, int], float | None]:
+    """Call ``litellm.acompletion`` and return ``(message, usage, cost)``.
 
     Returns the message exactly as litellm produced it, including any
     provider-specific extensions like ``reasoning_content`` or
     ``thinking_blocks``. The harness stores the message dict opaquely.
-    Usage is normalized to our canonical field names.
+    Usage is normalized to our canonical field names. Cost is LiteLLM's
+    per-request USD figure, or ``None`` when the provider doesn't report it.
     """
     inject_cache_breakpoints(messages, tools)
 
@@ -209,13 +230,14 @@ async def call_litellm(
     usage = _normalize_usage(
         usage_obj.model_dump() if hasattr(usage_obj, "model_dump") else usage_obj or {}
     )
+    cost = _extract_cost(response)
     message = response["choices"][0]["message"]
     # litellm returns a Message object that supports model_dump()
     if hasattr(message, "model_dump"):
         result: dict[str, Any] = message.model_dump()
-        return _normalize_message(result), usage
+        return _normalize_message(result), usage, cost
     if isinstance(message, dict):
-        return _normalize_message(message), usage
+        return _normalize_message(message), usage, cost
     raise TypeError(f"unexpected message type from litellm.acompletion: {type(message).__name__}")
 
 
@@ -228,8 +250,8 @@ async def stream_litellm(
     extra: dict[str, Any] | None = None,
     pool: asyncpg.Pool[Any],
     session_id: str,
-) -> tuple[dict[str, Any], dict[str, int]]:
-    """Call ``litellm.acompletion`` with streaming, returning ``(message, usage)``.
+) -> tuple[dict[str, Any], dict[str, int], float | None]:
+    """Call ``litellm.acompletion`` with streaming, returning ``(message, usage, cost)``.
 
     Each content delta fires a transient ``pg_notify`` on the session's
     event channel. SSE clients receive these as ``event: delta`` — no DB
@@ -265,12 +287,13 @@ async def stream_litellm(
     usage = _normalize_usage(
         usage_obj.model_dump() if hasattr(usage_obj, "model_dump") else usage_obj or {}
     )
+    cost = _extract_cost(assembled)
     message = assembled["choices"][0]["message"]
     if hasattr(message, "model_dump"):
         result: dict[str, Any] = message.model_dump()
-        return _normalize_message(result), usage
+        return _normalize_message(result), usage, cost
     if isinstance(message, dict):
-        return _normalize_message(message), usage
+        return _normalize_message(message), usage, cost
     raise TypeError(f"unexpected message type from stream_chunk_builder: {type(message).__name__}")
 
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -194,7 +194,7 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
 
     # Call the model exactly once (streaming — deltas go to SSE via pg_notify).
     try:
-        assistant_msg, usage = await stream_litellm(
+        assistant_msg, usage, cost_usd = await stream_litellm(
             model=agent.model,
             messages=ctx.messages,
             tools=tools if tools else None,
@@ -212,6 +212,7 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
                 "model_request_start_id": start_event.id,
                 "is_error": True,
                 "model_usage": {},
+                "cost_usd": None,
             },
         )
 
@@ -231,7 +232,7 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
         await _append_lifecycle(pool, session_id, "turn_ended", "idle", "error")
         raise
 
-    # Emit span end with per-request token usage.
+    # Emit span end with per-request token usage and LiteLLM-reported cost.
     await sessions_service.append_event(
         pool,
         session_id,
@@ -241,6 +242,7 @@ async def run_session_step(session_id: str, *, cause: str = "message") -> None:
             "model_request_start_id": start_event.id,
             "is_error": False,
             "model_usage": usage,
+            "cost_usd": cost_usd,
         },
     )
 

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -1535,6 +1535,8 @@ class TestUsageTracking:
         assert end.data["is_error"] is False
         assert end.data["model_usage"]["input_tokens"] == 10
         assert end.data["model_usage"]["output_tokens"] == 5
+        assert "cost_usd" in end.data
+        assert end.data["cost_usd"] is None
 
     async def test_span_events_for_multi_step(self, harness: Harness) -> None:
         """Two model calls produce two span pairs."""

--- a/tests/unit/test_completion_cost.py
+++ b/tests/unit/test_completion_cost.py
@@ -1,0 +1,38 @@
+"""Tests for cost extraction in ``aios.harness.completion``."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from aios.harness.completion import _extract_cost
+
+
+class TestExtractCost:
+    def test_returns_float_when_hidden_params_has_response_cost(self) -> None:
+        response = SimpleNamespace(_hidden_params={"response_cost": 0.00342})
+        assert _extract_cost(response) == 0.00342
+
+    def test_returns_none_when_hidden_params_attribute_missing(self) -> None:
+        assert _extract_cost(SimpleNamespace()) is None
+
+    def test_returns_none_when_hidden_params_is_none(self) -> None:
+        response = SimpleNamespace(_hidden_params=None)
+        assert _extract_cost(response) is None
+
+    def test_returns_none_when_response_cost_key_missing(self) -> None:
+        response = SimpleNamespace(_hidden_params={})
+        assert _extract_cost(response) is None
+
+    def test_returns_none_when_response_cost_is_none(self) -> None:
+        response = SimpleNamespace(_hidden_params={"response_cost": None})
+        assert _extract_cost(response) is None
+
+    def test_returns_none_for_plain_dict_response(self) -> None:
+        """Plain dicts (used in e2e harness mocks) have no _hidden_params attr."""
+        assert _extract_cost({"choices": [], "usage": {}}) is None
+
+    def test_coerces_int_cost_to_float(self) -> None:
+        response = SimpleNamespace(_hidden_params={"response_cost": 1})
+        result = _extract_cost(response)
+        assert result == 1.0
+        assert isinstance(result, float)


### PR DESCRIPTION
## Summary

- LiteLLM already computes per-request USD cost during its logging pipeline and stashes it at \`response._hidden_params[\"response_cost\"]\`. We just weren't surfacing it.
- Added \`_extract_cost(response)\` (defensive lookup), widened \`call_litellm\` / \`stream_litellm\` return to \`(msg, usage, cost)\`, and emit \`cost_usd\` at the top level of the \`model_request_end\` span.
- \`cost_usd\` is always present in the span; value is \`None\` on error or when a provider doesn't report cost. Lets consumers do \`sum(s.cost_usd or 0 for s in spans)\` without \`.get()\`.

## Why it matters

External orchestrators (Paperclip et al.) can now enforce budgets without maintaining their own per-model / per-provider price tables or recomputing OpenRouter routing surcharges.

## Test plan

- [x] 7 new unit tests for \`_extract_cost\` (present / missing attr / attr=None / key missing / value=None / plain-dict / int→float)
- [x] e2e: \`test_span_events_emitted\` now asserts \`cost_usd\` is in the span (with \`None\` value, since scripted models don't populate \`_hidden_params\`)
- [x] \`uv run pytest tests/unit -q\` — 699 passed
- [x] \`uv run pytest tests/e2e -q\` (non-Docker subset) — 198 passed
- [x] mypy + ruff clean

Closes #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)