### PR TITLE
feat(harness): instrument sweep SQL with sweep_* spans (#139)

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -133,7 +133,33 @@ async def _run_session_step_body(
 
     # Sweep-based guard: does this session actually need work?
     # Prevents wasted DB/model calls from stale or duplicate wakes.
-    needs = await find_sessions_needing_inference(pool, task_registry, session_id=session_id)
+    #
+    # Bracket with a ``sweep_start``/``sweep_end`` span pair (site="entry").
+    # Only ``find_sessions_needing_inference`` runs here — no ghost repair,
+    # no ``defer_wake`` — so ``repaired_ghosts`` is always 0. ``woken_sessions``
+    # at ``site="entry"`` is 0 or 1: it records whether the guard determined
+    # this specific session had work. 0 indicates a wasted wake.
+    sweep_start = await sessions_service.append_event(
+        pool,
+        session_id,
+        "span",
+        {"event": "sweep_start", "site": "entry"},
+    )
+    needs: set[str] = set()
+    try:
+        needs = await find_sessions_needing_inference(pool, task_registry, session_id=session_id)
+    finally:
+        await sessions_service.append_event(
+            pool,
+            session_id,
+            "span",
+            {
+                "event": "sweep_end",
+                "sweep_start_id": sweep_start.id,
+                "repaired_ghosts": 0,
+                "woken_sessions": 1 if session_id in needs else 0,
+            },
+        )
     if session_id not in needs:
         log.debug("step.early_out", session_id=session_id, cause=cause)
         return None

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -20,6 +20,7 @@ Called from three sites:
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import asyncpg
@@ -33,6 +34,21 @@ from aios.logging import get_logger
 from aios.services import sessions as sessions_service
 
 log = get_logger("aios.harness.sweep")
+
+
+@dataclass(frozen=True, slots=True)
+class SweepResult:
+    """Return value of :func:`wake_sessions_needing_inference`.
+
+    Exposes both counts so the tail-site sweep span can stamp them on
+    ``sweep_end`` without unrolling the composition. ``woken_sessions``
+    is the number of procrastinate wakes deferred; ``repaired_ghosts``
+    is the number of synthetic tool-error events appended during ghost
+    repair.
+    """
+
+    repaired_ghosts: int
+    woken_sessions: int
 
 
 # ─── ghost repair ────────────────────────────────────────────────────────────
@@ -420,17 +436,19 @@ async def wake_sessions_needing_inference(
     task_registry: TaskRegistry,
     *,
     session_id: str | None = None,
-) -> set[str]:
+) -> SweepResult:
     """The main sweep function.
 
     1. Repairs ghosts (appends synthetic error results).
     2. Finds sessions needing inference.
     3. Defers procrastinate wakes for those sessions.
 
-    Returns the set of session IDs that were woken.
+    Returns a :class:`SweepResult` carrying the repaired-ghost count and
+    the number of procrastinate wakes deferred, so the tail-site
+    ``sweep_end`` span can stamp both without unrolling the composition.
     """
-    await find_and_repair_ghosts(pool, task_registry, session_id=session_id)
-    session_ids = await find_sessions_needing_inference(pool, task_registry, session_id=session_id)
-    for sid in session_ids:
+    repaired = await find_and_repair_ghosts(pool, task_registry, session_id=session_id)
+    woken = await find_sessions_needing_inference(pool, task_registry, session_id=session_id)
+    for sid in woken:
         await defer_wake(pool, sid, cause="sweep")
-    return session_ids
+    return SweepResult(repaired_ghosts=len(repaired), woken_sessions=len(woken))

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -273,15 +273,41 @@ async def _trigger_sweep(
 ) -> None:
     """Run the sweep for this session. Called from the finally block of
     every tool task — both built-in and MCP.
-    """
-    try:
-        from aios.harness.sweep import wake_sessions_needing_inference
 
-        await wake_sessions_needing_inference(
-            pool, runtime.require_task_registry(), session_id=session_id
+    Brackets the sweep with a ``sweep_start``/``sweep_end`` span pair
+    (``site="tail"``). The tail site exercises the full composite sweep
+    (ghost repair + find + defer), so ``sweep_end`` carries the real
+    ``repaired_ghosts`` and ``woken_sessions`` counts from
+    :class:`SweepResult`.
+    """
+    from aios.harness.sweep import SweepResult, wake_sessions_needing_inference
+
+    sweep_start = await sessions_service.append_event(
+        pool,
+        session_id,
+        "span",
+        {"event": "sweep_start", "site": "tail"},
+    )
+    result = SweepResult(repaired_ghosts=0, woken_sessions=0)
+    try:
+        try:
+            result = await wake_sessions_needing_inference(
+                pool, runtime.require_task_registry(), session_id=session_id
+            )
+        except Exception:
+            bound_log.warning("tool.sweep_failed")
+    finally:
+        await sessions_service.append_event(
+            pool,
+            session_id,
+            "span",
+            {
+                "event": "sweep_end",
+                "sweep_start_id": sweep_start.id,
+                "repaired_ghosts": result.repaired_ghosts,
+                "woken_sessions": result.woken_sessions,
+            },
         )
-    except Exception:
-        bound_log.warning("tool.sweep_failed")
 
 
 # ── MCP tool dispatch ─────────────────────────────────────────────────────────

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -273,12 +273,6 @@ async def _trigger_sweep(
 ) -> None:
     """Run the sweep for this session. Called from the finally block of
     every tool task — both built-in and MCP.
-
-    Brackets the sweep with a ``sweep_start``/``sweep_end`` span pair
-    (``site="tail"``). The tail site exercises the full composite sweep
-    (ghost repair + find + defer), so ``sweep_end`` carries the real
-    ``repaired_ghosts`` and ``woken_sessions`` counts from
-    :class:`SweepResult`.
     """
     from aios.harness.sweep import SweepResult, wake_sessions_needing_inference
 

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -77,9 +77,13 @@ async def worker_main() -> None:
 
     try:
         # Startup sweep: repair ghosts and wake sessions needing inference.
-        woken = await wake_sessions_needing_inference(pool, task_registry)
-        if woken:
-            log.info("worker.startup_sweep", woken=len(woken))
+        sweep = await wake_sessions_needing_inference(pool, task_registry)
+        if sweep.woken_sessions or sweep.repaired_ghosts:
+            log.info(
+                "worker.startup_sweep",
+                woken=sweep.woken_sessions,
+                repaired_ghosts=sweep.repaired_ghosts,
+            )
 
         # Reap orphaned sandbox containers.
         async with pool.acquire() as conn:
@@ -128,8 +132,12 @@ async def _periodic_sweep(
     while True:
         await asyncio.sleep(interval)
         try:
-            woken = await wake_sessions_needing_inference(pool, task_registry)
-            if woken:
-                log.info("periodic_sweep.woken", count=len(woken))
+            sweep = await wake_sessions_needing_inference(pool, task_registry)
+            if sweep.woken_sessions or sweep.repaired_ghosts:
+                log.info(
+                    "periodic_sweep.woken",
+                    count=sweep.woken_sessions,
+                    repaired_ghosts=sweep.repaired_ghosts,
+                )
         except Exception:
             log.exception("periodic_sweep.failed")

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -1,0 +1,286 @@
+"""Unit tests for sweep-SQL instrumentation (issue #139, prereq for #132).
+
+Covers:
+
+- ``sweep_start``/``sweep_end`` span pair at the **tail site**
+  (``_trigger_sweep`` in ``tool_dispatch``), with real ``repaired_ghosts``
+  and ``woken_sessions`` counts from :class:`SweepResult`.
+- Same pair at the **entry site** (``_run_session_step_body`` guard),
+  where ``repaired_ghosts`` is always 0 and ``woken_sessions`` is 0 or 1
+  (load-bearing: 0 marks a wasted wake).
+- ``sweep_end`` fires on exception via ``try/finally``.
+- The periodic "all"-scope sweep in ``worker._periodic_sweep`` does
+  **not** emit a sweep span — spans are per-session and the periodic
+  sweep scans across sessions, so its instrumentation is deferred.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _span_events(append_event: AsyncMock) -> list[dict[str, object]]:
+    """Extract every span payload (the 4th positional arg) in order."""
+    return [call.args[3] for call in append_event.await_args_list if call.args[2] == "span"]
+
+
+def _sweep_events(append_event: AsyncMock) -> list[dict[str, object]]:
+    return [
+        payload
+        for payload in _span_events(append_event)
+        if payload.get("event", "").startswith("sweep_")
+    ]
+
+
+# ─── tail site (tool_dispatch._trigger_sweep) ────────────────────────────────
+
+
+class TestTailSweepSpan:
+    async def test_emits_pair_with_counts_from_sweep_result(self) -> None:
+        from aios.harness.sweep import SweepResult
+        from aios.harness.tool_dispatch import _trigger_sweep
+
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_sweep"))
+        wake_mock = AsyncMock(return_value=SweepResult(repaired_ghosts=2, woken_sessions=5))
+
+        with (
+            patch("aios.harness.tool_dispatch.sessions_service.append_event", append_event),
+            patch(
+                "aios.harness.tool_dispatch.runtime.require_task_registry", return_value=MagicMock()
+            ),
+            patch("aios.harness.sweep.wake_sessions_needing_inference", wake_mock),
+        ):
+            await _trigger_sweep(MagicMock(), "sess_x", MagicMock())
+
+        sweep_events = _sweep_events(append_event)
+        assert [e["event"] for e in sweep_events] == ["sweep_start", "sweep_end"]
+        assert sweep_events[0] == {"event": "sweep_start", "site": "tail"}
+        assert sweep_events[1] == {
+            "event": "sweep_end",
+            "sweep_start_id": "ev_sweep",
+            "repaired_ghosts": 2,
+            "woken_sessions": 5,
+        }
+
+    async def test_sweep_end_fires_when_sweep_raises(self) -> None:
+        """``_trigger_sweep`` catches and logs sweep failures, so the pair
+        still closes cleanly — but the counts fall back to zero because
+        no ``SweepResult`` was produced."""
+        from aios.harness.tool_dispatch import _trigger_sweep
+
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_sweep"))
+        wake_mock = AsyncMock(side_effect=RuntimeError("db down"))
+        bound_log = MagicMock()
+
+        with (
+            patch("aios.harness.tool_dispatch.sessions_service.append_event", append_event),
+            patch(
+                "aios.harness.tool_dispatch.runtime.require_task_registry", return_value=MagicMock()
+            ),
+            patch("aios.harness.sweep.wake_sessions_needing_inference", wake_mock),
+        ):
+            await _trigger_sweep(MagicMock(), "sess_x", bound_log)
+
+        sweep_events = _sweep_events(append_event)
+        assert [e["event"] for e in sweep_events] == ["sweep_start", "sweep_end"]
+        assert sweep_events[1]["repaired_ghosts"] == 0
+        assert sweep_events[1]["woken_sessions"] == 0
+        bound_log.warning.assert_called_once_with("tool.sweep_failed")
+
+
+# ─── entry site (loop._run_session_step_body guard) ──────────────────────────
+
+
+@pytest.fixture
+def mock_runtime() -> Iterator[None]:
+    with (
+        patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+        patch(
+            "aios.harness.loop.runtime.require_task_registry",
+            return_value=MagicMock(),
+        ),
+    ):
+        yield
+
+
+class TestEntrySweepSpan:
+    async def test_wasted_wake_marks_woken_sessions_zero(self, mock_runtime: None) -> None:
+        """Guard early-out: find_sessions_needing_inference returns empty set.
+        ``sweep_end`` stamps ``woken_sessions=0`` — the profiler's wasted-wake signal.
+        """
+        from aios.harness.loop import run_session_step
+
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_sweep"))
+        with (
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(return_value=set()),
+            ),
+            patch("aios.harness.loop.sessions_service.append_event", append_event),
+        ):
+            await run_session_step("sess_x", cause="message")
+
+        sweep_events = _sweep_events(append_event)
+        assert [e["event"] for e in sweep_events] == ["sweep_start", "sweep_end"]
+        assert sweep_events[0] == {"event": "sweep_start", "site": "entry"}
+        assert sweep_events[1] == {
+            "event": "sweep_end",
+            "sweep_start_id": "ev_sweep",
+            "repaired_ghosts": 0,
+            "woken_sessions": 0,
+        }
+
+    async def test_happy_path_marks_woken_sessions_one(self) -> None:
+        """Guard passes: session is in the needs set. ``woken_sessions=1``
+        marks "keep going" for the profiler."""
+        from aios.harness.loop import run_session_step
+
+        session = SimpleNamespace(
+            id="sess_x", agent_id="agt_x", agent_version=None, focal_channel=None
+        )
+        agent = SimpleNamespace(
+            model="openrouter/x",
+            tools=[],
+            mcp_servers=[],
+            skills=[],
+            system="sys",
+            litellm_extra={},
+            window_min=1000,
+            window_max=10000,
+        )
+        start_event = SimpleNamespace(id="ev_sweep")
+
+        with (
+            patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+            patch(
+                "aios.harness.loop.runtime.require_task_registry",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(return_value={"sess_x"}),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.get_session",
+                AsyncMock(return_value=session),
+            ),
+            patch(
+                "aios.harness.loop.agents_service.get_agent",
+                AsyncMock(return_value=agent),
+            ),
+            patch(
+                "aios.harness.channels.list_bindings_and_connections",
+                AsyncMock(return_value=([], [])),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.read_windowed_events",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "aios.harness.loop._dispatch_confirmed_tools",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "aios.harness.loop.compose_step_context",
+                AsyncMock(
+                    return_value=SimpleNamespace(
+                        model="openrouter/x",
+                        messages=[],
+                        tools=[],
+                        reacting_to=0,
+                        skill_versions=[],
+                    )
+                ),
+            ),
+            patch("aios.harness.loop.sessions_service.set_session_status", AsyncMock()),
+            patch(
+                "aios.harness.loop.sessions_service.append_event",
+                AsyncMock(return_value=start_event),
+            ) as append_event,
+            patch(
+                "aios.harness.loop.call_litellm",
+                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+            ),
+            patch(
+                "aios.harness.loop.stream_litellm",
+                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.increment_usage",
+                AsyncMock(),
+            ),
+            patch(
+                "aios.db.sse_lock.has_subscriber",
+                AsyncMock(return_value=False),
+            ),
+        ):
+            await run_session_step("sess_x")
+
+        sweep_events = _sweep_events(append_event)
+        assert [e["event"] for e in sweep_events] == ["sweep_start", "sweep_end"]
+        assert sweep_events[0] == {"event": "sweep_start", "site": "entry"}
+        assert sweep_events[1] == {
+            "event": "sweep_end",
+            "sweep_start_id": "ev_sweep",
+            "repaired_ghosts": 0,
+            "woken_sessions": 1,
+        }
+
+    async def test_sweep_end_fires_when_find_raises(self, mock_runtime: None) -> None:
+        """If ``find_sessions_needing_inference`` raises, the outer try/finally
+        in ``run_session_step`` still emits ``step_end``, and the body's own
+        try/finally still emits ``sweep_end`` (with ``woken_sessions=0``)."""
+        from aios.harness.loop import run_session_step
+
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_sweep"))
+        with (
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(side_effect=RuntimeError("db down")),
+            ),
+            patch("aios.harness.loop.sessions_service.append_event", append_event),
+            pytest.raises(RuntimeError, match="db down"),
+        ):
+            await run_session_step("sess_x", cause="message")
+
+        sweep_events = _sweep_events(append_event)
+        assert [e["event"] for e in sweep_events] == ["sweep_start", "sweep_end"]
+        assert sweep_events[1]["woken_sessions"] == 0
+        assert sweep_events[1]["repaired_ghosts"] == 0
+
+
+# ─── periodic sweep (regression fence on the "deferred entirely" decision) ───
+
+
+class TestPeriodicSweepEmitsNoSpan:
+    async def test_periodic_sweep_does_not_emit_sweep_span(self) -> None:
+        """The 30s ``_periodic_sweep`` in worker.py runs at worker scope,
+        scanning across all sessions. Spans are per-session; there is no
+        natural ``session_id`` to stamp against, so instrumentation is
+        deferred. Regression fence: catch any accidental emission."""
+        from aios.harness.sweep import SweepResult
+        from aios.harness.worker import _periodic_sweep
+
+        append_event = AsyncMock()
+        wake_mock = AsyncMock(return_value=SweepResult(repaired_ghosts=0, woken_sessions=0))
+
+        with (
+            patch(
+                "aios.harness.worker.wake_sessions_needing_inference",
+                wake_mock,
+            ),
+            # Make ``asyncio.sleep`` raise on the first sleep to break the
+            # infinite loop after exactly one iteration.
+            patch("aios.harness.worker.asyncio.sleep", AsyncMock(side_effect=StopAsyncIteration)),
+            patch("aios.services.sessions.append_event", append_event),
+            pytest.raises(StopAsyncIteration),
+        ):
+            await _periodic_sweep(MagicMock(), MagicMock(), interval=30)
+
+        # The periodic sweep must not emit any sweep_start/sweep_end spans.
+        for call in append_event.await_args_list:
+            assert call.args[2] != "span" or not call.args[3].get("event", "").startswith("sweep_")

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -163,7 +163,14 @@ class TestStepStartEndSpans:
         ):
             await run_session_step("sess_x", cause="message")
 
-        assert _span_event_names(append_event) == ["step_start", "step_end"]
+        # Entry-site sweep spans wrap the guard check even on the
+        # wasted-wake path, so the profiler can see the SQL cost.
+        assert _span_event_names(append_event) == [
+            "step_start",
+            "sweep_start",
+            "sweep_end",
+            "step_end",
+        ]
         # step_end must reference step_start by id
         start_id = append_event.await_args_list[0].args[3]
         assert start_id == {"event": "step_start", "cause": "message"}
@@ -361,6 +368,8 @@ class TestStepStartEndSpans:
 
         assert _span_event_names(append_event) == [
             "step_start",
+            "sweep_start",
+            "sweep_end",
             "context_build_start",
             "context_build_end",
             "model_request_start",


### PR DESCRIPTION
## Summary

- Adds `sweep_start` / `sweep_end` span pair at the two single-session sweep call sites: **tail** (tool-dispatch finally) and **entry** (`_run_session_step_body` guard).
- `sweep_end` payload carries `repaired_ghosts` and `woken_sessions`. At the entry site, `woken_sessions ∈ {0, 1}` is load-bearing — **0 marks a wasted wake**.
- `wake_sessions_needing_inference` now returns `SweepResult` (frozen dataclass) instead of `set[str]`, so the tail span can stamp both counts without unrolling the composition. Two callers updated.
- Periodic 30s "all"-scope sweep in `worker._periodic_sweep` is **deliberately not instrumented** — spans are per-session, the periodic sweep runs at worker scope with no natural `session_id` to stamp against. Its cost is already visible indirectly as the `wake_deferred.cause="sweep"` → `step_start` gap on woken sessions.

## Why

Issue #132 (CLI `aios sessions profile`) needs span coverage of sweep SQL. On a live JN session (~6200 events, plain Signal ping→reply, 31.65s wall-clock), **~79% was sweep SQL** — unspanned before this PR, which would report as "unaccounted" in the profiler. See [#138 (comment)](https://github.com/eumemic/aios/pull/138#issuecomment-4292299042) for the full decomposition.

After this lands, the profiler's between-step decomposition becomes: `tool_execute` + `sweep` + `queue_wait`, each individually attributable.

## Pairing convention

Matches #138 exactly: `<phase>_start` / `<phase>_end` event names, `<phase>_start_id` backpointer on the end event, `try/finally` to guarantee pairing. On the tail-site exception path (sweep failure), counts fall back to 0 — the pair still closes cleanly and the existing `tool.sweep_failed` warning still fires.

## Deliberately out of scope

- Periodic 30s "all"-scope sweep instrumentation (needs a worker-level event-routing convention that doesn't exist today). Revisit if profiling identifies it as a regression source.
- Internal decomposition of `find_and_repair_ghosts` vs `find_sessions_needing_inference` sub-phases. One span per call site is sufficient; decompose only if the coarse picture ambiguates.
- SQL/index performance for `find_sessions_needing_inference` on long sessions — tracked separately as #140, parallelizable with #132.

Closes #139. Unblocks #132.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 848 passed (5 new sweep-span tests, 2 updated `test_wake_instrumentation` span-order assertions)
- [ ] End-to-end smoke on a live worker: `aios sessions events <sid> --kind span | jq` — verify ordering `step_start → sweep_start(entry) → sweep_end(entry, woken=1) → context_build_* → model_request_* → tool_execute_* → sweep_start(tail) → sweep_end(tail) → step_end`, and that a forced wasted wake produces `sweep_end(entry, woken=0)` followed immediately by `step_end`

🤖 Generated with [Claude Code](https://claude.com/claude-code)