### PR TITLE
feat(cli): aios sessions profile — per-phase latency breakdown (#132)

### DIFF
--- a/src/aios/cli/commands/_shared.py
+++ b/src/aios/cli/commands/_shared.py
@@ -93,3 +93,38 @@ def fetch_all(
         if cursor is None:
             break
     return {"data": accumulated, "has_more": False, "next_after": None}
+
+
+def fetch_all_events(
+    client: AiosClient,
+    session_id: str,
+    *,
+    kind: str | None = None,
+    after_seq: int = 0,
+    page_size: int = 200,
+) -> list[dict[str, Any]]:
+    """Walk every page of ``/v1/sessions/:id/events`` and return the raw list.
+
+    The events endpoint paginates by ``after_seq`` (monotonic session seq),
+    not by the cursor id that :func:`fetch_all` consumes — so it needs its
+    own walker. Returns just the event list; callers can wrap in an
+    envelope for ``render_list`` or consume directly.
+    """
+    accumulated: list[dict[str, Any]] = []
+    cursor_seq = after_seq
+    while True:
+        page = client.request(
+            "GET",
+            f"/v1/sessions/{session_id}/events",
+            params={"after_seq": cursor_seq, "kind": kind, "limit": page_size},
+        )
+        assert isinstance(page, dict)
+        page_data = page.get("data", [])
+        if not page_data:
+            break
+        accumulated.extend(page_data)
+        last_seq = page_data[-1].get("seq")
+        if not page.get("has_more") or last_seq is None:
+            break
+        cursor_seq = int(last_seq)
+    return accumulated

--- a/src/aios/cli/commands/sessions.py
+++ b/src/aios/cli/commands/sessions.py
@@ -11,6 +11,7 @@ import typer
 
 from aios.cli.commands._shared import (
     fetch_all,
+    fetch_all_events,
     just_client,
     render_list,
     render_single,
@@ -229,34 +230,19 @@ def events(
 ) -> None:
     def _run() -> None:
         state, client = with_client(ctx)
-        params: dict[str, Any] = {"after_seq": after_seq, "kind": kind}
         with client:
             if all_:
-                # The events endpoint paginates by seq, not cursor id. Walk
-                # pages manually, bumping after_seq to the last seen seq.
-                data: list[dict[str, Any]] = []
-                cursor_seq = after_seq
-                while True:
-                    page = client.request(
-                        "GET",
-                        f"/v1/sessions/{session_id}/events",
-                        params={"after_seq": cursor_seq, "kind": kind, "limit": 200},
-                    )
-                    assert isinstance(page, dict)
-                    page_data = page.get("data", [])
-                    if not page_data:
-                        break
-                    data.extend(page_data)
-                    last_seq = page_data[-1].get("seq")
-                    if not page.get("has_more") or last_seq is None:
-                        break
-                    cursor_seq = int(last_seq)
-                envelope = {"data": data, "has_more": False, "next_after": None}
+                data = fetch_all_events(client, session_id, kind=kind, after_seq=after_seq)
+                envelope: dict[str, Any] = {
+                    "data": data,
+                    "has_more": False,
+                    "next_after": None,
+                }
             else:
                 envelope = client.request(
                     "GET",
                     f"/v1/sessions/{session_id}/events",
-                    params={**params, "limit": limit},
+                    params={"after_seq": after_seq, "kind": kind, "limit": limit},
                 )
         render_list(
             state.output_format,
@@ -286,23 +272,7 @@ def profile(
     def _run() -> None:
         state, client = with_client(ctx)
         with client:
-            events_data: list[dict[str, Any]] = []
-            cursor_seq = 0
-            while True:
-                page = client.request(
-                    "GET",
-                    f"/v1/sessions/{session_id}/events",
-                    params={"after_seq": cursor_seq, "kind": "span", "limit": 200},
-                )
-                assert isinstance(page, dict)
-                page_data = page.get("data", [])
-                if not page_data:
-                    break
-                events_data.extend(page_data)
-                last_seq = page_data[-1].get("seq")
-                if not page.get("has_more") or last_seq is None:
-                    break
-                cursor_seq = int(last_seq)
+            events_data = fetch_all_events(client, session_id, kind="span")
 
         result = compute_profile(events_data, turns=turns)
         if state.output_format == "json":

--- a/src/aios/cli/commands/sessions.py
+++ b/src/aios/cli/commands/sessions.py
@@ -17,7 +17,8 @@ from aios.cli.commands._shared import (
     with_client,
 )
 from aios.cli.files import PayloadError, load_json_object, load_payload
-from aios.cli.output import cyan, dim, print_error, print_success
+from aios.cli.output import cyan, dim, print_error, print_json, print_success
+from aios.cli.profile import compute_profile, profile_to_dict, render_profile
 from aios.cli.runtime import get_state, run_or_die
 from aios.cli.tail_format import iter_formatted_events
 
@@ -262,6 +263,52 @@ def events(
             envelope,
             columns=("seq", "kind", "created_at"),
         )
+
+    run_or_die(_run)
+
+
+@app.command(
+    "profile",
+    help="Per-phase latency breakdown of a session's span events.",
+)
+def profile(
+    ctx: typer.Context,
+    session_id: str,
+    turns: Annotated[
+        int | None,
+        typer.Option(
+            "--turns",
+            min=1,
+            help="Restrict to the last N turns (a turn starts at a user- or time-initiated wake).",
+        ),
+    ] = None,
+) -> None:
+    def _run() -> None:
+        state, client = with_client(ctx)
+        with client:
+            events_data: list[dict[str, Any]] = []
+            cursor_seq = 0
+            while True:
+                page = client.request(
+                    "GET",
+                    f"/v1/sessions/{session_id}/events",
+                    params={"after_seq": cursor_seq, "kind": "span", "limit": 200},
+                )
+                assert isinstance(page, dict)
+                page_data = page.get("data", [])
+                if not page_data:
+                    break
+                events_data.extend(page_data)
+                last_seq = page_data[-1].get("seq")
+                if not page.get("has_more") or last_seq is None:
+                    break
+                cursor_seq = int(last_seq)
+
+        result = compute_profile(events_data, turns=turns)
+        if state.output_format == "json":
+            print_json(profile_to_dict(result))
+        else:
+            sys.stdout.write(render_profile(result))
 
     run_or_die(_run)
 

--- a/src/aios/cli/profile.py
+++ b/src/aios/cli/profile.py
@@ -118,30 +118,21 @@ def _parse_spans(raw_events: list[dict[str, Any]]) -> list[Span]:
     return spans
 
 
-_START_ID_FIELDS = {
-    "step_end": "step_start_id",
-    "sweep_end": "sweep_start_id",
-    "context_build_end": "context_build_start_id",
-    "model_request_end": "model_request_start_id",
-    "tool_execute_end": "tool_execute_start_id",
-    "sandbox_provision_end": "sandbox_provision_start_id",
-}
-
-
 def _pair_spans(spans: list[Span]) -> tuple[dict[str, Pair], list[str]]:
     """Return (pairs_by_start_id, warnings).
 
-    Pairs ``*_end`` back to ``*_start`` via the backpointer convention.
-    ``wake_deferred`` is a singular span with no pair. Unpaired ends are
-    reported as warnings but do not fail the profile.
+    Pairs ``*_end`` back to ``*_start`` via the backpointer convention
+    (``<phase>_start_id`` lives on the end event). ``wake_deferred`` is
+    singular with no pair. Unpaired ends are reported as warnings but do
+    not fail the profile.
     """
     by_id = {s.id: s for s in spans}
     pairs: dict[str, Pair] = {}
     warnings: list[str] = []
     for s in spans:
-        field_name = _START_ID_FIELDS.get(s.event)
-        if field_name is None:
+        if not s.event.endswith("_end"):
             continue
+        field_name = f"{s.event.removesuffix('_end')}_start_id"
         start_id = s.data.get(field_name)
         if not isinstance(start_id, str):
             warnings.append(f"seq={s.seq} {s.event}: missing {field_name}")
@@ -224,7 +215,7 @@ def compute_profile(
         (p for p in pairs.values() if p.start.event == "step_start"),
         key=lambda p: p.start.seq,
     )
-    if turns is not None and turns > 0:
+    if turns is not None:
         step_pairs = _slice_last_turns(step_pairs, turns)
 
     if not step_pairs:

--- a/src/aios/cli/profile.py
+++ b/src/aios/cli/profile.py
@@ -1,0 +1,489 @@
+"""Session profiler — reconstructs per-phase latency from span events.
+
+Consumed by ``aios sessions profile <session_id>`` (issue #132). Pure
+functions over the span event stream; no HTTP or I/O.
+
+The session step has two distinct time domains:
+
+* **Inside-step** — strictly nested within ``step_start``/``step_end``:
+  ``sweep`` (site=entry), ``context_build``, ``model_request``. These
+  shares sum to ~100% of step time.
+* **Between-step** — the gap between consecutive steps (``step_end`` →
+  next ``step_start``). ``tool_execute`` and ``sweep`` (site=tail) run
+  here async, overlapping procrastinate queue wait. The gap's cause is
+  **not** the next step's ``cause`` field (Procrastinate coalescing
+  can desynchronise them); instead, use the earliest ``wake_deferred``
+  since the previous ``step_end`` — that's the wake that actually fired.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from statistics import median
+from typing import Any
+
+# Causes that start a new user-or-time-initiated turn. Their between-step
+# gap preceding them represents user idle / network wait, not glue overhead.
+_TURN_STARTING_CAUSES = frozenset({"message", "inbound_message", "initial_message", "scheduled"})
+# Causes whose gap represents intentional delay — subtract delay_seconds.
+_DELAYED_CAUSES = frozenset({"scheduled", "reschedule"})
+
+
+@dataclass(frozen=True, slots=True)
+class Span:
+    id: str
+    seq: int
+    event: str
+    created_at: datetime
+    data: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class Pair:
+    start: Span
+    end: Span
+    duration_s: float
+
+
+@dataclass(frozen=True, slots=True)
+class PhaseStats:
+    phase: str
+    n: int
+    total_s: float
+    p50_s: float
+    p95_s: float
+    share_of_step: float  # 0..1
+
+
+@dataclass(frozen=True, slots=True)
+class GapCategory:
+    """Between-step gaps grouped by the earliest wake_deferred.cause."""
+
+    name: str  # "same-turn", "cross-turn", "scheduled/reschedule"
+    n: int
+    total_s: float
+    p50_s: float
+    # Async work that ran in these gaps (tail sweep overlaps the next queue wait).
+    tool_execute_s: float
+    sweep_tail_s: float
+    # For scheduled/reschedule gaps only: the intentional delay that should
+    # be subtracted when attributing orchestration cost.
+    intentional_delay_s: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class Profile:
+    n_steps: int
+    inside: list[PhaseStats]
+    step_total_s: float
+    gaps: list[GapCategory]
+    elapsed_s: float
+    user_idle_s: float  # cross-turn gap total
+    orchestration_s: float  # non-tool, non-sweep, non-idle residual
+    # Unpaired / malformed span diagnostics (non-fatal).
+    warnings: list[str] = field(default_factory=list)
+
+
+# ─── parsing and pairing ─────────────────────────────────────────────────────
+
+
+def _parse_ts(value: Any) -> datetime:
+    """Accept either datetime or ISO 8601 string. FastAPI returns the latter."""
+    if isinstance(value, datetime):
+        return value
+    return datetime.fromisoformat(str(value))
+
+
+def _parse_spans(raw_events: list[dict[str, Any]]) -> list[Span]:
+    spans: list[Span] = []
+    for ev in raw_events:
+        if ev.get("kind") != "span":
+            continue
+        data = ev.get("data") or {}
+        name = data.get("event")
+        if not isinstance(name, str):
+            continue
+        spans.append(
+            Span(
+                id=str(ev["id"]),
+                seq=int(ev["seq"]),
+                event=name,
+                created_at=_parse_ts(ev["created_at"]),
+                data=data,
+            )
+        )
+    spans.sort(key=lambda s: s.seq)
+    return spans
+
+
+_START_ID_FIELDS = {
+    "step_end": "step_start_id",
+    "sweep_end": "sweep_start_id",
+    "context_build_end": "context_build_start_id",
+    "model_request_end": "model_request_start_id",
+    "tool_execute_end": "tool_execute_start_id",
+    "sandbox_provision_end": "sandbox_provision_start_id",
+}
+
+
+def _pair_spans(spans: list[Span]) -> tuple[dict[str, Pair], list[str]]:
+    """Return (pairs_by_start_id, warnings).
+
+    Pairs ``*_end`` back to ``*_start`` via the backpointer convention.
+    ``wake_deferred`` is a singular span with no pair. Unpaired ends are
+    reported as warnings but do not fail the profile.
+    """
+    by_id = {s.id: s for s in spans}
+    pairs: dict[str, Pair] = {}
+    warnings: list[str] = []
+    for s in spans:
+        field_name = _START_ID_FIELDS.get(s.event)
+        if field_name is None:
+            continue
+        start_id = s.data.get(field_name)
+        if not isinstance(start_id, str):
+            warnings.append(f"seq={s.seq} {s.event}: missing {field_name}")
+            continue
+        start = by_id.get(start_id)
+        if start is None:
+            warnings.append(f"seq={s.seq} {s.event}: start id {start_id} not in window")
+            continue
+        pairs[start_id] = Pair(
+            start=start,
+            end=s,
+            duration_s=(s.created_at - start.created_at).total_seconds(),
+        )
+    return pairs, warnings
+
+
+# ─── turn slicing ────────────────────────────────────────────────────────────
+
+
+def _slice_last_turns(step_pairs: list[Pair], turns: int) -> list[Pair]:
+    """Keep only the last ``turns`` turns of steps.
+
+    A turn starts at a ``step_start`` whose ``cause`` is user- or
+    time-initiated (message, inbound_message, initial_message, scheduled).
+    Subsequent continuation steps (cause=sweep / tool_confirmation /
+    custom_tool_result / reschedule) belong to the same turn.
+    """
+    boundaries = [
+        i for i, p in enumerate(step_pairs) if p.start.data.get("cause") in _TURN_STARTING_CAUSES
+    ]
+    if not boundaries:
+        return step_pairs
+    cut_at = boundaries[-turns] if turns <= len(boundaries) else boundaries[0]
+    return step_pairs[cut_at:]
+
+
+# ─── gap classification ──────────────────────────────────────────────────────
+
+
+def _earliest_wake_cause_in(gap_spans: list[Span]) -> tuple[str | None, float]:
+    """Earliest wake_deferred.cause in the gap, plus its delay_seconds (0 if absent).
+
+    Multiple wake_deferred events can land in one gap (Procrastinate coalescing);
+    the earliest one is the wake that actually fired the next step.
+    """
+    for s in gap_spans:
+        if s.event == "wake_deferred":
+            cause = s.data.get("cause")
+            delay = s.data.get("delay_seconds") or 0
+            return (str(cause) if cause else None, float(delay))
+    return (None, 0.0)
+
+
+def _gap_category_name(cause: str | None) -> str:
+    if cause is None:
+        return "(no wake)"
+    # Delayed causes win over turn-starting: "scheduled" appears in both sets
+    # (it starts a new turn AND carries intentional delay), and for gap
+    # classification the delay semantics are what matter.
+    if cause in _DELAYED_CAUSES:
+        return "scheduled/reschedule"
+    if cause in _TURN_STARTING_CAUSES:
+        return "cross-turn"
+    return "same-turn"
+
+
+# ─── main entry point ───────────────────────────────────────────────────────
+
+
+def compute_profile(
+    raw_events: list[dict[str, Any]],
+    *,
+    turns: int | None = None,
+) -> Profile:
+    """Analyse span events and return a :class:`Profile` breakdown."""
+    spans = _parse_spans(raw_events)
+    pairs, warnings = _pair_spans(spans)
+
+    step_pairs = sorted(
+        (p for p in pairs.values() if p.start.event == "step_start"),
+        key=lambda p: p.start.seq,
+    )
+    if turns is not None and turns > 0:
+        step_pairs = _slice_last_turns(step_pairs, turns)
+
+    if not step_pairs:
+        return Profile(
+            n_steps=0,
+            inside=[],
+            step_total_s=0.0,
+            gaps=[],
+            elapsed_s=0.0,
+            user_idle_s=0.0,
+            orchestration_s=0.0,
+            warnings=warnings,
+        )
+
+    step_total_s = sum(p.duration_s for p in step_pairs)
+
+    # Inside-step phases: pairs whose start sits between a selected step's
+    # start and end (by seq).
+    step_ranges = [(p.start.seq, p.end.seq) for p in step_pairs]
+    inside_durations: dict[str, list[float]] = defaultdict(list)
+    for pair in pairs.values():
+        if pair.start.event == "step_start":
+            continue
+        if pair.start.event == "sandbox_provision_start":
+            # Rare; skip for the primary phase list but still accounted in totals.
+            continue
+        if any(lo <= pair.start.seq <= hi for lo, hi in step_ranges):
+            phase = pair.start.event.removesuffix("_start")
+            inside_durations[phase].append(pair.duration_s)
+
+    inside_stats: list[PhaseStats] = []
+    for phase in ("sweep", "context_build", "model_request"):
+        durations = inside_durations.get(phase, [])
+        if not durations:
+            continue
+        total = sum(durations)
+        inside_stats.append(
+            PhaseStats(
+                phase=phase,
+                n=len(durations),
+                total_s=total,
+                p50_s=median(durations),
+                p95_s=_p95(durations),
+                share_of_step=(total / step_total_s) if step_total_s > 0 else 0.0,
+            )
+        )
+
+    # Between-step gaps: one per consecutive (step_end, next step_start).
+    gap_buckets: dict[str, _GapAccumulator] = defaultdict(_GapAccumulator)
+    cross_turn_total = 0.0
+    scheduled_delay_total = 0.0
+    for i in range(len(step_pairs) - 1):
+        gap_start = step_pairs[i].end
+        gap_end = step_pairs[i + 1].start
+        gap_span = [
+            s
+            for s in spans
+            if gap_start.seq < s.seq < gap_end.seq
+            and gap_start.created_at <= s.created_at <= gap_end.created_at
+        ]
+        duration = (gap_end.created_at - gap_start.created_at).total_seconds()
+        cause, delay = _earliest_wake_cause_in(gap_span)
+        category = _gap_category_name(cause)
+
+        tool_s = sum(
+            pairs[s.id].duration_s
+            for s in gap_span
+            if s.event == "tool_execute_start" and s.id in pairs
+        )
+        sweep_s = sum(
+            pairs[s.id].duration_s
+            for s in gap_span
+            if s.event == "sweep_start" and s.data.get("site") == "tail" and s.id in pairs
+        )
+
+        bucket = gap_buckets[category]
+        bucket.durations.append(duration)
+        bucket.tool_execute_s += tool_s
+        bucket.sweep_tail_s += sweep_s
+        bucket.intentional_delay_s += delay if cause in _DELAYED_CAUSES else 0.0
+        if category == "cross-turn":
+            cross_turn_total += duration
+        if cause in _DELAYED_CAUSES:
+            scheduled_delay_total += delay
+
+    gap_cats: list[GapCategory] = []
+    for name in ("same-turn", "cross-turn", "scheduled/reschedule", "(no wake)"):
+        if name not in gap_buckets:
+            continue
+        cat_bucket = gap_buckets[name]
+        if not cat_bucket.durations:
+            continue
+        gap_cats.append(
+            GapCategory(
+                name=name,
+                n=len(cat_bucket.durations),
+                total_s=sum(cat_bucket.durations),
+                p50_s=median(cat_bucket.durations),
+                tool_execute_s=cat_bucket.tool_execute_s,
+                sweep_tail_s=cat_bucket.sweep_tail_s,
+                intentional_delay_s=cat_bucket.intentional_delay_s,
+            )
+        )
+
+    first = step_pairs[0].start
+    last = step_pairs[-1].end
+    elapsed_s = (last.created_at - first.created_at).total_seconds()
+
+    same_turn_total = gap_buckets.get("same-turn", _GapAccumulator())
+    same_turn_duration = sum(same_turn_total.durations)
+    orchestration_s = max(
+        0.0,
+        same_turn_duration - same_turn_total.tool_execute_s - same_turn_total.sweep_tail_s,
+    )
+
+    return Profile(
+        n_steps=len(step_pairs),
+        inside=inside_stats,
+        step_total_s=step_total_s,
+        gaps=gap_cats,
+        elapsed_s=elapsed_s,
+        user_idle_s=cross_turn_total,
+        orchestration_s=orchestration_s,
+        warnings=warnings,
+    )
+
+
+@dataclass
+class _GapAccumulator:
+    durations: list[float] = field(default_factory=list)
+    tool_execute_s: float = 0.0
+    sweep_tail_s: float = 0.0
+    intentional_delay_s: float = 0.0
+
+
+def _p95(values: list[float]) -> float:
+    """Nearest-rank 95th percentile; tiny samples collapse to max."""
+    if not values:
+        return 0.0
+    ranked = sorted(values)
+    idx = min(len(ranked) - 1, round(0.95 * (len(ranked) - 1)))
+    return ranked[idx]
+
+
+# ─── rendering ───────────────────────────────────────────────────────────────
+
+
+def format_duration(seconds: float) -> str:
+    """Human-readable duration: '9.45s', '120ms', '0.02s' — choose the unit
+    that keeps the number two-to-four digits where possible."""
+    if seconds < 0.001:
+        return f"{seconds * 1_000_000:.0f}µs"
+    if seconds < 1.0:
+        return f"{seconds * 1000:.0f}ms"
+    return f"{seconds:.2f}s"
+
+
+def render_profile(profile: Profile) -> str:
+    """Render a :class:`Profile` as a human-readable multi-section report."""
+    if profile.n_steps == 0:
+        return "(no steps in range — session may be empty or spans missing)\n"
+
+    lines: list[str] = []
+
+    lines.append(f"INSIDE-STEP (n={profile.n_steps})")
+    if not profile.inside:
+        lines.append("  (no inside-step phases detected)")
+    else:
+        for p in profile.inside:
+            lines.append(
+                f"  {p.phase:<16} n={p.n:<4} p50={format_duration(p.p50_s):<8}"
+                f" p95={format_duration(p.p95_s):<8}"
+                f" total={format_duration(p.total_s):<8}"
+                f" {p.share_of_step * 100:5.1f}%"
+            )
+        lines.append(
+            f"  {'step total':<16} n={profile.n_steps:<4}"
+            f" total={format_duration(profile.step_total_s)}"
+        )
+
+    lines.append("")
+    lines.append("BETWEEN-STEP")
+    if not profile.gaps:
+        lines.append("  (only one step — no gaps)")
+    else:
+        for g in profile.gaps:
+            suffix = ""
+            if g.name == "cross-turn":
+                suffix = " (user idle)"
+            lines.append(
+                f"  {g.name + ':':<24} {g.n} gap(s), total={format_duration(g.total_s)},"
+                f" p50={format_duration(g.p50_s)}{suffix}"
+            )
+            if g.tool_execute_s > 0:
+                lines.append(f"    of which tool_execute: {format_duration(g.tool_execute_s)}")
+            if g.sweep_tail_s > 0:
+                lines.append(f"    of which sweep (tail): {format_duration(g.sweep_tail_s)}")
+            if g.intentional_delay_s > 0:
+                lines.append(
+                    f"    intentional delay (schedule_wake/retry): "
+                    f"{format_duration(g.intentional_delay_s)}"
+                )
+
+    lines.append("")
+    lines.append("WALL-CLOCK")
+    elapsed = profile.elapsed_s
+    lines.append(f"  total elapsed:   {format_duration(elapsed)}")
+    pct = (profile.step_total_s / elapsed * 100) if elapsed > 0 else 0.0
+    lines.append(f"  inside steps:    {format_duration(profile.step_total_s)} ({pct:.1f}%)")
+    between_total = elapsed - profile.step_total_s
+    pct_b = (between_total / elapsed * 100) if elapsed > 0 else 0.0
+    lines.append(f"  between steps:   {format_duration(between_total)} ({pct_b:.1f}%)")
+    if profile.user_idle_s > 0:
+        pct_u = (profile.user_idle_s / elapsed * 100) if elapsed > 0 else 0.0
+        lines.append(f"  user idle:       {format_duration(profile.user_idle_s)} ({pct_u:.1f}%)")
+    pct_o = (profile.orchestration_s / elapsed * 100) if elapsed > 0 else 0.0
+    lines.append(f"  orchestration:   {format_duration(profile.orchestration_s)} ({pct_o:.1f}%)")
+
+    if profile.warnings:
+        lines.append("")
+        lines.append(f"warnings ({len(profile.warnings)}):")
+        for w in profile.warnings[:10]:
+            lines.append(f"  {w}")
+        if len(profile.warnings) > 10:
+            lines.append(f"  … {len(profile.warnings) - 10} more")
+
+    return "\n".join(lines) + "\n"
+
+
+def profile_to_dict(profile: Profile) -> dict[str, Any]:
+    """JSON-mode rendering — mirrors the dataclass structure."""
+    return {
+        "n_steps": profile.n_steps,
+        "elapsed_s": profile.elapsed_s,
+        "step_total_s": profile.step_total_s,
+        "user_idle_s": profile.user_idle_s,
+        "orchestration_s": profile.orchestration_s,
+        "inside": [
+            {
+                "phase": p.phase,
+                "n": p.n,
+                "total_s": p.total_s,
+                "p50_s": p.p50_s,
+                "p95_s": p.p95_s,
+                "share_of_step": p.share_of_step,
+            }
+            for p in profile.inside
+        ],
+        "gaps": [
+            {
+                "category": g.name,
+                "n": g.n,
+                "total_s": g.total_s,
+                "p50_s": g.p50_s,
+                "tool_execute_s": g.tool_execute_s,
+                "sweep_tail_s": g.sweep_tail_s,
+                "intentional_delay_s": g.intentional_delay_s,
+            }
+            for g in profile.gaps
+        ],
+        "warnings": profile.warnings,
+    }

--- a/tests/unit/cli/test_cli_sessions.py
+++ b/tests/unit/cli/test_cli_sessions.py
@@ -33,3 +33,108 @@ def test_delete_is_hard_delete_with_yes(mocked_cli):
     # grep and humans a visible ack (the server returns 204 with no body).
     assert "deleted" in result.output
     assert "sess_1" in result.output
+
+
+def _profile_events_page() -> dict:
+    """Minimal events envelope with a single complete step, enough for the
+    profiler to emit every section."""
+    return {
+        "data": [
+            {
+                "id": "ev_1",
+                "seq": 1,
+                "kind": "span",
+                "data": {"event": "step_start", "cause": "message"},
+                "created_at": "2026-04-21T12:00:00.000000",
+            },
+            {
+                "id": "ev_2",
+                "seq": 2,
+                "kind": "span",
+                "data": {"event": "sweep_start", "site": "entry"},
+                "created_at": "2026-04-21T12:00:00.010000",
+            },
+            {
+                "id": "ev_3",
+                "seq": 3,
+                "kind": "span",
+                "data": {
+                    "event": "sweep_end",
+                    "sweep_start_id": "ev_2",
+                    "repaired_ghosts": 0,
+                    "woken_sessions": 1,
+                },
+                "created_at": "2026-04-21T12:00:00.012000",
+            },
+            {
+                "id": "ev_4",
+                "seq": 4,
+                "kind": "span",
+                "data": {"event": "context_build_start"},
+                "created_at": "2026-04-21T12:00:00.015000",
+            },
+            {
+                "id": "ev_5",
+                "seq": 5,
+                "kind": "span",
+                "data": {"event": "context_build_end", "context_build_start_id": "ev_4"},
+                "created_at": "2026-04-21T12:00:00.017000",
+            },
+            {
+                "id": "ev_6",
+                "seq": 6,
+                "kind": "span",
+                "data": {"event": "model_request_start"},
+                "created_at": "2026-04-21T12:00:00.020000",
+            },
+            {
+                "id": "ev_7",
+                "seq": 7,
+                "kind": "span",
+                "data": {"event": "model_request_end", "model_request_start_id": "ev_6"},
+                "created_at": "2026-04-21T12:00:01.020000",
+            },
+            {
+                "id": "ev_8",
+                "seq": 8,
+                "kind": "span",
+                "data": {"event": "step_end", "step_start_id": "ev_1"},
+                "created_at": "2026-04-21T12:00:01.025000",
+            },
+        ],
+        "has_more": False,
+        "next_after": None,
+    }
+
+
+def test_profile_table_output(mocked_cli):
+    mocked_cli.queue_response(httpx.Response(200, json=_profile_events_page()))
+    result = runner.invoke(app, ["sessions", "profile", "sess_1"])
+    assert result.exit_code == 0, result.output
+    assert mocked_cli.captured.method == "GET"
+    assert mocked_cli.captured.path == "/v1/sessions/sess_1/events"
+    assert mocked_cli.captured.query.get("kind") == ["span"]
+    # Table output must have the three headline sections the user will scan for.
+    assert "INSIDE-STEP" in result.output
+    assert "WALL-CLOCK" in result.output
+    assert "model_request" in result.output
+
+
+def test_profile_json_output_is_machine_readable(mocked_cli):
+    import json
+
+    mocked_cli.queue_response(httpx.Response(200, json=_profile_events_page()))
+    result = runner.invoke(app, ["--format", "json", "sessions", "profile", "sess_1"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["n_steps"] == 1
+    assert any(p["phase"] == "model_request" for p in parsed["inside"])
+
+
+def test_profile_empty_session_gracefully(mocked_cli):
+    mocked_cli.queue_response(
+        httpx.Response(200, json={"data": [], "has_more": False, "next_after": None})
+    )
+    result = runner.invoke(app, ["sessions", "profile", "sess_empty"])
+    assert result.exit_code == 0, result.output
+    assert "no steps" in result.output

--- a/tests/unit/test_cli_profile.py
+++ b/tests/unit/test_cli_profile.py
@@ -1,0 +1,329 @@
+"""Unit tests for ``aios.cli.profile`` — pure-function profiler over span events.
+
+Constructs synthetic span event streams and asserts on the resulting
+:class:`Profile`. No HTTP, no CLI — those are exercised separately.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+
+from aios.cli.profile import (
+    compute_profile,
+    format_duration,
+    profile_to_dict,
+    render_profile,
+)
+
+# ─── span event fixture builder ──────────────────────────────────────────────
+
+
+class _Stream:
+    """Append-order span event builder. Each appended event auto-advances
+    ``seq`` and ``created_at`` by ``step_ms`` unless an explicit offset is passed.
+    """
+
+    def __init__(self, start: datetime | None = None, step_ms: int = 10) -> None:
+        self._t = start or datetime(2026, 4, 21, 12, 0, 0)
+        self._seq = 0
+        self._step = timedelta(milliseconds=step_ms)
+        self.events: list[dict[str, Any]] = []
+
+    def advance(self, ms: int) -> None:
+        self._t += timedelta(milliseconds=ms)
+
+    def span(
+        self,
+        event: str,
+        *,
+        id: str | None = None,
+        advance_ms: int | None = None,
+        **payload: Any,
+    ) -> dict[str, Any]:
+        self._seq += 1
+        self._t += self._step if advance_ms is None else timedelta(milliseconds=advance_ms)
+        ev_id = id if id is not None else f"ev_{self._seq:04d}"
+        data = {"event": event, **payload}
+        rec = {
+            "id": ev_id,
+            "seq": self._seq,
+            "kind": "span",
+            "data": data,
+            "created_at": self._t.isoformat(),
+        }
+        self.events.append(rec)
+        return rec
+
+
+def _full_step(
+    s: _Stream,
+    *,
+    cause: str = "message",
+    sweep_ms: int = 5,
+    context_build_ms: int = 2,
+    model_request_ms: int = 1500,
+) -> tuple[str, str]:
+    """Emit a complete inside-step span sequence. Returns (step_start_id, step_end_id)."""
+    step_start = s.span("step_start", cause=cause)
+    sweep_start = s.span("sweep_start", site="entry")
+    s.span(
+        "sweep_end",
+        sweep_start_id=sweep_start["id"],
+        repaired_ghosts=0,
+        woken_sessions=1,
+        advance_ms=sweep_ms,
+    )
+    cb_start = s.span("context_build_start")
+    s.span("context_build_end", context_build_start_id=cb_start["id"], advance_ms=context_build_ms)
+    mr_start = s.span("model_request_start")
+    s.span("model_request_end", model_request_start_id=mr_start["id"], advance_ms=model_request_ms)
+    step_end = s.span("step_end", step_start_id=step_start["id"])
+    return step_start["id"], step_end["id"]
+
+
+def _wasted_wake_step(s: _Stream, *, cause: str) -> None:
+    """Emit a step that early-outs at the sweep guard (woken_sessions=0)."""
+    step_start = s.span("step_start", cause=cause)
+    sweep_start = s.span("sweep_start", site="entry")
+    s.span(
+        "sweep_end",
+        sweep_start_id=sweep_start["id"],
+        repaired_ghosts=0,
+        woken_sessions=0,
+    )
+    s.span("step_end", step_start_id=step_start["id"])
+
+
+def _between_step_work(
+    s: _Stream,
+    *,
+    tool_ms: int = 500,
+    tail_sweep_ms: int = 20,
+    wake_cause: str = "sweep",
+    delay_seconds: int | None = None,
+) -> None:
+    """Emit the async work that happens between two steps: a tool_execute, a
+    tail sweep, and a wake_deferred for the next step."""
+    tool_start = s.span("tool_execute_start", tool_name="bash", tool_call_id="tc_1")
+    s.span(
+        "tool_execute_end",
+        tool_execute_start_id=tool_start["id"],
+        tool_name="bash",
+        tool_call_id="tc_1",
+        is_error=False,
+        advance_ms=tool_ms,
+    )
+    sweep_start = s.span("sweep_start", site="tail")
+    s.span(
+        "sweep_end",
+        sweep_start_id=sweep_start["id"],
+        repaired_ghosts=0,
+        woken_sessions=1,
+        advance_ms=tail_sweep_ms,
+    )
+    payload: dict[str, Any] = {"cause": wake_cause}
+    if delay_seconds is not None:
+        payload["delay_seconds"] = delay_seconds
+    s.span("wake_deferred", **payload)
+
+
+# ─── tests ───────────────────────────────────────────────────────────────────
+
+
+class TestInsideStepPairing:
+    def test_single_step_groups_all_phases(self) -> None:
+        s = _Stream()
+        _full_step(s, model_request_ms=1000)
+
+        profile = compute_profile(s.events)
+
+        assert profile.n_steps == 1
+        phases = {p.phase: p for p in profile.inside}
+        assert set(phases) == {"sweep", "context_build", "model_request"}
+        assert phases["model_request"].n == 1
+        assert phases["model_request"].total_s == pytest.approx(1.0, abs=0.02)
+        # Phase shares sum to approximately 100% of step total.
+        total_share = sum(p.share_of_step for p in profile.inside)
+        assert 0.9 < total_share < 1.05
+
+    def test_unpaired_end_becomes_warning(self) -> None:
+        s = _Stream()
+        s.span("step_start", cause="message")
+        # Dangling end with unknown start_id.
+        s.span("step_end", step_start_id="ev_nonexistent")
+
+        profile = compute_profile(s.events)
+
+        assert profile.n_steps == 0
+        assert any("not in window" in w for w in profile.warnings)
+
+
+class TestTurnSlicing:
+    def test_turns_keeps_only_last_n(self) -> None:
+        """Three turns of one step each; --turns 1 should keep only the last."""
+        s = _Stream()
+        _full_step(s, cause="message", model_request_ms=100)
+        _between_step_work(s, wake_cause="message")
+        _full_step(s, cause="message", model_request_ms=200)
+        _between_step_work(s, wake_cause="message")
+        _full_step(s, cause="message", model_request_ms=300)
+
+        one = compute_profile(s.events, turns=1)
+        all_three = compute_profile(s.events, turns=None)
+
+        assert one.n_steps == 1
+        assert all_three.n_steps == 3
+        # The last turn's only model_request is the 300ms one.
+        mr = next(p for p in one.inside if p.phase == "model_request")
+        assert mr.total_s == pytest.approx(0.3, abs=0.02)
+
+    def test_continuation_steps_stay_with_their_turn(self) -> None:
+        """cause=sweep is a continuation; --turns 1 on (message, sweep, message) keeps the last message-started turn alone."""
+        s = _Stream()
+        _full_step(s, cause="message", model_request_ms=100)
+        _between_step_work(s, wake_cause="sweep")
+        _full_step(s, cause="sweep", model_request_ms=150)  # continuation
+        _between_step_work(s, wake_cause="message")
+        _full_step(s, cause="message", model_request_ms=200)
+
+        profile = compute_profile(s.events, turns=1)
+        assert profile.n_steps == 1  # just the last message-started step
+
+        profile2 = compute_profile(s.events, turns=2)
+        assert profile2.n_steps == 3  # last 2 turns = message+continuation, then message
+
+
+class TestGapClassification:
+    def test_same_turn_gap_attributes_tool_and_sweep(self) -> None:
+        s = _Stream()
+        _full_step(s, cause="message", model_request_ms=100)
+        _between_step_work(s, tool_ms=500, tail_sweep_ms=30, wake_cause="sweep")
+        _full_step(s, cause="sweep", model_request_ms=50)
+
+        profile = compute_profile(s.events)
+
+        assert profile.n_steps == 2
+        same_turn = next((g for g in profile.gaps if g.name == "same-turn"), None)
+        assert same_turn is not None
+        assert same_turn.n == 1
+        assert same_turn.tool_execute_s == pytest.approx(0.5, abs=0.02)
+        assert same_turn.sweep_tail_s == pytest.approx(0.03, abs=0.005)
+
+    def test_cross_turn_gap_is_user_idle(self) -> None:
+        s = _Stream()
+        _full_step(s, cause="message", model_request_ms=50)
+        # No async work between turns — just user idle, then wake_deferred(message).
+        s.advance(2000)  # 2s of "user idle"
+        s.span("wake_deferred", cause="message")
+        _full_step(s, cause="message", model_request_ms=50)
+
+        profile = compute_profile(s.events)
+
+        cross = next((g for g in profile.gaps if g.name == "cross-turn"), None)
+        assert cross is not None
+        assert cross.n == 1
+        assert profile.user_idle_s > 1.9
+        # Cross-turn gaps should not contribute to orchestration.
+        assert profile.orchestration_s == pytest.approx(0.0, abs=0.01)
+
+    def test_earliest_wake_deferred_wins_over_step_cause(self) -> None:
+        """Procrastinate coalescing: N wake_deferreds → 1 step_start. The gap's
+        category must reflect the EARLIEST wake_deferred.cause, not the step's.
+        """
+        s = _Stream()
+        _full_step(s, cause="message", model_request_ms=50)
+        # Sweep wake first (5ms after step_end), then a coalesced message wake 100ms later.
+        s.advance(5)
+        s.span("wake_deferred", cause="sweep")
+        s.advance(100)
+        s.span("wake_deferred", cause="message")
+        s.advance(5)
+        # step_start's own cause disagrees with the earliest wake — this is
+        # the coalescing artifact the rule guards against.
+        _full_step(s, cause="message", model_request_ms=50)
+
+        profile = compute_profile(s.events)
+
+        assert any(g.name == "same-turn" for g in profile.gaps), (
+            "Gap must classify by earliest wake_deferred.cause (sweep), "
+            "not by the next step's cause (message)"
+        )
+
+    def test_scheduled_gap_records_intentional_delay(self) -> None:
+        s = _Stream()
+        _full_step(s, cause="message", model_request_ms=50)
+        s.advance(100)
+        s.span("wake_deferred", cause="scheduled", delay_seconds=30)
+        s.advance(200)
+        _full_step(s, cause="scheduled", model_request_ms=50)
+
+        profile = compute_profile(s.events)
+
+        scheduled = next((g for g in profile.gaps if g.name == "scheduled/reschedule"), None)
+        assert scheduled is not None
+        assert scheduled.intentional_delay_s == 30.0
+
+
+class TestWastedWake:
+    def test_wasted_wake_step_marks_woken_zero(self) -> None:
+        """A wasted wake is a step whose entry-site sweep returned 0 — the
+        guard early-out. The profiler should still see the step, and the
+        woken_sessions=0 in the sweep_end is inspectable via JSON mode."""
+        s = _Stream()
+        _full_step(s, cause="message", model_request_ms=100)
+        s.advance(10)
+        s.span("wake_deferred", cause="sweep")
+        s.advance(5)
+        _wasted_wake_step(s, cause="sweep")
+
+        profile = compute_profile(s.events)
+
+        assert profile.n_steps == 2
+        sweep_phase = next((p for p in profile.inside if p.phase == "sweep"), None)
+        assert sweep_phase is not None
+        assert sweep_phase.n == 2  # one entry sweep per step, including the wasted one
+
+
+class TestRendering:
+    def test_render_profile_contains_key_sections(self) -> None:
+        s = _Stream()
+        _full_step(s, cause="message", model_request_ms=100)
+
+        out = render_profile(compute_profile(s.events))
+
+        assert "INSIDE-STEP" in out
+        assert "model_request" in out
+        assert "WALL-CLOCK" in out
+
+    def test_render_empty_profile(self) -> None:
+        out = render_profile(compute_profile([]))
+        assert "no steps" in out
+
+    def test_profile_to_dict_json_roundtrip(self) -> None:
+        import json
+
+        s = _Stream()
+        _full_step(s, cause="message", model_request_ms=100)
+
+        d = profile_to_dict(compute_profile(s.events))
+        # Must be JSON-serializable.
+        json.dumps(d)
+        assert d["n_steps"] == 1
+        assert len(d["inside"]) == 3  # sweep, context_build, model_request
+
+
+class TestFormatDuration:
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (1.5, "1.50s"),
+            (0.123, "123ms"),
+            (0.0005, "500µs"),
+            (30.0, "30.00s"),
+        ],
+    )
+    def test_units(self, seconds: float, expected: str) -> None:
+        assert format_duration(seconds) == expected


### PR DESCRIPTION
## Summary

New `aios sessions profile <session_id>` subcommand that analyses span events and prints where a session's wall-clock time is going — no more hand-rolled Python against the events endpoint.

Two time domains, rendered as separate sections:

- **Inside-step** (strictly nested in `step_start`/`step_end`): `sweep` (site=entry), `context_build`, `model_request`. Shares sum to ~100% of step time.
- **Between-step** gaps classified by **earliest `wake_deferred.cause` since the previous `step_end`** — not by the next step's own `cause` field, which Procrastinate coalescing can desynchronise from the wake that actually fired. Buckets:
  - `same-turn` (sweep / tool_confirmation / custom_tool_result): orchestration cost
  - `cross-turn` (message / inbound_message / initial_message): user idle
  - `scheduled/reschedule`: intentional delay tracked separately

Plus a wall-clock summary: elapsed, inside steps, between steps, user idle, orchestration.

## Flags

- `--turns N` — restrict to the last N user/time-initiated turns. Continuation steps (cause=sweep / tool_confirmation / etc.) stay with their initiating turn.
- `-f json` (global) — machine-readable dict output.

## Architecture

The analysis lives in `src/aios/cli/profile.py` as **pure functions over the event stream** — no HTTP, no CLI coupling — so it's unit-testable in isolation (19 new unit tests). The subcommand in `sessions.py` fetches all `kind=span` events via the existing seq-based pagination loop, then delegates to `compute_profile`.

## Stacked on #141

This PR is **stacked on `wt/concurrent-spinning-rose`** (the #141 sweep-spans branch) — GitHub will show only #132-specific diff. When #141 merges, I'll retarget this PR to master.

The entry-site `sweep` phase in the inside-step table, and the tail-site sweep decomposition in between-step gaps, both depend on the spans #141 adds.

## Deliberately out of scope for v1

Straightforward follow-ups once the core shape is validated in use:
- `--gaps` — timeline with inter-span gap detail
- `--by-tool` — break `tool_execute` by `tool_name`
- `--by-model` — break `model_request` by model
- `--from-seq` / `--to-seq` — explicit seq range
- Cost attribution — sum `cost_usd` from `model_request_end` payloads

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 867 passed (16 new analysis tests, 3 new CLI integration tests)
- [ ] End-to-end smoke: `uv run aios sessions profile <real_session_id>` on a live session and sanity-check the numbers against a Python script run against the same session

🤖 Generated with [Claude Code](https://claude.com/claude-code)