### PR TITLE
fix(telegram): surface bot identity in MCP init instructions (#55)

### DIFF
--- a/connectors/telegram/src/aios_telegram/app.py
+++ b/connectors/telegram/src/aios_telegram/app.py
@@ -13,7 +13,7 @@ import asyncio
 
 import structlog
 
-from .bot import build_application, discover_bot_id, install_handler, run_application
+from .bot import build_application, discover_bot_identity, install_handler, run_application
 from .config import Settings
 from .ingest import IngestClient
 from .mcp import build_mcp_app, build_mcp_server, parse_bind, serve_mcp
@@ -25,7 +25,7 @@ async def run(cfg: Settings) -> None:
     application = build_application(cfg.bot_token)
     await application.initialize()
     try:
-        bot_id = await discover_bot_id(application)
+        identity = await discover_bot_identity(application)
     except BaseException:
         await application.shutdown()
         raise
@@ -35,11 +35,19 @@ async def run(cfg: Settings) -> None:
         api_key=cfg.aios_api_key,
         connection_id=cfg.aios_connection_id,
     ) as ingest:
-        install_handler(application, bot_id=bot_id, ingest=ingest)
-        mcp_app = build_mcp_app(build_mcp_server(bot=application.bot), token=cfg.mcp_token)
+        install_handler(application, bot_id=identity.id, ingest=ingest)
+        mcp_app = build_mcp_app(
+            build_mcp_server(
+                bot=application.bot,
+                bot_id=identity.id,
+                first_name=identity.first_name,
+                username=identity.username,
+            ),
+            token=cfg.mcp_token,
+        )
         host, port = parse_bind(cfg.mcp_bind)
 
-        log.info("telegram.ready", bot_id=bot_id)
+        log.info("telegram.ready", bot_id=identity.id)
 
         try:
             async with asyncio.TaskGroup() as tg:

--- a/connectors/telegram/src/aios_telegram/bot.py
+++ b/connectors/telegram/src/aios_telegram/bot.py
@@ -3,8 +3,10 @@
 Three responsibilities:
 
 1. Build the PTB ``Application`` from the bot token.
-2. Discover the bot's numeric id on startup (the ``<account>`` segment of
-   channel addresses) via ``Bot.get_me()``.
+2. Discover the bot's identity on startup (numeric id, ``@username``,
+   display ``first_name``) via ``Bot.get_me()`` — surfaced to the agent
+   in the MCP init instructions (issue #55).  The numeric id doubles as
+   the ``<account>`` segment of channel addresses.
 3. Register a single message handler that parses each incoming text
    message and POSTs it to aios via :class:`aios_telegram.ingest.IngestClient`.
 
@@ -16,33 +18,58 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from dataclasses import dataclass
 
 import structlog
 from telegram import Update
 from telegram.ext import Application, ContextTypes, MessageHandler, filters
 
-from .errors import BotIdentityError
 from .ingest import IngestClient, build_metadata
 from .parse import parse_message
 
 log = structlog.get_logger(__name__)
 
 
+@dataclass(frozen=True, slots=True)
+class BotIdentity:
+    """Bot's own surface on Telegram, captured from ``Bot.get_me()``.
+
+    ``id`` and ``first_name`` are guaranteed by Telegram's schema —
+    BotFather sets a ``first_name`` at creation time and the numeric id
+    is always present.  ``username`` is optional: a bot can exist without
+    one during the initial BotFather configuration window.  The
+    renderer in ``prompts.py`` omits ``username`` when unset.
+    """
+
+    id: int
+    first_name: str
+    username: str | None
+
+
 def build_application(token: str) -> Application:  # type: ignore[type-arg]
     return Application.builder().token(token).build()
 
 
-async def discover_bot_id(application: Application) -> int:  # type: ignore[type-arg]
-    """Call ``getMe`` and return the bot's numeric user id.
+async def discover_bot_identity(application: Application) -> BotIdentity:  # type: ignore[type-arg]
+    """Call ``getMe`` and return the bot's identity surface.
 
-    Raises :class:`BotIdentityError` if Telegram's response is unusable.
-    Called once on startup after ``application.initialize()``.
+    Called once on startup after ``application.initialize()``.  PTB's
+    ``User`` schema guarantees ``id`` and ``first_name``; a genuinely
+    malformed response would raise inside ``get_me`` or violate PTB's
+    types, so we trust the fields here.
     """
     me = await application.bot.get_me()
-    if not me.id:
-        raise BotIdentityError("getMe returned no id")
-    log.info("telegram.bot.identified", bot_id=me.id, username=me.username)
-    return int(me.id)
+    log.info(
+        "telegram.bot.identified",
+        bot_id=me.id,
+        username=me.username,
+        first_name=me.first_name,
+    )
+    return BotIdentity(
+        id=int(me.id),
+        first_name=me.first_name,
+        username=me.username or None,
+    )
 
 
 def install_handler(

--- a/connectors/telegram/src/aios_telegram/errors.py
+++ b/connectors/telegram/src/aios_telegram/errors.py
@@ -5,7 +5,3 @@ from __future__ import annotations
 
 class TelegramConnectorError(Exception):
     """Base class for all aios-telegram errors."""
-
-
-class BotIdentityError(TelegramConnectorError):
-    """Raised when we can't resolve the bot's numeric id at startup."""

--- a/connectors/telegram/src/aios_telegram/mcp.py
+++ b/connectors/telegram/src/aios_telegram/mcp.py
@@ -27,7 +27,7 @@ from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 from telegram import Bot
 
-from .prompts import TELEGRAM_SERVER_INSTRUCTIONS
+from .prompts import build_instructions
 
 log = structlog.get_logger(__name__)
 
@@ -92,10 +92,20 @@ class BearerAuthMiddleware:
         await self._app(scope, receive, send)
 
 
-def build_mcp_server(*, bot: Bot) -> FastMCP:
+def build_mcp_server(
+    *,
+    bot: Bot,
+    bot_id: int,
+    first_name: str,
+    username: str | None = None,
+) -> FastMCP:
     mcp = FastMCP(
         "aios-telegram",
-        instructions=TELEGRAM_SERVER_INSTRUCTIONS,
+        instructions=build_instructions(
+            bot_id=bot_id,
+            first_name=first_name,
+            username=username,
+        ),
         stateless_http=True,
     )
 

--- a/connectors/telegram/src/aios_telegram/prompts.py
+++ b/connectors/telegram/src/aios_telegram/prompts.py
@@ -7,9 +7,49 @@ heading.
 
 Covers only the tool this server exposes — ``telegram_send``. Telling the
 model about tools that don't exist would be worse than silence.
+
+``build_instructions`` prepends an identity block (the bot's own numeric
+``bot_id``, ``@username``, and display ``first_name``) so the agent knows
+who it is on Telegram without having to learn that from inbound traffic
+(issue #55).
 """
 
 from __future__ import annotations
+
+
+def build_instructions(
+    *,
+    bot_id: int,
+    first_name: str,
+    username: str | None = None,
+) -> str:
+    """Compose the MCP ``initialize`` instructions with identity prelude.
+
+    All three identity fields come from ``Bot.get_me()`` at connector
+    startup.  ``bot_id`` and ``first_name`` are guaranteed by Telegram's
+    schema; ``username`` is optional (a bot can exist without one during
+    BotFather setup) and its bullet is omitted when absent or empty.
+    ``bot_id`` doubles as the ``<account>`` segment of this connector's
+    channel addresses.
+    """
+    lines = [
+        "## Your identity on this Telegram bot account",
+        "",
+        f"- **bot_id**: `{bot_id}` — this is YOU.  In group chats, any "
+        f"inbound whose header shows this id is your own prior message, "
+        f"not another participant.  It also appears as the ``<account>`` "
+        f"segment of every ``telegram/<account>/<chat_id>`` address.",
+    ]
+    if username:
+        lines.append(
+            f"- **username**: `@{username}` — what users type to mention "
+            f"you in chats and how people refer to your bot."
+        )
+    if first_name:
+        lines.append(f"- **first_name**: `{first_name}` — your display name on Telegram.")
+    identity = "\n".join(lines) + "\n"
+    return identity + "\n" + TELEGRAM_SERVER_INSTRUCTIONS
+
 
 TELEGRAM_SERVER_INSTRUCTIONS = """\
 ## chat_id

--- a/connectors/telegram/tests/test_mcp.py
+++ b/connectors/telegram/tests/test_mcp.py
@@ -60,7 +60,9 @@ def test_focal_meta_not_integer_raises() -> None:
 
 
 async def _call_send(bot: Bot, text: str, *, focal: str | None) -> dict[str, Any]:
-    mcp = build_mcp_server(bot=bot)
+    # Identity args are required by build_mcp_server but not exercised by
+    # telegram_send — dummy values keep these tool tests focused.
+    mcp = build_mcp_server(bot=bot, bot_id=1, first_name="Test", username="test_bot")
     result = await mcp._tool_manager.call_tool(
         "telegram_send",
         {"text": text},
@@ -95,6 +97,31 @@ async def test_telegram_send_group_negative_chat_id() -> None:
 
     assert out == {"message_id": 7}
     bot.send_message.assert_awaited_once_with(chat_id=-1001234567890, text="yo")
+
+
+# ─── build_mcp_server identity plumbing ─────────────────────────────────────
+
+
+def test_build_mcp_server_threads_identity_into_instructions() -> None:
+    """The bot's identity fields (issue #55) must end up in FastMCP's
+    ``instructions`` so they surface in ``InitializeResult``."""
+    bot = MagicMock(spec=Bot)
+    mcp = build_mcp_server(bot=bot, bot_id=987654321, first_name="Example", username="example_bot")
+    assert mcp.instructions is not None
+    assert "987654321" in mcp.instructions
+    assert "@example_bot" in mcp.instructions
+    assert "Example" in mcp.instructions
+
+
+def test_build_mcp_server_omits_username_when_absent() -> None:
+    """Bots without a set ``username`` should get an identity block
+    that simply lacks that bullet — ``first_name`` stays present."""
+    bot = MagicMock(spec=Bot)
+    mcp = build_mcp_server(bot=bot, bot_id=42, first_name="Example", username=None)
+    assert mcp.instructions is not None
+    assert "42" in mcp.instructions
+    assert "Example" in mcp.instructions
+    assert "username" not in mcp.instructions
 
 
 # ─── bearer auth middleware ─────────────────────────────────────────────────

--- a/connectors/telegram/tests/test_prompts.py
+++ b/connectors/telegram/tests/test_prompts.py
@@ -1,0 +1,62 @@
+"""Unit tests for the Telegram instructions builder (issue #55).
+
+Mirrors the Signal connector's ``test_prompts.py`` — the agent otherwise
+has no canonical source of truth for who it is on Telegram (numeric
+``bot_id``, ``@username``, and display ``first_name`` all come from
+``Bot.get_me()`` and should be surfaced in the MCP init instructions).
+"""
+
+from __future__ import annotations
+
+from aios_telegram.prompts import TELEGRAM_SERVER_INSTRUCTIONS, build_instructions
+
+
+class TestBuildInstructions:
+    def test_includes_bot_id(self) -> None:
+        result = build_instructions(bot_id=123456789, username="mybot_bot", first_name="My Bot")
+        assert "123456789" in result
+
+    def test_includes_username(self) -> None:
+        result = build_instructions(bot_id=123456789, username="mybot_bot", first_name="My Bot")
+        assert "mybot_bot" in result
+
+    def test_includes_first_name(self) -> None:
+        result = build_instructions(bot_id=123456789, username="mybot_bot", first_name="My Bot")
+        assert "My Bot" in result
+
+    def test_appends_tool_instructions_body(self) -> None:
+        """The static affordance body must appear verbatim after the
+        identity block — we're prepending, not rewriting."""
+        result = build_instructions(bot_id=1, username="u", first_name="n")
+        assert TELEGRAM_SERVER_INSTRUCTIONS in result
+
+    def test_identity_block_comes_first(self) -> None:
+        result = build_instructions(bot_id=1, username="u", first_name="n")
+        identity_idx = result.find("## Your identity")
+        body_idx = result.find("## chat_id")
+        assert identity_idx >= 0
+        assert body_idx > identity_idx
+
+    def test_is_string(self) -> None:
+        result = build_instructions(bot_id=1, username="u", first_name="n")
+        assert isinstance(result, str)
+
+    def test_username_rendered_with_at_prefix(self) -> None:
+        """``@username`` is how Telegram users actually refer to bots, so
+        render it that way rather than as a bare token — makes the agent's
+        mental model match what it sees in chats."""
+        result = build_instructions(bot_id=1, username="mybot_bot", first_name="My Bot")
+        assert "@mybot_bot" in result
+
+    def test_omits_username_line_when_none(self) -> None:
+        """Not every bot has a username set (rare, but possible via
+        BotFather before the bot is finalized).  Skip the bullet entirely
+        rather than render a blank entry — the agent's parse of the
+        identity block stays consistent."""
+        result = build_instructions(bot_id=1, first_name="My Bot", username=None)
+        assert "username" not in result
+
+    def test_omits_username_line_when_empty_string(self) -> None:
+        """Empty string equivalent to None — don't render a blank entry."""
+        result = build_instructions(bot_id=1, first_name="My Bot", username="")
+        assert "username" not in result


### PR DESCRIPTION
## Summary

- Telegram connector now includes an \`## Your identity on this Telegram bot account\` block in its MCP \`InitializeResult.instructions\` — parity with what the Signal connector already does.
- Fields surfaced: numeric \`bot_id\`, \`@username\` (optional, omitted when unset), and display \`first_name\`.
- Source: \`Bot.get_me()\` at connector startup.

Closes #55 (the last remaining connector without an identity block).

## Why

Without a canonical identity clause, models confabulate. The issue cites minimax inventing a name when asked 'do you know who you are?' on a generic 'helpful assistant reachable via Signal' prompt. Signal already surfaces bot identity via \`prompts.build_instructions\`; Telegram shipped a static instructions string with no identity prelude.

## Changes

- \`connectors/telegram/src/aios_telegram/prompts.py\` — new \`build_instructions(*, bot_id, first_name, username=None)\` prepending the identity block to the existing \`TELEGRAM_SERVER_INSTRUCTIONS\` body.
- \`connectors/telegram/src/aios_telegram/bot.py\` — new \`BotIdentity\` dataclass; \`discover_bot_id\` renamed \`discover_bot_identity\` returning all three fields.
- \`connectors/telegram/src/aios_telegram/mcp.py\` — \`build_mcp_server\` accepts identity kwargs and threads them through \`build_instructions\`.
- \`connectors/telegram/src/aios_telegram/app.py\` — wires the new signature.
- \`connectors/telegram/src/aios_telegram/errors.py\` — removed unused \`BotIdentityError\` (relying on PTB's type guarantees per CLAUDE.md).
- \`connectors/telegram/tests/test_prompts.py\` (new) — 9 unit tests mirroring Signal's pattern.
- \`connectors/telegram/tests/test_mcp.py\` — existing callers updated; two new integration tests verifying \`build_mcp_server\` threads identity into \`FastMCP.instructions\`.

## Test plan
- [x] \`uv run pytest -q\` in \`connectors/telegram/\` — 37 passed.
- [x] \`uv run mypy src\` (connectors/telegram) — clean.
- [x] \`uv run ruff check src tests\` + format — clean.
- [x] Signal connector sanity pass — 103 passed, untouched.
- [x] Root project unit tests — 882 passed, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)