### PR TITLE
feat(cli): aios rules list + create (progresses #35 item 4)

### DIFF
--- a/src/aios/__main__.py
+++ b/src/aios/__main__.py
@@ -8,6 +8,7 @@ Subcommands:
 * ``aios tail``        — structured real-time session event viewer (SSE client)
 * ``aios connections`` — connection CRUD wrappers (list/create)
 * ``aios bindings``    — channel-binding CRUD wrappers (list/create)
+* ``aios rules``       — routing-rule CRUD wrappers (list/create)
 """
 
 from __future__ import annotations
@@ -89,7 +90,7 @@ def _run_migrate() -> int:
 def main() -> int:
     if len(sys.argv) < 2:
         print(
-            "usage: aios <api|worker|migrate|tail|connections|bindings>",
+            "usage: aios <api|worker|migrate|tail|connections|bindings|rules>",
             file=sys.stderr,
         )
         return 2
@@ -114,6 +115,10 @@ def main() -> int:
             from aios.cli.bindings import run as _run_bindings
 
             return _run_bindings(sys.argv[2:])
+        case "rules":
+            from aios.cli.rules import run as _run_rules
+
+            return _run_rules(sys.argv[2:])
         case _:
             print(f"aios: unknown subcommand {cmd!r}", file=sys.stderr)
             return 2

--- a/src/aios/cli/rules.py
+++ b/src/aios/cli/rules.py
@@ -1,0 +1,161 @@
+"""``aios rules <verb>`` — operator CLI for routing-rule CRUD.
+
+Routing rules are per-connection (``/v1/connections/<id>/routing-rules``)
+so both verbs require ``--connection-id``.  The nested ``SessionParams``
+block is accepted as a JSON string via ``--session-params-json``; absent
+flag means the rule is created with an empty ``SessionParams``.
+
+Env handling and exit semantics mirror :mod:`aios.cli.connections` —
+wraps the same API with an optional JSON-blob flag for the nested param.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+
+import httpx
+
+
+def run(argv: list[str]) -> int:
+    """Sync entry point for ``__main__``.  Tests use ``run_async`` directly."""
+    return asyncio.run(run_async(argv))
+
+
+async def run_async(argv: list[str]) -> int:
+    """Parse ``argv`` and dispatch to a verb handler.
+
+    ``argv`` is the slice *after* ``rules``.
+    """
+    parser = argparse.ArgumentParser(
+        prog="aios rules",
+        description="Manage aios routing rules (per-connection).",
+    )
+    sub = parser.add_subparsers(dest="verb")
+
+    lst = sub.add_parser("list", help="List routing rules for a connection")
+    lst.add_argument("--connection-id", required=True, help="Owning connection id")
+
+    create = sub.add_parser("create", help="Create a new routing rule")
+    create.add_argument("--connection-id", required=True, help="Owning connection id")
+    create.add_argument(
+        "--prefix",
+        required=True,
+        help='Channel-path prefix ("" = per-connection catch-all)',
+    )
+    create.add_argument(
+        "--target",
+        required=True,
+        help='Route target, e.g. "agent:claude-sonnet-4" or "session:sess_01"',
+    )
+    create.add_argument(
+        "--session-params-json",
+        default=None,
+        help="JSON object for nested SessionParams (default: empty object)",
+    )
+
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code) if exc.code is not None else 2
+
+    if args.verb is None:
+        parser.print_usage(sys.stderr)
+        return 2
+
+    try:
+        api_url, api_key = _require_env()
+    except _CliError as err:
+        print(str(err), file=sys.stderr)
+        return 2
+
+    if args.verb == "list":
+        return await _list(api_url, api_key, connection_id=args.connection_id)
+    if args.verb == "create":
+        try:
+            session_params = _parse_session_params(args.session_params_json)
+        except _CliError as err:
+            print(str(err), file=sys.stderr)
+            return 2
+        return await _create(
+            api_url,
+            api_key,
+            connection_id=args.connection_id,
+            prefix=args.prefix,
+            target=args.target,
+            session_params=session_params,
+        )
+    parser.print_usage(sys.stderr)
+    return 2
+
+
+class _CliError(Exception):
+    """Raised for user-visible config errors (missing env, bad JSON, etc.)."""
+
+
+def _require_env() -> tuple[str, str]:
+    api_key = os.environ.get("AIOS_API_KEY")
+    if not api_key:
+        raise _CliError("aios rules: AIOS_API_KEY is required")
+    api_url = os.environ.get(
+        "AIOS_API_URL",
+        f"http://{os.environ.get('AIOS_API_HOST', '127.0.0.1')}"
+        f":{os.environ.get('AIOS_API_PORT', '8080')}",
+    )
+    return api_url, api_key
+
+
+def _parse_session_params(raw: str | None) -> dict[str, Any]:
+    if raw is None:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise _CliError(f"aios rules: --session-params-json is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise _CliError("aios rules: --session-params-json must be a JSON object")
+    return parsed
+
+
+async def _list(api_url: str, api_key: str, *, connection_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/connections/{connection_id}/routing-rules"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(url, headers=headers)
+    if response.status_code != 200:
+        print(
+            f"aios rules: HTTP {response.status_code}: {response.text}",
+            file=sys.stderr,
+        )
+        return 2
+    body: dict[str, Any] = response.json()
+    print(json.dumps(body.get("data", []), indent=2))
+    return 0
+
+
+async def _create(
+    api_url: str,
+    api_key: str,
+    *,
+    connection_id: str,
+    prefix: str,
+    target: str,
+    session_params: dict[str, Any],
+) -> int:
+    url = f"{api_url.rstrip('/')}/v1/connections/{connection_id}/routing-rules"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    payload = {"prefix": prefix, "target": target, "session_params": session_params}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(url, headers=headers, json=payload)
+    if response.status_code not in {200, 201}:
+        print(
+            f"aios rules: HTTP {response.status_code}: {response.text}",
+            file=sys.stderr,
+        )
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0

--- a/tests/unit/test_cli_rules.py
+++ b/tests/unit/test_cli_rules.py
@@ -1,0 +1,260 @@
+"""Unit tests for ``aios rules <verb>`` CLI (progresses #35 item 4).
+
+Routing rules are per-connection (nested resource), so both verbs take
+``--connection-id``.  ``create`` accepts ``--session-params-json`` for
+the nested ``SessionParams`` block; default is an empty object which
+the API treats as a session_params-less rule.
+
+Tests exercise ``run_async`` directly — same pytest-asyncio rationale
+as ``test_cli_connections.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.cli.rules import run_async
+
+
+def _setup_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIOS_API_KEY", "test-key")
+    monkeypatch.setenv("AIOS_API_URL", "http://test.server:8090")
+
+
+def _mock_response(status_code: int, body: Any) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=body)
+    resp.text = json.dumps(body)
+    return resp
+
+
+def _mock_async_client(method: str, response: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    setattr(client, method, AsyncMock(return_value=response))
+    return client
+
+
+class TestListRules:
+    async def test_prints_json_array_and_hits_nested_route(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        payload = {
+            "data": [
+                {
+                    "id": "rul_01",
+                    "connection_id": "conn_01",
+                    "prefix": "group",
+                    "target": "agent:claude-sonnet-4",
+                    "session_params": {
+                        "environment_id": None,
+                        "vault_ids": [],
+                        "title": None,
+                        "metadata": {},
+                    },
+                    "created_at": "2026-04-20T00:00:00Z",
+                    "updated_at": "2026-04-20T00:00:00Z",
+                    "archived_at": None,
+                }
+            ],
+            "has_more": False,
+            "next_after": None,
+        }
+        client = _mock_async_client("get", _mock_response(200, payload))
+
+        with patch("aios.cli.rules.httpx.AsyncClient", return_value=client):
+            rc = await run_async(["list", "--connection-id", "conn_01"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "rul_01" in out
+        assert "group" in out
+        # Nested route under the connection id
+        call = client.get.await_args
+        assert call.args[0].endswith("/v1/connections/conn_01/routing-rules")
+
+    async def test_http_error_returns_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("get", _mock_response(500, {"error": "boom"}))
+
+        with patch("aios.cli.rules.httpx.AsyncClient", return_value=client):
+            rc = await run_async(["list", "--connection-id", "conn_01"])
+
+        assert rc != 0
+        assert "500" in capsys.readouterr().err
+
+    async def test_missing_api_key_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.delenv("AIOS_API_KEY", raising=False)
+        monkeypatch.setenv("AIOS_API_URL", "http://test.server:8090")
+        rc = await run_async(["list", "--connection-id", "conn_01"])
+        assert rc != 0
+        assert "AIOS_API_KEY" in capsys.readouterr().err
+
+    async def test_missing_connection_id_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(["list"])
+        assert rc != 0
+        assert "required" in capsys.readouterr().err.lower()
+
+
+class TestCreateRule:
+    async def test_posts_expected_body_with_default_session_params(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_env(monkeypatch)
+        created = {
+            "id": "rul_new",
+            "connection_id": "conn_01",
+            "prefix": "group",
+            "target": "agent:claude-sonnet-4",
+            "session_params": {
+                "environment_id": None,
+                "vault_ids": [],
+                "title": None,
+                "metadata": {},
+            },
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:00:00Z",
+            "archived_at": None,
+        }
+        client = _mock_async_client("post", _mock_response(201, created))
+
+        with patch("aios.cli.rules.httpx.AsyncClient", return_value=client):
+            rc = await run_async(
+                [
+                    "create",
+                    "--connection-id",
+                    "conn_01",
+                    "--prefix",
+                    "group",
+                    "--target",
+                    "agent:claude-sonnet-4",
+                ]
+            )
+
+        assert rc == 0
+        client.post.assert_awaited_once()
+        call = client.post.await_args
+        assert call.args[0].endswith("/v1/connections/conn_01/routing-rules")
+        assert call.kwargs["json"] == {
+            "prefix": "group",
+            "target": "agent:claude-sonnet-4",
+            "session_params": {},
+        }
+
+    async def test_posts_with_session_params_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        created = {
+            "id": "rul_new",
+            "connection_id": "conn_01",
+            "prefix": "",
+            "target": "agent:claude-sonnet-4",
+            "session_params": {
+                "environment_id": "env_01",
+                "vault_ids": ["vlt_01"],
+                "title": "chat {address}",
+                "metadata": {},
+            },
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:00:00Z",
+            "archived_at": None,
+        }
+        client = _mock_async_client("post", _mock_response(201, created))
+
+        sp_json = json.dumps(
+            {
+                "environment_id": "env_01",
+                "vault_ids": ["vlt_01"],
+                "title": "chat {address}",
+            }
+        )
+        with patch("aios.cli.rules.httpx.AsyncClient", return_value=client):
+            rc = await run_async(
+                [
+                    "create",
+                    "--connection-id",
+                    "conn_01",
+                    "--prefix",
+                    "",
+                    "--target",
+                    "agent:claude-sonnet-4",
+                    "--session-params-json",
+                    sp_json,
+                ]
+            )
+
+        assert rc == 0
+        call = client.post.await_args
+        assert call.kwargs["json"] == {
+            "prefix": "",
+            "target": "agent:claude-sonnet-4",
+            "session_params": {
+                "environment_id": "env_01",
+                "vault_ids": ["vlt_01"],
+                "title": "chat {address}",
+            },
+        }
+
+    async def test_missing_required_flag_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(
+            ["create", "--connection-id", "conn_01", "--prefix", "group"]
+        )  # missing --target
+        assert rc != 0
+        assert "required" in capsys.readouterr().err.lower()
+
+    async def test_invalid_session_params_json_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(
+            [
+                "create",
+                "--connection-id",
+                "conn_01",
+                "--prefix",
+                "group",
+                "--target",
+                "agent:claude-sonnet-4",
+                "--session-params-json",
+                "not-json{{",
+            ]
+        )
+        assert rc != 0
+        err = capsys.readouterr().err.lower()
+        assert "json" in err or "session-params" in err
+
+
+class TestDispatch:
+    async def test_unknown_verb_prints_usage(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = await run_async(["bogus-verb"])
+        assert rc == 2
+        assert "usage" in capsys.readouterr().err.lower()
+
+    async def test_no_verb_prints_usage(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = await run_async([])
+        assert rc == 2
+        assert "usage" in capsys.readouterr().err.lower()
+
+    async def test_help_prints_usage_and_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        rc = await run_async(["--help"])
+        assert rc == 0


### PR DESCRIPTION
## Summary

Adds the third CLI in this series (after #102 connections, #103 bindings) — routing-rule CRUD. Progresses #35 item 4.

- \`aios rules list --connection-id <cid>\` — GET /v1/connections/<cid>/routing-rules
- \`aios rules create --connection-id <cid> --prefix <p> --target <t> [--session-params-json '{...}']\` — POST /v1/connections/<cid>/routing-rules

## Design notes

Two justified divergences from the two earlier CLIs:

1. **Nested endpoint**: both verbs require \`--connection-id\`.
2. **\`session_params\` JSON payload**: accepted as \`--session-params-json\`, optional (defaults to \`{}\`). Invalid JSON or a non-object value exits non-zero before any HTTP call.

## Follow-up

With three sibling CLI modules now sharing ~30 lines of boilerplate per file (\`_require_env\`, \`_CliError\`, HTTP error print), there's a natural extraction into \`aios/cli/_http.py\`. Leaving for a separate refactor PR so the "third sibling" diff stays a clean parallel-structure addition against #102/#103.

## Test plan

- [x] \`uv run pytest tests/unit -q\` — 763 passed (11 new)
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] Reviewer subagent: clean "ship as-is" verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)