### PR TITLE
fix(cli): print confirmation on connections archive success (#134)

### DIFF
--- a/src/aios/cli/commands/connections.py
+++ b/src/aios/cli/commands/connections.py
@@ -15,7 +15,7 @@ from aios.cli.commands._shared import (
     with_client,
 )
 from aios.cli.files import PayloadError, load_json_object, load_payload, resolve_payload
-from aios.cli.output import print_error
+from aios.cli.output import print_error, print_success
 from aios.cli.runtime import run_or_die
 
 app = typer.Typer(name="connections", help="Manage connector connections.", no_args_is_help=True)
@@ -149,6 +149,7 @@ def archive(ctx: typer.Context, connection_id: str) -> None:
         client = just_client(ctx)
         with client:
             client.request("DELETE", f"/v1/connections/{connection_id}")
+        print_success("archived", connection_id)
 
     run_or_die(_run)
 

--- a/tests/unit/cli/test_cli_connections.py
+++ b/tests/unit/cli/test_cli_connections.py
@@ -116,6 +116,9 @@ def test_archive_uses_delete(mocked_cli):
     assert result.exit_code == 0, result.output
     assert mocked_cli.captured.method == "DELETE"
     assert mocked_cli.captured.path == "/v1/connections/conn_01"
+    # Success line on stdout so scripts + humans get a visible ack.
+    assert "archived" in result.output
+    assert "conn_01" in result.output
 
 
 def test_inbound_posts_to_messages(mocked_cli):


### PR DESCRIPTION
## Summary
- Fixes #134 — `aios connections archive <id>` was silent on success (exit 0, no stdout). Now prints `archived <id>` on the 204, matching `bindings archive` and every other archive/delete verb.
- Completes the PR #130 sweep: that PR added `print_success` to every sibling archive/delete verb based on the #126 P3 enumeration, but `connections archive` wasn't in that list and got missed.

## Test plan
- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 831 passed
- [x] New `test_archive_uses_delete` in `tests/unit/cli/test_cli_connections.py` asserts stdout contains both "archived" and the id (mirrors `test_cli_bindings.py::test_archive_uses_delete`)

Generated with [Claude Code](https://claude.com/claude-code)