### PR TITLE
feat(sandbox): emit sandbox_provision span on cold-start (closes #78)

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -21,11 +21,15 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
 
 from aios.logging import get_logger
 from aios.sandbox.container import ContainerHandle
 from aios.sandbox.provisioner import force_remove, list_managed_containers, provision_for_session
 from aios.sandbox.provisioner import release as provisioner_release
+
+if TYPE_CHECKING:
+    import asyncpg
 
 log = get_logger("aios.sandbox.registry")
 
@@ -46,8 +50,18 @@ class SandboxRegistry:
             self._locks[session_id] = lock
         return lock
 
-    async def get_or_provision(self, session_id: str) -> ContainerHandle:
-        """Return the cached handle, or provision a new container."""
+    async def get_or_provision(
+        self,
+        session_id: str,
+        *,
+        pool: asyncpg.Pool[Any] | None = None,
+    ) -> ContainerHandle:
+        """Return the cached handle, or provision a new container.
+
+        Passing ``pool`` emits a ``sandbox_provision_*`` span pair on
+        the cold-start path only (issue #78) — warm hits stay
+        zero-observable-cost.
+        """
         handle = self._handles.get(session_id)
         if handle is not None:
             self._last_used[session_id] = time.monotonic()
@@ -58,10 +72,39 @@ class SandboxRegistry:
             if handle is not None:
                 self._last_used[session_id] = time.monotonic()
                 return handle
-            handle = await provision_for_session(session_id)
+            handle = await self._provision_with_span(session_id, pool=pool)
             self._handles[session_id] = handle
             self._last_used[session_id] = time.monotonic()
             return handle
+
+    async def _provision_with_span(
+        self, session_id: str, *, pool: asyncpg.Pool[Any] | None
+    ) -> ContainerHandle:
+        if pool is None:
+            return await provision_for_session(session_id)
+
+        from aios.services import sessions as sessions_service
+
+        span_start = await sessions_service.append_event(
+            pool, session_id, "span", {"event": "sandbox_provision_start"}
+        )
+        is_error = False
+        handle: ContainerHandle | None = None
+        try:
+            handle = await provision_for_session(session_id)
+            return handle
+        except Exception:
+            is_error = True
+            raise
+        finally:
+            end_payload: dict[str, Any] = {
+                "event": "sandbox_provision_end",
+                "sandbox_provision_start_id": span_start.id,
+                "is_error": is_error,
+            }
+            if handle is not None:
+                end_payload["container_id"] = handle.container_id[:12]
+            await sessions_service.append_event(pool, session_id, "span", end_payload)
 
     async def release(self, session_id: str) -> None:
         """Tear down one session's container. No-op if not cached."""

--- a/src/aios/tools/bash.py
+++ b/src/aios/tools/bash.py
@@ -122,7 +122,7 @@ async def bash_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     timeout = min(raw_timeout, max_timeout)
 
     sandbox = runtime.require_sandbox_registry()
-    handle = await sandbox.get_or_provision(session_id)
+    handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
     result = await handle.run_command(
         command,

--- a/src/aios/tools/edit.py
+++ b/src/aios/tools/edit.py
@@ -110,7 +110,7 @@ async def edit_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
 
     settings = get_settings()
     sandbox = runtime.require_sandbox_registry()
-    handle = await sandbox.get_or_provision(session_id)
+    handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
     quoted_path = shlex.quote(path)
 

--- a/src/aios/tools/glob.py
+++ b/src/aios/tools/glob.py
@@ -65,7 +65,7 @@ async def glob_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
 
     settings = get_settings()
     sandbox = runtime.require_sandbox_registry()
-    handle = await sandbox.get_or_provision(session_id)
+    handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
     cmd = f"rg --files --glob {shlex.quote(pattern)} {shlex.quote(path)} 2>/dev/null | head -500"
 

--- a/src/aios/tools/grep.py
+++ b/src/aios/tools/grep.py
@@ -116,7 +116,7 @@ async def grep_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
 
     settings = get_settings()
     sandbox = runtime.require_sandbox_registry()
-    handle = await sandbox.get_or_provision(session_id)
+    handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
     parts = ["rg"]
 

--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -88,7 +88,7 @@ async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
 
     settings = get_settings()
     sandbox = runtime.require_sandbox_registry()
-    handle = await sandbox.get_or_provision(session_id)
+    handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
     # cat -n numbers lines (1-indexed) with the format `   N\tCONTENT`.
     # sed -n 'START,ENDp' slices by line number. Using cat first means

--- a/src/aios/tools/write.py
+++ b/src/aios/tools/write.py
@@ -83,7 +83,7 @@ async def write_handler(session_id: str, arguments: dict[str, Any]) -> dict[str,
 
     settings = get_settings()
     sandbox = runtime.require_sandbox_registry()
-    handle = await sandbox.get_or_provision(session_id)
+    handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
     content_bytes = content.encode("utf-8")
     b64 = base64.b64encode(content_bytes).decode("ascii")

--- a/tests/unit/test_bash_handler.py
+++ b/tests/unit/test_bash_handler.py
@@ -24,7 +24,7 @@ class _StubRegistry:
         self._handle = handle
         self.get_or_provision_calls: list[str] = []
 
-    async def get_or_provision(self, session_id: str) -> ContainerHandle:
+    async def get_or_provision(self, session_id: str, **_kwargs: Any) -> ContainerHandle:
         self.get_or_provision_calls.append(session_id)
         return self._handle
 
@@ -53,13 +53,18 @@ def stub_handle() -> ContainerHandle:
 @pytest.fixture
 def stub_registry(stub_handle: ContainerHandle) -> _StubRegistry:
     """Install a stub sandbox registry on the runtime module, restore after."""
-    previous = runtime.sandbox_registry
+    from unittest.mock import MagicMock
+
+    prev_registry = runtime.sandbox_registry
+    prev_pool = runtime.pool
     stub = _StubRegistry(stub_handle)
     runtime.sandbox_registry = stub  # type: ignore[assignment]
+    runtime.pool = MagicMock()
     try:
         yield stub
     finally:
-        runtime.sandbox_registry = previous
+        runtime.sandbox_registry = prev_registry
+        runtime.pool = prev_pool
 
 
 class TestArguments:

--- a/tests/unit/test_edit_handler.py
+++ b/tests/unit/test_edit_handler.py
@@ -22,7 +22,7 @@ class _StubRegistry:
     def __init__(self, handle: ContainerHandle) -> None:
         self._handle = handle
 
-    async def get_or_provision(self, session_id: str) -> ContainerHandle:
+    async def get_or_provision(self, session_id: str, **_kwargs: Any) -> ContainerHandle:
         return self._handle
 
 
@@ -47,12 +47,17 @@ def stub_handle() -> ContainerHandle:
 
 @pytest.fixture
 def stub_registry(stub_handle: ContainerHandle) -> Any:
-    previous = runtime.sandbox_registry
+    from unittest.mock import MagicMock
+
+    prev_registry = runtime.sandbox_registry
+    prev_pool = runtime.pool
     runtime.sandbox_registry = _StubRegistry(stub_handle)  # type: ignore[assignment]
+    runtime.pool = MagicMock()
     try:
         yield
     finally:
-        runtime.sandbox_registry = previous
+        runtime.sandbox_registry = prev_registry
+        runtime.pool = prev_pool
 
 
 def _script_responses(*responses: CommandResult) -> AsyncMock:

--- a/tests/unit/test_glob_handler.py
+++ b/tests/unit/test_glob_handler.py
@@ -21,7 +21,7 @@ class _StubRegistry:
     def __init__(self, handle: ContainerHandle) -> None:
         self._handle = handle
 
-    async def get_or_provision(self, session_id: str) -> ContainerHandle:
+    async def get_or_provision(self, session_id: str, **_kwargs: Any) -> ContainerHandle:
         return self._handle
 
 
@@ -46,12 +46,17 @@ def stub_handle() -> ContainerHandle:
 
 @pytest.fixture
 def stub_registry(stub_handle: ContainerHandle) -> Any:
-    previous = runtime.sandbox_registry
+    from unittest.mock import MagicMock
+
+    prev_registry = runtime.sandbox_registry
+    prev_pool = runtime.pool
     runtime.sandbox_registry = _StubRegistry(stub_handle)  # type: ignore[assignment]
+    runtime.pool = MagicMock()
     try:
         yield
     finally:
-        runtime.sandbox_registry = previous
+        runtime.sandbox_registry = prev_registry
+        runtime.pool = prev_pool
 
 
 class TestArguments:

--- a/tests/unit/test_grep_handler.py
+++ b/tests/unit/test_grep_handler.py
@@ -21,7 +21,7 @@ class _StubRegistry:
     def __init__(self, handle: ContainerHandle) -> None:
         self._handle = handle
 
-    async def get_or_provision(self, session_id: str) -> ContainerHandle:
+    async def get_or_provision(self, session_id: str, **_kwargs: Any) -> ContainerHandle:
         return self._handle
 
 
@@ -46,12 +46,17 @@ def stub_handle() -> ContainerHandle:
 
 @pytest.fixture
 def stub_registry(stub_handle: ContainerHandle) -> Any:
-    previous = runtime.sandbox_registry
+    from unittest.mock import MagicMock
+
+    prev_registry = runtime.sandbox_registry
+    prev_pool = runtime.pool
     runtime.sandbox_registry = _StubRegistry(stub_handle)  # type: ignore[assignment]
+    runtime.pool = MagicMock()
     try:
         yield
     finally:
-        runtime.sandbox_registry = previous
+        runtime.sandbox_registry = prev_registry
+        runtime.pool = prev_pool
 
 
 class TestArguments:

--- a/tests/unit/test_read_handler.py
+++ b/tests/unit/test_read_handler.py
@@ -21,7 +21,7 @@ class _StubRegistry:
     def __init__(self, handle: ContainerHandle) -> None:
         self._handle = handle
 
-    async def get_or_provision(self, session_id: str) -> ContainerHandle:
+    async def get_or_provision(self, session_id: str, **_kwargs: Any) -> ContainerHandle:
         return self._handle
 
 
@@ -46,12 +46,17 @@ def stub_handle() -> ContainerHandle:
 
 @pytest.fixture
 def stub_registry(stub_handle: ContainerHandle) -> Any:
-    previous = runtime.sandbox_registry
+    from unittest.mock import MagicMock
+
+    prev_registry = runtime.sandbox_registry
+    prev_pool = runtime.pool
     runtime.sandbox_registry = _StubRegistry(stub_handle)  # type: ignore[assignment]
+    runtime.pool = MagicMock()
     try:
         yield
     finally:
-        runtime.sandbox_registry = previous
+        runtime.sandbox_registry = prev_registry
+        runtime.pool = prev_pool
 
 
 class TestArguments:

--- a/tests/unit/test_sandbox_provision_span.py
+++ b/tests/unit/test_sandbox_provision_span.py
@@ -1,0 +1,98 @@
+"""Unit tests for the ``sandbox_provision_*`` span pair (issue #78)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.sandbox.registry import SandboxRegistry
+
+
+@pytest.fixture
+def fake_handle() -> SimpleNamespace:
+    return SimpleNamespace(
+        session_id="sess_01TEST",
+        container_id="abc123def456abc123def456",
+        workspace_path="/tmp/w",
+    )
+
+
+class TestSandboxProvisionSpan:
+    async def test_cold_start_emits_span_pair(self, fake_handle: SimpleNamespace) -> None:
+        registry = SandboxRegistry()
+        pool = MagicMock()
+        span_start = SimpleNamespace(id="ev_span_start")
+        append_event = AsyncMock(return_value=span_start)
+
+        with (
+            patch(
+                "aios.sandbox.registry.provision_for_session",
+                AsyncMock(return_value=fake_handle),
+            ),
+            patch("aios.services.sessions.append_event", append_event),
+        ):
+            await registry.get_or_provision("sess_01TEST", pool=pool)
+
+        assert append_event.await_count == 2
+        start_data = append_event.await_args_list[0].args[3]
+        end_data = append_event.await_args_list[1].args[3]
+        assert start_data == {"event": "sandbox_provision_start"}
+        assert end_data["event"] == "sandbox_provision_end"
+        assert end_data["sandbox_provision_start_id"] == "ev_span_start"
+        assert end_data["is_error"] is False
+        assert end_data["container_id"] == "abc123def456"  # 12-char short id
+
+    async def test_warm_hit_emits_no_span(self, fake_handle: SimpleNamespace) -> None:
+        registry = SandboxRegistry()
+        registry._handles["sess_01TEST"] = fake_handle  # type: ignore[assignment]
+        pool = MagicMock()
+        append_event = AsyncMock()
+
+        with patch("aios.services.sessions.append_event", append_event):
+            result = await registry.get_or_provision("sess_01TEST", pool=pool)
+
+        assert result is fake_handle
+        append_event.assert_not_awaited()
+
+    async def test_no_pool_no_span(self, fake_handle: SimpleNamespace) -> None:
+        """When pool is not passed (e.g. worker startup paths), no span emission."""
+        registry = SandboxRegistry()
+        append_event = AsyncMock()
+
+        with (
+            patch(
+                "aios.sandbox.registry.provision_for_session",
+                AsyncMock(return_value=fake_handle),
+            ),
+            patch("aios.services.sessions.append_event", append_event),
+        ):
+            await registry.get_or_provision("sess_01TEST")
+
+        append_event.assert_not_awaited()
+
+    async def test_provision_failure_emits_error_end_span(self) -> None:
+        registry = SandboxRegistry()
+        pool = MagicMock()
+        span_start = SimpleNamespace(id="ev_span_start")
+        append_event = AsyncMock(return_value=span_start)
+
+        class ProvisionError(Exception):
+            pass
+
+        with (
+            patch(
+                "aios.sandbox.registry.provision_for_session",
+                AsyncMock(side_effect=ProvisionError("docker exploded")),
+            ),
+            patch("aios.services.sessions.append_event", append_event),
+            pytest.raises(ProvisionError),
+        ):
+            await registry.get_or_provision("sess_01TEST", pool=pool)
+
+        assert append_event.await_count == 2
+        end_data = append_event.await_args_list[1].args[3]
+        assert end_data["event"] == "sandbox_provision_end"
+        assert end_data["is_error"] is True
+        assert "container_id" not in end_data

--- a/tests/unit/test_write_handler.py
+++ b/tests/unit/test_write_handler.py
@@ -23,7 +23,7 @@ class _StubRegistry:
     def __init__(self, handle: ContainerHandle) -> None:
         self._handle = handle
 
-    async def get_or_provision(self, session_id: str) -> ContainerHandle:
+    async def get_or_provision(self, session_id: str, **_kwargs: Any) -> ContainerHandle:
         return self._handle
 
 
@@ -48,12 +48,17 @@ def stub_handle() -> ContainerHandle:
 
 @pytest.fixture
 def stub_registry(stub_handle: ContainerHandle) -> Any:
-    previous = runtime.sandbox_registry
+    from unittest.mock import MagicMock
+
+    prev_registry = runtime.sandbox_registry
+    prev_pool = runtime.pool
     runtime.sandbox_registry = _StubRegistry(stub_handle)  # type: ignore[assignment]
+    runtime.pool = MagicMock()
     try:
         yield
     finally:
-        runtime.sandbox_registry = previous
+        runtime.sandbox_registry = prev_registry
+        runtime.pool = prev_pool
 
 
 class TestArguments:


### PR DESCRIPTION
## Summary

Third and final per-stage span from issue #78. Closes out the issue — all three stages (\`context_build_*\` in #94, \`tool_execute_*\` in #96, \`sandbox_provision_*\` here) now land.

## What

- \`SandboxRegistry.get_or_provision\` gains an optional \`pool\` kwarg. On the cold path (cache miss), it emits a \`sandbox_provision_start\` / \`sandbox_provision_end\` pair around \`provision_for_session\`. Warm hits short-circuit before touching pool — zero observable overhead on subsequent tool calls for the same session.
- 6 tool handlers (\`bash\`, \`read\`, \`write\`, \`edit\`, \`grep\`, \`glob\`) pass \`runtime.require_pool()\`.
- End span carries \`is_error\` + (on success) a 12-char \`container_id\` matching docker's short-id convention — lets operators correlate span timings with \`docker logs\` output.

## Test plan

- [x] 4 new unit tests: cold-start emits pair, warm hit silent, missing-pool silent, provision failure emits \`is_error=True\`
- [x] 6 tool-handler \`_StubRegistry\` stubs widened to accept \`**_kwargs\`; their fixtures set \`runtime.pool = MagicMock()\`
- [x] \`pytest tests/unit\` — 731 passed
- [x] \`pytest tests/e2e\` — 227 passed
- [x] mypy + ruff clean

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)