### PR TITLE
feat(connectors): add telegram connector (v1, text-only)

### DIFF
--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -1,0 +1,156 @@
+# aios-telegram
+
+Telegram connector for [aios](../../README.md). One long-running process per
+Telegram bot — ingests inbound messages into aios via
+`POST /v1/connections/{id}/messages`, and serves an MCP server exposing a
+`telegram_send` tool that the aios worker calls back into.
+
+## Prerequisites
+
+- Python ≥ 3.13
+- A Telegram bot token (talk to [@BotFather](https://t.me/BotFather))
+- A running aios instance with the connector/channel routing infra
+
+## Install
+
+Pip-installable standalone:
+
+```
+pip install ./connectors/telegram
+```
+
+Or as a uv workspace member (already wired from the repo root):
+
+```
+uv sync --all-packages --dev
+```
+
+## Operator walkthrough
+
+### 1. Create the bot
+
+Message [@BotFather](https://t.me/BotFather) on Telegram: `/newbot`. Copy
+the token. Learn the bot's numeric id by running a throwaway script
+(`curl https://api.telegram.org/bot<TOKEN>/getMe`) — you'll need it for
+the routing rule.
+
+### 2. Create an aios vault + credential for the MCP token
+
+```
+VLT=$(curl -X POST :8090/v1/vaults -d '{"display_name": "Telegram personal"}' | jq -r .id)
+
+curl -X POST :8090/v1/vaults/$VLT/credentials -d '{
+  "mcp_server_url": "http://localhost:9200/mcp",
+  "auth_type": "static_bearer",
+  "token": "supersecret"
+}'
+```
+
+### 3. Register the aios connection
+
+```
+curl -X POST :8090/v1/connections -d "{
+  \"connector\": \"telegram\",
+  \"account\": \"<bot-numeric-id-from-step-1>\",
+  \"mcp_url\": \"http://localhost:9200/mcp\",
+  \"vault_id\": \"$VLT\"
+}"
+```
+
+### 4. Start the connector
+
+```
+export AIOS_URL=http://localhost:8090
+export AIOS_API_KEY=...
+export AIOS_CONNECTION_ID=conn_...
+export AIOS_TELEGRAM_MCP_TOKEN=supersecret
+
+python -m aios_telegram start --bot-token 123456:AA...
+```
+
+All settings can also be passed via env vars. Full list via
+`python -m aios_telegram start --help`.
+
+### 5. Add a routing rule
+
+```
+curl -X POST :8090/v1/routing-rules -d '{
+  "prefix": "telegram/<bot-numeric-id>",
+  "target": "agent:<agent-id>",
+  "session_params": {"environment_id": "<env-id>"}
+}'
+```
+
+### 6. DM the bot — the agent replies
+
+DM the bot from a Telegram client. Watch the aios event log: the inbound
+message shows up with `metadata.channel` set, a session is created on
+first inbound, and the agent's `telegram_send` call delivers the reply
+back to Telegram.
+
+## Configuration reference
+
+| Flag | Env var | Default | Description |
+|---|---|---|---|
+| `--bot-token` | `AIOS_TELEGRAM_BOT_TOKEN` | required | Bot token from BotFather |
+| `--aios-url` | `AIOS_URL` | required | Base URL of aios API |
+| `--aios-api-key` | `AIOS_API_KEY` | required | Bearer token for aios API |
+| `--aios-connection-id` | `AIOS_CONNECTION_ID` | required | ID of the pre-registered connection |
+| `--mcp-bind` | `AIOS_TELEGRAM_MCP_BIND` | `127.0.0.1:9200` | Host:port for MCP server |
+| `--mcp-token` | `AIOS_TELEGRAM_MCP_TOKEN` | required | Token MCP clients must present |
+
+## Architecture
+
+`app.run()` wires two tasks under a single `asyncio.TaskGroup`:
+
+1. **PTB `Application`** — python-telegram-bot's asyncio Application drives
+   the update loop (long polling). Discovers the bot's numeric id via
+   `getMe` on startup. Every incoming message is parsed into an
+   `InboundMessage` and posted to aios via
+   `POST /v1/connections/{id}/messages`.
+2. **MCP server** — FastMCP on uvicorn, bearer-auth-gated, exposing
+   `telegram_send`.
+
+**Crash-is-fatal.** Any task failure propagates through the TaskGroup and
+exits the process non-zero. There is no auto-reconnect. Run under systemd
+(`Restart=on-failure`) or Docker (`restart: unless-stopped`).
+
+## Out of scope for v1
+
+- Inbound media (photos, voice, documents, stickers) — dropped silently.
+- Outbound media — no `telegram_send_photo` / `_document`.
+- Reactions — punt.
+- Message editing / deletion.
+- Typing indicators / chat actions.
+- Forum topics (`message_thread_id`) — ignored; every message treated as
+  top-level in the chat.
+- Webhook mode — polling only.
+- Markdown rendering — plain text only. The agent's `**bold**` will render
+  literally until a v2 adds MarkdownV2 escaping.
+- Message splitting — Telegram's 4096-char limit surfaces as a Bad Request
+  the model must handle by retrying shorter.
+- User allowlist — routing rules gate access server-side.
+- Auto-reconnect on Telegram outage.
+
+## Troubleshooting
+
+- **MCP calls returning 401**: the `--mcp-token` on the connector doesn't
+  match the `token` stored in the aios vault's credential for this
+  connection.
+- **Inbound messages never appear in aios**: check the connector logs for
+  `ingest.client_error` (malformed payload — likely a connector bug) or
+  `ingest.retries_exhausted` (aios was unreachable long enough to exhaust
+  the 1/2/4/8s backoff).
+- **`Unauthorized` from Telegram on startup**: the bot token is wrong or
+  revoked. Re-check with BotFather.
+
+## Development
+
+From `connectors/telegram/`:
+
+```
+uv run pytest -q           # unit tests, no network
+uv run mypy src tests      # strict
+uv run ruff check src tests
+uv run ruff format --check src tests
+```

--- a/connectors/telegram/pyproject.toml
+++ b/connectors/telegram/pyproject.toml
@@ -1,39 +1,20 @@
 [project]
-name = "aios"
+name = "aios-telegram"
 version = "0.1.0"
-description = "Open-source agent runtime: Postgres-backed sessions, Docker sandbox, any LiteLLM model"
+description = "Telegram connector for aios"
 readme = "README.md"
 requires-python = ">=3.13"
 license = { text = "MIT" }
 authors = [{ name = "aios contributors" }]
 
 dependencies = [
-    # HTTP + SSE
-    "fastapi>=0.115",
-    "uvicorn[standard]>=0.32",
-    "sse-starlette>=2.1",
-    # Validation + settings
     "pydantic>=2.9",
     "pydantic-settings>=2.6",
-    # Postgres + migrations + job queue
-    "asyncpg>=0.30",
-    "alembic>=1.13",
-    "sqlalchemy>=2.0",          # required by alembic even when used without the ORM
-    "procrastinate==3.8.1",     # exact pin so the task/connector API stays stable
-    "psycopg[binary]>=3.2",     # required by procrastinate; aios uses asyncpg directly
-    # Sandbox
-    "aiodocker>=0.23",
-    # Crypto + ids
-    "pynacl>=1.5",
-    "python-ulid>=3.0",
-    # LLM client
-    "litellm>=1.55",
-    # MCP client
-    "mcp>=1.20",
-    # Web tools
     "httpx>=0.27",
-    # Observability
+    "mcp>=1.20,<2.0",
+    "uvicorn[standard]>=0.32",
     "structlog>=24.4",
+    "python-telegram-bot>=22.6,<23",
 ]
 
 [dependency-groups]
@@ -41,25 +22,19 @@ dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
     "pytest-mock>=3.14",
-    "httpx>=0.27",                # FastAPI TestClient backend
-    "testcontainers[postgres]>=4.8",
     "ruff>=0.8",
     "mypy>=1.13",
 ]
 
 [project.scripts]
-aios = "aios.__main__:main"
+aios-telegram = "aios_telegram.__main__:main"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/aios"]
-
-# ─── uv workspace ────────────────────────────────────────────────────────────
-[tool.uv.workspace]
-members = ["connectors/signal", "connectors/telegram"]
+packages = ["src/aios_telegram"]
 
 # ─── ruff ────────────────────────────────────────────────────────────────────
 [tool.ruff]
@@ -69,25 +44,23 @@ src = ["src", "tests"]
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "B",   # bugbear
-    "UP",  # pyupgrade
-    "SIM", # simplify
-    "RUF", # ruff-specific
-    "TID", # tidy imports
-    "ASYNC", # async-specific lints
+    "E",
+    "W",
+    "F",
+    "I",
+    "B",
+    "UP",
+    "SIM",
+    "RUF",
+    "TID",
+    "ASYNC",
 ]
 ignore = [
-    "E501",  # line length is enforced by the formatter
+    "E501",
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = [
-    "B011",       # allow asserts in tests
-]
+"tests/**/*.py" = ["B011"]
 
 [tool.ruff.format]
 quote-style = "double"
@@ -107,15 +80,7 @@ no_implicit_optional = true
 plugins = ["pydantic.mypy"]
 
 [[tool.mypy.overrides]]
-module = [
-    "litellm.*",
-    "mcp.*",
-    "aiodocker.*",
-    "procrastinate.*",
-    "testcontainers.*",
-    "asyncpg",
-    "asyncpg.*",
-]
+module = ["mcp.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
@@ -130,8 +95,4 @@ addopts = [
     "-ra",
     "--strict-markers",
     "--strict-config",
-]
-markers = [
-    "integration: tests requiring a Postgres testcontainer",
-    "e2e: end-to-end tests requiring Docker + a real or recorded model",
 ]

--- a/connectors/telegram/src/aios_telegram/__init__.py
+++ b/connectors/telegram/src/aios_telegram/__init__.py
@@ -1,0 +1,1 @@
+"""Telegram connector for aios."""

--- a/connectors/telegram/src/aios_telegram/__main__.py
+++ b/connectors/telegram/src/aios_telegram/__main__.py
@@ -1,0 +1,66 @@
+"""CLI entry point.
+
+``python -m aios_telegram start`` launches the connector. CLI flags override
+env vars; env vars override defaults.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+from . import app
+from .config import Settings
+from .logging import configure_logging
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="aios_telegram")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    start = sub.add_parser("start", help="start the telegram connector")
+    start.add_argument("--bot-token", help="Telegram bot token (AIOS_TELEGRAM_BOT_TOKEN)")
+    start.add_argument("--aios-url", help="aios base URL (AIOS_URL)")
+    start.add_argument("--aios-api-key", help="aios bearer token (AIOS_API_KEY)")
+    start.add_argument("--aios-connection-id", help="aios connection id (AIOS_CONNECTION_ID)")
+    start.add_argument("--mcp-bind", help="MCP host:port (AIOS_TELEGRAM_MCP_BIND)")
+    start.add_argument("--mcp-token", help="MCP bearer token (AIOS_TELEGRAM_MCP_TOKEN)")
+    return parser
+
+
+def _apply_cli_overrides(args: argparse.Namespace) -> None:
+    mapping = {
+        "bot_token": "AIOS_TELEGRAM_BOT_TOKEN",
+        "aios_url": "AIOS_URL",
+        "aios_api_key": "AIOS_API_KEY",
+        "aios_connection_id": "AIOS_CONNECTION_ID",
+        "mcp_bind": "AIOS_TELEGRAM_MCP_BIND",
+        "mcp_token": "AIOS_TELEGRAM_MCP_TOKEN",
+    }
+    for attr, env in mapping.items():
+        value = getattr(args, attr, None)
+        if value is not None:
+            os.environ[env] = str(value)
+
+
+def main(argv: list[str] | None = None) -> int:
+    configure_logging()
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command != "start":
+        parser.error(f"unknown command: {args.command}")
+
+    _apply_cli_overrides(args)
+    cfg = Settings()  # fields are populated from env / CLI overrides
+
+    try:
+        asyncio.run(app.run(cfg))
+    except KeyboardInterrupt:
+        return 130
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/connectors/telegram/src/aios_telegram/app.py
+++ b/connectors/telegram/src/aios_telegram/app.py
@@ -1,0 +1,51 @@
+"""Top-level orchestration.
+
+``run(cfg)`` supervises two tasks under one ``asyncio.TaskGroup``: the PTB
+``Application`` driving the Telegram long-polling loop and posting inbound
+messages to aios, and the MCP server serving ``telegram_send``. Any task
+failure propagates through the group and exits the process non-zero —
+operator systemd/Docker restarts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import structlog
+
+from .bot import build_application, discover_bot_id, install_handler, run_application
+from .config import Settings
+from .ingest import IngestClient
+from .mcp import build_mcp_app, build_mcp_server, parse_bind, serve_mcp
+
+log = structlog.get_logger(__name__)
+
+
+async def run(cfg: Settings) -> None:
+    application = build_application(cfg.bot_token)
+    await application.initialize()
+    try:
+        bot_id = await discover_bot_id(application)
+    except BaseException:
+        await application.shutdown()
+        raise
+
+    async with IngestClient(
+        base_url=cfg.aios_url,
+        api_key=cfg.aios_api_key,
+        connection_id=cfg.aios_connection_id,
+    ) as ingest:
+        install_handler(application, bot_id=bot_id, ingest=ingest)
+        mcp_app = build_mcp_app(build_mcp_server(bot=application.bot), token=cfg.mcp_token)
+        host, port = parse_bind(cfg.mcp_bind)
+
+        log.info("telegram.ready", bot_id=bot_id)
+
+        try:
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(run_application(application), name="telegram-bot")
+                tg.create_task(serve_mcp(mcp_app, host=host, port=port), name="telegram-mcp")
+        except* Exception as eg:
+            # Surface the first real exception so operators see a conventional
+            # traceback rather than ExceptionGroup noise.
+            raise eg.exceptions[0] from None

--- a/connectors/telegram/src/aios_telegram/bot.py
+++ b/connectors/telegram/src/aios_telegram/bot.py
@@ -1,0 +1,101 @@
+"""python-telegram-bot Application wrapper.
+
+Three responsibilities:
+
+1. Build the PTB ``Application`` from the bot token.
+2. Discover the bot's numeric id on startup (the ``<account>`` segment of
+   channel addresses) via ``Bot.get_me()``.
+3. Register a single message handler that parses each incoming text
+   message and POSTs it to aios via :class:`aios_telegram.ingest.IngestClient`.
+
+Long-polling is driven by PTB's own ``Updater``; :func:`run_application`
+starts it, blocks until cancelled, then shuts down cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import structlog
+from telegram import Update
+from telegram.ext import Application, ContextTypes, MessageHandler, filters
+
+from .errors import BotIdentityError
+from .ingest import IngestClient, build_metadata
+from .parse import parse_message
+
+log = structlog.get_logger(__name__)
+
+
+def build_application(token: str) -> Application:  # type: ignore[type-arg]
+    return Application.builder().token(token).build()
+
+
+async def discover_bot_id(application: Application) -> int:  # type: ignore[type-arg]
+    """Call ``getMe`` and return the bot's numeric user id.
+
+    Raises :class:`BotIdentityError` if Telegram's response is unusable.
+    Called once on startup after ``application.initialize()``.
+    """
+    me = await application.bot.get_me()
+    if not me.id:
+        raise BotIdentityError("getMe returned no id")
+    log.info("telegram.bot.identified", bot_id=me.id, username=me.username)
+    return int(me.id)
+
+
+def install_handler(
+    application: Application,  # type: ignore[type-arg]
+    *,
+    bot_id: int,
+    ingest: IngestClient,
+) -> None:
+    """Wire the parse → build_metadata → post_message pipeline onto PTB.
+
+    Filter: plain text messages only (no commands — commands look like text
+    to the agent). Non-text payloads and edits are dropped by the filter;
+    self / bot-to-bot / empty-text are dropped by :func:`parse_message`.
+    """
+
+    async def on_message(update: Update, _ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        message = update.message
+        if message is None:
+            return
+        parsed = parse_message(message, bot_id=bot_id)
+        if parsed is None:
+            return
+        await ingest.post_message(
+            path=str(parsed.chat_id),
+            content=parsed.text,
+            metadata=build_metadata(parsed, bot_id),
+        )
+
+    async def on_error(_update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+        log.error("telegram.handler.error", error=str(context.error))
+
+    application.add_handler(MessageHandler(filters.TEXT, on_message))
+    application.add_error_handler(on_error)
+
+
+async def run_application(application: Application) -> None:  # type: ignore[type-arg]
+    """Run PTB's long-polling loop until cancelled.
+
+    Assumes ``application.initialize()`` has already been awaited by the
+    caller — :func:`app.run` does so eagerly to allow ``getMe`` before
+    polling starts. Lifecycle here: start → start_polling → (wait
+    forever) → stop_polling → stop → shutdown. Cancellation from the
+    enclosing TaskGroup triggers the shutdown half.
+    """
+    await application.start()
+    assert application.updater is not None
+    await application.updater.start_polling()
+    try:
+        await asyncio.Event().wait()
+    finally:
+        with contextlib.suppress(Exception):
+            await application.updater.stop()
+        with contextlib.suppress(Exception):
+            await application.stop()
+        with contextlib.suppress(Exception):
+            await application.shutdown()

--- a/connectors/telegram/src/aios_telegram/config.py
+++ b/connectors/telegram/src/aios_telegram/config.py
@@ -1,0 +1,32 @@
+"""Runtime configuration.
+
+Pydantic-settings sourcing: ``AIOS_TELEGRAM_*`` env vars for connector-specific
+settings, plus three shared aios env vars via explicit aliases
+(``AIOS_URL``, ``AIOS_API_KEY``, ``AIOS_CONNECTION_ID``). All may be
+overridden on the CLI (see ``__main__.py``).
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="AIOS_TELEGRAM_",
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+    # Telegram
+    bot_token: str
+
+    # aios side
+    aios_url: str = Field(validation_alias="AIOS_URL")
+    aios_api_key: str = Field(validation_alias="AIOS_API_KEY")
+    aios_connection_id: str = Field(validation_alias="AIOS_CONNECTION_ID")
+
+    # MCP server
+    mcp_bind: str = "127.0.0.1:9200"
+    mcp_token: str

--- a/connectors/telegram/src/aios_telegram/errors.py
+++ b/connectors/telegram/src/aios_telegram/errors.py
@@ -1,0 +1,11 @@
+"""Exception hierarchy for aios-telegram."""
+
+from __future__ import annotations
+
+
+class TelegramConnectorError(Exception):
+    """Base class for all aios-telegram errors."""
+
+
+class BotIdentityError(TelegramConnectorError):
+    """Raised when we can't resolve the bot's numeric id at startup."""

--- a/connectors/telegram/src/aios_telegram/ingest.py
+++ b/connectors/telegram/src/aios_telegram/ingest.py
@@ -1,0 +1,109 @@
+"""aios ingest client.
+
+POSTs inbound Telegram messages to ``/v1/connections/{id}/messages``. Retries
+transient failures (network, 5xx) with exponential backoff; 4xx and
+retry-exhaustion both log and drop. Missing messages are unrecoverable
+(Telegram does not redeliver long-polling updates we've already acked by
+advancing ``offset``), but the connector advances ``offset`` only after the
+handler returns — so a crash mid-handler causes redelivery on the next run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Self
+
+import httpx
+import structlog
+
+from .parse import InboundMessage
+
+log = structlog.get_logger(__name__)
+
+RETRY_DELAYS_SECONDS: tuple[float, ...] = (1.0, 2.0, 4.0, 8.0)
+
+
+@dataclass(slots=True)
+class IngestClient:
+    base_url: str
+    api_key: str
+    connection_id: str
+    _client: httpx.AsyncClient | None = None
+
+    async def __aenter__(self) -> Self:
+        self._client = httpx.AsyncClient(
+            base_url=self.base_url,
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            timeout=httpx.Timeout(30.0, connect=10.0),
+        )
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def post_message(
+        self,
+        *,
+        path: str,
+        content: str,
+        metadata: dict[str, Any],
+    ) -> None:
+        if self._client is None:
+            raise RuntimeError("IngestClient must be used as an async context manager")
+        url = f"/v1/connections/{self.connection_id}/messages"
+        body = {"path": path, "content": content, "metadata": metadata}
+
+        for attempt, delay in enumerate((0.0, *RETRY_DELAYS_SECONDS)):
+            if delay:
+                await asyncio.sleep(delay)
+            try:
+                response = await self._client.post(url, json=body)
+            except httpx.HTTPError as e:
+                log.warning("ingest.network_error", attempt=attempt, error=str(e), path=path)
+                continue
+
+            if response.is_success:
+                return
+            if 400 <= response.status_code < 500:
+                # 4xx is our bug — retrying won't help.
+                log.error(
+                    "ingest.client_error",
+                    status=response.status_code,
+                    body=response.text[:500],
+                    path=path,
+                )
+                return
+            log.warning(
+                "ingest.server_error",
+                attempt=attempt,
+                status=response.status_code,
+                body=response.text[:500],
+                path=path,
+            )
+
+        log.error("ingest.retries_exhausted", path=path)
+
+
+def build_metadata(msg: InboundMessage, bot_id: int) -> dict[str, Any]:
+    # `channel` is redundant with what aios stamps server-side, but we
+    # include it so events are self-describing when read outside aios.
+    metadata: dict[str, Any] = {
+        "channel": f"telegram/{bot_id}/{msg.chat_id}",
+        "chat_type": msg.chat_kind,
+        "sender_id": msg.sender_id,
+        "message_id": msg.message_id,
+        "timestamp_ms": msg.timestamp_ms,
+    }
+    if msg.sender_name is not None:
+        metadata["sender_name"] = msg.sender_name
+    if msg.chat_name is not None:
+        metadata["chat_name"] = msg.chat_name
+    if msg.reply is not None:
+        metadata["reply_to"] = {
+            "message_id": msg.reply.message_id,
+            "text": msg.reply.text,
+        }
+    return metadata

--- a/connectors/telegram/src/aios_telegram/logging.py
+++ b/connectors/telegram/src/aios_telegram/logging.py
@@ -1,0 +1,47 @@
+"""structlog wiring for the connector.
+
+Mirrors the parent aios project's setup (stdlib LoggerFactory, JSON in
+production, console renderer in development based on
+``AIOS_TELEGRAM_LOG_FORMAT``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import structlog
+
+
+def configure_logging() -> None:
+    """Configure structlog once. Idempotent."""
+    log_format = os.environ.get("AIOS_TELEGRAM_LOG_FORMAT", "console")
+    level_name = os.environ.get("AIOS_TELEGRAM_LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    logging.basicConfig(
+        format="%(message)s",
+        stream=sys.stderr,
+        level=level,
+    )
+
+    renderer: structlog.types.Processor = (
+        structlog.dev.ConsoleRenderer()
+        if log_format == "console"
+        else structlog.processors.JSONRenderer()
+    )
+
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            renderer,
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(level),
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )

--- a/connectors/telegram/src/aios_telegram/mcp.py
+++ b/connectors/telegram/src/aios_telegram/mcp.py
@@ -1,0 +1,147 @@
+"""MCP server exposing Telegram connector tools.
+
+Tools (invoked by the aios worker over streamable HTTP):
+
+- ``telegram_send`` → python-telegram-bot ``Bot.send_message``
+
+We don't use FastMCP's built-in auth because it requires AuthSettings with
+an OAuth-shaped ``issuer_url`` that doesn't fit a static-token deployment.
+A thin Starlette middleware wrapping the ASGI app gives us a uniform
+``Authorization: Bearer`` contract across loopback and remote deployments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hmac
+import urllib.parse
+from typing import Any
+
+import structlog
+import uvicorn
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import RequestParams
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+from telegram import Bot
+
+from .prompts import TELEGRAM_SERVER_INSTRUCTIONS
+
+log = structlog.get_logger(__name__)
+
+
+# Key under a JSON-RPC tool-call request's ``_meta`` populated by the
+# aios worker when dispatching a connection-provided tool.  Its value
+# is the focal-channel path suffix — for Telegram's 3-segment address
+# ``telegram/<bot_id>/<chat_id>``, the suffix is just ``<chat_id>`` and
+# can be parsed as a signed integer.
+_FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
+
+
+def focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> int:
+    """Extract the Telegram ``chat_id`` from an MCP request's ``_meta``.
+
+    aios injects ``aios.focal_channel_path`` for connection-provided tool
+    calls; its value is the full focal-channel suffix (stripped of
+    ``<connector>/<account>``), which for a 3-segment Telegram address
+    is the decimal chat id. Missing / malformed meta raises — the agent
+    shouldn't be able to reach these tools without a focal channel set
+    (aios filters them out of the tool list when focal is NULL), so any
+    absence here is a real error to surface.
+    """
+    path: Any = None
+    if meta is not None:
+        extra = getattr(meta, "model_extra", None) or {}
+        path = extra.get(_FOCAL_CHANNEL_META_KEY)
+    if not isinstance(path, str) or not path:
+        raise ValueError(
+            "telegram tools require a focal channel — aios should inject "
+            f"{_FOCAL_CHANNEL_META_KEY!r} in _meta when focal is set"
+        )
+    try:
+        return int(path)
+    except ValueError as e:
+        raise ValueError(f"telegram chat_id must be an integer; got {path!r}") from e
+
+
+class BearerAuthMiddleware:
+    def __init__(self, app: ASGIApp, *, expected_token: str) -> None:
+        self._app = app
+        self._expected = expected_token.encode("utf-8")
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+        headers: list[tuple[bytes, bytes]] = scope.get("headers") or []
+        token: bytes | None = None
+        for name, value in headers:
+            if name.lower() == b"authorization":
+                if value.startswith(b"Bearer "):
+                    token = value[len(b"Bearer ") :]
+                break
+        if token is None or not hmac.compare_digest(token, self._expected):
+            response = JSONResponse(
+                {"error": {"type": "unauthorized", "message": "invalid bearer token"}},
+                status_code=401,
+            )
+            await response(scope, receive, send)
+            return
+        await self._app(scope, receive, send)
+
+
+def build_mcp_server(*, bot: Bot) -> FastMCP:
+    mcp = FastMCP(
+        "aios-telegram",
+        instructions=TELEGRAM_SERVER_INSTRUCTIONS,
+        stateless_http=True,
+    )
+
+    @mcp.tool()
+    async def telegram_send(text: str, ctx: Context[Any, Any, Any]) -> dict[str, Any]:
+        """Send a text message to your focal Telegram chat.
+
+        The chat id is taken implicitly from your focal channel —
+        aios injects it via the JSON-RPC ``_meta`` field on each call.
+        Set focal with the built-in ``switch_channel`` tool.
+
+        Args:
+            text: Message body. Plain text only — markdown is not rendered.
+        """
+        chat_id = focal_chat_id_from_meta(ctx.request_context.meta)
+        sent = await bot.send_message(chat_id=chat_id, text=text)
+        return {"message_id": sent.message_id}
+
+    return mcp
+
+
+def build_mcp_app(mcp: FastMCP, *, token: str) -> Starlette:
+    inner = mcp.streamable_http_app()
+    app = Starlette(routes=inner.routes, lifespan=inner.router.lifespan_context)
+    app.add_middleware(BearerAuthMiddleware, expected_token=token)
+    return app
+
+
+async def serve_mcp(app: Starlette, *, host: str, port: int) -> None:
+    # Uvicorn's Server.serve doesn't react to CancelledError; we flip
+    # should_exit and await shutdown ourselves.
+    config = uvicorn.Config(app, host=host, port=port, log_config=None, lifespan="on")
+    server = uvicorn.Server(config)
+    log.info("telegram.mcp.serving", host=host, port=port)
+    try:
+        await server.serve()
+    except asyncio.CancelledError:
+        server.should_exit = True
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(server.shutdown(), timeout=5.0)
+        raise
+
+
+def parse_bind(bind: str) -> tuple[str, int]:
+    # urlsplit handles both "host:port" and "[::1]:port" (IPv6) correctly.
+    parts = urllib.parse.urlsplit(f"//{bind}")
+    if not parts.hostname or parts.port is None:
+        raise ValueError(f"invalid bind {bind!r} — expected host:port")
+    return parts.hostname, parts.port

--- a/connectors/telegram/src/aios_telegram/parse.py
+++ b/connectors/telegram/src/aios_telegram/parse.py
@@ -1,0 +1,90 @@
+"""Parse python-telegram-bot ``Message`` objects into :class:`InboundMessage`.
+
+v1 scope is text only. We return ``None`` for anything we don't forward to
+aios — messages from the bot itself, bot-to-bot traffic, non-text payloads
+(photos, stickers, voice, documents), and messages without a sender.
+
+Edits (``update.edited_message``) and channel posts never reach this
+function because the handler in :mod:`aios_telegram.bot` registers on
+``update.message`` with a ``filters.TEXT`` gate — this module is only
+responsible for the parse, not for the filter-at-dispatch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from telegram import Message
+from telegram.constants import ChatType
+
+ChatKind = Literal["dm", "group", "supergroup", "channel"]
+
+
+@dataclass(slots=True, frozen=True)
+class Reply:
+    message_id: int
+    text: str | None
+
+
+@dataclass(slots=True, frozen=True)
+class InboundMessage:
+    chat_kind: ChatKind
+    chat_id: int
+    chat_name: str | None
+    sender_id: int
+    sender_name: str | None
+    message_id: int
+    timestamp_ms: int
+    text: str
+    reply: Reply | None
+
+
+def _chat_kind(chat_type: str) -> ChatKind:
+    if chat_type == ChatType.PRIVATE:
+        return "dm"
+    if chat_type == ChatType.GROUP:
+        return "group"
+    if chat_type == ChatType.SUPERGROUP:
+        return "supergroup"
+    return "channel"
+
+
+def parse_message(message: Message, *, bot_id: int) -> InboundMessage | None:
+    sender = message.from_user
+    if sender is None:
+        # Channel posts and anonymous admins have no ``from_user``. Out of
+        # scope for v1.
+        return None
+    if sender.id == bot_id:
+        return None
+    if sender.is_bot:
+        return None
+
+    text = message.text
+    if not text:
+        # v1 is text-only. Media, stickers, voice, etc. are dropped.
+        return None
+
+    chat = message.chat
+    chat_kind = _chat_kind(chat.type)
+    chat_name: str | None = chat.title if chat_kind != "dm" else None
+
+    reply: Reply | None = None
+    if message.reply_to_message is not None:
+        reply = Reply(
+            message_id=message.reply_to_message.message_id,
+            text=message.reply_to_message.text or message.reply_to_message.caption,
+        )
+
+    return InboundMessage(
+        chat_kind=chat_kind,
+        chat_id=chat.id,
+        chat_name=chat_name,
+        sender_id=sender.id,
+        sender_name=sender.full_name or None,
+        message_id=message.message_id,
+        timestamp_ms=int(message.date.timestamp() * 1000),
+        text=text,
+        reply=reply,
+    )

--- a/connectors/telegram/src/aios_telegram/prompts.py
+++ b/connectors/telegram/src/aios_telegram/prompts.py
@@ -1,0 +1,64 @@
+"""Per-connector affordance prose surfaced to the agent via MCP.
+
+Returned in the ``InitializeResult.instructions`` field of the MCP
+``initialize`` response; the aios harness concatenates it into the
+session's system prompt under a ``## Connector: telegram/<account>``
+heading.
+
+Covers only the tool this server exposes — ``telegram_send``. Telling the
+model about tools that don't exist would be worse than silence.
+"""
+
+from __future__ import annotations
+
+TELEGRAM_SERVER_INSTRUCTIONS = """\
+## chat_id
+
+Each Telegram channel address is path-shaped: ``telegram/<bot_id>/<chat_id>``.
+The ``chat_id`` segment is a signed integer:
+
+- Positive for direct messages (the counterparty's user id).
+- Negative for groups (``-123456789``) and supergroups (``-1001234567890``).
+
+Pass it verbatim from the channel path — do not decode or modify it.
+
+## Sending messages — `telegram_send`
+
+**Your text responses are NOT sent automatically.** Bare assistant text
+is internal monologue; nobody on Telegram sees it. To deliver a message
+you MUST call:
+
+    telegram_send(text="your message here")
+
+The chat_id is taken implicitly from your focal channel — aios injects
+it on each call. Set focal with the built-in ``switch_channel`` tool.
+
+If you don't call this tool, no one will see your response.
+
+### Plain text only — no markdown
+
+v1 sends messages without a ``parse_mode``. Any markdown you write
+(``**bold**``, ``*italic*``, backticks, links) will appear as literal
+characters in the recipient's chat, not as formatted text.
+
+Write plain prose. If you need emphasis, use word choice, not syntax.
+
+### Avoid splitting one thought into multiple messages
+
+Before calling `telegram_send`, ask: "am I about to do some trivial work
+and then send again?" If yes, finish the work first and send one
+combined message. Back-to-back messages without substantial work in
+between feel like a bot narrating its own steps.
+
+Multiple `telegram_send` calls are fine when there is genuinely heavy
+work between them (research, file processing, long tasks) and you are
+giving progress updates. The test is whether the human would be left
+wondering what is happening — if so, send an update.
+
+### Message length
+
+Telegram caps a single message at 4096 characters. Longer messages are
+rejected by the API. Keep replies under that — concise is usually
+better anyway. If you truly need more, split the content across multiple
+``telegram_send`` calls on your own judgment.
+"""

--- a/connectors/telegram/tests/conftest.py
+++ b/connectors/telegram/tests/conftest.py
@@ -1,0 +1,161 @@
+"""Shared test fixtures.
+
+PTB's ``Message.de_json`` needs a ``Bot`` (or close enough) for its date
+deserialization to resolve the right tzinfo. We pass a ``MagicMock(spec=Bot)``
+with ``defaults=None`` — that's the minimum PTB will accept without opening
+a network connection.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from telegram import Bot, Message
+
+BOT_ID = 99999999
+
+
+@pytest.fixture
+def bot_id() -> int:
+    return BOT_ID
+
+
+@pytest.fixture
+def ptb_bot() -> Bot:
+    """Minimal Bot double for ``Message.de_json`` construction."""
+    bot = MagicMock(spec=Bot)
+    bot.defaults = None
+    return bot
+
+
+def _make_message(data: dict[str, Any], bot: Bot) -> Message:
+    msg = Message.de_json(data, bot)
+    assert msg is not None
+    return msg
+
+
+@pytest.fixture
+def message_dm_text(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 101,
+            "date": 1700000000,
+            "chat": {"id": 123456789, "type": "private"},
+            "from": {"id": 123456789, "is_bot": False, "first_name": "Alice"},
+            "text": "hello there",
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
+def message_group_text(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 202,
+            "date": 1700000001,
+            "chat": {"id": -987654321, "type": "group", "title": "Friends"},
+            "from": {
+                "id": 111222333,
+                "is_bot": False,
+                "first_name": "Bob",
+                "last_name": "Smith",
+            },
+            "text": "hey everyone",
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
+def message_supergroup_text(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 303,
+            "date": 1700000002,
+            "chat": {"id": -1001234567890, "type": "supergroup", "title": "Big Chat"},
+            "from": {"id": 444555666, "is_bot": False, "first_name": "Carol"},
+            "text": "in the supergroup",
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
+def message_reply(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 404,
+            "date": 1700000003,
+            "chat": {"id": 123456789, "type": "private"},
+            "from": {"id": 123456789, "is_bot": False, "first_name": "Alice"},
+            "text": "agreed!",
+            "reply_to_message": {
+                "message_id": 400,
+                "date": 1699999999,
+                "chat": {"id": 123456789, "type": "private"},
+                "from": {"id": BOT_ID, "is_bot": True, "first_name": "Bot"},
+                "text": "Original message",
+            },
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
+def message_from_self(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 505,
+            "date": 1700000004,
+            "chat": {"id": 123456789, "type": "private"},
+            "from": {"id": BOT_ID, "is_bot": True, "first_name": "Bot"},
+            "text": "I'm the bot",
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
+def message_from_other_bot(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 606,
+            "date": 1700000005,
+            "chat": {"id": -987654321, "type": "group", "title": "Friends"},
+            "from": {"id": 888888888, "is_bot": True, "first_name": "OtherBot"},
+            "text": "bot-to-bot",
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
+def message_photo_no_text(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 707,
+            "date": 1700000006,
+            "chat": {"id": 123456789, "type": "private"},
+            "from": {"id": 123456789, "is_bot": False, "first_name": "Alice"},
+            "photo": [
+                {"file_id": "AAA", "file_unique_id": "A", "width": 90, "height": 90},
+            ],
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
+def message_channel_post_no_sender(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 808,
+            "date": 1700000007,
+            "chat": {"id": -1009999999999, "type": "channel", "title": "News"},
+            "text": "announcement",
+        },
+        ptb_bot,
+    )

--- a/connectors/telegram/tests/test_ingest.py
+++ b/connectors/telegram/tests/test_ingest.py
@@ -1,0 +1,120 @@
+"""Tests for IngestClient retry behavior and metadata building."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from aios_telegram import ingest as ingest_module
+from aios_telegram.ingest import IngestClient, build_metadata
+from aios_telegram.parse import InboundMessage, Reply
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Drop backoff delays to 0 so tests run instantly.
+    monkeypatch.setattr(ingest_module, "RETRY_DELAYS_SECONDS", (0.0, 0.0, 0.0, 0.0))
+
+
+class _RecordingTransport(httpx.AsyncBaseTransport):
+    def __init__(self, responses: list[httpx.Response | Exception]) -> None:
+        self._responses = list(responses)
+        self.requests: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        if not self._responses:
+            raise AssertionError("unexpected extra request")
+        nxt = self._responses.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+
+async def _run_post(transport: httpx.AsyncBaseTransport) -> None:
+    async with IngestClient(
+        base_url="http://aios.local", api_key="k", connection_id="conn_1"
+    ) as client:
+        await client._client.aclose()  # type: ignore[union-attr]
+        client._client = httpx.AsyncClient(
+            base_url="http://aios.local",
+            headers={"Authorization": "Bearer k"},
+            transport=transport,
+        )
+        await client.post_message(path="c1", content="hi", metadata={"a": 1})
+
+
+async def test_success_first_try() -> None:
+    transport = _RecordingTransport([httpx.Response(201, json={})])
+    await _run_post(transport)
+    assert len(transport.requests) == 1
+    body = transport.requests[0].read()
+    assert b'"path":"c1"' in body.replace(b" ", b"")
+    assert b'"content":"hi"' in body.replace(b" ", b"")
+    assert transport.requests[0].headers["authorization"] == "Bearer k"
+
+
+async def test_client_error_no_retry() -> None:
+    transport = _RecordingTransport([httpx.Response(422, json={"error": "bad"})])
+    await _run_post(transport)
+    assert len(transport.requests) == 1
+
+
+async def test_server_error_retries_then_drops() -> None:
+    # 5 attempts total (initial + 4 retries) all 503 → log and drop.
+    transport = _RecordingTransport([httpx.Response(503, json={})] * 5)
+    await _run_post(transport)
+    assert len(transport.requests) == 5
+
+
+async def test_network_error_retries_then_succeeds() -> None:
+    transport = _RecordingTransport(
+        [
+            httpx.ConnectError("boom"),
+            httpx.ConnectError("boom again"),
+            httpx.Response(201, json={}),
+        ]
+    )
+    await _run_post(transport)
+    assert len(transport.requests) == 3
+
+
+def test_build_metadata_dm_minimal() -> None:
+    msg = InboundMessage(
+        chat_kind="dm",
+        chat_id=123,
+        chat_name=None,
+        sender_id=123,
+        sender_name="Alice",
+        message_id=1,
+        timestamp_ms=1700000000000,
+        text="hi",
+        reply=None,
+    )
+    meta = build_metadata(msg, bot_id=999)
+    assert meta == {
+        "channel": "telegram/999/123",
+        "chat_type": "dm",
+        "sender_id": 123,
+        "sender_name": "Alice",
+        "message_id": 1,
+        "timestamp_ms": 1700000000000,
+    }
+
+
+def test_build_metadata_group_with_reply() -> None:
+    msg = InboundMessage(
+        chat_kind="group",
+        chat_id=-987,
+        chat_name="Friends",
+        sender_id=111,
+        sender_name="Bob",
+        message_id=2,
+        timestamp_ms=1700000001000,
+        text="hi",
+        reply=Reply(message_id=1, text="earlier"),
+    )
+    meta = build_metadata(msg, bot_id=999)
+    assert meta["channel"] == "telegram/999/-987"
+    assert meta["chat_name"] == "Friends"
+    assert meta["reply_to"] == {"message_id": 1, "text": "earlier"}

--- a/connectors/telegram/tests/test_mcp.py
+++ b/connectors/telegram/tests/test_mcp.py
@@ -1,0 +1,153 @@
+"""Tests for mcp.py — telegram_send tool + bearer-auth middleware."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from mcp.server.fastmcp import Context
+from mcp.shared.context import RequestContext
+from mcp.types import RequestParams
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from telegram import Bot, Message
+
+from aios_telegram.mcp import (
+    BearerAuthMiddleware,
+    build_mcp_server,
+    focal_chat_id_from_meta,
+    parse_bind,
+)
+
+
+def _ctx_with_focal(chat_id: str | None) -> Context[Any, Any, Any]:
+    rc = MagicMock(spec=RequestContext)
+    if chat_id is None:
+        rc.meta = None
+    else:
+        rc.meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": chat_id})
+    return Context(request_context=rc)
+
+
+# ─── focal_chat_id_from_meta ────────────────────────────────────────────────
+
+
+def test_focal_meta_dm_id() -> None:
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "123456789"})
+    assert focal_chat_id_from_meta(meta) == 123456789
+
+
+def test_focal_meta_group_negative_id() -> None:
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "-1001234567890"})
+    assert focal_chat_id_from_meta(meta) == -1001234567890
+
+
+def test_focal_meta_missing_raises() -> None:
+    with pytest.raises(ValueError, match="focal channel"):
+        focal_chat_id_from_meta(None)
+
+
+def test_focal_meta_not_integer_raises() -> None:
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "abc"})
+    with pytest.raises(ValueError, match="integer"):
+        focal_chat_id_from_meta(meta)
+
+
+# ─── telegram_send tool ─────────────────────────────────────────────────────
+
+
+async def _call_send(bot: Bot, text: str, *, focal: str | None) -> dict[str, Any]:
+    mcp = build_mcp_server(bot=bot)
+    result = await mcp._tool_manager.call_tool(
+        "telegram_send",
+        {"text": text},
+        _ctx_with_focal(focal),
+        convert_result=True,
+    )
+    assert isinstance(result, tuple)
+    structured: Any = result[1]
+    assert isinstance(structured, dict)
+    return structured
+
+
+async def test_telegram_send_happy_path() -> None:
+    sent = MagicMock(spec=Message)
+    sent.message_id = 42
+    bot = MagicMock(spec=Bot)
+    bot.send_message = AsyncMock(return_value=sent)
+
+    out = await _call_send(bot, "hello", focal="123456789")
+
+    assert out == {"message_id": 42}
+    bot.send_message.assert_awaited_once_with(chat_id=123456789, text="hello")
+
+
+async def test_telegram_send_group_negative_chat_id() -> None:
+    sent = MagicMock(spec=Message)
+    sent.message_id = 7
+    bot = MagicMock(spec=Bot)
+    bot.send_message = AsyncMock(return_value=sent)
+
+    out = await _call_send(bot, "yo", focal="-1001234567890")
+
+    assert out == {"message_id": 7}
+    bot.send_message.assert_awaited_once_with(chat_id=-1001234567890, text="yo")
+
+
+# ─── bearer auth middleware ─────────────────────────────────────────────────
+
+
+def _auth_app(token: str) -> Starlette:
+    async def ok(_request: Any) -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+    app = Starlette(routes=[Route("/", ok)])
+    app.add_middleware(BearerAuthMiddleware, expected_token=token)
+    return app
+
+
+async def test_bearer_auth_rejects_missing_header() -> None:
+    app = _auth_app("secret")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://t"
+    ) as client:
+        resp = await client.get("/")
+    assert resp.status_code == 401
+
+
+async def test_bearer_auth_rejects_wrong_token() -> None:
+    app = _auth_app("secret")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://t"
+    ) as client:
+        resp = await client.get("/", headers={"Authorization": "Bearer nope"})
+    assert resp.status_code == 401
+
+
+async def test_bearer_auth_accepts_correct_token() -> None:
+    app = _auth_app("secret")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://t"
+    ) as client:
+        resp = await client.get("/", headers={"Authorization": "Bearer secret"})
+    assert resp.status_code == 200
+    assert resp.text == "ok"
+
+
+# ─── parse_bind ─────────────────────────────────────────────────────────────
+
+
+def test_parse_bind_ipv4() -> None:
+    assert parse_bind("127.0.0.1:9200") == ("127.0.0.1", 9200)
+
+
+def test_parse_bind_ipv6() -> None:
+    assert parse_bind("[::1]:9200") == ("::1", 9200)
+
+
+def test_parse_bind_invalid() -> None:
+    with pytest.raises(ValueError):
+        parse_bind("not-a-bind")

--- a/connectors/telegram/tests/test_parse.py
+++ b/connectors/telegram/tests/test_parse.py
@@ -1,0 +1,66 @@
+"""Tests for parse_message — telegram.Message → InboundMessage."""
+
+from __future__ import annotations
+
+from telegram import Message
+
+from aios_telegram.parse import parse_message
+
+
+def test_dm_text(message_dm_text: Message, bot_id: int) -> None:
+    msg = parse_message(message_dm_text, bot_id=bot_id)
+    assert msg is not None
+    assert msg.chat_kind == "dm"
+    assert msg.chat_id == 123456789
+    assert msg.chat_name is None
+    assert msg.sender_id == 123456789
+    assert msg.sender_name == "Alice"
+    assert msg.message_id == 101
+    assert msg.text == "hello there"
+    assert msg.timestamp_ms == 1700000000 * 1000
+    assert msg.reply is None
+
+
+def test_group_text(message_group_text: Message, bot_id: int) -> None:
+    msg = parse_message(message_group_text, bot_id=bot_id)
+    assert msg is not None
+    assert msg.chat_kind == "group"
+    assert msg.chat_id == -987654321
+    assert msg.chat_name == "Friends"
+    assert msg.sender_name == "Bob Smith"
+
+
+def test_supergroup_text(message_supergroup_text: Message, bot_id: int) -> None:
+    msg = parse_message(message_supergroup_text, bot_id=bot_id)
+    assert msg is not None
+    assert msg.chat_kind == "supergroup"
+    assert msg.chat_id == -1001234567890
+    assert msg.chat_name == "Big Chat"
+
+
+def test_reply(message_reply: Message, bot_id: int) -> None:
+    msg = parse_message(message_reply, bot_id=bot_id)
+    assert msg is not None
+    assert msg.text == "agreed!"
+    assert msg.reply is not None
+    assert msg.reply.message_id == 400
+    assert msg.reply.text == "Original message"
+
+
+def test_self_message_returns_none(message_from_self: Message, bot_id: int) -> None:
+    assert parse_message(message_from_self, bot_id=bot_id) is None
+
+
+def test_other_bot_returns_none(message_from_other_bot: Message, bot_id: int) -> None:
+    assert parse_message(message_from_other_bot, bot_id=bot_id) is None
+
+
+def test_photo_without_text_returns_none(message_photo_no_text: Message, bot_id: int) -> None:
+    assert parse_message(message_photo_no_text, bot_id=bot_id) is None
+
+
+def test_channel_post_without_sender_returns_none(
+    message_channel_post_no_sender: Message, bot_id: int
+) -> None:
+    # Channel posts have no ``from_user`` — out of scope for v1.
+    assert parse_message(message_channel_post_no_sender, bot_id=bot_id) is None

--- a/uv.lock
+++ b/uv.lock
@@ -1,11 +1,16 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [manifest]
 members = [
     "aios",
     "aios-signal",
+    "aios-telegram",
 ]
 
 [[package]]
@@ -192,6 +197,49 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.20,<2.0" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.6" },
+    { name = "structlog", specifier = ">=24.4" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.13" },
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-mock", specifier = ">=3.14" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "aios-telegram"
+version = "0.1.0"
+source = { editable = "connectors/telegram" }
+dependencies = [
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "python-telegram-bot" },
+    { name = "structlog" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "mcp", specifier = ">=1.20,<2.0" },
+    { name = "pydantic", specifier = ">=2.9" },
+    { name = "pydantic-settings", specifier = ">=2.6" },
+    { name = "python-telegram-bot", specifier = ">=22.6,<23" },
     { name = "structlog", specifier = ">=24.4" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
@@ -1665,6 +1713,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+]
+
+[[package]]
+name = "python-telegram-bot"
+version = "22.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpcore", marker = "python_full_version >= '3.14'" },
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/25/2258161b1069e66d6c39c0a602dbe57461d4767dc0012539970ea40bc9d6/python_telegram_bot-22.7.tar.gz", hash = "sha256:784b59ea3852fe4616ad63b4a0264c755637f5d725e87755ecdee28300febf61", size = 1516454, upload-time = "2026-03-16T09:36:03.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/f7/0e2f89dd62f45d46d4ea0d8aec5893ce5b37389638db010c117f46f11450/python_telegram_bot-22.7-py3-none-any.whl", hash = "sha256:d72eed532cf763758cd9331b57a6d790aff0bb4d37d8f4e92149436fe21c6475", size = 745365, upload-time = "2026-03-16T09:36:01.498Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `connectors/telegram/` as a standalone uv workspace package, mirroring the Signal connector pattern: ingests inbound Telegram messages into aios via `POST /v1/connections/{id}/messages` and serves an MCP server exposing `telegram_send` for outbound replies.
- Substantially smaller than `connectors/signal/` — no `daemon.py` / `rpc.py` / `markdown.py` / `addressing.py` because Telegram's Bot API is HTTP-native, chat IDs are URL-safe integers, and mentions are literal `@username` in text. Uses `python-telegram-bot>=22.6,<23` (proven in hermes-agent).
- v1 scope matches Signal v1: text in / text out in DMs, groups, and supergroups. No media, reactions, edits, forum topics, markdown rendering, message splitting, webhooks, or user allowlists — those are deferred to future PRs.

## Design choices (confirmed before coding)

- **Bot account segment**: numeric `bot.id` from `getMe`, not the mutable `@username`.
- **Chat scope**: DMs + groups + supergroups handled uniformly; operators gate access via aios routing rules.
- **Markdown**: plain text only (no `parse_mode`); the agent prompt tells the model to avoid markdown syntax.

## Architecture

`app.run()` wires two tasks under one `asyncio.TaskGroup`:
1. **PTB `Application`** — long-polling update loop. `getMe` on startup discovers the bot id; every text message is parsed → `build_metadata` → `IngestClient.post_message`.
2. **MCP server** — FastMCP on uvicorn, bearer-auth-gated, exposes `telegram_send(text)`.

The `telegram_send` tool reads the chat id from the `aios.focal_channel_path` meta field (same contract Signal uses) and calls `bot.send_message(chat_id=..., text=...)`.

## Test plan

- [x] `uv run pytest -q` in `connectors/telegram/` — 26 tests (parse, ingest retry + metadata, mcp tool + bearer auth + parse_bind) all passing
- [x] `uv run mypy src tests` — strict, no issues
- [x] `uv run ruff check src tests && uv run ruff format --check src tests`
- [x] Pre-commit hook suite (ruff + mypy + 699 root pytest) passes
- [x] Signal connector tests still pass (79/79) — no regressions
- [x] `python -m aios_telegram start --help` resolves
- [ ] Manual smoke test end-to-end: create a BotFather bot, register vault + credential + connection, add routing rule, DM the bot, confirm reply arrives (documented in `connectors/telegram/README.md`; requires a running aios instance with Phase 2 connection-provided MCP wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)