### PR TITLE
feat(cli): add delete verb (hard-delete with --yes guard) to vaults + vault-credentials

### DIFF
--- a/src/aios/cli/vault_credentials.py
+++ b/src/aios/cli/vault_credentials.py
@@ -54,6 +54,18 @@ async def run_async(argv: list[str]) -> int:
     archive.add_argument("credential_id", help="Credential id")
     archive.add_argument("--vault-id", required=True, help="Owning vault id")
 
+    delete = sub.add_parser(
+        "delete",
+        help="Hard-delete a credential (irreversible; prefer `archive` instead)",
+    )
+    delete.add_argument("credential_id", help="Credential id")
+    delete.add_argument("--vault-id", required=True, help="Owning vault id")
+    delete.add_argument(
+        "--yes",
+        action="store_true",
+        help="Required to confirm hard-delete (no interactive prompt)",
+    )
+
     update = sub.add_parser(
         "update",
         help="Update a credential (body from file; mcp_server_url + auth_type are immutable)",
@@ -107,6 +119,16 @@ async def run_async(argv: list[str]) -> int:
         )
     if args.verb == "archive":
         return await _archive(
+            api_url, api_key, vault_id=args.vault_id, credential_id=args.credential_id
+        )
+    if args.verb == "delete":
+        if not args.yes:
+            print(
+                f"{_PROG}: hard-delete is irreversible; pass --yes to confirm",
+                file=sys.stderr,
+            )
+            return 2
+        return await _delete(
             api_url, api_key, vault_id=args.vault_id, credential_id=args.credential_id
         )
     if args.verb == "update":
@@ -172,6 +194,17 @@ async def _update(
         print_http_error(_PROG, response)
         return 2
     print(json.dumps(response.json(), indent=2))
+    return 0
+
+
+async def _delete(api_url: str, api_key: str, *, vault_id: str, credential_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/vaults/{vault_id}/credentials/{credential_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.delete(url, headers=headers)
+    if response.status_code != 204:
+        print_http_error(_PROG, response)
+        return 2
     return 0
 
 

--- a/src/aios/cli/vaults.py
+++ b/src/aios/cli/vaults.py
@@ -55,6 +55,17 @@ async def run_async(argv: list[str]) -> int:
     )
     archive.add_argument("vault_id", help="Vault id")
 
+    delete = sub.add_parser(
+        "delete",
+        help="Hard-delete a vault (irreversible; prefer `archive` instead)",
+    )
+    delete.add_argument("vault_id", help="Vault id")
+    delete.add_argument(
+        "--yes",
+        action="store_true",
+        help="Required to confirm hard-delete (no interactive prompt)",
+    )
+
     update = sub.add_parser("update", help="Update a vault's display name or metadata")
     update.add_argument("vault_id", help="Vault id")
     update.add_argument("--display-name", default=None, help="New display name")
@@ -97,6 +108,14 @@ async def run_async(argv: list[str]) -> int:
         return await _get(api_url, api_key, vault_id=args.vault_id)
     if args.verb == "archive":
         return await _archive(api_url, api_key, vault_id=args.vault_id)
+    if args.verb == "delete":
+        if not args.yes:
+            print(
+                f"{_PROG}: hard-delete is irreversible; pass --yes to confirm",
+                file=sys.stderr,
+            )
+            return 2
+        return await _delete(api_url, api_key, vault_id=args.vault_id)
     if args.verb == "update":
         metadata: dict[str, Any] | None = None
         if args.metadata_json is not None:
@@ -161,6 +180,17 @@ async def _update(
         print_http_error(_PROG, response)
         return 2
     print(json.dumps(response.json(), indent=2))
+    return 0
+
+
+async def _delete(api_url: str, api_key: str, *, vault_id: str) -> int:
+    url = f"{api_url.rstrip('/')}/v1/vaults/{vault_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with async_client() as client:
+        response = await client.delete(url, headers=headers)
+    if response.status_code != 204:
+        print_http_error(_PROG, response)
+        return 2
     return 0
 
 

--- a/tests/unit/test_cli_vault_credentials.py
+++ b/tests/unit/test_cli_vault_credentials.py
@@ -297,6 +297,32 @@ class TestUpdateVaultCredential:
         assert "required" in capsys.readouterr().err.lower()
 
 
+class TestDeleteVaultCredential:
+    async def test_deletes_when_yes_passed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("delete", _mock_response(204, None))
+
+        with patch("aios.cli.vault_credentials.async_client", return_value=client):
+            rc = await run_async(["delete", "vcr_01", "--vault-id", "vlt_01", "--yes"])
+
+        assert rc == 0
+        assert client.delete.await_args.args[0].endswith("/v1/vaults/vlt_01/credentials/vcr_01")
+
+    async def test_refuses_without_yes(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("delete", _mock_response(204, None))
+
+        with patch("aios.cli.vault_credentials.async_client", return_value=client):
+            rc = await run_async(["delete", "vcr_01", "--vault-id", "vlt_01"])
+
+        assert rc != 0
+        err = capsys.readouterr().err.lower()
+        assert "--yes" in err or "confirm" in err
+        client.delete.assert_not_awaited()
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/test_cli_vaults.py
+++ b/tests/unit/test_cli_vaults.py
@@ -271,6 +271,46 @@ class TestUpdateVault:
         assert call.kwargs["json"] == {"metadata": md}
 
 
+class TestDeleteVault:
+    async def test_deletes_when_yes_passed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("delete", _mock_response(204, None))
+
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(["delete", "vlt_01", "--yes"])
+
+        assert rc == 0
+        assert client.delete.await_args.args[0].endswith("/v1/vaults/vlt_01")
+
+    async def test_refuses_without_yes(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        # No --yes → should NOT hit the server.
+        client = _mock_async_client("delete", _mock_response(204, None))
+
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(["delete", "vlt_01"])
+
+        assert rc != 0
+        err = capsys.readouterr().err.lower()
+        assert "--yes" in err or "confirm" in err
+        # Crucially: no HTTP call issued
+        client.delete.assert_not_awaited()
+
+    async def test_http_error_returns_nonzero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _setup_env(monkeypatch)
+        client = _mock_async_client("delete", _mock_response(404, {"error": "not found"}))
+
+        with patch("aios.cli.vaults.async_client", return_value=client):
+            rc = await run_async(["delete", "vlt_missing", "--yes"])
+
+        assert rc != 0
+        assert "404" in capsys.readouterr().err
+
+
 class TestDispatch:
     async def test_unknown_verb_prints_usage(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## Summary

Deferred from #111 (archive). Adds true hard-delete for the two resources whose routers expose both a separate \`POST /.../archive\` (soft) AND a \`DELETE /...\` (hard):

- \`aios vaults delete <vault_id> --yes\`
- \`aios vault-credentials delete <credential_id> --vault-id <vid> --yes\`

## Protection

The \`--yes\` flag is required. Without it the CLI refuses with \`"hard-delete is irreversible; pass --yes to confirm"\` on stderr, exit code 2, and issues **NO HTTP call** (verified by \`client.delete.assert_not_awaited()\` in the refusal test).

No interactive prompt — keeps the CLI non-interactive, consistent with all sibling verbs. Matches the kubectl/pg_dump/ansible convention.

## Why only these two resources

Connections / bindings / rules are NOT given a \`delete\` verb: their \`DELETE\` endpoints are internally soft-archives (already wrapped by the \`archive\` verb from #111); no separate hard-delete exists. Vaults and vault-credentials are the only two with both \`archive\` and real \`delete\`.

## Test plan

- [x] 5 new tests: yes-path, refusal-path (with no-HTTP-call assertion), 404-path on the vaults side
- [x] \`uv run pytest tests/unit -q\` — 818 passed
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] Reviewer subagent: no high-confidence issues; endpoint contracts verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)