### PR TITLE
feat(harness): dynamic streaming — stream only when a subscriber is attached (closes #81)

### DIFF
--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -60,6 +60,7 @@ from typing import TYPE_CHECKING
 
 import asyncpg
 
+from aios.db.sse_lock import acquire_subscriber_lock
 from aios.logging import get_logger
 
 if TYPE_CHECKING:
@@ -131,6 +132,10 @@ async def listen_for_events(
                 pass
 
     await conn.add_listener(channel, _callback)
+    # Hold a shared advisory lock on this dedicated connection so the
+    # worker can detect that an SSE subscriber exists (issue #81).
+    # pg_locks releases automatically on connection close — no cleanup.
+    await acquire_subscriber_lock(conn, session_id)
     try:
         yield queue
     finally:

--- a/src/aios/db/sse_lock.py
+++ b/src/aios/db/sse_lock.py
@@ -1,0 +1,76 @@
+"""Advisory-lock-based SSE subscriber detection (issue #81).
+
+The dynamic-streaming decision — "is anyone watching this session's SSE
+stream right now?" — is answered by whether a backend holds a shared
+advisory lock keyed to the session.  When an SSE endpoint opens, it
+grabs the lock on its dedicated connection.  When the connection dies
+(client disconnect, API crash, TCP reset), Postgres releases the lock
+automatically: no tracking table, no cleanup job.
+
+The worker queries ``pg_locks`` before each step to decide whether the
+model call should stream (deltas → ``pg_notify`` → SSE clients) or run
+non-streaming (faster end-to-end on proxies like OpenRouter→Groq when
+nobody is consuming deltas).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import asyncpg
+
+
+def session_lock_key(session_id: str) -> tuple[int, int]:
+    """Derive a ``(classid, objid)`` advisory-lock key pair from ``session_id``.
+
+    BLAKE2b hashes the session identifier into 8 bytes, then splits into
+    two signed int32s so the pair maps directly onto ``pg_locks.classid``
+    and ``pg_locks.objid``.  Deterministic; collision probability is
+    negligible for realistic deployments.
+    """
+    digest = hashlib.blake2b(session_id.encode("utf-8"), digest_size=8).digest()
+    classid, objid = struct.unpack("<ii", digest)
+    return classid, objid
+
+
+async def acquire_subscriber_lock(conn: asyncpg.Connection[Any], session_id: str) -> None:
+    """Hold a shared advisory lock on ``conn`` for the duration of the connection.
+
+    Multiple subscribers coexist via shared-mode.  The lock releases
+    automatically when ``conn`` closes (client disconnect, crash, TCP
+    reset) — that auto-release is the whole point of the pattern.
+
+    The ``::int`` casts are load-bearing: asyncpg infers the parameter
+    type as ``oid`` (uint32) from context if we don't pin it, which
+    fails for negative keys coming out of the BLAKE2 hash.
+    """
+    classid, objid = session_lock_key(session_id)
+    await conn.execute("SELECT pg_advisory_lock_shared($1::int, $2::int)", classid, objid)
+
+
+async def has_subscriber(pool: asyncpg.Pool[Any], session_id: str) -> bool:
+    """Return True if any backend holds a shared subscriber lock for this session.
+
+    ``pg_locks.classid`` / ``objid`` are ``oid`` (uint32) but our keys are
+    signed int32.  Casting the parameter as ``int::oid`` reinterprets the
+    sign bit so equality works correctly across the signed/unsigned
+    boundary.  The ``database = (...)`` predicate scopes the scan to the
+    current database so a busy cluster's cross-db locks don't bloat this
+    hot-path query.
+    """
+    classid, objid = session_lock_key(session_id)
+    async with pool.acquire() as conn:
+        result = await conn.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM pg_locks "
+            "WHERE locktype = 'advisory' "
+            "AND database = (SELECT oid FROM pg_database WHERE datname = current_database()) "
+            "AND classid = ($1::int)::oid "
+            "AND objid = ($2::int)::oid "
+            "AND mode = 'ShareLock')",
+            classid,
+            objid,
+        )
+    return bool(result)

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from aios.db.sse_lock import has_subscriber
 from aios.harness import runtime
-from aios.harness.completion import stream_litellm
+from aios.harness.completion import call_litellm, stream_litellm
 from aios.harness.step_context import compose_step_context
 from aios.harness.sweep import find_sessions_needing_inference
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
@@ -209,16 +210,28 @@ async def run_session_step(
         {"event": "model_request_start"},
     )
 
-    # Call the model exactly once (streaming — deltas go to SSE via pg_notify).
+    # Call the model exactly once.  Stream deltas via pg_notify only when
+    # an SSE subscriber is attached (issue #81); otherwise run the faster
+    # non-streaming path.  OpenRouter-style proxies can be 2-3x slower on
+    # the streaming path when nobody is consuming the deltas.
+    subscribed = await has_subscriber(pool, session_id)
     try:
-        assistant_msg, usage, cost_usd = await stream_litellm(
-            model=agent.model,
-            messages=messages,
-            tools=tools if tools else None,
-            extra=agent.litellm_extra or None,
-            pool=pool,
-            session_id=session_id,
-        )
+        if subscribed:
+            assistant_msg, usage, cost_usd = await stream_litellm(
+                model=agent.model,
+                messages=messages,
+                tools=tools if tools else None,
+                extra=agent.litellm_extra or None,
+                pool=pool,
+                session_id=session_id,
+            )
+        else:
+            assistant_msg, usage, cost_usd = await call_litellm(
+                model=agent.model,
+                messages=messages,
+                tools=tools if tools else None,
+                extra=agent.litellm_extra or None,
+            )
     except Exception:
         log.exception("step.litellm_failed", session_id=session_id)
         await sessions_service.append_event(

--- a/tests/e2e/test_sse_lock.py
+++ b/tests/e2e/test_sse_lock.py
@@ -1,0 +1,97 @@
+"""E2E tests for the SSE subscriber lock → Postgres pg_locks integration."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+class TestSubscriberLockRoundTrip:
+    async def test_acquire_then_probe_true_release_then_probe_false(
+        self, pool: Any, aios_env: dict[str, str]
+    ) -> None:
+        from aios.config import get_settings
+        from aios.db.listen import _normalize_dsn
+        from aios.db.sse_lock import acquire_subscriber_lock, has_subscriber
+
+        settings = get_settings()
+        dsn = _normalize_dsn(settings.db_url)
+        session_id = "sess_01KAAA_LOCK_TEST_XX"
+
+        assert await has_subscriber(pool, session_id) is False
+
+        conn = await asyncpg.connect(dsn)
+        try:
+            await acquire_subscriber_lock(conn, session_id)
+            assert await has_subscriber(pool, session_id) is True
+        finally:
+            await conn.close()
+
+        # Give pg a moment to release — auto-release on close is
+        # synchronous in Postgres, but asyncpg's close is async.
+        for _ in range(10):
+            if not await has_subscriber(pool, session_id):
+                break
+            await asyncio.sleep(0.05)
+        assert await has_subscriber(pool, session_id) is False
+
+    async def test_multiple_subscribers_coexist(self, pool: Any, aios_env: dict[str, str]) -> None:
+        from aios.config import get_settings
+        from aios.db.listen import _normalize_dsn
+        from aios.db.sse_lock import acquire_subscriber_lock, has_subscriber
+
+        settings = get_settings()
+        dsn = _normalize_dsn(settings.db_url)
+        session_id = "sess_01KBBB_MULTI_LOCK"
+
+        conn_a = await asyncpg.connect(dsn)
+        conn_b = await asyncpg.connect(dsn)
+        try:
+            await acquire_subscriber_lock(conn_a, session_id)
+            await acquire_subscriber_lock(conn_b, session_id)
+            assert await has_subscriber(pool, session_id) is True
+
+            await conn_a.close()
+            # Subscriber B still holds.
+            assert await has_subscriber(pool, session_id) is True
+        finally:
+            await conn_b.close()
+
+        for _ in range(10):
+            if not await has_subscriber(pool, session_id):
+                break
+            await asyncio.sleep(0.05)
+        assert await has_subscriber(pool, session_id) is False
+
+    async def test_different_sessions_are_isolated(
+        self, pool: Any, aios_env: dict[str, str]
+    ) -> None:
+        from aios.config import get_settings
+        from aios.db.listen import _normalize_dsn
+        from aios.db.sse_lock import acquire_subscriber_lock, has_subscriber
+
+        settings = get_settings()
+        dsn = _normalize_dsn(settings.db_url)
+
+        conn = await asyncpg.connect(dsn)
+        try:
+            await acquire_subscriber_lock(conn, "sess_01KCC_SESSION_A")
+            assert await has_subscriber(pool, "sess_01KCC_SESSION_A") is True
+            assert await has_subscriber(pool, "sess_01KDD_SESSION_B") is False
+        finally:
+            await conn.close()

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -622,10 +622,20 @@ class TestReactingTo:
 @needs_docker
 class TestStreamingInference:
     async def test_streaming_basic_chat(self, harness: Harness) -> None:
-        """Streaming produces the same final result as non-streaming."""
+        """Streaming produces the same final result as non-streaming.
+
+        Opens ``listen_for_events`` around the step so the dynamic-streaming
+        decision (issue #81) sees a subscriber and picks the streaming path.
+        """
+        from aios.config import get_settings
+        from aios.db.listen import listen_for_events
+
         harness.script_model([assistant("Hello, world!")])
         session = await harness.start("Say hello")
-        await harness.run_until_idle(session.id)
+
+        settings = get_settings()
+        async with listen_for_events(settings.db_url, session.id):
+            await harness.run_until_idle(session.id)
 
         events = await harness.events(session.id)
         assert last_assistant_content(events) == "Hello, world!"
@@ -639,6 +649,8 @@ class TestStreamingInference:
 
     async def test_streaming_tool_round_trip(self, harness: Harness) -> None:
         """Streaming works correctly with tool calls."""
+        from aios.config import get_settings
+        from aios.db.listen import listen_for_events
 
         async def echo_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
             return {"output": arguments.get("text", "")}
@@ -651,7 +663,10 @@ class TestStreamingInference:
             ]
         )
         session = await harness.start("echo streamed", tools=[])
-        await harness.run_until_idle(session.id)
+
+        settings = get_settings()
+        async with listen_for_events(settings.db_url, session.id):
+            await harness.run_until_idle(session.id)
 
         events = await harness.events(session.id)
         tr = first_tool_result(events)
@@ -695,15 +710,33 @@ class TestStreamingInference:
 
     async def test_streaming_reacting_to_preserved(self, harness: Harness) -> None:
         """reacting_to field is set correctly on streamed responses."""
+        from aios.config import get_settings
+        from aios.db.listen import listen_for_events
+
         harness.script_model([assistant("Streamed response")])
         session = await harness.start("hello")
-        await harness.run_until_idle(session.id)
+
+        settings = get_settings()
+        async with listen_for_events(settings.db_url, session.id):
+            await harness.run_until_idle(session.id)
 
         events = await harness.events(session.id)
         asst = next(e for e in events if e.data.get("role") == "assistant")
         assert "reacting_to" in asst.data
         user_seq = next(e.seq for e in events if e.data.get("role") == "user")
         assert asst.data["reacting_to"] == user_seq
+
+    async def test_no_subscriber_uses_non_streaming_path(self, harness: Harness) -> None:
+        """Dynamic streaming (issue #81): with no SSE subscriber, the worker
+        picks the non-streaming code path to avoid the proxy latency tax
+        (OpenRouter→Groq is 3x slower streaming without a consumer)."""
+        harness.script_model([assistant("fast path")])
+        session = await harness.start("run")
+        # No ``listen_for_events`` → no advisory lock → worker sees no
+        # subscriber → non-streaming.
+        await harness.run_until_idle(session.id)
+
+        assert harness.model_calls[0].get("stream") is not True
 
     async def test_streaming_empty_content_chunks_skipped(self, harness: Harness) -> None:
         """Tool-only responses (no text content) don't produce deltas."""

--- a/tests/unit/test_sse_lock.py
+++ b/tests/unit/test_sse_lock.py
@@ -1,0 +1,23 @@
+"""Unit tests for the SSE subscriber lock helpers (issue #81)."""
+
+from __future__ import annotations
+
+from aios.db.sse_lock import session_lock_key
+
+
+class TestSessionLockKey:
+    def test_deterministic(self) -> None:
+        assert session_lock_key("sess_01KAAABBBCCC") == session_lock_key("sess_01KAAABBBCCC")
+
+    def test_different_sessions_get_different_keys(self) -> None:
+        a = session_lock_key("sess_01KAAAAAAAAA")
+        b = session_lock_key("sess_01KBBBBBBBBB")
+        assert a != b
+
+    def test_keys_fit_in_int32(self) -> None:
+        classid, objid = session_lock_key("sess_01KAAABBBCCC")
+        assert -(2**31) <= classid < 2**31
+        assert -(2**31) <= objid < 2**31
+
+    def test_empty_string_does_not_crash(self) -> None:
+        session_lock_key("")


### PR DESCRIPTION
## Summary

The worker unconditionally streams every model call, but some provider proxies (notably OpenRouter→Groq) are 2-3× slower on the streaming path when nobody consumes the deltas. Observed 5.2s non-stream vs 17.0s stream for gpt-oss-20b via OpenRouter — pure tax paid to the proxy's streaming bridge. This PR makes streaming conditional on whether an SSE subscriber is actually watching.

## How

SSE subscribers hold a Postgres shared advisory lock on their dedicated \`LISTEN\` connection (key derived via BLAKE2b from \`session_id\`). Before each model call, \`run_session_step\` queries \`pg_locks\`:

- **Subscriber present** → \`stream_litellm\` (deltas → \`pg_notify\` → SSE clients)
- **Subscriber absent** → \`call_litellm\` (non-streaming, faster path)

Self-healing: lock auto-releases on connection close (client disconnect, API crash, TCP reset). No subscriber-tracking table, no cleanup job.

## Design choices

- **Two-int advisory-lock form** over the bigint form — maps trivially onto \`pg_locks.classid\` / \`objid\`.
- **\`::int::oid\` casts** bridge the signed (our key space) vs unsigned (\`pg_locks\` column type) boundary.
- **\`database =\` predicate** scopes the probe to the current database so the hot-path query doesn't scan cluster-wide locks.

## Test plan

- [x] 4 new unit tests: key derivation determinism, distinctness, int32 bounds, empty-safe
- [x] 3 new e2e tests: acquire→probe round-trip, shared-mode coexistence, session isolation
- [x] Existing \`TestStreamingInference\` tests wrapped in \`listen_for_events\` to trigger the streaming branch; new \`test_no_subscriber_uses_non_streaming_path\` pins the dynamic-off path
- [x] \`pytest tests/unit\` — 735 passed
- [x] \`pytest tests/e2e\` — 231 passed
- [x] mypy + ruff clean

Closes #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)