### PR TITLE
feat(cli): add update verb to 3 operator CLI modules with PUT endpoints

### DIFF
--- a/src/aios/cli/rules.py
+++ b/src/aios/cli/rules.py
@@ -52,6 +52,18 @@ async def run_async(argv: list[str]) -> int:
     archive.add_argument("rule_id", help="Rule id")
     archive.add_argument("--connection-id", required=True, help="Owning connection id")
 
+    update = sub.add_parser(
+        "update", help="Update a routing rule's target or session_params (prefix is immutable)"
+    )
+    update.add_argument("rule_id", help="Rule id")
+    update.add_argument("--connection-id", required=True, help="Owning connection id")
+    update.add_argument("--target", default=None, help="New target")
+    update.add_argument(
+        "--session-params-json",
+        default=None,
+        help="New SessionParams (JSON object, replaces existing)",
+    )
+
     create = sub.add_parser("create", help="Create a new routing rule")
     create.add_argument("--connection-id", required=True, help="Owning connection id")
     create.add_argument(
@@ -93,6 +105,22 @@ async def run_async(argv: list[str]) -> int:
         return await _archive(
             api_url, api_key, connection_id=args.connection_id, rule_id=args.rule_id
         )
+    if args.verb == "update":
+        session_params: dict[str, Any] | None = None
+        if args.session_params_json is not None:
+            try:
+                session_params = _parse_session_params(args.session_params_json)
+            except CliError as err:
+                print(str(err), file=sys.stderr)
+                return 2
+        return await _update(
+            api_url,
+            api_key,
+            connection_id=args.connection_id,
+            rule_id=args.rule_id,
+            target=args.target,
+            session_params=session_params,
+        )
     if args.verb == "create":
         try:
             session_params = _parse_session_params(args.session_params_json)
@@ -121,6 +149,31 @@ def _parse_session_params(raw: str | None) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise CliError(f"{_PROG}: --session-params-json must be a JSON object")
     return parsed
+
+
+async def _update(
+    api_url: str,
+    api_key: str,
+    *,
+    connection_id: str,
+    rule_id: str,
+    target: str | None,
+    session_params: dict[str, Any] | None,
+) -> int:
+    url = f"{api_url.rstrip('/')}/v1/connections/{connection_id}/routing-rules/{rule_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    body: dict[str, Any] = {}
+    if target is not None:
+        body["target"] = target
+    if session_params is not None:
+        body["session_params"] = session_params
+    async with async_client() as client:
+        response = await client.put(url, headers=headers, json=body)
+    if response.status_code != 200:
+        print_http_error(_PROG, response)
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0
 
 
 async def _archive(api_url: str, api_key: str, *, connection_id: str, rule_id: str) -> int:

--- a/src/aios/cli/vault_credentials.py
+++ b/src/aios/cli/vault_credentials.py
@@ -50,6 +50,22 @@ async def run_async(argv: list[str]) -> int:
     archive.add_argument("credential_id", help="Credential id")
     archive.add_argument("--vault-id", required=True, help="Owning vault id")
 
+    update = sub.add_parser(
+        "update",
+        help="Update a credential (body from file; mcp_server_url + auth_type are immutable)",
+    )
+    update.add_argument("credential_id", help="Credential id")
+    update.add_argument("--vault-id", required=True, help="Owning vault id")
+    update.add_argument(
+        "--body-file",
+        required=True,
+        help=(
+            "Path to a JSON file containing the VaultCredentialUpdate body, "
+            "or '-' to read from stdin.  Same secret-hygiene argument as "
+            "`create`: tokens passed as shell args leak into history."
+        ),
+    )
+
     create = sub.add_parser("create", help="Create a new credential in a vault")
     create.add_argument("--vault-id", required=True, help="Owning vault id")
     create.add_argument(
@@ -87,6 +103,19 @@ async def run_async(argv: list[str]) -> int:
         return await _archive(
             api_url, api_key, vault_id=args.vault_id, credential_id=args.credential_id
         )
+    if args.verb == "update":
+        try:
+            body = _read_body(args.body_file)
+        except CliError as err:
+            print(str(err), file=sys.stderr)
+            return 2
+        return await _update(
+            api_url,
+            api_key,
+            vault_id=args.vault_id,
+            credential_id=args.credential_id,
+            body=body,
+        )
     if args.verb == "create":
         try:
             body = _read_body(args.body_file)
@@ -119,6 +148,25 @@ def _read_body(path: str) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise CliError(f"{_PROG}: --body-file must contain a JSON object")
     return parsed
+
+
+async def _update(
+    api_url: str,
+    api_key: str,
+    *,
+    vault_id: str,
+    credential_id: str,
+    body: dict[str, Any],
+) -> int:
+    url = f"{api_url.rstrip('/')}/v1/vaults/{vault_id}/credentials/{credential_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.put(url, headers=headers, json=body)
+    if response.status_code != 200:
+        print_http_error(_PROG, response)
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0
 
 
 async def _archive(api_url: str, api_key: str, *, vault_id: str, credential_id: str) -> int:

--- a/src/aios/cli/vaults.py
+++ b/src/aios/cli/vaults.py
@@ -51,6 +51,15 @@ async def run_async(argv: list[str]) -> int:
     )
     archive.add_argument("vault_id", help="Vault id")
 
+    update = sub.add_parser("update", help="Update a vault's display name or metadata")
+    update.add_argument("vault_id", help="Vault id")
+    update.add_argument("--display-name", default=None, help="New display name")
+    update.add_argument(
+        "--metadata-json",
+        default=None,
+        help="New metadata (JSON object, replaces existing)",
+    )
+
     create = sub.add_parser("create", help="Create a new vault")
     create.add_argument(
         "--display-name",
@@ -84,6 +93,21 @@ async def run_async(argv: list[str]) -> int:
         return await _get(api_url, api_key, vault_id=args.vault_id)
     if args.verb == "archive":
         return await _archive(api_url, api_key, vault_id=args.vault_id)
+    if args.verb == "update":
+        metadata: dict[str, Any] | None = None
+        if args.metadata_json is not None:
+            try:
+                metadata = _parse_metadata(args.metadata_json)
+            except CliError as err:
+                print(str(err), file=sys.stderr)
+                return 2
+        return await _update(
+            api_url,
+            api_key,
+            vault_id=args.vault_id,
+            display_name=args.display_name,
+            metadata=metadata,
+        )
     if args.verb == "create":
         try:
             metadata = _parse_metadata(args.metadata_json)
@@ -110,6 +134,30 @@ def _parse_metadata(raw: str | None) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise CliError(f"{_PROG}: --metadata-json must be a JSON object")
     return parsed
+
+
+async def _update(
+    api_url: str,
+    api_key: str,
+    *,
+    vault_id: str,
+    display_name: str | None,
+    metadata: dict[str, Any] | None,
+) -> int:
+    url = f"{api_url.rstrip('/')}/v1/vaults/{vault_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    body: dict[str, Any] = {}
+    if display_name is not None:
+        body["display_name"] = display_name
+    if metadata is not None:
+        body["metadata"] = metadata
+    async with async_client() as client:
+        response = await client.put(url, headers=headers, json=body)
+    if response.status_code != 200:
+        print_http_error(_PROG, response)
+        return 2
+    print(json.dumps(response.json(), indent=2))
+    return 0
 
 
 async def _archive(api_url: str, api_key: str, *, vault_id: str) -> int:

--- a/tests/unit/test_cli_rules.py
+++ b/tests/unit/test_cli_rules.py
@@ -303,6 +303,66 @@ class TestArchiveRule:
         assert "required" in capsys.readouterr().err.lower()
 
 
+class TestUpdateRule:
+    async def test_puts_expected_body_with_target_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_env(monkeypatch)
+        updated = {
+            "id": "rul_01",
+            "connection_id": "conn_01",
+            "prefix": "group",
+            "target": "agent:new-model",
+            "session_params": {
+                "environment_id": None,
+                "vault_ids": [],
+                "title": None,
+                "metadata": {},
+            },
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:01:00Z",
+            "archived_at": None,
+        }
+        client = _mock_async_client("put", _mock_response(200, updated))
+
+        with patch("aios.cli.rules.async_client", return_value=client):
+            rc = await run_async(
+                [
+                    "update",
+                    "rul_01",
+                    "--connection-id",
+                    "conn_01",
+                    "--target",
+                    "agent:new-model",
+                ]
+            )
+
+        assert rc == 0
+        call = client.put.await_args
+        assert call.args[0].endswith("/v1/connections/conn_01/routing-rules/rul_01")
+        # Only target provided; session_params omitted from body
+        assert call.kwargs["json"] == {"target": "agent:new-model"}
+
+    async def test_puts_with_session_params_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("put", _mock_response(200, {}))
+        sp = {"environment_id": "env_02"}
+        with patch("aios.cli.rules.async_client", return_value=client):
+            rc = await run_async(
+                [
+                    "update",
+                    "rul_01",
+                    "--connection-id",
+                    "conn_01",
+                    "--session-params-json",
+                    json.dumps(sp),
+                ]
+            )
+        assert rc == 0
+        call = client.put.await_args
+        assert call.kwargs["json"] == {"session_params": sp}
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/test_cli_vault_credentials.py
+++ b/tests/unit/test_cli_vault_credentials.py
@@ -261,6 +261,42 @@ class TestArchiveVaultCredential:
         assert "archived_at" in out
 
 
+class TestUpdateVaultCredential:
+    async def test_puts_body_read_from_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _setup_env(monkeypatch)
+        body = {"display_name": "renamed", "token": "tok_rotated"}
+        body_file = tmp_path / "update.json"
+        body_file.write_text(json.dumps(body))
+        client = _mock_async_client("put", _mock_response(200, _CREATED_CREDENTIAL))
+
+        with patch("aios.cli.vault_credentials.async_client", return_value=client):
+            rc = await run_async(
+                [
+                    "update",
+                    "vcr_new",
+                    "--vault-id",
+                    "vlt_01",
+                    "--body-file",
+                    str(body_file),
+                ]
+            )
+
+        assert rc == 0
+        call = client.put.await_args
+        assert call.args[0].endswith("/v1/vaults/vlt_01/credentials/vcr_new")
+        assert call.kwargs["json"] == body
+
+    async def test_missing_vault_id_exits_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        rc = await run_async(["update", "vcr_01", "--body-file", "/tmp/anything"])
+        assert rc != 0
+        assert "required" in capsys.readouterr().err.lower()
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/test_cli_vaults.py
+++ b/tests/unit/test_cli_vaults.py
@@ -239,6 +239,38 @@ class TestArchiveVault:
         assert "404" in capsys.readouterr().err
 
 
+class TestUpdateVault:
+    async def test_puts_with_display_name_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        updated = {
+            "id": "vlt_01",
+            "display_name": "renamed",
+            "metadata": {},
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:01:00Z",
+            "archived_at": None,
+        }
+        client = _mock_async_client("put", _mock_response(200, updated))
+
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(["update", "vlt_01", "--display-name", "renamed"])
+
+        assert rc == 0
+        call = client.put.await_args
+        assert call.args[0].endswith("/v1/vaults/vlt_01")
+        assert call.kwargs["json"] == {"display_name": "renamed"}
+
+    async def test_puts_with_metadata_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("put", _mock_response(200, {}))
+        md = {"env": "staging"}
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(["update", "vlt_01", "--metadata-json", json.dumps(md)])
+        assert rc == 0
+        call = client.put.await_args
+        assert call.kwargs["json"] == {"metadata": md}
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## Summary

Extends rules / vaults / vault-credentials with a PATCH-style update:

- \`aios rules update <rule_id> --connection-id <cid> [--target <t>] [--session-params-json '{...}']\`
- \`aios vaults update <vault_id> [--display-name <n>] [--metadata-json '{...}']\`
- \`aios vault-credentials update <credential_id> --vault-id <vid> --body-file <path|->\`

Connections and bindings are NOT included — \`connections\` has no PUT endpoint exposed, and bindings are immutable-by-design.

## Flag-shape split

**rules, vaults**: per-field optional flags. Only flags that are actually set show up in the PUT body (\`if x is not None\`), matching the server's \`Optional[...]\` schema where omitted = "preserve".

**vault-credentials**: \`--body-file\` (same pattern as \`create\` #109) because the update schema has the same \`auth_type\`-dependent \`SecretStr\` branching and the same shell-history concern.

## Empty-update semantics

\`aios vaults update vlt_01\` with no flags sends \`PUT {}\`. Server accepts it as a no-op (everything optional). Deliberately no client-side "no fields to update" guard — that would be defensive complexity against the CLAUDE.md grain.

## Test plan

- [x] 6 new tests across the 3 test files
- [x] \`uv run pytest tests/unit -q\` — 811 passed
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] Reviewer subagent: no high-confidence issues; schema ↔ handler alignment verified for all 3 resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)