### PR TITLE
perf(sweep): eliminate N+1 and swap to role column (#140)

### DIFF
--- a/migrations/versions/0023_sweep_indexes_role_column.py
+++ b/migrations/versions/0023_sweep_indexes_role_column.py
@@ -1,0 +1,84 @@
+"""Re-predicate the two sweep partial indexes from ``data->>'role'`` to the
+``role`` column so the sweep queries can use the normalized column (promoted
+in 0022) without losing index coverage.
+
+Issue #140. The queries in ``sweep.py`` were reaching into JSONB with
+``data->>'role'`` even after 0022 added the real ``role`` column, because
+the partial indexes ``events_tool_result_idx`` and
+``events_assistant_tool_calls_idx`` both had ``data->>'role' = <value>``
+in their WHERE clauses. Any query that swapped to the column would lose
+the index match. This migration updates both indexes to use ``role``,
+unblocking the query rewrites in the same PR.
+
+Run with ``CREATE INDEX CONCURRENTLY`` / ``DROP INDEX CONCURRENTLY`` so the
+switchover never takes an ACCESS EXCLUSIVE lock on ``events`` — the table
+is live-written by every session. The price is that we can't run inside
+a transaction, so we disable alembic's implicit BEGIN via
+``op.get_context().autocommit_block()``.
+
+The ``role`` column was backfilled in 0022 from ``data->>'role'`` for every
+message-kind row, so the set of rows covered by each partial index is
+unchanged byte-for-byte.
+
+Revision ID: 0023
+Revises: 0022
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0023"
+down_revision: str = "0022"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # events_tool_result_idx: tool-result lookup by tool_call_id.
+        op.execute(
+            "CREATE INDEX CONCURRENTLY events_tool_result_idx_new "
+            "ON events (session_id, (data->>'tool_call_id')) "
+            "WHERE kind = 'message' AND role = 'tool'"
+        )
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_tool_result_idx")
+        op.execute("ALTER INDEX events_tool_result_idx_new RENAME TO events_tool_result_idx")
+
+        # events_assistant_tool_calls_idx: scan for assistant messages with tool_calls.
+        op.execute(
+            "CREATE INDEX CONCURRENTLY events_assistant_tool_calls_idx_new "
+            "ON events (session_id, seq) "
+            "WHERE kind = 'message' AND role = 'assistant' "
+            "AND data ? 'tool_calls'"
+        )
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_assistant_tool_calls_idx")
+        op.execute(
+            "ALTER INDEX events_assistant_tool_calls_idx_new "
+            "RENAME TO events_assistant_tool_calls_idx"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY events_tool_result_idx_old "
+            "ON events (session_id, (data->>'tool_call_id')) "
+            "WHERE kind = 'message' AND data->>'role' = 'tool'"
+        )
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_tool_result_idx")
+        op.execute("ALTER INDEX events_tool_result_idx_old RENAME TO events_tool_result_idx")
+
+        op.execute(
+            "CREATE INDEX CONCURRENTLY events_assistant_tool_calls_idx_old "
+            "ON events (session_id, seq) "
+            "WHERE kind = 'message' AND data->>'role' = 'assistant' "
+            "AND data ? 'tool_calls'"
+        )
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_assistant_tool_calls_idx")
+        op.execute(
+            "ALTER INDEX events_assistant_tool_calls_idx_old "
+            "RENAME TO events_assistant_tool_calls_idx"
+        )

--- a/migrations/versions/0023_sweep_indexes_role_column.py
+++ b/migrations/versions/0023_sweep_indexes_role_column.py
@@ -20,6 +20,14 @@ The ``role`` column was backfilled in 0022 from ``data->>'role'`` for every
 message-kind row, so the set of rows covered by each partial index is
 unchanged byte-for-byte.
 
+Runtime: seconds on small deployments (<100k rows); expect ~10-30 minutes
+per index on 100M-row tables. CONCURRENTLY does not block reads or writes
+during the build, so running during a normal traffic window is safe — but
+the migration command itself will not return until both indexes finish.
+If the build fails mid-flight, the partially-built ``*_new`` index lingers
+as INVALID; drop it manually (``DROP INDEX CONCURRENTLY IF EXISTS
+events_tool_result_idx_new``) before retrying.
+
 Revision ID: 0023
 Revises: 0022
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,4 +136,5 @@ addopts = [
 markers = [
     "integration: tests requiring a Postgres testcontainer",
     "e2e: end-to-end tests requiring Docker + a real or recorded model",
+    "slow: heavy tests (benchmarks, large fixtures) — skipped on PR CI, run nightly",
 ]

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -60,7 +60,7 @@ class SweepResult:
 # migration 0022) instead of ``data->>'role'``; partial indexes were
 # re-predicated to match in migration 0023. The two MAX(reacting_to)
 # queries use a CTE to hoist the aggregation out of the outer scan —
-# see PR #NNN for the ~800-900x speedup that revealed.
+# see PR #145 for the ~800-900x speedup that revealed.
 
 
 GHOST_ASST_SQL = """
@@ -89,6 +89,7 @@ CANDIDATE_ROWS_SQL = """
                MAX(COALESCE((data->>'reacting_to')::bigint, seq)) AS max_reacting
           FROM events
          WHERE kind = 'message' AND role = 'assistant'
+         {cte_scope_clause}
          GROUP BY session_id
     )
     SELECT DISTINCT e.session_id
@@ -339,11 +340,15 @@ async def find_sessions_needing_inference(
     yet ready. Case (c) sessions bypass this filter.
     """
     scope_clause = "AND s.id = $1" if session_id else ""
+    # CANDIDATE_ROWS_SQL's CTE aggregates per-session; when scoped, prune it
+    # to the target session too so the planner isn't leaning on predicate-
+    # pushdown-through-GROUP-BY to rescue an unscoped scan at scale.
+    cte_scope_clause = "AND session_id = $1" if session_id else ""
     scope_params: list[Any] = [session_id] if session_id else []
 
     async with pool.acquire() as conn:
         candidate_rows = await conn.fetch(
-            CANDIDATE_ROWS_SQL.format(scope_clause=scope_clause),
+            CANDIDATE_ROWS_SQL.format(scope_clause=scope_clause, cte_scope_clause=cte_scope_clause),
             *scope_params,
         )
 

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -51,6 +51,123 @@ class SweepResult:
     woken_sessions: int
 
 
+# ─── query constants ─────────────────────────────────────────────────────────
+#
+# Sweep SQL lives here as module constants so tests/e2e/test_sweep_perf.py
+# can EXPLAIN the exact production query text — a structural assertion
+# guards against accidental reintroduction of the correlated-subquery
+# N+1 pattern that #140 fixed. Column predicates use ``role`` (from
+# migration 0022) instead of ``data->>'role'``; partial indexes were
+# re-predicated to match in migration 0023. The two MAX(reacting_to)
+# queries use a CTE to hoist the aggregation out of the outer scan —
+# see PR #NNN for the ~800-900x speedup that revealed.
+
+
+GHOST_ASST_SQL = """
+    SELECT e.session_id, e.data
+      FROM events e
+      JOIN sessions s ON s.id = e.session_id
+     WHERE s.archived_at IS NULL
+       AND e.kind = 'message'
+       AND e.role = 'assistant'
+       AND jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls', 'null'::jsonb), '[]'::jsonb)) > 0
+       {scope_clause}
+"""
+
+GHOST_RESULT_SQL = """
+    SELECT e.session_id, e.data->>'tool_call_id' AS tool_call_id
+      FROM events e
+     WHERE e.session_id = ANY($1::text[])
+       AND e.kind = 'message'
+       AND e.role = 'tool'
+"""
+
+GHOST_LIFECYCLE_SQL = """
+    SELECT e.session_id, e.data->>'tool_call_id' AS tool_call_id
+      FROM events e
+     WHERE e.session_id = ANY($1::text[])
+       AND e.kind = 'lifecycle'
+       AND e.data->>'event' = 'tool_confirmed'
+       AND e.data->>'result' = 'allow'
+"""
+
+# CTE hoists MAX(reacting_to) out of the outer scan. The correlated form
+# ran 2338 times on JN's events table (~3.8s); the hoisted form is one
+# pass per session (~4ms). Do NOT inline this back into a per-row subquery.
+CANDIDATE_ROWS_SQL = """
+    WITH session_max_reacting AS (
+        SELECT session_id,
+               MAX(COALESCE((data->>'reacting_to')::bigint, seq)) AS max_reacting
+          FROM events
+         WHERE kind = 'message' AND role = 'assistant'
+         GROUP BY session_id
+    )
+    SELECT DISTINCT e.session_id
+      FROM events e
+      JOIN sessions s ON s.id = e.session_id
+      LEFT JOIN session_max_reacting smr ON smr.session_id = e.session_id
+     WHERE s.archived_at IS NULL
+       AND e.kind = 'message'
+       AND e.role <> 'assistant'
+       AND (smr.max_reacting IS NULL OR e.seq > smr.max_reacting)
+       {scope_clause}
+"""
+
+CONFIRMED_ROWS_SQL = """
+    SELECT DISTINCT lc.session_id
+      FROM events lc
+      JOIN sessions s ON s.id = lc.session_id
+     WHERE s.archived_at IS NULL
+       AND lc.kind = 'lifecycle'
+       AND lc.data->>'event' = 'tool_confirmed'
+       AND lc.data->>'result' = 'allow'
+       AND NOT EXISTS (
+           SELECT 1 FROM events tr
+            WHERE tr.session_id = lc.session_id
+              AND tr.kind = 'message'
+              AND tr.role = 'tool'
+              AND tr.data->>'tool_call_id' = lc.data->>'tool_call_id'
+       )
+       {scope_clause}
+"""
+
+# Same CTE hoist as CANDIDATE_ROWS_SQL — identical pathology.
+UNREACTED_ROWS_SQL = """
+    WITH session_max_reacting AS (
+        SELECT session_id,
+               MAX(COALESCE((data->>'reacting_to')::bigint, seq)) AS max_reacting
+          FROM events
+         WHERE kind = 'message' AND role = 'assistant'
+           AND session_id = ANY($1::text[])
+         GROUP BY session_id
+    )
+    SELECT e.session_id, e.data
+      FROM events e
+      LEFT JOIN session_max_reacting smr ON smr.session_id = e.session_id
+     WHERE e.session_id = ANY($1::text[])
+       AND e.kind = 'message'
+       AND e.role <> 'assistant'
+       AND e.seq > COALESCE(smr.max_reacting, 0)
+"""
+
+ALL_RESULT_ROWS_SQL = """
+    SELECT e.session_id, e.data->>'tool_call_id' AS tool_call_id
+      FROM events e
+     WHERE e.session_id = ANY($1::text[])
+       AND e.kind = 'message'
+       AND e.role = 'tool'
+"""
+
+ALL_ASST_ROWS_SQL = """
+    SELECT e.session_id, e.data
+      FROM events e
+     WHERE e.session_id = ANY($1::text[])
+       AND e.kind = 'message'
+       AND e.role = 'assistant'
+       AND jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls', 'null'::jsonb), '[]'::jsonb)) > 0
+"""
+
+
 # ─── ghost repair ────────────────────────────────────────────────────────────
 
 
@@ -80,16 +197,7 @@ async def find_and_repair_ghosts(
 
     async with pool.acquire() as conn:
         asst_rows = await conn.fetch(
-            f"""
-            SELECT e.session_id, e.data
-              FROM events e
-              JOIN sessions s ON s.id = e.session_id
-             WHERE s.archived_at IS NULL
-               AND e.kind = 'message'
-               AND e.data->>'role' = 'assistant'
-               AND jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls', 'null'::jsonb), '[]'::jsonb)) > 0
-               {scope_clause}
-            """,
+            GHOST_ASST_SQL.format(scope_clause=scope_clause),
             *scope_params,
         )
 
@@ -98,31 +206,12 @@ async def find_and_repair_ghosts(
 
         session_ids = list({r["session_id"] for r in asst_rows})
 
-        result_rows = await conn.fetch(
-            """
-            SELECT e.session_id, e.data->>'tool_call_id' AS tool_call_id
-              FROM events e
-             WHERE e.session_id = ANY($1::text[])
-               AND e.kind = 'message'
-               AND e.data->>'role' = 'tool'
-            """,
-            session_ids,
-        )
+        result_rows = await conn.fetch(GHOST_RESULT_SQL, session_ids)
         results_by_session: dict[str, set[str]] = {}
         for r in result_rows:
             results_by_session.setdefault(r["session_id"], set()).add(r["tool_call_id"])
 
-        lifecycle_rows = await conn.fetch(
-            """
-            SELECT e.session_id, e.data->>'tool_call_id' AS tool_call_id
-              FROM events e
-             WHERE e.session_id = ANY($1::text[])
-               AND e.kind = 'lifecycle'
-               AND e.data->>'event' = 'tool_confirmed'
-               AND e.data->>'result' = 'allow'
-            """,
-            session_ids,
-        )
+        lifecycle_rows = await conn.fetch(GHOST_LIFECYCLE_SQL, session_ids)
         confirmed_by_session: dict[str, set[str]] = {}
         for r in lifecycle_rows:
             confirmed_by_session.setdefault(r["session_id"], set()).add(r["tool_call_id"])
@@ -266,32 +355,7 @@ async def find_sessions_needing_inference(
 
     async with pool.acquire() as conn:
         candidate_rows = await conn.fetch(
-            f"""
-            SELECT DISTINCT e.session_id
-              FROM events e
-              JOIN sessions s ON s.id = e.session_id
-             WHERE s.archived_at IS NULL
-               AND e.kind = 'message'
-               AND e.data->>'role' != 'assistant'
-               AND (
-                   NOT EXISTS (
-                       SELECT 1 FROM events a
-                        WHERE a.session_id = e.session_id
-                          AND a.kind = 'message'
-                          AND a.data->>'role' = 'assistant'
-                   )
-                   OR
-                   e.seq > COALESCE(
-                       (SELECT MAX(COALESCE((a.data->>'reacting_to')::bigint, a.seq))
-                          FROM events a
-                         WHERE a.session_id = e.session_id
-                           AND a.kind = 'message'
-                           AND a.data->>'role' = 'assistant'),
-                       0
-                   )
-               )
-               {scope_clause}
-            """,
+            CANDIDATE_ROWS_SQL.format(scope_clause=scope_clause),
             *scope_params,
         )
 
@@ -299,23 +363,7 @@ async def find_sessions_needing_inference(
 
         # Case (c) bypasses the batch filter — confirmed tools need dispatch.
         confirmed_rows = await conn.fetch(
-            f"""
-            SELECT DISTINCT lc.session_id
-              FROM events lc
-              JOIN sessions s ON s.id = lc.session_id
-             WHERE s.archived_at IS NULL
-               AND lc.kind = 'lifecycle'
-               AND lc.data->>'event' = 'tool_confirmed'
-               AND lc.data->>'result' = 'allow'
-               AND NOT EXISTS (
-                   SELECT 1 FROM events tr
-                    WHERE tr.session_id = lc.session_id
-                      AND tr.kind = 'message'
-                      AND tr.data->>'role' = 'tool'
-                      AND tr.data->>'tool_call_id' = lc.data->>'tool_call_id'
-               )
-               {scope_clause}
-            """,
+            CONFIRMED_ROWS_SQL.format(scope_clause=scope_clause),
             *scope_params,
         )
         confirmed_sessions = {r["session_id"] for r in confirmed_rows}
@@ -340,46 +388,9 @@ async def _filter_incomplete_batches(
     session_list = list(candidates)
 
     async with pool.acquire() as conn:
-        unreacted_rows = await conn.fetch(
-            """
-            SELECT e.session_id, e.data
-              FROM events e
-             WHERE e.session_id = ANY($1::text[])
-               AND e.kind = 'message'
-               AND e.data->>'role' != 'assistant'
-               AND e.seq > COALESCE(
-                   (SELECT MAX(COALESCE((a.data->>'reacting_to')::bigint, a.seq))
-                      FROM events a
-                     WHERE a.session_id = e.session_id
-                       AND a.kind = 'message'
-                       AND a.data->>'role' = 'assistant'),
-                   0)
-            """,
-            session_list,
-        )
-
-        all_result_rows = await conn.fetch(
-            """
-            SELECT e.session_id, e.data->>'tool_call_id' AS tool_call_id
-              FROM events e
-             WHERE e.session_id = ANY($1::text[])
-               AND e.kind = 'message'
-               AND e.data->>'role' = 'tool'
-            """,
-            session_list,
-        )
-
-        all_asst_rows = await conn.fetch(
-            """
-            SELECT e.session_id, e.data
-              FROM events e
-             WHERE e.session_id = ANY($1::text[])
-               AND e.kind = 'message'
-               AND e.data->>'role' = 'assistant'
-               AND jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls', 'null'::jsonb), '[]'::jsonb)) > 0
-            """,
-            session_list,
-        )
+        unreacted_rows = await conn.fetch(UNREACTED_ROWS_SQL, session_list)
+        all_result_rows = await conn.fetch(ALL_RESULT_ROWS_SQL, session_list)
+        all_asst_rows = await conn.fetch(ALL_ASST_ROWS_SQL, session_list)
 
     unreacted_by_sid = _group_event_data(unreacted_rows)
     results_by_sid = _group_tool_call_ids(all_result_rows)

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -74,14 +74,6 @@ GHOST_ASST_SQL = """
        {scope_clause}
 """
 
-GHOST_RESULT_SQL = """
-    SELECT e.session_id, e.data->>'tool_call_id' AS tool_call_id
-      FROM events e
-     WHERE e.session_id = ANY($1::text[])
-       AND e.kind = 'message'
-       AND e.role = 'tool'
-"""
-
 GHOST_LIFECYCLE_SQL = """
     SELECT e.session_id, e.data->>'tool_call_id' AS tool_call_id
       FROM events e
@@ -91,9 +83,6 @@ GHOST_LIFECYCLE_SQL = """
        AND e.data->>'result' = 'allow'
 """
 
-# CTE hoists MAX(reacting_to) out of the outer scan. The correlated form
-# ran 2338 times on JN's events table (~3.8s); the hoisted form is one
-# pass per session (~4ms). Do NOT inline this back into a per-row subquery.
 CANDIDATE_ROWS_SQL = """
     WITH session_max_reacting AS (
         SELECT session_id,
@@ -131,7 +120,6 @@ CONFIRMED_ROWS_SQL = """
        {scope_clause}
 """
 
-# Same CTE hoist as CANDIDATE_ROWS_SQL — identical pathology.
 UNREACTED_ROWS_SQL = """
     WITH session_max_reacting AS (
         SELECT session_id,
@@ -206,7 +194,7 @@ async def find_and_repair_ghosts(
 
         session_ids = list({r["session_id"] for r in asst_rows})
 
-        result_rows = await conn.fetch(GHOST_RESULT_SQL, session_ids)
+        result_rows = await conn.fetch(ALL_RESULT_ROWS_SQL, session_ids)
         results_by_session: dict[str, set[str]] = {}
         for r in result_rows:
             results_by_session.setdefault(r["session_id"], set()).add(r["tool_call_id"])

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -35,19 +35,18 @@ from tests.support import find_subplans_over_events
 # ─── fixture: pathological session ───────────────────────────────────────────
 
 
-async def _seed_pathological(
-    pool: asyncpg.Pool[Any],
-    *,
-    n_sessions: int = 3,
-    n_assistant_per: int = 400,
-    n_unreacted_per: int = 30,
-) -> list[str]:
-    """Seed ``n_sessions`` sessions each with a realistic shape that triggers
-    the N+1 pathology: many assistant messages (each with reacting_to set)
-    plus a handful of unreacted user messages at the tail. Returns the
-    seeded session ids.
+_N_SESSIONS = 3
+_N_ASSISTANT_PER = 400
+_N_UNREACTED_PER = 30
+
+
+async def _seed_pathological(pool: asyncpg.Pool[Any]) -> list[str]:
+    """Seed the shape that triggers the pre-#140 correlated-subquery
+    pathology: multiple sessions, each with many assistant messages
+    carrying ``reacting_to``, plus unreacted user messages at the tail.
+    Returns the seeded session ids.
     """
-    session_ids: list[str] = [f"sess_perf_{i:03d}" for i in range(n_sessions)]
+    session_ids: list[str] = [f"sess_perf_{i:03d}" for i in range(_N_SESSIONS)]
 
     async with pool.acquire() as conn:
         # Dependencies for the session FK chain.
@@ -79,7 +78,7 @@ async def _seed_pathological(
             # the previous user event (seq = 2*i for i-th assistant).
             rows = []
             seq = 1
-            for i in range(n_assistant_per):
+            for i in range(_N_ASSISTANT_PER):
                 # user msg
                 rows.append(
                     (
@@ -112,7 +111,7 @@ async def _seed_pathological(
                 seq += 1
             # A handful of **unreacted** user messages at the tail —
             # candidates the sweep must notice.
-            for j in range(n_unreacted_per):
+            for j in range(_N_UNREACTED_PER):
                 rows.append(
                     (
                         f"ev_tail_u_{sid}_{j}",
@@ -180,7 +179,7 @@ class TestNoCorrelatedSubplanOverEvents:
         )
 
     async def test_unreacted_rows_is_not_n_plus_1(self, seeded_pool: asyncpg.Pool[Any]) -> None:
-        session_ids = [f"sess_perf_{i:03d}" for i in range(3)]
+        session_ids = [f"sess_perf_{i:03d}" for i in range(_N_SESSIONS)]
         plan = await _explain(seeded_pool, UNREACTED_ROWS_SQL, session_ids)
         found = find_subplans_over_events(plan)
         assert not found, (

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -1,0 +1,220 @@
+"""Perf regression tests for sweep queries (issue #140).
+
+The sweep path ran correlated subqueries against ``events`` that computed
+``MAX(reacting_to)`` per session inside a per-row SubPlan — an N+1 pattern
+that on JN's live data made one sweep pass cost ~7.5s on a 10k-event
+table. The fix in this PR hoists the aggregation to a CTE and swaps
+``data->>'role'`` for the normalized ``role`` column (from migration 0022).
+
+These tests encode the fix as a **structural** invariant: after
+``EXPLAIN (FORMAT JSON)``, no node in the plan tree is a SubPlan scanning
+``events``. Deterministic, no wall-clock assertion, no flake on slow CI.
+A regression from a well-meaning refactor ("why is this a CTE?") fails
+this test immediately.
+
+The budget smoke test (``@pytest.mark.slow``) is a secondary fence: on
+the same seeded fixture, assert the rewritten queries actually complete
+under a buffer-hits budget. Catches plan-choice regressions the
+structural check might miss (e.g., Postgres version that reshapes the
+plan in some other quadratic direction).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.harness.sweep import CANDIDATE_ROWS_SQL, UNREACTED_ROWS_SQL
+from tests.conftest import needs_docker
+from tests.support import find_subplans_over_events
+
+# ─── fixture: pathological session ───────────────────────────────────────────
+
+
+async def _seed_pathological(
+    pool: asyncpg.Pool[Any],
+    *,
+    n_sessions: int = 3,
+    n_assistant_per: int = 400,
+    n_unreacted_per: int = 30,
+) -> list[str]:
+    """Seed ``n_sessions`` sessions each with a realistic shape that triggers
+    the N+1 pathology: many assistant messages (each with reacting_to set)
+    plus a handful of unreacted user messages at the tail. Returns the
+    seeded session ids.
+    """
+    session_ids: list[str] = [f"sess_perf_{i:03d}" for i in range(n_sessions)]
+
+    async with pool.acquire() as conn:
+        # Dependencies for the session FK chain.
+        await conn.execute(
+            """
+            INSERT INTO agents (id, name, model)
+            VALUES ('agt_perf', 'perf', 'openrouter/x')
+            ON CONFLICT (id) DO NOTHING
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO environments (id, name)
+            VALUES ('env_perf', 'env_perf')
+            ON CONFLICT (id) DO NOTHING
+            """
+        )
+
+        for sid in session_ids:
+            await conn.execute(
+                """
+                INSERT INTO sessions (id, agent_id, environment_id, status, workspace_volume_path)
+                VALUES ($1, 'agt_perf', 'env_perf', 'idle', '/tmp/ws_' || $1)
+                ON CONFLICT (id) DO NOTHING
+                """,
+                sid,
+            )
+            # Seed assistant messages. Each has reacting_to pointing back to
+            # the previous user event (seq = 2*i for i-th assistant).
+            rows = []
+            seq = 1
+            for i in range(n_assistant_per):
+                # user msg
+                rows.append(
+                    (
+                        f"ev_u_{sid}_{i}",
+                        sid,
+                        seq,
+                        "message",
+                        json.dumps({"role": "user", "content": f"u{i}"}),
+                        "user",
+                    )
+                )
+                seq += 1
+                # assistant reply referring back to that user msg
+                rows.append(
+                    (
+                        f"ev_a_{sid}_{i}",
+                        sid,
+                        seq,
+                        "message",
+                        json.dumps(
+                            {
+                                "role": "assistant",
+                                "content": f"a{i}",
+                                "reacting_to": seq - 1,
+                            }
+                        ),
+                        "assistant",
+                    )
+                )
+                seq += 1
+            # A handful of **unreacted** user messages at the tail —
+            # candidates the sweep must notice.
+            for j in range(n_unreacted_per):
+                rows.append(
+                    (
+                        f"ev_tail_u_{sid}_{j}",
+                        sid,
+                        seq,
+                        "message",
+                        json.dumps({"role": "user", "content": f"tail{j}"}),
+                        "user",
+                    )
+                )
+                seq += 1
+            await conn.executemany(
+                "INSERT INTO events (id, session_id, seq, kind, data, role) "
+                "VALUES ($1, $2, $3, $4, $5::jsonb, $6) "
+                "ON CONFLICT (id) DO NOTHING",
+                rows,
+            )
+
+        # ANALYZE so the planner has fresh stats matching the fixture.
+        await conn.execute("ANALYZE events")
+        await conn.execute("ANALYZE sessions")
+
+    return session_ids
+
+
+@pytest.fixture
+async def seeded_pool(aios_env: dict[str, str]) -> AsyncIterator[asyncpg.Pool[Any]]:
+    from aios.db.pool import create_pool
+
+    pool = await create_pool(aios_env["AIOS_DB_URL"], min_size=1, max_size=4)
+    await _seed_pathological(pool)
+    try:
+        yield pool
+    finally:
+        await pool.close()
+
+
+# ─── plan tree helpers ───────────────────────────────────────────────────────
+
+
+async def _explain(pool: asyncpg.Pool[Any], sql: str, *args: Any) -> dict[str, Any]:
+    async with pool.acquire() as conn:
+        result = await conn.fetchval(f"EXPLAIN (FORMAT JSON) {sql}", *args)
+    # asyncpg decodes JSON columns to Python lists/dicts already.
+    if isinstance(result, str):
+        result = json.loads(result)
+    return result[0]["Plan"]
+
+
+# ─── structural tests (primary, always-on) ───────────────────────────────────
+
+
+@needs_docker
+class TestNoCorrelatedSubplanOverEvents:
+    """The central invariant: no sweep query may re-scan ``events`` inside
+    a correlated SubPlan. That shape was the N+1 pathology behind #140."""
+
+    async def test_candidate_rows_is_not_n_plus_1(self, seeded_pool: asyncpg.Pool[Any]) -> None:
+        plan = await _explain(seeded_pool, CANDIDATE_ROWS_SQL.format(scope_clause=""))
+        found = find_subplans_over_events(plan)
+        assert not found, (
+            f"N+1 regression in find_sessions_needing_inference candidate query: "
+            f"{len(found)} correlated subplan(s) over events. "
+            f"See PR #NNN — this query must hoist MAX(reacting_to) via a CTE."
+        )
+
+    async def test_unreacted_rows_is_not_n_plus_1(self, seeded_pool: asyncpg.Pool[Any]) -> None:
+        session_ids = [f"sess_perf_{i:03d}" for i in range(3)]
+        plan = await _explain(seeded_pool, UNREACTED_ROWS_SQL, session_ids)
+        found = find_subplans_over_events(plan)
+        assert not found, (
+            f"N+1 regression in _filter_incomplete_batches unreacted query: "
+            f"{len(found)} correlated subplan(s) over events. Same CTE fix applies."
+        )
+
+
+# ─── budget smoke (secondary, slow-marker) ───────────────────────────────────
+
+
+@needs_docker
+@pytest.mark.slow
+class TestSweepQueryBudget:
+    """Buffer-hit budget as a backstop for plan-choice regressions the
+    structural check might miss. Buffer hits are far more stable across
+    hardware than wall-clock."""
+
+    async def test_candidate_rows_buffer_budget(self, seeded_pool: asyncpg.Pool[Any]) -> None:
+        async with seeded_pool.acquire() as conn:
+            result = await conn.fetchval(
+                f"EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) {CANDIDATE_ROWS_SQL.format(scope_clause='')}"
+            )
+        if isinstance(result, str):
+            result = json.loads(result)
+        root = result[0]["Plan"]
+        hits = _total_buffer_hits(root)
+        # Fixture seeds ~2600 events; linear-scan cost is ~2.6k hits. We
+        # allow generous headroom; the pre-fix path burnt ~1.8M here.
+        assert hits < 50_000, f"candidate_rows uses {hits} buffer hits — N+1 regression?"
+
+
+def _total_buffer_hits(plan_node: dict[str, Any]) -> int:
+    total = int(plan_node.get("Shared Hit Blocks", 0) or 0)
+    for child in plan_node.get("Plans", []):
+        total += _total_buffer_hits(child)
+    return total

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -170,12 +170,14 @@ class TestNoCorrelatedSubplanOverEvents:
     a correlated SubPlan. That shape was the N+1 pathology behind #140."""
 
     async def test_candidate_rows_is_not_n_plus_1(self, seeded_pool: asyncpg.Pool[Any]) -> None:
-        plan = await _explain(seeded_pool, CANDIDATE_ROWS_SQL.format(scope_clause=""))
+        plan = await _explain(
+            seeded_pool, CANDIDATE_ROWS_SQL.format(scope_clause="", cte_scope_clause="")
+        )
         found = find_subplans_over_events(plan)
         assert not found, (
             f"N+1 regression in find_sessions_needing_inference candidate query: "
             f"{len(found)} correlated subplan(s) over events. "
-            f"See PR #NNN — this query must hoist MAX(reacting_to) via a CTE."
+            f"See PR #145 — this query must hoist MAX(reacting_to) via a CTE."
         )
 
     async def test_unreacted_rows_is_not_n_plus_1(self, seeded_pool: asyncpg.Pool[Any]) -> None:
@@ -201,7 +203,7 @@ class TestSweepQueryBudget:
     async def test_candidate_rows_buffer_budget(self, seeded_pool: asyncpg.Pool[Any]) -> None:
         async with seeded_pool.acquire() as conn:
             result = await conn.fetchval(
-                f"EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) {CANDIDATE_ROWS_SQL.format(scope_clause='')}"
+                f"EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) {CANDIDATE_ROWS_SQL.format(scope_clause='', cte_scope_clause='')}"
             )
         if isinstance(result, str):
             result = json.loads(result)

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,31 @@
+"""Test-side utilities shared across tiers.
+
+Kept at the top level of ``tests/`` (not inside ``unit/`` or ``e2e/``) so
+either tier can import it without crossing boundaries.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def find_subplans_over_events(plan_node: dict[str, Any]) -> list[dict[str, Any]]:
+    """Walk a Postgres EXPLAIN (FORMAT JSON) plan tree. Return every node
+    whose ancestry includes a ``Parent Relationship: SubPlan`` **and**
+    whose scan target is the ``events`` relation.
+
+    Used by the sweep perf regression guard (#140): the N+1 pathology we
+    fixed was exactly a correlated SubPlan re-scanning ``events`` per
+    outer row. If the fix ever regresses, this detector lights up.
+    """
+    found: list[dict[str, Any]] = []
+
+    def walk(node: dict[str, Any], in_subplan: bool) -> None:
+        here_subplan = node.get("Parent Relationship") == "SubPlan" or in_subplan
+        if here_subplan and node.get("Relation Name") == "events":
+            found.append(node)
+        for child in node.get("Plans", []):
+            walk(child, here_subplan)
+
+    walk(plan_node, False)
+    return found

--- a/tests/unit/test_plan_introspect.py
+++ b/tests/unit/test_plan_introspect.py
@@ -1,0 +1,142 @@
+"""Unit tests for the ``find_subplans_over_events`` detector used by the
+sweep perf regression guard (issue #140).
+
+The e2e test (``tests/e2e/test_sweep_perf.py``) only proves the current
+production SQL is SubPlan-free — it cannot show that the detector would
+actually catch a regression. These tests fill that gap: hand-crafted plan
+fixtures (one pathological, one clean) demonstrate the detector fires on
+the former and stays silent on the latter.
+
+This is the "RED evidence" in the TDD cycle that never rots: even after
+the production SQL is fixed, these tests still prove the guard works.
+"""
+
+from __future__ import annotations
+
+from tests.support import find_subplans_over_events
+
+# Fixture: an EXPLAIN (FORMAT JSON) "Plan" subtree matching the pre-#140
+# shape — outer Index Scan on events whose Filter contains a SubPlan
+# that itself scans events. This is the pathology the e2e test guards
+# against; the detector must flag it.
+_BAD_PLAN = {
+    "Node Type": "Unique",
+    "Plans": [
+        {
+            "Node Type": "Nested Loop",
+            "Plans": [
+                {
+                    "Node Type": "Index Scan",
+                    "Relation Name": "events",
+                    "Plans": [
+                        {
+                            "Node Type": "Bitmap Heap Scan",
+                            "Relation Name": "events",
+                            "Parent Relationship": "SubPlan",
+                            "Subplan Name": "SubPlan 3",
+                            "Plans": [
+                                {
+                                    "Node Type": "Bitmap Index Scan",
+                                    "Parent Relationship": "Outer",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+# Fixture: the post-#140 shape — Hash Join over a HashAggregate on events.
+# No SubPlan over events anywhere in the tree; the detector must not fire.
+_GOOD_PLAN = {
+    "Node Type": "Unique",
+    "Plans": [
+        {
+            "Node Type": "Hash Join",
+            "Plans": [
+                {
+                    "Node Type": "Hash Left Join",
+                    "Plans": [
+                        {
+                            "Node Type": "Seq Scan",
+                            "Relation Name": "events",
+                            "Parent Relationship": "Outer",
+                        },
+                        {
+                            "Node Type": "Hash",
+                            "Plans": [
+                                {
+                                    "Node Type": "HashAggregate",
+                                    "Plans": [
+                                        {
+                                            "Node Type": "Seq Scan",
+                                            "Relation Name": "events",
+                                            "Parent Relationship": "Outer",
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+class TestFindSubplansOverEvents:
+    def test_detects_correlated_subplan_over_events(self) -> None:
+        """The pre-#140 shape (SubPlan re-scanning events) must be caught."""
+        found = find_subplans_over_events(_BAD_PLAN)
+        assert len(found) == 1
+        assert found[0]["Parent Relationship"] == "SubPlan"
+        assert found[0]["Relation Name"] == "events"
+
+    def test_ignores_hoisted_cte_shape(self) -> None:
+        """The post-#140 shape (HashAggregate-driven) must NOT trip the guard."""
+        found = find_subplans_over_events(_GOOD_PLAN)
+        assert found == []
+
+    def test_ignores_subplans_over_non_events_relations(self) -> None:
+        """A SubPlan scanning some other table is fine — we only care about
+        events, the load-bearing hot table."""
+        plan = {
+            "Node Type": "Seq Scan",
+            "Relation Name": "sessions",
+            "Plans": [
+                {
+                    "Node Type": "Seq Scan",
+                    "Relation Name": "agents",
+                    "Parent Relationship": "SubPlan",
+                }
+            ],
+        }
+        assert find_subplans_over_events(plan) == []
+
+    def test_inherits_subplan_context_into_descendants(self) -> None:
+        """A deeper Bitmap Heap Scan inside a SubPlan subtree still counts —
+        Postgres often labels the outer node with the Parent Relationship
+        and its children get 'Outer' / 'Inner' relationships."""
+        plan = {
+            "Node Type": "Index Scan",
+            "Relation Name": "events",
+            "Plans": [
+                {
+                    "Node Type": "Aggregate",
+                    "Parent Relationship": "SubPlan",
+                    "Plans": [
+                        {
+                            "Node Type": "Bitmap Heap Scan",
+                            "Relation Name": "events",
+                            "Parent Relationship": "Outer",
+                        }
+                    ],
+                }
+            ],
+        }
+        found = find_subplans_over_events(plan)
+        assert len(found) == 1
+        assert found[0]["Node Type"] == "Bitmap Heap Scan"


### PR DESCRIPTION
## Summary

Sweep SQL was the dominant cost on long-running sessions — on JN's live DB (~10k events, 39 sessions) a single periodic sweep was **~7.5s**, and per-turn tail/entry sweeps were proportionally slow. EXPLAIN ANALYZE revealed two independent issues; this PR fixes both.

## Before / after (live JN DB, 10k events)

| query (all-sessions scope) | before | after | speedup |
|---|---:|---:|---:|
| ``candidate_rows`` (find_sessions_needing_inference) | 3848 ms | **4 ms** | ~930x |
| ``unreacted_rows`` (_filter_incomplete_batches) | 3632 ms | **4.4 ms** | ~820x |
| ``ghosts asst`` (find_and_repair_ghosts, 1st query) | 6.65 ms | 4.2 ms | 1.6x |

Shared buffer hits on the unscoped ``candidate_rows`` path drop from **1.8 M** to **2.6 K** (~700x less memory churn).

### Representative EXPLAIN pair (``candidate_rows`` unscoped)

**Before** — correlated subplan re-executes 2338 times:
` + "```" + `
Unique  (cost=0.28..3066089.13 rows=33) (actual time=3825.742..3825.753 rows=0)
  Buffers: shared hit=1814143
  ->  Nested Loop  (actual time=3825.741..3825.748 rows=0)
        SubPlan 3
          ->  Aggregate  (actual time=1.567..1.567 rows=1 loops=2338)
                ->  Bitmap Heap Scan on events a_1  (rows=786 loops=2338)
                      Heap Blocks: exact=1023478
Execution Time: 3848.964 ms
` + "```" + `

**After** — one HashAggregate pass per session, joined once:
` + "```" + `
Unique  (cost=2709.11..2710.71 rows=33) (actual time=4.070..4.071 rows=0)
  Buffers: shared hit=2627
  ->  Hash Join  (actual time=4.055..4.057 rows=0)
        ->  Hash Left Join  (actual time=4.028..4.030 rows=0)
              ->  Seq Scan on events e  (rows=2338)
              ->  Hash  ->  HashAggregate (rows=39)
                    ->  Seq Scan on events (rows=1894)
Execution Time: 4.139 ms
` + "```" + `

## The two problems and their fixes

### 1. Correlated SubPlan (N+1 structural)

``candidate_rows`` and ``unreacted_rows`` computed ``MAX(reacting_to)`` per session inside a per-row SubPlan — one full index+heap scan of assistant messages for every outer candidate row. Hoisting the aggregation to a CTE makes it one pass per session.

### 2. Ignored normalized ``role`` column

Migration 0022 (#117) promoted ``data->>'role'`` to a real column, but the sweep queries never switched. Six queries swap to ``role`` in this PR.

The two partial indexes whose WHERE clauses used the JSONB expression (``events_tool_result_idx``, ``events_assistant_tool_calls_idx``) are re-predicated in **migration 0023** so the column-predicated queries still hit them. The ``role`` column was backfilled from ``data->>'role'`` in 0022, so the new indexes cover byte-identical row sets.

## Migration 0023: CONCURRENTLY

The index switchover runs inside ``alembic.op.get_context().autocommit_block()`` with ``CREATE INDEX CONCURRENTLY`` + ``DROP INDEX CONCURRENTLY`` so it never takes an ACCESS EXCLUSIVE lock on ``events`` — the table is live-written by every session.

## Regression guards — two tiers

1. **Unit: detector correctness** (``tests/unit/test_plan_introspect.py``). Hand-crafted pathological and clean EXPLAIN plan fixtures prove ``find_subplans_over_events`` fires on the former and stays silent on the latter. The "RED evidence" that never rots — even after the production SQL is fixed, these 4 tests still prove the guard works.
2. **E2E: structural invariant** (``tests/e2e/test_sweep_perf.py``). Seeds ~2.6k events with the pathological shape, EXPLAINs the **actual production** CTE queries (imported from ``aios.harness.sweep``), asserts no SubPlan anywhere scans ``events``. Plus a ``@pytest.mark.slow`` buffer-hit budget check (< 50 K hits) as backstop for future plan-choice regressions the structural check might miss.

The SQL is extracted as module constants in ``sweep.py`` so the e2e test guards production code, not a hardcoded copy.

## Migration dependency

Code depends on 0022 (``role`` column + backfill, from #117). Every aios deployment current as of early 2026 has this applied — 0023 applies cleanly on top. Very old forks must apply 0022 first; the rewritten queries read ``role`` unconditionally.

## Deliberately out of scope

- Extract common SQL snippets into reusable views / query-builder helpers. The constants-in-module pattern is enough for now.
- Further decomposition of ``find_and_repair_ghosts``'s remaining non-role JSONB predicates (``data->>'event'``, ``data->>'result'`` on lifecycle rows). Those scans are already fast and the schema doesn't have normalized columns for them.

## Test plan

- [x] ``uv run mypy src`` — clean
- [x] ``uv run ruff check src tests`` + ``ruff format --check`` — clean
- [x] ``uv run pytest tests/unit -q`` — 852 passed (4 new detector tests)
- [x] Sweep-related e2e suite (``test_sweep.py``, ``test_sweep_perf.py``, ``test_orphan_stuck.py``) — 14 passed, including the new structural + budget guards
- [ ] Post-merge: apply migration 0023 to live aios-pg and re-run the EXPLAIN ANALYZE pair on the 10k-event snapshot to confirm index usage holds as expected

Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)