### PR TITLE
feat(cli): aios tail <session_id> — structured session event viewer (closes #61)

### DIFF
--- a/src/aios/__main__.py
+++ b/src/aios/__main__.py
@@ -1,10 +1,11 @@
 """CLI entrypoint: ``python -m aios <subcommand>``.
 
-Phase 2 wires up all three subcommands:
+Subcommands:
 
 * ``aios api``     — uvicorn boot of the FastAPI app
 * ``aios worker``  — procrastinate worker process (runs the harness loop)
 * ``aios migrate`` — alembic upgrade head + procrastinate schema apply
+* ``aios tail``    — structured real-time session event viewer (SSE client)
 """
 
 from __future__ import annotations
@@ -85,7 +86,7 @@ def _run_migrate() -> int:
 
 def main() -> int:
     if len(sys.argv) < 2:
-        print("usage: aios <api|worker|migrate>", file=sys.stderr)
+        print("usage: aios <api|worker|migrate|tail>", file=sys.stderr)
         return 2
 
     cmd = sys.argv[1]
@@ -96,6 +97,10 @@ def main() -> int:
             return _run_worker()
         case "migrate":
             return _run_migrate()
+        case "tail":
+            from aios.tail import run as _run_tail
+
+            return _run_tail(sys.argv[2:])
         case _:
             print(f"aios: unknown subcommand {cmd!r}", file=sys.stderr)
             return 2

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -49,7 +49,12 @@ def _event_to_sse(event_dict: dict[str, Any]) -> ServerSentEvent:
 
 
 def _serialize_event(row: asyncpg.Record) -> dict[str, Any]:
-    """Convert an asyncpg event row to a JSON-friendly dict."""
+    """Convert an asyncpg event row to a JSON-friendly dict.
+
+    ``orig_channel`` and ``channel`` come along so downstream consumers
+    (e.g. the ``aios tail`` CLI) can tag user messages and spot
+    wrong-channel sends without re-querying.
+    """
     import json
 
     raw_data = row["data"]
@@ -61,6 +66,8 @@ def _serialize_event(row: asyncpg.Record) -> dict[str, Any]:
         "kind": row["kind"],
         "data": parsed,
         "created_at": row["created_at"].isoformat(),
+        "orig_channel": row["orig_channel"],
+        "channel": row["channel"],
     }
 
 

--- a/src/aios/tail.py
+++ b/src/aios/tail.py
@@ -1,0 +1,213 @@
+"""``aios tail <session_id>`` — structured real-time session event viewer.
+
+Subscribes to the session's SSE stream and emits one-line summaries keyed
+by event kind + role + content shape.  Feedback loop for catching silent
+turns, wrong-channel sends, tool-call-id corruption, etc. during live
+operator work.
+
+Transient streaming-delta payloads (``event: delta``) are skipped so the
+terminal doesn't drown in per-token notifications; only persisted events
+(``event: event``) reach the formatter.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import AsyncIterator
+from typing import Any
+
+MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: "
+CONTENT_PREVIEW_MAX = 240
+
+
+def format_event(event: dict[str, Any]) -> str | None:
+    """Format one persisted session event as a one-line summary.
+
+    Returns ``None`` for events the tail viewer should silently skip
+    (spans, unknown kinds).
+    """
+    seq = event.get("seq", "?")
+    kind = event.get("kind")
+
+    if kind == "message":
+        return _format_message(seq, event)
+    if kind == "lifecycle":
+        data = event.get("data") or {}
+        ev = data.get("event", "?")
+        status = data.get("status", "?")
+        stop = data.get("stop_reason", "?")
+        return f"#{seq} LIFECYCLE {ev} (status={status}, stop_reason={stop})"
+    return None
+
+
+def _format_message(seq: Any, event: dict[str, Any]) -> str | None:
+    data = event.get("data") or {}
+    role = data.get("role")
+
+    if role == "user":
+        content = _preview(_as_text(data.get("content")))
+        channel = event.get("orig_channel")
+        tag = f"USER[{channel}]" if channel else "USER"
+        return f"#{seq} {tag}: {content}"
+
+    if role == "assistant":
+        tool_calls = data.get("tool_calls") or []
+        if tool_calls:
+            rendered = ", ".join(_render_tool_call(tc) for tc in tool_calls)
+            return f"#{seq} AGENT→{rendered}"
+        text = _as_text(data.get("content"))
+        if not text:
+            return f"#{seq} AGENT(silent) ⚠ no tool, no text"
+        if text.startswith(MONOLOGUE_PREFIX):
+            return f"#{seq} AGENT(mono): {_preview(text[len(MONOLOGUE_PREFIX) :])}"
+        return f"#{seq} AGENT(bare): {_preview(text)}"
+
+    if role == "tool":
+        tcid = data.get("tool_call_id") or "?"
+        content = _preview(_as_text(data.get("content")))
+        if data.get("is_error"):
+            return f"#{seq} TOOL⚠ ERROR[{tcid}]: {content}"
+        return f"#{seq} TOOL[{tcid}]: {content}"
+
+    return None
+
+
+def _render_tool_call(tc: dict[str, Any]) -> str:
+    fn = tc.get("function") or {}
+    name = fn.get("name") or "?"
+    args = fn.get("arguments")
+    if not isinstance(args, str):
+        args = ""
+    return f"{name}: {_preview(args)}" if args else f"{name}()"
+
+
+def _as_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return "".join(parts)
+    return str(content)
+
+
+def _preview(text: str) -> str:
+    text = text.replace("\n", " ")
+    if len(text) <= CONTENT_PREVIEW_MAX:
+        return text
+    return text[: CONTENT_PREVIEW_MAX - 1] + "…"
+
+
+# ─── SSE subscription ───────────────────────────────────────────────────────
+
+
+async def _iter_sse_events(
+    response: Any,
+) -> AsyncIterator[tuple[str, str]]:
+    """Yield ``(event_type, data)`` tuples from an httpx streaming response."""
+    event_type = "message"
+    data_parts: list[str] = []
+    async for raw in response.aiter_lines():
+        line = raw.rstrip("\r")
+        if not line:
+            if data_parts:
+                yield event_type, "\n".join(data_parts)
+            event_type = "message"
+            data_parts = []
+            continue
+        if line.startswith("event: "):
+            event_type = line[7:]
+        elif line.startswith("data: "):
+            data_parts.append(line[6:])
+
+
+async def stream(
+    session_id: str,
+    *,
+    api_url: str,
+    api_key: str,
+    from_seq: int = 0,
+) -> int:
+    """Subscribe and print formatted events until the server closes the stream."""
+    import httpx
+
+    url = f"{api_url.rstrip('/')}/v1/sessions/{session_id}/stream"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    params: dict[str, str | int] = {}
+    if from_seq:
+        params["after_seq"] = from_seq
+
+    try:
+        async with (
+            httpx.AsyncClient(timeout=None) as client,
+            client.stream("GET", url, headers=headers, params=params) as response,
+        ):
+            if response.status_code != 200:
+                body = await response.aread()
+                print(
+                    f"aios tail: HTTP {response.status_code}: {body.decode(errors='replace')}",
+                    file=sys.stderr,
+                )
+                return 2
+            async for ev_type, payload in _iter_sse_events(response):
+                if ev_type != "event":
+                    continue
+                try:
+                    event = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                line = format_event(event)
+                if line is not None:
+                    print(line, flush=True)
+    except KeyboardInterrupt:
+        return 130
+    return 0
+
+
+def run(argv: list[str]) -> int:
+    from_seq = 0
+    positional: list[str] = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg in {"-h", "--help"}:
+            print("usage: aios tail <session_id> [--from-seq N]", file=sys.stderr)
+            return 0
+        if arg == "--from-seq":
+            if i + 1 >= len(argv):
+                print("aios tail: --from-seq requires a value", file=sys.stderr)
+                return 2
+            try:
+                from_seq = int(argv[i + 1])
+            except ValueError:
+                print("aios tail: --from-seq must be an integer", file=sys.stderr)
+                return 2
+            i += 2
+            continue
+        positional.append(arg)
+        i += 1
+
+    if len(positional) != 1:
+        print("usage: aios tail <session_id> [--from-seq N]", file=sys.stderr)
+        return 2
+
+    session_id = positional[0]
+    api_key = os.environ.get("AIOS_API_KEY")
+    if not api_key:
+        print("aios tail: AIOS_API_KEY is required", file=sys.stderr)
+        return 2
+    api_url = os.environ.get(
+        "AIOS_API_URL",
+        f"http://{os.environ.get('AIOS_API_HOST', '127.0.0.1')}"
+        f":{os.environ.get('AIOS_API_PORT', '8080')}",
+    )
+
+    import asyncio
+
+    return asyncio.run(stream(session_id, api_url=api_url, api_key=api_key, from_seq=from_seq))

--- a/tests/unit/test_tail_formatter.py
+++ b/tests/unit/test_tail_formatter.py
@@ -1,0 +1,162 @@
+"""Unit tests for ``aios.tail.format_event`` — the one-line session-event renderer."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.tail import format_event
+
+
+def _msg(
+    seq: int,
+    role: str,
+    *,
+    content: str | None = None,
+    tool_calls: list[dict[str, Any]] | None = None,
+    tool_call_id: str | None = None,
+    is_error: bool = False,
+    orig_channel: str | None = None,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {"role": role}
+    if content is not None:
+        data["content"] = content
+    if tool_calls is not None:
+        data["tool_calls"] = tool_calls
+    if tool_call_id is not None:
+        data["tool_call_id"] = tool_call_id
+    if is_error:
+        data["is_error"] = True
+    event: dict[str, Any] = {"seq": seq, "kind": "message", "data": data}
+    if orig_channel is not None:
+        event["orig_channel"] = orig_channel
+    return event
+
+
+class TestUserEvents:
+    def test_plain_user_message(self) -> None:
+        e = _msg(144, "user", content="hey")
+        assert format_event(e) == "#144 USER: hey"
+
+    def test_user_message_with_channel(self) -> None:
+        e = _msg(144, "user", content="hey", orig_channel="signal/dm/alice")
+        assert format_event(e) == "#144 USER[signal/dm/alice]: hey"
+
+    def test_user_message_truncates_long_content(self) -> None:
+        e = _msg(1, "user", content="x" * 500)
+        out = format_event(e)
+        assert out is not None
+        assert len(out) < 500
+        assert out.endswith("…")
+
+
+class TestAssistantEvents:
+    def test_bare_text_assistant(self) -> None:
+        e = _msg(150, "assistant", content="hello world")
+        assert format_event(e) == "#150 AGENT(bare): hello world"
+
+    def test_monologue_assistant(self) -> None:
+        e = _msg(
+            151,
+            "assistant",
+            content="INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: thinking...",
+        )
+        assert format_event(e) == "#151 AGENT(mono): thinking..."
+
+    def test_tool_call_assistant(self) -> None:
+        e = _msg(
+            147,
+            "assistant",
+            tool_calls=[
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"command":"ls"}'},
+                }
+            ],
+        )
+        assert format_event(e) == '#147 AGENT→bash: {"command":"ls"}'
+
+    def test_multiple_tool_calls_concatenated(self) -> None:
+        e = _msg(
+            149,
+            "assistant",
+            tool_calls=[
+                {"function": {"name": "read", "arguments": "{}"}},
+                {"function": {"name": "write", "arguments": "{}"}},
+            ],
+        )
+        assert format_event(e) == "#149 AGENT→read: {}, write: {}"
+
+    def test_silent_assistant_flagged(self) -> None:
+        e = _msg(1764, "assistant", content="")
+        assert format_event(e) == "#1764 AGENT(silent) ⚠ no tool, no text"
+
+    def test_silent_assistant_with_null_content(self) -> None:
+        e = _msg(1765, "assistant", content=None)
+        assert format_event(e) == "#1765 AGENT(silent) ⚠ no tool, no text"
+
+    def test_mixed_content_and_tool_calls_prefers_tool_calls(self) -> None:
+        e = _msg(
+            200,
+            "assistant",
+            content="here's my plan",
+            tool_calls=[{"function": {"name": "bash", "arguments": "{}"}}],
+        )
+        assert format_event(e) == "#200 AGENT→bash: {}"
+
+
+class TestToolEvents:
+    def test_normal_tool_result(self) -> None:
+        e = _msg(148, "tool", content="file contents...", tool_call_id="call_1")
+        assert format_event(e) == "#148 TOOL[call_1]: file contents..."
+
+    def test_error_tool_result(self) -> None:
+        e = _msg(
+            1303,
+            "tool",
+            content="MCP server 'conn_abc' not found",
+            tool_call_id="call_9",
+            is_error=True,
+        )
+        assert format_event(e) == "#1303 TOOL⚠ ERROR[call_9]: MCP server 'conn_abc' not found"
+
+    def test_tool_result_without_tool_call_id(self) -> None:
+        e = _msg(149, "tool", content="ok")
+        assert format_event(e) == "#149 TOOL[?]: ok"
+
+
+class TestLifecycleEvents:
+    def test_turn_ended(self) -> None:
+        e: dict[str, Any] = {
+            "seq": 200,
+            "kind": "lifecycle",
+            "data": {"event": "turn_ended", "status": "idle", "stop_reason": "end_turn"},
+        }
+        out = format_event(e)
+        assert out is not None
+        assert out.startswith("#200 LIFECYCLE ")
+        assert "turn_ended" in out
+
+    def test_interrupted(self) -> None:
+        e: dict[str, Any] = {
+            "seq": 201,
+            "kind": "lifecycle",
+            "data": {"event": "interrupted", "status": "idle", "stop_reason": "interrupt"},
+        }
+        out = format_event(e)
+        assert out is not None
+        assert "interrupted" in out
+
+
+class TestSkippableEvents:
+    def test_span_events_return_none(self) -> None:
+        e: dict[str, Any] = {
+            "seq": 10,
+            "kind": "span",
+            "data": {"event": "model_request_start"},
+        }
+        assert format_event(e) is None
+
+    def test_unknown_kind_returns_none(self) -> None:
+        e: dict[str, Any] = {"seq": 99, "kind": "weird_new_kind", "data": {}}
+        assert format_event(e) is None


### PR DESCRIPTION
## Summary

- New \`aios tail <session_id>\` subcommand. Subscribes to the existing SSE stream and emits one-line summaries keyed by kind + role + content shape. Built-in feedback loop for catching silent turns, wrong-channel sends, tool-call-id corruption, etc.
- SSE envelope now also carries \`orig_channel\` and \`channel\` (the derived "which channel does this event belong to" field) so the tail viewer can label user messages and spot wrong-channel sends without re-querying. Backwards-compatible addition.

## Example output

\`\`\`
#144 USER[signal/dm/Tom]: hey
#147 AGENT→switch_channel: {\"channel_id\": \"...\"}
#148 TOOL[call_1]: focal set
#151 AGENT→signal_send: {\"text\": \"Hey! What's up?\"}
#155 AGENT(mono): OK. Focused on your DM.
#1303 TOOL⚠ ERROR[call_9]: MCP server 'conn_...' not found
\`\`\`

## Test plan

- [x] 17 unit tests for \`format_event\` across every message/role/shape + lifecycle + skippable kinds
- [x] \`pytest tests/unit\` — 727 passed
- [x] \`pytest tests/e2e\` — 206 passed (SSE envelope extension doesn't break existing consumers)
- [x] mypy + ruff clean
- [x] Manual smoke: \`uv run python -m aios tail\` (usage), \`--help\`, missing API key message

Closes #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)