### PR TITLE
feat(harness): emit context_build span pair around the step prologue (progresses #78)

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -135,67 +135,107 @@ async def run_session_step(
         )
         return
 
-    # Discovery runs before prompt assembly because each MCP server's
-    # instructions feed the per-connector affordance block.
-    tools = to_openai_tools(agent.tools)
-    # Inject the built-in switch_channel tool when the session has any
-    # active bindings — it's the only way the agent can mutate its
-    # focal attention, so expose it whenever focal-aware rendering is
-    # relevant.  Agents don't need to opt in via ``agent.tools``; the
-    # focal machinery is session-state-level, not agent-level.
-    if bindings:
-        tools.append(_switch_channel_tool_spec())
-    mcp_instructions: dict[str, str] = {}
-    if agent.mcp_servers or connections:
-        mcp_tools, mcp_instructions = await discover_session_mcp_tools(
-            pool, session_id, agent, connections
+    # Span the remainder of the prologue so "why is the step slow?"
+    # can separate context-build cost from model-call cost (issue #78).
+    # Bracketing starts AFTER the dispatch early-return so every start
+    # has a matching end; on failure we still emit the end with
+    # ``is_error: True`` and re-raise, matching the ``model_request_*``
+    # symmetry.
+    context_build_start = await sessions_service.append_event(
+        pool,
+        session_id,
+        "span",
+        {"event": "context_build_start"},
+    )
+
+    try:
+        # Discovery runs before prompt assembly because each MCP server's
+        # instructions feed the per-connector affordance block.
+        tools = to_openai_tools(agent.tools)
+        # Inject the built-in switch_channel tool when the session has any
+        # active bindings — it's the only way the agent can mutate its
+        # focal attention, so expose it whenever focal-aware rendering is
+        # relevant.  Agents don't need to opt in via ``agent.tools``; the
+        # focal machinery is session-state-level, not agent-level.
+        if bindings:
+            tools.append(_switch_channel_tool_spec())
+        mcp_instructions: dict[str, str] = {}
+        if agent.mcp_servers or connections:
+            mcp_tools, mcp_instructions = await discover_session_mcp_tools(
+                pool, session_id, agent, connections
+            )
+            # Hide connection-provided MCP tools when the agent is in the
+            # "phone down" state (focal_channel is NULL).  You can't type in
+            # a chat app unless you're in a chat — the agent must call
+            # switch_channel first if it wants to send.
+            mcp_tools = _hide_conn_tools_when_phone_down(mcp_tools, session.focal_channel)
+            tools.extend(mcp_tools)
+
+        # Resolve skills and augment system prompt.
+        from aios.harness.channels import (
+            augment_with_connector_instructions,
+            augment_with_focal_paradigm,
+            build_channels_tail_block,
         )
-        # Hide connection-provided MCP tools when the agent is in the
-        # "phone down" state (focal_channel is NULL).  You can't type in
-        # a chat app unless you're in a chat — the agent must call
-        # switch_channel first if it wants to send.
-        mcp_tools = _hide_conn_tools_when_phone_down(mcp_tools, session.focal_channel)
-        tools.extend(mcp_tools)
+        from aios.harness.skills import augment_system_prompt, provision_skill_files
+        from aios.services import skills as skills_service
 
-    # Resolve skills and augment system prompt.
-    from aios.harness.channels import (
-        augment_with_connector_instructions,
-        augment_with_focal_paradigm,
-        build_channels_tail_block,
+        skill_versions = (
+            await skills_service.resolve_skill_refs(pool, agent.skills) if agent.skills else []
+        )
+        system_prompt = augment_system_prompt(agent.system, skill_versions)
+        system_prompt = augment_with_focal_paradigm(system_prompt, bindings)
+        system_prompt = augment_with_connector_instructions(
+            system_prompt, mcp_instructions, connections
+        )
+
+        # Provision skill files to workspace (idempotent, host-side writes).
+        if skill_versions:
+            await provision_skill_files(session_id, skill_versions)
+
+        ctx = build_messages(
+            events,
+            system_prompt=system_prompt,
+        )
+
+        # The tail block lives *after* build_messages so its per-step
+        # mutations (unread counts, previews) don't bust the prefix cache.
+        # Paradigm prose (symbol meanings, switch_channel semantics) stays
+        # in the cache-stable system prompt above.
+        tail = build_channels_tail_block(bindings, events, session.focal_channel)
+        if tail is not None:
+            ctx.messages.append(tail)
+
+        # Block LiteLLM's adjacent-same-role merge on Anthropic so the tail
+        # block isn't concatenated into the preceding user inbound.  See
+        # :func:`separate_adjacent_user_messages` for the mechanism.
+        ctx.messages = separate_adjacent_user_messages(ctx.messages)
+    except Exception:
+        await sessions_service.append_event(
+            pool,
+            session_id,
+            "span",
+            {
+                "event": "context_build_end",
+                "context_build_start_id": context_build_start.id,
+                "is_error": True,
+            },
+        )
+        raise
+
+    await sessions_service.append_event(
+        pool,
+        session_id,
+        "span",
+        {
+            "event": "context_build_end",
+            "context_build_start_id": context_build_start.id,
+            "is_error": False,
+            "event_count_read": len(events),
+            "message_count": len(ctx.messages),
+            "tools_count": len(tools),
+        },
     )
-    from aios.harness.skills import augment_system_prompt, provision_skill_files
-    from aios.services import skills as skills_service
-
-    skill_versions = (
-        await skills_service.resolve_skill_refs(pool, agent.skills) if agent.skills else []
-    )
-    system_prompt = augment_system_prompt(agent.system, skill_versions)
-    system_prompt = augment_with_focal_paradigm(system_prompt, bindings)
-    system_prompt = augment_with_connector_instructions(
-        system_prompt, mcp_instructions, connections
-    )
-
-    # Provision skill files to workspace (idempotent, host-side writes).
-    if skill_versions:
-        await provision_skill_files(session_id, skill_versions)
-
-    ctx = build_messages(
-        events,
-        system_prompt=system_prompt,
-    )
-
-    # The tail block lives *after* build_messages so its per-step
-    # mutations (unread counts, previews) don't bust the prefix cache.
-    # Paradigm prose (symbol meanings, switch_channel semantics) stays
-    # in the cache-stable system prompt above.
-    tail = build_channels_tail_block(bindings, events, session.focal_channel)
-    if tail is not None:
-        ctx.messages.append(tail)
-
-    # Block LiteLLM's adjacent-same-role merge on Anthropic so the tail
-    # block isn't concatenated into the preceding user inbound.  See
-    # :func:`separate_adjacent_user_messages` for the mechanism.
-    ctx.messages = separate_adjacent_user_messages(ctx.messages)
 
     # Dump the exact chat-completions payload we're about to send to LiteLLM
     # when AIOS_DUMP_CONTEXT is set — useful for debugging prompt construction

--- a/tests/e2e/test_context_build_span.py
+++ b/tests/e2e/test_context_build_span.py
@@ -1,0 +1,76 @@
+"""E2E tests for the ``context_build_*`` span pair (issue #78, first stage)."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from tests.e2e.harness import Harness, assistant
+
+
+class TestContextBuildSpan:
+    async def test_context_build_span_pair_per_step(self, harness: Harness) -> None:
+        harness.script_model([assistant("Hi!")])
+        session = await harness.start("hello")
+        await harness.run_until_idle(session.id)
+
+        events = await harness.all_events(session.id)
+        spans = [e for e in events if e.kind == "span"]
+        starts = [s for s in spans if s.data["event"] == "context_build_start"]
+        ends = [s for s in spans if s.data["event"] == "context_build_end"]
+
+        assert len(starts) == 1, starts
+        assert len(ends) == 1, ends
+
+        end = ends[0]
+        assert end.data["context_build_start_id"] == starts[0].id
+        assert end.data["is_error"] is False
+        assert end.data["event_count_read"] >= 1
+        assert end.data["message_count"] >= 1
+        assert end.data["tools_count"] >= 0
+
+    async def test_context_build_precedes_model_request(self, harness: Harness) -> None:
+        """The context_build_end span must land before the model_request_start
+        for the same step — the builder feeds the model call.
+        """
+        harness.script_model([assistant("Hi!")])
+        session = await harness.start("hello")
+        await harness.run_until_idle(session.id)
+
+        events = await harness.all_events(session.id)
+        spans = [e for e in events if e.kind == "span"]
+
+        cb_end_seq = next(s.seq for s in spans if s.data["event"] == "context_build_end")
+        model_start_seq = next(s.seq for s in spans if s.data["event"] == "model_request_start")
+        assert cb_end_seq < model_start_seq
+
+    async def test_context_build_end_emitted_with_is_error_on_failure(
+        self, harness: Harness
+    ) -> None:
+        """If the prologue raises, the end span still lands with ``is_error: True``
+        (matches the ``model_request_*`` symmetry — operators shouldn't see
+        orphan starts)."""
+        harness.script_model([assistant("Hi!")])
+        session = await harness.start("hello")
+
+        # Poison ``build_messages`` on the specific step we drive next.
+        with (
+            mock.patch(
+                "aios.harness.loop.build_messages",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            await harness.run_until_idle(session.id)
+
+        events = await harness.all_events(session.id)
+        spans = [e for e in events if e.kind == "span"]
+        starts = [s for s in spans if s.data["event"] == "context_build_start"]
+        ends = [s for s in spans if s.data["event"] == "context_build_end"]
+
+        assert len(starts) == len(ends), (
+            f"mismatched spans: {len(starts)} starts vs {len(ends)} ends"
+        )
+        error_ends = [e for e in ends if e.data.get("is_error") is True]
+        assert error_ends, "expected at least one context_build_end with is_error"

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -1529,11 +1529,15 @@ class TestUsageTracking:
         await harness.run_until_idle(session.id)
 
         all_evts = await harness.all_events(session.id)
-        spans = [e for e in all_evts if e.kind == "span"]
-        assert len(spans) == 2
+        model_spans = [
+            e
+            for e in all_evts
+            if e.kind == "span" and e.data["event"] in {"model_request_start", "model_request_end"}
+        ]
+        assert len(model_spans) == 2
 
-        start = spans[0]
-        end = spans[1]
+        start = model_spans[0]
+        end = model_spans[1]
         assert start.data["event"] == "model_request_start"
         assert end.data["event"] == "model_request_end"
         assert end.data["model_request_start_id"] == start.id
@@ -1560,11 +1564,15 @@ class TestUsageTracking:
         await harness.run_until_idle(session.id)
 
         all_evts = await harness.all_events(session.id)
-        spans = [e for e in all_evts if e.kind == "span"]
-        assert len(spans) == 4  # 2 start + 2 end
+        model_spans = [
+            e
+            for e in all_evts
+            if e.kind == "span" and e.data["event"] in {"model_request_start", "model_request_end"}
+        ]
+        assert len(model_spans) == 4  # 2 start + 2 end
 
-        starts = [s for s in spans if s.data["event"] == "model_request_start"]
-        ends = [s for s in spans if s.data["event"] == "model_request_end"]
+        starts = [s for s in model_spans if s.data["event"] == "model_request_start"]
+        ends = [s for s in model_spans if s.data["event"] == "model_request_end"]
         assert len(starts) == 2
         assert len(ends) == 2
 


### PR DESCRIPTION
## Summary

- First per-stage span from issue #78. Operators debugging \"why is the step slow?\" can now separate context-build cost from model-call cost via queryable span events (same shape as \`model_request_*\`).
- Bracket sits AFTER \`_dispatch_confirmed_tools\` early-return (every start has a matching end) and BEFORE the model call. End payload: \`context_build_start_id\`, \`is_error\`, plus shape metrics \`event_count_read\`, \`message_count\`, \`tools_count\` — the three knobs that drive \"is context build pathological right now?\" debugging.
- Error-symmetry: if anything in the prologue raises, the end still lands with \`is_error: true\` (matches \`model_request_*\` — no orphan starts).

## Scope

Progresses #78 but does not close it — \`tool_dispatch\`, \`sandbox_provisioning\`, and the other stages named in the issue are follow-up PRs, each small enough to land independently on top of this foundation.

## Test plan

- [x] 3 new e2e tests: span pair present with linked id + populated metrics; ordering (\`context_build_end\` precedes \`model_request_start\`); error-path (build_messages raises → \`is_error: true\` end + exception re-propagates)
- [x] Updated \`test_span_events_emitted\` + \`test_span_events_for_multi_step\` to filter by \`model_request_*\` only (they previously counted all spans)
- [x] \`pytest tests/unit\` — 727 passed
- [x] \`pytest tests/e2e\` — 212 passed
- [x] mypy + ruff clean

Progresses #78 (does not close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)