### PR TITLE
fix(harness): reserve channels-tail-block budget during windowing

### DIFF
--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -273,9 +273,12 @@ async def get_context(
         bindings=bindings,
         connections=connections,
     )
-    overhead_local = approx_tokens(
-        [{"role": "system", "content": prelude.system_prompt}],
-        tools=prelude.tools,
+    overhead_local = (
+        approx_tokens(
+            [{"role": "system", "content": prelude.system_prompt}],
+            tools=prelude.tools,
+        )
+        + prelude.tail_block_upper_bound_local
     )
 
     events = await service.read_windowed_events(

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -148,6 +148,32 @@ def augment_with_focal_paradigm(base_system: str, bindings: list[ChannelBinding]
     return block
 
 
+def max_tail_block_local(bindings: list[ChannelBinding]) -> int:
+    """Worst-case local-token cost of :func:`build_channels_tail_block`.
+
+    Called at windowing time when the *actual* tail block isn't yet
+    knowable (it depends on the windowed events).  Returns the upper
+    bound by synthesizing the fattest line each binding can contribute
+    — non-focal, non-muted, 9999 unread, with a maxed-out preview —
+    then summing via :func:`~aios.harness.tokens.approx_tokens`.  The
+    produced tail at send time is guaranteed ≤ this bound, so reserving
+    it from the window budget never overshoots ``window_max``.
+
+    Returns 0 when no bindings: :func:`build_channels_tail_block`
+    returns ``None`` in that case and the composer appends nothing.
+    """
+    from aios.harness.tokens import approx_tokens
+
+    if not bindings:
+        return 0
+    lines = ["━━━ Channels ━━━"]
+    for b in bindings:
+        # Preview length matches the 60-char truncation + ellipsis in
+        # build_channels_tail_block above.
+        lines.append(f'○ channel_id={b.address} — 9999 unread: "{"x" * 61}"')
+    return approx_tokens([{"role": "user", "content": "\n".join(lines)}])
+
+
 def build_channels_tail_block(
     bindings: list[ChannelBinding],
     events: list[Event],

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -198,9 +198,12 @@ async def _run_session_step_body(
         bindings=bindings,
         connections=connections,
     )
-    overhead_local = approx_tokens(
-        [{"role": "system", "content": prelude.system_prompt}],
-        tools=prelude.tools,
+    overhead_local = (
+        approx_tokens(
+            [{"role": "system", "content": prelude.system_prompt}],
+            tools=prelude.tools,
+        )
+        + prelude.tail_block_upper_bound_local
     )
 
     # Read windowed message events for this session.

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -50,11 +50,19 @@ class StepPrelude:
     ``connections`` / ``session`` — not on which events windowing picks.
     Computed before windowing so ``read_windowed_events`` can subtract
     the overhead from the budget (see ``overhead_local`` there).
+
+    ``tail_block_upper_bound_local`` is the worst-case size of the
+    channels tail block the composer will append after windowing — a
+    conservative bound computed from ``bindings`` alone (no events, no
+    unread counts).  Reserving this ahead of time keeps the send-time
+    payload under ``window_max`` even when the tail renders at its
+    fattest (every channel at 9999 unread with a maxed-out preview).
     """
 
     system_prompt: str
     tools: list[dict[str, Any]]
     skill_versions: list[SkillVersion]
+    tail_block_upper_bound_local: int
 
 
 @dataclass(frozen=True)
@@ -87,6 +95,7 @@ async def compute_step_prelude(
     from aios.harness.channels import (
         augment_with_connector_instructions,
         augment_with_focal_paradigm,
+        max_tail_block_local,
     )
     from aios.harness.loop import (
         _hide_conn_tools_when_phone_down,
@@ -125,6 +134,7 @@ async def compute_step_prelude(
         system_prompt=system_prompt,
         tools=tools,
         skill_versions=skill_versions,
+        tail_block_upper_bound_local=max_tail_block_local(bindings),
     )
 
 

--- a/tests/e2e/test_windowing_overhead.py
+++ b/tests/e2e/test_windowing_overhead.py
@@ -1,13 +1,16 @@
 """E2E regression: the full payload sent to the model must fit within
-the agent's ``window_max`` — including system prompt and tool-schema
-overhead.
+the agent's ``window_max`` — including system prompt, tool-schema, and
+channels-tail-block overhead.
 
-Pre-fix, :func:`aios.db.queries.read_windowed_events` used
-``cumulative_tokens`` (the per-event sum, with tools and system
-excluded) as its budget target.  That undercount meant the harness
-layered the system prompt and tool schemas on top at send time and
-the actual prompt could exceed ``window_max`` by the entire overhead
-amount.  This case pins the full-payload invariant against regression.
+PR #165 established the full-payload invariant but only counted the
+system prompt + tool schemas.  The channels tail block
+(:func:`~aios.harness.channels.build_channels_tail_block`) is appended
+in :func:`~aios.harness.step_context.compose_step_context` AFTER
+windowing runs, so its size was leaking out of the budget too.  On JN
+(6 Signal bindings) that leak was ~1.5K provider tokens — enough to
+push the post-windowing prompt over ``window_max`` by the tail size.
+This file pins BOTH contributions (system+tools AND tail block) against
+regression.
 """
 
 from __future__ import annotations
@@ -15,8 +18,11 @@ from __future__ import annotations
 from aios.harness.tokens import approx_tokens
 from aios.models.agents import ToolSpec
 from aios.services import agents as agents_service
+from aios.services import channels as channels_service
+from aios.services import connections as connections_service
 from aios.services import environments as environments_service
 from aios.services import sessions as sessions_service
+from aios.services import vaults as vaults_service
 from tests.e2e.harness import Harness, assistant
 
 
@@ -71,4 +77,118 @@ class TestWindowingOverhead:
             f"full payload {full_local} tokens exceeds window_max "
             f"{agent.window_max} (messages={len(call['messages'])}, "
             f"tools={len(call.get('tools') or [])})"
+        )
+
+    async def test_full_payload_fits_window_max_with_tail_block(self, harness: Harness) -> None:
+        """Same invariant, but with channel bindings active so
+        :func:`~aios.harness.channels.build_channels_tail_block` emits
+        a non-trivial tail block appended after windowing.  Pre-fix the
+        tail's size was not subtracted from the window budget, so its
+        contents would push the send-time payload past ``window_max``.
+        """
+        system = (
+            "You are a test assistant. Be helpful, harmless, and honest. "
+            "Use tools when appropriate. "
+        ) * 60
+        env = await environments_service.create_environment(harness._pool, name="overhead-tail-env")
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name="overhead-tail-agent",
+            model="fake/test",
+            system=system,
+            tools=[ToolSpec(type=t) for t in ("bash", "read", "write", "edit", "glob", "grep")],
+            description=None,
+            metadata={},
+            # Snug window — the tail block's ~400 local tokens push past
+            # the cap if they aren't reserved during windowing.
+            window_min=3_500,
+            window_max=4_500,
+        )
+        session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent.id,
+            environment_id=env.id,
+            title="overhead-tail-test",
+            metadata={},
+        )
+
+        # Register a connector + connection so bindings resolve.  The MCP
+        # URL isn't actually dialed in this test path — bindings are
+        # purely a routing-metadata construct for the tail block.
+        vault = await vaults_service.create_vault(harness._pool, display_name="tb", metadata={})
+        await connections_service.create_connection(
+            harness._pool,
+            connector="signal",
+            account="test",
+            mcp_url="https://nope",
+            vault_id=vault.id,
+            metadata={},
+        )
+        # Six bindings with Signal-realistic address widths (UUID + base64
+        # group id) — the on-wire size of JN's fan-out.  Short stub
+        # addresses undercount the tail block by ~3x and hide the bug.
+        addresses = [
+            f"signal/test/{uuid}/base64groupid-{i:02d}-{'x' * 30}="
+            for i, uuid in enumerate(f"{i:08d}-{i:04d}-{i:04d}-{i:04d}-{i:012d}" for i in range(6))
+        ]
+        for addr in addresses:
+            await channels_service.create_binding(
+                harness._pool,
+                address=addr,
+                session_id=session.id,
+            )
+
+        # Direct (non-channel) user messages so windowing is forced to
+        # drop events.  Appended FIRST so the per-channel messages below
+        # land near the tail and survive the drop — otherwise the tail
+        # block renders with 0-unread / no-preview on every channel and
+        # collapses to a minimal stub.
+        for i in range(80):
+            await sessions_service.append_user_message(
+                harness._pool,
+                session.id,
+                f"direct message {i:03d}: " + "word " * 40,
+            )
+
+        # Per-channel inbound so the tail shows non-zero unread + a preview
+        # string per channel — the full-fat shape that appears on a live
+        # session.
+        for addr in addresses:
+            for j in range(3):
+                await sessions_service.append_user_message(
+                    harness._pool,
+                    session.id,
+                    f"inbound on {addr} — body number {j} " + "word " * 8,
+                    metadata={"channel": addr},
+                )
+
+        harness.script_model([assistant("ack")])
+        await harness.run_until_idle(session.id)
+
+        assert len(harness.model_calls) == 1
+        call = harness.model_calls[0]
+        full_local = approx_tokens(call["messages"], tools=call.get("tools"))
+
+        # Sanity: a non-trivial tail block really did render.  Minimum
+        # floor: header + 6 listing lines with Signal-width addresses
+        # and preview clauses is >= 100 local tokens.
+        tail_text = next(
+            (
+                m["content"]
+                for m in call["messages"]
+                if isinstance(m.get("content"), str) and "━━━ Channels ━━━" in m["content"]
+            ),
+            None,
+        )
+        assert tail_text is not None, "channels tail block not present — preconditions broken"
+        tail_local = approx_tokens([{"role": "user", "content": tail_text}])
+        assert tail_local >= 100, (
+            f"tail block only {tail_local} local tokens — not chunky enough "
+            f"to exercise the bug path; test preconditions weak"
+        )
+
+        assert full_local <= agent.window_max, (
+            f"full payload {full_local} tokens exceeds window_max "
+            f"{agent.window_max} (messages={len(call['messages'])}, "
+            f"tools={len(call.get('tools') or [])}, tail_local={tail_local})"
         )


### PR DESCRIPTION
## Summary
- PR #165 fixed system+tools overhead. This PR closes the remaining budget leak: the channels tail block (\`build_channels_tail_block\`) is appended AFTER windowing runs, so its contribution was still escaping the budget.
- Observed on JN (6 Signal bindings): ~1.5K provider tokens of tail, pushing live payloads past \`window_max\` (32K actual on a 30K cap).

## Approach
New helper \`max_tail_block_local(bindings)\` synthesises the fattest possible tail block from the binding list alone — every channel rendered as non-focal, non-muted, 9999 unread, with a maxed-out preview. The real tail at send time is always ≤ this bound (fewer unread, shorter previews, possible focal/muted lines that render smaller).

\`StepPrelude\` now carries the bound, and both \`run_session_step\` and \`GET /sessions/:id/context\` add it to \`overhead_local\` before calling \`read_windowed_events\`. Correct-by-construction: reserving the worst case prevents any overshoot regardless of how the tail ultimately renders.

## TDD
- New \`tests/e2e/test_windowing_overhead.py::test_full_payload_fits_window_max_with_tail_block\` seeds six Signal-width bindings + per-channel inbound traffic so the tail renders at full fat (unread counts + previews), asserts \`approx_tokens(messages, tools) <= window_max\`.
- Pre-fix: RED (overshoot 249 tokens at window_max=4500).
- Post-fix: GREEN.

## Test plan
- [x] \`uv run mypy src\` — clean.
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean.
- [x] \`uv run pytest tests/unit -q\` — 900 passed.
- [x] \`uv run pytest tests/e2e -q\` — 250 passed (+1 new).
- [ ] Post-merge: incorporate + observe JN under tight window; actual should now stay ≤ \`window_max\` per-span-R variance caveats only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)