### PR TITLE
refactor(cli): rename delete→archive where server soft-archives (#135)

### DIFF
--- a/src/aios/cli/commands/agents.py
+++ b/src/aios/cli/commands/agents.py
@@ -103,8 +103,8 @@ def update(
     run_or_die(_run)
 
 
-@app.command("delete", help="Soft-archive an agent.")
-def delete(ctx: typer.Context, agent_id: str) -> None:
+@app.command("archive", help="Archive an agent (soft-delete, retained for audit).")
+def archive(ctx: typer.Context, agent_id: str) -> None:
     def _run() -> None:
         client = just_client(ctx)
         with client:

--- a/src/aios/cli/commands/envs.py
+++ b/src/aios/cli/commands/envs.py
@@ -101,8 +101,8 @@ def update(
     run_or_die(_run)
 
 
-@app.command("delete", help="Soft-archive an environment.")
-def delete(ctx: typer.Context, env_id: str) -> None:
+@app.command("archive", help="Archive an environment (soft-delete, retained for audit).")
+def archive(ctx: typer.Context, env_id: str) -> None:
     def _run() -> None:
         client = just_client(ctx)
         with client:

--- a/src/aios/cli/commands/skills.py
+++ b/src/aios/cli/commands/skills.py
@@ -84,8 +84,8 @@ def create(
     run_or_die(_run)
 
 
-@app.command("delete", help="Soft-archive a skill.")
-def delete(ctx: typer.Context, skill_id: str) -> None:
+@app.command("archive", help="Archive a skill (soft-delete, retained for audit).")
+def archive(ctx: typer.Context, skill_id: str) -> None:
     def _run() -> None:
         client = just_client(ctx)
         with client:


### PR DESCRIPTION
## Summary

Fixes #135. Three CLI `delete` subcommands were misleadingly named: their server endpoints call `archive_*` handlers (soft-archive, retained for audit), not hard-delete. Rename the CLI verbs to match server semantics and the already-correct `bindings archive` / `rules archive` / `connections archive`.

### Before / after

| CLI | Server handler | Before | After |
|-----|----------------|--------|-------|
| `agents ...`  | `archive_agent`       | `delete` | **`archive`** |
| `skills ...`  | `archive_skill`       | `delete` | **`archive`** |
| `envs ...`    | `archive_environment` | `delete` | **`archive`** |

No aliases, no deprecation shims. v1 CLI has no prior release to preserve.

### Breaking change

This is a breaking CLI change. Scripts calling `aios agents delete`, `aios skills delete`, or `aios envs delete` must switch to `... archive`. Hard-delete verbs elsewhere (`sessions delete`, `vaults delete`, `vaults credentials delete`) are unaffected.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 810 passed
- [x] `uv run aios agents --help` / `skills --help` / `envs --help` show `archive` with the new help text; no `delete` entry
- [x] Exhaustive grep for `agents delete` / `skills delete` / `envs delete` / `environments delete` across `src`, `tests`, `CLAUDE.md`, `README*` returns no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)