### PR TITLE
feat(cli): aios vaults list + create (progresses #35 item 4)

### DIFF
--- a/src/aios/__main__.py
+++ b/src/aios/__main__.py
@@ -9,6 +9,7 @@ Subcommands:
 * ``aios connections`` — connection CRUD wrappers (list/create)
 * ``aios bindings``    — channel-binding CRUD wrappers (list/create)
 * ``aios rules``       — routing-rule CRUD wrappers (list/create)
+* ``aios vaults``      — vault CRUD wrappers (list/create)
 """
 
 from __future__ import annotations
@@ -90,7 +91,7 @@ def _run_migrate() -> int:
 def main() -> int:
     if len(sys.argv) < 2:
         print(
-            "usage: aios <api|worker|migrate|tail|connections|bindings|rules>",
+            "usage: aios <api|worker|migrate|tail|connections|bindings|rules|vaults>",
             file=sys.stderr,
         )
         return 2
@@ -119,6 +120,10 @@ def main() -> int:
             from aios.cli.rules import run as _run_rules
 
             return _run_rules(sys.argv[2:])
+        case "vaults":
+            from aios.cli.vaults import run as _run_vaults
+
+            return _run_vaults(sys.argv[2:])
         case _:
             print(f"aios: unknown subcommand {cmd!r}", file=sys.stderr)
             return 2

--- a/src/aios/cli/vaults.py
+++ b/src/aios/cli/vaults.py
@@ -1,0 +1,131 @@
+"""``aios vaults <verb>`` — operator CLI for vault CRUD.
+
+Wraps ``POST``/``GET /v1/vaults`` (#35 item 4).  The ``metadata`` field
+on ``VaultCreate`` is a free-form JSON object; CLI accepts it as
+``--metadata-json`` (optional; default ``{}``) — same shape as
+``aios rules --session-params-json``.
+
+Credential management (``/v1/vaults/<id>/credentials``) is deliberately
+NOT surfaced here — the credential payload is ``auth_type``-dependent
+with several ``SecretStr`` branches and warrants its own
+``aios vaults credentials <verb>`` subcommand group in a later PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+from aios.cli._http import CliError, async_client, print_http_error, require_env
+
+_PROG = "aios vaults"
+
+
+def run(argv: list[str]) -> int:
+    """Sync entry point for ``__main__``.  Tests use ``run_async`` directly."""
+    return asyncio.run(run_async(argv))
+
+
+async def run_async(argv: list[str]) -> int:
+    """Parse ``argv`` and dispatch to a verb handler.
+
+    ``argv`` is the slice *after* ``vaults``.
+    """
+    parser = argparse.ArgumentParser(
+        prog=_PROG,
+        description="Manage aios vaults.",
+    )
+    sub = parser.add_subparsers(dest="verb")
+
+    sub.add_parser("list", help="List vaults")
+
+    create = sub.add_parser("create", help="Create a new vault")
+    create.add_argument(
+        "--display-name",
+        required=True,
+        help="Human-readable name for the vault (1-128 chars)",
+    )
+    create.add_argument(
+        "--metadata-json",
+        default=None,
+        help="JSON object of vault metadata (default: empty object)",
+    )
+
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code) if exc.code is not None else 2
+
+    if args.verb is None:
+        parser.print_usage(sys.stderr)
+        return 2
+
+    try:
+        api_url, api_key = require_env(_PROG)
+    except CliError as err:
+        print(str(err), file=sys.stderr)
+        return 2
+
+    if args.verb == "list":
+        return await _list(api_url, api_key)
+    if args.verb == "create":
+        try:
+            metadata = _parse_metadata(args.metadata_json)
+        except CliError as err:
+            print(str(err), file=sys.stderr)
+            return 2
+        return await _create(
+            api_url,
+            api_key,
+            display_name=args.display_name,
+            metadata=metadata,
+        )
+    parser.print_usage(sys.stderr)
+    return 2
+
+
+def _parse_metadata(raw: str | None) -> dict[str, Any]:
+    if raw is None:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CliError(f"{_PROG}: --metadata-json is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise CliError(f"{_PROG}: --metadata-json must be a JSON object")
+    return parsed
+
+
+async def _list(api_url: str, api_key: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/vaults"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.get(url, headers=headers)
+    if response.status_code != 200:
+        print_http_error(_PROG, response)
+        return 2
+    body: dict[str, Any] = response.json()
+    print(json.dumps(body.get("data", []), indent=2))
+    return 0
+
+
+async def _create(
+    api_url: str,
+    api_key: str,
+    *,
+    display_name: str,
+    metadata: dict[str, Any],
+) -> int:
+    url = f"{api_url.rstrip('/')}/v1/vaults"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    payload = {"display_name": display_name, "metadata": metadata}
+    async with async_client() as client:
+        response = await client.post(url, headers=headers, json=payload)
+    if response.status_code not in {200, 201}:
+        print_http_error(_PROG, response)
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0

--- a/tests/unit/test_cli_vaults.py
+++ b/tests/unit/test_cli_vaults.py
@@ -1,0 +1,184 @@
+"""Unit tests for ``aios vaults <verb>`` CLI (progresses #35 item 4).
+
+Vaults have a nested ``metadata`` object in ``VaultCreate``; CLI
+accepts it as ``--metadata-json`` (optional, default ``{}``), same
+shape as ``aios rules --session-params-json``.
+
+Tests exercise ``run_async`` directly and patch ``async_client``
+through the per-module binding introduced in #105.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.cli.vaults import run_async
+
+
+def _setup_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIOS_API_KEY", "test-key")
+    monkeypatch.setenv("AIOS_API_URL", "http://test.server:8090")
+
+
+def _mock_response(status_code: int, body: Any) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=body)
+    resp.text = json.dumps(body)
+    return resp
+
+
+def _mock_async_client(method: str, response: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    setattr(client, method, AsyncMock(return_value=response))
+    return client
+
+
+class TestListVaults:
+    async def test_prints_json_array(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        payload = {
+            "data": [
+                {
+                    "id": "vlt_01",
+                    "display_name": "Signal secrets",
+                    "metadata": {},
+                    "created_at": "2026-04-20T00:00:00Z",
+                    "updated_at": "2026-04-20T00:00:00Z",
+                    "archived_at": None,
+                }
+            ],
+            "has_more": False,
+            "next_after": None,
+        }
+        client = _mock_async_client("get", _mock_response(200, payload))
+
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(["list"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "vlt_01" in out
+        assert "Signal secrets" in out
+
+    async def test_http_error_returns_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("get", _mock_response(500, {"error": "boom"}))
+
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(["list"])
+
+        assert rc != 0
+        assert "500" in capsys.readouterr().err
+
+    async def test_missing_api_key_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.delenv("AIOS_API_KEY", raising=False)
+        monkeypatch.setenv("AIOS_API_URL", "http://test.server:8090")
+        rc = await run_async(["list"])
+        assert rc != 0
+        assert "AIOS_API_KEY" in capsys.readouterr().err
+
+
+class TestCreateVault:
+    async def test_posts_expected_body_with_default_metadata(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_env(monkeypatch)
+        created = {
+            "id": "vlt_new",
+            "display_name": "My vault",
+            "metadata": {},
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:00:00Z",
+            "archived_at": None,
+        }
+        client = _mock_async_client("post", _mock_response(201, created))
+
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(["create", "--display-name", "My vault"])
+
+        assert rc == 0
+        client.post.assert_awaited_once()
+        call = client.post.await_args
+        assert call.args[0].endswith("/v1/vaults")
+        assert call.kwargs["json"] == {"display_name": "My vault", "metadata": {}}
+
+    async def test_posts_with_metadata_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        created = {
+            "id": "vlt_new",
+            "display_name": "Tagged vault",
+            "metadata": {"env": "prod", "owner": "ops"},
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:00:00Z",
+            "archived_at": None,
+        }
+        client = _mock_async_client("post", _mock_response(201, created))
+
+        md = json.dumps({"env": "prod", "owner": "ops"})
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(
+                [
+                    "create",
+                    "--display-name",
+                    "Tagged vault",
+                    "--metadata-json",
+                    md,
+                ]
+            )
+
+        assert rc == 0
+        call = client.post.await_args
+        assert call.kwargs["json"] == {
+            "display_name": "Tagged vault",
+            "metadata": {"env": "prod", "owner": "ops"},
+        }
+
+    async def test_invalid_metadata_json_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(["create", "--display-name", "x", "--metadata-json", "not-json{{"])
+        assert rc != 0
+        err = capsys.readouterr().err.lower()
+        assert "json" in err or "metadata" in err
+
+    async def test_missing_required_flag_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(["create"])  # missing --display-name
+        assert rc != 0
+        assert "required" in capsys.readouterr().err.lower()
+
+
+class TestDispatch:
+    async def test_unknown_verb_prints_usage(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = await run_async(["bogus-verb"])
+        assert rc == 2
+        assert "usage" in capsys.readouterr().err.lower()
+
+    async def test_no_verb_prints_usage(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = await run_async([])
+        assert rc == 2
+        assert "usage" in capsys.readouterr().err.lower()
+
+    async def test_help_prints_usage_and_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        rc = await run_async(["--help"])
+        assert rc == 0


### PR DESCRIPTION
## Summary

Fourth CLI in the operator series — after #102 connections, #103 bindings, #104 rules, #105 shared \`_http\` helpers. Progresses #35 item 4.

- \`aios vaults list\` — GET /v1/vaults
- \`aios vaults create --display-name <name> [--metadata-json '{...}']\` — POST /v1/vaults

Uses the shared \`aios.cli._http\` helpers from #105. Pattern closest to \`rules.py\` — both have a \`--*-json\` flag for a nested dict payload.

## Scope

**NOT included**: vault credentials (\`/v1/vaults/<id>/credentials\`). Credential payload is \`auth_type\`-dependent with several \`SecretStr\` branches — deferred to its own \`aios vaults credentials <verb>\` subcommand group in a later PR.

## Test plan

- [x] \`uv run pytest tests/unit -q\` — 773 passed (10 new)
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] Reviewer subagent: clean, no high-confidence issues; behavior parity with \`rules.py\` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)