### PR TITLE
feat(harness): per-model token-ratio correction for context windowing (#160)

### DIFF
--- a/migrations/versions/0024_model_request_end_calibration_index.py
+++ b/migrations/versions/0024_model_request_end_calibration_index.py
@@ -1,0 +1,50 @@
+"""Partial index for the per-model token-count correction lookup.
+
+Issue #160. ``model_token_ratio`` aggregates the most recent N successful
+``model_request_end`` spans for a given model. This partial index lets that
+subquery run as an index-only scan keyed on ``(data->>'model', seq DESC)``,
+filtered to rows that actually carry the calibration fields stamped by the
+new ``harness/loop.py`` code.
+
+Historical spans emitted before this change lack ``local_tokens`` / ``model``
+keys and are auto-excluded by the predicate — no backfill needed.
+
+Built with ``CREATE INDEX CONCURRENTLY`` to avoid an ACCESS EXCLUSIVE lock on
+the live ``events`` table; alembic's implicit BEGIN is disabled via
+``autocommit_block()`` so CONCURRENTLY is allowed.
+
+Revision ID: 0024
+Revises: 0023
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0024"
+down_revision: str = "0023"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY events_model_request_end_calibration_idx "
+            "ON events ((data->>'model'), seq DESC) "
+            "WHERE kind = 'span' "
+            "AND data->>'event' = 'model_request_end' "
+            "AND (data->>'is_error')::boolean = false "
+            "AND data ? 'local_tokens' "
+            "AND data ? 'model'"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "events_model_request_end_calibration_idx"
+        )

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -265,7 +265,11 @@ async def get_context(
     bindings, connections = await list_bindings_and_connections(pool, session_id)
 
     events = await service.read_windowed_events(
-        pool, session_id, window_min=agent.window_min, window_max=agent.window_max
+        pool,
+        session_id,
+        window_min=agent.window_min,
+        window_max=agent.window_max,
+        model=agent.model,
     )
 
     step_ctx = await compose_step_context(

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -14,6 +14,7 @@ seqs even when the API and the harness are appending concurrently.
 from __future__ import annotations
 
 import json
+import math
 from types import EllipsisType
 from typing import Any
 
@@ -900,8 +901,6 @@ async def model_token_ratio(
     assert row is not None
     if row["k"] < n:
         return 1.0
-    if row["total_local"] <= 0 or row["total_actual"] <= 0:
-        return 1.0
     return float(row["total_actual"]) / float(row["total_local"])
 
 
@@ -1256,7 +1255,10 @@ async def read_windowed_events(
     cache for that turn.  With ``n=100`` samples, per-step drift in R is
     <1 % for the models we've measured, so the expected invalidation rate
     is well below Anthropic's ~5-minute cache TTL — accept-the-noise
-    tradeoff documented here for the next reader.
+    tradeoff documented here for the next reader.  Revisit the ``n``
+    default in :func:`model_token_ratio` if a newly-onboarded model
+    shows per-sample CV above ~5 %, or if prefix-cache invalidation ever
+    shows up in telemetry for a steady-state workload.
 
     Falls back to :func:`read_message_events` (loading all events) when
     cumulative data is not available (pre-backfill sessions or rolling
@@ -1267,6 +1269,14 @@ async def read_windowed_events(
 
     # Fallback: no cumulative data yet — load everything.
     if total is None:
+        return await read_message_events(conn, session_id)
+
+    # Skip the ratio lookup when the session cannot possibly need a drop.
+    # ``total <= window_min`` guarantees ``total * R <= window_max`` for
+    # any ``R <= window_max / window_min`` — a ceiling of 3.0 for the
+    # default 50k/150k config, well above any measured per-model ratio.
+    # Saves one DB query on the common small-session path.
+    if total <= window_min:
         return await read_message_events(conn, session_id)
 
     ratio = await model_token_ratio(conn, model)
@@ -1283,9 +1293,7 @@ async def read_windowed_events(
     if drop_effective == 0:
         return await read_message_events(conn, session_id)
 
-    import math
-
-    drop = drop_effective if ratio == 1.0 else math.ceil(drop_effective / ratio)
+    drop = math.ceil(drop_effective / ratio)
 
     # Bounded range scan: only events past the boundary.
     rows = await conn.fetch(

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -839,7 +839,7 @@ async def model_token_ratio(
     *,
     n: int = 100,
 ) -> float:
-    """Per-model actual/local token correction (issue #160).
+    """Per-model actual/local token correction.
 
     Returns ``SUM(actual) / SUM(local)`` over the most recent ``n``
     successful ``model_request_end`` spans for ``model``.  Below ``n``
@@ -1232,13 +1232,14 @@ async def read_windowed_events(
     ``cumulative_tokens`` is stored in model-agnostic units (see
     :func:`aios.harness.tokens.approx_tokens`), so the raw value
     systematically diverges from what the provider actually counts —
-    ~18 % low on Sonnet 4.6, ~34 % low on Opus 4.7.  Issue #160 corrects
-    for this at read time: ``window_min`` / ``window_max`` are interpreted
-    as provider tokens, ``total_effective = total_local * R`` where
-    ``R = model_token_ratio(model)``, and the drop boundary is translated
-    back to local units for the ``cumulative_tokens`` index scan.  When
-    the model has fewer than ``model_token_ratio``'s sample threshold,
-    ``R`` falls back to ``1.0`` and behavior matches pre-#160 exactly.
+    ~18 % low on Sonnet 4.6, ~34 % low on Opus 4.7.  This function
+    corrects for that at read time: ``window_min`` / ``window_max`` are
+    interpreted as provider tokens, ``total_effective = total_local * R``
+    where ``R = model_token_ratio(model)``, and the drop boundary is
+    translated back to local units for the ``cumulative_tokens`` index
+    scan.  When the model has fewer than ``model_token_ratio``'s sample
+    threshold, ``R`` is ``1.0`` and the math reduces to the plain
+    chunked-snap algorithm.
 
     ``model`` must be the session's currently-active mind string —
     ``agent.model`` on the session's pinned agent/version.  The same
@@ -1246,15 +1247,15 @@ async def read_windowed_events(
     ``model_request_end`` spans, so stamp-side and query-side stay
     partitioned on identical keys.
 
-    Prefix-cache invariant (versus the pre-#160 design): the chunked-snap
-    algorithm gave a *strict* guarantee of byte-identical prompt prefix
-    within a snap chunk.  This function weakens that to a *quantitatively-
-    bounded* guarantee: R can shift slightly between consecutive reads as
-    new calibration samples land, which can nudge ``drop_local`` across an
-    event boundary and invalidate the prefix cache for that turn.  With
-    ``n=100`` the per-step drift is <1 % for the models we've measured, so
-    the expected invalidation rate is well below Anthropic's ~5-minute
-    cache TTL.  Not equivalent to the original invariant; accept-the-noise
+    Prefix-cache invariant: the plain chunked-snap algorithm gave a
+    *strict* guarantee of byte-identical prompt prefix within a snap
+    chunk.  With the ratio correction this weakens to a
+    *quantitatively-bounded* guarantee: R can shift slightly between
+    consecutive reads as new calibration samples land, which can nudge
+    ``drop_local`` across an event boundary and invalidate the prefix
+    cache for that turn.  With ``n=100`` samples, per-step drift in R is
+    <1 % for the models we've measured, so the expected invalidation rate
+    is well below Anthropic's ~5-minute cache TTL — accept-the-noise
     tradeoff documented here for the next reader.
 
     Falls back to :func:`read_message_events` (loading all events) when

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -852,7 +852,15 @@ async def model_token_ratio(
     ``model`` is the raw mind string (``agent.model``) — NO NORMALIZATION.
     Different LiteLLM routes (``anthropic/...`` vs
     ``openrouter/anthropic/...``) hit different provider tokenizers and
-    must partition separately.
+    must partition separately.  The same string must appear at stamp time
+    and at query time for the same step — always plumb ``agent.model`` on
+    both sides.  aios sessions do not carry a model override; the session's
+    active mind is always its agent's configured model.
+
+    Scope: the aggregate pools samples across every session in this
+    database.  Token counts are scalar only — no content crosses between
+    sessions — but the ratio reflects the mixed workload of whatever
+    traffic has accumulated.
 
     "actual" sums ``input_tokens + cache_read_input_tokens +
     cache_creation_input_tokens`` from the provider's usage.  Output
@@ -1232,6 +1240,23 @@ async def read_windowed_events(
     the model has fewer than ``model_token_ratio``'s sample threshold,
     ``R`` falls back to ``1.0`` and behavior matches pre-#160 exactly.
 
+    ``model`` must be the session's currently-active mind string —
+    ``agent.model`` on the session's pinned agent/version.  The same
+    string is what :func:`~aios.harness.loop.run_session_step` stamps on
+    ``model_request_end`` spans, so stamp-side and query-side stay
+    partitioned on identical keys.
+
+    Prefix-cache invariant (versus the pre-#160 design): the chunked-snap
+    algorithm gave a *strict* guarantee of byte-identical prompt prefix
+    within a snap chunk.  This function weakens that to a *quantitatively-
+    bounded* guarantee: R can shift slightly between consecutive reads as
+    new calibration samples land, which can nudge ``drop_local`` across an
+    event boundary and invalidate the prefix cache for that turn.  With
+    ``n=100`` the per-step drift is <1 % for the models we've measured, so
+    the expected invalidation rate is well below Anthropic's ~5-minute
+    cache TTL.  Not equivalent to the original invariant; accept-the-noise
+    tradeoff documented here for the next reader.
+
     Falls back to :func:`read_message_events` (loading all events) when
     cumulative data is not available (pre-backfill sessions or rolling
     deploys) or when the entire session fits within ``window_max``.
@@ -1244,21 +1269,19 @@ async def read_windowed_events(
         return await read_message_events(conn, session_id)
 
     ratio = await model_token_ratio(conn, model)
-    # Defensive: a pathological recorded ratio must not zero-divide below.
-    if ratio <= 0.0:
-        ratio = 1.0
 
     from aios.harness.tokens import tokens_to_drop
 
+    # Forward-convert local → effective with plain rounding: best-estimate
+    # of the provider-token total.  Back-convert effective → local with
+    # ceil: deliberately asymmetric so the post-drop remaining fits under
+    # ``window_max`` even when ratio error would otherwise leave one
+    # message straddling the boundary.
     total_effective = round(total * ratio)
     drop_effective = tokens_to_drop(total_effective, window_min=window_min, window_max=window_max)
     if drop_effective == 0:
         return await read_message_events(conn, session_id)
 
-    # Translate the provider-token drop boundary back to local units for
-    # the cumulative_tokens index scan.  Ceil-divide so the post-drop
-    # effective total is <= window_max, never over — dropping slightly
-    # too many is preferable to the alternative.
     import math
 
     drop = drop_effective if ratio == 1.0 else math.ceil(drop_effective / ratio)

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -833,6 +833,70 @@ async def _latest_cumulative_tokens(conn: asyncpg.Connection[Any], session_id: s
     return val
 
 
+async def model_token_ratio(
+    conn: asyncpg.Connection[Any],
+    model: str,
+    *,
+    n: int = 100,
+) -> float:
+    """Per-model actual/local token correction (issue #160).
+
+    Returns ``SUM(actual) / SUM(local)`` over the most recent ``n``
+    successful ``model_request_end`` spans for ``model``.  Below ``n``
+    samples: returns ``1.0`` — R is too noisy to trust and applying it
+    would churn the prefix cache.  At or above ``n``: aggregates exactly
+    the last ``n`` samples.  The single parameter governs both the
+    activation threshold and the sliding-window size, so per-step drift
+    in R is bounded by the window itself.
+
+    ``model`` is the raw mind string (``agent.model``) — NO NORMALIZATION.
+    Different LiteLLM routes (``anthropic/...`` vs
+    ``openrouter/anthropic/...``) hit different provider tokenizers and
+    must partition separately.
+
+    "actual" sums ``input_tokens + cache_read_input_tokens +
+    cache_creation_input_tokens`` from the provider's usage.  Output
+    tokens are excluded: we're correcting the size of the context we
+    sent, not what the model returned.  Uses the
+    ``events_model_request_end_calibration_idx`` partial index (migration
+    0024).
+    """
+    row = await conn.fetchrow(
+        """
+        WITH recent AS (
+            SELECT
+                (data->'model_usage'->>'input_tokens')::bigint              AS it,
+                (data->'model_usage'->>'cache_read_input_tokens')::bigint    AS cr,
+                (data->'model_usage'->>'cache_creation_input_tokens')::bigint AS cc,
+                (data->>'local_tokens')::bigint                               AS lt
+            FROM events
+            WHERE kind = 'span'
+              AND data->>'event' = 'model_request_end'
+              AND (data->>'is_error')::boolean = false
+              AND data->>'model' = $1
+              AND data ? 'local_tokens'
+              AND (data->>'local_tokens')::bigint > 0
+            ORDER BY seq DESC
+            LIMIT $2
+        )
+        SELECT
+            COUNT(*)                                                 AS k,
+            COALESCE(SUM(COALESCE(it, 0) + COALESCE(cr, 0)
+                         + COALESCE(cc, 0)), 0)::bigint              AS total_actual,
+            COALESCE(SUM(lt), 0)::bigint                             AS total_local
+        FROM recent
+        """,
+        model,
+        n,
+    )
+    assert row is not None
+    if row["k"] < n:
+        return 1.0
+    if row["total_local"] <= 0 or row["total_actual"] <= 0:
+        return 1.0
+    return float(row["total_actual"]) / float(row["total_local"])
+
+
 def _derive_tool_name(kind: str, data: dict[str, Any]) -> str | None:
     """Compute the stamped ``tool_name`` column for a new event.
 
@@ -1149,12 +1213,24 @@ async def read_windowed_events(
     *,
     window_min: int,
     window_max: int,
+    model: str,
 ) -> list[Event]:
     """Read message events for the session's trailing context window.
 
     Uses the ``cumulative_tokens`` column to compute the chunked-window
     snap boundary (same math as :func:`~aios.harness.window.select_window`)
     and loads only the events past that boundary.
+
+    ``cumulative_tokens`` is stored in model-agnostic units (see
+    :func:`aios.harness.tokens.approx_tokens`), so the raw value
+    systematically diverges from what the provider actually counts —
+    ~18 % low on Sonnet 4.6, ~34 % low on Opus 4.7.  Issue #160 corrects
+    for this at read time: ``window_min`` / ``window_max`` are interpreted
+    as provider tokens, ``total_effective = total_local * R`` where
+    ``R = model_token_ratio(model)``, and the drop boundary is translated
+    back to local units for the ``cumulative_tokens`` index scan.  When
+    the model has fewer than ``model_token_ratio``'s sample threshold,
+    ``R`` falls back to ``1.0`` and behavior matches pre-#160 exactly.
 
     Falls back to :func:`read_message_events` (loading all events) when
     cumulative data is not available (pre-backfill sessions or rolling
@@ -1167,11 +1243,25 @@ async def read_windowed_events(
     if total is None:
         return await read_message_events(conn, session_id)
 
+    ratio = await model_token_ratio(conn, model)
+    # Defensive: a pathological recorded ratio must not zero-divide below.
+    if ratio <= 0.0:
+        ratio = 1.0
+
     from aios.harness.tokens import tokens_to_drop
 
-    drop = tokens_to_drop(total, window_min=window_min, window_max=window_max)
-    if drop == 0:
+    total_effective = round(total * ratio)
+    drop_effective = tokens_to_drop(total_effective, window_min=window_min, window_max=window_max)
+    if drop_effective == 0:
         return await read_message_events(conn, session_id)
+
+    # Translate the provider-token drop boundary back to local units for
+    # the cumulative_tokens index scan.  Ceil-divide so the post-drop
+    # effective total is <= window_max, never over — dropping slightly
+    # too many is preferable to the alternative.
+    import math
+
+    drop = drop_effective if ratio == 1.0 else math.ceil(drop_effective / ratio)
 
     # Bounded range scan: only events past the boundary.
     rows = await conn.fetch(

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -186,9 +186,7 @@ async def _run_session_step_body(
     for c in connections:
         mcp_server_map[connection_server_name(c)] = c.mcp_url
 
-    # Read windowed message events for this session.  ``model=agent.model``
-    # feeds the issue #160 per-model ratio correction so the configured
-    # ``window_min`` / ``window_max`` are honored as provider tokens.
+    # Read windowed message events for this session.
     events = await sessions_service.read_windowed_events(
         pool,
         session_id,
@@ -347,13 +345,10 @@ async def _run_session_step_body(
         await _append_lifecycle(pool, session_id, "turn_ended", "idle", "error")
         raise
 
-    # Emit span end with per-request token usage and LiteLLM-reported cost.
-    # Stamp ``local_tokens`` + ``model`` for issue #160: the per-model token
-    # ratio is derived from SUM(actual)/SUM(local) over recent successful
-    # ends for the same model, pulled by ``model_token_ratio`` at windowing
-    # time.  ``local_tokens`` is of the full payload (messages + tools) so
-    # it matches what the provider actually counted; the error branch above
-    # deliberately stays un-stamped (partial index excludes it).
+    # ``local_tokens`` costs the full payload (messages + tools) so it
+    # matches what the provider counts.  The error branch above stays
+    # un-stamped — the calibration partial index excludes rows missing
+    # ``local_tokens`` / ``model``.
     local_tokens = approx_tokens(messages, tools=tools)
     await sessions_service.append_event(
         pool,

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -354,7 +354,7 @@ async def _run_session_step_body(
     # time.  ``local_tokens`` is of the full payload (messages + tools) so
     # it matches what the provider actually counted; the error branch above
     # deliberately stays un-stamped (partial index excludes it).
-    local_tokens = approx_tokens(messages, tools=tools or None)
+    local_tokens = approx_tokens(messages, tools=tools)
     await sessions_service.append_event(
         pool,
         session_id,

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -347,8 +347,9 @@ async def _run_session_step_body(
 
     # ``local_tokens`` costs the full payload (messages + tools) so it
     # matches what the provider counts.  The error branch above stays
-    # un-stamped — the calibration partial index excludes rows missing
-    # ``local_tokens`` / ``model``.
+    # un-stamped; its ``is_error=True`` alone is enough to keep it out of
+    # calibration reads (the partial index and the aggregate query both
+    # filter on ``is_error=false``).
     local_tokens = approx_tokens(messages, tools=tools)
     await sessions_service.append_event(
         pool,

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -28,6 +28,7 @@ from aios.harness import runtime
 from aios.harness.completion import call_litellm, stream_litellm
 from aios.harness.step_context import compose_step_context
 from aios.harness.sweep import find_sessions_needing_inference
+from aios.harness.tokens import approx_tokens
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
 from aios.harness.wake import defer_retry_wake
 from aios.logging import get_logger
@@ -185,9 +186,15 @@ async def _run_session_step_body(
     for c in connections:
         mcp_server_map[connection_server_name(c)] = c.mcp_url
 
-    # Read windowed message events for this session.
+    # Read windowed message events for this session.  ``model=agent.model``
+    # feeds the issue #160 per-model ratio correction so the configured
+    # ``window_min`` / ``window_max`` are honored as provider tokens.
     events = await sessions_service.read_windowed_events(
-        pool, session_id, window_min=agent.window_min, window_max=agent.window_max
+        pool,
+        session_id,
+        window_min=agent.window_min,
+        window_max=agent.window_max,
+        model=agent.model,
     )
 
     # Check for confirmed-but-undispatched tool calls (always_ask → allow).
@@ -341,6 +348,13 @@ async def _run_session_step_body(
         raise
 
     # Emit span end with per-request token usage and LiteLLM-reported cost.
+    # Stamp ``local_tokens`` + ``model`` for issue #160: the per-model token
+    # ratio is derived from SUM(actual)/SUM(local) over recent successful
+    # ends for the same model, pulled by ``model_token_ratio`` at windowing
+    # time.  ``local_tokens`` is of the full payload (messages + tools) so
+    # it matches what the provider actually counted; the error branch above
+    # deliberately stays un-stamped (partial index excludes it).
+    local_tokens = approx_tokens(messages, tools=tools or None)
     await sessions_service.append_event(
         pool,
         session_id,
@@ -351,6 +365,8 @@ async def _run_session_step_body(
             "is_error": False,
             "model_usage": usage,
             "cost_usd": cost_usd,
+            "local_tokens": local_tokens,
+            "model": agent.model,
         },
     )
 

--- a/src/aios/harness/tokens.py
+++ b/src/aios/harness/tokens.py
@@ -20,7 +20,11 @@ from litellm import token_counter
 # ─── estimator (delegates to litellm's local tokenizers) ──────────────────
 
 
-def approx_tokens(messages: Iterable[Mapping[str, Any]]) -> int:
+def approx_tokens(
+    messages: Iterable[Mapping[str, Any]],
+    *,
+    tools: Iterable[Mapping[str, Any]] | None = None,
+) -> int:
     """Estimate the chat-completions token cost of ``messages``.
 
     Delegates to :func:`litellm.token_counter` with no ``model``
@@ -33,12 +37,24 @@ def approx_tokens(messages: Iterable[Mapping[str, Any]]) -> int:
     The canonical shape is a list, so passing a bare dict would be a
     bug (it'd iterate the dict's keys as messages).
 
+    ``tools`` is optional and only passed by the model_request_end
+    span-stamp call site so the recorded ``local_tokens`` matches the
+    full payload the provider actually sees (messages + tools).  The
+    per-event ``cumulative_tokens`` call sites in ``append_event`` do
+    NOT pass tools: tool-schema overhead isn't per-event, and baking
+    it into per-event counts would perturb the running sum whenever
+    the agent's tool list changes.  The per-model ratio correction
+    (issue #160) absorbs the per-request tools overhead at read time.
+
     ``cumulative_tokens`` storage depends on this formula.  If the
     implementation changes (e.g. a different tokenizer, passing
     ``model=...``), re-run the backfill script to keep stored values
     honest.
     """
-    return int(token_counter(messages=list(messages)))
+    kwargs: dict[str, Any] = {"messages": list(messages)}
+    if tools:
+        kwargs["tools"] = list(tools)
+    return int(token_counter(**kwargs))
 
 
 # ─── snap boundary math ───────────────────────────────────────────────────

--- a/src/aios/harness/tokens.py
+++ b/src/aios/harness/tokens.py
@@ -43,8 +43,9 @@ def approx_tokens(
     per-event ``cumulative_tokens`` call sites in ``append_event`` do
     NOT pass tools: tool-schema overhead isn't per-event, and baking
     it into per-event counts would perturb the running sum whenever
-    the agent's tool list changes.  The per-model ratio correction
-    (issue #160) absorbs the per-request tools overhead at read time.
+    the agent's tool list changes.  The per-model ratio correction in
+    ``read_windowed_events`` absorbs the per-request tools overhead at
+    read time.
 
     ``cumulative_tokens`` storage depends on this formula.  If the
     implementation changes (e.g. a different tokenizer, passing

--- a/src/aios/harness/tokens.py
+++ b/src/aios/harness/tokens.py
@@ -51,10 +51,12 @@ def approx_tokens(
     ``model=...``), re-run the backfill script to keep stored values
     honest.
     """
-    kwargs: dict[str, Any] = {"messages": list(messages)}
-    if tools:
-        kwargs["tools"] = list(tools)
-    return int(token_counter(**kwargs))
+    return int(
+        token_counter(
+            messages=list(messages),
+            tools=list(tools) if tools else None,
+        )
+    )
 
 
 # ─── snap boundary math ───────────────────────────────────────────────────

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -174,10 +174,15 @@ async def read_windowed_events(
     *,
     window_min: int,
     window_max: int,
+    model: str,
 ) -> list[Event]:
     async with pool.acquire() as conn:
         return await queries.read_windowed_events(
-            conn, session_id, window_min=window_min, window_max=window_max
+            conn,
+            session_id,
+            window_min=window_min,
+            window_max=window_max,
+            model=model,
         )
 
 

--- a/tests/e2e/test_model_token_ratio_sql.py
+++ b/tests/e2e/test_model_token_ratio_sql.py
@@ -1,0 +1,212 @@
+"""E2E tests for :func:`aios.db.queries.model_token_ratio` against a real
+Postgres with migration 0024's partial index applied.
+
+Unlike the mock-based unit tests in ``tests/unit/test_model_token_ratio.py``
+(which pin only the Python arithmetic), these cases exercise the SQL
+itself — JSON extraction, the ``(data->>'is_error')::boolean`` cast, the
+``data ? 'local_tokens'`` existence predicate, the ``(data->>'model') = $1``
+partitioning, and the ``ORDER BY seq DESC LIMIT $2`` sliding window.
+
+Every test uses a UUID-based synthetic model name, so spans seeded by one
+test cannot contaminate another test's aggregate even though the ``events``
+table persists across cases within the module-scoped pool fixture.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from aios.db import queries
+from aios.services import sessions as sessions_service
+from tests.e2e.harness import Harness
+
+
+async def _seed_valid_span(
+    harness: Harness,
+    session_id: str,
+    *,
+    model: str,
+    local_tokens: int,
+    input_tokens: int,
+    cache_read: int = 0,
+    cache_creation: int = 0,
+) -> None:
+    """Insert a successful ``model_request_end`` span of the shape
+    ``harness/loop.py`` stamps.  Pool-acquiring via the service wrapper
+    matches the production write path.
+    """
+    await sessions_service.append_event(
+        harness._pool,
+        session_id,
+        "span",
+        {
+            "event": "model_request_end",
+            "is_error": False,
+            "model_usage": {
+                "input_tokens": input_tokens,
+                "cache_read_input_tokens": cache_read,
+                "cache_creation_input_tokens": cache_creation,
+            },
+            "cost_usd": None,
+            "local_tokens": local_tokens,
+            "model": model,
+        },
+    )
+
+
+async def _seed_error_span(harness: Harness, session_id: str) -> None:
+    """Insert an error-branch ``model_request_end`` — the shape emitted
+    by the except-path in ``run_session_step``.  Missing ``local_tokens``
+    and ``model`` keys; ``is_error = True``.  Must be excluded by the
+    partial index and by the query's WHERE clause.
+    """
+    await sessions_service.append_event(
+        harness._pool,
+        session_id,
+        "span",
+        {
+            "event": "model_request_end",
+            "is_error": True,
+            "model_usage": {},
+            "cost_usd": None,
+        },
+    )
+
+
+class TestModelTokenRatioSQL:
+    async def test_below_n_returns_1(self, harness: Harness) -> None:
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        for _ in range(5):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=150
+            )
+        async with harness._pool.acquire() as conn:
+            assert await queries.model_token_ratio(conn, model, n=30) == 1.0
+
+    async def test_at_n_returns_sum_ratio(self, harness: Harness) -> None:
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        for _ in range(30):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=150
+            )
+        async with harness._pool.acquire() as conn:
+            ratio = await queries.model_token_ratio(conn, model, n=30)
+        assert ratio == pytest.approx(1.5)
+
+    async def test_sums_cache_tokens_into_actual(self, harness: Harness) -> None:
+        """Anthropic's usage splits input into plain + cache_read +
+        cache_creation.  The ratio has to count the total prefill, not just
+        the uncached slice."""
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        for _ in range(30):
+            await _seed_valid_span(
+                harness,
+                session.id,
+                model=model,
+                local_tokens=100,
+                input_tokens=50,
+                cache_read=60,
+                cache_creation=40,
+            )
+        async with harness._pool.acquire() as conn:
+            ratio = await queries.model_token_ratio(conn, model, n=30)
+        # total_actual per span = 50+60+40 = 150 → ratio = 150/100 = 1.5
+        assert ratio == pytest.approx(1.5)
+
+    async def test_excludes_error_spans(self, harness: Harness) -> None:
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        for _ in range(30):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=150
+            )
+        for _ in range(30):
+            await _seed_error_span(harness, session.id)
+        async with harness._pool.acquire() as conn:
+            ratio = await queries.model_token_ratio(conn, model, n=30)
+        assert ratio == pytest.approx(1.5)
+
+    async def test_partitions_by_model_string(self, harness: Harness) -> None:
+        model_a = f"test-model-{uuid.uuid4().hex[:8]}"
+        model_b = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        for _ in range(30):
+            await _seed_valid_span(
+                harness, session.id, model=model_a, local_tokens=100, input_tokens=150
+            )
+        for _ in range(30):
+            await _seed_valid_span(
+                harness, session.id, model=model_b, local_tokens=100, input_tokens=120
+            )
+        async with harness._pool.acquire() as conn:
+            ratio_a = await queries.model_token_ratio(conn, model_a, n=30)
+            ratio_b = await queries.model_token_ratio(conn, model_b, n=30)
+        assert ratio_a == pytest.approx(1.5)
+        assert ratio_b == pytest.approx(1.2)
+
+    async def test_cross_session_aggregation(self, harness: Harness) -> None:
+        """Ratio pools spans across every session in the DB for a given
+        model — a new session on a known model inherits the calibration
+        from prior traffic."""
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session_a = await harness.start("seed-a")
+        session_b = await harness.start("seed-b")
+        for _ in range(15):
+            await _seed_valid_span(
+                harness, session_a.id, model=model, local_tokens=100, input_tokens=150
+            )
+        for _ in range(15):
+            await _seed_valid_span(
+                harness, session_b.id, model=model, local_tokens=100, input_tokens=150
+            )
+        async with harness._pool.acquire() as conn:
+            ratio = await queries.model_token_ratio(conn, model, n=30)
+        assert ratio == pytest.approx(1.5)
+
+    async def test_sliding_window_discards_old_samples(self, harness: Harness) -> None:
+        """LIMIT N in the CTE keeps only the most recent N; older samples
+        with a different ratio fall out of the aggregate as traffic
+        accumulates."""
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        # Older regime: ratio 2.0.
+        for _ in range(30):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=200
+            )
+        # Newer regime: ratio 1.5.
+        for _ in range(30):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=150
+            )
+        async with harness._pool.acquire() as conn:
+            # n=30 → only the newer regime counts.
+            assert await queries.model_token_ratio(conn, model, n=30) == pytest.approx(1.5)
+            # n=60 → both regimes count:
+            # total_actual = 30*200 + 30*150 = 10500; total_local = 60*100 = 6000.
+            assert await queries.model_token_ratio(conn, model, n=60) == pytest.approx(1.75)
+
+    async def test_zero_local_tokens_excluded(self, harness: Harness) -> None:
+        """The WHERE clause filters ``(data->>'local_tokens')::bigint > 0``
+        so zero-local rows never contribute (shouldn't happen in practice
+        but must be robust to the edge)."""
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        # 30 with local_tokens=0 (all excluded).
+        for _ in range(30):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=0, input_tokens=999
+            )
+        # 30 valid.
+        for _ in range(30):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=150
+            )
+        async with harness._pool.acquire() as conn:
+            ratio = await queries.model_token_ratio(conn, model, n=30)
+        assert ratio == pytest.approx(1.5)

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -1580,8 +1580,15 @@ class TestUsageTracking:
         assert "cost_usd" in end.data
         assert end.data["cost_usd"] is None
         # Issue #160: calibration fields stamped on every successful end span.
-        assert isinstance(end.data["local_tokens"], int)
-        assert end.data["local_tokens"] > 0
+        # Recompute approx_tokens from the exact payload the harness captured
+        # litellm receiving; a future refactor that stamps on the wrong list
+        # would slowly skew the ratio without this equality check noticing.
+        from aios.harness.tokens import approx_tokens
+
+        assert harness.model_calls, "expected at least one litellm call"
+        sent = harness.model_calls[-1]
+        expected_local = approx_tokens(sent["messages"], tools=sent.get("tools"))
+        assert end.data["local_tokens"] == expected_local
         assert end.data["model"] == "fake/test"
 
     async def test_span_events_for_multi_step(self, harness: Harness) -> None:

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -1579,6 +1579,10 @@ class TestUsageTracking:
         assert end.data["model_usage"]["output_tokens"] == 5
         assert "cost_usd" in end.data
         assert end.data["cost_usd"] is None
+        # Issue #160: calibration fields stamped on every successful end span.
+        assert isinstance(end.data["local_tokens"], int)
+        assert end.data["local_tokens"] > 0
+        assert end.data["model"] == "fake/test"
 
     async def test_span_events_for_multi_step(self, harness: Harness) -> None:
         """Two model calls produce two span pairs."""

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -1579,10 +1579,10 @@ class TestUsageTracking:
         assert end.data["model_usage"]["output_tokens"] == 5
         assert "cost_usd" in end.data
         assert end.data["cost_usd"] is None
-        # Issue #160: calibration fields stamped on every successful end span.
-        # Recompute approx_tokens from the exact payload the harness captured
-        # litellm receiving; a future refactor that stamps on the wrong list
-        # would slowly skew the ratio without this equality check noticing.
+        # Recompute approx_tokens from the exact payload the harness
+        # captured litellm receiving; a future refactor that stamps on the
+        # wrong list would slowly skew the ratio without this equality
+        # check noticing.
         from aios.harness.tokens import approx_tokens
 
         assert harness.model_calls, "expected at least one litellm call"

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -90,6 +90,8 @@ def test_migration_creates_all_tables(postgres: object) -> None:
                 "agents_name_uniq",
                 "events_session_seq_idx",
                 "events_session_message_seq_idx",
+                # Migration 0024 (issue #160): per-model token-ratio lookup.
+                "events_model_request_end_calibration_idx",
             ):
                 assert required in index_names, f"missing index {required}"
         finally:

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -90,7 +90,6 @@ def test_migration_creates_all_tables(postgres: object) -> None:
                 "agents_name_uniq",
                 "events_session_seq_idx",
                 "events_session_message_seq_idx",
-                # Migration 0024 (issue #160): per-model token-ratio lookup.
                 "events_model_request_end_calibration_idx",
             ):
                 assert required in index_names, f"missing index {required}"

--- a/tests/unit/test_model_token_ratio.py
+++ b/tests/unit/test_model_token_ratio.py
@@ -1,10 +1,10 @@
 """Unit tests for :func:`aios.db.queries.model_token_ratio`.
 
-The SQL itself (partial-index coverage, JSON extraction, is_error filter,
-model-string partitioning, LIMIT-based sliding window) is exercised in
-``tests/e2e/test_model_token_ratio_sql.py`` against a real Postgres.  These
-tests pin the Python-side contract: below-N fallback, zero-totals
-defensive path, and the SUM/SUM arithmetic.
+The SQL itself — partial-index coverage, JSON extraction, is_error
+filter, model-string partitioning, and LIMIT-based sliding window — is
+exercised against a real Postgres in
+``tests/e2e/test_model_token_ratio_sql.py``.  These tests pin the
+Python-side contract only: below-N fallback and the SUM/SUM arithmetic.
 """
 
 from __future__ import annotations
@@ -49,21 +49,6 @@ class TestModelTokenRatio:
         conn = _mock_conn(k=100, total_actual=11_824, total_local=10_000)
         ratio = await model_token_ratio(conn, "model-x", n=100)
         assert ratio == pytest.approx(1.1824)
-
-    @pytest.mark.asyncio
-    async def test_zero_total_local_returns_1(self) -> None:
-        """Defensive: a row with k>=n but total_local=0 (shouldn't happen
-        because the WHERE filters local_tokens>0, but guard anyway).
-        """
-        conn = _mock_conn(k=50, total_actual=100, total_local=0)
-        ratio = await model_token_ratio(conn, "model-x", n=30)
-        assert ratio == 1.0
-
-    @pytest.mark.asyncio
-    async def test_zero_total_actual_returns_1(self) -> None:
-        conn = _mock_conn(k=50, total_actual=0, total_local=10_000)
-        ratio = await model_token_ratio(conn, "model-x", n=30)
-        assert ratio == 1.0
 
     @pytest.mark.asyncio
     async def test_default_n_is_100(self) -> None:

--- a/tests/unit/test_model_token_ratio.py
+++ b/tests/unit/test_model_token_ratio.py
@@ -1,0 +1,85 @@
+"""Unit tests for :func:`aios.db.queries.model_token_ratio`.
+
+The SQL itself (partial-index coverage, JSON extraction, is_error filter,
+model-string partitioning, LIMIT-based sliding window) is exercised in
+``tests/e2e/test_model_token_ratio_sql.py`` against a real Postgres.  These
+tests pin the Python-side contract: below-N fallback, zero-totals
+defensive path, and the SUM/SUM arithmetic.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.db.queries import model_token_ratio
+
+
+def _mock_conn(*, k: int, total_actual: int, total_local: int) -> MagicMock:
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value={
+            "k": k,
+            "total_actual": total_actual,
+            "total_local": total_local,
+        }
+    )
+    return conn
+
+
+class TestModelTokenRatio:
+    @pytest.mark.asyncio
+    async def test_below_n_returns_1(self) -> None:
+        conn = _mock_conn(k=29, total_actual=15_000, total_local=10_000)
+        ratio = await model_token_ratio(conn, "model-x", n=30)
+        assert ratio == 1.0
+
+    @pytest.mark.asyncio
+    async def test_at_n_returns_sum_ratio(self) -> None:
+        # 30 spans, actual sums to 1.5x the local sum -> R = 1.5 exactly.
+        conn = _mock_conn(k=30, total_actual=1_500, total_local=1_000)
+        ratio = await model_token_ratio(conn, "model-x", n=30)
+        assert ratio == pytest.approx(1.5)
+
+    @pytest.mark.asyncio
+    async def test_above_n_returns_sum_ratio(self) -> None:
+        # LIMIT in the SQL caps the sample set at n; the helper trusts the
+        # row it got back.  Just verify the division when k >= n.
+        conn = _mock_conn(k=100, total_actual=11_824, total_local=10_000)
+        ratio = await model_token_ratio(conn, "model-x", n=100)
+        assert ratio == pytest.approx(1.1824)
+
+    @pytest.mark.asyncio
+    async def test_zero_total_local_returns_1(self) -> None:
+        """Defensive: a row with k>=n but total_local=0 (shouldn't happen
+        because the WHERE filters local_tokens>0, but guard anyway).
+        """
+        conn = _mock_conn(k=50, total_actual=100, total_local=0)
+        ratio = await model_token_ratio(conn, "model-x", n=30)
+        assert ratio == 1.0
+
+    @pytest.mark.asyncio
+    async def test_zero_total_actual_returns_1(self) -> None:
+        conn = _mock_conn(k=50, total_actual=0, total_local=10_000)
+        ratio = await model_token_ratio(conn, "model-x", n=30)
+        assert ratio == 1.0
+
+    @pytest.mark.asyncio
+    async def test_default_n_is_100(self) -> None:
+        # With k=99 and no explicit n, the 100-default should return 1.0.
+        conn = _mock_conn(k=99, total_actual=1_500, total_local=1_000)
+        assert await model_token_ratio(conn, "model-x") == 1.0
+        # k=100 activates the default threshold.
+        conn2 = _mock_conn(k=100, total_actual=1_500, total_local=1_000)
+        assert await model_token_ratio(conn2, "model-x") == pytest.approx(1.5)
+
+    @pytest.mark.asyncio
+    async def test_passes_model_and_n_to_query(self) -> None:
+        conn = _mock_conn(k=0, total_actual=0, total_local=0)
+        await model_token_ratio(conn, "anthropic/claude-sonnet-4-6", n=200)
+        args = conn.fetchrow.await_args
+        assert args is not None
+        # Positional args after the SQL string: (model, n)
+        assert args.args[1] == "anthropic/claude-sonnet-4-6"
+        assert args.args[2] == 200

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, ClassVar
+
 from aios.harness.context import render_user_event
 from aios.harness.tokens import approx_tokens
 
@@ -84,3 +86,37 @@ class TestApproxTokensUnderFocalRendering:
         data = {"role": "user", "content": "hello"}
         rendered = render_user_event(data, None, None)
         assert approx_tokens([rendered]) == approx_tokens([data])
+
+
+class TestApproxTokensWithTools:
+    """The ``tools=`` kwarg exists so the issue #160 span-stamp call site
+    can cost the exact payload the provider sees (messages + tools).
+
+    The two existing call sites in ``db/queries.py`` (per-event
+    cumulative_tokens) and ``tools/switch_channel.py`` (recap budget) hand
+    messages only — these tests pin that the default behavior is
+    byte-identical whether the kwarg is omitted, None, or [].
+    """
+
+    _MSGS: ClassVar[list[dict[str, Any]]] = [{"role": "user", "content": "what files are here"}]
+    _TOOL: ClassVar[dict[str, Any]] = {
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        },
+    }
+
+    def test_tools_increase_cost(self) -> None:
+        assert approx_tokens(self._MSGS, tools=[self._TOOL]) > approx_tokens(self._MSGS)
+
+    def test_tools_none_identical_to_omitted(self) -> None:
+        assert approx_tokens(self._MSGS, tools=None) == approx_tokens(self._MSGS)
+
+    def test_tools_empty_list_identical_to_omitted(self) -> None:
+        assert approx_tokens(self._MSGS, tools=[]) == approx_tokens(self._MSGS)

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -89,8 +89,9 @@ class TestApproxTokensUnderFocalRendering:
 
 
 class TestApproxTokensWithTools:
-    """The ``tools=`` kwarg exists so the issue #160 span-stamp call site
-    can cost the exact payload the provider sees (messages + tools).
+    """The ``tools=`` kwarg exists so the ``model_request_end`` span-stamp
+    call site can cost the exact payload the provider sees (messages +
+    tools).
 
     The two existing call sites in ``db/queries.py`` (per-event
     cumulative_tokens) and ``tools/switch_channel.py`` (recap budget) hand

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -77,8 +77,12 @@ async def test_no_cumulative_falls_back_to_full_read() -> None:
 
 @pytest.mark.asyncio
 async def test_below_n_ratio_1_matches_today() -> None:
-    """With fewer than N samples, model_token_ratio returns 1.0 and the
-    math reduces to plain tokens_to_drop(total) — no ratio applied.
+    """Load-bearing backward-compatibility fence.  Do not delete.
+
+    While model_token_ratio is still warming up (or on a model the DB has
+    never seen), it returns 1.0 and ``read_windowed_events`` must behave
+    byte-identically to the pre-ratio chunked-snap algorithm — otherwise
+    the "gradual rollout" rollout property breaks.  This test pins that.
     """
     conn = _FakeConn(total_local=3_000, ratio_k=10, ratio_actual=0, ratio_local=0)
     # window_min=1000, window_max=2000 → chunk size 1000.

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -1,0 +1,182 @@
+"""Unit tests for the per-model ratio application in ``read_windowed_events``.
+
+These tests pin the arithmetic: how ``total * ratio`` drives
+``tokens_to_drop``, and how the resulting provider-token boundary is
+translated back to local units for the ``cumulative_tokens`` SQL scan.
+Full SQL behavior (index usage, real event rows) is covered by the e2e
+layer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.db import queries
+
+
+class _FakeConn:
+    """Minimal asyncpg.Connection stand-in.
+
+    ``fetchval`` serves ``_latest_cumulative_tokens`` (total local tokens).
+    ``fetchrow`` serves ``model_token_ratio`` (the ``SELECT k, total_actual,
+    total_local`` row).  ``fetch`` captures the bounded range scan's args so
+    tests can assert the computed ``drop_local``.
+    """
+
+    def __init__(
+        self,
+        *,
+        total_local: int | None,
+        ratio_k: int,
+        ratio_actual: int,
+        ratio_local: int,
+    ) -> None:
+        self.total_local = total_local
+        self.ratio_row = {
+            "k": ratio_k,
+            "total_actual": ratio_actual,
+            "total_local": ratio_local,
+        }
+        self.fetch_calls: list[tuple[Any, ...]] = []
+
+    async def fetchval(self, _sql: str, *_args: Any) -> int | None:
+        return self.total_local
+
+    async def fetchrow(self, _sql: str, *_args: Any) -> dict[str, Any]:
+        return self.ratio_row
+
+    async def fetch(self, _sql: str, *args: Any) -> list[Any]:
+        self.fetch_calls.append(args)
+        return []
+
+
+@pytest.fixture(autouse=True)
+def _stub_read_message_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Short-circuit ``read_message_events`` so no real DB is hit when the
+    code path falls back to 'load everything'.  We sentinel its return so
+    tests can detect the fallback."""
+    monkeypatch.setattr(
+        queries,
+        "read_message_events",
+        AsyncMock(return_value=["_fallback_sentinel"]),
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_cumulative_falls_back_to_full_read() -> None:
+    conn = _FakeConn(total_local=None, ratio_k=0, ratio_actual=0, ratio_local=0)
+    result = await queries.read_windowed_events(
+        conn, "sess_x", window_min=1_000, window_max=2_000, model="m"
+    )
+    # Fallback short-circuit — ratio never consulted.
+    assert result == ["_fallback_sentinel"]
+
+
+@pytest.mark.asyncio
+async def test_below_n_ratio_1_matches_today() -> None:
+    """With fewer than N samples, model_token_ratio returns 1.0 and the
+    math must match the pre-#160 behavior: drop_local = tokens_to_drop(total).
+    """
+    conn = _FakeConn(total_local=3_000, ratio_k=10, ratio_actual=0, ratio_local=0)
+    # window_min=1000, window_max=2000 → chunk size 1000.
+    # total=3000 → overshoot 1000 → drop 1000 (one chunk).
+    await queries.read_windowed_events(
+        conn, "sess_x", window_min=1_000, window_max=2_000, model="m"
+    )
+    assert conn.fetch_calls, "expected bounded range scan to be called"
+    # Second positional arg to conn.fetch is the drop value.
+    _session_id, drop_local = conn.fetch_calls[-1]
+    assert drop_local == 1_000
+
+
+@pytest.mark.asyncio
+async def test_ratio_above_1_drops_more() -> None:
+    """ratio=1.5 inflates total_effective so the drop boundary crosses a
+    snap, and the returned drop_local ceil-divides back.
+
+    total_local=1500, ratio=1.5 → total_effective=2250.
+    window_min=1000, window_max=2000, chunk=1000.
+    overshoot=250 → drop_effective=1000.
+    drop_local = ceil(1000 / 1.5) = 667.
+    """
+    conn = _FakeConn(total_local=1_500, ratio_k=100, ratio_actual=150, ratio_local=100)
+    await queries.read_windowed_events(
+        conn, "sess_x", window_min=1_000, window_max=2_000, model="m"
+    )
+    _session_id, drop_local = conn.fetch_calls[-1]
+    assert drop_local == 667
+
+
+@pytest.mark.asyncio
+async def test_ratio_below_1_drops_fewer() -> None:
+    """ratio=0.5 deflates total_effective below window_max → no drop."""
+    conn = _FakeConn(total_local=3_000, ratio_k=100, ratio_actual=50, ratio_local=100)
+    result = await queries.read_windowed_events(
+        conn, "sess_x", window_min=1_000, window_max=2_000, model="m"
+    )
+    # total_effective = 1500 < 2000 → drop_effective = 0 → fallback.
+    assert result == ["_fallback_sentinel"]
+    assert not conn.fetch_calls
+
+
+@pytest.mark.asyncio
+async def test_defensive_ratio_zero_treated_as_1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pathological recorded ratio must not zero-divide."""
+    monkeypatch.setattr(
+        queries,
+        "model_token_ratio",
+        AsyncMock(return_value=0.0),
+    )
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=3_000)
+
+    async def _fetch(_sql: str, *args: Any) -> list[Any]:
+        conn._last_fetch_args = args
+        return []
+
+    conn.fetch = _fetch
+    await queries.read_windowed_events(
+        conn, "sess_x", window_min=1_000, window_max=2_000, model="m"
+    )
+    # ratio clamped to 1.0 → drop = 1000 (same as the ratio=1 case).
+    assert conn._last_fetch_args[1] == 1_000
+
+
+@pytest.mark.asyncio
+async def test_ceil_div_never_overshoots_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Post-drop effective size must be <= window_max for any ratio > 1."""
+    ratio = 1.37
+    total_local = 10_000
+    window_min, window_max = 3_000, 5_000
+
+    monkeypatch.setattr(
+        queries,
+        "model_token_ratio",
+        AsyncMock(return_value=ratio),
+    )
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=total_local)
+
+    captured: dict[str, int] = {}
+
+    async def _fetch(_sql: str, *args: Any) -> list[Any]:
+        captured["drop_local"] = args[1]
+        return []
+
+    conn.fetch = _fetch
+    await queries.read_windowed_events(
+        conn, "sess_x", window_min=window_min, window_max=window_max, model="m"
+    )
+    drop_local = captured["drop_local"]
+    remaining_local = total_local - drop_local
+    remaining_effective = remaining_local * ratio
+    assert remaining_effective <= window_max, (
+        f"post-drop {remaining_effective} exceeds window_max={window_max}"
+    )

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -123,31 +123,6 @@ async def test_ratio_below_1_drops_fewer() -> None:
 
 
 @pytest.mark.asyncio
-async def test_defensive_ratio_zero_treated_as_1(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A pathological recorded ratio must not zero-divide."""
-    monkeypatch.setattr(
-        queries,
-        "model_token_ratio",
-        AsyncMock(return_value=0.0),
-    )
-    conn = MagicMock()
-    conn.fetchval = AsyncMock(return_value=3_000)
-
-    async def _fetch(_sql: str, *args: Any) -> list[Any]:
-        conn._last_fetch_args = args
-        return []
-
-    conn.fetch = _fetch
-    await queries.read_windowed_events(
-        conn, "sess_x", window_min=1_000, window_max=2_000, model="m"
-    )
-    # ratio clamped to 1.0 → drop = 1000 (same as the ratio=1 case).
-    assert conn._last_fetch_args[1] == 1_000
-
-
-@pytest.mark.asyncio
 async def test_ceil_div_never_overshoots_window(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -78,7 +78,7 @@ async def test_no_cumulative_falls_back_to_full_read() -> None:
 @pytest.mark.asyncio
 async def test_below_n_ratio_1_matches_today() -> None:
     """With fewer than N samples, model_token_ratio returns 1.0 and the
-    math must match the pre-#160 behavior: drop_local = tokens_to_drop(total).
+    math reduces to plain tokens_to_drop(total) — no ratio applied.
     """
     conn = _FakeConn(total_local=3_000, ratio_k=10, ratio_actual=0, ratio_local=0)
     # window_min=1000, window_max=2000 → chunk size 1000.


### PR DESCRIPTION
Closes #160.

## Summary

- `cumulative_tokens` storage unchanged (stays model-agnostic — required for mid-session model switches).
- Stamp `local_tokens` + `model` on every successful `model_request_end` span.
- New `model_token_ratio` helper aggregates `SUM(actual) / SUM(local)` over the most recent N=100 successful end spans, filtered by model; returns 1.0 below N.
- `read_windowed_events` applies R to interpret `window_min` / `window_max` as provider tokens, ceil-divides back for the index scan.
- Migration 0024 adds a partial index on the new stamped fields; no backfill needed.

Empirical basis: Anthropic's `count_tokens` endpoint, compared against `approx_tokens` on 5 production dumps per model, gave R=1.1824 (CV 0.91%) for Sonnet 4.6 and R=1.5172 (CV ~0%) for Opus 4.7. Opus R is constant to 4 decimals across 54 additional messages of context, so the correction is essentially exact once N samples accumulate.

Single parameter N (default 100) governs both activation threshold and sliding-window width, so per-step drift in R is bounded by the window itself. No session-scoped freeze machinery: Anthropic's 5-min cache TTL already busts caches at comparable rates during normal conversation rhythm.

## Test plan

- [x] `uv run mypy src`
- [x] `uv run ruff check src tests && uv run ruff format --check src tests`
- [x] `uv run pytest tests/unit -q` — 902 passed
- [ ] `uv run pytest tests/e2e -q` — ran locally via the existing step-model tests; a fresh pass against testcontainer Postgres would confirm the new `local_tokens`/`model` stamp assertions
- [ ] `uv run pytest tests/integration -q` — covers the 0024 migration index assertion
- [ ] Manual sanity: run a session until ≥N `model_request_end` spans exist under a given model, confirm `model_token_ratio` returns a value near the measured ratio, confirm `read_windowed_events` retains the expected set when the session exceeds `window_max`

## Design context

See issue #160 for the full problem statement, empirical measurements, and design discussion (including why single-parameter N replaces the initially-considered freeze-per-session mitigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)