### PR TITLE
feat(cli): aios vault-credentials create via --body-file (progresses #35 item 4)

### DIFF
--- a/src/aios/cli/vault_credentials.py
+++ b/src/aios/cli/vault_credentials.py
@@ -1,9 +1,11 @@
-"""``aios vault-credentials <verb>`` — operator CLI for credential inspection.
+"""``aios vault-credentials <verb>`` — operator CLI for credential CRUD.
 
-Scope for this module: ``list`` only.  Credential *creation* has an
-``auth_type``-dependent schema branch (``mcp_oauth`` vs
-``static_bearer``) with several ``SecretStr`` fields whose CLI flag
-design deserves its own PR.
+Verbs: ``list`` (#108) and ``create`` (this PR).  ``create`` takes the
+full ``VaultCredentialCreate`` body from a file (``--body-file <path>``
+or ``-`` for stdin) rather than per-field flags — the schema branches
+on ``auth_type`` with several ``SecretStr`` fields, and passing
+secrets as shell args would leak them to shell history.  The
+``kubectl create -f`` pattern sidesteps both concerns.
 
 Uses :mod:`aios.cli._http` for env + HTTP + error-format plumbing.
 """
@@ -30,12 +32,24 @@ async def run_async(argv: list[str]) -> int:
     """Parse ``argv`` and dispatch to a verb handler."""
     parser = argparse.ArgumentParser(
         prog=_PROG,
-        description="Inspect aios vault credentials.",
+        description="Manage aios vault credentials.",
     )
     sub = parser.add_subparsers(dest="verb")
 
     lst = sub.add_parser("list", help="List credentials in a vault")
     lst.add_argument("--vault-id", required=True, help="Owning vault id")
+
+    create = sub.add_parser("create", help="Create a new credential in a vault")
+    create.add_argument("--vault-id", required=True, help="Owning vault id")
+    create.add_argument(
+        "--body-file",
+        required=True,
+        help=(
+            "Path to a JSON file containing the full VaultCredentialCreate "
+            "body, or '-' to read from stdin.  Using a file avoids leaking "
+            "secret fields (tokens, client secrets) into shell history."
+        ),
+    )
 
     try:
         args = parser.parse_args(argv)
@@ -54,8 +68,38 @@ async def run_async(argv: list[str]) -> int:
 
     if args.verb == "list":
         return await _list(api_url, api_key, vault_id=args.vault_id)
+    if args.verb == "create":
+        try:
+            body = _read_body(args.body_file)
+        except CliError as err:
+            print(str(err), file=sys.stderr)
+            return 2
+        return await _create(api_url, api_key, vault_id=args.vault_id, body=body)
     parser.print_usage(sys.stderr)
     return 2
+
+
+def _read_body(path: str) -> dict[str, Any]:
+    """Read a JSON object from ``path``.  ``-`` reads stdin.
+
+    Raises :class:`CliError` for IO failures, malformed JSON, or
+    non-object top-level values.
+    """
+    if path == "-":
+        raw = sys.stdin.read()
+    else:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                raw = fh.read()
+        except OSError as exc:
+            raise CliError(f"{_PROG}: cannot read --body-file {path!r}: {exc}") from exc
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CliError(f"{_PROG}: --body-file contents are not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise CliError(f"{_PROG}: --body-file must contain a JSON object")
+    return parsed
 
 
 async def _list(api_url: str, api_key: str, *, vault_id: str) -> int:
@@ -68,4 +112,22 @@ async def _list(api_url: str, api_key: str, *, vault_id: str) -> int:
         return 2
     body: dict[str, Any] = response.json()
     print(json.dumps(body.get("data", []), indent=2))
+    return 0
+
+
+async def _create(
+    api_url: str,
+    api_key: str,
+    *,
+    vault_id: str,
+    body: dict[str, Any],
+) -> int:
+    url = f"{api_url.rstrip('/')}/v1/vaults/{vault_id}/credentials"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.post(url, headers=headers, json=body)
+    if response.status_code not in {200, 201}:
+        print_http_error(_PROG, response)
+        return 2
+    print(json.dumps(response.json(), indent=2))
     return 0

--- a/tests/unit/test_cli_vault_credentials.py
+++ b/tests/unit/test_cli_vault_credentials.py
@@ -1,13 +1,18 @@
 """Unit tests for ``aios vault-credentials <verb>`` CLI (progresses #35 item 4).
 
-Scope: ``list`` only — credential *creation* has an ``auth_type``-
-dependent schema branch with several ``SecretStr`` fields; that
-warrants its own PR with a deliberate CLI flag design.
+Covers ``list`` and ``create`` (#108 + this PR).  ``create`` takes
+``--body-file`` (or ``-`` for stdin) rather than per-field flags: the
+credential schema branches on ``auth_type`` with several ``SecretStr``
+fields, and passing secrets as shell args leaks them into history.
+``--body-file`` is the ``kubectl create -f`` pattern — operator hands
+the CLI a JSON file they prepared locally.
 """
 
 from __future__ import annotations
 
+import io
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -98,6 +103,116 @@ class TestListVaultCredentials:
     ) -> None:
         _setup_env(monkeypatch)
         rc = await run_async(["list"])
+        assert rc != 0
+        assert "required" in capsys.readouterr().err.lower()
+
+
+_CREATED_CREDENTIAL: dict[str, Any] = {
+    "id": "vcr_new",
+    "vault_id": "vlt_01",
+    "display_name": "Signal MCP bearer",
+    "mcp_server_url": "http://mcp.signal.local",
+    "auth_type": "static_bearer",
+    "metadata": {},
+    "created_at": "2026-04-20T00:00:00Z",
+    "updated_at": "2026-04-20T00:00:00Z",
+    "archived_at": None,
+}
+
+
+class TestCreateVaultCredential:
+    async def test_posts_body_read_from_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _setup_env(monkeypatch)
+        body = {
+            "display_name": "Signal MCP bearer",
+            "mcp_server_url": "http://mcp.signal.local",
+            "auth_type": "static_bearer",
+            "bearer_token": "tok_secret",
+        }
+        body_file = tmp_path / "cred.json"
+        body_file.write_text(json.dumps(body))
+        client = _mock_async_client("post", _mock_response(201, _CREATED_CREDENTIAL))
+
+        with patch("aios.cli.vault_credentials.async_client", return_value=client):
+            rc = await run_async(
+                [
+                    "create",
+                    "--vault-id",
+                    "vlt_01",
+                    "--body-file",
+                    str(body_file),
+                ]
+            )
+
+        assert rc == 0
+        client.post.assert_awaited_once()
+        call = client.post.await_args
+        assert call.args[0].endswith("/v1/vaults/vlt_01/credentials")
+        assert call.kwargs["json"] == body
+
+    async def test_posts_body_read_from_stdin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        body = {
+            "display_name": "piped",
+            "mcp_server_url": "http://m",
+            "auth_type": "static_bearer",
+            "bearer_token": "tok_secret",
+        }
+        client = _mock_async_client("post", _mock_response(201, _CREATED_CREDENTIAL))
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(body)))
+
+        with patch("aios.cli.vault_credentials.async_client", return_value=client):
+            rc = await run_async(["create", "--vault-id", "vlt_01", "--body-file", "-"])
+
+        assert rc == 0
+        assert client.post.await_args.kwargs["json"] == body
+
+    async def test_missing_body_file_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(
+            [
+                "create",
+                "--vault-id",
+                "vlt_01",
+                "--body-file",
+                "/nonexistent/path/cred.json",
+            ]
+        )
+        assert rc != 0
+        err = capsys.readouterr().err.lower()
+        assert "body-file" in err or "no such" in err or "cannot" in err
+
+    async def test_invalid_json_body_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        body_file = tmp_path / "bad.json"
+        body_file.write_text("not-json{{")
+        rc = await run_async(["create", "--vault-id", "vlt_01", "--body-file", str(body_file)])
+        assert rc != 0
+        err = capsys.readouterr().err.lower()
+        assert "json" in err
+
+    async def test_non_object_json_body_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        body_file = tmp_path / "arr.json"
+        body_file.write_text("[]")
+        rc = await run_async(["create", "--vault-id", "vlt_01", "--body-file", str(body_file)])
+        assert rc != 0
+        err = capsys.readouterr().err.lower()
+        assert "object" in err or "json" in err
+
+    async def test_missing_required_flag_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(["create", "--vault-id", "vlt_01"])  # no --body-file
         assert rc != 0
         assert "required" in capsys.readouterr().err.lower()
 


### PR DESCRIPTION
## Summary

Adds \`create\` to the \`aios vault-credentials\` module (from #108). Sixth CLI verb in the operator series.

\`\`\`
aios vault-credentials create --vault-id <id> --body-file <path|->
\`\`\`

## Design decision: \`--body-file\`, not per-field flags

\`VaultCredentialCreate\` branches on \`auth_type\` (\`mcp_oauth\` vs \`static_bearer\`) with several \`SecretStr\` fields per type. Two reasons to take the whole body from a file:

1. **Schema complexity**: per-field flags would be large, auth-type-conditional, and would duplicate server-side validation that we want as the source of truth.
2. **Secret hygiene**: tokens and client secrets as shell args leak into shell history. The \`kubectl create -f\` pattern sidesteps both concerns.

Stdin (\`--body-file -\`) is also accepted, so \`echo "\$(gopass show mcp/cred)" | aios vault-credentials create --body-file -\` works without touching history.

## Validation

Three failure modes, all exit 2 before any HTTP call:

- IO error reading the file → \`CliError\`
- Invalid JSON → \`CliError\`
- Non-object top-level value (\`null\`, \`[]\`, number, string) → \`CliError\`

Server validates auth-type-specific required fields; the CLI deliberately does not re-validate.

## Test plan

- [x] 6 new tests: file, stdin, missing file, invalid JSON, non-object, missing flag
- [x] \`uv run pytest tests/unit -q\` — 786 passed (6 new)
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] Reviewer subagent: clean ship-it, no high-confidence issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)