### PR TITLE
fix(api): stamp tool name on custom tool results (#133)

### DIFF
--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -24,6 +24,7 @@ from aios.api.deps import (
     ProcrastinateDep,
 )
 from aios.api.sse import sse_event_stream
+from aios.db import queries
 from aios.db.listen import listen_for_events
 from aios.harness.wake import defer_wake
 from aios.models.common import ListResponse
@@ -165,12 +166,22 @@ async def submit_tool_result(
     pool: PoolDep,
     _auth: AuthDep,
 ) -> Event:
-    """Submit a custom tool result. Appends a tool-role message and wakes the session."""
+    """Submit a custom tool result. Appends a tool-role message and wakes the session.
+
+    Stamps the tool's ``name`` into the event data by looking it up on the
+    parent assistant's ``tool_calls`` array — same source the harness uses
+    for built-in/MCP results — so the derived ``tool_name`` column stays
+    populated for custom tools too (issue #133).
+    """
+    async with pool.acquire() as conn:
+        name = await queries.lookup_tool_name_by_call_id(conn, session_id, body.tool_call_id)
     data: dict[str, Any] = {
         "role": "tool",
         "tool_call_id": body.tool_call_id,
         "content": body.content,
     }
+    if name is not None:
+        data["name"] = name
     if body.is_error:
         data["is_error"] = True
     event = await service.append_event(pool, session_id, "message", data)

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -942,6 +942,48 @@ async def _derive_event_channel(
     return None
 
 
+async def lookup_tool_name_by_call_id(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    tool_call_id: str,
+) -> str | None:
+    """Return the function name of the matching ``tool_call`` on the parent
+    assistant event, or None if no parent is found.
+
+    Used by the custom tool-result handler to stamp a ``name`` field on
+    the tool-role event it appends, so ``_derive_tool_name`` populates
+    the ``tool_name`` column (issue #133, migration 0022).  Mirrors the
+    parent-assistant lookup in ``_derive_event_channel`` — same ``@>``
+    predicate, same partial index (``events_assistant_tool_calls_idx``).
+    """
+    raw = await conn.fetchval(
+        "SELECT data->'tool_calls' FROM events "
+        "WHERE session_id = $1 "
+        "  AND kind = 'message' "
+        "  AND data->>'role' = 'assistant' "
+        "  AND data ? 'tool_calls' "
+        "  AND data->'tool_calls' @> jsonb_build_array("
+        "    jsonb_build_object('id', $2::text)) "
+        "ORDER BY seq DESC LIMIT 1",
+        session_id,
+        tool_call_id,
+    )
+    if raw is None:
+        return None
+    tool_calls = _parse_jsonb(raw)
+    if not isinstance(tool_calls, list):
+        return None
+    for tc in tool_calls:
+        if not isinstance(tc, dict) or tc.get("id") != tool_call_id:
+            continue
+        function = tc.get("function")
+        if not isinstance(function, dict):
+            return None
+        name = function.get("name")
+        return name if isinstance(name, str) else None
+    return None
+
+
 async def append_event(
     conn: asyncpg.Connection[Any],
     *,

--- a/tests/e2e/test_submit_tool_result_name.py
+++ b/tests/e2e/test_submit_tool_result_name.py
@@ -1,0 +1,220 @@
+"""E2E regression test for issue #133.
+
+When the API receives a custom tool result via
+``POST /v1/sessions/{id}/tool-results``, the appended tool-role event must
+carry the tool's ``name`` so the derived ``tool_name`` column on the
+``events`` table (see migration 0022 + ``_derive_tool_name`` in
+``db/queries.py``) is populated.  Without it, ``events_search`` queries
+filtering ``WHERE tool_name = '<custom>'`` silently skip custom results.
+
+The server knows the name — it lives on the parent assistant's
+``data->'tool_calls'`` — so the client should not have to pass it.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+
+import httpx
+import pytest
+
+
+def _uniq() -> str:
+    return secrets.token_hex(4)
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    settings = get_settings()
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    transport = httpx.ASGITransport(app=app)
+    # No real worker in these tests; avoid enqueueing a wake for the
+    # procrastinate MagicMock.
+    with mock.patch(
+        "aios.api.routers.sessions.defer_wake",
+        new_callable=mock.AsyncMock,
+    ):
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            headers={"Authorization": f"Bearer {aios_env['AIOS_API_KEY']}"},
+        ) as client:
+            yield client
+
+
+@pytest.fixture
+async def session_id(pool: Any) -> str:
+    from aios.db import queries
+    from aios.services import agents as agents_svc
+    from aios.services import sessions as sessions_svc
+
+    async with pool.acquire() as conn:
+        env = await queries.insert_environment(conn, name=f"custom-tool-env-{_uniq()}")
+    agent = await agents_svc.create_agent(
+        pool,
+        name=f"custom-tool-agent-{_uniq()}",
+        model="openai/gpt-4o-mini",
+        system="",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    session = await sessions_svc.create_session(
+        pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+    )
+    return session.id
+
+
+async def _seed_assistant_tool_call(
+    pool: Any,
+    session_id: str,
+    *,
+    tool_call_id: str,
+    tool_name: str,
+) -> None:
+    """Append an assistant event that requests a single custom tool call."""
+    from aios.services import sessions as sessions_svc
+
+    await sessions_svc.append_user_message(pool, session_id, "what is the weather?")
+    await sessions_svc.append_event(
+        pool,
+        session_id,
+        "message",
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": tool_call_id,
+                    "type": "function",
+                    "function": {
+                        "name": tool_name,
+                        "arguments": json.dumps({"city": "SF"}),
+                    },
+                }
+            ],
+        },
+    )
+
+
+class TestSubmitToolResultStampsName:
+    """Regression coverage for issue #133."""
+
+    async def test_stamps_tool_name_from_parent_assistant(
+        self,
+        http_client: httpx.AsyncClient,
+        pool: Any,
+        session_id: str,
+    ) -> None:
+        """Submitting a result matches the parent's tool_call name into the event."""
+        call_id = f"call_{_uniq()}"
+        await _seed_assistant_tool_call(
+            pool,
+            session_id,
+            tool_call_id=call_id,
+            tool_name="get_weather",
+        )
+
+        r = await http_client.post(
+            f"/v1/sessions/{session_id}/tool-results",
+            json={"tool_call_id": call_id, "content": '{"temp_f": 72}'},
+        )
+        assert r.status_code == 201, r.text
+        event = r.json()
+
+        assert event["kind"] == "message"
+        assert event["data"]["role"] == "tool"
+        assert event["data"]["tool_call_id"] == call_id
+        # The regression: the server should promote the parent's tool_call
+        # function name into the appended event's data.
+        assert event["data"].get("name") == "get_weather"
+
+    async def test_derived_tool_name_column_populated(
+        self,
+        http_client: httpx.AsyncClient,
+        pool: Any,
+        session_id: str,
+    ) -> None:
+        """The physical ``tool_name`` column on events picks up the name.
+
+        A custom tool result queried through ``events_search`` / the raw
+        ``events`` table should be discoverable by ``tool_name`` the same
+        way built-in and MCP tool results are.
+        """
+        call_id = f"call_{_uniq()}"
+        await _seed_assistant_tool_call(
+            pool,
+            session_id,
+            tool_call_id=call_id,
+            tool_name="get_weather",
+        )
+
+        r = await http_client.post(
+            f"/v1/sessions/{session_id}/tool-results",
+            json={"tool_call_id": call_id, "content": "ok"},
+        )
+        assert r.status_code == 201, r.text
+        new_seq = r.json()["seq"]
+
+        async with pool.acquire() as conn:
+            tool_name = await conn.fetchval(
+                "SELECT tool_name FROM events WHERE session_id = $1 AND seq = $2",
+                session_id,
+                new_seq,
+            )
+        assert tool_name == "get_weather"
+
+    async def test_unknown_call_id_leaves_name_unset(
+        self,
+        http_client: httpx.AsyncClient,
+        pool: Any,
+        session_id: str,
+    ) -> None:
+        """When no parent assistant is found, ``name`` stays absent.
+
+        The operation still succeeds — the server does not reject a
+        submission whose ``tool_call_id`` can't be matched to a parent —
+        and the derived ``tool_name`` column simply stays NULL.  Same
+        shape the code had before the fix; just no upgrade possible.
+        """
+        r = await http_client.post(
+            f"/v1/sessions/{session_id}/tool-results",
+            json={"tool_call_id": "call_nonexistent", "content": "whatever"},
+        )
+        assert r.status_code == 201, r.text
+        event = r.json()
+        assert "name" not in event["data"]
+
+        async with pool.acquire() as conn:
+            tool_name = await conn.fetchval(
+                "SELECT tool_name FROM events WHERE session_id = $1 AND seq = $2",
+                session_id,
+                event["seq"],
+            )
+        assert tool_name is None


### PR DESCRIPTION
## Summary

- Custom (client-executed) tool results posted to `POST /v1/sessions/{id}/tool-results` now carry the tool's `name`, so the derived `tool_name` column on the `events` table is populated for them too.
- Built-in and MCP tool results already had this via `harness/tool_dispatch.py` — this closes the gap for the third code path.
- The server derives the name by walking back to the parent assistant event's `tool_calls` by `tool_call_id`; the client API surface is unchanged.

Closes #133.

## How it works

1. New helper `lookup_tool_name_by_call_id` in `src/aios/db/queries.py` mirrors the parent-assistant lookup already used by `_derive_event_channel` — same `@>` containment against `data->'tool_calls'`, same partial index `events_assistant_tool_calls_idx` (migration 0011).
2. `submit_tool_result` in `src/aios/api/routers/sessions.py` calls it and stamps `name` into the event data when found. Existing `_derive_tool_name` then populates the column.
3. Unknown `tool_call_id`s are still accepted without rejection; they just leave `tool_name` NULL, same as pre-fix behavior.

## Test plan
- [x] New e2e regression test `tests/e2e/test_submit_tool_result_name.py` (3 scenarios: happy path, column population, unknown call_id).
- [x] Test fails before the fix, passes after (red→green TDD).
- [x] `uv run mypy src` — clean.
- [x] `uv run ruff check src tests` + format — clean.
- [x] `uv run pytest tests/unit -q` — 879 passed.
- [x] `uv run pytest tests/e2e -q` — 240 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)