### PR TITLE
feat(signal): surface bot's own profile_name in MCP instructions (progresses #55)

### DIFF
--- a/connectors/signal/src/aios_signal/mcp.py
+++ b/connectors/signal/src/aios_signal/mcp.py
@@ -147,11 +147,17 @@ def build_mcp_server(
     groups: list[Any] | None = None,
     contact_names: dict[str, str] | None = None,
 ) -> FastMCP:
+    # If `listContacts` included the bot's own entry, use its display
+    # name as the profile_name for the identity block.  Absent when the
+    # bot hasn't set a profile or isn't listed in its own contacts —
+    # `build_instructions` renders nothing for that case.
+    profile_name = (contact_names or {}).get(bot_uuid)
     mcp = FastMCP(
         "aios-signal",
         instructions=build_instructions(
             bot_uuid=bot_uuid,
             phone=phone,
+            profile_name=profile_name,
             groups=groups,
             contact_names=contact_names,
         ),

--- a/connectors/signal/src/aios_signal/prompts.py
+++ b/connectors/signal/src/aios_signal/prompts.py
@@ -28,6 +28,7 @@ def build_instructions(
     *,
     bot_uuid: str,
     phone: str,
+    profile_name: str | None = None,
     groups: list[GroupInfo] | None = None,
     contact_names: dict[str, str] | None = None,
 ) -> str:
@@ -38,6 +39,11 @@ def build_instructions(
     identities in group chats when this is absent.  The group-roster
     block makes every participant knowable without having to wait for
     them to speak; silent peers don't effectively disappear.
+
+    ``profile_name``, when set, is the display name peers see for this
+    account.  Rendered as a third identity bullet; omitted entirely if
+    ``None`` or empty so an un-set-profile account doesn't get a blank
+    line in the system prompt.
     """
     identity = (
         "## Your identity on this Signal account\n"
@@ -48,6 +54,8 @@ def build_instructions(
         f"- **phone**: `{phone}` — this Signal account is identified to "
         "peers by this number.\n"
     )
+    if profile_name:
+        identity += f"- **profile_name**: `{profile_name}` — your display name on Signal.\n"
     roster = _render_group_roster(bot_uuid, groups or [], contact_names or {})
     return identity + roster + "\n" + SIGNAL_SERVER_INSTRUCTIONS
 

--- a/connectors/signal/tests/test_mcp.py
+++ b/connectors/signal/tests/test_mcp.py
@@ -327,6 +327,39 @@ def test_build_mcp_app_returns_starlette() -> None:
     assert isinstance(app, Starlette)
 
 
+def test_build_mcp_server_surfaces_profile_name_from_contacts() -> None:
+    """When ``contact_names`` contains the bot's own uuid, its display
+    name flows into the identity block as ``profile_name``.  Signal's
+    ``listContacts`` sometimes includes the account owner's own profile
+    entry; when it does, this gives the agent the same self-reference
+    peers see (progresses #55 beyond uuid/phone).
+    """
+    rpc = FakeRpc()
+    mcp = build_mcp_server(
+        rpc=rpc,
+        bot_uuid="test-bot-uuid",
+        phone="+15550000000",
+        contact_names={"test-bot-uuid": "Bot McBotface", "other-uuid": "Alice"},
+    )  # type: ignore[arg-type]
+    assert "profile_name" in mcp.instructions
+    assert "Bot McBotface" in mcp.instructions
+
+
+def test_build_mcp_server_omits_profile_name_when_bot_not_in_contacts() -> None:
+    """Graceful-if-missing: if ``listContacts`` doesn't include the bot's
+    own uuid, the profile-name line is simply absent.  Same rendering
+    as calling ``build_mcp_server`` without ``contact_names`` at all.
+    """
+    rpc = FakeRpc()
+    mcp = build_mcp_server(
+        rpc=rpc,
+        bot_uuid="test-bot-uuid",
+        phone="+15550000000",
+        contact_names={"other-uuid": "Alice"},
+    )  # type: ignore[arg-type]
+    assert "profile_name" not in mcp.instructions
+
+
 def test_build_mcp_server_passes_signal_instructions() -> None:
     """The MCP server's ``instructions`` field is the transport for
     Signal's per-connector affordance prose; aios reads it from the

--- a/connectors/signal/tests/test_prompts.py
+++ b/connectors/signal/tests/test_prompts.py
@@ -36,6 +36,30 @@ class TestBuildInstructions:
         result = build_instructions(bot_uuid="u", phone="+1")
         assert isinstance(result, str)
 
+    def test_includes_profile_name_when_set(self) -> None:
+        result = build_instructions(bot_uuid="u", phone="+1", profile_name="Bot McBotface")
+        assert "Bot McBotface" in result
+
+    def test_profile_name_line_labeled(self) -> None:
+        """Profile-name line uses the same ``**label**:`` shape as the
+        other identity bullets so the agent can parse the block
+        consistently."""
+        result = build_instructions(bot_uuid="u", phone="+1", profile_name="Bot McBotface")
+        assert "profile_name" in result
+
+    def test_omits_profile_name_line_when_none(self) -> None:
+        result = build_instructions(bot_uuid="u", phone="+1")
+        # The whole "profile_name" token should be absent when the caller
+        # has no name to report — we don't render an empty line.
+        assert "profile_name" not in result
+
+    def test_omits_profile_name_line_when_empty_string(self) -> None:
+        """Empty string is equivalent to None — don't render a blank
+        entry.  signal-cli's ``listContacts`` filters empties already,
+        but we belt-and-braces it at the render layer too."""
+        result = build_instructions(bot_uuid="u", phone="+1", profile_name="")
+        assert "profile_name" not in result
+
 
 class TestGroupRoster:
     def test_no_groups_no_roster_section(self) -> None:


### PR DESCRIPTION
## Summary

PR #100 surfaced the bot's \`sender_uuid\` + \`phone\` in the MCP \`initialize\` instructions identity block. This adds the third field #55 called for: the bot's own **profile_name** (display name on Signal).

## Design

The original scope note on #100 suggested a new \`signal-cli getUserProfile\` round-trip. Instead, this PR **reuses the existing \`list_contacts()\` mapping** that already feeds the group-roster display names: if the bot's own UUID is present in \`listContacts\` output, its display name becomes the \`profile_name\`. If not — or if \`list_contacts\` returned empty for the bot — the line is simply omitted.

Zero new RPC surface. \`build_mcp_server\` already received \`contact_names\` for the group roster; we just look up \`bot_uuid\` in it.

## Tradeoff

The source value is "what the bot's contact store records for itself," which is typically but not always what peers see. For the stated goal (agent knows its own display name and doesn't confabulate), the contact-store name is close enough. A future dedicated profile RPC could refine if the distinction matters.

## Test plan

- [x] 4 new tests in \`test_prompts.py\`: profile_name renders when set, labeled consistently, omitted when None, omitted on empty string
- [x] 2 new tests in \`test_mcp.py\`: flows through from \`contact_names[bot_uuid]\`; graceful-absent when bot not in contacts
- [x] \`pytest connectors/signal/tests\` — 103 passed
- [x] \`pytest tests/unit\` (main repo) — 763 passed (untouched)
- [x] \`mypy src\` + \`ruff check src tests && ruff format --check src tests\` — clean
- [x] Reviewer subagent: ship-it verdict, one doc-wording nit addressed

Progresses #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)