### PR TITLE
feat(agents): litellm_extra JSONB column for provider-specific kwargs (closes #79)

### DIFF
--- a/migrations/versions/0021_agent_litellm_extra.py
+++ b/migrations/versions/0021_agent_litellm_extra.py
@@ -1,0 +1,40 @@
+"""Add ``litellm_extra`` JSONB column to agents + agent_versions.
+
+Lets an agent pin provider-specific LiteLLM kwargs (OpenRouter
+``extra_body.provider.order``, Anthropic ``thinking``, OpenAI
+``reasoning_effort``, raw sampling params, per-agent ``api_base``,
+etc.) without stuffing them into the loosely-specified ``metadata``
+column.  Default ``'{}'::jsonb`` so existing rows Just Work; changing
+the column creates a new agent version (same as changing ``model``).
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-04-21
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0021"
+down_revision: str = "0020"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE agents "
+        "ADD COLUMN litellm_extra jsonb NOT NULL DEFAULT '{}'::jsonb;"
+    )
+    op.execute(
+        "ALTER TABLE agent_versions "
+        "ADD COLUMN litellm_extra jsonb NOT NULL DEFAULT '{}'::jsonb;"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agents DROP COLUMN IF EXISTS litellm_extra;")
+    op.execute("ALTER TABLE agent_versions DROP COLUMN IF EXISTS litellm_extra;")

--- a/src/aios/api/routers/agents.py
+++ b/src/aios/api/routers/agents.py
@@ -24,6 +24,7 @@ async def create(body: AgentCreate, pool: PoolDep, _auth: AuthDep) -> Agent:
         mcp_servers=body.mcp_servers,
         description=body.description,
         metadata=body.metadata,
+        litellm_extra=body.litellm_extra,
         window_min=body.window_min,
         window_max=body.window_max,
     )
@@ -64,6 +65,7 @@ async def update(agent_id: str, body: AgentUpdate, pool: PoolDep, _auth: AuthDep
         mcp_servers=body.mcp_servers,
         description=body.description,
         metadata=body.metadata,
+        litellm_extra=body.litellm_extra,
         window_min=body.window_min,
         window_max=body.window_max,
     )

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -184,6 +184,7 @@ def _row_to_agent(row: asyncpg.Record) -> Agent:
     skills_data = _parse_jsonb(row["skills"])
     mcp_data = _parse_jsonb(row.get("mcp_servers", []))
     metadata = _parse_jsonb(row["metadata"])
+    litellm_extra = _parse_jsonb(row["litellm_extra"])
     return Agent(
         id=row["id"],
         version=row["version"],
@@ -195,6 +196,7 @@ def _row_to_agent(row: asyncpg.Record) -> Agent:
         mcp_servers=[McpServerSpec.model_validate(s) for s in (mcp_data or [])],
         description=row["description"],
         metadata=metadata,
+        litellm_extra=litellm_extra or {},
         window_min=row["window_min"],
         window_max=row["window_max"],
         created_at=row["created_at"],
@@ -207,6 +209,7 @@ def _row_to_agent_version(row: asyncpg.Record) -> AgentVersion:
     tools_data = _parse_jsonb(row["tools"])
     skills_data = _parse_jsonb(row["skills"])
     mcp_data = _parse_jsonb(row.get("mcp_servers", []))
+    litellm_extra = _parse_jsonb(row["litellm_extra"])
     return AgentVersion(
         agent_id=row["agent_id"],
         version=row["version"],
@@ -215,6 +218,7 @@ def _row_to_agent_version(row: asyncpg.Record) -> AgentVersion:
         tools=[ToolSpec.model_validate(t) for t in tools_data],
         skills=[AgentSkillRef.model_validate(s) for s in skills_data],
         mcp_servers=[McpServerSpec.model_validate(s) for s in (mcp_data or [])],
+        litellm_extra=litellm_extra or {},
         window_min=row["window_min"],
         window_max=row["window_max"],
         created_at=row["created_at"],
@@ -232,6 +236,7 @@ async def insert_agent(
     mcp_servers: list[McpServerSpec],
     description: str | None,
     metadata: dict[str, Any],
+    litellm_extra: dict[str, Any],
     window_min: int,
     window_max: int,
 ) -> Agent:
@@ -239,16 +244,18 @@ async def insert_agent(
     tools_json = json.dumps([t.model_dump() for t in tools])
     mcp_json = json.dumps([s.model_dump() for s in mcp_servers])
     metadata_json = json.dumps(metadata)
+    extra_json = json.dumps(litellm_extra)
     try:
         async with conn.transaction():
             row = await conn.fetchrow(
                 """
                 INSERT INTO agents (
                     id, name, model, system, tools, skills, mcp_servers,
-                    description, metadata, window_min, window_max, version
+                    description, metadata, litellm_extra,
+                    window_min, window_max, version
                 )
                 VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb,
-                        $8, $9::jsonb, $10, $11, 1)
+                        $8, $9::jsonb, $10::jsonb, $11, $12, 1)
                 RETURNING *
                 """,
                 new_id,
@@ -260,6 +267,7 @@ async def insert_agent(
                 mcp_json,
                 description,
                 metadata_json,
+                extra_json,
                 window_min,
                 window_max,
             )
@@ -269,9 +277,10 @@ async def insert_agent(
                 """
                 INSERT INTO agent_versions (
                     agent_id, version, model, system, tools, skills, mcp_servers,
-                    window_min, window_max
+                    litellm_extra, window_min, window_max
                 )
-                VALUES ($1, 1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7, $8)
+                VALUES ($1, 1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb,
+                        $7::jsonb, $8, $9)
                 """,
                 new_id,
                 model,
@@ -279,6 +288,7 @@ async def insert_agent(
                 tools_json,
                 skills_json,
                 mcp_json,
+                extra_json,
                 window_min,
                 window_max,
             )
@@ -340,6 +350,7 @@ async def update_agent(
     mcp_servers: list[McpServerSpec] | None = None,
     description: str | None = None,
     metadata: dict[str, Any] | None = None,
+    litellm_extra: dict[str, Any] | None = None,
     window_min: int | None = None,
     window_max: int | None = None,
 ) -> Agent:
@@ -371,6 +382,7 @@ async def update_agent(
     new_mcp = mcp_servers if mcp_servers is not None else current.mcp_servers
     new_desc = description if description is not None else current.description
     new_meta = metadata if metadata is not None else current.metadata
+    new_extra = litellm_extra if litellm_extra is not None else current.litellm_extra
     new_wmin = window_min if window_min is not None else current.window_min
     new_wmax = window_max if window_max is not None else current.window_max
 
@@ -384,6 +396,7 @@ async def update_agent(
         and new_mcp == current.mcp_servers
         and new_desc == current.description
         and new_meta == current.metadata
+        and new_extra == current.litellm_extra
         and new_wmin == current.window_min
         and new_wmax == current.window_max
     ):
@@ -393,6 +406,7 @@ async def update_agent(
     tools_json = json.dumps([t.model_dump() for t in new_tools])
     mcp_json = json.dumps([s.model_dump() for s in new_mcp])
     meta_json = json.dumps(new_meta)
+    extra_json = json.dumps(new_extra)
 
     async with conn.transaction():
         row = await conn.fetchrow(
@@ -401,7 +415,8 @@ async def update_agent(
                SET version = $2, name = $3, model = $4, system = $5,
                    tools = $6::jsonb, skills = $7::jsonb, mcp_servers = $8::jsonb,
                    description = $9, metadata = $10::jsonb,
-                   window_min = $11, window_max = $12,
+                   litellm_extra = $11::jsonb,
+                   window_min = $12, window_max = $13,
                    updated_at = now()
              WHERE id = $1
             RETURNING *
@@ -416,6 +431,7 @@ async def update_agent(
             mcp_json,
             new_desc,
             meta_json,
+            extra_json,
             new_wmin,
             new_wmax,
         )
@@ -424,9 +440,10 @@ async def update_agent(
             """
             INSERT INTO agent_versions (
                 agent_id, version, model, system, tools, skills, mcp_servers,
-                window_min, window_max
+                litellm_extra, window_min, window_max
             )
-            VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8, $9)
+            VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb,
+                    $8::jsonb, $9, $10)
             """,
             agent_id,
             new_version,
@@ -435,6 +452,7 @@ async def update_agent(
             tools_json,
             new_skills_json,
             mcp_json,
+            extra_json,
             new_wmin,
             new_wmax,
         )

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -259,6 +259,7 @@ async def run_session_step(
             model=agent.model,
             messages=ctx.messages,
             tools=tools if tools else None,
+            extra=agent.litellm_extra or None,
             pool=pool,
             session_id=session_id,
         )

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -159,6 +159,21 @@ class AgentCreate(BaseModel):
     mcp_servers: list[McpServerSpec] = Field(default_factory=list)
     description: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    litellm_extra: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Provider-specific LiteLLM kwargs merged into every model "
+            "request for this agent.  Common shapes: OpenRouter "
+            "``extra_body.provider.order`` for provider pinning, "
+            "Anthropic ``thinking``, OpenAI ``reasoning_effort``, raw "
+            "sampling knobs (``temperature``, ``max_tokens``), "
+            "``api_base`` for self-hosted inference.  Validated by "
+            "LiteLLM / the provider; bad kwargs surface as tool-path "
+            "errors the model sees.  Security: ``api_base`` redirects "
+            "the model call — treat operator-set agents as trusted "
+            "and don't accept this field from untrusted principals."
+        ),
+    )
     window_min: int = Field(default=50_000, ge=1)
     window_max: int = Field(default=150_000, ge=1)
 
@@ -183,6 +198,7 @@ class AgentUpdate(BaseModel):
     mcp_servers: list[McpServerSpec] | None = None
     description: str | None = None
     metadata: dict[str, Any] | None = None
+    litellm_extra: dict[str, Any] | None = None
     window_min: int | None = Field(default=None, ge=1)
     window_max: int | None = Field(default=None, ge=1)
 
@@ -200,6 +216,7 @@ class Agent(BaseModel):
     mcp_servers: list[McpServerSpec]
     description: str | None
     metadata: dict[str, Any]
+    litellm_extra: dict[str, Any] = Field(default_factory=dict)
     window_min: int
     window_max: int
     created_at: datetime
@@ -217,6 +234,7 @@ class AgentVersion(BaseModel):
     tools: list[ToolSpec]
     skills: list[AgentSkillRef] = Field(default_factory=list)
     mcp_servers: list[McpServerSpec]
+    litellm_extra: dict[str, Any] = Field(default_factory=dict)
     window_min: int
     window_max: int
     created_at: datetime

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -28,6 +28,7 @@ async def create_agent(
     mcp_servers: list[McpServerSpec] | None = None,
     description: str | None,
     metadata: dict[str, Any],
+    litellm_extra: dict[str, Any] | None = None,
     window_min: int,
     window_max: int,
 ) -> Agent:
@@ -52,6 +53,7 @@ async def create_agent(
             mcp_servers=mcp_servers or [],
             description=description,
             metadata=metadata,
+            litellm_extra=litellm_extra or {},
             window_min=window_min,
             window_max=window_max,
         )
@@ -91,6 +93,7 @@ async def update_agent(
     mcp_servers: list[McpServerSpec] | None = None,
     description: str | None = None,
     metadata: dict[str, Any] | None = None,
+    litellm_extra: dict[str, Any] | None = None,
     window_min: int | None = None,
     window_max: int | None = None,
 ) -> Agent:
@@ -111,6 +114,7 @@ async def update_agent(
             mcp_servers=mcp_servers,
             description=description,
             metadata=metadata,
+            litellm_extra=litellm_extra,
             window_min=window_min,
             window_max=window_max,
         )

--- a/tests/e2e/test_agent_litellm_extra.py
+++ b/tests/e2e/test_agent_litellm_extra.py
@@ -1,0 +1,121 @@
+"""E2E tests for the ``litellm_extra`` agent field (issue #79)."""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+
+import httpx
+import pytest
+
+
+def _uniq() -> str:
+    return secrets.token_hex(4)
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    settings = get_settings()
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+        headers={"Authorization": f"Bearer {aios_env['AIOS_API_KEY']}"},
+    ) as client:
+        yield client
+
+
+async def _create(
+    client: httpx.AsyncClient, name: str, *, litellm_extra: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "name": name,
+        "model": "openai/gpt-4o-mini",
+        "system": "",
+        "tools": [],
+        "metadata": {},
+    }
+    if litellm_extra is not None:
+        body["litellm_extra"] = litellm_extra
+    r = await client.post("/v1/agents", json=body)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+class TestLitellmExtraRoundTrip:
+    async def test_default_is_empty_dict(self, http_client: httpx.AsyncClient) -> None:
+        """Omitting the field yields ``{}`` on read back."""
+        agent = await _create(http_client, f"no-extras-{_uniq()}")
+        assert agent["litellm_extra"] == {}
+
+    async def test_create_with_extras_persists(self, http_client: httpx.AsyncClient) -> None:
+        extras = {
+            "extra_body": {"provider": {"order": ["friendli"]}},
+            "reasoning_effort": "high",
+            "temperature": 0.2,
+        }
+        agent = await _create(http_client, f"with-extras-{_uniq()}", litellm_extra=extras)
+        assert agent["litellm_extra"] == extras
+
+        r = await http_client.get(f"/v1/agents/{agent['id']}")
+        assert r.status_code == 200
+        assert r.json()["litellm_extra"] == extras
+
+
+class TestLitellmExtraVersionBump:
+    async def test_changing_extras_creates_new_version(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        agent = await _create(http_client, f"v-bump-{_uniq()}")
+        assert agent["version"] == 1
+
+        r = await http_client.put(
+            f"/v1/agents/{agent['id']}",
+            json={"version": 1, "litellm_extra": {"thinking": {"type": "enabled"}}},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["version"] == 2
+        assert r.json()["litellm_extra"] == {"thinking": {"type": "enabled"}}
+
+    async def test_noop_update_does_not_bump(self, http_client: httpx.AsyncClient) -> None:
+        agent = await _create(http_client, f"noop-{_uniq()}", litellm_extra={"temperature": 0.5})
+        assert agent["version"] == 1
+
+        r = await http_client.put(
+            f"/v1/agents/{agent['id']}",
+            json={"version": 1, "litellm_extra": {"temperature": 0.5}},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["version"] == 1
+
+    async def test_agent_version_snapshot_records_extras(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        agent = await _create(http_client, f"snap-{_uniq()}", litellm_extra={"temperature": 0.9})
+
+        r = await http_client.get(f"/v1/agents/{agent['id']}/versions/1")
+        assert r.status_code == 200, r.text
+        assert r.json()["litellm_extra"] == {"temperature": 0.9}

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -93,6 +93,7 @@ def mock_step_dependencies() -> Any:
         mcp_servers=[],
         skills=[],
         system="sys",
+        litellm_extra={},
         window_min=1000,
         window_max=10000,
     )


### PR DESCRIPTION
## Summary

- New \`litellm_extra: dict[str, Any]\` field on \`Agent\` / \`AgentCreate\` / \`AgentUpdate\` / \`AgentVersion\`. Merged into every model request via the existing \`extra=\` kwarg on \`stream_litellm\`/\`call_litellm\`.
- Migration 0021: \`ALTER TABLE ... ADD COLUMN litellm_extra jsonb NOT NULL DEFAULT '{}'::jsonb\` on both \`agents\` and \`agent_versions\`. Postgres metadata-only, no rewrite.
- Version-bump on change: same semantics as \`model\` — routing pins / thinking budgets / sampling params are functionally load-bearing.
- Covers common shapes: OpenRouter \`extra_body.provider.order\`, Anthropic \`thinking\`, OpenAI \`reasoning_effort\`, per-agent \`temperature\`/\`max_tokens\`/\`api_base\`.

## Design choices (issue flagged these as decisions worth naming)

1. **Flat dict vs structured sub-fields** → flat. Matches the existing \`extra=\` seam in \`completion.py\` with no translation layer.
2. **Dedicated column vs \`metadata\` reuse** → dedicated column. Keeps \`metadata\` as a free-form grab-bag.
3. **Version bump on change** → yes, mirrors \`model\`.

## Security note

\`api_base\` redirects the model call — it's a footgun if accepted from untrusted principals. Field docstring calls this out explicitly. Operator-owned deployments are the expected threat model.

## Test plan

- [x] 5 e2e tests: default empty-dict round-trip; create-with-extras persists; version bumps when extras change; no-op doesn't bump; \`agent_versions\` snapshot records extras
- [x] Existing \`test_loop_retry\` unit test updated to carry \`litellm_extra={}\` on its \`SimpleNamespace\` agent mock
- [x] \`pytest tests/unit\` — 727 passed
- [x] \`pytest tests/e2e\` — 217 passed
- [x] mypy + ruff clean

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)