### PR TITLE
feat(cli): add get <id> verb to all 5 operator CLI modules

### DIFF
--- a/src/aios/cli/bindings.py
+++ b/src/aios/cli/bindings.py
@@ -42,6 +42,9 @@ async def run_async(argv: list[str]) -> int:
         help="Filter to bindings for this session id",
     )
 
+    get = sub.add_parser("get", help="Show a single binding by id")
+    get.add_argument("binding_id", help="Binding id")
+
     create = sub.add_parser("create", help="Create a new channel binding")
     create.add_argument(
         "--address",
@@ -71,6 +74,8 @@ async def run_async(argv: list[str]) -> int:
 
     if args.verb == "list":
         return await _list(api_url, api_key, session_id=args.session_id)
+    if args.verb == "get":
+        return await _get(api_url, api_key, binding_id=args.binding_id)
     if args.verb == "create":
         return await _create(
             api_url,
@@ -80,6 +85,18 @@ async def run_async(argv: list[str]) -> int:
         )
     parser.print_usage(sys.stderr)
     return 2
+
+
+async def _get(api_url: str, api_key: str, *, binding_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/channel-bindings/{binding_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.get(url, headers=headers)
+    if response.status_code != 200:
+        print_http_error(_PROG, response)
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0
 
 
 async def _list(api_url: str, api_key: str, *, session_id: str | None) -> int:

--- a/src/aios/cli/connections.py
+++ b/src/aios/cli/connections.py
@@ -39,6 +39,9 @@ async def run_async(argv: list[str]) -> int:
 
     sub.add_parser("list", help="List connections")
 
+    get = sub.add_parser("get", help="Show a single connection by id")
+    get.add_argument("connection_id", help="Connection id")
+
     create = sub.add_parser("create", help="Create a new connection")
     create.add_argument("--connector", required=True, help="Connector type (e.g. signal)")
     create.add_argument("--account", required=True, help="Account identifier (e.g. bot uuid)")
@@ -62,6 +65,8 @@ async def run_async(argv: list[str]) -> int:
 
     if args.verb == "list":
         return await _list(api_url, api_key)
+    if args.verb == "get":
+        return await _get(api_url, api_key, connection_id=args.connection_id)
     if args.verb == "create":
         return await _create(
             api_url,
@@ -73,6 +78,18 @@ async def run_async(argv: list[str]) -> int:
         )
     parser.print_usage(sys.stderr)
     return 2
+
+
+async def _get(api_url: str, api_key: str, *, connection_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/connections/{connection_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.get(url, headers=headers)
+    if response.status_code != 200:
+        print_http_error(_PROG, response)
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0
 
 
 async def _list(api_url: str, api_key: str) -> int:

--- a/src/aios/cli/rules.py
+++ b/src/aios/cli/rules.py
@@ -41,6 +41,10 @@ async def run_async(argv: list[str]) -> int:
     lst = sub.add_parser("list", help="List routing rules for a connection")
     lst.add_argument("--connection-id", required=True, help="Owning connection id")
 
+    get = sub.add_parser("get", help="Show a single routing rule by id")
+    get.add_argument("rule_id", help="Rule id")
+    get.add_argument("--connection-id", required=True, help="Owning connection id")
+
     create = sub.add_parser("create", help="Create a new routing rule")
     create.add_argument("--connection-id", required=True, help="Owning connection id")
     create.add_argument(
@@ -76,6 +80,8 @@ async def run_async(argv: list[str]) -> int:
 
     if args.verb == "list":
         return await _list(api_url, api_key, connection_id=args.connection_id)
+    if args.verb == "get":
+        return await _get(api_url, api_key, connection_id=args.connection_id, rule_id=args.rule_id)
     if args.verb == "create":
         try:
             session_params = _parse_session_params(args.session_params_json)
@@ -104,6 +110,18 @@ def _parse_session_params(raw: str | None) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise CliError(f"{_PROG}: --session-params-json must be a JSON object")
     return parsed
+
+
+async def _get(api_url: str, api_key: str, *, connection_id: str, rule_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/connections/{connection_id}/routing-rules/{rule_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.get(url, headers=headers)
+    if response.status_code != 200:
+        print_http_error(_PROG, response)
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0
 
 
 async def _list(api_url: str, api_key: str, *, connection_id: str) -> int:

--- a/src/aios/cli/vault_credentials.py
+++ b/src/aios/cli/vault_credentials.py
@@ -39,6 +39,10 @@ async def run_async(argv: list[str]) -> int:
     lst = sub.add_parser("list", help="List credentials in a vault")
     lst.add_argument("--vault-id", required=True, help="Owning vault id")
 
+    get = sub.add_parser("get", help="Show a single credential by id")
+    get.add_argument("credential_id", help="Credential id")
+    get.add_argument("--vault-id", required=True, help="Owning vault id")
+
     create = sub.add_parser("create", help="Create a new credential in a vault")
     create.add_argument("--vault-id", required=True, help="Owning vault id")
     create.add_argument(
@@ -68,6 +72,10 @@ async def run_async(argv: list[str]) -> int:
 
     if args.verb == "list":
         return await _list(api_url, api_key, vault_id=args.vault_id)
+    if args.verb == "get":
+        return await _get(
+            api_url, api_key, vault_id=args.vault_id, credential_id=args.credential_id
+        )
     if args.verb == "create":
         try:
             body = _read_body(args.body_file)
@@ -100,6 +108,18 @@ def _read_body(path: str) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise CliError(f"{_PROG}: --body-file must contain a JSON object")
     return parsed
+
+
+async def _get(api_url: str, api_key: str, *, vault_id: str, credential_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/vaults/{vault_id}/credentials/{credential_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.get(url, headers=headers)
+    if response.status_code != 200:
+        print_http_error(_PROG, response)
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0
 
 
 async def _list(api_url: str, api_key: str, *, vault_id: str) -> int:

--- a/src/aios/cli/vaults.py
+++ b/src/aios/cli/vaults.py
@@ -42,6 +42,9 @@ async def run_async(argv: list[str]) -> int:
 
     sub.add_parser("list", help="List vaults")
 
+    get = sub.add_parser("get", help="Show a single vault by id")
+    get.add_argument("vault_id", help="Vault id")
+
     create = sub.add_parser("create", help="Create a new vault")
     create.add_argument(
         "--display-name",
@@ -71,6 +74,8 @@ async def run_async(argv: list[str]) -> int:
 
     if args.verb == "list":
         return await _list(api_url, api_key)
+    if args.verb == "get":
+        return await _get(api_url, api_key, vault_id=args.vault_id)
     if args.verb == "create":
         try:
             metadata = _parse_metadata(args.metadata_json)
@@ -97,6 +102,18 @@ def _parse_metadata(raw: str | None) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise CliError(f"{_PROG}: --metadata-json must be a JSON object")
     return parsed
+
+
+async def _get(api_url: str, api_key: str, *, vault_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/vaults/{vault_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.get(url, headers=headers)
+    if response.status_code != 200:
+        print_http_error(_PROG, response)
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0
 
 
 async def _list(api_url: str, api_key: str) -> int:

--- a/tests/unit/test_cli_bindings.py
+++ b/tests/unit/test_cli_bindings.py
@@ -156,6 +156,45 @@ class TestCreateBinding:
         assert "required" in capsys.readouterr().err.lower()
 
 
+class TestGetBinding:
+    async def test_prints_single_resource(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        binding = {
+            "id": "cbn_01",
+            "connection_id": "conn_01",
+            "path": "group/abc",
+            "address": "signal/+15550001/group/abc",
+            "session_id": "sess_01",
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:00:00Z",
+            "archived_at": None,
+            "notification_mode": "focal_candidate",
+        }
+        client = _mock_async_client("get", _mock_response(200, binding))
+
+        with patch("aios.cli.bindings.async_client", return_value=client):
+            rc = await run_async(["get", "cbn_01"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "cbn_01" in out
+        assert client.get.await_args.args[0].endswith("/v1/channel-bindings/cbn_01")
+
+    async def test_http_error_returns_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("get", _mock_response(404, {"error": "not found"}))
+
+        with patch("aios.cli.bindings.async_client", return_value=client):
+            rc = await run_async(["get", "cbn_missing"])
+
+        assert rc != 0
+        assert "404" in capsys.readouterr().err
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/test_cli_connections.py
+++ b/tests/unit/test_cli_connections.py
@@ -140,6 +140,52 @@ class TestCreateConnection:
         assert "required" in capsys.readouterr().err.lower()
 
 
+class TestGetConnection:
+    async def test_prints_single_resource(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        connection = {
+            "id": "conn_01",
+            "connector": "signal",
+            "account": "+15550001",
+            "mcp_url": "http://m",
+            "vault_id": "vlt_01",
+            "archived_at": None,
+        }
+        client = _mock_async_client("get", _mock_response(200, connection))
+
+        with patch("aios.cli.connections.async_client", return_value=client):
+            rc = await run_async(["get", "conn_01"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "conn_01" in out
+        assert "signal" in out
+        assert client.get.await_args.args[0].endswith("/v1/connections/conn_01")
+
+    async def test_http_error_returns_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("get", _mock_response(404, {"error": "not found"}))
+
+        with patch("aios.cli.connections.async_client", return_value=client):
+            rc = await run_async(["get", "conn_missing"])
+
+        assert rc != 0
+        assert "404" in capsys.readouterr().err
+
+    async def test_missing_id_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(["get"])
+        assert rc != 0
+        err = capsys.readouterr().err.lower()
+        assert "required" in err or "arguments" in err
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/test_cli_rules.py
+++ b/tests/unit/test_cli_rules.py
@@ -240,6 +240,47 @@ class TestCreateRule:
         assert "json" in err or "session-params" in err
 
 
+class TestGetRule:
+    async def test_prints_single_resource(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rule = {
+            "id": "rul_01",
+            "connection_id": "conn_01",
+            "prefix": "group",
+            "target": "agent:claude-sonnet-4",
+            "session_params": {
+                "environment_id": None,
+                "vault_ids": [],
+                "title": None,
+                "metadata": {},
+            },
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:00:00Z",
+            "archived_at": None,
+        }
+        client = _mock_async_client("get", _mock_response(200, rule))
+
+        with patch("aios.cli.rules.async_client", return_value=client):
+            rc = await run_async(["get", "rul_01", "--connection-id", "conn_01"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "rul_01" in out
+        assert client.get.await_args.args[0].endswith(
+            "/v1/connections/conn_01/routing-rules/rul_01"
+        )
+
+    async def test_missing_connection_id_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(["get", "rul_01"])
+        assert rc != 0
+        assert "required" in capsys.readouterr().err.lower()
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/test_cli_vault_credentials.py
+++ b/tests/unit/test_cli_vault_credentials.py
@@ -217,6 +217,30 @@ class TestCreateVaultCredential:
         assert "required" in capsys.readouterr().err.lower()
 
 
+class TestGetVaultCredential:
+    async def test_prints_single_resource(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("get", _mock_response(200, _CREATED_CREDENTIAL))
+
+        with patch("aios.cli.vault_credentials.async_client", return_value=client):
+            rc = await run_async(["get", "vcr_new", "--vault-id", "vlt_01"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "vcr_new" in out
+        assert client.get.await_args.args[0].endswith("/v1/vaults/vlt_01/credentials/vcr_new")
+
+    async def test_missing_vault_id_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(["get", "vcr_01"])
+        assert rc != 0
+        assert "required" in capsys.readouterr().err.lower()
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/test_cli_vaults.py
+++ b/tests/unit/test_cli_vaults.py
@@ -164,6 +164,43 @@ class TestCreateVault:
         assert "required" in capsys.readouterr().err.lower()
 
 
+class TestGetVault:
+    async def test_prints_single_resource(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        vault = {
+            "id": "vlt_01",
+            "display_name": "Signal secrets",
+            "metadata": {},
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:00:00Z",
+            "archived_at": None,
+        }
+        client = _mock_async_client("get", _mock_response(200, vault))
+
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(["get", "vlt_01"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "vlt_01" in out
+        assert "Signal secrets" in out
+        assert client.get.await_args.args[0].endswith("/v1/vaults/vlt_01")
+
+    async def test_http_error_returns_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("get", _mock_response(404, {"error": "not found"}))
+
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(["get", "vlt_missing"])
+
+        assert rc != 0
+        assert "404" in capsys.readouterr().err
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## Summary

Extends each existing CLI with a single-resource read. Same \`aios.cli._http\` plumbing as the list/create siblings.

- \`aios connections get <id>\`
- \`aios bindings get <id>\`
- \`aios rules get <id> --connection-id <cid>\`
- \`aios vaults get <id>\`
- \`aios vault-credentials get <id> --vault-id <vid>\`

## Flag shape decision

For nested resources (\`rules\`, \`vault-credentials\`): positional child id, parent as \`--<parent>-id\` flag. Mirrors the REST URL shape and matches the existing \`create\` verbs on the same modules — consistency within a module over cross-module symmetry.

## Test plan

- [x] 11 new tests across the 5 test files: happy path + URL shape + 404/missing-parent-id per module
- [x] \`uv run pytest tests/unit -q\` — 797 passed
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] Reviewer subagent: no high-confidence issues; pattern duplication flagged as acceptable at this scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)