### PR TITLE
fix(api): reject unknown tool_call_id on custom tool-result submission

### DIFF
--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -26,6 +26,7 @@ from aios.api.deps import (
 from aios.api.sse import sse_event_stream
 from aios.db import queries
 from aios.db.listen import listen_for_events
+from aios.errors import NotFoundError
 from aios.harness.wake import defer_wake
 from aios.models.common import ListResponse
 from aios.models.events import Event, EventKind
@@ -171,20 +172,23 @@ async def submit_tool_result(
     Stamps the tool's ``name`` into the event data by looking it up on the
     parent assistant's ``tool_calls`` array — same source the harness uses
     for built-in/MCP results — so the derived ``tool_name`` column stays
-    populated for custom tools too (issue #133).
+    populated for custom tools too (issue #133).  Returns 404 when the
+    ``tool_call_id`` has no matching parent assistant tool call, since a
+    result with no parent is a client bug that would leave an orphan row.
     """
     async with pool.acquire() as conn:
         name = await queries.lookup_tool_name_by_call_id(conn, session_id, body.tool_call_id)
-    data: dict[str, Any] = {
-        "role": "tool",
-        "tool_call_id": body.tool_call_id,
-        "content": body.content,
-    }
-    if name is not None:
-        data["name"] = name
-    if body.is_error:
-        data["is_error"] = True
-    event = await service.append_event(pool, session_id, "message", data)
+        if name is None:
+            raise NotFoundError(f"tool_call_id {body.tool_call_id!r} not found")
+        data: dict[str, Any] = {
+            "role": "tool",
+            "tool_call_id": body.tool_call_id,
+            "content": body.content,
+            "name": name,
+        }
+        if body.is_error:
+            data["is_error"] = True
+        event = await queries.append_event(conn, session_id=session_id, kind="message", data=data)
     await defer_wake(pool, session_id, cause="custom_tool_result")
     return event
 

--- a/tests/e2e/test_submit_tool_result_name.py
+++ b/tests/e2e/test_submit_tool_result_name.py
@@ -190,31 +190,31 @@ class TestSubmitToolResultStampsName:
             )
         assert tool_name == "get_weather"
 
-    async def test_unknown_call_id_leaves_name_unset(
+    async def test_unknown_call_id_returns_404(
         self,
         http_client: httpx.AsyncClient,
         pool: Any,
         session_id: str,
     ) -> None:
-        """When no parent assistant is found, ``name`` stays absent.
+        """Submitting a result for a ``tool_call_id`` with no parent is a
+        client bug; the server rejects it and appends no event.
 
-        The operation still succeeds — the server does not reject a
-        submission whose ``tool_call_id`` can't be matched to a parent —
-        and the derived ``tool_name`` column simply stays NULL.  Same
-        shape the code had before the fix; just no upgrade possible.
+        An orphan tool-role event (no matching assistant tool_call) would
+        leave a row with NULL ``tool_name`` in ``events`` that cannot be
+        reconciled with any parent.  Per CLAUDE.md's "fail hard, no
+        fallbacks" rule, the server refuses to store it.
         """
         r = await http_client.post(
             f"/v1/sessions/{session_id}/tool-results",
             json={"tool_call_id": "call_nonexistent", "content": "whatever"},
         )
-        assert r.status_code == 201, r.text
-        event = r.json()
-        assert "name" not in event["data"]
+        assert r.status_code == 404, r.text
+        assert r.json()["error"]["type"] == "not_found"
 
         async with pool.acquire() as conn:
-            tool_name = await conn.fetchval(
-                "SELECT tool_name FROM events WHERE session_id = $1 AND seq = $2",
+            count = await conn.fetchval(
+                "SELECT COUNT(*) FROM events "
+                "WHERE session_id = $1 AND kind = 'message' AND data->>'role' = 'tool'",
                 session_id,
-                event["seq"],
             )
-        assert tool_name is None
+        assert count == 0


### PR DESCRIPTION
Follow-up to #148 — applies the fail-hard behavior from draft #142 (never merged) to align with the "fail hard, no fallbacks" principle from CLAUDE.md.

## Summary
- `POST /v1/sessions/:id/tool-results` now returns **404** when the `tool_call_id` has no matching parent assistant `tool_calls[*].id` in the session event log (previously: 201 with no `name` field and NULL `tool_name` column — an orphan row).
- Folds the lookup + append into a single `pool.acquire()`: calls `queries.append_event(conn, …)` directly instead of round-tripping through the three-line `services.sessions.append_event` wrapper, since the wrapper does no extra work here.
- Updates the e2e test formerly named `test_unknown_call_id_leaves_name_unset` to `test_unknown_call_id_returns_404` — now asserts 404 + `error.type == "not_found"` + no tool-role event was appended.

## Why
Silently accepting a tool-result for a `tool_call_id` with no parent is exactly the kind of fallback CLAUDE.md forbids: the model can't observe the problem (no session event is correlatable with a non-existent parent), `events_search` gets orphan NULL-name rows, and a client bug gets papered over. `queries.append_event` already raises `NotFoundError` for a missing session row, so this aligns the endpoint with the surrounding pattern.

## Test plan
- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 882 passed
- [x] `DOCKER_HOST=unix:///Users/tom/.docker/run/docker.sock uv run pytest tests/e2e/test_submit_tool_result_name.py -q` — 3 passed (happy path, `tool_name` column stamped, unknown-id → 404)

Refs: #133 (original issue), #148 (merged happy-path fix this builds on), #142 (never-merged draft whose fail-hard shape this adopts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)