### PR TITLE
feat(cli): aios bindings list + create (progresses #35 item 4)

### DIFF
--- a/src/aios/__main__.py
+++ b/src/aios/__main__.py
@@ -7,6 +7,7 @@ Subcommands:
 * ``aios migrate``     — alembic upgrade head + procrastinate schema apply
 * ``aios tail``        — structured real-time session event viewer (SSE client)
 * ``aios connections`` — connection CRUD wrappers (list/create)
+* ``aios bindings``    — channel-binding CRUD wrappers (list/create)
 """
 
 from __future__ import annotations
@@ -87,7 +88,10 @@ def _run_migrate() -> int:
 
 def main() -> int:
     if len(sys.argv) < 2:
-        print("usage: aios <api|worker|migrate|tail|connections>", file=sys.stderr)
+        print(
+            "usage: aios <api|worker|migrate|tail|connections|bindings>",
+            file=sys.stderr,
+        )
         return 2
 
     cmd = sys.argv[1]
@@ -106,6 +110,10 @@ def main() -> int:
             from aios.cli.connections import run as _run_connections
 
             return _run_connections(sys.argv[2:])
+        case "bindings":
+            from aios.cli.bindings import run as _run_bindings
+
+            return _run_bindings(sys.argv[2:])
         case _:
             print(f"aios: unknown subcommand {cmd!r}", file=sys.stderr)
             return 2

--- a/src/aios/cli/bindings.py
+++ b/src/aios/cli/bindings.py
@@ -1,0 +1,140 @@
+"""``aios bindings <verb>`` — operator CLI for channel-binding CRUD.
+
+Wraps ``POST``/``GET /v1/channel-bindings`` so the onboarding
+walkthrough doesn't need a chain of curl invocations (#35 item 4).
+Mirrors :mod:`aios.cli.connections`: reads ``AIOS_API_KEY`` +
+``AIOS_API_URL`` / ``AIOS_API_HOST``+``AIOS_API_PORT`` from env and
+pipes through httpx.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+
+import httpx
+
+
+def run(argv: list[str]) -> int:
+    """Sync entry point for ``__main__``.  Tests use ``run_async`` directly."""
+    return asyncio.run(run_async(argv))
+
+
+async def run_async(argv: list[str]) -> int:
+    """Parse ``argv`` and dispatch to a verb handler.
+
+    ``argv`` is the slice *after* ``bindings`` — e.g. for
+    ``aios bindings list`` this is ``["list"]``.
+    """
+    parser = argparse.ArgumentParser(
+        prog="aios bindings",
+        description="Manage aios channel bindings (address → session mappings).",
+    )
+    sub = parser.add_subparsers(dest="verb")
+
+    lst = sub.add_parser("list", help="List channel bindings")
+    lst.add_argument(
+        "--session-id",
+        default=None,
+        help="Filter to bindings for this session id",
+    )
+
+    create = sub.add_parser("create", help="Create a new channel binding")
+    create.add_argument(
+        "--address",
+        required=True,
+        help="Full channel address (e.g. signal/+15550001/group/abc)",
+    )
+    create.add_argument(
+        "--session-id",
+        required=True,
+        help="Session id to bind the address to",
+    )
+
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code) if exc.code is not None else 2
+
+    if args.verb is None:
+        parser.print_usage(sys.stderr)
+        return 2
+
+    try:
+        api_url, api_key = _require_env()
+    except _CliError as err:
+        print(str(err), file=sys.stderr)
+        return 2
+
+    if args.verb == "list":
+        return await _list(api_url, api_key, session_id=args.session_id)
+    if args.verb == "create":
+        return await _create(
+            api_url,
+            api_key,
+            address=args.address,
+            session_id=args.session_id,
+        )
+    parser.print_usage(sys.stderr)
+    return 2
+
+
+class _CliError(Exception):
+    """Raised for user-visible config errors (missing env, etc.)."""
+
+
+def _require_env() -> tuple[str, str]:
+    api_key = os.environ.get("AIOS_API_KEY")
+    if not api_key:
+        raise _CliError("aios bindings: AIOS_API_KEY is required")
+    api_url = os.environ.get(
+        "AIOS_API_URL",
+        f"http://{os.environ.get('AIOS_API_HOST', '127.0.0.1')}"
+        f":{os.environ.get('AIOS_API_PORT', '8080')}",
+    )
+    return api_url, api_key
+
+
+async def _list(api_url: str, api_key: str, *, session_id: str | None) -> int:
+    url = f"{api_url.rstrip('/')}/v1/channel-bindings"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    params: dict[str, str] = {}
+    if session_id is not None:
+        params["session_id"] = session_id
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(url, headers=headers, params=params)
+    if response.status_code != 200:
+        print(
+            f"aios bindings: HTTP {response.status_code}: {response.text}",
+            file=sys.stderr,
+        )
+        return 2
+    body: dict[str, Any] = response.json()
+    print(json.dumps(body.get("data", []), indent=2))
+    return 0
+
+
+async def _create(
+    api_url: str,
+    api_key: str,
+    *,
+    address: str,
+    session_id: str,
+) -> int:
+    url = f"{api_url.rstrip('/')}/v1/channel-bindings"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    payload = {"address": address, "session_id": session_id}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(url, headers=headers, json=payload)
+    if response.status_code not in {200, 201}:
+        print(
+            f"aios bindings: HTTP {response.status_code}: {response.text}",
+            file=sys.stderr,
+        )
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0

--- a/tests/unit/test_cli_bindings.py
+++ b/tests/unit/test_cli_bindings.py
@@ -1,0 +1,176 @@
+"""Unit tests for ``aios bindings <verb>`` CLI (progresses #35 item 4).
+
+The HTTP client layer is mocked; these tests focus on argv parsing,
+request-body / query-param shaping, error propagation, and output
+formatting.
+
+Tests exercise ``run_async`` directly so pytest-asyncio owns the event
+loop — same rationale as ``test_cli_connections.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.cli.bindings import run_async
+
+
+def _setup_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIOS_API_KEY", "test-key")
+    monkeypatch.setenv("AIOS_API_URL", "http://test.server:8090")
+
+
+def _mock_response(status_code: int, body: Any) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=body)
+    resp.text = json.dumps(body)
+    return resp
+
+
+def _mock_async_client(method: str, response: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    setattr(client, method, AsyncMock(return_value=response))
+    return client
+
+
+class TestListBindings:
+    async def test_prints_json_array(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        payload = {
+            "data": [
+                {
+                    "id": "cbn_01",
+                    "connection_id": "conn_01",
+                    "path": "group/abc",
+                    "address": "signal/+15550001/group/abc",
+                    "session_id": "sess_01",
+                    "created_at": "2026-04-20T00:00:00Z",
+                    "updated_at": "2026-04-20T00:00:00Z",
+                    "archived_at": None,
+                    "notification_mode": "focal_candidate",
+                }
+            ],
+            "has_more": False,
+            "next_after": None,
+        }
+        client = _mock_async_client("get", _mock_response(200, payload))
+
+        with patch("aios.cli.bindings.httpx.AsyncClient", return_value=client):
+            rc = await run_async(["list"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "cbn_01" in out
+        assert "signal/+15550001/group/abc" in out
+        assert "sess_01" in out
+
+    async def test_filters_by_session_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        payload = {"data": [], "has_more": False, "next_after": None}
+        client = _mock_async_client("get", _mock_response(200, payload))
+
+        with patch("aios.cli.bindings.httpx.AsyncClient", return_value=client):
+            rc = await run_async(["list", "--session-id", "sess_target"])
+
+        assert rc == 0
+        client.get.assert_awaited_once()
+        call = client.get.await_args
+        # Accept either ?session_id=... on the URL, or passed via params=
+        url = call.args[0]
+        params = call.kwargs.get("params") or {}
+        assert "session_id" in url or params.get("session_id") == "sess_target"
+
+    async def test_http_error_returns_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("get", _mock_response(500, {"error": "boom"}))
+
+        with patch("aios.cli.bindings.httpx.AsyncClient", return_value=client):
+            rc = await run_async(["list"])
+
+        assert rc != 0
+        assert "500" in capsys.readouterr().err
+
+    async def test_missing_api_key_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.delenv("AIOS_API_KEY", raising=False)
+        monkeypatch.setenv("AIOS_API_URL", "http://test.server:8090")
+        rc = await run_async(["list"])
+        assert rc != 0
+        assert "AIOS_API_KEY" in capsys.readouterr().err
+
+
+class TestCreateBinding:
+    async def test_posts_expected_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        created = {
+            "id": "cbn_new",
+            "connection_id": "conn_01",
+            "path": "group/abc",
+            "address": "signal/+15550001/group/abc",
+            "session_id": "sess_01",
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:00:00Z",
+            "archived_at": None,
+            "notification_mode": "focal_candidate",
+        }
+        client = _mock_async_client("post", _mock_response(201, created))
+
+        with patch("aios.cli.bindings.httpx.AsyncClient", return_value=client):
+            rc = await run_async(
+                [
+                    "create",
+                    "--address",
+                    "signal/+15550001/group/abc",
+                    "--session-id",
+                    "sess_01",
+                ]
+            )
+
+        assert rc == 0
+        client.post.assert_awaited_once()
+        call = client.post.await_args
+        assert call.args[0].endswith("/v1/channel-bindings")
+        assert call.kwargs["json"] == {
+            "address": "signal/+15550001/group/abc",
+            "session_id": "sess_01",
+        }
+
+    async def test_missing_required_flag_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(["create", "--address", "signal/+15550001/group/abc"])
+        assert rc != 0
+        assert "required" in capsys.readouterr().err.lower()
+
+
+class TestDispatch:
+    async def test_unknown_verb_prints_usage(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = await run_async(["bogus-verb"])
+        assert rc == 2
+        assert "usage" in capsys.readouterr().err.lower()
+
+    async def test_no_verb_prints_usage(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = await run_async([])
+        assert rc == 2
+        assert "usage" in capsys.readouterr().err.lower()
+
+    async def test_help_prints_usage_and_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        rc = await run_async(["--help"])
+        assert rc == 0


### PR DESCRIPTION
## Summary

Extends the operator CLI with channel-binding CRUD wrappers — follow-on to #102. Progresses #35 item 4.

- \`aios bindings list [--session-id <id>]\` — GET /v1/channel-bindings, optional session_id filter
- \`aios bindings create --address <a> --session-id <sid>\` — POST /v1/channel-bindings

Pattern mirrors \`aios.cli.connections\`: same env handling (\`AIOS_API_KEY\` + \`AIOS_API_URL\` / \`AIOS_API_HOST\`+\`AIOS_API_PORT\`), same sync \`run\` / async \`run_async\` split so pytest-asyncio owns the loop, same HTTP error path and exit codes.

## Test plan

- [x] \`uv run pytest tests/unit -q\` — 752 passed (9 new)
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] Reviewer subagent: clean "ready to land" verdict

## Design note

Small API-shape detail: GET passes the filter via httpx \`params=\` rather than inline in the URL. Test is permissive — accepts either form — so a future refactor of the helper isn't blocked on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)