### PR TITLE
feat(signal): surface group rosters to the agent in MCP instructions (closes #57)

### DIFF
--- a/connectors/signal/src/aios_signal/app.py
+++ b/connectors/signal/src/aios_signal/app.py
@@ -31,11 +31,13 @@ async def run(cfg: Settings) -> None:
     ) as daemon:
         bot_uuid = await daemon.discover_bot_uuid()
         contact_names = await daemon.list_contacts()
+        groups = await daemon.list_groups()
         log.info(
             "signal.ready",
             bot_uuid=bot_uuid,
             phone=cfg.phone,
             contacts=len(contact_names),
+            groups=len(groups),
         )
 
         async with IngestClient(
@@ -50,7 +52,13 @@ async def run(cfg: Settings) -> None:
                 contact_names=contact_names,
             )
             mcp_app = build_mcp_app(
-                build_mcp_server(rpc=daemon.rpc, bot_uuid=bot_uuid, phone=cfg.phone),
+                build_mcp_server(
+                    rpc=daemon.rpc,
+                    bot_uuid=bot_uuid,
+                    phone=cfg.phone,
+                    groups=groups,
+                    contact_names=contact_names,
+                ),
                 token=cfg.mcp_token,
             )
             host, port = parse_bind(cfg.mcp_bind)

--- a/connectors/signal/src/aios_signal/daemon.py
+++ b/connectors/signal/src/aios_signal/daemon.py
@@ -11,13 +11,30 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import signal
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Self
 
 import structlog
 
+from .addressing import encode_chat_id
 from .errors import BotAccountNotFoundError, DaemonCrashError
 from .rpc import RpcClient, RpcListener
+
+
+@dataclass(frozen=True)
+class GroupInfo:
+    """One Signal group the bot is a member of.
+
+    ``id`` is the URL-safe-base64 form used as the channel-path suffix
+    (``signal/<bot>/<id>``).  ``member_uuids`` are the ACI UUIDs of the
+    other participants; cross-reference with ``list_contacts`` for
+    display names.
+    """
+
+    id: str
+    name: str
+    member_uuids: list[str]
 
 log = structlog.get_logger(__name__)
 
@@ -180,6 +197,53 @@ class SignalDaemon:
             f"signal-cli has no account for {self.phone} in {accounts_json}. "
             f"Run `signal-cli -a {self.phone} register` first."
         )
+
+    async def list_groups(self) -> list[GroupInfo]:
+        """Return the bot's group memberships via signal-cli ``listGroups``.
+
+        Best-effort: returns an empty list on RPC failure or malformed
+        responses.  Group IDs are re-encoded into URL-safe base64 so the
+        caller can use them directly as channel-path suffixes
+        (``signal/<bot>/<id>``) — matching :func:`encode_chat_id`'s
+        ``group`` branch.  Groups missing either an ``id`` or ``members``
+        are dropped; the agent-facing roster is supposed to be a
+        complete picture of "who is in this room with me."
+        """
+        try:
+            result = await self.rpc.call("listGroups", {})
+        except Exception:
+            log.warning("signal.list_groups.failed", exc_info=True)
+            return []
+        if not isinstance(result, list):
+            return []
+        out: list[GroupInfo] = []
+        for entry in result:
+            if not isinstance(entry, dict):
+                continue
+            raw_id = entry.get("id")
+            members = entry.get("members")
+            if not isinstance(raw_id, str) or not raw_id:
+                continue
+            if not isinstance(members, list) or not members:
+                continue
+            name = entry.get("name") if isinstance(entry.get("name"), str) else ""
+            member_uuids: list[str] = []
+            for m in members:
+                if not isinstance(m, dict):
+                    continue
+                uuid = m.get("uuid")
+                if isinstance(uuid, str) and uuid:
+                    member_uuids.append(uuid)
+            if not member_uuids:
+                continue
+            out.append(
+                GroupInfo(
+                    id=encode_chat_id(raw_id, "group"),
+                    name=name or "",
+                    member_uuids=member_uuids,
+                )
+            )
+        return out
 
     async def list_contacts(self) -> dict[str, str]:
         """Return a ``{uuid: display_name}`` map from signal-cli's contact store.

--- a/connectors/signal/src/aios_signal/mcp.py
+++ b/connectors/signal/src/aios_signal/mcp.py
@@ -139,10 +139,22 @@ class BearerAuthMiddleware:
         await self._app(scope, receive, send)
 
 
-def build_mcp_server(*, rpc: RpcClient, bot_uuid: str, phone: str) -> FastMCP:
+def build_mcp_server(
+    *,
+    rpc: RpcClient,
+    bot_uuid: str,
+    phone: str,
+    groups: list[Any] | None = None,
+    contact_names: dict[str, str] | None = None,
+) -> FastMCP:
     mcp = FastMCP(
         "aios-signal",
-        instructions=build_instructions(bot_uuid=bot_uuid, phone=phone),
+        instructions=build_instructions(
+            bot_uuid=bot_uuid,
+            phone=phone,
+            groups=groups,
+            contact_names=contact_names,
+        ),
         stateless_http=True,
     )
 

--- a/connectors/signal/src/aios_signal/prompts.py
+++ b/connectors/signal/src/aios_signal/prompts.py
@@ -10,21 +10,34 @@ Covers only the tools this server actually exposes — ``signal_send``,
 tools that don't exist would be worse than silence.
 
 The instructions are composed per-run: ``build_instructions`` prepends
-an identity block (bot's own ``sender_uuid`` + phone number) to the
-static body so the agent can recognise itself in group messages
-instead of confabulating about who the other participants are
-(issue #55).
+an identity block (bot's own ``sender_uuid`` + phone number) and a
+group-roster block (who's in each group the bot is a member of) to
+the static body so the agent knows who it is and who it's talking to
+without having to learn that from inbound traffic (issues #55, #57).
 """
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 
-def build_instructions(*, bot_uuid: str, phone: str) -> str:
-    """Compose the MCP ``initialize`` instructions with the bot's identity.
+if TYPE_CHECKING:
+    from .daemon import GroupInfo
 
-    The agent would otherwise have no reliable source of truth for which
+
+def build_instructions(
+    *,
+    bot_uuid: str,
+    phone: str,
+    groups: list[GroupInfo] | None = None,
+    contact_names: dict[str, str] | None = None,
+) -> str:
+    """Compose the MCP ``initialize`` instructions with identity + roster.
+
+    The agent otherwise has no reliable source of truth for which
     ``sender_uuid`` is itself — models have been observed confabulating
-    identities in group chats when this is absent.
+    identities in group chats when this is absent.  The group-roster
+    block makes every participant knowable without having to wait for
+    them to speak; silent peers don't effectively disappear.
     """
     identity = (
         "## Your identity on this Signal account\n"
@@ -35,7 +48,30 @@ def build_instructions(*, bot_uuid: str, phone: str) -> str:
         f"- **phone**: `{phone}` — this Signal account is identified to "
         "peers by this number.\n"
     )
-    return identity + "\n" + SIGNAL_SERVER_INSTRUCTIONS
+    roster = _render_group_roster(bot_uuid, groups or [], contact_names or {})
+    return identity + roster + "\n" + SIGNAL_SERVER_INSTRUCTIONS
+
+
+def _render_group_roster(
+    bot_uuid: str,
+    groups: list[GroupInfo],
+    contact_names: dict[str, str],
+) -> str:
+    if not groups:
+        return ""
+    lines: list[str] = ["\n## Your Signal groups\n"]
+    for g in groups:
+        name = g.name or "(unnamed)"
+        lines.append(f"\n- `{g.id}` — {name}")
+        for uuid in g.member_uuids:
+            if uuid == bot_uuid:
+                tag = "(YOU)"
+            else:
+                display = contact_names.get(uuid)
+                tag = display if display else "(name unknown)"
+            lines.append(f"    - `{uuid}`: {tag}")
+    lines.append("")
+    return "\n".join(lines) + "\n"
 
 
 SIGNAL_SERVER_INSTRUCTIONS = """\

--- a/connectors/signal/tests/test_list_groups.py
+++ b/connectors/signal/tests/test_list_groups.py
@@ -1,0 +1,100 @@
+"""Unit tests for ``SignalDaemon.list_groups`` (issue #57)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios_signal.daemon import GroupInfo, SignalDaemon
+
+
+def _make_daemon() -> SignalDaemon:
+    """Build a daemon with minimum scaffolding; tests drive the RPC directly."""
+    from pathlib import Path
+
+    return SignalDaemon(
+        phone="+15550001111",
+        config_dir=Path("/tmp/aios-signal-test"),
+        cli_bin="signal-cli",
+        host="127.0.0.1",
+        port=9100,
+    )
+
+
+class TestListGroups:
+    async def test_maps_rpc_response_into_group_infos(self) -> None:
+        daemon = _make_daemon()
+        daemon.rpc.call = AsyncMock(  # type: ignore[method-assign]
+            return_value=[
+                {
+                    "id": "abc+/xyz=",
+                    "name": "Group One",
+                    "members": [
+                        {"number": "+15551000001", "uuid": "11111111-0001-0000-0000-000000000000"},
+                        {"number": "+15551000002", "uuid": "22222222-0002-0000-0000-000000000000"},
+                    ],
+                },
+                {
+                    "id": "def==",
+                    "name": "Group Two",
+                    "members": [
+                        {"uuid": "33333333-0003-0000-0000-000000000000"},
+                    ],
+                },
+            ]
+        )
+
+        groups = await daemon.list_groups()
+
+        assert len(groups) == 2
+        assert groups[0] == GroupInfo(
+            id="abc-_xyz=",  # URL-safe-base64 re-encoded
+            name="Group One",
+            member_uuids=[
+                "11111111-0001-0000-0000-000000000000",
+                "22222222-0002-0000-0000-000000000000",
+            ],
+        )
+        assert groups[1] == GroupInfo(
+            id="def==",
+            name="Group Two",
+            member_uuids=["33333333-0003-0000-0000-000000000000"],
+        )
+
+    async def test_empty_list_when_rpc_fails(self) -> None:
+        daemon = _make_daemon()
+        daemon.rpc.call = AsyncMock(side_effect=RuntimeError("rpc broken"))  # type: ignore[method-assign]
+        assert await daemon.list_groups() == []
+
+    async def test_empty_list_when_rpc_returns_non_list(self) -> None:
+        daemon = _make_daemon()
+        daemon.rpc.call = AsyncMock(return_value={"unexpected": "shape"})  # type: ignore[method-assign]
+        assert await daemon.list_groups() == []
+
+    async def test_skips_malformed_entries(self) -> None:
+        daemon = _make_daemon()
+        daemon.rpc.call = AsyncMock(  # type: ignore[method-assign]
+            return_value=[
+                {"id": "valid=", "name": "Ok", "members": [{"uuid": "aaaa"}]},
+                "not a dict",
+                {"no_id_field": True},
+                {"id": "", "name": "empty id"},
+                {"id": "skip-no-members", "name": "no members"},
+            ]
+        )
+        groups = await daemon.list_groups()
+        # Only the valid entry survives.
+        assert len(groups) == 1
+        assert groups[0].id == "valid="
+        assert groups[0].name == "Ok"
+        assert groups[0].member_uuids == ["aaaa"]
+
+
+class TestGroupInfoIsFrozen:
+    def test_fields_and_equality(self) -> None:
+        a = GroupInfo(id="x", name="A", member_uuids=["u1"])
+        b = GroupInfo(id="x", name="A", member_uuids=["u1"])
+        assert a == b
+        with pytest.raises((AttributeError, TypeError)):
+            a.id = "y"  # type: ignore[misc]

--- a/connectors/signal/tests/test_prompts.py
+++ b/connectors/signal/tests/test_prompts.py
@@ -1,7 +1,8 @@
-"""Unit tests for the instructions builder (issue #55)."""
+"""Unit tests for the instructions builder (issues #55, #57)."""
 
 from __future__ import annotations
 
+from aios_signal.daemon import GroupInfo
 from aios_signal.prompts import SIGNAL_SERVER_INSTRUCTIONS, build_instructions
 
 
@@ -34,3 +35,79 @@ class TestBuildInstructions:
     def test_is_string(self) -> None:
         result = build_instructions(bot_uuid="u", phone="+1")
         assert isinstance(result, str)
+
+
+class TestGroupRoster:
+    def test_no_groups_no_roster_section(self) -> None:
+        result = build_instructions(bot_uuid="u", phone="+1")
+        assert "## Your Signal groups" not in result
+
+    def test_empty_groups_list_no_roster_section(self) -> None:
+        result = build_instructions(bot_uuid="u", phone="+1", groups=[])
+        assert "## Your Signal groups" not in result
+
+    def test_renders_group_name_and_id(self) -> None:
+        result = build_instructions(
+            bot_uuid="bot-uuid",
+            phone="+1",
+            groups=[
+                GroupInfo(id="grp-abc=", name="Weekend Plans", member_uuids=["bot-uuid", "u1"]),
+            ],
+            contact_names={"u1": "Alice"},
+        )
+        assert "## Your Signal groups" in result
+        assert "grp-abc=" in result
+        assert "Weekend Plans" in result
+
+    def test_flags_bot_as_YOU_in_member_list(self) -> None:
+        result = build_instructions(
+            bot_uuid="bot-uuid",
+            phone="+1",
+            groups=[GroupInfo(id="g", name="G", member_uuids=["bot-uuid", "u1"])],
+            contact_names={"u1": "Alice"},
+        )
+        assert "(YOU)" in result
+        # Alice rendered by display name, not uuid
+        assert "Alice" in result
+
+    def test_missing_name_shows_unknown_tag(self) -> None:
+        result = build_instructions(
+            bot_uuid="bot-uuid",
+            phone="+1",
+            groups=[GroupInfo(id="g", name="G", member_uuids=["u-anon"])],
+            contact_names={},
+        )
+        assert "(name unknown)" in result
+
+    def test_roster_block_comes_before_static_body(self) -> None:
+        result = build_instructions(
+            bot_uuid="u",
+            phone="+1",
+            groups=[GroupInfo(id="g", name="G", member_uuids=["u"])],
+        )
+        roster_idx = result.find("## Your Signal groups")
+        body_idx = result.find("## chat_id")
+        assert roster_idx >= 0 and body_idx >= 0
+        assert roster_idx < body_idx
+
+    def test_multiple_groups_listed(self) -> None:
+        result = build_instructions(
+            bot_uuid="b",
+            phone="+1",
+            groups=[
+                GroupInfo(id="g1", name="First", member_uuids=["b", "x"]),
+                GroupInfo(id="g2", name="Second", member_uuids=["b", "y"]),
+            ],
+            contact_names={"x": "Xavier", "y": "Yolanda"},
+        )
+        assert "First" in result and "Second" in result
+        assert "Xavier" in result and "Yolanda" in result
+
+    def test_unnamed_group_renders_as_unnamed(self) -> None:
+        result = build_instructions(
+            bot_uuid="b",
+            phone="+1",
+            groups=[GroupInfo(id="g", name="", member_uuids=["b", "x"])],
+            contact_names={"x": "X"},
+        )
+        assert "(unnamed)" in result


### PR DESCRIPTION
## Summary

Signal connector now reports every group the bot is a member of in its MCP \`initialize\` instructions — including all participants, keyed by their sender_uuid. Silent peers no longer effectively disappear from the agent's picture of the room.

## Design choice

Issue proposed two shapes: static (in \`instructions\`) vs dynamic (a \`signal_list_group_members\` tool). I picked static per the issue's own recommendation (\"simpler and works until groups change\"). Dynamic tool remains available as a follow-up if churn mid-session becomes a real concern.

## What lands

- \`daemon.list_groups() -> list[GroupInfo]\` — best-effort \`listGroups\` RPC, mirrors \`list_contacts\`. Group IDs re-encoded to URL-safe base64 (matches \`encode_chat_id\`'s \`group\` branch) so they're usable as channel-path suffixes.
- \`prompts.build_instructions\` renders a \"## Your Signal groups\" section between identity and tool body. Bot flagged \`(YOU)\`; unknown contacts flagged \`(name unknown)\`; unnamed groups flagged \`(unnamed)\`.
- \`mcp.build_mcp_server\` + \`app.run\` plumbing for the new fields.

## Test plan

- [x] 5 new unit tests for \`daemon.list_groups\`: RPC happy path, RPC failure → empty, non-list response → empty, malformed entries skipped, \`GroupInfo\` frozen
- [x] 7 new unit tests for the roster section of \`build_instructions\`: all the edge cases above plus bot flagging and ordering
- [x] \`pytest connectors/signal/tests\` — 97 passed (up from 84)
- [x] \`pytest tests/unit\` (main repo) — 735 passed (untouched)
- [x] mypy + ruff clean

Closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)