### PR TITLE
feat(api): long-poll endpoint GET /v1/sessions/:id/wait (closes #40)

### DIFF
--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -11,6 +11,7 @@ Postgres ``LISTEN``/``NOTIFY``.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Query, status
@@ -23,6 +24,7 @@ from aios.api.deps import (
     ProcrastinateDep,
 )
 from aios.api.sse import sse_event_stream
+from aios.db.listen import listen_for_events
 from aios.harness.wake import defer_wake
 from aios.models.common import ListResponse
 from aios.models.events import Event, EventKind
@@ -34,6 +36,7 @@ from aios.models.sessions import (
     SessionUserMessage,
     ToolConfirmationRequest,
     ToolResultRequest,
+    WaitResponse,
 )
 from aios.services import sessions as service
 
@@ -225,4 +228,53 @@ async def stream_events(
     return EventSourceResponse(
         sse_event_stream(db_url, pool, session_id, after_seq=after_seq),
         ping=15,
+    )
+
+
+@router.get("/{session_id}/wait")
+async def wait_for_events(
+    session_id: str,
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    _auth: AuthDep,
+    after_seq: int = 0,
+    timeout_seconds: Annotated[int, Query(alias="timeout", ge=0, le=60)] = 30,
+) -> WaitResponse:
+    """Long-poll for new events past ``after_seq``.
+
+    Blocks up to ``timeout`` seconds for events to arrive; returns an empty
+    list if none land in time. Alternative to SSE for clients whose HTTP
+    stack can't reliably consume server-sent events (notably Node's
+    ``fetch`` — see issue #40).
+    """
+    await service.get_session(pool, session_id)
+
+    async with listen_for_events(db_url, session_id) as queue:
+        events = await service.read_events(pool, session_id, after_seq=after_seq)
+        if not events and timeout_seconds > 0:
+            # The channel carries both committed-event IDs and transient
+            # streaming delta payloads (shaped like {"delta": "..."}); only
+            # the former advance the log, so delta pokes must not count
+            # against the wait budget.
+            deadline = asyncio.get_running_loop().time() + timeout_seconds
+            while True:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    break
+                try:
+                    payload = await asyncio.wait_for(queue.get(), timeout=remaining)
+                except TimeoutError:
+                    break
+                if payload.startswith("{"):
+                    continue
+                events = await service.read_events(pool, session_id, after_seq=after_seq)
+                if events:
+                    break
+
+    session = await service.get_session(pool, session_id)
+    return WaitResponse(
+        events=events,
+        session_status=session.status,
+        session_stop_reason=session.stop_reason,
+        next_after=events[-1].seq if events else after_seq,
     )

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -14,6 +14,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from aios.models.events import Event
+
 SessionStatus = Literal["running", "idle", "rescheduling", "terminated"]
 
 
@@ -143,6 +145,15 @@ class ToolResultRequest(BaseModel):
     tool_call_id: str = Field(description="The tool_call_id from the assistant's tool_calls.")
     content: str = Field(description="The result of executing the tool.")
     is_error: bool = Field(default=False, description="True if the tool execution failed.")
+
+
+class WaitResponse(BaseModel):
+    """Response for ``GET /v1/sessions/{id}/wait``."""
+
+    events: list[Event]
+    session_status: SessionStatus
+    session_stop_reason: dict[str, Any] | None
+    next_after: int
 
 
 class ToolConfirmationRequest(BaseModel):

--- a/tests/e2e/test_wait_endpoint.py
+++ b/tests/e2e/test_wait_endpoint.py
@@ -1,0 +1,192 @@
+"""E2E tests for the ``GET /v1/sessions/{id}/wait`` long-poll endpoint (issue #40)."""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+
+import httpx
+import pytest
+
+
+def _uniq() -> str:
+    return secrets.token_hex(4)
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    settings = get_settings()
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+        headers={"Authorization": f"Bearer {aios_env['AIOS_API_KEY']}"},
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def session_id(pool: Any) -> str:
+    from aios.db import queries
+    from aios.services import agents as agents_svc
+    from aios.services import sessions as sessions_svc
+
+    async with pool.acquire() as conn:
+        env = await queries.insert_environment(conn, name=f"wait-env-{_uniq()}")
+    agent = await agents_svc.create_agent(
+        pool,
+        name=f"wait-agent-{_uniq()}",
+        model="openai/gpt-4o-mini",
+        system="",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    session = await sessions_svc.create_session(
+        pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+    )
+    return session.id
+
+
+class TestWaitEndpoint:
+    async def test_returns_existing_events_immediately(
+        self, http_client: httpx.AsyncClient, pool: Any, session_id: str
+    ) -> None:
+        from aios.services import sessions as sessions_svc
+
+        await sessions_svc.append_user_message(pool, session_id, "hello")
+
+        r = await http_client.get(
+            f"/v1/sessions/{session_id}/wait",
+            params={"after_seq": 0, "timeout": 30},
+        )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert len(body["events"]) >= 1
+        assert any(
+            e["kind"] == "message" and e["data"].get("content") == "hello" for e in body["events"]
+        )
+        assert body["next_after"] == body["events"][-1]["seq"]
+        assert body["session_status"] in {"idle", "running"}
+
+    async def test_empty_after_timeout(
+        self, http_client: httpx.AsyncClient, session_id: str
+    ) -> None:
+        r = await http_client.get(
+            f"/v1/sessions/{session_id}/wait",
+            params={"after_seq": 9999, "timeout": 1},
+        )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["events"] == []
+        assert body["next_after"] == 9999
+
+    async def test_unblocks_on_new_event(
+        self, http_client: httpx.AsyncClient, pool: Any, session_id: str
+    ) -> None:
+        from aios.services import sessions as sessions_svc
+
+        async def wait_call() -> httpx.Response:
+            return await http_client.get(
+                f"/v1/sessions/{session_id}/wait",
+                params={"after_seq": 0, "timeout": 10},
+            )
+
+        async def delayed_append() -> None:
+            await asyncio.sleep(0.3)
+            await sessions_svc.append_user_message(pool, session_id, "late hello")
+
+        wait_task = asyncio.create_task(wait_call())
+        post_task = asyncio.create_task(delayed_append())
+
+        r, _ = await asyncio.gather(wait_task, post_task)
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert any(
+            e["kind"] == "message" and e["data"].get("content") == "late hello"
+            for e in body["events"]
+        )
+
+    async def test_rejects_timeout_above_cap(
+        self, http_client: httpx.AsyncClient, session_id: str
+    ) -> None:
+        """Request-level validation rejects out-of-range ``timeout``."""
+        r = await http_client.get(
+            f"/v1/sessions/{session_id}/wait",
+            params={"after_seq": 0, "timeout": 3600},
+        )
+        assert r.status_code == 422, r.text
+
+    async def test_delta_notifications_do_not_short_circuit_wait(
+        self, http_client: httpx.AsyncClient, pool: Any, session_id: str
+    ) -> None:
+        """Streaming delta pokes on the session channel must not return an empty response.
+
+        ``_notify_delta`` in ``aios.harness.completion`` fires transient
+        ``pg_notify`` payloads on ``events_<session_id>`` for every token; these
+        payloads start with ``{`` and carry no DB row. A long-poll handler that
+        re-reads events on every notification would return empty immediately
+        and cause clients to hot-loop on any streaming session.
+        """
+
+        async def fire_delta_then_append() -> None:
+            from aios.services import sessions as sessions_svc
+
+            async with pool.acquire() as conn:
+                for _ in range(3):
+                    await conn.execute(
+                        "SELECT pg_notify($1, $2)",
+                        f"events_{session_id}",
+                        '{"delta": "token"}',
+                    )
+                    await asyncio.sleep(0.05)
+            # Real event arrives later; the wait should latch onto this,
+            # not any of the deltas.
+            await asyncio.sleep(0.3)
+            await sessions_svc.append_user_message(pool, session_id, "real")
+
+        async def wait_call() -> httpx.Response:
+            return await http_client.get(
+                f"/v1/sessions/{session_id}/wait",
+                params={"after_seq": 0, "timeout": 5},
+            )
+
+        wait_task = asyncio.create_task(wait_call())
+        poke_task = asyncio.create_task(fire_delta_then_append())
+
+        r, _ = await asyncio.gather(wait_task, poke_task)
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert any(
+            e["kind"] == "message" and e["data"].get("content") == "real" for e in body["events"]
+        ), body


### PR DESCRIPTION
## Summary

- New \`GET /v1/sessions/:id/wait?after_seq=N&timeout=S\` long-poll endpoint. Blocks up to \`S\` seconds (capped server-side at 60) for new events past \`after_seq\`.
- Returns events, session_status, session_stop_reason, and \`next_after\` cursor.
- Built on the same \`listen_for_events\` primitive as the SSE endpoint; \`LISTEN\` attaches before backfill so no commit is lost.
- Skips transient streaming delta payloads on the channel so chatty sessions don't cause empty-response hot-loops on Node clients.

## Why it matters

Node's built-in \`fetch\` does not reliably consume SSE (platform quirk under HTTP/1.1 keep-alive). Orchestrators like Paperclip were polling every 1-2s — ~200 requests per 5-minute turn. Long-poll collapses that to ~10.

## Test plan

- [x] 5 e2e tests: immediate-backfill, timeout-empty, concurrent-post-and-wake, timeout-cap-rejected, **delta-notifications-do-not-short-circuit** (caught in review)
- [x] \`uv run pytest tests/unit -q\` — 699 passed
- [x] \`uv run pytest tests/e2e -q\` — 205 passed
- [x] mypy + ruff clean

Closes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)