### PR TITLE
fix(cli): polish — versions column, chat race, flag rename, status JSON error (#123, #125, #126 P1/P2)

### DIFF
--- a/src/aios/cli/client.py
+++ b/src/aios/cli/client.py
@@ -47,6 +47,21 @@ class AiosApiError(Exception):
         self.detail = detail or {}
 
 
+class NonJSONResponseError(Exception):
+    """Raised when a 2xx response body cannot be decoded as JSON.
+
+    Typically means the configured URL is not an aios API (e.g. points at
+    an HTML landing page). Callers (notably ``aios status``) handle this
+    explicitly to give a friendlier message than a raw decode traceback.
+    """
+
+    def __init__(self, *, status_code: int, content_type: str, snippet: str) -> None:
+        super().__init__(f"non-JSON response (status={status_code}, content-type={content_type!r})")
+        self.status_code = status_code
+        self.content_type = content_type
+        self.snippet = snippet
+
+
 class AiosClient:
     """Synchronous client bound to a single aios API base URL + bearer key."""
 
@@ -118,7 +133,15 @@ class AiosClient:
                 return None
             _raise_for_error(response)
         if 200 <= response.status_code < 300:
-            return response.json()
+            try:
+                return response.json()
+            except (ValueError, json.JSONDecodeError) as exc:
+                snippet = response.text.strip()[:200]
+                raise NonJSONResponseError(
+                    status_code=response.status_code,
+                    content_type=response.headers.get("content-type", ""),
+                    snippet=snippet,
+                ) from exc
         _raise_for_error(response)
         return None  # unreachable; keeps type checker happy
 

--- a/src/aios/cli/commands/agents.py
+++ b/src/aios/cli/commands/agents.py
@@ -135,8 +135,8 @@ def versions(
         render_list(
             state.output_format,
             envelope,
-            columns=("version", "name", "model", "created_at"),
-            max_widths={"name": 32, "model": 40},
+            columns=("version", "model", "created_at"),
+            max_widths={"model": 40},
         )
 
     run_or_die(_run)

--- a/src/aios/cli/commands/chat.py
+++ b/src/aios/cli/commands/chat.py
@@ -197,12 +197,19 @@ def _stream_until_idle(
             client.request("POST", f"/v1/sessions/{session_id}/interrupt", json_body={})
         sys.stderr.write(yellow("\n  [ctrl-c: interrupt requested]\n", stream=sys.stderr))
 
+    # Track whether any content delta arrived during the current assistant
+    # turn. Reset when a new assistant message is finalized so subsequent
+    # turns start fresh. On fast/cached turns, no deltas arrive and we must
+    # render the full message content directly from the final event.
+    turn_state = {"streamed_any_delta": False}
+
     previous_handler = signal.signal(signal.SIGINT, _handle_sigint)
     try:
         with client.stream_session(session_id, after_seq=last_seq) as messages:
             for msg in messages:
                 if msg.event == "delta":
-                    _write_delta(msg.data)
+                    if _write_delta(msg.data):
+                        turn_state["streamed_any_delta"] = True
                     continue
                 if msg.event == "done":
                     sys.stdout.write(dim("\n[session terminated]\n"))
@@ -216,7 +223,7 @@ def _stream_until_idle(
                 new_seq = obj.get("seq")
                 if isinstance(new_seq, int) and new_seq > last_seq:
                     last_seq = new_seq
-                _render_chat_event(obj, verbose=verbose)
+                _render_chat_event(obj, verbose=verbose, turn_state=turn_state)
                 if _is_turn_end(obj):
                     sys.stdout.write(dim(f"  [turn ended at seq={last_seq}]\n"))
                     return last_seq
@@ -225,18 +232,21 @@ def _stream_until_idle(
     return last_seq
 
 
-def _write_delta(data: str) -> None:
+def _write_delta(data: str) -> bool:
+    """Write a delta chunk to stdout. Returns True if a non-empty chunk was written."""
     try:
         obj = json.loads(data)
     except json.JSONDecodeError:
-        return
+        return False
     chunk = obj.get("delta")
-    if isinstance(chunk, str):
+    if isinstance(chunk, str) and chunk:
         sys.stdout.write(chunk)
         sys.stdout.flush()
+        return True
+    return False
 
 
-def _render_chat_event(obj: dict[str, Any], *, verbose: bool) -> None:
+def _render_chat_event(obj: dict[str, Any], *, verbose: bool, turn_state: dict[str, bool]) -> None:
     kind = obj.get("kind")
     data = obj.get("data") or {}
     if kind == "message":
@@ -248,13 +258,16 @@ def _render_chat_event(obj: dict[str, Any], *, verbose: bool) -> None:
             return
         if role == "assistant":
             if content and not tool_calls:
-                # Content may have already been streamed via deltas. The final
-                # event also carries it — detect by checking if we've already
-                # written non-empty text in this turn. Simpler: write a newline
-                # to terminate the delta stream, and suppress the full-content
-                # re-render. If no deltas came (e.g. non-streaming model),
-                # write the content now.
-                sys.stdout.write("\n")
+                # Content may have already been streamed via deltas. If we
+                # saw any delta in this turn, just terminate the line;
+                # otherwise (fast/cached turn, no deltas arrived) render the
+                # full content now.
+                if turn_state["streamed_any_delta"]:
+                    sys.stdout.write("\n")
+                else:
+                    sys.stdout.write(content + "\n")
+                # Reset for the next assistant message in the same turn.
+                turn_state["streamed_any_delta"] = False
                 return
             for call in tool_calls:
                 name = (call.get("function") or {}).get("name", "?")

--- a/src/aios/cli/commands/sessions.py
+++ b/src/aios/cli/commands/sessions.py
@@ -269,7 +269,7 @@ def stream(
     def _run() -> None:
         sys.stdout.write(dim(f"streaming {cyan(session_id)} after_seq={after_seq}\n"))
         if pretty:
-            tail_session(ctx, session_id, from_seq=after_seq)
+            tail_session(ctx, session_id, after_seq=after_seq)
             return
         client = get_state(ctx).client()
         with client, client.stream_session(session_id, after_seq=after_seq) as messages:
@@ -292,18 +292,18 @@ def stream(
 def tail(
     ctx: typer.Context,
     session_id: str,
-    from_seq: Annotated[int, typer.Option("--from-seq", min=0)] = 0,
+    after_seq: Annotated[int, typer.Option("--after-seq", min=0)] = 0,
 ) -> None:
     def _run() -> None:
-        tail_session(ctx, session_id, from_seq=from_seq)
+        tail_session(ctx, session_id, after_seq=after_seq)
 
     run_or_die(_run)
 
 
-def tail_session(ctx: typer.Context, session_id: str, *, from_seq: int) -> None:
+def tail_session(ctx: typer.Context, session_id: str, *, after_seq: int) -> None:
     """Shared implementation for ``aios sessions tail`` / top-level ``aios tail``."""
     client = get_state(ctx).client()
-    with client, client.stream_session(session_id, after_seq=from_seq) as messages:
+    with client, client.stream_session(session_id, after_seq=after_seq) as messages:
         for line in iter_formatted_events(messages):
             sys.stdout.write(line + "\n")
             sys.stdout.flush()

--- a/src/aios/cli/commands/status.py
+++ b/src/aios/cli/commands/status.py
@@ -6,7 +6,7 @@ import sys
 
 import typer
 
-from aios.cli.client import AiosApiError
+from aios.cli.client import AiosApiError, NonJSONResponseError
 from aios.cli.output import cyan, green, print_json, red, yellow
 from aios.cli.runtime import get_state, run_or_die
 
@@ -35,6 +35,11 @@ def register(app: typer.Typer) -> None:
         try:
             health = client.request("GET", "/health")
             sys.stdout.write(f"health:  {green('ok')} ({health})\n")
+        except NonJSONResponseError:
+            sys.stdout.write(
+                f"health:  {red('fail')} (server returned non-JSON response (not aios?))\n"
+            )
+            return 1
         except AiosApiError as exc:
             sys.stdout.write(f"health:  {red('fail')} ({exc.message})\n")
             return 1
@@ -56,6 +61,14 @@ def register(app: typer.Typer) -> None:
         payload: dict[str, object] = {"url": state.base_url, "api_key_set": bool(state.api_key)}
         try:
             payload["health"] = client.request("GET", "/health")
+        except NonJSONResponseError as exc:
+            payload["health_error"] = {
+                "type": "non_json_response",
+                "message": "server returned non-JSON response (not aios?)",
+                "content_type": exc.content_type,
+            }
+            print_json(payload)
+            return 1
         except AiosApiError as exc:
             payload["health_error"] = {"type": exc.error_type, "message": exc.message}
             print_json(payload)

--- a/src/aios/cli/commands/tail.py
+++ b/src/aios/cli/commands/tail.py
@@ -23,9 +23,9 @@ def register(app: typer.Typer) -> None:
     def tail(
         ctx: typer.Context,
         session_id: str,
-        from_seq: Annotated[int, typer.Option("--from-seq", min=0)] = 0,
+        after_seq: Annotated[int, typer.Option("--after-seq", min=0)] = 0,
     ) -> None:
         def _run() -> None:
-            tail_session(ctx, session_id, from_seq=from_seq)
+            tail_session(ctx, session_id, after_seq=after_seq)
 
         run_or_die(_run)

--- a/tests/unit/cli/test_cli_chat.py
+++ b/tests/unit/cli/test_cli_chat.py
@@ -1,0 +1,64 @@
+"""Tests for ``aios chat`` rendering helpers.
+
+Focus: regression for issue #125 — on fast/cached turns no deltas arrive,
+so the final ``message`` event must render the full content (not just a
+newline). The ``turn_state`` dict threads that flag through the loop.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.cli.commands.chat import _render_chat_event, _write_delta
+
+
+def test_write_delta_reports_true_when_chunk_written(capsys: pytest.CaptureFixture[str]) -> None:
+    assert _write_delta('{"delta": "hello"}') is True
+    assert capsys.readouterr().out == "hello"
+
+
+def test_write_delta_reports_false_for_empty_chunk(capsys: pytest.CaptureFixture[str]) -> None:
+    assert _write_delta('{"delta": ""}') is False
+    assert capsys.readouterr().out == ""
+
+
+def test_write_delta_reports_false_for_missing_chunk(capsys: pytest.CaptureFixture[str]) -> None:
+    assert _write_delta('{"other": "x"}') is False
+    assert capsys.readouterr().out == ""
+
+
+def test_write_delta_reports_false_for_bad_json(capsys: pytest.CaptureFixture[str]) -> None:
+    assert _write_delta("not-json") is False
+    assert capsys.readouterr().out == ""
+
+
+def test_final_assistant_message_renders_content_when_no_deltas(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Fast/cached turn: no delta events fired. The final message event
+    must print the full content so the user sees the assistant's reply."""
+    turn_state = {"streamed_any_delta": False}
+    obj = {
+        "kind": "message",
+        "data": {"role": "assistant", "content": "hello world"},
+    }
+    _render_chat_event(obj, verbose=False, turn_state=turn_state)
+    assert capsys.readouterr().out == "hello world\n"
+    # Should be reset so the next assistant message starts fresh.
+    assert turn_state["streamed_any_delta"] is False
+
+
+def test_final_assistant_message_only_newline_when_deltas_streamed(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Normal streaming turn: deltas already printed the content, the
+    final message event must not duplicate it — only terminate the line."""
+    turn_state = {"streamed_any_delta": True}
+    obj = {
+        "kind": "message",
+        "data": {"role": "assistant", "content": "hello world"},
+    }
+    _render_chat_event(obj, verbose=False, turn_state=turn_state)
+    assert capsys.readouterr().out == "\n"
+    # Flag resets so a subsequent assistant message in the same turn starts fresh.
+    assert turn_state["streamed_any_delta"] is False

--- a/tests/unit/cli/test_cli_status.py
+++ b/tests/unit/cli/test_cli_status.py
@@ -1,0 +1,55 @@
+"""Tests for ``aios status`` — reachability/auth checks.
+
+Regression: issue #126 P2 — when AIOS_URL points at something returning
+HTML, ``status`` must not dump a raw ``json.decoder.JSONDecodeError``
+traceback. It should report a friendly "non-JSON response" line and exit
+non-zero.
+"""
+
+from __future__ import annotations
+
+import httpx
+from typer.testing import CliRunner
+
+from aios.cli.app import app
+
+runner = CliRunner()
+
+
+def test_status_non_json_health_response_is_friendly(mocked_cli):
+    """AIOS_URL points at an HTML landing page. The status command should
+    degrade gracefully instead of raising a JSON decode traceback."""
+    mocked_cli.queue_response(
+        httpx.Response(
+            200,
+            content=b"<html>hi</html>",
+            headers={"content-type": "text/html"},
+        )
+    )
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 1
+    assert "health" in result.output
+    assert "non-JSON" in result.output
+    assert "traceback" not in result.output.lower()
+
+
+def test_status_non_json_health_response_json_format(mocked_cli):
+    mocked_cli.queue_response(
+        httpx.Response(
+            200,
+            content=b"<html>hi</html>",
+            headers={"content-type": "text/html"},
+        )
+    )
+    result = runner.invoke(app, ["--format", "json", "status"])
+    assert result.exit_code == 1
+    assert "non_json_response" in result.output
+
+
+def test_status_happy_path_health_only(mocked_cli, monkeypatch):
+    """Without an API key, status only probes /health and returns 0 on ok."""
+    monkeypatch.delenv("AIOS_API_KEY", raising=False)
+    mocked_cli.queue_response(httpx.Response(200, json={"ok": True}))
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "health" in result.output

--- a/tests/unit/cli/test_client.py
+++ b/tests/unit/cli/test_client.py
@@ -12,7 +12,7 @@ from typing import Any
 import httpx
 import pytest
 
-from aios.cli.client import AiosApiError, AiosClient
+from aios.cli.client import AiosApiError, AiosClient, NonJSONResponseError
 
 
 def _mock_client(handler, *, api_key: str | None = "key-123") -> AiosClient:
@@ -81,6 +81,25 @@ def test_non_envelope_error_body_handled_gracefully():
         client.request("GET", "/x")
     assert excinfo.value.status_code == 500
     assert "internal server error" in excinfo.value.message
+
+
+def test_2xx_non_json_body_raises_non_json_response_error():
+    """A 2xx response whose body is not JSON (e.g. an HTML landing page at
+    a misconfigured URL) must raise :class:`NonJSONResponseError` so
+    callers like ``aios status`` can present a friendly message."""
+
+    def handler(_r: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b"<html><body>not aios</body></html>",
+            headers={"content-type": "text/html"},
+        )
+
+    with _mock_client(handler) as client, pytest.raises(NonJSONResponseError) as excinfo:
+        client.request("GET", "/health")
+    assert excinfo.value.status_code == 200
+    assert excinfo.value.content_type == "text/html"
+    assert "<html>" in excinfo.value.snippet
 
 
 def test_params_pruned_of_none():


### PR DESCRIPTION
## Summary

Four independent CLI polish fixes:

- **#123** — `aios agents versions` dropped the empty NAME column. Name lives on the parent agents table, not per-version; the renderer was emitting empty strings. Table now shows `VERSION / MODEL / CREATED_AT`.
- **#125** — `aios chat -m` was swallowing assistant content on fast/cached turns. The final `message` event unconditionally wrote a newline on the theory that deltas had already rendered the text; on fast turns no deltas ever arrive. Now tracks a per-turn `streamed_any_delta` flag and falls back to rendering the full content when no deltas fired.
- **#126 P1** — Renamed `--from-seq` → `--after-seq` on `aios tail` and `aios sessions tail` to match `sessions stream` / `sessions events`. Fresh v1 CLI — no back-compat alias, per CLAUDE.md "don't deprecate, delete."
- **#126 P2** — `aios status` no longer dumps a raw `json.decoder.JSONDecodeError` when `AIOS_URL` points at an HTML/plain-text endpoint. `AiosClient.request()` raises a typed `NonJSONResponseError` on undecodable 2xx responses; `status` catches it and prints `health: fail (server returned non-JSON response (not aios?))`. Other callers still see the raw failure.

Each fix is its own commit with a conventional-commit message.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 820 passed (10 new tests: 6 for #125 delta tracking, 3 for #126 P2 status + non-JSON, 1 for the client raising `NonJSONResponseError`)
- [ ] Manual smoke: `aios agents versions <id>` — verify no NAME column in the table output
- [ ] Manual smoke: `aios chat --agent X --environment-id Y -m "hi"` against a cached/fast model — verify reply is printed
- [ ] Manual smoke: `AIOS_URL=https://example.com aios status` — verify friendly line, exit 1
- [ ] Manual smoke: `aios tail <sess> --after-seq 0` and `aios sessions tail <sess> --after-seq 0` — flag works; `--from-seq` is now unknown

🤖 Generated with [Claude Code](https://claude.com/claude-code)