### PR TITLE
fix(completion): gate cache_control injection on Anthropic provider

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -17,6 +17,7 @@ prefix.
 from __future__ import annotations
 
 import json
+from functools import cache
 from typing import TYPE_CHECKING, Any
 
 import litellm
@@ -61,16 +62,69 @@ def _set_content_block_cache(msg: dict[str, Any]) -> None:
         content[-1]["cache_control"] = _CACHE_CONTROL
 
 
+# LiteLLM providers that proxy Anthropic models and forward ``cache_control``
+# markers unchanged (OpenRouter's ``anthropic/*`` routes, Bedrock's
+# ``anthropic.*`` SKUs, Vertex AI's ``claude-*`` SKUs). Matching on provider
+# alone isn't sufficient — the same providers also host non-Anthropic models
+# (``openrouter/openai/*``, ``bedrock/amazon.titan-*``) that break on the
+# content-block format. We additionally require the model name to carry
+# ``claude`` or ``anthropic``.
+_ANTHROPIC_PROXY_PROVIDERS = frozenset({"openrouter", "bedrock", "vertex_ai"})
+
+
+@cache
+def _supports_anthropic_cache_control(model: str) -> bool:
+    """True when ``model`` accepts Anthropic ``cache_control`` markers.
+
+    Used to gate ``inject_cache_breakpoints`` — see its docstring for why
+    the gate is necessary. Unknown model strings return ``False`` so we
+    default to the safe no-op.
+
+    Covers direct Anthropic plus Anthropic-backed routes through
+    OpenRouter / Bedrock / Vertex (all of which preserve ``cache_control``
+    for Claude models). Non-Claude models on those same proxies stay
+    gated out because they don't necessarily handle the content-block
+    content shape that applying cache markers forces us into.
+
+    Cached: called once per inference step, result is a pure function of
+    the model string, and the distinct-model-string cardinality is low
+    (agents typically reuse one or two).
+    """
+    try:
+        model_name, provider, _, _ = litellm.get_llm_provider(model)
+    except Exception:
+        return False
+    if provider == "anthropic":
+        return True
+    if provider in _ANTHROPIC_PROXY_PROVIDERS:
+        lower = (model_name or model).lower()
+        return "claude" in lower or "anthropic" in lower
+    return False
+
+
 def inject_cache_breakpoints(
     messages: list[dict[str, Any]],
     tools: list[dict[str, Any]] | None,
+    model: str,
 ) -> None:
-    """Annotate messages and tools with ``cache_control`` breakpoints.
+    """Annotate messages and tools with Anthropic ``cache_control`` breakpoints.
 
     Anthropic's prompt caching requires explicit ``cache_control`` markers
     on **content blocks** (not on message dicts) to create cache entries.
-    LiteLLM strips them for providers that don't support them (e.g. OpenAI),
-    so this is safe to apply unconditionally.
+    Applying them means converting string ``content`` into a list of
+    content blocks — because only blocks can carry the marker.
+
+    **Gated on model.** The earlier implementation applied this
+    unconditionally under the assumption that "LiteLLM strips
+    cache_control for providers that don't support it." In practice
+    LiteLLM strips the ``cache_control`` key but leaves the list-of-
+    blocks content format, and some OpenAI-compatible servers (notably
+    MLX-based local Qwen servers) silently return empty completions
+    when a ``tool``-role message arrives as a content-block list. The
+    gate keeps the feature for Anthropic-backed routes (direct
+    Anthropic, plus ``openrouter/anthropic/*``, ``bedrock/anthropic.*``,
+    and ``vertex_ai/claude-*`` — all of which forward cache markers to
+    Anthropic) and leaves string content untouched for everyone else.
 
     Places breakpoints on:
 
@@ -89,6 +143,8 @@ def inject_cache_breakpoints(
     conversation-through-last-event is byte-identical and hits.
     """
     if not messages:
+        return
+    if not _supports_anthropic_cache_control(model):
         return
 
     if messages[0].get("role") == "system":
@@ -212,7 +268,7 @@ async def call_litellm(
     Usage is normalized to our canonical field names. Cost is LiteLLM's
     per-request USD figure, or ``None`` when the provider doesn't report it.
     """
-    inject_cache_breakpoints(messages, tools)
+    inject_cache_breakpoints(messages, tools, model)
 
     kwargs: dict[str, Any] = {
         "model": model,
@@ -259,7 +315,7 @@ async def stream_litellm(
     assembled via ``litellm.stream_chunk_builder`` and returned for
     storage as a normal event.
     """
-    inject_cache_breakpoints(messages, tools)
+    inject_cache_breakpoints(messages, tools, model)
 
     kwargs: dict[str, Any] = {
         "model": model,

--- a/tests/unit/test_task_registry.py
+++ b/tests/unit/test_task_registry.py
@@ -7,6 +7,12 @@ import asyncio
 from aios.harness.task_registry import TaskRegistry
 
 
+def _future() -> asyncio.Future[None]:
+    """Standalone Future for sync tests — Python 3.14 dropped the implicit
+    loop that ``asyncio.get_event_loop()`` used to autocreate."""
+    return asyncio.new_event_loop().create_future()
+
+
 async def _sleeper() -> None:
     await asyncio.sleep(3600)
 
@@ -14,13 +20,13 @@ async def _sleeper() -> None:
 class TestBasicLifecycle:
     def test_add_and_count(self) -> None:
         reg = TaskRegistry()
-        task = asyncio.get_event_loop().create_future()
+        task = _future()
         reg.add("sess_1", "call_a", task)  # type: ignore[arg-type]
         assert reg.in_flight_count("sess_1") == 1
 
     def test_remove(self) -> None:
         reg = TaskRegistry()
-        task = asyncio.get_event_loop().create_future()
+        task = _future()
         reg.add("sess_1", "call_a", task)  # type: ignore[arg-type]
         reg.remove("sess_1", "call_a")
         assert reg.in_flight_count("sess_1") == 0
@@ -71,16 +77,16 @@ class TestInFlightQueries:
 
     def test_in_flight_tool_call_ids(self) -> None:
         reg = TaskRegistry()
-        f1 = asyncio.get_event_loop().create_future()
-        f2 = asyncio.get_event_loop().create_future()
+        f1 = _future()
+        f2 = _future()
         reg.add("sess_1", "call_a", f1)  # type: ignore[arg-type]
         reg.add("sess_1", "call_b", f2)  # type: ignore[arg-type]
         assert reg.in_flight_tool_call_ids("sess_1") == {"call_a", "call_b"}
 
     def test_in_flight_tool_call_ids_excludes_done(self) -> None:
         reg = TaskRegistry()
-        f1 = asyncio.get_event_loop().create_future()
-        f2 = asyncio.get_event_loop().create_future()
+        f1 = _future()
+        f2 = _future()
         f2.set_result(None)  # mark as done
         reg.add("sess_1", "call_a", f1)  # type: ignore[arg-type]
         reg.add("sess_1", "call_b", f2)  # type: ignore[arg-type]
@@ -88,9 +94,9 @@ class TestInFlightQueries:
 
     def test_all_in_flight_tool_call_ids(self) -> None:
         reg = TaskRegistry()
-        f1 = asyncio.get_event_loop().create_future()
-        f2 = asyncio.get_event_loop().create_future()
-        f3 = asyncio.get_event_loop().create_future()
+        f1 = _future()
+        f2 = _future()
+        f3 = _future()
         f3.set_result(None)  # done — should be excluded
         reg.add("sess_1", "call_a", f1)  # type: ignore[arg-type]
         reg.add("sess_2", "call_b", f2)  # type: ignore[arg-type]
@@ -100,7 +106,7 @@ class TestInFlightQueries:
 
     def test_all_in_flight_excludes_sessions_with_no_active(self) -> None:
         reg = TaskRegistry()
-        f1 = asyncio.get_event_loop().create_future()
+        f1 = _future()
         f1.set_result(None)  # done
         reg.add("sess_1", "call_a", f1)  # type: ignore[arg-type]
         assert reg.all_in_flight_tool_call_ids() == {}

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -10,6 +10,12 @@ from aios.harness.completion import (
     inject_cache_breakpoints,
 )
 
+# Model string that LiteLLM routes through the Anthropic provider — used to
+# exercise the branch of inject_cache_breakpoints that actually mutates
+# messages. See TestInjectCacheBreakpointsProviderGuard for the non-Anthropic
+# case.
+_ANTHROPIC_MODEL = "anthropic/claude-opus-4-6"
+
 
 class TestNormalizeUsage:
     """Tests for _normalize_usage which maps LiteLLM fields to our names."""
@@ -141,7 +147,7 @@ def _tool_def(name: str) -> dict[str, Any]:
 class TestInjectCacheBreakpoints:
     def test_system_message_annotated(self) -> None:
         msgs = [_msg("system", "you are helpful"), _msg("user", "hi")]
-        inject_cache_breakpoints(msgs, None)
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         assert msgs[0]["content"] == [
             {"type": "text", "text": "you are helpful", "cache_control": _CACHE_CONTROL}
         ]
@@ -149,13 +155,13 @@ class TestInjectCacheBreakpoints:
     def test_last_tool_annotated(self) -> None:
         msgs = [_msg("system", "sys"), _msg("user", "hi")]
         tools = [_tool_def("bash"), _tool_def("read")]
-        inject_cache_breakpoints(msgs, tools)
+        inject_cache_breakpoints(msgs, tools, _ANTHROPIC_MODEL)
         assert "cache_control" not in tools[0]
         assert tools[1]["cache_control"] == _CACHE_CONTROL
 
     def test_last_conversation_message_annotated(self) -> None:
         msgs = [_msg("system", "sys"), _msg("user", "hi")]
-        inject_cache_breakpoints(msgs, None)
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         assert msgs[1]["content"] == [
             {"type": "text", "text": "hi", "cache_control": _CACHE_CONTROL}
         ]
@@ -163,7 +169,7 @@ class TestInjectCacheBreakpoints:
     def test_no_system_message(self) -> None:
         """First non-system message is not annotated; only last is."""
         msgs = [_msg("user", "hi"), _msg("assistant", "hello")]
-        inject_cache_breakpoints(msgs, None)
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         assert msgs[0]["content"] == "hi"  # untouched
         assert msgs[1]["content"] == [
             {"type": "text", "text": "hello", "cache_control": _CACHE_CONTROL}
@@ -171,20 +177,20 @@ class TestInjectCacheBreakpoints:
 
     def test_no_tools(self) -> None:
         msgs = [_msg("system", "sys"), _msg("user", "hi")]
-        inject_cache_breakpoints(msgs, None)
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         # No crash; system and last message still annotated via content blocks.
         assert msgs[0]["content"][0]["cache_control"] == _CACHE_CONTROL
         assert msgs[1]["content"][0]["cache_control"] == _CACHE_CONTROL
 
     def test_empty_messages(self) -> None:
-        inject_cache_breakpoints([], None)  # no crash
+        inject_cache_breakpoints([], None, _ANTHROPIC_MODEL)  # no crash
 
     def test_system_only_no_double_annotate(self) -> None:
         """When the only message is the system message, it gets one
         annotation from the system-message rule.  The last-message rule
         skips it to avoid redundancy."""
         msgs = [_msg("system", "sys")]
-        inject_cache_breakpoints(msgs, None)
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         assert msgs[0]["content"] == [
             {"type": "text", "text": "sys", "cache_control": _CACHE_CONTROL}
         ]
@@ -196,7 +202,7 @@ class TestInjectCacheBreakpoints:
             {"role": "assistant", "content": "", "tool_calls": [{"id": "a"}]},
             {"role": "tool", "tool_call_id": "a", "content": "done"},
         ]
-        inject_cache_breakpoints(msgs, None)
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         assert msgs[3]["content"] == [
             {"type": "text", "text": "done", "cache_control": _CACHE_CONTROL}
         ]
@@ -204,7 +210,7 @@ class TestInjectCacheBreakpoints:
     def test_all_three_breakpoints(self) -> None:
         msgs = [_msg("system", "sys"), _msg("user", "hi")]
         tools = [_tool_def("bash")]
-        inject_cache_breakpoints(msgs, tools)
+        inject_cache_breakpoints(msgs, tools, _ANTHROPIC_MODEL)
         assert msgs[0]["content"][0]["cache_control"] == _CACHE_CONTROL
         assert tools[0]["cache_control"] == _CACHE_CONTROL
 
@@ -221,7 +227,7 @@ class TestInjectCacheBreakpoints:
             _msg("assistant", "hello"),
             tail,
         ]
-        inject_cache_breakpoints(msgs, None)
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         # Last stable message (the assistant) gets the breakpoint.
         assert msgs[2]["content"] == [
             {"type": "text", "text": "hello", "cache_control": _CACHE_CONTROL}
@@ -240,7 +246,7 @@ class TestInjectCacheBreakpoints:
         stable = _msg("user", "real peer message")
         separator = {"role": "assistant", "content": ""}
         msgs = [_msg("system", "sys"), stable, separator, tail]
-        inject_cache_breakpoints(msgs, None)
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         # Breakpoint lands on the stable user message, not the separator.
         assert msgs[1]["content"] == [
             {"type": "text", "text": "real peer message", "cache_control": _CACHE_CONTROL}
@@ -255,7 +261,7 @@ class TestInjectCacheBreakpoints:
         but the system breakpoint still applies."""
         tail = _msg("user", "━━━ Channels ━━━\n▸ channel_id=x (focal)")
         msgs = [_msg("system", "sys"), tail]
-        inject_cache_breakpoints(msgs, None)
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         assert msgs[0]["content"] == [
             {"type": "text", "text": "sys", "cache_control": _CACHE_CONTROL}
         ]
@@ -273,6 +279,81 @@ class TestInjectCacheBreakpoints:
                 ],
             },
         ]
-        inject_cache_breakpoints(msgs, None)
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         assert "cache_control" not in msgs[1]["content"][0]
         assert msgs[1]["content"][1]["cache_control"] == _CACHE_CONTROL
+
+
+class TestInjectCacheBreakpointsProviderGuard:
+    """The gate that prevents cache_control injection for non-Anthropic providers.
+
+    Reason: some OpenAI-compatible servers (notably MLX-based local model
+    servers) return empty completions when a ``tool``-role message arrives
+    in content-block format. Silently swallowing responses is worse than
+    skipping the optimization, so we only mutate for providers that need it.
+    """
+
+    def test_openai_model_unchanged(self) -> None:
+        msgs = [_msg("system", "sys"), _msg("user", "hi")]
+        tools = [_tool_def("bash")]
+        inject_cache_breakpoints(msgs, tools, "openai/gpt-4o")
+        assert msgs[0]["content"] == "sys"
+        assert msgs[1]["content"] == "hi"
+        assert "cache_control" not in tools[0]
+
+    def test_local_openai_compat_model_unchanged(self) -> None:
+        """The exact shape that surfaced the MLX-Qwen empty-response bug:
+        a tool-role last message with plain-string content must remain a
+        plain string after the gate kicks in."""
+        msgs = [
+            _msg("system", "sys"),
+            _msg("user", "do it"),
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "a"}]},
+            {"role": "tool", "tool_call_id": "a", "content": "done"},
+        ]
+        inject_cache_breakpoints(msgs, None, "openai/mlx-community/Qwen3.6-35B-A3B-4bit-DWQ")
+        assert msgs[3]["content"] == "done"  # still a string, no blocks
+
+    def test_unknown_model_unchanged(self) -> None:
+        """Unknown model strings fall through the LiteLLM provider probe and
+        default to the safe no-op."""
+        msgs = [_msg("system", "sys"), _msg("user", "hi")]
+        inject_cache_breakpoints(msgs, None, "completely-unknown-model-string")
+        assert msgs[0]["content"] == "sys"
+        assert msgs[1]["content"] == "hi"
+
+    def test_openrouter_anthropic_annotated(self) -> None:
+        """OpenRouter's ``anthropic/*`` routes forward ``cache_control`` to
+        Anthropic, so they must still get injection. This is the path the
+        README quickstart uses."""
+        msgs = [_msg("system", "sys"), _msg("user", "hi")]
+        inject_cache_breakpoints(msgs, None, "openrouter/anthropic/claude-opus-4")
+        assert msgs[1]["content"] == [
+            {"type": "text", "text": "hi", "cache_control": _CACHE_CONTROL}
+        ]
+
+    def test_openrouter_non_anthropic_unchanged(self) -> None:
+        """A non-Claude model on OpenRouter stays gated out — we don't know
+        whether the downstream provider tolerates content-block format."""
+        msgs = [_msg("system", "sys"), _msg("user", "hi")]
+        inject_cache_breakpoints(msgs, None, "openrouter/openai/gpt-4o")
+        assert msgs[1]["content"] == "hi"
+
+    def test_bedrock_claude_annotated(self) -> None:
+        msgs = [_msg("system", "sys"), _msg("user", "hi")]
+        inject_cache_breakpoints(msgs, None, "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0")
+        assert msgs[1]["content"] == [
+            {"type": "text", "text": "hi", "cache_control": _CACHE_CONTROL}
+        ]
+
+    def test_bedrock_non_claude_unchanged(self) -> None:
+        msgs = [_msg("system", "sys"), _msg("user", "hi")]
+        inject_cache_breakpoints(msgs, None, "bedrock/amazon.titan-text-express-v1")
+        assert msgs[1]["content"] == "hi"
+
+    def test_vertex_claude_annotated(self) -> None:
+        msgs = [_msg("system", "sys"), _msg("user", "hi")]
+        inject_cache_breakpoints(msgs, None, "vertex_ai/claude-3-5-sonnet@20240620")
+        assert msgs[1]["content"] == [
+            {"type": "text", "text": "hi", "cache_control": _CACHE_CONTROL}
+        ]


### PR DESCRIPTION
## Summary

- Non-Anthropic model calls lose the assistant response when the session has any tool-result turn.
- Root cause: `inject_cache_breakpoints` (in `src/aios/harness/completion.py`) unconditionally converts the last message's string `content` into a content-block list so it can carry an Anthropic `cache_control` marker. LiteLLM strips the marker for non-Anthropic providers but doesn't flatten the list back to a string. MLX-based local Qwen servers (and probably others) respond with a single empty chunk when a `role: tool` message arrives as a content-block list — `output_tokens=0`, `content=""`, `finish_reason: stop`. Harness stores the empty assistant message and emits `turn_ended`.
- Fix: gate the injection on `litellm.get_llm_provider(model)`. Anthropic-backed routes still get injection; others (including local OpenAI-compat servers) keep plain-string content.
- Drive-by: the Python 3.14 `asyncio.get_event_loop()` rot in `test_task_registry.py` — tests were using the removed implicit-loop behavior. Replaced the 8 call sites with a `_future()` helper that makes a dedicated loop. Backwards-compatible with 3.13.

## Allowlist

Mutation happens for:

- `anthropic/*` — direct Anthropic.
- `openrouter/anthropic/*` — OpenRouter forwards `cache_control` unchanged to Anthropic. (README quickstart route.)
- `bedrock/anthropic.*` — Bedrock Claude SKUs.
- `vertex_ai/claude-*` — Vertex AI Claude SKUs.

For the three proxy providers, the model name must additionally contain `claude` or `anthropic` — so non-Claude models on those same proxies (`openrouter/openai/gpt-4o`, `bedrock/amazon.titan-*`, etc.) stay gated out. They can't rely on the downstream provider tolerating the content-block shape.

## Reproduction against a real MLX Qwen3-35B OpenAI-compat endpoint

Same prompt, same messages, same tools — only differs in whether `inject_cache_breakpoints` was invoked on the last `role: tool` message before the streaming call:

| | chunks | content deltas | assembled content |
|---|---:|---:|---|
| without mutation | 136 | 86 | ~900 chars, clean response |
| with mutation (pre-patch) | 1 | 0 | empty |
| gated (patched) | 172 | 86 | ~900 chars, clean response |

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 619 passed
- [x] New `TestInjectCacheBreakpointsProviderGuard` class covers eight cases — direct OpenAI, MLX-Qwen tool-last-message shape, unknown model, OpenRouter+Claude, OpenRouter+GPT, Bedrock+Claude, Bedrock+Titan, Vertex+Claude.
- [x] Verified against a live MLX Qwen3-35B-A3B-4bit endpoint: empty responses resolved end-to-end.
- [ ] Integration / e2e tests not run locally (need Docker; maintainer CI).

## Changes since initial push

Addressed Codex review feedback (P2: preserve cache markers for Anthropic-compatible proxy providers) by expanding the allowlist beyond strict `provider == "anthropic"` to include OpenRouter, Bedrock, and Vertex when the model name carries `claude` or `anthropic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)