### PR TITLE
refactor(cli): extract shared HTTP helpers into aios.cli._http

### DIFF
--- a/src/aios/cli/_http.py
+++ b/src/aios/cli/_http.py
@@ -1,0 +1,57 @@
+"""Shared HTTP + env plumbing for ``aios <verb-group>`` CLI modules.
+
+The sibling modules — ``aios.cli.connections``, ``aios.cli.bindings``,
+``aios.cli.rules`` — all do the same four things around an httpx call:
+
+1. Read ``AIOS_API_KEY`` + ``AIOS_API_URL`` (or host+port) from env.
+2. Open a timed-out ``httpx.AsyncClient``.
+3. Print a ``"{prog}: HTTP {code}: {text}"`` line to stderr on non-2xx.
+4. Print the JSON body to stdout on success.
+
+This module hosts the first three — the fourth is one line and stays
+in the verb handlers so the success shape (array vs. single object)
+stays explicit per call site.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import httpx
+
+
+class CliError(Exception):
+    """Raised for user-visible config or argument errors (bad env, bad JSON, etc.).
+
+    Handler wraps this at the dispatch layer: prints the message to
+    stderr and returns exit code 2 without issuing any HTTP call.
+    """
+
+
+def require_env(prog: str) -> tuple[str, str]:
+    """Return ``(api_url, api_key)`` from env or raise :class:`CliError`.
+
+    ``prog`` is the CLI program name (e.g. ``"aios connections"``) —
+    used in the error message so operators know which verb-group
+    complained.
+    """
+    api_key = os.environ.get("AIOS_API_KEY")
+    if not api_key:
+        raise CliError(f"{prog}: AIOS_API_KEY is required")
+    api_url = os.environ.get(
+        "AIOS_API_URL",
+        f"http://{os.environ.get('AIOS_API_HOST', '127.0.0.1')}"
+        f":{os.environ.get('AIOS_API_PORT', '8080')}",
+    )
+    return api_url, api_key
+
+
+def print_http_error(prog: str, response: httpx.Response) -> None:
+    """Print the standard ``"{prog}: HTTP {code}: {text}"`` line to stderr."""
+    print(f"{prog}: HTTP {response.status_code}: {response.text}", file=sys.stderr)
+
+
+def async_client() -> httpx.AsyncClient:
+    """Return an httpx.AsyncClient with the standard CLI timeout."""
+    return httpx.AsyncClient(timeout=30.0)

--- a/src/aios/cli/bindings.py
+++ b/src/aios/cli/bindings.py
@@ -1,10 +1,8 @@
 """``aios bindings <verb>`` — operator CLI for channel-binding CRUD.
 
-Wraps ``POST``/``GET /v1/channel-bindings`` so the onboarding
-walkthrough doesn't need a chain of curl invocations (#35 item 4).
-Mirrors :mod:`aios.cli.connections`: reads ``AIOS_API_KEY`` +
-``AIOS_API_URL`` / ``AIOS_API_HOST``+``AIOS_API_PORT`` from env and
-pipes through httpx.
+Wraps ``POST``/``GET /v1/channel-bindings`` (#35 item 4).  Env
+handling, ``httpx`` setup, and HTTP-error formatting live in
+:mod:`aios.cli._http`.
 """
 
 from __future__ import annotations
@@ -12,11 +10,12 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import os
 import sys
 from typing import Any
 
-import httpx
+from aios.cli._http import CliError, async_client, print_http_error, require_env
+
+_PROG = "aios bindings"
 
 
 def run(argv: list[str]) -> int:
@@ -31,7 +30,7 @@ async def run_async(argv: list[str]) -> int:
     ``aios bindings list`` this is ``["list"]``.
     """
     parser = argparse.ArgumentParser(
-        prog="aios bindings",
+        prog=_PROG,
         description="Manage aios channel bindings (address → session mappings).",
     )
     sub = parser.add_subparsers(dest="verb")
@@ -65,8 +64,8 @@ async def run_async(argv: list[str]) -> int:
         return 2
 
     try:
-        api_url, api_key = _require_env()
-    except _CliError as err:
+        api_url, api_key = require_env(_PROG)
+    except CliError as err:
         print(str(err), file=sys.stderr)
         return 2
 
@@ -83,35 +82,16 @@ async def run_async(argv: list[str]) -> int:
     return 2
 
 
-class _CliError(Exception):
-    """Raised for user-visible config errors (missing env, etc.)."""
-
-
-def _require_env() -> tuple[str, str]:
-    api_key = os.environ.get("AIOS_API_KEY")
-    if not api_key:
-        raise _CliError("aios bindings: AIOS_API_KEY is required")
-    api_url = os.environ.get(
-        "AIOS_API_URL",
-        f"http://{os.environ.get('AIOS_API_HOST', '127.0.0.1')}"
-        f":{os.environ.get('AIOS_API_PORT', '8080')}",
-    )
-    return api_url, api_key
-
-
 async def _list(api_url: str, api_key: str, *, session_id: str | None) -> int:
     url = f"{api_url.rstrip('/')}/v1/channel-bindings"
     headers = {"Authorization": f"Bearer {api_key}"}
     params: dict[str, str] = {}
     if session_id is not None:
         params["session_id"] = session_id
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with async_client() as client:
         response = await client.get(url, headers=headers, params=params)
     if response.status_code != 200:
-        print(
-            f"aios bindings: HTTP {response.status_code}: {response.text}",
-            file=sys.stderr,
-        )
+        print_http_error(_PROG, response)
         return 2
     body: dict[str, Any] = response.json()
     print(json.dumps(body.get("data", []), indent=2))
@@ -128,13 +108,10 @@ async def _create(
     url = f"{api_url.rstrip('/')}/v1/channel-bindings"
     headers = {"Authorization": f"Bearer {api_key}"}
     payload = {"address": address, "session_id": session_id}
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with async_client() as client:
         response = await client.post(url, headers=headers, json=payload)
     if response.status_code not in {200, 201}:
-        print(
-            f"aios bindings: HTTP {response.status_code}: {response.text}",
-            file=sys.stderr,
-        )
+        print_http_error(_PROG, response)
         return 2
     print(json.dumps(response.json(), indent=2))
     return 0

--- a/src/aios/cli/connections.py
+++ b/src/aios/cli/connections.py
@@ -1,9 +1,10 @@
 """``aios connections <verb>`` — operator CLI for connection CRUD.
 
 Wraps ``POST``/``GET /v1/connections`` so the onboarding walkthrough
-doesn't need a chain of curl invocations (#35 item 4).  Mirrors the
-shape of ``aios tail``: reads ``AIOS_API_KEY`` + ``AIOS_API_URL`` /
-``AIOS_API_HOST``+``AIOS_API_PORT`` from env and pipes through httpx.
+doesn't need a chain of curl invocations (#35 item 4).  Env handling,
+``httpx`` setup, and HTTP-error formatting live in
+:mod:`aios.cli._http`; this module stays focused on argv shape and the
+two verb handlers.
 """
 
 from __future__ import annotations
@@ -11,11 +12,12 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import os
 import sys
 from typing import Any
 
-import httpx
+from aios.cli._http import CliError, async_client, print_http_error, require_env
+
+_PROG = "aios connections"
 
 
 def run(argv: list[str]) -> int:
@@ -30,7 +32,7 @@ async def run_async(argv: list[str]) -> int:
     ``aios connections list`` this is ``["list"]``.
     """
     parser = argparse.ArgumentParser(
-        prog="aios connections",
+        prog=_PROG,
         description="Manage aios connections.",
     )
     sub = parser.add_subparsers(dest="verb")
@@ -53,8 +55,8 @@ async def run_async(argv: list[str]) -> int:
         return 2
 
     try:
-        api_url, api_key = _require_env()
-    except _CliError as err:
+        api_url, api_key = require_env(_PROG)
+    except CliError as err:
         print(str(err), file=sys.stderr)
         return 2
 
@@ -73,32 +75,13 @@ async def run_async(argv: list[str]) -> int:
     return 2
 
 
-class _CliError(Exception):
-    """Raised for user-visible config errors (missing env, etc.)."""
-
-
-def _require_env() -> tuple[str, str]:
-    api_key = os.environ.get("AIOS_API_KEY")
-    if not api_key:
-        raise _CliError("aios connections: AIOS_API_KEY is required")
-    api_url = os.environ.get(
-        "AIOS_API_URL",
-        f"http://{os.environ.get('AIOS_API_HOST', '127.0.0.1')}"
-        f":{os.environ.get('AIOS_API_PORT', '8080')}",
-    )
-    return api_url, api_key
-
-
 async def _list(api_url: str, api_key: str) -> int:
     url = f"{api_url.rstrip('/')}/v1/connections"
     headers = {"Authorization": f"Bearer {api_key}"}
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with async_client() as client:
         response = await client.get(url, headers=headers)
     if response.status_code != 200:
-        print(
-            f"aios connections: HTTP {response.status_code}: {response.text}",
-            file=sys.stderr,
-        )
+        print_http_error(_PROG, response)
         return 2
     body: dict[str, Any] = response.json()
     print(json.dumps(body.get("data", []), indent=2))
@@ -122,13 +105,10 @@ async def _create(
         "mcp_url": mcp_url,
         "vault_id": vault_id,
     }
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with async_client() as client:
         response = await client.post(url, headers=headers, json=payload)
     if response.status_code not in {200, 201}:
-        print(
-            f"aios connections: HTTP {response.status_code}: {response.text}",
-            file=sys.stderr,
-        )
+        print_http_error(_PROG, response)
         return 2
     print(json.dumps(response.json(), indent=2))
     return 0

--- a/src/aios/cli/rules.py
+++ b/src/aios/cli/rules.py
@@ -5,8 +5,8 @@ so both verbs require ``--connection-id``.  The nested ``SessionParams``
 block is accepted as a JSON string via ``--session-params-json``; absent
 flag means the rule is created with an empty ``SessionParams``.
 
-Env handling and exit semantics mirror :mod:`aios.cli.connections` —
-wraps the same API with an optional JSON-blob flag for the nested param.
+Env handling, ``httpx`` setup, and HTTP-error formatting live in
+:mod:`aios.cli._http`.
 """
 
 from __future__ import annotations
@@ -14,11 +14,12 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import os
 import sys
 from typing import Any
 
-import httpx
+from aios.cli._http import CliError, async_client, print_http_error, require_env
+
+_PROG = "aios rules"
 
 
 def run(argv: list[str]) -> int:
@@ -32,7 +33,7 @@ async def run_async(argv: list[str]) -> int:
     ``argv`` is the slice *after* ``rules``.
     """
     parser = argparse.ArgumentParser(
-        prog="aios rules",
+        prog=_PROG,
         description="Manage aios routing rules (per-connection).",
     )
     sub = parser.add_subparsers(dest="verb")
@@ -68,8 +69,8 @@ async def run_async(argv: list[str]) -> int:
         return 2
 
     try:
-        api_url, api_key = _require_env()
-    except _CliError as err:
+        api_url, api_key = require_env(_PROG)
+    except CliError as err:
         print(str(err), file=sys.stderr)
         return 2
 
@@ -78,7 +79,7 @@ async def run_async(argv: list[str]) -> int:
     if args.verb == "create":
         try:
             session_params = _parse_session_params(args.session_params_json)
-        except _CliError as err:
+        except CliError as err:
             print(str(err), file=sys.stderr)
             return 2
         return await _create(
@@ -93,44 +94,25 @@ async def run_async(argv: list[str]) -> int:
     return 2
 
 
-class _CliError(Exception):
-    """Raised for user-visible config errors (missing env, bad JSON, etc.)."""
-
-
-def _require_env() -> tuple[str, str]:
-    api_key = os.environ.get("AIOS_API_KEY")
-    if not api_key:
-        raise _CliError("aios rules: AIOS_API_KEY is required")
-    api_url = os.environ.get(
-        "AIOS_API_URL",
-        f"http://{os.environ.get('AIOS_API_HOST', '127.0.0.1')}"
-        f":{os.environ.get('AIOS_API_PORT', '8080')}",
-    )
-    return api_url, api_key
-
-
 def _parse_session_params(raw: str | None) -> dict[str, Any]:
     if raw is None:
         return {}
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as exc:
-        raise _CliError(f"aios rules: --session-params-json is not valid JSON: {exc}") from exc
+        raise CliError(f"{_PROG}: --session-params-json is not valid JSON: {exc}") from exc
     if not isinstance(parsed, dict):
-        raise _CliError("aios rules: --session-params-json must be a JSON object")
+        raise CliError(f"{_PROG}: --session-params-json must be a JSON object")
     return parsed
 
 
 async def _list(api_url: str, api_key: str, *, connection_id: str) -> int:
     url = f"{api_url.rstrip('/')}/v1/connections/{connection_id}/routing-rules"
     headers = {"Authorization": f"Bearer {api_key}"}
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with async_client() as client:
         response = await client.get(url, headers=headers)
     if response.status_code != 200:
-        print(
-            f"aios rules: HTTP {response.status_code}: {response.text}",
-            file=sys.stderr,
-        )
+        print_http_error(_PROG, response)
         return 2
     body: dict[str, Any] = response.json()
     print(json.dumps(body.get("data", []), indent=2))
@@ -149,13 +131,10 @@ async def _create(
     url = f"{api_url.rstrip('/')}/v1/connections/{connection_id}/routing-rules"
     headers = {"Authorization": f"Bearer {api_key}"}
     payload = {"prefix": prefix, "target": target, "session_params": session_params}
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with async_client() as client:
         response = await client.post(url, headers=headers, json=payload)
     if response.status_code not in {200, 201}:
-        print(
-            f"aios rules: HTTP {response.status_code}: {response.text}",
-            file=sys.stderr,
-        )
+        print_http_error(_PROG, response)
         return 2
     print(json.dumps(response.json(), indent=2))
     return 0

--- a/tests/unit/test_cli_bindings.py
+++ b/tests/unit/test_cli_bindings.py
@@ -64,7 +64,7 @@ class TestListBindings:
         }
         client = _mock_async_client("get", _mock_response(200, payload))
 
-        with patch("aios.cli.bindings.httpx.AsyncClient", return_value=client):
+        with patch("aios.cli.bindings.async_client", return_value=client):
             rc = await run_async(["list"])
 
         assert rc == 0
@@ -78,7 +78,7 @@ class TestListBindings:
         payload = {"data": [], "has_more": False, "next_after": None}
         client = _mock_async_client("get", _mock_response(200, payload))
 
-        with patch("aios.cli.bindings.httpx.AsyncClient", return_value=client):
+        with patch("aios.cli.bindings.async_client", return_value=client):
             rc = await run_async(["list", "--session-id", "sess_target"])
 
         assert rc == 0
@@ -95,7 +95,7 @@ class TestListBindings:
         _setup_env(monkeypatch)
         client = _mock_async_client("get", _mock_response(500, {"error": "boom"}))
 
-        with patch("aios.cli.bindings.httpx.AsyncClient", return_value=client):
+        with patch("aios.cli.bindings.async_client", return_value=client):
             rc = await run_async(["list"])
 
         assert rc != 0
@@ -127,7 +127,7 @@ class TestCreateBinding:
         }
         client = _mock_async_client("post", _mock_response(201, created))
 
-        with patch("aios.cli.bindings.httpx.AsyncClient", return_value=client):
+        with patch("aios.cli.bindings.async_client", return_value=client):
             rc = await run_async(
                 [
                     "create",

--- a/tests/unit/test_cli_connections.py
+++ b/tests/unit/test_cli_connections.py
@@ -61,7 +61,7 @@ class TestListConnections:
         }
         client = _mock_async_client("get", _mock_response(200, payload))
 
-        with patch("aios.cli.connections.httpx.AsyncClient", return_value=client):
+        with patch("aios.cli.connections.async_client", return_value=client):
             rc = await run_async(["list"])
 
         assert rc == 0
@@ -76,7 +76,7 @@ class TestListConnections:
         _setup_env(monkeypatch)
         client = _mock_async_client("get", _mock_response(500, {"error": "boom"}))
 
-        with patch("aios.cli.connections.httpx.AsyncClient", return_value=client):
+        with patch("aios.cli.connections.async_client", return_value=client):
             rc = await run_async(["list"])
 
         assert rc != 0
@@ -105,7 +105,7 @@ class TestCreateConnection:
         }
         client = _mock_async_client("post", _mock_response(201, created))
 
-        with patch("aios.cli.connections.httpx.AsyncClient", return_value=client):
+        with patch("aios.cli.connections.async_client", return_value=client):
             rc = await run_async(
                 [
                     "create",

--- a/tests/unit/test_cli_rules.py
+++ b/tests/unit/test_cli_rules.py
@@ -69,7 +69,7 @@ class TestListRules:
         }
         client = _mock_async_client("get", _mock_response(200, payload))
 
-        with patch("aios.cli.rules.httpx.AsyncClient", return_value=client):
+        with patch("aios.cli.rules.async_client", return_value=client):
             rc = await run_async(["list", "--connection-id", "conn_01"])
 
         assert rc == 0
@@ -86,7 +86,7 @@ class TestListRules:
         _setup_env(monkeypatch)
         client = _mock_async_client("get", _mock_response(500, {"error": "boom"}))
 
-        with patch("aios.cli.rules.httpx.AsyncClient", return_value=client):
+        with patch("aios.cli.rules.async_client", return_value=client):
             rc = await run_async(["list", "--connection-id", "conn_01"])
 
         assert rc != 0
@@ -132,7 +132,7 @@ class TestCreateRule:
         }
         client = _mock_async_client("post", _mock_response(201, created))
 
-        with patch("aios.cli.rules.httpx.AsyncClient", return_value=client):
+        with patch("aios.cli.rules.async_client", return_value=client):
             rc = await run_async(
                 [
                     "create",
@@ -181,7 +181,7 @@ class TestCreateRule:
                 "title": "chat {address}",
             }
         )
-        with patch("aios.cli.rules.httpx.AsyncClient", return_value=client):
+        with patch("aios.cli.rules.async_client", return_value=client):
             rc = await run_async(
                 [
                     "create",


### PR DESCRIPTION
## Summary

Pure refactor — no behavior change. Extracts the ~30-lines-per-module boilerplate that accumulated across the three CLI modules that just landed (#102 connections, #103 bindings, #104 rules) into \`src/aios/cli/_http.py\`:

- \`CliError\` — replaces three per-module \`_CliError\` classes.
- \`require_env(prog)\` — env-read, formats error with caller's \`prog\` name.
- \`print_http_error(prog, resp)\` — the standard \`"{prog}: HTTP {code}: {text}"\` line.
- \`async_client()\` — \`httpx.AsyncClient(timeout=30.0)\` factory.

## Net diff

- New: \`src/aios/cli/_http.py\` (57 lines)
- -64 lines across the three CLI modules (117 removed, 53 added)
- New verb groups will consume ~5 lines of boilerplate instead of ~30

## Test strategy

The existing 28 tests across the three CLI suites pass unmodified, except for their \`patch()\` targets: \`aios.cli.<module>.httpx.AsyncClient\` → \`aios.cli.<module>.async_client\`. Both patch per-module bindings, so the mocking contract is the same.

## Why stop here

Considered further: a unified \`request()\` helper for the per-verb httpx pattern. Rejected — the variation (\`params=\` yes/no, \`json=\` yes/no, 200 vs {200,201} accept, \`body["data"]\` vs full body extraction) would require too many knobs to be a readability win.

## Test plan

- [x] \`uv run pytest tests/unit -q\` — 763 passed (same as before)
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] Reviewer subagent: no high-confidence issues, behavior byte-for-byte preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)