### PR TITLE
feat(cli): aios vault-credentials list (progresses #35 item 4)

### DIFF
--- a/src/aios/__main__.py
+++ b/src/aios/__main__.py
@@ -10,6 +10,7 @@ Subcommands:
 * ``aios bindings``    — channel-binding CRUD wrappers (list/create)
 * ``aios rules``       — routing-rule CRUD wrappers (list/create)
 * ``aios vaults``      — vault CRUD wrappers (list/create)
+* ``aios vault-credentials`` — vault credential inspection (list)
 """
 
 from __future__ import annotations
@@ -91,7 +92,7 @@ def _run_migrate() -> int:
 def main() -> int:
     if len(sys.argv) < 2:
         print(
-            "usage: aios <api|worker|migrate|tail|connections|bindings|rules|vaults>",
+            "usage: aios <api|worker|migrate|tail|connections|bindings|rules|vaults|vault-credentials>",
             file=sys.stderr,
         )
         return 2
@@ -124,6 +125,10 @@ def main() -> int:
             from aios.cli.vaults import run as _run_vaults
 
             return _run_vaults(sys.argv[2:])
+        case "vault-credentials":
+            from aios.cli.vault_credentials import run as _run_vault_credentials
+
+            return _run_vault_credentials(sys.argv[2:])
         case _:
             print(f"aios: unknown subcommand {cmd!r}", file=sys.stderr)
             return 2

--- a/src/aios/cli/vault_credentials.py
+++ b/src/aios/cli/vault_credentials.py
@@ -1,0 +1,71 @@
+"""``aios vault-credentials <verb>`` — operator CLI for credential inspection.
+
+Scope for this module: ``list`` only.  Credential *creation* has an
+``auth_type``-dependent schema branch (``mcp_oauth`` vs
+``static_bearer``) with several ``SecretStr`` fields whose CLI flag
+design deserves its own PR.
+
+Uses :mod:`aios.cli._http` for env + HTTP + error-format plumbing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+from aios.cli._http import CliError, async_client, print_http_error, require_env
+
+_PROG = "aios vault-credentials"
+
+
+def run(argv: list[str]) -> int:
+    """Sync entry point for ``__main__``.  Tests use ``run_async`` directly."""
+    return asyncio.run(run_async(argv))
+
+
+async def run_async(argv: list[str]) -> int:
+    """Parse ``argv`` and dispatch to a verb handler."""
+    parser = argparse.ArgumentParser(
+        prog=_PROG,
+        description="Inspect aios vault credentials.",
+    )
+    sub = parser.add_subparsers(dest="verb")
+
+    lst = sub.add_parser("list", help="List credentials in a vault")
+    lst.add_argument("--vault-id", required=True, help="Owning vault id")
+
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code) if exc.code is not None else 2
+
+    if args.verb is None:
+        parser.print_usage(sys.stderr)
+        return 2
+
+    try:
+        api_url, api_key = require_env(_PROG)
+    except CliError as err:
+        print(str(err), file=sys.stderr)
+        return 2
+
+    if args.verb == "list":
+        return await _list(api_url, api_key, vault_id=args.vault_id)
+    parser.print_usage(sys.stderr)
+    return 2
+
+
+async def _list(api_url: str, api_key: str, *, vault_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/vaults/{vault_id}/credentials"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.get(url, headers=headers)
+    if response.status_code != 200:
+        print_http_error(_PROG, response)
+        return 2
+    body: dict[str, Any] = response.json()
+    print(json.dumps(body.get("data", []), indent=2))
+    return 0

--- a/src/aios/cli/vaults.py
+++ b/src/aios/cli/vaults.py
@@ -5,10 +5,10 @@ on ``VaultCreate`` is a free-form JSON object; CLI accepts it as
 ``--metadata-json`` (optional; default ``{}``) — same shape as
 ``aios rules --session-params-json``.
 
-Credential management (``/v1/vaults/<id>/credentials``) is deliberately
-NOT surfaced here — the credential payload is ``auth_type``-dependent
-with several ``SecretStr`` branches and warrants its own
-``aios vaults credentials <verb>`` subcommand group in a later PR.
+Credential management (``/v1/vaults/<id>/credentials``) lives in its
+own top-level sibling — :mod:`aios.cli.vault_credentials` — matching
+the flat one-group-per-top-level-subcommand shape the other CLI
+modules follow.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_cli_vault_credentials.py
+++ b/tests/unit/test_cli_vault_credentials.py
@@ -1,0 +1,122 @@
+"""Unit tests for ``aios vault-credentials <verb>`` CLI (progresses #35 item 4).
+
+Scope: ``list`` only — credential *creation* has an ``auth_type``-
+dependent schema branch with several ``SecretStr`` fields; that
+warrants its own PR with a deliberate CLI flag design.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.cli.vault_credentials import run_async
+
+
+def _setup_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIOS_API_KEY", "test-key")
+    monkeypatch.setenv("AIOS_API_URL", "http://test.server:8090")
+
+
+def _mock_response(status_code: int, body: Any) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=body)
+    resp.text = json.dumps(body)
+    return resp
+
+
+def _mock_async_client(method: str, response: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    setattr(client, method, AsyncMock(return_value=response))
+    return client
+
+
+class TestListVaultCredentials:
+    async def test_prints_json_array_and_hits_nested_route(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        payload = {
+            "data": [
+                {
+                    "id": "vcr_01",
+                    "vault_id": "vlt_01",
+                    "display_name": "Signal MCP bearer",
+                    "mcp_server_url": "http://m",
+                    "auth_type": "static_bearer",
+                    "metadata": {},
+                    "created_at": "2026-04-20T00:00:00Z",
+                    "updated_at": "2026-04-20T00:00:00Z",
+                    "archived_at": None,
+                }
+            ],
+            "has_more": False,
+            "next_after": None,
+        }
+        client = _mock_async_client("get", _mock_response(200, payload))
+
+        with patch("aios.cli.vault_credentials.async_client", return_value=client):
+            rc = await run_async(["list", "--vault-id", "vlt_01"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "vcr_01" in out
+        assert "Signal MCP bearer" in out
+        # Nested route under the vault id
+        call = client.get.await_args
+        assert call.args[0].endswith("/v1/vaults/vlt_01/credentials")
+
+    async def test_http_error_returns_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("get", _mock_response(500, {"error": "boom"}))
+
+        with patch("aios.cli.vault_credentials.async_client", return_value=client):
+            rc = await run_async(["list", "--vault-id", "vlt_01"])
+
+        assert rc != 0
+        assert "500" in capsys.readouterr().err
+
+    async def test_missing_api_key_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.delenv("AIOS_API_KEY", raising=False)
+        monkeypatch.setenv("AIOS_API_URL", "http://test.server:8090")
+        rc = await run_async(["list", "--vault-id", "vlt_01"])
+        assert rc != 0
+        assert "AIOS_API_KEY" in capsys.readouterr().err
+
+    async def test_missing_vault_id_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(["list"])
+        assert rc != 0
+        assert "required" in capsys.readouterr().err.lower()
+
+
+class TestDispatch:
+    async def test_unknown_verb_prints_usage(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = await run_async(["bogus-verb"])
+        assert rc == 2
+        assert "usage" in capsys.readouterr().err.lower()
+
+    async def test_no_verb_prints_usage(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = await run_async([])
+        assert rc == 2
+        assert "usage" in capsys.readouterr().err.lower()
+
+    async def test_help_prints_usage_and_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        rc = await run_async(["--help"])
+        assert rc == 0


### PR DESCRIPTION
## Summary

Fifth CLI module in the operator series — after #102 connections, #103 bindings, #104 rules, #107 vaults, with #105 shared \`_http\` helpers between. Uses the same plumbing.

- \`aios vault-credentials list --vault-id <id>\` — GET /v1/vaults/<id>/credentials (read-only inspection)

## Scope: list only

\`VaultCredentialCreate\` is \`auth_type\`-dependent (\`mcp_oauth\` vs \`static_bearer\`) with several \`SecretStr\` branches. The CLI flag shape for that merits its own design pass. \`list\` stands alone here so operators can inspect credentials (e.g. confirm one exists, see \`display_name\` and \`auth_type\`) while \`create\` comes later.

## Naming decision

Shipped as a **flat top-level** subcommand (\`aios vault-credentials\`), mirroring the one-group-per-subcommand shape the other CLI modules follow. Updated the \`vaults.py\` docstring that had previously sketched a nested \`aios vaults credentials <verb>\` shape — per reviewer feedback, the inconsistency with the already-flat siblings wasn't worth carrying.

## Test plan

- [x] \`uv run pytest tests/unit -q\` — 780 passed (7 new)
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] Reviewer subagent: caught a naming inconsistency with the \`vaults.py\` docstring (from #107); docstring now updated to match the flat shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)