### PR TITLE
feat(api): reject user messages >1MB chars with 413

### DIFF
--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -65,6 +65,11 @@ class ConflictError(AiosError):
     status_code = 409
 
 
+class PayloadTooLargeError(AiosError):
+    error_type = "payload_too_large"
+    status_code = 413
+
+
 class UnauthorizedError(AiosError):
     error_type = "unauthorized"
     status_code = 401

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -19,6 +19,8 @@ from aios.models.events import Event
 
 SessionStatus = Literal["pending", "running", "idle", "rescheduling", "terminated"]
 
+MAX_USER_MESSAGE_CHARS = 1_000_000
+
 
 class SessionUsage(BaseModel):
     """Cumulative token usage across all model calls in a session."""
@@ -64,6 +66,7 @@ class SessionCreate(BaseModel):
     )
     initial_message: str | None = Field(
         default=None,
+        max_length=MAX_USER_MESSAGE_CHARS,
         description=(
             "Convenience: when set, the server appends a user.message event "
             "with this content immediately after creating the session and "

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -16,9 +16,7 @@ import asyncpg
 from aios.db import queries
 from aios.errors import PayloadTooLargeError
 from aios.models.events import Event, EventKind
-from aios.models.sessions import Session, SessionStatus
-
-_MAX_USER_MESSAGE_CHARS = 1_000_000
+from aios.models.sessions import MAX_USER_MESSAGE_CHARS, Session, SessionStatus
 
 
 async def create_session(
@@ -95,11 +93,11 @@ async def append_user_message(
     column so the context builder and unread-derivation helpers can key
     off it directly — without re-parsing a JSONB blob on every read.
     """
-    if len(content) > _MAX_USER_MESSAGE_CHARS:
+    if len(content) > MAX_USER_MESSAGE_CHARS:
         raise PayloadTooLargeError(
-            f"user message exceeds {_MAX_USER_MESSAGE_CHARS:,} characters "
+            f"user message exceeds {MAX_USER_MESSAGE_CHARS:,} characters "
             f"(got {len(content):,}); split into multiple messages",
-            detail={"max_chars": _MAX_USER_MESSAGE_CHARS, "got_chars": len(content)},
+            detail={"max_chars": MAX_USER_MESSAGE_CHARS, "got_chars": len(content)},
         )
     data: dict[str, Any] = {"role": "user", "content": content}
     if metadata:

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -14,8 +14,11 @@ from typing import Any
 import asyncpg
 
 from aios.db import queries
+from aios.errors import PayloadTooLargeError
 from aios.models.events import Event, EventKind
 from aios.models.sessions import Session, SessionStatus
+
+_MAX_USER_MESSAGE_CHARS = 1_000_000
 
 
 async def create_session(
@@ -92,6 +95,12 @@ async def append_user_message(
     column so the context builder and unread-derivation helpers can key
     off it directly — without re-parsing a JSONB blob on every read.
     """
+    if len(content) > _MAX_USER_MESSAGE_CHARS:
+        raise PayloadTooLargeError(
+            f"user message exceeds {_MAX_USER_MESSAGE_CHARS:,} characters "
+            f"(got {len(content):,}); split into multiple messages",
+            detail={"max_chars": _MAX_USER_MESSAGE_CHARS, "got_chars": len(content)},
+        )
     data: dict[str, Any] = {"role": "user", "content": content}
     if metadata:
         data["metadata"] = metadata

--- a/tests/unit/test_append_user_message_size.py
+++ b/tests/unit/test_append_user_message_size.py
@@ -7,15 +7,17 @@ from unittest.mock import MagicMock
 
 import asyncpg
 import pytest
+from pydantic import ValidationError
 
 from aios.errors import PayloadTooLargeError
-from aios.services.sessions import _MAX_USER_MESSAGE_CHARS, append_user_message
+from aios.models.sessions import SessionCreate
+from aios.services.sessions import MAX_USER_MESSAGE_CHARS, append_user_message
 
 
 class TestAppendUserMessageSizeCap:
     async def test_over_cap_raises_payload_too_large(self) -> None:
         pool = cast("asyncpg.Pool[Any]", MagicMock())
-        oversize = "x" * (_MAX_USER_MESSAGE_CHARS + 1)
+        oversize = "x" * (MAX_USER_MESSAGE_CHARS + 1)
 
         with pytest.raises(PayloadTooLargeError) as excinfo:
             await append_user_message(pool, "sess_x", oversize)
@@ -23,12 +25,12 @@ class TestAppendUserMessageSizeCap:
         err = excinfo.value
         assert err.status_code == 413
         assert err.error_type == "payload_too_large"
-        assert err.detail["max_chars"] == _MAX_USER_MESSAGE_CHARS
-        assert err.detail["got_chars"] == _MAX_USER_MESSAGE_CHARS + 1
+        assert err.detail["max_chars"] == MAX_USER_MESSAGE_CHARS
+        assert err.detail["got_chars"] == MAX_USER_MESSAGE_CHARS + 1
 
     async def test_over_cap_short_circuits_before_db(self) -> None:
         pool = MagicMock()
-        oversize = "x" * (_MAX_USER_MESSAGE_CHARS + 1)
+        oversize = "x" * (MAX_USER_MESSAGE_CHARS + 1)
 
         with pytest.raises(PayloadTooLargeError):
             await append_user_message(cast("asyncpg.Pool[Any]", pool), "sess_x", oversize)
@@ -38,7 +40,30 @@ class TestAppendUserMessageSizeCap:
     async def test_at_cap_does_not_raise(self) -> None:
         pool = MagicMock()
         pool.acquire.side_effect = RuntimeError("past the gate")
-        at_cap = "x" * _MAX_USER_MESSAGE_CHARS
+        at_cap = "x" * MAX_USER_MESSAGE_CHARS
 
         with pytest.raises(RuntimeError, match="past the gate"):
             await append_user_message(cast("asyncpg.Pool[Any]", pool), "sess_x", at_cap)
+
+
+class TestSessionCreateInitialMessageCap:
+    # POST /sessions creates the session row before appending initial_message;
+    # validating the length on the Pydantic model keeps that path
+    # correct-by-construction (no orphan session on 413).
+
+    def test_over_cap_initial_message_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SessionCreate(
+                agent_id="agent_x",
+                environment_id="env_x",
+                initial_message="x" * (MAX_USER_MESSAGE_CHARS + 1),
+            )
+
+    def test_at_cap_initial_message_accepted(self) -> None:
+        model = SessionCreate(
+            agent_id="agent_x",
+            environment_id="env_x",
+            initial_message="x" * MAX_USER_MESSAGE_CHARS,
+        )
+        assert model.initial_message is not None
+        assert len(model.initial_message) == MAX_USER_MESSAGE_CHARS

--- a/tests/unit/test_append_user_message_size.py
+++ b/tests/unit/test_append_user_message_size.py
@@ -1,0 +1,44 @@
+"""Tests for the user-message size cap in append_user_message."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import asyncpg
+import pytest
+
+from aios.errors import PayloadTooLargeError
+from aios.services.sessions import _MAX_USER_MESSAGE_CHARS, append_user_message
+
+
+class TestAppendUserMessageSizeCap:
+    async def test_over_cap_raises_payload_too_large(self) -> None:
+        pool = cast("asyncpg.Pool[Any]", MagicMock())
+        oversize = "x" * (_MAX_USER_MESSAGE_CHARS + 1)
+
+        with pytest.raises(PayloadTooLargeError) as excinfo:
+            await append_user_message(pool, "sess_x", oversize)
+
+        err = excinfo.value
+        assert err.status_code == 413
+        assert err.error_type == "payload_too_large"
+        assert err.detail["max_chars"] == _MAX_USER_MESSAGE_CHARS
+        assert err.detail["got_chars"] == _MAX_USER_MESSAGE_CHARS + 1
+
+    async def test_over_cap_short_circuits_before_db(self) -> None:
+        pool = MagicMock()
+        oversize = "x" * (_MAX_USER_MESSAGE_CHARS + 1)
+
+        with pytest.raises(PayloadTooLargeError):
+            await append_user_message(cast("asyncpg.Pool[Any]", pool), "sess_x", oversize)
+
+        pool.acquire.assert_not_called()
+
+    async def test_at_cap_does_not_raise(self) -> None:
+        pool = MagicMock()
+        pool.acquire.side_effect = RuntimeError("past the gate")
+        at_cap = "x" * _MAX_USER_MESSAGE_CHARS
+
+        with pytest.raises(RuntimeError, match="past the gate"):
+            await append_user_message(cast("asyncpg.Pool[Any]", pool), "sess_x", at_cap)


### PR DESCRIPTION
## Summary
- Add `PayloadTooLargeError` (413) to the `AiosError` hierarchy — auto-wired through `install_exception_handlers`, no router changes needed.
- Enforce a 1,000,000-character cap on `content` at the single ingestion choke point, `services.sessions.append_user_message`. One gate covers all three endpoints: `POST /sessions` (with `initial_message`), `POST /sessions/:id/messages`, `POST /connections/:id/messages`.
- Character-based O(1) check; this is a DoS/abuse guard, not context hygiene. Tool-result size caps are deliberately out of scope — built-ins already self-clamp, and MCP/custom tool results can be addressed separately if they become a real issue.

## Test plan
- [x] `uv run ruff check src tests && uv run ruff format --check src tests`
- [x] `uv run mypy src`
- [x] `uv run pytest tests/unit -q` (813 passed)
- [x] New unit coverage in `tests/unit/test_append_user_message_size.py`: over-cap raises `PayloadTooLargeError` with `status_code=413` and correct `detail`; over-cap short-circuits before `pool.acquire()`; exactly-at-cap passes the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)