### PR TITLE
fix(harness): read lifecycle tail newest-first in _dispatch_confirmed_tools (#155)

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -679,11 +679,14 @@ async def _dispatch_confirmed_tools(
             if tcid:
                 completed.add(tcid)
 
-    # Read lifecycle events to find tool_confirmed allow events.
+    # Read the recent tail; on long sessions the default ASC scan would read
+    # the oldest 200 lifecycle events and miss any fresh tool_confirmed.
     lifecycle_events = await sessions_service.read_events(
         pool,
         session_id,
         kind="lifecycle",
+        newest_first=True,
+        limit=200,
     )
     confirmed: set[str] = set()
     for e in lifecycle_events:

--- a/tests/unit/test_dispatch_confirmed_tools.py
+++ b/tests/unit/test_dispatch_confirmed_tools.py
@@ -1,0 +1,59 @@
+"""Unit tests for ``_dispatch_confirmed_tools`` tool-confirmation lookup."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aios.harness.loop import _dispatch_confirmed_tools
+
+
+def _assistant_with_tool_calls(tool_call_ids: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(
+        kind="message",
+        data={
+            "role": "assistant",
+            "tool_calls": [{"id": tcid, "type": "function"} for tcid in tool_call_ids],
+        },
+    )
+
+
+def _confirmed(tool_call_id: str, result: str = "allow") -> SimpleNamespace:
+    return SimpleNamespace(
+        data={"event": "tool_confirmed", "result": result, "tool_call_id": tool_call_id}
+    )
+
+
+class TestDispatchConfirmedTools:
+    async def test_returns_empty_when_no_assistant_tool_calls(self) -> None:
+        pool = MagicMock()
+        with patch(
+            "aios.harness.loop.sessions_service.read_events",
+            AsyncMock(return_value=[]),
+        ):
+            assert await _dispatch_confirmed_tools(pool, "sess_x", []) == []
+
+    async def test_returns_confirmed_but_not_completed(self) -> None:
+        """Baseline: a confirmed tool call with no tool result is pending."""
+        msg_events = [_assistant_with_tool_calls(["tc1"])]
+        pool = MagicMock()
+        with patch(
+            "aios.harness.loop.sessions_service.read_events",
+            AsyncMock(return_value=[_confirmed("tc1")]),
+        ):
+            pending = await _dispatch_confirmed_tools(pool, "sess_x", msg_events)
+        assert [tc["id"] for tc in pending] == ["tc1"]
+
+    async def test_reads_lifecycle_tail_newest_first(self) -> None:
+        """Regression for #155: default ASC + LIMIT 200 scan drops recent
+        ``tool_confirmed`` events on long sessions (bulk are ancient
+        ``turn_ended``). The user clicks allow but the confirmation is
+        invisible to the dispatch sweep.
+        """
+        msg_events = [_assistant_with_tool_calls(["tc1"])]
+        mock_read = AsyncMock(return_value=[_confirmed("tc1")])
+        pool = MagicMock()
+        with patch("aios.harness.loop.sessions_service.read_events", mock_read):
+            pending = await _dispatch_confirmed_tools(pool, "sess_x", msg_events)
+        assert [tc["id"] for tc in pending] == ["tc1"]
+        assert mock_read.call_args.kwargs["newest_first"] is True


### PR DESCRIPTION
## Summary
- Sibling of #154 at a different caller. `_dispatch_confirmed_tools` at `loop.py:682` was reading lifecycle events with default `LIMIT 200 ORDER BY seq ASC`. On sessions with >200 lifecycle events the query returns the oldest 200 (ancient `turn_ended` events) and drops fresh `tool_confirmed` — visible as "user clicks allow, nothing happens."
- One-line behavior change: pass `newest_first=True, limit=200` to `read_events` (parameter introduced in #154).
- New test module `tests/unit/test_dispatch_confirmed_tools.py` with a regression test asserting the call shape + baseline coverage.

## Bound justification
`limit=200` (same width as default, just flipped direction). Between the user clicking allow and the next dispatch sweep the session is idle waiting — producing >200 new lifecycle events in that window is effectively impossible.

## Test plan
- [x] `uv run mypy src` clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` clean
- [x] `uv run pytest tests/unit -q` — 886 passed (883 pre-existing + 3 new)
- [x] Regression test `test_reads_lifecycle_tail_newest_first` fails on base (`KeyError: 'newest_first'`), passes on fix
- [ ] CI green

Fixes #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)