### PR TITLE
fix: validator-error 422 + skills --dir upload shape (#121, #122)

### DIFF
--- a/src/aios/cli/files.py
+++ b/src/aios/cli/files.py
@@ -98,9 +98,15 @@ def resolve_payload(
 def walk_skill_dir(root: Path) -> dict[str, str]:
     """Build the ``files`` dict a skills endpoint expects from a directory.
 
-    Keys are POSIX-style paths relative to ``root``. Values are file contents
-    (text, UTF-8). A ``SKILL.md`` must exist directly under ``root``; the
-    server validates this but we check early for a friendlier error.
+    Keys are POSIX-style paths of the form ``{root.name}/<relpath>``: the
+    server's ``_extract_skill_metadata`` parses the directory name from the
+    ``SKILL.md`` key, so a bare ``SKILL.md`` is rejected with
+    *"SKILL.md must be inside a directory"*. Prepending ``root.name`` gives
+    the server the ``my-skill/SKILL.md`` shape it expects.
+
+    Values are file contents (text, UTF-8). A ``SKILL.md`` must exist
+    directly under ``root``; the server validates this but we check early
+    for a friendlier error.
     """
     if not root.is_dir():
         raise PayloadError(f"not a directory: {root}")
@@ -108,13 +114,19 @@ def walk_skill_dir(root: Path) -> dict[str, str]:
     if not skill_md.is_file():
         raise PayloadError(f"missing SKILL.md at {skill_md}")
 
+    # ``Path("foo/").name`` is ``"foo"`` — trailing slashes don't matter.
+    # We do need ``resolve()`` though so ``Path(".")`` / ``Path("")`` still
+    # yield a meaningful directory name rather than ``""``.
+    prefix = root.resolve().name
+
     files: dict[str, str] = {}
     for path in sorted(root.rglob("*")):
         if not path.is_file():
             continue
         rel = path.relative_to(root).as_posix()
+        key = f"{prefix}/{rel}"
         try:
-            files[rel] = path.read_text(encoding="utf-8")
+            files[key] = path.read_text(encoding="utf-8")
         except UnicodeDecodeError as exc:
             raise PayloadError(f"non-UTF-8 file in skill: {path}: {exc}") from exc
     return files

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -140,15 +140,24 @@ async def http_exception_handler(_request: Request, exc: Exception) -> JSONRespo
 
 
 async def validation_error_handler(_request: Request, exc: Exception) -> JSONResponse:
-    """Render pydantic/FastAPI request validation errors."""
+    """Render pydantic/FastAPI request validation errors.
+
+    Pydantic's ``value_error`` entries include a ``ctx`` field that
+    carries a live ``ValueError`` instance — unserializable by
+    ``json.dumps``, so the handler itself would raise and Starlette
+    would fall back to a generic 500. We strip ``ctx`` from every
+    entry; it's internal pydantic bookkeeping, not load-bearing for
+    clients.
+    """
     assert isinstance(exc, RequestValidationError)
+    errors = [{k: v for k, v in err.items() if k != "ctx"} for err in exc.errors()]
     return JSONResponse(
         status_code=422,
         content={
             "error": {
                 "type": "validation_error",
                 "message": "request body failed validation",
-                "detail": {"errors": exc.errors()},
+                "detail": {"errors": errors},
             }
         },
     )

--- a/tests/unit/cli/test_files.py
+++ b/tests/unit/cli/test_files.py
@@ -54,17 +54,47 @@ def test_load_invalid_json_raises(tmp_path: Path):
 
 
 def test_walk_skill_dir(tmp_path: Path):
-    skill = tmp_path / "skill"
+    """Keys are prefixed with the root directory's basename.
+
+    The server's ``_extract_skill_metadata`` parses the directory name
+    from the ``SKILL.md`` key and rejects bare ``SKILL.md``. Prepending
+    ``root.name`` gives it the ``my-skill/SKILL.md`` shape it requires.
+    """
+    skill = tmp_path / "my-skill"
     skill.mkdir()
     (skill / "SKILL.md").write_text("---\nname: x\ndescription: y\n---\nhello")
     (skill / "inner").mkdir()
     (skill / "inner" / "helper.py").write_text("print(1)")
 
     files = walk_skill_dir(skill)
-    assert "SKILL.md" in files
-    assert files["SKILL.md"].startswith("---")
-    assert "inner/helper.py" in files
-    assert files["inner/helper.py"] == "print(1)"
+    assert "my-skill/SKILL.md" in files
+    assert files["my-skill/SKILL.md"].startswith("---")
+    assert "my-skill/inner/helper.py" in files
+    assert files["my-skill/inner/helper.py"] == "print(1)"
+    # A bare ``SKILL.md`` key would be rejected by the server.
+    assert "SKILL.md" not in files
+
+
+def test_walk_skill_dir_matches_server_contract(tmp_path: Path):
+    """End-to-end shape check: the dict returned by ``walk_skill_dir``
+    round-trips through the server's ``_extract_skill_metadata`` without
+    the *"SKILL.md must be inside a directory"* failure that motivated
+    the fix."""
+    from aios.services.skills import _extract_skill_metadata
+
+    skill = tmp_path / "my-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: my-skill\ndescription: does a thing\n---\nbody")
+    (skill / "helper.py").write_text("print(1)")
+
+    files = walk_skill_dir(skill)
+    directory, name, description, normalized = _extract_skill_metadata(files)
+    assert directory == "my-skill"
+    assert name == "my-skill"
+    assert description == "does a thing"
+    # Normalized keys have the directory prefix stripped.
+    assert "SKILL.md" in normalized
+    assert "helper.py" in normalized
 
 
 def test_walk_skill_dir_missing_skill_md(tmp_path: Path):

--- a/tests/unit/test_errors_handler.py
+++ b/tests/unit/test_errors_handler.py
@@ -1,0 +1,99 @@
+"""Unit tests for ``aios.errors.validation_error_handler``.
+
+Pydantic's ``value_error`` entries include a ``ctx.error`` field that is a
+live ``ValueError`` instance — unserializable by ``json.dumps``. Before
+the fix the handler itself raised ``TypeError`` and Starlette fell back
+to a generic 500. The routing-rule prefix validator in
+``aios.models.routing_rules.RoutingRuleCreate`` is a real trigger: a
+``prefix`` like ``"a/"`` fails ``validate_path_segments`` with a raised
+``ValueError``.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, field_validator
+
+from aios.errors import install_exception_handlers
+from aios.models.routing_rules import RoutingRuleCreate
+
+
+def test_field_validator_value_error_returns_422_not_500() -> None:
+    """A body that trips a ``@field_validator`` raising ``ValueError``
+    must render as 422 in our envelope, not Starlette's generic 500.
+
+    Uses the real ``RoutingRuleCreate`` with the problematic prefix
+    from issue #121: ``"a/"`` (trailing empty segment).
+    """
+    app = FastAPI()
+    install_exception_handlers(app)
+
+    @app.post("/echo")
+    async def _echo(body: RoutingRuleCreate) -> dict[str, str]:
+        return {"ok": "true"}
+
+    client = TestClient(app)
+    response = client.post("/echo", json={"prefix": "a/", "target": "session:s_x"})
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["type"] == "validation_error"
+    assert body["error"]["message"] == "request body failed validation"
+    errors = body["error"]["detail"]["errors"]
+    assert isinstance(errors, list) and len(errors) >= 1
+    # ctx must be stripped — it's what held the unserializable ValueError.
+    for err in errors:
+        assert "ctx" not in err
+    # The prefix validator's message should be visible in msg.
+    assert any("must not contain empty segments" in err.get("msg", "") for err in errors)
+
+
+class _CustomModel(BaseModel):
+    x: str
+
+    @field_validator("x")
+    @classmethod
+    def _v(cls, v: str) -> str:
+        if v == "bad":
+            raise ValueError("x must not be 'bad'")
+        return v
+
+
+def test_field_validator_value_error_custom_model() -> None:
+    """Minimal synthetic model proves the handler strips ``ctx`` for any
+    ``@field_validator`` that raises ``ValueError``."""
+    app = FastAPI()
+    install_exception_handlers(app)
+
+    @app.post("/echo")
+    async def _echo(body: _CustomModel) -> dict[str, str]:
+        return {"ok": "true"}
+
+    client = TestClient(app)
+    response = client.post("/echo", json={"x": "bad"})
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["type"] == "validation_error"
+    errors = body["error"]["detail"]["errors"]
+    assert all("ctx" not in err for err in errors)
+    assert any("x must not be 'bad'" in err.get("msg", "") for err in errors)
+
+
+class _IntModel(BaseModel):
+    n: int
+
+
+def test_regular_type_error_still_422() -> None:
+    """Plain type-mismatch validation (no custom validator, no ctx) still
+    renders as 422."""
+    app = FastAPI()
+    install_exception_handlers(app)
+
+    @app.post("/echo")
+    async def _echo(body: _IntModel) -> dict[str, str]:
+        return {"ok": "true"}
+
+    client = TestClient(app)
+    response = client.post("/echo", json={"n": "not-an-int"})
+    assert response.status_code == 422
+    assert response.json()["error"]["type"] == "validation_error"


### PR DESCRIPTION
## Summary

Two independent bug fixes that each broke an otherwise-advertised CLI flow.

### #121 — validation handler 500s instead of 422

- Root cause: `validation_error_handler` passed `exc.errors()` straight into `JSONResponse`. Pydantic's `value_error` entries (from a `@field_validator` that raises `ValueError`) include a `ctx` field holding a live `ValueError` instance — unserializable by `json.dumps`, so the handler itself raised `TypeError` and Starlette fell back to a generic 500.
- Fix: strip `ctx` from each error entry in the handler before handing them to `JSONResponse`. FastAPI's `RequestValidationError.errors()` doesn't expose pydantic's `include_context=False` kwarg, so the filter is done inline.
- Real trigger: `aios rules create ... --data '{"prefix":"a/","target":"session:<sid>"}'` — the routing-rule prefix validator rejects trailing `/` with a raised `ValueError`.

### #122 — `skills create --dir` CLI/server disagreed on upload shape

- Root cause: `walk_skill_dir` keyed uploaded files by their path relative to `root`, so `--dir my-skill` produced `{"SKILL.md": ..., "inner/x": ...}`. The server's `_extract_skill_metadata` derives the skill's directory from the leading segment of the `SKILL.md` key and rejects bare `SKILL.md` with *"SKILL.md must be inside a directory"*.
- Fix on the CLI side (per the orchestrator's decision): prepend `root.name` to every key, yielding `{"my-skill/SKILL.md": ..., "my-skill/inner/x": ...}`. `root.resolve()` is used so `--dir .` still produces a meaningful basename rather than `""`.
- Server contract is untouched — one clean CLI behavior, no dual-shape handling.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 814 passed
- [x] New unit tests cover:
  - `validation_error_handler` returns 422 (not 500) for a `@field_validator` raising `ValueError` (using the real `RoutingRuleCreate` + a synthetic model), and that the response body drops `ctx`
  - `walk_skill_dir` keys every entry as `{root.name}/<relpath>`
  - End-to-end shape check: `walk_skill_dir` output round-trips through the server's `_extract_skill_metadata` without the directory-name failure

Closes #121, closes #122.