### PR TITLE
fix(harness): model_token_ratio was double-counting LiteLLM input_tokens

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -863,21 +863,23 @@ async def model_token_ratio(
     sessions — but the ratio reflects the mixed workload of whatever
     traffic has accumulated.
 
-    "actual" sums ``input_tokens + cache_read_input_tokens +
-    cache_creation_input_tokens`` from the provider's usage.  Output
-    tokens are excluded: we're correcting the size of the context we
-    sent, not what the model returned.  Uses the
-    ``events_model_request_end_calibration_idx`` partial index (migration
-    0024).
+    "actual" is the provider's ``input_tokens`` usage value, which
+    LiteLLM normalizes to the OpenAI convention: ``input_tokens`` is
+    **the full prompt count**, including any cached-read or
+    cache-creation portion.  Do NOT sum ``cache_read_input_tokens`` or
+    ``cache_creation_input_tokens`` on top — they are breakdown metrics
+    within the same total, not disjoint extensions.  Output tokens are
+    excluded: we're correcting the size of the context we sent, not
+    what the model returned.  Uses the
+    ``events_model_request_end_calibration_idx`` partial index
+    (migration 0024).
     """
     row = await conn.fetchrow(
         """
         WITH recent AS (
             SELECT
-                (data->'model_usage'->>'input_tokens')::bigint              AS it,
-                (data->'model_usage'->>'cache_read_input_tokens')::bigint    AS cr,
-                (data->'model_usage'->>'cache_creation_input_tokens')::bigint AS cc,
-                (data->>'local_tokens')::bigint                               AS lt
+                (data->'model_usage'->>'input_tokens')::bigint AS it,
+                (data->>'local_tokens')::bigint                 AS lt
             FROM events
             WHERE kind = 'span'
               AND data->>'event' = 'model_request_end'
@@ -889,10 +891,9 @@ async def model_token_ratio(
             LIMIT $2
         )
         SELECT
-            COUNT(*)                                                 AS k,
-            COALESCE(SUM(COALESCE(it, 0) + COALESCE(cr, 0)
-                         + COALESCE(cc, 0)), 0)::bigint              AS total_actual,
-            COALESCE(SUM(lt), 0)::bigint                             AS total_local
+            COUNT(*)                                AS k,
+            COALESCE(SUM(it), 0)::bigint            AS total_actual,
+            COALESCE(SUM(lt), 0)::bigint            AS total_local
         FROM recent
         """,
         model,

--- a/tests/e2e/test_model_token_ratio_sql.py
+++ b/tests/e2e/test_model_token_ratio_sql.py
@@ -97,10 +97,15 @@ class TestModelTokenRatioSQL:
             ratio = await queries.model_token_ratio(conn, model, n=30)
         assert ratio == pytest.approx(1.5)
 
-    async def test_sums_cache_tokens_into_actual(self, harness: Harness) -> None:
-        """Anthropic's usage splits input into plain + cache_read +
-        cache_creation.  The ratio has to count the total prefill, not just
-        the uncached slice."""
+    async def test_ignores_cache_breakdown_fields(self, harness: Harness) -> None:
+        """LiteLLM normalizes Anthropic's usage to the OpenAI convention:
+        ``input_tokens`` is already the full prompt count (including any
+        cached-read and cache-creation portions).  ``cache_read_input_tokens``
+        and ``cache_creation_input_tokens`` are breakdown metrics within
+        that total — they MUST NOT be summed on top.  This case pins the
+        invariant: seeding spans with nonzero cache_* fields does not
+        change the ratio; only ``input_tokens`` and ``local_tokens``
+        contribute."""
         model = f"test-model-{uuid.uuid4().hex[:8]}"
         session = await harness.start("seed")
         for _ in range(30):
@@ -109,13 +114,14 @@ class TestModelTokenRatioSQL:
                 session.id,
                 model=model,
                 local_tokens=100,
-                input_tokens=50,
+                input_tokens=150,
                 cache_read=60,
                 cache_creation=40,
             )
         async with harness._pool.acquire() as conn:
             ratio = await queries.model_token_ratio(conn, model, n=30)
-        # total_actual per span = 50+60+40 = 150 → ratio = 150/100 = 1.5
+        # total_actual per span = input_tokens = 150 (cache_* ignored).
+        # ratio = 150/100 = 1.5.
         assert ratio == pytest.approx(1.5)
 
     async def test_excludes_error_spans(self, harness: Harness) -> None:

--- a/tests/unit/test_model_token_ratio.py
+++ b/tests/unit/test_model_token_ratio.py
@@ -68,3 +68,15 @@ class TestModelTokenRatio:
         # Positional args after the SQL string: (model, n)
         assert args.args[1] == "anthropic/claude-sonnet-4-6"
         assert args.args[2] == 200
+
+    @pytest.mark.asyncio
+    async def test_sql_does_not_sum_cache_fields(self) -> None:
+        """Regression: summing ``cache_*`` breakdown fields with
+        ``input_tokens`` double-counts and roughly doubles R on
+        cache-hot workloads."""
+        conn = _mock_conn(k=0, total_actual=0, total_local=0)
+        await model_token_ratio(conn, "model-x", n=1)
+        sql = conn.fetchrow.await_args.args[0]
+        assert sql.count("'input_tokens'") == 1
+        assert "cache_read_input_tokens" not in sql
+        assert "cache_creation_input_tokens" not in sql


### PR DESCRIPTION
Closes #162.

## Summary

`model_token_ratio`'s SQL treated `input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` as disjoint and summed them. In LiteLLM's normalized `model_usage` payload they're not: `input_tokens` is already the full prompt count (OpenAI convention), and the two `cache_*` fields are breakdown metrics within that total.

Dropping the `cache_*` terms from the SUM. `input_tokens` alone is the correct "actual" value.

## Evidence

Three consecutive Opus-4.7 `model_request_end` spans from JN's live session:

| seq   | local   | input   | cache_read | cache_create | read+create |
|-------|--------:|--------:|-----------:|-------------:|------------:|
| 10172 | 159,504 | 242,347 | 241,046    | 897          | 241,943     |
| 10153 | 158,891 | 241,477 | 8,102      | 232,944      | 241,046     |
| 10140 | 430,095 | 652,121 | 651,047    | 617          | 651,664     |

`cache_read + cache_creation` consistently equals `input_tokens` within ~500 tokens (the uncached-input residual). Confirms LiteLLM's normalization.

Resulting ratios:

- **Pre-fix** (summed): 3.04, 3.04, 3.03
- **Post-fix** (`input_tokens` alone): 1.519, 1.520, 1.516 — matches the measured Opus R = 1.517 from #160

## Impact if shipped as-is

Once N=100 samples accumulated, `read_windowed_events` would multiply `cumulative_tokens` by ~3× instead of ~1.5× and drop events roughly twice as aggressively as intended. A configured `window_max=200k` would have produced prompts around 100k in provider tokens rather than 200k.

The pre-N=100 fallback (`ratio = 1.0`) means the bug is latent until enough real samples accumulate — JN's currently at ~6 Opus samples since #161 shipped, so still in safe territory. Worth landing before N crosses 100 on any model to avoid a sudden one-time cache invalidation at activation.

## Changes

- `src/aios/db/queries.py`: drop `cache_read_input_tokens` and `cache_creation_input_tokens` from the `total_actual` SUM; update docstring to explain the LiteLLM-vs-Anthropic-native convention.
- `tests/unit/test_model_token_ratio.py`: new `test_sql_does_not_sum_cache_fields` regression fence — asserts the SQL string extracts `input_tokens` exactly once and does not reference the `cache_*` usage fields. Catches this specific bug pattern recurring.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 900 passed
- [ ] Live-data sanity: after merge + worker restart, query `model_token_ratio(conn, 'anthropic/claude-opus-4-7', n=1)` directly against the DB and confirm it returns a value in [1.50, 1.53] for the accumulated Opus samples.
- [ ] E2E suite has not been re-run post-fix; no behavior change expected since `model_token_ratio`'s interface is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)