### PR TITLE
tweak(harness): drop model_token_ratio default N from 100 to 30

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -838,7 +838,7 @@ async def model_token_ratio(
     conn: asyncpg.Connection[Any],
     model: str,
     *,
-    n: int = 100,
+    n: int = 30,
 ) -> float:
     """Per-model actual/local token correction.
 
@@ -1253,12 +1253,11 @@ async def read_windowed_events(
     *quantitatively-bounded* guarantee: R can shift slightly between
     consecutive reads as new calibration samples land, which can nudge
     ``drop_local`` across an event boundary and invalidate the prefix
-    cache for that turn.  With ``n=100`` samples, per-step drift in R is
-    <1 % for the models we've measured, so the expected invalidation rate
-    is well below Anthropic's ~5-minute cache TTL — accept-the-noise
-    tradeoff documented here for the next reader.  Revisit the ``n``
+    cache for that turn.  With ``n=30`` samples, per-step drift in R
+    scales with the per-sample CV — Opus measured at ~0.2 % CV, putting
+    drift well below Anthropic's ~5-minute cache TTL.  Revisit the ``n``
     default in :func:`model_token_ratio` if a newly-onboarded model
-    shows per-sample CV above ~5 %, or if prefix-cache invalidation ever
+    shows per-sample CV above ~1 %, or if prefix-cache invalidation ever
     shows up in telemetry for a steady-state workload.
 
     Falls back to :func:`read_message_events` (loading all events) when

--- a/tests/unit/test_model_token_ratio.py
+++ b/tests/unit/test_model_token_ratio.py
@@ -51,12 +51,12 @@ class TestModelTokenRatio:
         assert ratio == pytest.approx(1.1824)
 
     @pytest.mark.asyncio
-    async def test_default_n_is_100(self) -> None:
-        # With k=99 and no explicit n, the 100-default should return 1.0.
-        conn = _mock_conn(k=99, total_actual=1_500, total_local=1_000)
+    async def test_default_n_is_30(self) -> None:
+        # k=29 with no explicit n: 30-default returns 1.0.
+        conn = _mock_conn(k=29, total_actual=1_500, total_local=1_000)
         assert await model_token_ratio(conn, "model-x") == 1.0
-        # k=100 activates the default threshold.
-        conn2 = _mock_conn(k=100, total_actual=1_500, total_local=1_000)
+        # k=30 activates the default threshold.
+        conn2 = _mock_conn(k=30, total_actual=1_500, total_local=1_000)
         assert await model_token_ratio(conn2, "model-x") == pytest.approx(1.5)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Default threshold for activating the per-model ratio correction drops from N=100 to N=30.
- Justified by observed Opus 4.7 dispersion: CV ≈ 0.2 % over 62 spans (min 1.507 / max 1.527 / std 0.004).  At that tightness, the law of large numbers kicks in by 30 samples and the extra 70 just delays activation.
- Prefix-cache reasoning in \`read_windowed_events\` docstring re-phrased in terms of per-sample CV (no longer claiming a hard-coded <1 % drift number tied to N=100).

## Test plan
- [x] \`uv run mypy src\` — clean.
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean.
- [x] \`uv run pytest tests/unit -q\` — 900 passed (includes the re-pinned \`test_default_n_is_30\`).
- [x] \`uv run pytest tests/e2e/test_model_token_ratio_sql.py -q\` — 8/8 passed.
- [ ] Post-merge: worker restart → watch model_token_ratio(opus-4-7) flip from 1.0 to ~1.52 once 30 samples accumulate (currently 62 spans already, so it'll activate immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)