### PR TITLE
fix(cli): preserve server-write success on broken output pipe (#116)

### DIFF
--- a/src/aios/cli/app.py
+++ b/src/aios/cli/app.py
@@ -8,6 +8,7 @@ the resolved state from :class:`typer.Context` via :func:`get_state` in
 
 from __future__ import annotations
 
+import signal
 from typing import Annotated
 
 import typer
@@ -15,6 +16,24 @@ import typer
 from aios.cli.config import resolve_base_url
 from aios.cli.output import OutputFormat
 from aios.cli.runtime import CliState
+
+# Restore the default SIGPIPE disposition so piping the CLI into a
+# consumer that exits early (``aios ... | head``, a scripted pipeline
+# that dies mid-read) terminates the process silently instead of raising
+# a Python BrokenPipeError traceback (issue #116).  The process exits
+# 141 (128 + SIGPIPE) — standard UNIX convention, same as ``yes | head``.
+# The explicit BrokenPipeError catch in :func:`aios.cli.runtime.run_or_die`
+# covers Windows (no SIGPIPE) and any buffered-stdout case where Python
+# observes the broken pipe before SIGPIPE is delivered; that path exits 0.
+#
+# IMPORTANT: this fires at module import.  The API and worker processes
+# (``aios api`` / ``aios worker``) must not import :mod:`aios.cli.app`
+# directly — SIGPIPE terminating the process is correct CLI behavior but
+# would silently kill a long-running server on a broken socket write.
+# Current entrypoints route through :mod:`aios.__main__` which only
+# imports this module for the CLI subcommands.
+if hasattr(signal, "SIGPIPE"):
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 app = typer.Typer(
     name="aios",

--- a/src/aios/cli/runtime.py
+++ b/src/aios/cli/runtime.py
@@ -7,6 +7,8 @@ module at its tail to register sub-apps).
 
 from __future__ import annotations
 
+import contextlib
+import os
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -41,7 +43,11 @@ def run_or_die(fn: Callable[[], int | None]) -> None:
     """Execute ``fn`` and translate ``AiosApiError`` into a clean CLI exit.
 
     Keeps tracebacks hidden and prints the server's error envelope.
-    Non-API exceptions bubble.
+    ``BrokenPipeError`` during output rendering — raised when a downstream
+    consumer (pipe, pager, script) closed its end while we were writing —
+    resolves to a silent ``exit 0``; by the time we're rendering, any
+    server-side mutation has already landed, and we don't want pipe
+    failures to mask that (issue #116).  Non-API exceptions bubble.
     """
     try:
         rc = fn()
@@ -51,8 +57,34 @@ def run_or_die(fn: Callable[[], int | None]) -> None:
             print_error(f"detail: {exc.detail}")
         exit_code = 2 if exc.status_code == 401 else 1
         raise typer.Exit(exit_code) from exc
+    except BrokenPipeError:
+        _silence_stdout()
+        raise typer.Exit(0) from None
     except KeyboardInterrupt:
         sys.stderr.write("\n")
         raise typer.Exit(130) from None
     if rc:
         raise typer.Exit(rc)
+
+
+def _silence_stdout() -> None:
+    """Swap ``sys.stdout`` for ``/dev/null`` so later writes (notably the
+    interpreter-shutdown flush) don't re-raise ``BrokenPipeError`` on the
+    closed pipe.
+
+    Python 3.13 routes ``__del__`` exceptions through
+    ``sys.unraisablehook`` — it no longer silently drops them as earlier
+    versions did — so we also explicitly close the original stream when
+    it's the real process stdout, swallowing the ``BrokenPipeError`` the
+    flush inside ``close()`` will raise.  Pytest capture streams and
+    test monkeypatches are left untouched so teardown can restore them.
+    """
+    # Kept open for the remainder of the process; closing the devnull
+    # stream would make subsequent writes (or the shutdown flush) raise
+    # again.
+    devnull = open(os.devnull, "w")  # noqa: SIM115
+    old = sys.stdout
+    sys.stdout = devnull
+    if sys.__stdout__ is not None and old is sys.__stdout__:
+        with contextlib.suppress(Exception):
+            old.close()

--- a/tests/unit/cli/test_cli_broken_pipe.py
+++ b/tests/unit/cli/test_cli_broken_pipe.py
@@ -1,0 +1,90 @@
+"""Regression coverage for issue #116.
+
+When the stdout pipe breaks while the CLI is writing a response (e.g. a
+downstream pager or scripted consumer exits early), ``run_or_die`` must
+translate the resulting ``BrokenPipeError`` into a clean exit instead of
+a traceback.  This keeps mutating verbs from looking like they failed
+when in fact the server-side write already landed.
+"""
+
+from __future__ import annotations
+
+import io
+import signal
+import sys
+
+import pytest
+import typer
+
+from aios.cli.runtime import run_or_die
+
+
+def test_run_or_die_swallows_brokenpipe_and_exits_clean(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``fn`` raises ``BrokenPipeError`` directly, we exit 0 quietly.
+
+    Swaps ``sys.stdout`` to an in-memory stream first so the silence-
+    stdout path has a non-__stdout__ object to replace, mirroring the
+    real-runtime shape where the broken stdout is a pipe-backed dup of
+    fd 1 rather than the interpreter's own stdout.
+    """
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+
+    def fn() -> int | None:
+        raise BrokenPipeError(32, "Broken pipe")
+
+    with pytest.raises(typer.Exit) as excinfo:
+        run_or_die(fn)
+
+    assert excinfo.value.exit_code == 0
+
+
+def test_run_or_die_swallows_brokenpipe_raised_from_stdout_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Broken pipe raised from a buffered ``stdout.write`` inside the command
+    still resolves to a clean exit — the typical real-world shape where
+    ``json`` rendering fails mid-flush after the HTTP call succeeded."""
+
+    class BrokenStream(io.StringIO):
+        def write(self, _s: str) -> int:  # type: ignore[override]
+            raise BrokenPipeError(32, "Broken pipe")
+
+    monkeypatch.setattr(sys, "stdout", BrokenStream())
+
+    def fn() -> int | None:
+        # Simulates the post-HTTP rendering step that fails when the
+        # consumer closed its end of the pipe.
+        sys.stdout.write('{"ok": true}\n')
+        return None
+
+    with pytest.raises(typer.Exit) as excinfo:
+        run_or_die(fn)
+
+    assert excinfo.value.exit_code == 0
+
+
+def test_sigpipe_handler_installed_at_cli_import() -> None:
+    """Importing the CLI app should restore the default SIGPIPE disposition.
+
+    Python by default turns SIGPIPE into a BrokenPipeError; that's
+    helpful for handling it in Python code, but it means ``aios | head``
+    leaves a BrokenPipeError traceback on stderr once the consumer
+    exits.  Restoring ``SIG_DFL`` lets the kernel kill us silently on
+    SIGPIPE, matching the behavior of standard UNIX tools.
+
+    Note: signal handlers are process-wide; this test is a sanity check
+    on the initial import's effect and does not guarantee isolation
+    from other tests that touch SIGPIPE.  No other code in the project
+    sets a SIGPIPE handler, so ordering flakes would indicate someone
+    added one.
+    """
+    if not hasattr(signal, "SIGPIPE"):
+        pytest.skip("SIGPIPE not available on this platform")
+
+    # Import for side-effect — this should install the handler.
+    import aios.cli.app  # noqa: F401
+
+    handler = signal.getsignal(signal.SIGPIPE)
+    assert handler == signal.SIG_DFL


### PR DESCRIPTION
## Summary

- Piping `aios` output to a consumer that exits early no longer leaves a Python `BrokenPipeError` traceback that makes a successful mutation look like a failure.
- Two complementary mechanisms: SIGPIPE→SIG_DFL at CLI import handles the common Unix case silently (exit 141); `BrokenPipeError` catch in `run_or_die` handles Windows and buffered-stdout edges (exit 0).

Closes #116.

## Why

\`\`\`
\$ aios --format json agents update <agent_id> --data '...' | python3 -c '...SyntaxError...'
Exception ignored on flushing sys.stdout:
BrokenPipeError: [Errno 32] Broken pipe
\`\`\`

The HTTP PUT already succeeded on the server; the consumer just closed the pipe early. Users reading that traceback reasonably assume the command failed and re-run, hitting 409s from optimistic-concurrency version checks.

## How it works

1. **`src/aios/cli/app.py`** — `signal.signal(SIGPIPE, SIG_DFL)` at module import (Unix-guarded). Writing to a closed pipe now silently terminates the process (standard `yes | head` behavior).
2. **`src/aios/cli/runtime.py`** — `run_or_die` catches `BrokenPipeError`, swaps stdout to `/dev/null` (so shutdown flush can't re-raise), and exits 0. Covers Windows and rare buffered-stdout cases.

Module-level SIGPIPE install is an intentional CLI-only behavior; the comment flags that the API/worker must not import `aios.cli.app`.

## Test plan
- [x] New `tests/unit/cli/test_cli_broken_pipe.py` — 3 unit tests (red→green TDD).
- [x] Passes under both `pytest` and `pytest -s`.
- [x] \`uv run mypy src\` — clean.
- [x] \`uv run ruff check src tests\` + format — clean.
- [x] \`uv run pytest tests/unit -q\` — 882 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)