### PR TITLE
feat(cli): add archive verb to all 5 operator CLI modules

### DIFF
--- a/src/aios/cli/bindings.py
+++ b/src/aios/cli/bindings.py
@@ -45,6 +45,12 @@ async def run_async(argv: list[str]) -> int:
     get = sub.add_parser("get", help="Show a single binding by id")
     get.add_argument("binding_id", help="Binding id")
 
+    archive = sub.add_parser(
+        "archive",
+        help="Archive a channel binding (soft-delete, retained for audit)",
+    )
+    archive.add_argument("binding_id", help="Binding id")
+
     create = sub.add_parser("create", help="Create a new channel binding")
     create.add_argument(
         "--address",
@@ -76,6 +82,8 @@ async def run_async(argv: list[str]) -> int:
         return await _list(api_url, api_key, session_id=args.session_id)
     if args.verb == "get":
         return await _get(api_url, api_key, binding_id=args.binding_id)
+    if args.verb == "archive":
+        return await _archive(api_url, api_key, binding_id=args.binding_id)
     if args.verb == "create":
         return await _create(
             api_url,
@@ -85,6 +93,17 @@ async def run_async(argv: list[str]) -> int:
         )
     parser.print_usage(sys.stderr)
     return 2
+
+
+async def _archive(api_url: str, api_key: str, *, binding_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/channel-bindings/{binding_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.delete(url, headers=headers)
+    if response.status_code != 204:
+        print_http_error(_PROG, response)
+        return 2
+    return 0
 
 
 async def _get(api_url: str, api_key: str, *, binding_id: str) -> int:

--- a/src/aios/cli/connections.py
+++ b/src/aios/cli/connections.py
@@ -42,6 +42,12 @@ async def run_async(argv: list[str]) -> int:
     get = sub.add_parser("get", help="Show a single connection by id")
     get.add_argument("connection_id", help="Connection id")
 
+    archive = sub.add_parser(
+        "archive",
+        help="Archive a connection (soft-delete, retained for audit)",
+    )
+    archive.add_argument("connection_id", help="Connection id")
+
     create = sub.add_parser("create", help="Create a new connection")
     create.add_argument("--connector", required=True, help="Connector type (e.g. signal)")
     create.add_argument("--account", required=True, help="Account identifier (e.g. bot uuid)")
@@ -67,6 +73,8 @@ async def run_async(argv: list[str]) -> int:
         return await _list(api_url, api_key)
     if args.verb == "get":
         return await _get(api_url, api_key, connection_id=args.connection_id)
+    if args.verb == "archive":
+        return await _archive(api_url, api_key, connection_id=args.connection_id)
     if args.verb == "create":
         return await _create(
             api_url,
@@ -78,6 +86,17 @@ async def run_async(argv: list[str]) -> int:
         )
     parser.print_usage(sys.stderr)
     return 2
+
+
+async def _archive(api_url: str, api_key: str, *, connection_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/connections/{connection_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.delete(url, headers=headers)
+    if response.status_code != 204:
+        print_http_error(_PROG, response)
+        return 2
+    return 0
 
 
 async def _get(api_url: str, api_key: str, *, connection_id: str) -> int:

--- a/src/aios/cli/rules.py
+++ b/src/aios/cli/rules.py
@@ -45,6 +45,13 @@ async def run_async(argv: list[str]) -> int:
     get.add_argument("rule_id", help="Rule id")
     get.add_argument("--connection-id", required=True, help="Owning connection id")
 
+    archive = sub.add_parser(
+        "archive",
+        help="Archive a routing rule (soft-delete, retained for audit)",
+    )
+    archive.add_argument("rule_id", help="Rule id")
+    archive.add_argument("--connection-id", required=True, help="Owning connection id")
+
     create = sub.add_parser("create", help="Create a new routing rule")
     create.add_argument("--connection-id", required=True, help="Owning connection id")
     create.add_argument(
@@ -82,6 +89,10 @@ async def run_async(argv: list[str]) -> int:
         return await _list(api_url, api_key, connection_id=args.connection_id)
     if args.verb == "get":
         return await _get(api_url, api_key, connection_id=args.connection_id, rule_id=args.rule_id)
+    if args.verb == "archive":
+        return await _archive(
+            api_url, api_key, connection_id=args.connection_id, rule_id=args.rule_id
+        )
     if args.verb == "create":
         try:
             session_params = _parse_session_params(args.session_params_json)
@@ -110,6 +121,17 @@ def _parse_session_params(raw: str | None) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise CliError(f"{_PROG}: --session-params-json must be a JSON object")
     return parsed
+
+
+async def _archive(api_url: str, api_key: str, *, connection_id: str, rule_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/connections/{connection_id}/routing-rules/{rule_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.delete(url, headers=headers)
+    if response.status_code != 204:
+        print_http_error(_PROG, response)
+        return 2
+    return 0
 
 
 async def _get(api_url: str, api_key: str, *, connection_id: str, rule_id: str) -> int:

--- a/src/aios/cli/vault_credentials.py
+++ b/src/aios/cli/vault_credentials.py
@@ -43,6 +43,13 @@ async def run_async(argv: list[str]) -> int:
     get.add_argument("credential_id", help="Credential id")
     get.add_argument("--vault-id", required=True, help="Owning vault id")
 
+    archive = sub.add_parser(
+        "archive",
+        help="Archive a credential (soft-delete, retained for audit)",
+    )
+    archive.add_argument("credential_id", help="Credential id")
+    archive.add_argument("--vault-id", required=True, help="Owning vault id")
+
     create = sub.add_parser("create", help="Create a new credential in a vault")
     create.add_argument("--vault-id", required=True, help="Owning vault id")
     create.add_argument(
@@ -74,6 +81,10 @@ async def run_async(argv: list[str]) -> int:
         return await _list(api_url, api_key, vault_id=args.vault_id)
     if args.verb == "get":
         return await _get(
+            api_url, api_key, vault_id=args.vault_id, credential_id=args.credential_id
+        )
+    if args.verb == "archive":
+        return await _archive(
             api_url, api_key, vault_id=args.vault_id, credential_id=args.credential_id
         )
     if args.verb == "create":
@@ -108,6 +119,18 @@ def _read_body(path: str) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise CliError(f"{_PROG}: --body-file must contain a JSON object")
     return parsed
+
+
+async def _archive(api_url: str, api_key: str, *, vault_id: str, credential_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/vaults/{vault_id}/credentials/{credential_id}/archive"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.post(url, headers=headers)
+    if response.status_code != 200:
+        print_http_error(_PROG, response)
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0
 
 
 async def _get(api_url: str, api_key: str, *, vault_id: str, credential_id: str) -> int:

--- a/src/aios/cli/vaults.py
+++ b/src/aios/cli/vaults.py
@@ -45,6 +45,12 @@ async def run_async(argv: list[str]) -> int:
     get = sub.add_parser("get", help="Show a single vault by id")
     get.add_argument("vault_id", help="Vault id")
 
+    archive = sub.add_parser(
+        "archive",
+        help="Archive a vault (soft-delete, retained for audit)",
+    )
+    archive.add_argument("vault_id", help="Vault id")
+
     create = sub.add_parser("create", help="Create a new vault")
     create.add_argument(
         "--display-name",
@@ -76,6 +82,8 @@ async def run_async(argv: list[str]) -> int:
         return await _list(api_url, api_key)
     if args.verb == "get":
         return await _get(api_url, api_key, vault_id=args.vault_id)
+    if args.verb == "archive":
+        return await _archive(api_url, api_key, vault_id=args.vault_id)
     if args.verb == "create":
         try:
             metadata = _parse_metadata(args.metadata_json)
@@ -102,6 +110,18 @@ def _parse_metadata(raw: str | None) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise CliError(f"{_PROG}: --metadata-json must be a JSON object")
     return parsed
+
+
+async def _archive(api_url: str, api_key: str, *, vault_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/vaults/{vault_id}/archive"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.post(url, headers=headers)
+    if response.status_code != 200:
+        print_http_error(_PROG, response)
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0
 
 
 async def _get(api_url: str, api_key: str, *, vault_id: str) -> int:

--- a/tests/unit/test_cli_bindings.py
+++ b/tests/unit/test_cli_bindings.py
@@ -195,6 +195,18 @@ class TestGetBinding:
         assert "404" in capsys.readouterr().err
 
 
+class TestArchiveBinding:
+    async def test_archives_via_delete_endpoint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("delete", _mock_response(204, None))
+
+        with patch("aios.cli.bindings.async_client", return_value=client):
+            rc = await run_async(["archive", "cbn_01"])
+
+        assert rc == 0
+        assert client.delete.await_args.args[0].endswith("/v1/channel-bindings/cbn_01")
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/test_cli_connections.py
+++ b/tests/unit/test_cli_connections.py
@@ -186,6 +186,31 @@ class TestGetConnection:
         assert "required" in err or "arguments" in err
 
 
+class TestArchiveConnection:
+    async def test_archives_via_delete_endpoint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("delete", _mock_response(204, None))
+
+        with patch("aios.cli.connections.async_client", return_value=client):
+            rc = await run_async(["archive", "conn_01"])
+
+        assert rc == 0
+        client.delete.assert_awaited_once()
+        assert client.delete.await_args.args[0].endswith("/v1/connections/conn_01")
+
+    async def test_http_error_returns_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("delete", _mock_response(404, {"error": "not found"}))
+
+        with patch("aios.cli.connections.async_client", return_value=client):
+            rc = await run_async(["archive", "conn_missing"])
+
+        assert rc != 0
+        assert "404" in capsys.readouterr().err
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/test_cli_rules.py
+++ b/tests/unit/test_cli_rules.py
@@ -281,6 +281,28 @@ class TestGetRule:
         assert "required" in capsys.readouterr().err.lower()
 
 
+class TestArchiveRule:
+    async def test_archives_via_delete_endpoint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("delete", _mock_response(204, None))
+
+        with patch("aios.cli.rules.async_client", return_value=client):
+            rc = await run_async(["archive", "rul_01", "--connection-id", "conn_01"])
+
+        assert rc == 0
+        assert client.delete.await_args.args[0].endswith(
+            "/v1/connections/conn_01/routing-rules/rul_01"
+        )
+
+    async def test_missing_connection_id_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(["archive", "rul_01"])
+        assert rc != 0
+        assert "required" in capsys.readouterr().err.lower()
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/test_cli_vault_credentials.py
+++ b/tests/unit/test_cli_vault_credentials.py
@@ -241,6 +241,26 @@ class TestGetVaultCredential:
         assert "required" in capsys.readouterr().err.lower()
 
 
+class TestArchiveVaultCredential:
+    async def test_archives_via_post_archive_endpoint_and_prints_resource(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        archived = {**_CREATED_CREDENTIAL, "archived_at": "2026-04-20T00:01:00Z"}
+        client = _mock_async_client("post", _mock_response(200, archived))
+
+        with patch("aios.cli.vault_credentials.async_client", return_value=client):
+            rc = await run_async(["archive", "vcr_new", "--vault-id", "vlt_01"])
+
+        assert rc == 0
+        assert client.post.await_args.args[0].endswith(
+            "/v1/vaults/vlt_01/credentials/vcr_new/archive"
+        )
+        out = capsys.readouterr().out
+        assert "vcr_new" in out
+        assert "archived_at" in out
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/test_cli_vaults.py
+++ b/tests/unit/test_cli_vaults.py
@@ -201,6 +201,44 @@ class TestGetVault:
         assert "404" in capsys.readouterr().err
 
 
+class TestArchiveVault:
+    async def test_archives_via_post_archive_endpoint_and_prints_resource(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        archived = {
+            "id": "vlt_01",
+            "display_name": "Signal secrets",
+            "metadata": {},
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:01:00Z",
+            "archived_at": "2026-04-20T00:01:00Z",
+        }
+        client = _mock_async_client("post", _mock_response(200, archived))
+
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(["archive", "vlt_01"])
+
+        assert rc == 0
+        assert client.post.await_args.args[0].endswith("/v1/vaults/vlt_01/archive")
+        # vaults' archive endpoint returns the archived resource; print it.
+        out = capsys.readouterr().out
+        assert "vlt_01" in out
+        assert "archived_at" in out
+
+    async def test_http_error_returns_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("post", _mock_response(404, {"error": "not found"}))
+
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(["archive", "vlt_missing"])
+
+        assert rc != 0
+        assert "404" in capsys.readouterr().err
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## Summary

Extends each operator CLI with a soft-delete verb:

- \`aios connections archive <id>\`
- \`aios bindings archive <id>\`
- \`aios rules archive <id> --connection-id <cid>\`
- \`aios vaults archive <id>\`
- \`aios vault-credentials archive <id> --vault-id <vid>\`

## Server-side asymmetry the CLI papers over

For **connections, bindings, rules**: the HTTP \`DELETE\` endpoint is actually a soft-archive under the hood (router calls \`archive_*\`). Expects 204, silent on success.

For **vaults, vault-credentials**: there's an explicit \`POST /.../archive\` endpoint that returns the archived resource, alongside a separate true-hard-delete \`DELETE\`. The CLI hits the POST endpoint; expects 200, prints the archived resource JSON.

A uniform \`archive\` verb lets operators think "archive this" without knowing the HTTP-verb accident per resource.

## Hard-delete: deliberately not shipped

Hard delete is a riskier operation. Deferred to its own PR with possibly a confirmation prompt. Operators who need hard-delete today can curl.

## Test plan

- [x] 8 new tests across the 5 test files: happy path + URL shape + a spread of failure modes
- [x] \`uv run pytest tests/unit -q\` — 805 passed
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] Reviewer subagent: no high-confidence issues; endpoint contracts verified against all 5 routers

🤖 Generated with [Claude Code](https://claude.com/claude-code)