### PR TITLE
feat(cli): aios connections list + create (progresses #35 item 4)

### DIFF
--- a/src/aios/__main__.py
+++ b/src/aios/__main__.py
@@ -2,10 +2,11 @@
 
 Subcommands:
 
-* ``aios api``     — uvicorn boot of the FastAPI app
-* ``aios worker``  — procrastinate worker process (runs the harness loop)
-* ``aios migrate`` — alembic upgrade head + procrastinate schema apply
-* ``aios tail``    — structured real-time session event viewer (SSE client)
+* ``aios api``         — uvicorn boot of the FastAPI app
+* ``aios worker``      — procrastinate worker process (runs the harness loop)
+* ``aios migrate``     — alembic upgrade head + procrastinate schema apply
+* ``aios tail``        — structured real-time session event viewer (SSE client)
+* ``aios connections`` — connection CRUD wrappers (list/create)
 """
 
 from __future__ import annotations
@@ -86,7 +87,7 @@ def _run_migrate() -> int:
 
 def main() -> int:
     if len(sys.argv) < 2:
-        print("usage: aios <api|worker|migrate|tail>", file=sys.stderr)
+        print("usage: aios <api|worker|migrate|tail|connections>", file=sys.stderr)
         return 2
 
     cmd = sys.argv[1]
@@ -101,6 +102,10 @@ def main() -> int:
             from aios.tail import run as _run_tail
 
             return _run_tail(sys.argv[2:])
+        case "connections":
+            from aios.cli.connections import run as _run_connections
+
+            return _run_connections(sys.argv[2:])
         case _:
             print(f"aios: unknown subcommand {cmd!r}", file=sys.stderr)
             return 2

--- a/src/aios/cli/__init__.py
+++ b/src/aios/cli/__init__.py
@@ -1,0 +1,8 @@
+"""Operator-facing CLI subcommands (progresses #35 item 4).
+
+Each submodule implements one top-level verb group (``connections``,
+eventually ``vaults``, ``routing-rules``, etc.).  Dispatched from
+:mod:`aios.__main__`.
+"""
+
+from __future__ import annotations

--- a/src/aios/cli/connections.py
+++ b/src/aios/cli/connections.py
@@ -1,0 +1,134 @@
+"""``aios connections <verb>`` — operator CLI for connection CRUD.
+
+Wraps ``POST``/``GET /v1/connections`` so the onboarding walkthrough
+doesn't need a chain of curl invocations (#35 item 4).  Mirrors the
+shape of ``aios tail``: reads ``AIOS_API_KEY`` + ``AIOS_API_URL`` /
+``AIOS_API_HOST``+``AIOS_API_PORT`` from env and pipes through httpx.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+
+import httpx
+
+
+def run(argv: list[str]) -> int:
+    """Sync entry point for ``__main__``.  Tests use ``run_async`` directly."""
+    return asyncio.run(run_async(argv))
+
+
+async def run_async(argv: list[str]) -> int:
+    """Parse ``argv`` and dispatch to a verb handler.
+
+    ``argv`` is the slice *after* ``connections`` — e.g. for
+    ``aios connections list`` this is ``["list"]``.
+    """
+    parser = argparse.ArgumentParser(
+        prog="aios connections",
+        description="Manage aios connections.",
+    )
+    sub = parser.add_subparsers(dest="verb")
+
+    sub.add_parser("list", help="List connections")
+
+    create = sub.add_parser("create", help="Create a new connection")
+    create.add_argument("--connector", required=True, help="Connector type (e.g. signal)")
+    create.add_argument("--account", required=True, help="Account identifier (e.g. bot uuid)")
+    create.add_argument("--mcp-url", required=True, help="MCP server URL")
+    create.add_argument("--vault-id", required=True, help="Vault id with the MCP credential")
+
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code) if exc.code is not None else 2
+
+    if args.verb is None:
+        parser.print_usage(sys.stderr)
+        return 2
+
+    try:
+        api_url, api_key = _require_env()
+    except _CliError as err:
+        print(str(err), file=sys.stderr)
+        return 2
+
+    if args.verb == "list":
+        return await _list(api_url, api_key)
+    if args.verb == "create":
+        return await _create(
+            api_url,
+            api_key,
+            connector=args.connector,
+            account=args.account,
+            mcp_url=args.mcp_url,
+            vault_id=args.vault_id,
+        )
+    parser.print_usage(sys.stderr)
+    return 2
+
+
+class _CliError(Exception):
+    """Raised for user-visible config errors (missing env, etc.)."""
+
+
+def _require_env() -> tuple[str, str]:
+    api_key = os.environ.get("AIOS_API_KEY")
+    if not api_key:
+        raise _CliError("aios connections: AIOS_API_KEY is required")
+    api_url = os.environ.get(
+        "AIOS_API_URL",
+        f"http://{os.environ.get('AIOS_API_HOST', '127.0.0.1')}"
+        f":{os.environ.get('AIOS_API_PORT', '8080')}",
+    )
+    return api_url, api_key
+
+
+async def _list(api_url: str, api_key: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/connections"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(url, headers=headers)
+    if response.status_code != 200:
+        print(
+            f"aios connections: HTTP {response.status_code}: {response.text}",
+            file=sys.stderr,
+        )
+        return 2
+    body: dict[str, Any] = response.json()
+    print(json.dumps(body.get("data", []), indent=2))
+    return 0
+
+
+async def _create(
+    api_url: str,
+    api_key: str,
+    *,
+    connector: str,
+    account: str,
+    mcp_url: str,
+    vault_id: str,
+) -> int:
+    url = f"{api_url.rstrip('/')}/v1/connections"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    payload = {
+        "connector": connector,
+        "account": account,
+        "mcp_url": mcp_url,
+        "vault_id": vault_id,
+    }
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(url, headers=headers, json=payload)
+    if response.status_code not in {200, 201}:
+        print(
+            f"aios connections: HTTP {response.status_code}: {response.text}",
+            file=sys.stderr,
+        )
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0

--- a/tests/unit/test_cli_connections.py
+++ b/tests/unit/test_cli_connections.py
@@ -1,0 +1,160 @@
+"""Unit tests for ``aios connections <verb>`` CLI (progresses #35 item 4).
+
+The HTTP client layer is mocked; these tests focus on argv parsing,
+request-body shaping, error propagation, and output formatting.
+
+Tests exercise ``run_async`` directly so pytest-asyncio owns the event
+loop — avoids the ``asyncio.run`` → closed-loop interaction with other
+tests in the suite that use ``asyncio.get_event_loop()``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.cli.connections import run_async
+
+
+def _setup_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIOS_API_KEY", "test-key")
+    monkeypatch.setenv("AIOS_API_URL", "http://test.server:8090")
+
+
+def _mock_response(status_code: int, body: Any) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=body)
+    resp.text = json.dumps(body)
+    return resp
+
+
+def _mock_async_client(method: str, response: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    setattr(client, method, AsyncMock(return_value=response))
+    return client
+
+
+class TestListConnections:
+    async def test_prints_json_array(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        payload = {
+            "data": [
+                {
+                    "id": "conn_01",
+                    "connector": "signal",
+                    "account": "+15550001",
+                    "mcp_url": "http://m",
+                    "vault_id": "vlt_01",
+                    "archived_at": None,
+                }
+            ],
+            "has_more": False,
+            "next_after": None,
+        }
+        client = _mock_async_client("get", _mock_response(200, payload))
+
+        with patch("aios.cli.connections.httpx.AsyncClient", return_value=client):
+            rc = await run_async(["list"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "conn_01" in out
+        assert "signal" in out
+        assert "+15550001" in out
+
+    async def test_http_error_returns_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("get", _mock_response(500, {"error": "boom"}))
+
+        with patch("aios.cli.connections.httpx.AsyncClient", return_value=client):
+            rc = await run_async(["list"])
+
+        assert rc != 0
+        assert "500" in capsys.readouterr().err
+
+    async def test_missing_api_key_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.delenv("AIOS_API_KEY", raising=False)
+        monkeypatch.setenv("AIOS_API_URL", "http://test.server:8090")
+        rc = await run_async(["list"])
+        assert rc != 0
+        assert "AIOS_API_KEY" in capsys.readouterr().err
+
+
+class TestCreateConnection:
+    async def test_posts_expected_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        created = {
+            "id": "conn_new",
+            "connector": "signal",
+            "account": "+15550001",
+            "mcp_url": "http://m",
+            "vault_id": "vlt_01",
+            "archived_at": None,
+        }
+        client = _mock_async_client("post", _mock_response(201, created))
+
+        with patch("aios.cli.connections.httpx.AsyncClient", return_value=client):
+            rc = await run_async(
+                [
+                    "create",
+                    "--connector",
+                    "signal",
+                    "--account",
+                    "+15550001",
+                    "--mcp-url",
+                    "http://m",
+                    "--vault-id",
+                    "vlt_01",
+                ]
+            )
+
+        assert rc == 0
+        client.post.assert_awaited_once()
+        call = client.post.await_args
+        assert call.args[0].endswith("/v1/connections")
+        assert call.kwargs["json"] == {
+            "connector": "signal",
+            "account": "+15550001",
+            "mcp_url": "http://m",
+            "vault_id": "vlt_01",
+        }
+
+    async def test_missing_required_flag_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(["create", "--connector", "signal"])
+        assert rc != 0
+        assert "required" in capsys.readouterr().err.lower()
+
+
+class TestDispatch:
+    async def test_unknown_verb_prints_usage(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = await run_async(["bogus-verb"])
+        assert rc == 2
+        assert "usage" in capsys.readouterr().err.lower()
+
+    async def test_no_verb_prints_usage(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = await run_async([])
+        assert rc == 2
+        assert "usage" in capsys.readouterr().err.lower()
+
+    async def test_help_prints_usage_and_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        rc = await run_async(["--help"])
+        assert rc == 0


### PR DESCRIPTION
## Summary

Operator-facing CLI wrappers for connection CRUD so onboarding doesn't need a chain of curl invocations. Progresses #35 item 4.

- `aios connections list` — GET /v1/connections, prints JSON array
- `aios connections create --connector --account --mcp-url --vault-id` — POST /v1/connections, prints created row

Mirrors the `aios tail` shape: reads \`AIOS_API_KEY\` + \`AIOS_API_URL\` (or \`AIOS_API_HOST\`+\`AIOS_API_PORT\`) from env, pipes through httpx. HTTP errors return exit code 2 with stderr diagnostics.

## Design note

Module splits sync \`run(argv)\` (calls \`asyncio.run\`) from async \`run_async(argv)\` (the actual logic). Tests drive \`run_async\` directly so pytest-asyncio owns the event loop — avoids the \`asyncio.run\` → closed-loop interaction with other test modules that still use \`asyncio.get_event_loop()\`.

## Test plan

- [x] \`uv run pytest tests/unit -q\` — 743 passed (8 new)
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [ ] Smoke test against a local API process before shipping to an operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)