### PR TITLE
feat(signal): surface bot's own sender_uuid + phone in MCP instructions (progresses #55)

### DIFF
--- a/connectors/signal/src/aios_signal/app.py
+++ b/connectors/signal/src/aios_signal/app.py
@@ -49,7 +49,10 @@ async def run(cfg: Settings) -> None:
                 messages=daemon.listener.messages(),
                 contact_names=contact_names,
             )
-            mcp_app = build_mcp_app(build_mcp_server(rpc=daemon.rpc), token=cfg.mcp_token)
+            mcp_app = build_mcp_app(
+                build_mcp_server(rpc=daemon.rpc, bot_uuid=bot_uuid, phone=cfg.phone),
+                token=cfg.mcp_token,
+            )
             host, port = parse_bind(cfg.mcp_bind)
 
             try:

--- a/connectors/signal/src/aios_signal/mcp.py
+++ b/connectors/signal/src/aios_signal/mcp.py
@@ -35,7 +35,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from .addressing import decode_chat_id
 from .markdown import convert_markdown_to_signal_styles
-from .prompts import SIGNAL_SERVER_INSTRUCTIONS
+from .prompts import build_instructions
 from .rpc import RpcClient
 
 log = structlog.get_logger(__name__)
@@ -139,10 +139,10 @@ class BearerAuthMiddleware:
         await self._app(scope, receive, send)
 
 
-def build_mcp_server(*, rpc: RpcClient) -> FastMCP:
+def build_mcp_server(*, rpc: RpcClient, bot_uuid: str, phone: str) -> FastMCP:
     mcp = FastMCP(
         "aios-signal",
-        instructions=SIGNAL_SERVER_INSTRUCTIONS,
+        instructions=build_instructions(bot_uuid=bot_uuid, phone=phone),
         stateless_http=True,
     )
 

--- a/connectors/signal/src/aios_signal/prompts.py
+++ b/connectors/signal/src/aios_signal/prompts.py
@@ -8,9 +8,35 @@ heading.
 Covers only the tools this server actually exposes — ``signal_send``,
 ``signal_react``, ``signal_read_receipt``.  Telling the model about
 tools that don't exist would be worse than silence.
+
+The instructions are composed per-run: ``build_instructions`` prepends
+an identity block (bot's own ``sender_uuid`` + phone number) to the
+static body so the agent can recognise itself in group messages
+instead of confabulating about who the other participants are
+(issue #55).
 """
 
 from __future__ import annotations
+
+
+def build_instructions(*, bot_uuid: str, phone: str) -> str:
+    """Compose the MCP ``initialize`` instructions with the bot's identity.
+
+    The agent would otherwise have no reliable source of truth for which
+    ``sender_uuid`` is itself — models have been observed confabulating
+    identities in group chats when this is absent.
+    """
+    identity = (
+        "## Your identity on this Signal account\n"
+        "\n"
+        f"- **sender_uuid**: `{bot_uuid}` — this is YOU.  In group "
+        "messages, any inbound whose header shows this uuid is your own "
+        "prior message, not another participant.\n"
+        f"- **phone**: `{phone}` — this Signal account is identified to "
+        "peers by this number.\n"
+    )
+    return identity + "\n" + SIGNAL_SERVER_INSTRUCTIONS
+
 
 SIGNAL_SERVER_INSTRUCTIONS = """\
 ## chat_id

--- a/connectors/signal/tests/test_mcp.py
+++ b/connectors/signal/tests/test_mcp.py
@@ -66,7 +66,7 @@ async def _call_tool(
     Goes through ``FastMCP.tool_manager.call_tool`` so the tool handler's
     ``ctx: Context`` dependency is filled in with the constructed meta.
     """
-    mcp = build_mcp_server(rpc=rpc)  # type: ignore[arg-type]
+    mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
     result = await mcp._tool_manager.call_tool(
         name,
         args,
@@ -171,7 +171,7 @@ async def test_signal_send_reads_focal_from_meta() -> None:
 
 async def test_signal_send_errors_without_meta() -> None:
     rpc = FakeRpc()
-    mcp = build_mcp_server(rpc=rpc)  # type: ignore[arg-type]
+    mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
     # No focal — aios should have filtered this tool out, but defend.
     ctx_no_meta = _ctx_with_focal(None)
     with pytest.raises(Exception, match="focal channel"):
@@ -322,7 +322,7 @@ async def test_bearer_auth_rejects_non_bearer_scheme() -> None:
 
 def test_build_mcp_app_returns_starlette() -> None:
     rpc = FakeRpc()
-    mcp = build_mcp_server(rpc=rpc)  # type: ignore[arg-type]
+    mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
     app = build_mcp_app(mcp, token="t")
     assert isinstance(app, Starlette)
 
@@ -336,9 +336,13 @@ def test_build_mcp_server_passes_signal_instructions() -> None:
     from aios_signal.prompts import SIGNAL_SERVER_INSTRUCTIONS
 
     rpc = FakeRpc()
-    mcp = build_mcp_server(rpc=rpc)  # type: ignore[arg-type]
-    assert mcp.instructions == SIGNAL_SERVER_INSTRUCTIONS
-    # Sanity-check the prose covers the v1 toolset.
+    mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
+    # The static tool prose comes through verbatim — ``build_instructions``
+    # prepends an identity block but doesn't rewrite the body.
+    assert SIGNAL_SERVER_INSTRUCTIONS in mcp.instructions
     assert "signal_send" in mcp.instructions
     assert "signal_react" in mcp.instructions
     assert "signal_read_receipt" in mcp.instructions
+    # Identity block is present and names this bot.
+    assert "test-bot-uuid" in mcp.instructions
+    assert "+15550000000" in mcp.instructions

--- a/connectors/signal/tests/test_prompts.py
+++ b/connectors/signal/tests/test_prompts.py
@@ -1,0 +1,36 @@
+"""Unit tests for the instructions builder (issue #55)."""
+
+from __future__ import annotations
+
+from aios_signal.prompts import SIGNAL_SERVER_INSTRUCTIONS, build_instructions
+
+
+class TestBuildInstructions:
+    def test_includes_bot_uuid(self) -> None:
+        result = build_instructions(
+            bot_uuid="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", phone="+15551234567"
+        )
+        assert "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" in result
+
+    def test_includes_phone(self) -> None:
+        result = build_instructions(
+            bot_uuid="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", phone="+15551234567"
+        )
+        assert "+15551234567" in result
+
+    def test_appends_tool_instructions_body(self) -> None:
+        result = build_instructions(bot_uuid="u", phone="+1")
+        # Every line of the static body must appear verbatim after the
+        # identity block — we're prepending, not rewriting.
+        assert SIGNAL_SERVER_INSTRUCTIONS in result
+
+    def test_identity_block_comes_first(self) -> None:
+        result = build_instructions(bot_uuid="u", phone="+1")
+        identity_idx = result.find("## Your identity")
+        body_idx = result.find("## chat_id")
+        assert identity_idx >= 0
+        assert body_idx > identity_idx
+
+    def test_is_string(self) -> None:
+        result = build_instructions(bot_uuid="u", phone="+1")
+        assert isinstance(result, str)


### PR DESCRIPTION
## Summary

Signal connector now prepends an \"## Your identity\" block to the MCP \`initialize\` instructions naming the bot's own \`sender_uuid\` + phone. Fixes the confabulation case called out in issue #55 (minimax inventing the name \"Ora\" when asked who it was) by giving the agent a canonical self-reference in group-chat inbound.

## Scope note

Addresses 2/3 of the identity fields the issue names. Phone + sender_uuid are already in scope at MCP build time (zero new I/O). Profile name needs a separate \`signal-cli getUserProfile\` round-trip and is left for a follow-up — framing is \"progresses\", not \"closes.\"

## Test plan

- [x] 5 new unit tests for \`build_instructions\`: uuid/phone appear, static tool body still present, identity comes before body, string return
- [x] 4 existing \`build_mcp_server\` call sites updated to pass the new kwargs; the instructions-passthrough test extended to verify identity + static body both land in \`mcp.instructions\`
- [x] \`pytest connectors/signal/tests\` — 84 passed
- [x] \`pytest tests/unit\` (main repo) — 735 passed (untouched)
- [x] mypy + ruff clean

Progresses #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)