### PR TITLE
fix(harness): window budget must subtract system+tools overhead

### DIFF
--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -248,7 +248,8 @@ async def get_context(
     read-only.
     """
     from aios.harness.channels import list_bindings_and_connections
-    from aios.harness.step_context import compose_step_context
+    from aios.harness.step_context import compose_step_context, compute_step_prelude
+    from aios.harness.tokens import approx_tokens
     from aios.models.agents import Agent, AgentVersion
     from aios.services import agents as agents_service
 
@@ -264,21 +265,33 @@ async def get_context(
 
     bindings, connections = await list_bindings_and_connections(pool, session_id)
 
-    events = await service.read_windowed_events(
-        pool,
-        session_id,
-        window_min=agent.window_min,
-        window_max=agent.window_max,
-        model=agent.model,
-    )
-
-    step_ctx = await compose_step_context(
+    prelude = await compute_step_prelude(
         pool,
         session_id,
         session=session,
         agent=agent,
         bindings=bindings,
         connections=connections,
+    )
+    overhead_local = approx_tokens(
+        [{"role": "system", "content": prelude.system_prompt}],
+        tools=prelude.tools,
+    )
+
+    events = await service.read_windowed_events(
+        pool,
+        session_id,
+        window_min=agent.window_min,
+        window_max=agent.window_max,
+        model=agent.model,
+        overhead_local=overhead_local,
+    )
+
+    step_ctx = await compose_step_context(
+        session=session,
+        agent=agent,
+        bindings=bindings,
+        prelude=prelude,
         events=events,
     )
     return ContextResponse(

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1222,6 +1222,7 @@ async def read_windowed_events(
     window_min: int,
     window_max: int,
     model: str,
+    overhead_local: int,
 ) -> list[Event]:
     """Read message events for the session's trailing context window.
 
@@ -1240,6 +1241,14 @@ async def read_windowed_events(
     scan.  When the model has fewer than ``model_token_ratio``'s sample
     threshold, ``R`` is ``1.0`` and the math reduces to the plain
     chunked-snap algorithm.
+
+    ``overhead_local`` is the token cost the caller will add on top of
+    the returned events — system prompt plus tool schemas — in local
+    (``approx_tokens``) units.  It is NOT included in
+    ``cumulative_tokens``, so the windower has to subtract it from the
+    effective budget up-front or the sent prompt will exceed
+    ``window_max`` by the overhead amount.  Callers that don't have any
+    such overhead (preview tooling, test scaffolds) pass ``0``.
 
     ``model`` must be the session's currently-active mind string —
     ``agent.model`` on the session's pinned agent/version.  The same
@@ -1271,15 +1280,23 @@ async def read_windowed_events(
     if total is None:
         return await read_message_events(conn, session_id)
 
-    # Skip the ratio lookup when the session cannot possibly need a drop.
-    # ``total <= window_min`` guarantees ``total * R <= window_max`` for
-    # any ``R <= window_max / window_min`` — a ceiling of 3.0 for the
-    # default 50k/150k config, well above any measured per-model ratio.
-    # Saves one DB query on the common small-session path.
-    if total <= window_min:
-        return await read_message_events(conn, session_id)
-
     ratio = await model_token_ratio(conn, model)
+
+    # Shrink the effective window by the caller's overhead contribution.
+    # Apply R to overhead_local up-front so the subtraction happens in the
+    # same effective (provider-token) space tokens_to_drop operates in.
+    overhead_effective = round(overhead_local * ratio)
+    events_window_max = window_max - overhead_effective
+    events_window_min = max(0, window_min - overhead_effective)
+    if events_window_max <= 0:
+        raise ValueError(
+            f"system+tools overhead ({overhead_effective} provider tokens) "
+            f"exceeds window_max ({window_max}); no budget remains for events"
+        )
+
+    total_effective = round(total * ratio)
+    if total_effective <= events_window_max:
+        return await read_message_events(conn, session_id)
 
     from aios.harness.tokens import tokens_to_drop
 
@@ -1288,8 +1305,9 @@ async def read_windowed_events(
     # ceil: deliberately asymmetric so the post-drop remaining fits under
     # ``window_max`` even when ratio error would otherwise leave one
     # message straddling the boundary.
-    total_effective = round(total * ratio)
-    drop_effective = tokens_to_drop(total_effective, window_min=window_min, window_max=window_max)
+    drop_effective = tokens_to_drop(
+        total_effective, window_min=events_window_min, window_max=events_window_max
+    )
     if drop_effective == 0:
         return await read_message_events(conn, session_id)
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any
 from aios.db.sse_lock import has_subscriber
 from aios.harness import runtime
 from aios.harness.completion import call_litellm, stream_litellm
-from aios.harness.step_context import compose_step_context
+from aios.harness.step_context import compose_step_context, compute_step_prelude
 from aios.harness.sweep import find_sessions_needing_inference
 from aios.harness.tokens import approx_tokens
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
@@ -186,6 +186,23 @@ async def _run_session_step_body(
     for c in connections:
         mcp_server_map[connection_server_name(c)] = c.mcp_url
 
+    # Build the events-independent prelude (system prompt + tools)
+    # before windowing so its overhead can be subtracted from the
+    # window budget — otherwise the sent prompt can exceed window_max
+    # by exactly that overhead.
+    prelude = await compute_step_prelude(
+        pool,
+        session_id,
+        session=session,
+        agent=agent,
+        bindings=bindings,
+        connections=connections,
+    )
+    overhead_local = approx_tokens(
+        [{"role": "system", "content": prelude.system_prompt}],
+        tools=prelude.tools,
+    )
+
     # Read windowed message events for this session.
     events = await sessions_service.read_windowed_events(
         pool,
@@ -193,6 +210,7 @@ async def _run_session_step_body(
         window_min=agent.window_min,
         window_max=agent.window_max,
         model=agent.model,
+        overhead_local=overhead_local,
     )
 
     # Check for confirmed-but-undispatched tool calls (always_ask → allow).
@@ -233,12 +251,10 @@ async def _run_session_step_body(
 
     try:
         step_ctx = await compose_step_context(
-            pool,
-            session_id,
             session=session,
             agent=agent,
             bindings=bindings,
-            connections=connections,
+            prelude=prelude,
             events=events,
         )
     except Exception:

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -43,6 +43,21 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
+class StepPrelude:
+    """Events-independent portion of a step's payload.
+
+    Everything here depends only on ``agent`` / ``bindings`` /
+    ``connections`` / ``session`` — not on which events windowing picks.
+    Computed before windowing so ``read_windowed_events`` can subtract
+    the overhead from the budget (see ``overhead_local`` there).
+    """
+
+    system_prompt: str
+    tools: list[dict[str, Any]]
+    skill_versions: list[SkillVersion]
+
+
+@dataclass(frozen=True)
 class StepContext:
     """Composed inputs for a single model call."""
 
@@ -53,7 +68,7 @@ class StepContext:
     skill_versions: list[SkillVersion]
 
 
-async def compose_step_context(
+async def compute_step_prelude(
     pool: asyncpg.Pool[Any],
     session_id: str,
     *,
@@ -61,19 +76,17 @@ async def compose_step_context(
     agent: Agent | AgentVersion,
     bindings: list[ChannelBinding],
     connections: list[Connection],
-    events: list[Event],
-) -> StepContext:
-    """Compose the chat-completions payload for a step.
+) -> StepPrelude:
+    """Build the events-independent parts of the step payload.
 
-    Callers must have already loaded ``session`` / ``agent`` / ``bindings``
-    / ``connections`` / ``events`` so the endpoint and the worker pay
-    the same I/O cost profile.  This function adds MCP discovery and
-    skill-ref resolution on top.
+    Exists so windowing can know the system+tools overhead before it
+    picks the event slate.  The returned ``StepPrelude`` feeds
+    :func:`compose_step_context` unchanged, so the composed prompt stays
+    byte-identical to what it was before the split.
     """
     from aios.harness.channels import (
         augment_with_connector_instructions,
         augment_with_focal_paradigm,
-        build_channels_tail_block,
     )
     from aios.harness.loop import (
         _hide_conn_tools_when_phone_down,
@@ -108,7 +121,29 @@ async def compose_step_context(
         system_prompt, mcp_instructions, connections
     )
 
-    ctx = build_messages(events, system_prompt=system_prompt)
+    return StepPrelude(
+        system_prompt=system_prompt,
+        tools=tools,
+        skill_versions=skill_versions,
+    )
+
+
+async def compose_step_context(
+    *,
+    session: Session,
+    agent: Agent | AgentVersion,
+    bindings: list[ChannelBinding],
+    prelude: StepPrelude,
+    events: list[Event],
+) -> StepContext:
+    """Compose the chat-completions payload for a step.
+
+    Takes a prelude built by :func:`compute_step_prelude` and the
+    windowed events slate; glues them into the final message list.
+    """
+    from aios.harness.channels import build_channels_tail_block
+
+    ctx = build_messages(events, system_prompt=prelude.system_prompt)
 
     # Tail block lives *after* build_messages so its per-step mutations
     # (unread counts, previews) don't bust the prefix cache.  Paradigm
@@ -124,7 +159,7 @@ async def compose_step_context(
     return StepContext(
         model=agent.model,
         messages=messages,
-        tools=tools,
+        tools=prelude.tools,
         reacting_to=ctx.reacting_to,
-        skill_versions=skill_versions,
+        skill_versions=prelude.skill_versions,
     )

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -175,6 +175,7 @@ async def read_windowed_events(
     window_min: int,
     window_max: int,
     model: str,
+    overhead_local: int,
 ) -> list[Event]:
     async with pool.acquire() as conn:
         return await queries.read_windowed_events(
@@ -183,6 +184,7 @@ async def read_windowed_events(
             window_min=window_min,
             window_max=window_max,
             model=model,
+            overhead_local=overhead_local,
         )
 
 

--- a/tests/e2e/test_windowing_overhead.py
+++ b/tests/e2e/test_windowing_overhead.py
@@ -1,0 +1,74 @@
+"""E2E regression: the full payload sent to the model must fit within
+the agent's ``window_max`` — including system prompt and tool-schema
+overhead.
+
+Pre-fix, :func:`aios.db.queries.read_windowed_events` used
+``cumulative_tokens`` (the per-event sum, with tools and system
+excluded) as its budget target.  That undercount meant the harness
+layered the system prompt and tool schemas on top at send time and
+the actual prompt could exceed ``window_max`` by the entire overhead
+amount.  This case pins the full-payload invariant against regression.
+"""
+
+from __future__ import annotations
+
+from aios.harness.tokens import approx_tokens
+from aios.models.agents import ToolSpec
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+from tests.e2e.harness import Harness, assistant
+
+
+class TestWindowingOverhead:
+    async def test_full_payload_fits_window_max(self, harness: Harness) -> None:
+        # Agent with a meaningfully chunky system prompt plus the
+        # standard built-in tool set → non-trivial per-step overhead.
+        system = (
+            "You are a test assistant. Be helpful, harmless, and honest. "
+            "Use tools when appropriate. "
+        ) * 60
+
+        env = await environments_service.create_environment(harness._pool, name="overhead-env")
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name="overhead-agent",
+            model="fake/test",
+            system=system,
+            tools=[ToolSpec(type=t) for t in ("bash", "read", "write", "edit", "glob", "grep")],
+            description=None,
+            metadata={},
+            # Snug window: overhead consumes most of it, leaving only
+            # ~1-2k for kept events.  Windowing is forced to drop.
+            window_min=4_000,
+            window_max=6_000,
+        )
+        session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent.id,
+            environment_id=env.id,
+            title="overhead-test",
+            metadata={},
+        )
+        # Pile enough user messages to force drops.
+        for i in range(80):
+            await sessions_service.append_user_message(
+                harness._pool,
+                session.id,
+                f"message {i:03d}: " + "word " * 40,
+            )
+
+        harness.script_model([assistant("ack")])
+        await harness.run_until_idle(session.id)
+
+        # Exactly one model call was issued; its kwargs are the authoritative
+        # record of what the provider saw.
+        assert len(harness.model_calls) == 1
+        call = harness.model_calls[0]
+        full_local = approx_tokens(call["messages"], tools=call.get("tools"))
+
+        assert full_local <= agent.window_max, (
+            f"full payload {full_local} tokens exceeds window_max "
+            f"{agent.window_max} (messages={len(call['messages'])}, "
+            f"tools={len(call.get('tools') or [])})"
+        )

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -69,7 +69,7 @@ def _stub_read_message_events(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_no_cumulative_falls_back_to_full_read() -> None:
     conn = _FakeConn(total_local=None, ratio_k=0, ratio_actual=0, ratio_local=0)
     result = await queries.read_windowed_events(
-        conn, "sess_x", window_min=1_000, window_max=2_000, model="m"
+        conn, "sess_x", window_min=1_000, window_max=2_000, model="m", overhead_local=0
     )
     # Fallback short-circuit — ratio never consulted.
     assert result == ["_fallback_sentinel"]
@@ -88,7 +88,7 @@ async def test_below_n_ratio_1_matches_today() -> None:
     # window_min=1000, window_max=2000 → chunk size 1000.
     # total=3000 → overshoot 1000 → drop 1000 (one chunk).
     await queries.read_windowed_events(
-        conn, "sess_x", window_min=1_000, window_max=2_000, model="m"
+        conn, "sess_x", window_min=1_000, window_max=2_000, model="m", overhead_local=0
     )
     assert conn.fetch_calls, "expected bounded range scan to be called"
     # Second positional arg to conn.fetch is the drop value.
@@ -108,7 +108,7 @@ async def test_ratio_above_1_drops_more() -> None:
     """
     conn = _FakeConn(total_local=1_500, ratio_k=100, ratio_actual=150, ratio_local=100)
     await queries.read_windowed_events(
-        conn, "sess_x", window_min=1_000, window_max=2_000, model="m"
+        conn, "sess_x", window_min=1_000, window_max=2_000, model="m", overhead_local=0
     )
     _session_id, drop_local = conn.fetch_calls[-1]
     assert drop_local == 667
@@ -119,7 +119,7 @@ async def test_ratio_below_1_drops_fewer() -> None:
     """ratio=0.5 deflates total_effective below window_max → no drop."""
     conn = _FakeConn(total_local=3_000, ratio_k=100, ratio_actual=50, ratio_local=100)
     result = await queries.read_windowed_events(
-        conn, "sess_x", window_min=1_000, window_max=2_000, model="m"
+        conn, "sess_x", window_min=1_000, window_max=2_000, model="m", overhead_local=0
     )
     # total_effective = 1500 < 2000 → drop_effective = 0 → fallback.
     assert result == ["_fallback_sentinel"]
@@ -151,7 +151,7 @@ async def test_ceil_div_never_overshoots_window(
 
     conn.fetch = _fetch
     await queries.read_windowed_events(
-        conn, "sess_x", window_min=window_min, window_max=window_max, model="m"
+        conn, "sess_x", window_min=window_min, window_max=window_max, model="m", overhead_local=0
     )
     drop_local = captured["drop_local"]
     remaining_local = total_local - drop_local


### PR DESCRIPTION
## Summary
- \`read_windowed_events\` was using \`cumulative_tokens\` (events-only sum) as its budget. The harness then layered the system prompt and tool schemas on top at send time, so the actual prompt could exceed \`window_max\` by the entire overhead amount.
- Diagnosis thread in this session: with a 10K–20K window on JN (Opus 4.7), windower picked \`local=17.9K\` for the events slate; at ratio 1.53 the provider counted \`27.4K\` — a 37% overshoot. The overhead alone was ≈ 19.2K provider tokens, nearly the entire 20K cap.
- Fix: caller computes overhead once and passes \`overhead_local\` to \`read_windowed_events\`. The windower subtracts \`overhead_local * R\` from both window bounds before the chunked-snap math runs. Kept-events + fixed overhead now lands inside \`window_max\`.

## Structural change
Splits \`compose_step_context\` into:
- \`compute_step_prelude\` — events-independent (system prompt + tools + skill versions). Called first so windowing can see the overhead.
- \`compose_step_context\` — takes a prelude and the windowed events, glues them into the final message list.

Both call sites (worker \`run_session_step\` and the \`/sessions/:id/context\` preview endpoint) do the split the same way, so preview output stays byte-identical to what the worker sends.

## TDD
Test was written RED, then the fix made it GREEN:
- New \`tests/e2e/test_windowing_overhead.py\` drives \`run_session_step\` through the harness, captures the scripted \`litellm.acompletion\` kwargs, and asserts \`approx_tokens(messages, tools) <= window_max\`.
- Pre-fix: \`full_local = 6508\` > \`window_max = 6000\` (AssertionError).
- Post-fix: passes.

## Test plan
- [x] \`uv run mypy src\` — clean.
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean.
- [x] \`uv run pytest tests/unit -q\` — 900 passed (includes \`test_windowed_ratio.py\` updated call sites).
- [x] \`uv run pytest tests/e2e -q\` — 249 passed (includes new overhead test).
- [ ] Post-merge: incorporate into worker, set JN window to 10K–20K again, send a probe, verify actual \`input_tokens\` lands around 20K (snap state) then 10K (post-snap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)