### PR TITLE
feat(harness): emit tool_execute span pair around per-tool dispatch (progresses #78)

### DIFF
--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -78,7 +78,10 @@ async def _execute_tool_async(
     session_id: str,
     call: dict[str, Any],
 ) -> None:
-    """Execute one tool call: parse, invoke, append result, defer wake."""
+    """Execute one tool call: parse, invoke, append result, defer wake.
+
+    Brackets the lifecycle in a ``tool_execute_*`` span pair (issue #78).
+    """
     call_id = call.get("id") or "unknown"
     function = call.get("function") or {}
     name = function.get("name") or ""
@@ -86,11 +89,24 @@ async def _execute_tool_async(
 
     bound_log = log.bind(session_id=session_id, tool_call_id=call_id, tool_name=name)
 
+    span_start = await sessions_service.append_event(
+        pool,
+        session_id,
+        "span",
+        {
+            "event": "tool_execute_start",
+            "tool_call_id": call_id,
+            "tool_name": name,
+        },
+    )
+    is_error = False
+
     try:
         # Parse arguments.
         arguments = _parse_arguments(raw_args)
         if arguments is None:
             bound_log.warning("tool.bad_arguments")
+            is_error = True
             await _append_tool_result(
                 pool, session_id, call_id, name, error="arguments were not valid JSON"
             )
@@ -101,6 +117,7 @@ async def _execute_tool_async(
             tool = registry.get(name)
         except ToolNotFoundError as err:
             bound_log.warning("tool.not_registered")
+            is_error = True
             await _append_tool_result(pool, session_id, call_id, name, error=err.message)
             return
 
@@ -115,6 +132,7 @@ async def _execute_tool_async(
         schema_error = _validate_arguments(arguments, tool.parameters_schema)
         if schema_error is not None:
             bound_log.info("tool.schema_error", error=schema_error)
+            is_error = True
             await _append_tool_result(pool, session_id, call_id, name, error=schema_error)
             return
 
@@ -136,6 +154,7 @@ async def _execute_tool_async(
                 event_data["metadata"] = result.metadata
             if result.is_error:
                 event_data["is_error"] = True
+                is_error = True
         else:
             event_data["content"] = json.dumps(result, ensure_ascii=False)
         bound_log.info("tool.completed")
@@ -148,16 +167,30 @@ async def _execute_tool_async(
 
     except asyncio.CancelledError:
         bound_log.info("tool.cancelled")
+        is_error = True
         await _append_tool_result(pool, session_id, call_id, name, error="cancelled")
 
     except Exception as err:
         bound_log.exception("tool.handler_failed")
+        is_error = True
         _evict_session_container(session_id)
         await _append_tool_result(
             pool, session_id, call_id, name, error=f"{type(err).__name__}: {err}"
         )
 
     finally:
+        await sessions_service.append_event(
+            pool,
+            session_id,
+            "span",
+            {
+                "event": "tool_execute_end",
+                "tool_execute_start_id": span_start.id,
+                "tool_call_id": call_id,
+                "tool_name": name,
+                "is_error": is_error,
+            },
+        )
         await _trigger_sweep(pool, session_id, bound_log)
 
 
@@ -318,10 +351,23 @@ async def _execute_mcp_tool_async(
 
     bound_log = log.bind(session_id=session_id, tool_call_id=call_id, tool_name=name)
 
+    span_start = await sessions_service.append_event(
+        pool,
+        session_id,
+        "span",
+        {
+            "event": "tool_execute_start",
+            "tool_call_id": call_id,
+            "tool_name": name,
+        },
+    )
+    is_error = False
+
     try:
         arguments = _parse_arguments(raw_args)
         if arguments is None:
             bound_log.warning("mcp_tool.bad_arguments")
+            is_error = True
             await _append_tool_result(
                 pool, session_id, call_id, name, error="arguments were not valid JSON"
             )
@@ -331,6 +377,7 @@ async def _execute_mcp_tool_async(
         url = mcp_server_map.get(server_name)
         if url is None:
             bound_log.warning("mcp_tool.server_not_found", server_name=server_name)
+            is_error = True
             await _append_tool_result(
                 pool, session_id, call_id, name, error=f"MCP server {server_name!r} not found"
             )
@@ -347,6 +394,7 @@ async def _execute_mcp_tool_async(
                 # focal is NULL — loop.py filters them out of the tool
                 # list in that state — but defend in depth if it slips
                 # through (stale tool_calls, etc.).
+                is_error = True
                 await _append_tool_result(
                     pool,
                     session_id,
@@ -365,28 +413,43 @@ async def _execute_mcp_tool_async(
         result = await call_mcp_tool(url, headers, tool_name, arguments, meta=meta)
 
         content_str = json.dumps(result, ensure_ascii=False)
-        is_error = "error" in result
+        mcp_is_error = "error" in result
         event_data: dict[str, Any] = {
             "role": "tool",
             "tool_call_id": call_id,
             "name": name,
             "content": content_str,
         }
-        if is_error:
+        if mcp_is_error:
             event_data["is_error"] = True
+            is_error = True
 
-        bound_log.info("mcp_tool.completed", is_error=is_error)
+        bound_log.info("mcp_tool.completed", is_error=mcp_is_error)
         await sessions_service.append_event(pool, session_id, "message", event_data)
 
     except asyncio.CancelledError:
         bound_log.info("mcp_tool.cancelled")
+        is_error = True
         await _append_tool_result(pool, session_id, call_id, name, error="cancelled")
 
     except Exception as err:
         bound_log.exception("mcp_tool.handler_failed")
+        is_error = True
         await _append_tool_result(
             pool, session_id, call_id, name, error=f"{type(err).__name__}: {err}"
         )
 
     finally:
+        await sessions_service.append_event(
+            pool,
+            session_id,
+            "span",
+            {
+                "event": "tool_execute_end",
+                "tool_execute_start_id": span_start.id,
+                "tool_call_id": call_id,
+                "tool_name": name,
+                "is_error": is_error,
+            },
+        )
         await _trigger_sweep(pool, session_id, bound_log)

--- a/tests/e2e/test_tool_execute_span.py
+++ b/tests/e2e/test_tool_execute_span.py
@@ -1,0 +1,130 @@
+"""E2E tests for the ``tool_execute_*`` span pair (issue #78, second stage)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tests.e2e.harness import Harness, assistant, tool_call
+
+
+class TestToolExecuteSpan:
+    async def test_span_pair_on_success(self, harness: Harness) -> None:
+        async def echo_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+            return {"echoed": arguments.get("text", "")}
+
+        harness.register_tool("echo", echo_handler)
+        harness.script_model(
+            [
+                assistant(tool_calls=[tool_call("echo", {"text": "ping"})]),
+                assistant("Done."),
+            ]
+        )
+        session = await harness.start("echo ping", tools=[])
+        await harness.run_until_idle(session.id)
+
+        events = await harness.all_events(session.id)
+        spans = [e for e in events if e.kind == "span"]
+        starts = [s for s in spans if s.data["event"] == "tool_execute_start"]
+        ends = [s for s in spans if s.data["event"] == "tool_execute_end"]
+
+        assert len(starts) == 1, starts
+        assert len(ends) == 1, ends
+
+        start = starts[0]
+        end = ends[0]
+        assert start.data["tool_name"] == "echo"
+        assert start.data["tool_call_id"]
+        assert end.data["tool_execute_start_id"] == start.id
+        assert end.data["tool_name"] == "echo"
+        assert end.data["tool_call_id"] == start.data["tool_call_id"]
+        assert end.data["is_error"] is False
+
+    async def test_span_pair_flags_error_on_handler_exception(self, harness: Harness) -> None:
+        async def failing_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+        harness.register_tool("fails", failing_handler)
+        harness.script_model(
+            [
+                assistant(tool_calls=[tool_call("fails", {})]),
+                assistant("I see the tool failed."),
+            ]
+        )
+        session = await harness.start("do the thing", tools=[])
+        await harness.run_until_idle(session.id)
+
+        events = await harness.all_events(session.id)
+        ends = [e for e in events if e.kind == "span" and e.data["event"] == "tool_execute_end"]
+        assert len(ends) == 1
+        assert ends[0].data["is_error"] is True
+        assert ends[0].data["tool_name"] == "fails"
+
+    async def test_span_pair_flags_error_on_schema_violation(self, harness: Harness) -> None:
+        """Schema validation failure is still a tool-execute failure for span purposes."""
+
+        async def strict_handler(
+            session_id: str, arguments: dict[str, Any]
+        ) -> dict[str, Any]:  # pragma: no cover - never reached
+            return {}
+
+        harness.register_tool(
+            "strict",
+            strict_handler,
+            schema={
+                "type": "object",
+                "properties": {"required_arg": {"type": "string"}},
+                "required": ["required_arg"],
+                "additionalProperties": False,
+            },
+        )
+        harness.script_model(
+            [
+                assistant(tool_calls=[tool_call("strict", {})]),  # missing required_arg
+                assistant("Got the schema error."),
+            ]
+        )
+        session = await harness.start("call strict", tools=[])
+        await harness.run_until_idle(session.id)
+
+        events = await harness.all_events(session.id)
+        ends = [e for e in events if e.kind == "span" and e.data["event"] == "tool_execute_end"]
+        assert len(ends) == 1
+        assert ends[0].data["is_error"] is True
+
+    async def test_span_pair_per_tool_call_on_batch(self, harness: Harness) -> None:
+        """Three parallel tool calls produce three span pairs, each linked correctly."""
+
+        async def noop_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+            return {"n": arguments.get("n", 0)}
+
+        harness.register_tool("noop", noop_handler)
+        harness.script_model(
+            [
+                assistant(
+                    tool_calls=[
+                        tool_call("noop", {"n": 1}),
+                        tool_call("noop", {"n": 2}),
+                        tool_call("noop", {"n": 3}),
+                    ]
+                ),
+                assistant("All three done."),
+            ]
+        )
+        session = await harness.start("batch", tools=[])
+        await harness.run_until_idle(session.id)
+
+        events = await harness.all_events(session.id)
+        spans = [e for e in events if e.kind == "span"]
+        starts = [s for s in spans if s.data["event"] == "tool_execute_start"]
+        ends = [s for s in spans if s.data["event"] == "tool_execute_end"]
+
+        assert len(starts) == 3
+        assert len(ends) == 3
+
+        # Each end links to its own start by both id and tool_call_id.
+        start_ids = {s.id for s in starts}
+        for e in ends:
+            assert e.data["tool_execute_start_id"] in start_ids
+        start_call_ids = {s.data["tool_call_id"] for s in starts}
+        end_call_ids = {e.data["tool_call_id"] for e in ends}
+        assert start_call_ids == end_call_ids


### PR DESCRIPTION
## Summary

Second per-stage span from issue #78 (first was \`context_build_*\` in #94). Operators can now attribute slow steps to specific tools and track per-tool error rates.

Covers both \`_execute_tool_async\` (built-in tools) and \`_execute_mcp_tool_async\` (MCP tools) with identical span shape — one predicate (\`event IN ('tool_execute_start','tool_execute_end')\`) covers both.

## Span payload

- start: \`{tool_call_id, tool_name}\`
- end: \`{tool_execute_start_id, tool_call_id, tool_name, is_error}\`

\`is_error\` on end is True for every failure mode: bad args, unregistered tool, schema violation, handler exception, cancellation, successful call where handler returned \`ToolResult(is_error=True)\`, and MCP error-result responses.

## Span ordering vs tool_result

End span sits AFTER the tool_result message event so the span delta measures the full dispatch lifecycle — handler invocation + result append — not just handler time. This is the opposite of \`model_request_*\` ordering (where the assistant message lands AFTER the end span) but it's the useful measurement for \"how long did this tool take from the session's perspective.\"

## Test plan

- [x] 4 e2e tests: success, handler-exception, schema-violation, concurrent-batch
- [x] \`pytest tests/unit\` — 727 passed
- [x] \`pytest tests/e2e\` — 221 passed
- [x] mypy + ruff clean

Progresses #78. Sandbox-provisioning span is the remaining follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)