### PR TITLE
feat(cli): add --limit/--after pagination to list verbs

### DIFF
--- a/src/aios/cli/bindings.py
+++ b/src/aios/cli/bindings.py
@@ -41,6 +41,10 @@ async def run_async(argv: list[str]) -> int:
         default=None,
         help="Filter to bindings for this session id",
     )
+    lst.add_argument("--limit", type=int, default=None, help="Max items per page")
+    lst.add_argument(
+        "--after", default=None, help="Pagination cursor (pass next_after from prior response)"
+    )
 
     get = sub.add_parser("get", help="Show a single binding by id")
     get.add_argument("binding_id", help="Binding id")
@@ -79,7 +83,13 @@ async def run_async(argv: list[str]) -> int:
         return 2
 
     if args.verb == "list":
-        return await _list(api_url, api_key, session_id=args.session_id)
+        return await _list(
+            api_url,
+            api_key,
+            session_id=args.session_id,
+            limit=args.limit,
+            after=args.after,
+        )
     if args.verb == "get":
         return await _get(api_url, api_key, binding_id=args.binding_id)
     if args.verb == "archive":
@@ -118,19 +128,29 @@ async def _get(api_url: str, api_key: str, *, binding_id: str) -> int:
     return 0
 
 
-async def _list(api_url: str, api_key: str, *, session_id: str | None) -> int:
+async def _list(
+    api_url: str,
+    api_key: str,
+    *,
+    session_id: str | None,
+    limit: int | None,
+    after: str | None,
+) -> int:
     url = f"{api_url.rstrip('/')}/v1/channel-bindings"
     headers = {"Authorization": f"Bearer {api_key}"}
-    params: dict[str, str] = {}
+    params: dict[str, Any] = {}
     if session_id is not None:
         params["session_id"] = session_id
+    if limit is not None:
+        params["limit"] = limit
+    if after is not None:
+        params["after"] = after
     async with async_client() as client:
         response = await client.get(url, headers=headers, params=params)
     if response.status_code != 200:
         print_http_error(_PROG, response)
         return 2
-    body: dict[str, Any] = response.json()
-    print(json.dumps(body.get("data", []), indent=2))
+    print(json.dumps(response.json(), indent=2))
     return 0
 
 

--- a/src/aios/cli/connections.py
+++ b/src/aios/cli/connections.py
@@ -37,7 +37,11 @@ async def run_async(argv: list[str]) -> int:
     )
     sub = parser.add_subparsers(dest="verb")
 
-    sub.add_parser("list", help="List connections")
+    lst = sub.add_parser("list", help="List connections")
+    lst.add_argument("--limit", type=int, default=None, help="Max items per page")
+    lst.add_argument(
+        "--after", default=None, help="Pagination cursor (pass next_after from prior response)"
+    )
 
     get = sub.add_parser("get", help="Show a single connection by id")
     get.add_argument("connection_id", help="Connection id")
@@ -70,7 +74,7 @@ async def run_async(argv: list[str]) -> int:
         return 2
 
     if args.verb == "list":
-        return await _list(api_url, api_key)
+        return await _list(api_url, api_key, limit=args.limit, after=args.after)
     if args.verb == "get":
         return await _get(api_url, api_key, connection_id=args.connection_id)
     if args.verb == "archive":
@@ -111,16 +115,20 @@ async def _get(api_url: str, api_key: str, *, connection_id: str) -> int:
     return 0
 
 
-async def _list(api_url: str, api_key: str) -> int:
+async def _list(api_url: str, api_key: str, *, limit: int | None, after: str | None) -> int:
     url = f"{api_url.rstrip('/')}/v1/connections"
     headers = {"Authorization": f"Bearer {api_key}"}
+    params: dict[str, Any] = {}
+    if limit is not None:
+        params["limit"] = limit
+    if after is not None:
+        params["after"] = after
     async with async_client() as client:
-        response = await client.get(url, headers=headers)
+        response = await client.get(url, headers=headers, params=params)
     if response.status_code != 200:
         print_http_error(_PROG, response)
         return 2
-    body: dict[str, Any] = response.json()
-    print(json.dumps(body.get("data", []), indent=2))
+    print(json.dumps(response.json(), indent=2))
     return 0
 
 

--- a/src/aios/cli/rules.py
+++ b/src/aios/cli/rules.py
@@ -40,6 +40,10 @@ async def run_async(argv: list[str]) -> int:
 
     lst = sub.add_parser("list", help="List routing rules for a connection")
     lst.add_argument("--connection-id", required=True, help="Owning connection id")
+    lst.add_argument("--limit", type=int, default=None, help="Max items per page")
+    lst.add_argument(
+        "--after", default=None, help="Pagination cursor (pass next_after from prior response)"
+    )
 
     get = sub.add_parser("get", help="Show a single routing rule by id")
     get.add_argument("rule_id", help="Rule id")
@@ -98,7 +102,13 @@ async def run_async(argv: list[str]) -> int:
         return 2
 
     if args.verb == "list":
-        return await _list(api_url, api_key, connection_id=args.connection_id)
+        return await _list(
+            api_url,
+            api_key,
+            connection_id=args.connection_id,
+            limit=args.limit,
+            after=args.after,
+        )
     if args.verb == "get":
         return await _get(api_url, api_key, connection_id=args.connection_id, rule_id=args.rule_id)
     if args.verb == "archive":
@@ -199,16 +209,27 @@ async def _get(api_url: str, api_key: str, *, connection_id: str, rule_id: str) 
     return 0
 
 
-async def _list(api_url: str, api_key: str, *, connection_id: str) -> int:
+async def _list(
+    api_url: str,
+    api_key: str,
+    *,
+    connection_id: str,
+    limit: int | None,
+    after: str | None,
+) -> int:
     url = f"{api_url.rstrip('/')}/v1/connections/{connection_id}/routing-rules"
     headers = {"Authorization": f"Bearer {api_key}"}
+    params: dict[str, Any] = {}
+    if limit is not None:
+        params["limit"] = limit
+    if after is not None:
+        params["after"] = after
     async with async_client() as client:
-        response = await client.get(url, headers=headers)
+        response = await client.get(url, headers=headers, params=params)
     if response.status_code != 200:
         print_http_error(_PROG, response)
         return 2
-    body: dict[str, Any] = response.json()
-    print(json.dumps(body.get("data", []), indent=2))
+    print(json.dumps(response.json(), indent=2))
     return 0
 
 

--- a/src/aios/cli/vault_credentials.py
+++ b/src/aios/cli/vault_credentials.py
@@ -38,6 +38,10 @@ async def run_async(argv: list[str]) -> int:
 
     lst = sub.add_parser("list", help="List credentials in a vault")
     lst.add_argument("--vault-id", required=True, help="Owning vault id")
+    lst.add_argument("--limit", type=int, default=None, help="Max items per page")
+    lst.add_argument(
+        "--after", default=None, help="Pagination cursor (pass next_after from prior response)"
+    )
 
     get = sub.add_parser("get", help="Show a single credential by id")
     get.add_argument("credential_id", help="Credential id")
@@ -94,7 +98,9 @@ async def run_async(argv: list[str]) -> int:
         return 2
 
     if args.verb == "list":
-        return await _list(api_url, api_key, vault_id=args.vault_id)
+        return await _list(
+            api_url, api_key, vault_id=args.vault_id, limit=args.limit, after=args.after
+        )
     if args.verb == "get":
         return await _get(
             api_url, api_key, vault_id=args.vault_id, credential_id=args.credential_id
@@ -193,16 +199,22 @@ async def _get(api_url: str, api_key: str, *, vault_id: str, credential_id: str)
     return 0
 
 
-async def _list(api_url: str, api_key: str, *, vault_id: str) -> int:
+async def _list(
+    api_url: str, api_key: str, *, vault_id: str, limit: int | None, after: str | None
+) -> int:
     url = f"{api_url.rstrip('/')}/v1/vaults/{vault_id}/credentials"
     headers = {"Authorization": f"Bearer {api_key}"}
+    params: dict[str, Any] = {}
+    if limit is not None:
+        params["limit"] = limit
+    if after is not None:
+        params["after"] = after
     async with async_client() as client:
-        response = await client.get(url, headers=headers)
+        response = await client.get(url, headers=headers, params=params)
     if response.status_code != 200:
         print_http_error(_PROG, response)
         return 2
-    body: dict[str, Any] = response.json()
-    print(json.dumps(body.get("data", []), indent=2))
+    print(json.dumps(response.json(), indent=2))
     return 0
 
 

--- a/src/aios/cli/vaults.py
+++ b/src/aios/cli/vaults.py
@@ -40,7 +40,11 @@ async def run_async(argv: list[str]) -> int:
     )
     sub = parser.add_subparsers(dest="verb")
 
-    sub.add_parser("list", help="List vaults")
+    lst = sub.add_parser("list", help="List vaults")
+    lst.add_argument("--limit", type=int, default=None, help="Max items per page")
+    lst.add_argument(
+        "--after", default=None, help="Pagination cursor (pass next_after from prior response)"
+    )
 
     get = sub.add_parser("get", help="Show a single vault by id")
     get.add_argument("vault_id", help="Vault id")
@@ -88,7 +92,7 @@ async def run_async(argv: list[str]) -> int:
         return 2
 
     if args.verb == "list":
-        return await _list(api_url, api_key)
+        return await _list(api_url, api_key, limit=args.limit, after=args.after)
     if args.verb == "get":
         return await _get(api_url, api_key, vault_id=args.vault_id)
     if args.verb == "archive":
@@ -184,16 +188,20 @@ async def _get(api_url: str, api_key: str, *, vault_id: str) -> int:
     return 0
 
 
-async def _list(api_url: str, api_key: str) -> int:
+async def _list(api_url: str, api_key: str, *, limit: int | None, after: str | None) -> int:
     url = f"{api_url.rstrip('/')}/v1/vaults"
     headers = {"Authorization": f"Bearer {api_key}"}
+    params: dict[str, Any] = {}
+    if limit is not None:
+        params["limit"] = limit
+    if after is not None:
+        params["after"] = after
     async with async_client() as client:
-        response = await client.get(url, headers=headers)
+        response = await client.get(url, headers=headers, params=params)
     if response.status_code != 200:
         print_http_error(_PROG, response)
         return 2
-    body: dict[str, Any] = response.json()
-    print(json.dumps(body.get("data", []), indent=2))
+    print(json.dumps(response.json(), indent=2))
     return 0
 
 

--- a/tests/unit/test_cli_connections.py
+++ b/tests/unit/test_cli_connections.py
@@ -70,6 +70,44 @@ class TestListConnections:
         assert "signal" in out
         assert "+15550001" in out
 
+    async def test_list_output_includes_pagination_metadata(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``list`` prints the full server response including
+        ``has_more`` / ``next_after`` so paginating scripts can drive
+        the next page."""
+        _setup_env(monkeypatch)
+        payload = {
+            "data": [{"id": "conn_01"}],
+            "has_more": True,
+            "next_after": "conn_01",
+        }
+        client = _mock_async_client("get", _mock_response(200, payload))
+
+        with patch("aios.cli.connections.async_client", return_value=client):
+            rc = await run_async(["list"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "has_more" in out
+        assert "next_after" in out
+
+    async def test_list_passes_limit_and_after_as_params(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_env(monkeypatch)
+        payload = {"data": [], "has_more": False, "next_after": None}
+        client = _mock_async_client("get", _mock_response(200, payload))
+
+        with patch("aios.cli.connections.async_client", return_value=client):
+            rc = await run_async(["list", "--limit", "10", "--after", "conn_prev"])
+
+        assert rc == 0
+        call = client.get.await_args
+        params = call.kwargs.get("params") or {}
+        assert params.get("limit") == 10
+        assert params.get("after") == "conn_prev"
+
     async def test_http_error_returns_nonzero(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
## Summary

Adds pagination to all 5 \`list\` verbs in the operator CLI:

\`\`\`
aios <resource> list --limit 10 --after <prev_id>
\`\`\`

Both flags are passed through to the server as query params. The server clamps/validates per its own schema.

## Breaking output change

\`aios <resource> list\` previously printed the \`data\` array (\`[{...}, {...}]\`). It now prints the **full server response body** (\`{"data": [...], "has_more": ..., "next_after": ...}\`) so paginating scripts can see \`next_after\` and drive the next page. Scripts piping \`| jq '.[0]'\` must switch to \`| jq '.data[0]'\`.

The CLI is brand-new (not yet in anyone's scripts) — delete, don't deprecate per CLAUDE.md.

## Modules touched

- \`connections.py\` — flat path
- \`bindings.py\` — flat path; preserves \`--session-id\` filter
- \`rules.py\` — nested path; preserves \`--connection-id\`
- \`vaults.py\` — flat path
- \`vault_credentials.py\` — nested path; preserves \`--vault-id\`

## Test plan

- [x] 2 new tests in \`test_cli_connections.py\` pin the new behavior (params-passthrough + full-body output). Other 4 list handlers are structurally identical — reviewer confirmed replicating the pair is zero-value boilerplate.
- [x] \`uv run pytest tests/unit -q\` — 813 passed
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] Reviewer subagent: no high-confidence issues; applied a minor help-text wording suggestion ("Pagination cursor (pass next_after from prior response)")

🤖 Generated with [Claude Code](https://claude.com/claude-code)