### PR TITLE
feat(tools): add schedule_wake primitive for delayed re-entry (closes #59)

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -48,15 +48,36 @@ def _retry_delay_for_attempt(attempt: int) -> float | None:
     return _RETRY_BACKOFF_SECONDS[attempt]
 
 
-async def run_session_step(session_id: str, *, cause: str = "message") -> None:
+async def run_session_step(
+    session_id: str,
+    *,
+    cause: str = "message",
+    wake_reason: str | None = None,
+) -> None:
     """Run one inference step for the session.
 
     Called by the procrastinate ``wake_session`` task. The procrastinate
     ``lock`` parameter guarantees only one step runs per session at a
     time.
+
+    When ``cause == "scheduled"`` and ``wake_reason`` is set (the
+    ``schedule_wake`` tool's delayed wake), a user-role marker is
+    appended before the sweep guard so the model has something to
+    react to on this step.
     """
     pool = runtime.require_pool()
     task_registry = runtime.require_task_registry()
+
+    if cause == "scheduled" and wake_reason:
+        await sessions_service.append_event(
+            pool,
+            session_id,
+            "message",
+            {
+                "role": "user",
+                "content": f"[Your scheduled wake fired. Reason: {wake_reason}]",
+            },
+        )
 
     # Sweep-based guard: does this session actually need work?
     # Prevents wasted DB/model calls from stale or duplicate wakes.

--- a/src/aios/harness/tasks.py
+++ b/src/aios/harness/tasks.py
@@ -35,8 +35,12 @@ from aios.harness.procrastinate_app import app
     retry=False,
     pass_context=False,
 )
-async def wake_session(session_id: str, cause: str = "message") -> None:
+async def wake_session(
+    session_id: str,
+    cause: str = "message",
+    wake_reason: str | None = None,
+) -> None:
     """Run one inference step for the session."""
     from aios.harness.loop import run_session_step
 
-    await run_session_step(session_id, cause=cause)
+    await run_session_step(session_id, cause=cause, wake_reason=wake_reason)

--- a/src/aios/harness/wake.py
+++ b/src/aios/harness/wake.py
@@ -8,28 +8,54 @@ one place without creating a circular ``api → harness`` dependency.
 from __future__ import annotations
 
 from procrastinate import exceptions as procrastinate_exceptions
+from procrastinate.types import JSONValue
 
 from aios.logging import get_logger
 
 log = get_logger("aios.harness.wake")
 
 
-async def defer_wake(session_id: str, *, cause: str = "message") -> None:
+async def defer_wake(
+    session_id: str,
+    *,
+    cause: str = "message",
+    delay_seconds: float | None = None,
+    wake_reason: str | None = None,
+) -> None:
     """Enqueue a ``wake_session`` job, swallowing ``AlreadyEnqueued``.
 
     If a wake is already queued for this session (``queueing_lock``
     deduplication), the existing job will process any new events when
     it runs — no need for a second job.
+
+    ``delay_seconds`` schedules the job that many seconds in the future
+    (procrastinate's ``schedule_in``).  ``wake_reason`` is a short string
+    carried as a task kwarg and surfaced to the agent at wake time when
+    ``cause == "scheduled"``; see ``run_session_step``.
     """
     from aios.harness.procrastinate_app import app
 
+    task_kwargs: dict[str, JSONValue] = {"session_id": session_id, "cause": cause}
+    if wake_reason is not None:
+        task_kwargs["wake_reason"] = wake_reason
+
+    if delay_seconds is not None:
+        deferrer = app.configure_task(
+            "harness.wake_session",
+            schedule_in={"seconds": delay_seconds},
+        )
+    else:
+        deferrer = app.configure_task("harness.wake_session")
+
     try:
-        await app.configure_task("harness.wake_session").defer_async(
+        await deferrer.defer_async(**task_kwargs)
+    except procrastinate_exceptions.AlreadyEnqueued:
+        log.debug(
+            "wake.already_enqueued",
             session_id=session_id,
             cause=cause,
+            delay_seconds=delay_seconds,
         )
-    except procrastinate_exceptions.AlreadyEnqueued:
-        log.debug("wake.already_enqueued", session_id=session_id, cause=cause)
 
 
 async def defer_retry_wake(session_id: str, *, delay_seconds: float) -> None:

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -27,6 +27,7 @@ BuiltinToolType = Literal[
     "web_search",
     "search_events",
     "cancel",
+    "schedule_wake",
 ]
 
 # Permission policy for built-in tools. Custom tools are always client-controlled

--- a/src/aios/tools/__init__.py
+++ b/src/aios/tools/__init__.py
@@ -25,6 +25,7 @@ from aios.tools import edit as _edit  # noqa: F401
 from aios.tools import glob as _glob  # noqa: F401
 from aios.tools import grep as _grep  # noqa: F401
 from aios.tools import read as _read  # noqa: F401
+from aios.tools import schedule_wake as _schedule_wake  # noqa: F401
 from aios.tools import search_events as _search_events  # noqa: F401
 from aios.tools import switch_channel as _switch_channel  # noqa: F401
 from aios.tools import web_fetch as _web_fetch  # noqa: F401

--- a/src/aios/tools/schedule_wake.py
+++ b/src/aios/tools/schedule_wake.py
@@ -1,0 +1,103 @@
+"""The schedule_wake tool — ask the harness to wake this session after a delay.
+
+Gives an agent without bash access a first-class "wait N seconds and then
+do X" primitive.  The tool returns immediately; at T+delay the session
+wakes with ``cause="scheduled"`` and a user-role marker whose content
+echoes ``reason`` is appended before the sweep guard runs, so the model
+has something to react to.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.errors import AiosError
+from aios.harness.wake import defer_wake
+from aios.tools.registry import registry
+
+
+class ScheduleWakeArgumentError(AiosError):
+    error_type = "schedule_wake_argument_error"
+    status_code = 400
+
+
+SCHEDULE_WAKE_MIN_DELAY_SECONDS = 1
+SCHEDULE_WAKE_MAX_DELAY_SECONDS = 3600
+
+
+SCHEDULE_WAKE_DESCRIPTION = (
+    "Ask the harness to wake you again after a delay. Use this for "
+    "'wait N seconds and then do X' tasks instead of occupying a sandbox "
+    "with `sleep`. Returns immediately; you'll receive a new step at "
+    "T+delay_seconds with a marker echoing your `reason` so you remember "
+    "why you scheduled this. While the scheduled wake is pending, new "
+    "user messages will queue but not trigger an earlier step — keep "
+    "delays short if the conversation is active."
+)
+
+SCHEDULE_WAKE_PARAMETERS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "delay_seconds": {
+            "type": "integer",
+            "minimum": SCHEDULE_WAKE_MIN_DELAY_SECONDS,
+            "maximum": SCHEDULE_WAKE_MAX_DELAY_SECONDS,
+            "description": (
+                f"How long to wait before the next wake, in seconds. "
+                f"Range {SCHEDULE_WAKE_MIN_DELAY_SECONDS}"
+                f"-{SCHEDULE_WAKE_MAX_DELAY_SECONDS}."
+            ),
+        },
+        "reason": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Short note shown back to you at wake time so you remember why you scheduled this."
+            ),
+        },
+    },
+    "required": ["delay_seconds", "reason"],
+    "additionalProperties": False,
+}
+
+
+async def schedule_wake_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    delay_seconds = arguments.get("delay_seconds")
+    if not isinstance(delay_seconds, int):
+        raise ScheduleWakeArgumentError("delay_seconds must be an integer")
+    if (
+        delay_seconds < SCHEDULE_WAKE_MIN_DELAY_SECONDS
+        or delay_seconds > SCHEDULE_WAKE_MAX_DELAY_SECONDS
+    ):
+        raise ScheduleWakeArgumentError(
+            f"delay_seconds must be between {SCHEDULE_WAKE_MIN_DELAY_SECONDS} "
+            f"and {SCHEDULE_WAKE_MAX_DELAY_SECONDS}"
+        )
+    reason = arguments.get("reason")
+    if not isinstance(reason, str) or not reason:
+        raise ScheduleWakeArgumentError("reason must be a non-empty string")
+
+    await defer_wake(
+        session_id,
+        cause="scheduled",
+        delay_seconds=delay_seconds,
+        wake_reason=reason,
+    )
+
+    return {
+        "scheduled": True,
+        "delay_seconds": delay_seconds,
+        "reason": reason,
+    }
+
+
+def _register() -> None:
+    registry.register(
+        name="schedule_wake",
+        description=SCHEDULE_WAKE_DESCRIPTION,
+        parameters_schema=SCHEDULE_WAKE_PARAMETERS_SCHEMA,
+        handler=schedule_wake_handler,
+    )
+
+
+_register()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -23,7 +23,13 @@ import pytest
 from tests.e2e.harness import Harness
 
 
-async def _noop_defer_wake(session_id: str, *, cause: str = "message") -> None:
+async def _noop_defer_wake(
+    session_id: str,
+    *,
+    cause: str = "message",
+    delay_seconds: float | None = None,
+    wake_reason: str | None = None,
+) -> None:
     pass
 
 

--- a/tests/unit/test_schedule_wake_handler.py
+++ b/tests/unit/test_schedule_wake_handler.py
@@ -1,0 +1,77 @@
+"""Unit tests for the ``schedule_wake`` tool handler."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios.tools.schedule_wake import (
+    ScheduleWakeArgumentError,
+    schedule_wake_handler,
+)
+
+
+class TestScheduleWakeHandler:
+    async def test_valid_delay_calls_defer_wake(self, monkeypatch: Any) -> None:
+        mock_defer = AsyncMock()
+        monkeypatch.setattr("aios.tools.schedule_wake.defer_wake", mock_defer)
+
+        result = await schedule_wake_handler(
+            "sess_01TEST",
+            {"delay_seconds": 30, "reason": "check back later"},
+        )
+
+        mock_defer.assert_awaited_once_with(
+            "sess_01TEST",
+            cause="scheduled",
+            delay_seconds=30,
+            wake_reason="check back later",
+        )
+        assert result["scheduled"] is True
+        assert result["delay_seconds"] == 30
+        assert result["reason"] == "check back later"
+
+    async def test_delay_below_one_rejects(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr("aios.tools.schedule_wake.defer_wake", AsyncMock())
+
+        with pytest.raises(ScheduleWakeArgumentError, match=r"1.*3600"):
+            await schedule_wake_handler(
+                "sess_01TEST",
+                {"delay_seconds": 0, "reason": "bad"},
+            )
+
+    async def test_delay_above_one_hour_rejects(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr("aios.tools.schedule_wake.defer_wake", AsyncMock())
+
+        with pytest.raises(ScheduleWakeArgumentError, match=r"1.*3600"):
+            await schedule_wake_handler(
+                "sess_01TEST",
+                {"delay_seconds": 3601, "reason": "too long"},
+            )
+
+    async def test_non_integer_delay_rejects(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr("aios.tools.schedule_wake.defer_wake", AsyncMock())
+
+        with pytest.raises(ScheduleWakeArgumentError, match="integer"):
+            await schedule_wake_handler(
+                "sess_01TEST",
+                {"delay_seconds": "sleep_thirty", "reason": "bad"},
+            )
+
+    async def test_missing_reason_rejects(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr("aios.tools.schedule_wake.defer_wake", AsyncMock())
+
+        with pytest.raises(ScheduleWakeArgumentError, match="reason"):
+            await schedule_wake_handler("sess_01TEST", {"delay_seconds": 5})
+
+    async def test_boundary_delays_accepted(self, monkeypatch: Any) -> None:
+        """Exact boundaries (1s and 3600s) land on the accepted side."""
+        mock_defer = AsyncMock()
+        monkeypatch.setattr("aios.tools.schedule_wake.defer_wake", mock_defer)
+
+        await schedule_wake_handler("sess_01TEST", {"delay_seconds": 1, "reason": "min"})
+        await schedule_wake_handler("sess_01TEST", {"delay_seconds": 3600, "reason": "max"})
+
+        assert mock_defer.await_count == 2

--- a/tests/unit/test_scheduled_wake_marker.py
+++ b/tests/unit/test_scheduled_wake_marker.py
@@ -1,0 +1,141 @@
+"""Unit tests for the ``cause="scheduled"`` marker-append in ``run_session_step``.
+
+When the ``schedule_wake`` tool's delayed wake fires, the step must
+materialize a synthetic user-role event before the sweep guard runs —
+otherwise the sweep sees no unreacted messages and early-outs, and the
+agent never actually gets a step at T+delay.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aios.harness.loop import run_session_step
+
+
+class TestScheduledWakeMarker:
+    async def test_marker_appended_before_sweep_for_scheduled_wake(self) -> None:
+        append_event = AsyncMock()
+        with (
+            patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+            patch(
+                "aios.harness.loop.runtime.require_task_registry",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(return_value=set()),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.append_event",
+                append_event,
+            ),
+        ):
+            await run_session_step("sess_x", cause="scheduled", wake_reason="ping home")
+
+        assert append_event.await_count == 1
+        call = append_event.await_args
+        assert call is not None
+        args, _ = call.args, call.kwargs
+        assert args[2] == "message"
+        assert args[3] == {
+            "role": "user",
+            "content": "[Your scheduled wake fired. Reason: ping home]",
+        }
+
+    async def test_no_marker_for_non_scheduled_causes(self) -> None:
+        append_event = AsyncMock()
+        with (
+            patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+            patch(
+                "aios.harness.loop.runtime.require_task_registry",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(return_value=set()),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.append_event",
+                append_event,
+            ),
+        ):
+            await run_session_step("sess_x", cause="message", wake_reason=None)
+            await run_session_step("sess_x", cause="reschedule", wake_reason=None)
+            await run_session_step("sess_x", cause="tool_result", wake_reason=None)
+
+        append_event.assert_not_awaited()
+
+    async def test_scheduled_cause_without_reason_is_noop(self) -> None:
+        """Defensive: ``cause="scheduled"`` with no reason attached doesn't inject noise."""
+        append_event = AsyncMock()
+        with (
+            patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+            patch(
+                "aios.harness.loop.runtime.require_task_registry",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(return_value=set()),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.append_event",
+                append_event,
+            ),
+        ):
+            await run_session_step("sess_x", cause="scheduled", wake_reason=None)
+
+        append_event.assert_not_awaited()
+
+
+class TestDeferWakeExtension:
+    async def test_defer_wake_with_delay_schedules_in_future(self, monkeypatch: Any) -> None:
+        """``defer_wake`` with ``delay_seconds`` routes through ``configure_task``'s
+        ``schedule_in`` and carries ``wake_reason`` as a task kwarg.
+        """
+        from datetime import UTC, datetime, timedelta
+
+        from procrastinate import App
+        from procrastinate.testing import InMemoryConnector
+
+        from aios.harness.procrastinate_app import app
+        from aios.harness.wake import defer_wake
+
+        patched: App
+        with app.replace_connector(InMemoryConnector()) as patched:
+            before = datetime.now(UTC)
+            await defer_wake(
+                "sess_x",
+                cause="scheduled",
+                delay_seconds=42,
+                wake_reason="ring",
+            )
+            after = datetime.now(UTC)
+
+            (job,) = patched.connector.jobs.values()
+            assert job["args"] == {
+                "session_id": "sess_x",
+                "cause": "scheduled",
+                "wake_reason": "ring",
+            }
+            assert job["scheduled_at"] is not None
+            assert (
+                before + timedelta(seconds=42)
+                <= job["scheduled_at"]
+                <= after + timedelta(seconds=42)
+            )
+
+    async def test_defer_wake_without_delay_is_immediate(self) -> None:
+        from procrastinate.testing import InMemoryConnector
+
+        from aios.harness.procrastinate_app import app
+        from aios.harness.wake import defer_wake
+
+        with app.replace_connector(InMemoryConnector()) as patched:
+            await defer_wake("sess_x", cause="message")
+
+            (job,) = patched.connector.jobs.values()
+            assert job["scheduled_at"] is None
+            assert "wake_reason" not in job["args"]


### PR DESCRIPTION
## Summary

- New \`schedule_wake(delay_seconds, reason)\` built-in tool. Agents without bash gain a first-class \"wait N seconds then do X\" primitive without occupying a sandbox with \`sleep\`.
- Plumbing: \`defer_wake\` gains optional \`delay_seconds\` + \`wake_reason\`; the task propagates the reason; \`run_session_step\` appends a user-role marker \`[Your scheduled wake fired. Reason: R]\` before the sweep guard, which is the unreacted event the sweep needs to let the step proceed.

## Why the marker-before-sweep matters

The sweep (\`find_sessions_needing_inference\`) gates \`run_session_step\` on unreacted message events. Without materializing a marker at wake time, the scheduled wake would fire the job but the step would short-circuit — no model call, no \"new step at T+delay\" that the tool promises.

## Limitation (documented in tool description)

While a scheduled wake is in the queue, new user-message \`defer_wake\` calls dedup against the task's \`queueing_lock\` and don't trigger an earlier step. The tool description warns agents to keep delays short on active conversations. Unifying / preempting scheduled wakes on hot-path interruption is a follow-up.

## Test plan

- [x] 6 handler tests: validation, range boundaries, defer_wake call shape
- [x] 3 step tests: marker appended only for \`cause=\"scheduled\"\` + \`wake_reason\"\`, otherwise no-op
- [x] 2 \`defer_wake\` wiring tests with \`InMemoryConnector\` (delayed job has future \`scheduled_at\` + \`wake_reason\` in args; no-delay job stays immediate)
- [x] \`pytest tests/unit\` — 710 passed
- [x] \`pytest tests/e2e\` — 206 passed (includes fixture update so \`_noop_defer_wake\` accepts the new kwargs)
- [x] mypy + ruff clean

Closes #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)