### PR TITLE
fix(cli): destructive commands — confirmation guards + success output (#124, #126 P3)

### DIFF
--- a/src/aios/cli/commands/agents.py
+++ b/src/aios/cli/commands/agents.py
@@ -15,7 +15,7 @@ from aios.cli.commands._shared import (
     with_client,
 )
 from aios.cli.files import PayloadError, load_payload
-from aios.cli.output import print_error
+from aios.cli.output import print_error, print_success
 from aios.cli.runtime import run_or_die
 
 app = typer.Typer(name="agents", help="Manage agents.", no_args_is_help=True)
@@ -109,6 +109,7 @@ def delete(ctx: typer.Context, agent_id: str) -> None:
         client = just_client(ctx)
         with client:
             client.request("DELETE", f"/v1/agents/{agent_id}")
+        print_success("archived", agent_id)
 
     run_or_die(_run)
 

--- a/src/aios/cli/commands/bindings.py
+++ b/src/aios/cli/commands/bindings.py
@@ -15,7 +15,7 @@ from aios.cli.commands._shared import (
     with_client,
 )
 from aios.cli.files import PayloadError, resolve_payload
-from aios.cli.output import print_error
+from aios.cli.output import print_error, print_success
 from aios.cli.runtime import run_or_die
 
 app = typer.Typer(name="bindings", help="Manage channel bindings.", no_args_is_help=True)
@@ -101,5 +101,6 @@ def archive(ctx: typer.Context, binding_id: str) -> None:
         client = just_client(ctx)
         with client:
             client.request("DELETE", f"/v1/channel-bindings/{binding_id}")
+        print_success("archived", binding_id)
 
     run_or_die(_run)

--- a/src/aios/cli/commands/envs.py
+++ b/src/aios/cli/commands/envs.py
@@ -15,7 +15,7 @@ from aios.cli.commands._shared import (
     with_client,
 )
 from aios.cli.files import PayloadError, load_payload
-from aios.cli.output import print_error
+from aios.cli.output import print_error, print_success
 from aios.cli.runtime import run_or_die
 
 app = typer.Typer(name="envs", help="Manage environments (sandbox configs).", no_args_is_help=True)
@@ -101,11 +101,12 @@ def update(
     run_or_die(_run)
 
 
-@app.command("delete")
+@app.command("delete", help="Soft-archive an environment.")
 def delete(ctx: typer.Context, env_id: str) -> None:
     def _run() -> None:
         client = just_client(ctx)
         with client:
             client.request("DELETE", f"/v1/environments/{env_id}")
+        print_success("archived", env_id)
 
     run_or_die(_run)

--- a/src/aios/cli/commands/rules.py
+++ b/src/aios/cli/commands/rules.py
@@ -15,7 +15,7 @@ from aios.cli.commands._shared import (
     with_client,
 )
 from aios.cli.files import PayloadError, load_json_object, load_payload, resolve_payload
-from aios.cli.output import print_error
+from aios.cli.output import print_error, print_success
 from aios.cli.runtime import run_or_die
 
 app = typer.Typer(
@@ -152,5 +152,6 @@ def archive(ctx: typer.Context, connection_id: str, rule_id: str) -> None:
         client = just_client(ctx)
         with client:
             client.request("DELETE", f"/v1/connections/{connection_id}/routing-rules/{rule_id}")
+        print_success("archived", rule_id)
 
     run_or_die(_run)

--- a/src/aios/cli/commands/sessions.py
+++ b/src/aios/cli/commands/sessions.py
@@ -142,12 +142,29 @@ def archive(ctx: typer.Context, session_id: str) -> None:
     run_or_die(_run)
 
 
-@app.command("delete", help="Hard-delete a session.")
-def delete(ctx: typer.Context, session_id: str) -> None:
-    def _run() -> None:
+@app.command(
+    "delete",
+    help="Hard-delete a session (irreversible; prefer `archive` instead).",
+)
+def delete(
+    ctx: typer.Context,
+    session_id: str,
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", help="Required to confirm hard-delete (no interactive prompt)."),
+    ] = False,
+) -> None:
+    def _run() -> int | None:
+        if not yes:
+            print_error(
+                "hard-delete is irreversible; pass --yes to confirm "
+                "(or use `aios sessions archive` for a reversible soft-delete)"
+            )
+            return 2
         client = just_client(ctx)
         with client:
             client.request("DELETE", f"/v1/sessions/{session_id}")
+        return None
 
     run_or_die(_run)
 

--- a/src/aios/cli/commands/sessions.py
+++ b/src/aios/cli/commands/sessions.py
@@ -17,7 +17,7 @@ from aios.cli.commands._shared import (
     with_client,
 )
 from aios.cli.files import PayloadError, load_json_object, load_payload
-from aios.cli.output import cyan, dim, print_error
+from aios.cli.output import cyan, dim, print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
 from aios.cli.tail_format import iter_formatted_events
 
@@ -164,6 +164,7 @@ def delete(
         client = just_client(ctx)
         with client:
             client.request("DELETE", f"/v1/sessions/{session_id}")
+        print_success("deleted", session_id)
         return None
 
     run_or_die(_run)

--- a/src/aios/cli/commands/skills.py
+++ b/src/aios/cli/commands/skills.py
@@ -15,7 +15,7 @@ from aios.cli.commands._shared import (
     with_client,
 )
 from aios.cli.files import PayloadError, load_payload, walk_skill_dir
-from aios.cli.output import print_error
+from aios.cli.output import print_error, print_success
 from aios.cli.runtime import run_or_die
 
 app = typer.Typer(name="skills", help="Manage skills.", no_args_is_help=True)
@@ -90,6 +90,7 @@ def delete(ctx: typer.Context, skill_id: str) -> None:
         client = just_client(ctx)
         with client:
             client.request("DELETE", f"/v1/skills/{skill_id}")
+        print_success("archived", skill_id)
 
     run_or_die(_run)
 

--- a/src/aios/cli/commands/vaults.py
+++ b/src/aios/cli/commands/vaults.py
@@ -15,7 +15,7 @@ from aios.cli.commands._shared import (
     with_client,
 )
 from aios.cli.files import PayloadError, load_json_object, load_payload, resolve_payload
-from aios.cli.output import print_error
+from aios.cli.output import print_error, print_success
 from aios.cli.runtime import run_or_die
 
 app = typer.Typer(name="vaults", help="Manage vaults and credentials.", no_args_is_help=True)
@@ -154,11 +154,15 @@ def delete(
 ) -> None:
     def _run() -> int | None:
         if not yes:
-            print_error("hard-delete is irreversible; pass --yes to confirm")
+            print_error(
+                "hard-delete is irreversible; pass --yes to confirm "
+                "(or use `aios vaults archive` for a reversible soft-delete)"
+            )
             return 2
         client = just_client(ctx)
         with client:
             client.request("DELETE", f"/v1/vaults/{vault_id}")
+        print_success("deleted", vault_id)
         return None
 
     run_or_die(_run)
@@ -291,11 +295,15 @@ def cred_delete(
 ) -> None:
     def _run() -> int | None:
         if not yes:
-            print_error("hard-delete is irreversible; pass --yes to confirm")
+            print_error(
+                "hard-delete is irreversible; pass --yes to confirm "
+                "(or use `aios vaults credentials archive` for a reversible soft-delete)"
+            )
             return 2
         client = just_client(ctx)
         with client:
             client.request("DELETE", f"/v1/vaults/{vault_id}/credentials/{credential_id}")
+        print_success("deleted", credential_id)
         return None
 
     run_or_die(_run)

--- a/src/aios/cli/output.py
+++ b/src/aios/cli/output.py
@@ -160,3 +160,13 @@ def print_error(message: str) -> None:
 def print_note(message: str) -> None:
     """Write a dim informational note to stderr (so it doesn't pollute stdout pipes)."""
     sys.stderr.write(dim(message, stream=sys.stderr) + "\n")
+
+
+def print_success(verb: str, resource_id: str) -> None:
+    """Write a ``<verb> <id>`` confirmation line to stdout for terminal verbs.
+
+    Used by archive/delete commands whose server returns no body: we still
+    want to give the user a visible acknowledgement and something scripts
+    can grep for.
+    """
+    sys.stdout.write(f"{green(verb)} {resource_id}\n")

--- a/tests/unit/cli/test_cli_bindings.py
+++ b/tests/unit/cli/test_cli_bindings.py
@@ -117,6 +117,9 @@ def test_archive_uses_delete(mocked_cli):
     assert result.exit_code == 0, result.output
     assert mocked_cli.captured.method == "DELETE"
     assert mocked_cli.captured.path == "/v1/channel-bindings/cbn_01"
+    # Success line on stdout so scripts + humans get a visible ack.
+    assert "archived" in result.output
+    assert "cbn_01" in result.output
 
 
 def test_http_error_nonzero_exit(mocked_cli):

--- a/tests/unit/cli/test_cli_sessions.py
+++ b/tests/unit/cli/test_cli_sessions.py
@@ -1,0 +1,31 @@
+"""Tests for ``aios sessions ...`` destructive verbs via the typer app.
+
+Focuses on the ``delete`` guard (hard-delete requires ``--yes``) introduced
+to line ``sessions delete`` up with the other hard-delete commands. Happy-
+path CRUD is exercised elsewhere.
+"""
+
+from __future__ import annotations
+
+import httpx
+from typer.testing import CliRunner
+
+from aios.cli.app import app
+
+runner = CliRunner()
+
+
+def test_delete_refuses_without_yes_and_makes_no_request(mocked_cli):
+    result = runner.invoke(app, ["sessions", "delete", "sess_1"])
+    assert result.exit_code == 2
+    assert "--yes" in result.output
+    assert "archive" in result.output  # remind about the soft alternative
+    assert mocked_cli.captured.method == ""  # no HTTP call was made
+
+
+def test_delete_is_hard_delete_with_yes(mocked_cli):
+    mocked_cli.queue_response(httpx.Response(204))
+    result = runner.invoke(app, ["sessions", "delete", "sess_1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert mocked_cli.captured.method == "DELETE"
+    assert mocked_cli.captured.path == "/v1/sessions/sess_1"

--- a/tests/unit/cli/test_cli_sessions.py
+++ b/tests/unit/cli/test_cli_sessions.py
@@ -29,3 +29,7 @@ def test_delete_is_hard_delete_with_yes(mocked_cli):
     assert result.exit_code == 0, result.output
     assert mocked_cli.captured.method == "DELETE"
     assert mocked_cli.captured.path == "/v1/sessions/sess_1"
+    # Confirmation line on stdout — "deleted <id>" gives scripts something to
+    # grep and humans a visible ack (the server returns 204 with no body).
+    assert "deleted" in result.output
+    assert "sess_1" in result.output

--- a/tests/unit/cli/test_cli_vault_credentials.py
+++ b/tests/unit/cli/test_cli_vault_credentials.py
@@ -80,10 +80,13 @@ def test_delete_is_hard_delete_with_yes(mocked_cli):
     assert result.exit_code == 0, result.output
     assert mocked_cli.captured.method == "DELETE"
     assert mocked_cli.captured.path == "/v1/vaults/vlt_1/credentials/cred_1"
+    assert "deleted" in result.output
+    assert "cred_1" in result.output
 
 
 def test_delete_refuses_without_yes_and_makes_no_request(mocked_cli):
     result = runner.invoke(app, ["vaults", "credentials", "delete", "vlt_1", "cred_1"])
     assert result.exit_code == 2
     assert "--yes" in result.output
+    assert "archive" in result.output  # remind about the soft alternative
     assert mocked_cli.captured.method == ""  # no HTTP call was made

--- a/tests/unit/cli/test_cli_vaults.py
+++ b/tests/unit/cli/test_cli_vaults.py
@@ -72,10 +72,13 @@ def test_delete_is_hard_delete_with_yes(mocked_cli):
     assert result.exit_code == 0, result.output
     assert mocked_cli.captured.method == "DELETE"
     assert mocked_cli.captured.path == "/v1/vaults/vlt_1"
+    assert "deleted" in result.output
+    assert "vlt_1" in result.output
 
 
 def test_delete_refuses_without_yes_and_makes_no_request(mocked_cli):
     result = runner.invoke(app, ["vaults", "delete", "vlt_1"])
     assert result.exit_code == 2
     assert "--yes" in result.output
+    assert "archive" in result.output  # remind about the soft alternative
     assert mocked_cli.captured.method == ""  # no HTTP call was made


### PR DESCRIPTION
## Summary

One sweep through every destructive CLI verb in the `aios` client — bundling two related issues so the same command bodies don't get touched twice:

- **#124** — `aios sessions delete` now requires `--yes` to confirm the irreversible hard-delete (aligning it with `aios vaults delete` and `aios vaults credentials delete`, which already gated on `--yes`). Missing flag exits code 2, points at `aios sessions archive` as the reversible alternative, and never touches the API.
- **#126 P3** — every archive/delete verb whose server returns 204 now prints a short `<verb> <id>` confirmation line to stdout on success. Affected: `agents delete`, `skills delete`, `envs delete`, `rules archive`, `bindings archive`, `vaults delete`, `vaults credentials delete`, `sessions delete`. Verbs whose endpoint already returns the updated record (`sessions archive`, `vaults archive`, `vaults credentials archive`) keep rendering it — the JSON already serves as the ack.

Adds a tiny `print_success(verb, id)` helper in `aios.cli.output` (green-tints the verb on TTY) and extends the existing CLI resource tests.

Two commits, one per issue, keeping the reviewer story clean.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 812 passed
- [x] `aios sessions delete sess_X` without `--yes` exits 2, prints the guidance, makes no HTTP call
- [x] `aios sessions delete sess_X --yes` issues DELETE and prints `deleted sess_X`
- [x] `aios bindings archive cbn_X` prints `archived cbn_X` on success
- [x] Existing destructive tests in `test_cli_vaults.py` / `test_cli_vault_credentials.py` extended to assert the new output
- [x] New `tests/unit/cli/test_cli_sessions.py` covers the guard and the success path

Closes #124
Closes #126 (P3 bucket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)