### PR TITLE
feat(harness): instrument wake latency (#131)

### DIFF
--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -102,7 +102,7 @@ async def post_message(
     event = await sessions_service.append_user_message(
         pool, resolution.session_id, body.content, metadata=metadata
     )
-    await defer_wake(resolution.session_id, cause="inbound_message")
+    await defer_wake(pool, resolution.session_id, cause="inbound_message")
 
     return InboundMessageResponse(
         session_id=resolution.session_id,

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -65,7 +65,7 @@ async def create(
     )
     if body.initial_message is not None:
         await service.append_user_message(pool, session.id, body.initial_message)
-        await defer_wake(session.id, cause="initial_message")
+        await defer_wake(pool, session.id, cause="initial_message")
         session = await service.get_session(pool, session.id)
     return session
 
@@ -135,7 +135,7 @@ async def post_message(
     event = await service.append_user_message(
         pool, session_id, body.content, metadata=body.metadata or None
     )
-    await defer_wake(session_id, cause="message")
+    await defer_wake(pool, session_id, cause="message")
     return event
 
 
@@ -174,7 +174,7 @@ async def submit_tool_result(
     if body.is_error:
         data["is_error"] = True
     event = await service.append_event(pool, session_id, "message", data)
-    await defer_wake(session_id, cause="custom_tool_result")
+    await defer_wake(pool, session_id, cause="custom_tool_result")
     return event
 
 
@@ -196,7 +196,7 @@ async def submit_tool_confirmation(
     else:
         deny_msg = body.deny_message or "Tool use denied by user."
         event = await service.confirm_tool_deny(pool, session_id, body.tool_call_id, deny_msg)
-    await defer_wake(session_id, cause="tool_confirmation")
+    await defer_wake(pool, session_id, cause="tool_confirmation")
     return event
 
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -84,8 +84,9 @@ async def run_session_step(
         "span",
         {"event": "step_start", "cause": cause},
     )
+    retry_delay: float | None = None
     try:
-        await _run_session_step_body(
+        retry_delay = await _run_session_step_body(
             pool, task_registry, session_id, cause=cause, wake_reason=wake_reason
         )
     finally:
@@ -96,6 +97,15 @@ async def run_session_step(
             {"event": "step_end", "step_start_id": step_start.id},
         )
 
+    # Fire retry deferral AFTER ``step_end`` so its ``wake_deferred`` lands
+    # in step N+1's temporal window, not step N's. Under the "all
+    # wake_deferred since previous step_end" pairing rule, emitting
+    # inside the body would make the reschedule invisible to the next
+    # step's queue-latency calculation — the one path where delay is
+    # a known quantity (the retry backoff).
+    if retry_delay is not None:
+        await defer_retry_wake(pool, session_id, delay_seconds=retry_delay)
+
 
 async def _run_session_step_body(
     pool: asyncpg.Pool[Any],
@@ -104,7 +114,12 @@ async def _run_session_step_body(
     *,
     cause: str,
     wake_reason: str | None,
-) -> None:
+) -> float | None:
+    """Returns the retry backoff delay when the model errored and the
+    outer function should ``defer_retry_wake`` after ``step_end``; ``None``
+    otherwise.  Keeping the actual ``defer_retry_wake`` call outside the
+    body is what makes the reschedule's ``wake_deferred`` land in the
+    next step's temporal window."""
     if cause == "scheduled" and wake_reason:
         await sessions_service.append_event(
             pool,
@@ -121,7 +136,7 @@ async def _run_session_step_body(
     needs = await find_sessions_needing_inference(pool, task_registry, session_id=session_id)
     if session_id not in needs:
         log.debug("step.early_out", session_id=session_id, cause=cause)
-        return
+        return None
 
     session = await sessions_service.get_session(pool, session_id)
 
@@ -170,7 +185,7 @@ async def _run_session_step_body(
             session_id=session_id,
             count=len(pending),
         )
-        return
+        return None
 
     # Span the remainder of the prologue so "why is the step slow?"
     # can separate context-build cost from model-call cost (issue #78).
@@ -291,8 +306,7 @@ async def _run_session_step_body(
                 pool, session_id, "rescheduling", stop_reason={"type": "rescheduling"}
             )
             await _append_lifecycle(pool, session_id, "turn_ended", "rescheduling", "rescheduling")
-            await defer_retry_wake(pool, session_id, delay_seconds=delay)
-            return
+            return delay
 
         await sessions_service.set_session_status(
             pool, session_id, "idle", stop_reason={"type": "error"}
@@ -427,6 +441,7 @@ async def _run_session_step_body(
         )
         await _append_lifecycle(pool, session_id, "turn_ended", "idle", "end_turn")
         log.info("step.turn_ended", session_id=session_id, cause=cause)
+    return None
 
 
 def _switch_channel_tool_spec() -> dict[str, Any]:

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -21,7 +21,7 @@ and proceeds.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from aios.db.sse_lock import has_subscriber
 from aios.harness import runtime
@@ -34,6 +34,11 @@ from aios.logging import get_logger
 from aios.models.agents import ToolSpec
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
+
+if TYPE_CHECKING:
+    import asyncpg
+
+    from aios.harness.task_registry import TaskRegistry
 
 log = get_logger("aios.harness.loop")
 
@@ -68,6 +73,38 @@ async def run_session_step(
     pool = runtime.require_pool()
     task_registry = runtime.require_task_registry()
 
+    # Outermost span pair: brackets the entire step (issue #131).  Emitted
+    # before the sweep guard so early-outs are also measured — a "wasted
+    # wake" cost shows up as a ``step_start``/``step_end`` pair with no
+    # ``context_build_*`` inside.  ``step_start_id`` backpointer on the
+    # end event matches the ``context_build_start_id`` convention.
+    step_start = await sessions_service.append_event(
+        pool,
+        session_id,
+        "span",
+        {"event": "step_start", "cause": cause},
+    )
+    try:
+        await _run_session_step_body(
+            pool, task_registry, session_id, cause=cause, wake_reason=wake_reason
+        )
+    finally:
+        await sessions_service.append_event(
+            pool,
+            session_id,
+            "span",
+            {"event": "step_end", "step_start_id": step_start.id},
+        )
+
+
+async def _run_session_step_body(
+    pool: asyncpg.Pool[Any],
+    task_registry: TaskRegistry,
+    session_id: str,
+    *,
+    cause: str,
+    wake_reason: str | None,
+) -> None:
     if cause == "scheduled" and wake_reason:
         await sessions_service.append_event(
             pool,
@@ -254,7 +291,7 @@ async def run_session_step(
                 pool, session_id, "rescheduling", stop_reason={"type": "rescheduling"}
             )
             await _append_lifecycle(pool, session_id, "turn_ended", "rescheduling", "rescheduling")
-            await defer_retry_wake(session_id, delay_seconds=delay)
+            await defer_retry_wake(pool, session_id, delay_seconds=delay)
             return
 
         await sessions_service.set_session_status(

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -432,5 +432,5 @@ async def wake_sessions_needing_inference(
     await find_and_repair_ghosts(pool, task_registry, session_id=session_id)
     session_ids = await find_sessions_needing_inference(pool, task_registry, session_id=session_id)
     for sid in session_ids:
-        await defer_wake(sid, cause="sweep")
+        await defer_wake(pool, sid, cause="sweep")
     return session_ids

--- a/src/aios/harness/wake.py
+++ b/src/aios/harness/wake.py
@@ -7,15 +7,22 @@ one place without creating a circular ``api → harness`` dependency.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 from procrastinate import exceptions as procrastinate_exceptions
 from procrastinate.types import JSONValue
 
 from aios.logging import get_logger
+from aios.services import sessions as sessions_service
+
+if TYPE_CHECKING:
+    import asyncpg
 
 log = get_logger("aios.harness.wake")
 
 
 async def defer_wake(
+    pool: asyncpg.Pool[Any],
     session_id: str,
     *,
     cause: str = "message",
@@ -32,8 +39,18 @@ async def defer_wake(
     (procrastinate's ``schedule_in``).  ``wake_reason`` is a short string
     carried as a task kwarg and surfaced to the agent at wake time when
     ``cause == "scheduled"``; see ``run_session_step``.
+
+    Appends a ``wake_deferred`` span event before enqueuing — emitted
+    regardless of whether procrastinate coalesces this deferral with
+    an existing queued wake, so the profiler (issue #132) can observe
+    coalescing as N ``wake_deferred`` → 1 ``step_start``.
     """
     from aios.harness.procrastinate_app import app
+
+    span_data: dict[str, Any] = {"event": "wake_deferred", "cause": cause}
+    if delay_seconds is not None:
+        span_data["delay_seconds"] = delay_seconds
+    await sessions_service.append_event(pool, session_id, "span", span_data)
 
     task_kwargs: dict[str, JSONValue] = {"session_id": session_id, "cause": cause}
     if wake_reason is not None:
@@ -58,7 +75,12 @@ async def defer_wake(
         )
 
 
-async def defer_retry_wake(session_id: str, *, delay_seconds: float) -> None:
+async def defer_retry_wake(
+    pool: asyncpg.Pool[Any],
+    session_id: str,
+    *,
+    delay_seconds: float,
+) -> None:
     """Enqueue a delayed ``wake_session`` job for retry after a transient error.
 
     Mirrors :func:`defer_wake` but schedules the job ``delay_seconds``
@@ -68,6 +90,13 @@ async def defer_retry_wake(session_id: str, *, delay_seconds: float) -> None:
     the handler will defer a fresh retry.
     """
     from aios.harness.procrastinate_app import app
+
+    await sessions_service.append_event(
+        pool,
+        session_id,
+        "span",
+        {"event": "wake_deferred", "cause": "reschedule", "delay_seconds": delay_seconds},
+    )
 
     try:
         await app.configure_task(

--- a/src/aios/tools/schedule_wake.py
+++ b/src/aios/tools/schedule_wake.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Any
 
 from aios.errors import AiosError
+from aios.harness import runtime
 from aios.harness.wake import defer_wake
 from aios.tools.registry import registry
 
@@ -78,6 +79,7 @@ async def schedule_wake_handler(session_id: str, arguments: dict[str, Any]) -> d
         raise ScheduleWakeArgumentError("reason must be a non-empty string")
 
     await defer_wake(
+        runtime.require_pool(),
         session_id,
         cause="scheduled",
         delay_seconds=delay_seconds,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -24,6 +24,7 @@ from tests.e2e.harness import Harness
 
 
 async def _noop_defer_wake(
+    pool: Any,
     session_id: str,
     *,
     cause: str = "message",
@@ -33,7 +34,7 @@ async def _noop_defer_wake(
     pass
 
 
-async def _noop_defer_retry_wake(session_id: str, *, delay_seconds: float) -> None:
+async def _noop_defer_retry_wake(pool: Any, session_id: str, *, delay_seconds: float) -> None:
     pass
 
 

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -200,7 +200,7 @@ class TestRunSessionStepOnModelError:
         ):
             await run_session_step("sess_x")
 
-        mock_step_dependencies.defer_retry.assert_awaited_once_with("sess_x", delay_seconds=2)
+        mock_step_dependencies.defer_retry.assert_awaited_once_with(ANY, "sess_x", delay_seconds=2)
         status_calls = [call.args[2] for call in mock_step_dependencies.set_status.call_args_list]
         assert "rescheduling" in status_calls
         assert "idle" not in status_calls

--- a/tests/unit/test_schedule_wake_handler.py
+++ b/tests/unit/test_schedule_wake_handler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
@@ -11,6 +11,16 @@ from aios.tools.schedule_wake import (
     ScheduleWakeArgumentError,
     schedule_wake_handler,
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_runtime_pool(monkeypatch: Any) -> None:
+    """Stub the worker-only runtime pool so ``defer_wake``'s new pool
+    argument (issue #131) resolves without a live worker_main context."""
+    monkeypatch.setattr(
+        "aios.tools.schedule_wake.runtime.require_pool",
+        lambda: MagicMock(),
+    )
 
 
 class TestScheduleWakeHandler:
@@ -24,6 +34,7 @@ class TestScheduleWakeHandler:
         )
 
         mock_defer.assert_awaited_once_with(
+            ANY,
             "sess_01TEST",
             cause="scheduled",
             delay_seconds=30,

--- a/tests/unit/test_scheduled_wake_marker.py
+++ b/tests/unit/test_scheduled_wake_marker.py
@@ -8,15 +8,27 @@ agent never actually gets a step at T+delay.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aios.harness.loop import run_session_step
 
 
+def _message_appends(append_event: AsyncMock) -> list[tuple[Any, ...]]:
+    """Extract positional args of ``append_event`` calls with ``kind == 'message'``.
+
+    ``run_session_step`` now wraps its body in ``step_start``/``step_end``
+    span appends (issue #131), so a raw ``await_count`` check is no longer
+    the right assertion.  Filter to the ``message`` kind to focus on the
+    scheduled-wake marker specifically.
+    """
+    return [call.args for call in append_event.await_args_list if call.args[2] == "message"]
+
+
 class TestScheduledWakeMarker:
     async def test_marker_appended_before_sweep_for_scheduled_wake(self) -> None:
-        append_event = AsyncMock()
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_x"))
         with (
             patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
             patch(
@@ -34,10 +46,9 @@ class TestScheduledWakeMarker:
         ):
             await run_session_step("sess_x", cause="scheduled", wake_reason="ping home")
 
-        assert append_event.await_count == 1
-        call = append_event.await_args
-        assert call is not None
-        args, _ = call.args, call.kwargs
+        messages = _message_appends(append_event)
+        assert len(messages) == 1
+        args = messages[0]
         assert args[2] == "message"
         assert args[3] == {
             "role": "user",
@@ -45,7 +56,7 @@ class TestScheduledWakeMarker:
         }
 
     async def test_no_marker_for_non_scheduled_causes(self) -> None:
-        append_event = AsyncMock()
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_x"))
         with (
             patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
             patch(
@@ -65,11 +76,11 @@ class TestScheduledWakeMarker:
             await run_session_step("sess_x", cause="reschedule", wake_reason=None)
             await run_session_step("sess_x", cause="tool_result", wake_reason=None)
 
-        append_event.assert_not_awaited()
+        assert _message_appends(append_event) == []
 
     async def test_scheduled_cause_without_reason_is_noop(self) -> None:
         """Defensive: ``cause="scheduled"`` with no reason attached doesn't inject noise."""
-        append_event = AsyncMock()
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_x"))
         with (
             patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
             patch(
@@ -87,7 +98,7 @@ class TestScheduledWakeMarker:
         ):
             await run_session_step("sess_x", cause="scheduled", wake_reason=None)
 
-        append_event.assert_not_awaited()
+        assert _message_appends(append_event) == []
 
 
 class TestDeferWakeExtension:
@@ -103,10 +114,13 @@ class TestDeferWakeExtension:
         from aios.harness.procrastinate_app import app
         from aios.harness.wake import defer_wake
 
+        monkeypatch.setattr("aios.harness.wake.sessions_service.append_event", AsyncMock())
+
         patched: App
         with app.replace_connector(InMemoryConnector()) as patched:
             before = datetime.now(UTC)
             await defer_wake(
+                MagicMock(),
                 "sess_x",
                 cause="scheduled",
                 delay_seconds=42,
@@ -127,14 +141,16 @@ class TestDeferWakeExtension:
                 <= after + timedelta(seconds=42)
             )
 
-    async def test_defer_wake_without_delay_is_immediate(self) -> None:
+    async def test_defer_wake_without_delay_is_immediate(self, monkeypatch: Any) -> None:
         from procrastinate.testing import InMemoryConnector
 
         from aios.harness.procrastinate_app import app
         from aios.harness.wake import defer_wake
 
+        monkeypatch.setattr("aios.harness.wake.sessions_service.append_event", AsyncMock())
+
         with app.replace_connector(InMemoryConnector()) as patched:
-            await defer_wake("sess_x", cause="message")
+            await defer_wake(MagicMock(), "sess_x", cause="message")
 
             (job,) = patched.connector.jobs.values()
             assert job["scheduled_at"] is None

--- a/tests/unit/test_wake.py
+++ b/tests/unit/test_wake.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from procrastinate import App
@@ -20,10 +21,19 @@ async def in_memory_app() -> AsyncIterator[App]:
         yield patched
 
 
+@pytest.fixture(autouse=True)
+def mock_append_event() -> AsyncIterator[AsyncMock]:
+    """Patch ``sessions_service.append_event`` so ``wake_deferred`` span
+    emission doesn't require a real DB connection (issue #131)."""
+    mock = AsyncMock()
+    with patch("aios.harness.wake.sessions_service.append_event", mock):
+        yield mock
+
+
 class TestDeferRetryWake:
     async def test_schedules_job_delay_seconds_in_future(self, in_memory_app: App) -> None:
         before = datetime.now(UTC)
-        await defer_retry_wake("sess_x", delay_seconds=5)
+        await defer_retry_wake(MagicMock(), "sess_x", delay_seconds=5)
         after = datetime.now(UTC)
 
         (job,) = in_memory_app.connector.jobs.values()
@@ -31,18 +41,32 @@ class TestDeferRetryWake:
         assert before + timedelta(seconds=5) <= job["scheduled_at"] <= after + timedelta(seconds=5)
 
     async def test_does_not_leak_schedule_in_into_task_args(self, in_memory_app: App) -> None:
-        await defer_retry_wake("sess_x", delay_seconds=5)
+        await defer_retry_wake(MagicMock(), "sess_x", delay_seconds=5)
 
         (job,) = in_memory_app.connector.jobs.values()
         assert job["args"] == {"session_id": "sess_x", "cause": "reschedule"}
 
     async def test_targets_wake_session_task(self, in_memory_app: App) -> None:
-        await defer_retry_wake("sess_x", delay_seconds=5)
+        await defer_retry_wake(MagicMock(), "sess_x", delay_seconds=5)
 
         (job,) = in_memory_app.connector.jobs.values()
         assert job["task_name"] == "harness.wake_session"
 
     async def test_swallows_already_enqueued(self, in_memory_app: App) -> None:
-        await defer_retry_wake("sess_x", delay_seconds=5)
-        await defer_retry_wake("sess_x", delay_seconds=5)
+        await defer_retry_wake(MagicMock(), "sess_x", delay_seconds=5)
+        await defer_retry_wake(MagicMock(), "sess_x", delay_seconds=5)
         assert len(in_memory_app.connector.jobs) == 1
+
+    async def test_emits_wake_deferred_span_event(
+        self, in_memory_app: App, mock_append_event: AsyncMock
+    ) -> None:
+        """Every deferral emits a ``wake_deferred`` span carrying cause and delay."""
+        pool = MagicMock()
+        await defer_retry_wake(pool, "sess_x", delay_seconds=5)
+
+        mock_append_event.assert_awaited_once_with(
+            pool,
+            "sess_x",
+            "span",
+            {"event": "wake_deferred", "cause": "reschedule", "delay_seconds": 5},
+        )

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -141,8 +141,13 @@ class TestStepStartEndSpans:
         end = append_event.await_args_list[-1].args[3]
         assert end == {"event": "step_end", "step_start_id": "ev_step"}
 
-    async def test_step_end_on_model_error_reschedule(self) -> None:
-        """Exception path (model error + retry) must not skip ``step_end``."""
+    async def test_reschedule_defers_wake_after_step_end(self) -> None:
+        """On the model-error retry path, ``defer_retry_wake`` must fire AFTER
+        ``step_end`` so its ``wake_deferred`` lands in step N+1's temporal
+        window, not step N's.  Under the "all wake_deferred since previous
+        step_end" pairing rule, the reverse ordering would make the
+        reschedule invisible to the next step's queue-latency calculation —
+        the one path where delay is a known quantity (the backoff)."""
         from aios.harness.loop import run_session_step
 
         session = SimpleNamespace(
@@ -159,7 +164,12 @@ class TestStepStartEndSpans:
             window_max=10000,
         )
         start_event = SimpleNamespace(id="ev_step")
+
+        manager = MagicMock()
         append_event = AsyncMock(return_value=start_event)
+        defer_retry = AsyncMock()
+        manager.attach_mock(append_event, "append_event")
+        manager.attach_mock(defer_retry, "defer_retry")
 
         with (
             patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
@@ -209,7 +219,7 @@ class TestStepStartEndSpans:
                 "aios.harness.loop.stream_litellm",
                 AsyncMock(side_effect=RuntimeError("provider boom")),
             ),
-            patch("aios.harness.loop.defer_retry_wake", AsyncMock()),
+            patch("aios.harness.loop.defer_retry_wake", defer_retry),
             patch(
                 "aios.harness.loop._count_consecutive_rescheduling",
                 AsyncMock(return_value=0),
@@ -220,9 +230,114 @@ class TestStepStartEndSpans:
         span_names = _span_event_names(append_event)
         assert span_names[0] == "step_start"
         assert span_names[-1] == "step_end"
-        # The inner pairs still fire in their normal order
         assert "context_build_start" in span_names
         assert "model_request_end" in span_names
+
+        call_names = [c[0] for c in manager.mock_calls]
+        last_append = max(
+            i
+            for i, (name, args, _kw) in enumerate(manager.mock_calls)
+            if name == "append_event" and args[2] == "span" and args[3].get("event") == "step_end"
+        )
+        first_defer = call_names.index("defer_retry")
+        assert first_defer > last_append, (
+            f"defer_retry_wake must be called after step_end; "
+            f"got step_end at {last_append}, defer_retry at {first_defer}"
+        )
+
+    async def test_happy_path_span_ordering(self) -> None:
+        """Regression fence: on a clean end-turn, spans nest in the expected order."""
+        from aios.harness.loop import run_session_step
+
+        session = SimpleNamespace(
+            id="sess_x", agent_id="agt_x", agent_version=None, focal_channel=None
+        )
+        agent = SimpleNamespace(
+            model="openrouter/x",
+            tools=[],
+            mcp_servers=[],
+            skills=[],
+            system="sys",
+            litellm_extra={},
+            window_min=1000,
+            window_max=10000,
+        )
+        start_event = SimpleNamespace(id="ev_step")
+
+        with (
+            patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+            patch(
+                "aios.harness.loop.runtime.require_task_registry",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(return_value={"sess_x"}),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.get_session",
+                AsyncMock(return_value=session),
+            ),
+            patch(
+                "aios.harness.loop.agents_service.get_agent",
+                AsyncMock(return_value=agent),
+            ),
+            patch(
+                "aios.harness.channels.list_bindings_and_connections",
+                AsyncMock(return_value=([], [])),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.read_windowed_events",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "aios.harness.loop._dispatch_confirmed_tools",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "aios.harness.loop.compose_step_context",
+                AsyncMock(
+                    return_value=SimpleNamespace(
+                        model="openrouter/x",
+                        messages=[],
+                        tools=[],
+                        reacting_to=0,
+                        skill_versions=[],
+                    )
+                ),
+            ),
+            patch("aios.harness.loop.sessions_service.set_session_status", AsyncMock()),
+            patch(
+                "aios.harness.loop.sessions_service.append_event",
+                AsyncMock(return_value=start_event),
+            ) as append_event,
+            patch(
+                "aios.harness.loop.call_litellm",
+                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+            ),
+            patch(
+                "aios.harness.loop.stream_litellm",
+                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.increment_usage",
+                AsyncMock(),
+            ),
+            patch(
+                "aios.db.sse_lock.has_subscriber",
+                AsyncMock(return_value=False),
+            ),
+        ):
+            await run_session_step("sess_x")
+
+        assert _span_event_names(append_event) == [
+            "step_start",
+            "context_build_start",
+            "context_build_end",
+            "model_request_start",
+            "model_request_end",
+            "step_end",
+        ]
 
     async def test_step_end_emitted_when_body_raises(self) -> None:
         """If the body raises past the retry budget, ``step_end`` still fires."""

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -1,0 +1,305 @@
+"""Unit tests for wake-latency instrumentation (issue #131).
+
+Covers:
+
+- ``wake_deferred`` span event emitted inside ``defer_wake`` on every
+  deferral, including coalesced calls (``AlreadyEnqueued``).
+- ``step_start``/``step_end`` span pair bracketing ``run_session_step``
+  on all exit paths: sweep early-out, end-turn, model-error reschedule.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from procrastinate import App
+from procrastinate.testing import InMemoryConnector
+
+
+@pytest.fixture
+async def in_memory_app() -> AsyncIterator[App]:
+    from aios.harness.procrastinate_app import app
+
+    with app.replace_connector(InMemoryConnector()) as patched:
+        yield patched
+
+
+class TestWakeDeferredEvent:
+    async def test_defer_wake_emits_span_with_cause(self, in_memory_app: App) -> None:
+        from aios.harness.wake import defer_wake
+
+        mock_append = AsyncMock()
+        pool = MagicMock()
+        with patch("aios.harness.wake.sessions_service.append_event", mock_append):
+            await defer_wake(pool, "sess_x", cause="message")
+
+        mock_append.assert_awaited_once_with(
+            pool,
+            "sess_x",
+            "span",
+            {"event": "wake_deferred", "cause": "message"},
+        )
+
+    async def test_defer_wake_span_carries_delay_when_scheduled(self, in_memory_app: App) -> None:
+        from aios.harness.wake import defer_wake
+
+        mock_append = AsyncMock()
+        pool = MagicMock()
+        with patch("aios.harness.wake.sessions_service.append_event", mock_append):
+            await defer_wake(pool, "sess_x", cause="scheduled", delay_seconds=30, wake_reason="r")
+
+        mock_append.assert_awaited_once_with(
+            pool,
+            "sess_x",
+            "span",
+            {"event": "wake_deferred", "cause": "scheduled", "delay_seconds": 30},
+        )
+
+    async def test_defer_wake_emits_span_even_when_coalesced(self, in_memory_app: App) -> None:
+        """N deferrals must all emit ``wake_deferred``, even if procrastinate
+        coalesces them — the profiler observes coalescing as N deferred → 1 step."""
+        from aios.harness.wake import defer_wake
+
+        mock_append = AsyncMock()
+        pool = MagicMock()
+        with patch("aios.harness.wake.sessions_service.append_event", mock_append):
+            await defer_wake(pool, "sess_x", cause="message")
+            await defer_wake(pool, "sess_x", cause="sweep")
+            await defer_wake(pool, "sess_x", cause="tool_confirmation")
+
+        assert mock_append.await_count == 3
+        causes = [call.args[3]["cause"] for call in mock_append.await_args_list]
+        assert causes == ["message", "sweep", "tool_confirmation"]
+        # Procrastinate coalesced 2/3 but the third cause still wrote its span.
+        assert len(in_memory_app.connector.jobs) == 1
+
+    async def test_defer_retry_wake_emits_reschedule_span(self, in_memory_app: App) -> None:
+        from aios.harness.wake import defer_retry_wake
+
+        mock_append = AsyncMock()
+        pool = MagicMock()
+        with patch("aios.harness.wake.sessions_service.append_event", mock_append):
+            await defer_retry_wake(pool, "sess_x", delay_seconds=2)
+
+        mock_append.assert_awaited_once_with(
+            pool,
+            "sess_x",
+            "span",
+            {"event": "wake_deferred", "cause": "reschedule", "delay_seconds": 2},
+        )
+
+
+# ─── step_start / step_end span pair ─────────────────────────────────────────
+
+
+def _span_event_names(append_event: AsyncMock) -> list[str]:
+    """Extract the ``event`` field of every span append, in order."""
+    return [
+        call.args[3]["event"] for call in append_event.await_args_list if call.args[2] == "span"
+    ]
+
+
+@pytest.fixture
+def mock_runtime() -> Iterator[None]:
+    """Pool/registry globals aren't set outside a worker_main context."""
+    with (
+        patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+        patch(
+            "aios.harness.loop.runtime.require_task_registry",
+            return_value=MagicMock(),
+        ),
+    ):
+        yield
+
+
+class TestStepStartEndSpans:
+    async def test_sweep_early_out_still_emits_pair(self, mock_runtime: None) -> None:
+        """Early-out from the sweep guard is a "wasted wake" — must still
+        emit ``step_start``/``step_end`` so the profiler sees the cost."""
+        from aios.harness.loop import run_session_step
+
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_step"))
+        with (
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(return_value=set()),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.append_event",
+                append_event,
+            ),
+        ):
+            await run_session_step("sess_x", cause="message")
+
+        assert _span_event_names(append_event) == ["step_start", "step_end"]
+        # step_end must reference step_start by id
+        start_id = append_event.await_args_list[0].args[3]
+        assert start_id == {"event": "step_start", "cause": "message"}
+        end = append_event.await_args_list[-1].args[3]
+        assert end == {"event": "step_end", "step_start_id": "ev_step"}
+
+    async def test_step_end_on_model_error_reschedule(self) -> None:
+        """Exception path (model error + retry) must not skip ``step_end``."""
+        from aios.harness.loop import run_session_step
+
+        session = SimpleNamespace(
+            id="sess_x", agent_id="agt_x", agent_version=None, focal_channel=None
+        )
+        agent = SimpleNamespace(
+            model="openrouter/x",
+            tools=[],
+            mcp_servers=[],
+            skills=[],
+            system="sys",
+            litellm_extra={},
+            window_min=1000,
+            window_max=10000,
+        )
+        start_event = SimpleNamespace(id="ev_step")
+        append_event = AsyncMock(return_value=start_event)
+
+        with (
+            patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+            patch(
+                "aios.harness.loop.runtime.require_task_registry",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(return_value={"sess_x"}),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.get_session",
+                AsyncMock(return_value=session),
+            ),
+            patch(
+                "aios.harness.loop.agents_service.get_agent",
+                AsyncMock(return_value=agent),
+            ),
+            patch(
+                "aios.harness.channels.list_bindings_and_connections",
+                AsyncMock(return_value=([], [])),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.read_windowed_events",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "aios.harness.loop._dispatch_confirmed_tools",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "aios.harness.loop.compose_step_context",
+                AsyncMock(
+                    return_value=SimpleNamespace(
+                        model="openrouter/x",
+                        messages=[],
+                        tools=[],
+                        reacting_to=0,
+                        skill_versions=[],
+                    )
+                ),
+            ),
+            patch("aios.harness.loop.sessions_service.set_session_status", AsyncMock()),
+            patch("aios.harness.loop.sessions_service.append_event", append_event),
+            patch(
+                "aios.harness.loop.stream_litellm",
+                AsyncMock(side_effect=RuntimeError("provider boom")),
+            ),
+            patch("aios.harness.loop.defer_retry_wake", AsyncMock()),
+            patch(
+                "aios.harness.loop._count_consecutive_rescheduling",
+                AsyncMock(return_value=0),
+            ),
+        ):
+            await run_session_step("sess_x")
+
+        span_names = _span_event_names(append_event)
+        assert span_names[0] == "step_start"
+        assert span_names[-1] == "step_end"
+        # The inner pairs still fire in their normal order
+        assert "context_build_start" in span_names
+        assert "model_request_end" in span_names
+
+    async def test_step_end_emitted_when_body_raises(self) -> None:
+        """If the body raises past the retry budget, ``step_end`` still fires."""
+        from aios.harness.loop import run_session_step
+
+        session = SimpleNamespace(
+            id="sess_x", agent_id="agt_x", agent_version=None, focal_channel=None
+        )
+        agent = SimpleNamespace(
+            model="openrouter/x",
+            tools=[],
+            mcp_servers=[],
+            skills=[],
+            system="sys",
+            litellm_extra={},
+            window_min=1000,
+            window_max=10000,
+        )
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_step"))
+
+        with (
+            patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+            patch(
+                "aios.harness.loop.runtime.require_task_registry",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(return_value={"sess_x"}),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.get_session",
+                AsyncMock(return_value=session),
+            ),
+            patch(
+                "aios.harness.loop.agents_service.get_agent",
+                AsyncMock(return_value=agent),
+            ),
+            patch(
+                "aios.harness.channels.list_bindings_and_connections",
+                AsyncMock(return_value=([], [])),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.read_windowed_events",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "aios.harness.loop._dispatch_confirmed_tools",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "aios.harness.loop.compose_step_context",
+                AsyncMock(
+                    return_value=SimpleNamespace(
+                        model="openrouter/x",
+                        messages=[],
+                        tools=[],
+                        reacting_to=0,
+                        skill_versions=[],
+                    )
+                ),
+            ),
+            patch("aios.harness.loop.sessions_service.set_session_status", AsyncMock()),
+            patch("aios.harness.loop.sessions_service.append_event", append_event),
+            patch(
+                "aios.harness.loop.stream_litellm",
+                AsyncMock(side_effect=RuntimeError("provider boom")),
+            ),
+            patch("aios.harness.loop.defer_retry_wake", AsyncMock()),
+            patch(
+                "aios.harness.loop._count_consecutive_rescheduling",
+                AsyncMock(return_value=4),  # budget exhausted — re-raises
+            ),
+            pytest.raises(RuntimeError, match="provider boom"),
+        ):
+            await run_session_step("sess_x")
+
+        span_names = _span_event_names(append_event)
+        assert span_names[0] == "step_start"
+        assert span_names[-1] == "step_end"

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -27,6 +27,35 @@ async def in_memory_app() -> AsyncIterator[App]:
         yield patched
 
 
+class TestE2EConftestMockSignatures:
+    """The e2e conftest installs no-op mocks in place of ``defer_wake`` and
+    ``defer_retry_wake``.  If the mocks' signatures drift from the real
+    functions', every e2e test crashes with ``TypeError`` at the first
+    deferral.  This is exactly what happened when PR #138 added ``pool`` as
+    the first positional arg but forgot to update the conftest — catch
+    future drift with a signature-equality assertion."""
+
+    def test_noop_defer_wake_matches_real_defer_wake(self) -> None:
+        import inspect
+
+        from aios.harness.wake import defer_wake
+        from tests.e2e.conftest import _noop_defer_wake
+
+        real_params = list(inspect.signature(defer_wake).parameters.keys())
+        mock_params = list(inspect.signature(_noop_defer_wake).parameters.keys())
+        assert real_params == mock_params
+
+    def test_noop_defer_retry_wake_matches_real(self) -> None:
+        import inspect
+
+        from aios.harness.wake import defer_retry_wake
+        from tests.e2e.conftest import _noop_defer_retry_wake
+
+        real_params = list(inspect.signature(defer_retry_wake).parameters.keys())
+        mock_params = list(inspect.signature(_noop_defer_retry_wake).parameters.keys())
+        assert real_params == mock_params
+
+
 class TestWakeDeferredEvent:
     async def test_defer_wake_emits_span_with_cause(self, in_memory_app: App) -> None:
         from aios.harness.wake import defer_wake


### PR DESCRIPTION
## Summary

- Add `wake_deferred` span event inside `defer_wake` / `defer_retry_wake` — one emit site covers all 7 call sites, emitted before procrastinate enqueue so coalesced deferrals are still visible (profiler observes coalescing as N `wake_deferred` → 1 `step_start`).
- Add `step_start` / `step_end` outermost span pair wrapping `run_session_step`, with `step_start_id` backpointer matching the existing convention. Covers all exit paths via `try/finally`, including sweep-guard early-outs ("wasted wake" visibility).
- Pairing is temporal (no correlation id) — the profiler (#132) considers all `wake_deferred` since the previous `step_end` and computes `queue_latency = step_start.ts − min(wake_deferred.ts)`.

## Why

Profiling a live JN session (509 wakes) showed 7–11s inter-span gaps per turn with no user input. The emit→consume handoff across the procrastinate job boundary — sweep SQL, enqueue, dequeue, entry-sweep SQL — was unmeasured. Makes "is the agent bottlenecked on inference or orchestration?" fully answerable.

Closes #131. Feeds the event stream that #132 (CLI profiler) will consume.

## Deliberately out of scope

- `sweep_start`/`sweep_end` around `wake_sessions_needing_inference`. The two sweep invocations per wake cycle are captured as dead time within `step_start → context_build_start` and the pre-`wake_deferred` gap. Decompose later if the coarse picture identifies sweep as the bottleneck.
- Analyzer UI (issue #132).

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 839 passed (7 new in `test_wake_instrumentation.py`)
- [ ] Manual smoke: run a short multi-turn chat and inspect `aios sessions events <sid> --kind span` — expect ordering `wake_deferred` → `step_start` → `context_build_*` → `model_request_*` → `step_end` per step.
- [ ] E2E: `DOCKER_HOST=... uv run pytest tests/e2e -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)