### PR TITLE
feat(agents): ?name= filter on GET /v1/agents for idempotent lookup (closes #41)

### DIFF
--- a/src/aios/api/routers/agents.py
+++ b/src/aios/api/routers/agents.py
@@ -35,8 +35,9 @@ async def list_(
     _auth: AuthDep,
     limit: int = 50,
     after: str | None = None,
+    name: str | None = None,
 ) -> ListResponse[Agent]:
-    items = await service.list_agents(pool, limit=limit, after=after)
+    items = await service.list_agents(pool, limit=limit, after=after, name=name)
     return ListResponse[Agent](
         data=items,
         has_more=len(items) == limit,

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -298,19 +298,23 @@ async def get_agent(conn: asyncpg.Connection[Any], agent_id: str) -> Agent:
 
 
 async def list_agents(
-    conn: asyncpg.Connection[Any], *, limit: int = 50, after: str | None = None
+    conn: asyncpg.Connection[Any],
+    *,
+    limit: int = 50,
+    after: str | None = None,
+    name: str | None = None,
 ) -> list[Agent]:
-    if after is None:
-        rows = await conn.fetch(
-            "SELECT * FROM agents WHERE archived_at IS NULL ORDER BY id DESC LIMIT $1",
-            limit,
-        )
-    else:
-        rows = await conn.fetch(
-            "SELECT * FROM agents WHERE archived_at IS NULL AND id < $1 ORDER BY id DESC LIMIT $2",
-            after,
-            limit,
-        )
+    where = ["archived_at IS NULL"]
+    args: list[Any] = []
+    if name is not None:
+        args.append(name)
+        where.append(f"name = ${len(args)}")
+    if after is not None:
+        args.append(after)
+        where.append(f"id < ${len(args)}")
+    args.append(limit)
+    sql = f"SELECT * FROM agents WHERE {' AND '.join(where)} ORDER BY id DESC LIMIT ${len(args)}"
+    rows = await conn.fetch(sql, *args)
     return [_row_to_agent(r) for r in rows]
 
 

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -63,10 +63,14 @@ async def get_agent(pool: asyncpg.Pool[Any], agent_id: str) -> Agent:
 
 
 async def list_agents(
-    pool: asyncpg.Pool[Any], *, limit: int = 50, after: str | None = None
+    pool: asyncpg.Pool[Any],
+    *,
+    limit: int = 50,
+    after: str | None = None,
+    name: str | None = None,
 ) -> list[Agent]:
     async with pool.acquire() as conn:
-        return await queries.list_agents(conn, limit=limit, after=after)
+        return await queries.list_agents(conn, limit=limit, after=after, name=name)
 
 
 async def archive_agent(pool: asyncpg.Pool[Any], agent_id: str) -> None:

--- a/tests/e2e/test_agents_api.py
+++ b/tests/e2e/test_agents_api.py
@@ -1,0 +1,100 @@
+"""E2E tests for the ``/v1/agents`` HTTP endpoints.
+
+Currently focused on the ``?name=`` filter introduced for issue #41
+(idempotent agent lookup by name).
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+
+import httpx
+import pytest
+
+
+def _uniq() -> str:
+    return secrets.token_hex(4)
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    settings = get_settings()
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+        headers={"Authorization": f"Bearer {aios_env['AIOS_API_KEY']}"},
+    ) as client:
+        yield client
+
+
+async def _create_agent(http_client: httpx.AsyncClient, name: str) -> str:
+    r = await http_client.post(
+        "/v1/agents",
+        json={
+            "name": name,
+            "model": "openai/gpt-4o-mini",
+            "system": "",
+            "tools": [],
+            "metadata": {},
+        },
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+class TestListAgentsNameFilter:
+    async def test_returns_matching_agent(self, http_client: httpx.AsyncClient) -> None:
+        target_name = f"target-{_uniq()}"
+        other_name = f"other-{_uniq()}"
+        target_id = await _create_agent(http_client, target_name)
+        await _create_agent(http_client, other_name)
+
+        r = await http_client.get("/v1/agents", params={"name": target_name})
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert len(body["data"]) == 1
+        assert body["data"][0]["id"] == target_id
+        assert body["data"][0]["name"] == target_name
+
+    async def test_returns_empty_when_no_match(self, http_client: httpx.AsyncClient) -> None:
+        r = await http_client.get("/v1/agents", params={"name": f"nonexistent-{_uniq()}"})
+
+        assert r.status_code == 200, r.text
+        assert r.json()["data"] == []
+
+    async def test_excludes_archived(self, http_client: httpx.AsyncClient) -> None:
+        name = f"archive-me-{_uniq()}"
+        agent_id = await _create_agent(http_client, name)
+
+        r = await http_client.delete(f"/v1/agents/{agent_id}")
+        assert r.status_code == 204, r.text
+
+        r = await http_client.get("/v1/agents", params={"name": name})
+        assert r.status_code == 200, r.text
+        assert r.json()["data"] == []


### PR DESCRIPTION
## Summary

- External orchestrators (e.g. Paperclip) own their agent identity by name but had to fetch the entire agent list to recover the aios id after a DB wipe. Now: \`GET /v1/agents?name=<str>\`.
- Refactored \`queries.list_agents\` two-branch if/else into an incremental where-clause + args list so adding filters stays linear, not combinatorial.
- Archived agents are excluded (matches existing \`archived_at IS NULL\` behavior). The partial unique index \`agents_name_uniq WHERE archived_at IS NULL\` guarantees at most one active row per name, so \`?name=\` returns 0 or 1.

## Why it matters

Resolves the \"POST → 409 → list-all → filter-client-side\" dance described in the issue. One round trip, server-side, works even with a Paperclip-sized deployment.

## Test plan

- [x] 3 new e2e tests in \`tests/e2e/test_agents_api.py\` covering: match, no-match, archived-excluded
- [x] \`uv run pytest tests/unit -q\` — 699 passed
- [x] \`uv run pytest tests/e2e -q\` — 201 passed (3 new + 198 existing)
- [x] mypy + ruff clean

Closes #41. Option B (upsert) left for a follow-up if still needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)