### PR TITLE
[codex] stabilize model token ratio

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import math
+import time
 from types import EllipsisType
 from typing import Any
 
@@ -834,21 +835,47 @@ async def _latest_cumulative_tokens(conn: asyncpg.Connection[Any], session_id: s
     return val
 
 
+_MODEL_TOKEN_RATIO_MIN_SAMPLES = 5
+_MODEL_TOKEN_RATIO_MIN = 0.5
+_MODEL_TOKEN_RATIO_BUCKET_FLOOR = 0.001
+_MODEL_TOKEN_RATIO_CACHE_TTL_SECONDS = 60.0
+_model_token_ratio_cache: dict[tuple[str, float], tuple[float, float]] = {}
+
+
+def _clear_model_token_ratio_cache() -> None:
+    """Clear the process-local token-ratio cache for tests."""
+    _model_token_ratio_cache.clear()
+
+
 async def model_token_ratio(
     conn: asyncpg.Connection[Any],
     model: str,
     *,
-    n: int = 30,
+    k_bucket: float = 2.0,
 ) -> float:
     """Per-model actual/local token correction.
 
-    Returns ``SUM(actual) / SUM(local)`` over the most recent ``n``
-    successful ``model_request_end`` spans for ``model``.  Below ``n``
-    samples: returns ``1.0`` — R is too noisy to trust and applying it
-    would churn the prefix cache.  At or above ``n``: aggregates exactly
-    the last ``n`` samples.  The single parameter governs both the
-    activation threshold and the sliding-window size, so per-step drift
-    in R is bounded by the window itself.
+    Treats R as a fixed tokenizer parameter estimated from noisy observed
+    spans.  Returns the lifetime unweighted mean of per-span
+    ``actual/local`` ratios for successful ``model_request_end`` spans
+    for ``model``, quantized to a bucket derived from the standard error
+    of those same per-span ratios.  With very little data, returns
+    ``1.0`` so newly seen models preserve the old model-agnostic
+    windowing behavior until calibration is meaningful.
+
+    The bucket width is ``max(k_bucket * stddev(per_span_ratio) / sqrt(n),
+    0.001)``.  The floor prevents tiny floating-point changes in a mature
+    aggregate from nudging ``read_windowed_events`` across event
+    boundaries and invalidating provider prefix caches every turn.  The
+    returned ratio is clamped to ``0.5`` as a physical lower bound: when
+    calibration data is pathological, prefer near-neutral windowing over
+    dividing by a near-zero R and dropping almost everything.
+
+    Mature calibrated ratios are cached in-process for 60 seconds.  The
+    lifetime aggregate is intentionally slow-moving, and caching prevents
+    every windowing call from rescanning all historical calibration spans.
+    Below-threshold results are not cached, so newly accumulating models
+    can activate as soon as the minimum sample count is reached.
 
     ``model`` is the raw mind string (``agent.model``) — NO NORMALIZATION.
     Different LiteLLM routes (``anthropic/...`` vs
@@ -874,35 +901,59 @@ async def model_token_ratio(
     ``events_model_request_end_calibration_idx`` partial index
     (migration 0024).
     """
+    if k_bucket <= 0:
+        raise ValueError("k_bucket must be positive")
+
+    cache_key = (model, k_bucket)
+    now = time.monotonic()
+    cached = _model_token_ratio_cache.get(cache_key)
+    if cached is not None:
+        expires_at, ratio = cached
+        if expires_at > now:
+            return ratio
+        del _model_token_ratio_cache[cache_key]
+
     row = await conn.fetchrow(
         """
-        WITH recent AS (
+        WITH calibration AS (
             SELECT
-                (data->'model_usage'->>'input_tokens')::bigint AS it,
-                (data->>'local_tokens')::bigint                 AS lt
+                (data->'model_usage'->>'input_tokens')::float AS it,
+                (data->>'local_tokens')::bigint                AS lt
             FROM events
             WHERE kind = 'span'
               AND data->>'event' = 'model_request_end'
               AND (data->>'is_error')::boolean = false
               AND data->>'model' = $1
               AND data ? 'local_tokens'
+              AND data ? 'model'
+              -- Exclude old/malformed success spans before casting.
+              AND (data->'model_usage') ? 'input_tokens'
+              AND (data->'model_usage'->>'input_tokens') IS NOT NULL
               AND (data->>'local_tokens')::bigint > 0
-            ORDER BY seq DESC
-            LIMIT $2
         )
         SELECT
-            COUNT(*)                                AS k,
-            COALESCE(SUM(it), 0)::bigint            AS total_actual,
-            COALESCE(SUM(lt), 0)::bigint            AS total_local
-        FROM recent
+            COUNT(*)::bigint                                AS n,
+            COALESCE(AVG(it / NULLIF(lt, 0)), 0)::float      AS mean_ratio,
+            COALESCE(STDDEV(it / NULLIF(lt, 0)), 0)::float   AS stddev_ratio
+        FROM calibration
         """,
         model,
-        n,
     )
     assert row is not None
-    if row["k"] < n:
+    if row["n"] < _MODEL_TOKEN_RATIO_MIN_SAMPLES:
         return 1.0
-    return float(row["total_actual"]) / float(row["total_local"])
+
+    raw = float(row["mean_ratio"])
+    stddev_ratio = float(row["stddev_ratio"] or 0.0)
+    standard_error = stddev_ratio / math.sqrt(float(row["n"]))
+    bucket = max(k_bucket * standard_error, _MODEL_TOKEN_RATIO_BUCKET_FLOOR)
+    quantized = round(raw / bucket) * bucket
+    ratio = max(quantized, _MODEL_TOKEN_RATIO_MIN)
+    _model_token_ratio_cache[cache_key] = (
+        now + _MODEL_TOKEN_RATIO_CACHE_TTL_SECONDS,
+        ratio,
+    )
+    return ratio
 
 
 def _derive_tool_name(kind: str, data: dict[str, Any]) -> str | None:
@@ -1258,16 +1309,11 @@ async def read_windowed_events(
 
     Prefix-cache invariant: the plain chunked-snap algorithm gave a
     *strict* guarantee of byte-identical prompt prefix within a snap
-    chunk.  With the ratio correction this weakens to a
-    *quantitatively-bounded* guarantee: R can shift slightly between
-    consecutive reads as new calibration samples land, which can nudge
-    ``drop_local`` across an event boundary and invalidate the prefix
-    cache for that turn.  With ``n=30`` samples, per-step drift in R
-    scales with the per-sample CV — Opus measured at ~0.2 % CV, putting
-    drift well below Anthropic's ~5-minute cache TTL.  Revisit the ``n``
-    default in :func:`model_token_ratio` if a newly-onboarded model
-    shows per-sample CV above ~1 %, or if prefix-cache invalidation ever
-    shows up in telemetry for a steady-state workload.
+    chunk.  With the ratio correction this remains stable in practice
+    because :func:`model_token_ratio` uses a lifetime aggregate and
+    standard-error bucketing, so mature calibrations do not drift on every
+    new sample.  Early calibrations are coarse by design and converge as
+    the sample count grows.
 
     Falls back to :func:`read_message_events` (loading all events) when
     cumulative data is not available (pre-backfill sessions or rolling

--- a/tests/e2e/test_model_token_ratio_sql.py
+++ b/tests/e2e/test_model_token_ratio_sql.py
@@ -5,7 +5,7 @@ Unlike the mock-based unit tests in ``tests/unit/test_model_token_ratio.py``
 (which pin only the Python arithmetic), these cases exercise the SQL
 itself — JSON extraction, the ``(data->>'is_error')::boolean`` cast, the
 ``data ? 'local_tokens'`` existence predicate, the ``(data->>'model') = $1``
-partitioning, and the ``ORDER BY seq DESC LIMIT $2`` sliding window.
+partitioning, lifetime aggregation, and standard-error bucketing.
 
 Every test uses a UUID-based synthetic model name, so spans seeded by one
 test cannot contaminate another test's aggregate even though the ``events``
@@ -76,7 +76,17 @@ async def _seed_error_span(harness: Harness, session_id: str) -> None:
 
 
 class TestModelTokenRatioSQL:
-    async def test_below_n_returns_1(self, harness: Harness) -> None:
+    async def test_below_min_samples_returns_1(self, harness: Harness) -> None:
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        for _ in range(4):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=150
+            )
+        async with harness._pool.acquire() as conn:
+            assert await queries.model_token_ratio(conn, model) == 1.0
+
+    async def test_min_samples_returns_mean_ratio(self, harness: Harness) -> None:
         model = f"test-model-{uuid.uuid4().hex[:8]}"
         session = await harness.start("seed")
         for _ in range(5):
@@ -84,17 +94,7 @@ class TestModelTokenRatioSQL:
                 harness, session.id, model=model, local_tokens=100, input_tokens=150
             )
         async with harness._pool.acquire() as conn:
-            assert await queries.model_token_ratio(conn, model, n=30) == 1.0
-
-    async def test_at_n_returns_sum_ratio(self, harness: Harness) -> None:
-        model = f"test-model-{uuid.uuid4().hex[:8]}"
-        session = await harness.start("seed")
-        for _ in range(30):
-            await _seed_valid_span(
-                harness, session.id, model=model, local_tokens=100, input_tokens=150
-            )
-        async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(conn, model, n=30)
+            ratio = await queries.model_token_ratio(conn, model)
         assert ratio == pytest.approx(1.5)
 
     async def test_ignores_cache_breakdown_fields(self, harness: Harness) -> None:
@@ -108,7 +108,7 @@ class TestModelTokenRatioSQL:
         contribute."""
         model = f"test-model-{uuid.uuid4().hex[:8]}"
         session = await harness.start("seed")
-        for _ in range(30):
+        for _ in range(5):
             await _seed_valid_span(
                 harness,
                 session.id,
@@ -119,39 +119,39 @@ class TestModelTokenRatioSQL:
                 cache_creation=40,
             )
         async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(conn, model, n=30)
-        # total_actual per span = input_tokens = 150 (cache_* ignored).
+            ratio = await queries.model_token_ratio(conn, model)
+        # per-span ratio = input_tokens/local_tokens = 150/100 (cache_* ignored).
         # ratio = 150/100 = 1.5.
         assert ratio == pytest.approx(1.5)
 
     async def test_excludes_error_spans(self, harness: Harness) -> None:
         model = f"test-model-{uuid.uuid4().hex[:8]}"
         session = await harness.start("seed")
-        for _ in range(30):
+        for _ in range(5):
             await _seed_valid_span(
                 harness, session.id, model=model, local_tokens=100, input_tokens=150
             )
         for _ in range(30):
             await _seed_error_span(harness, session.id)
         async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(conn, model, n=30)
+            ratio = await queries.model_token_ratio(conn, model)
         assert ratio == pytest.approx(1.5)
 
     async def test_partitions_by_model_string(self, harness: Harness) -> None:
         model_a = f"test-model-{uuid.uuid4().hex[:8]}"
         model_b = f"test-model-{uuid.uuid4().hex[:8]}"
         session = await harness.start("seed")
-        for _ in range(30):
+        for _ in range(5):
             await _seed_valid_span(
                 harness, session.id, model=model_a, local_tokens=100, input_tokens=150
             )
-        for _ in range(30):
+        for _ in range(5):
             await _seed_valid_span(
                 harness, session.id, model=model_b, local_tokens=100, input_tokens=120
             )
         async with harness._pool.acquire() as conn:
-            ratio_a = await queries.model_token_ratio(conn, model_a, n=30)
-            ratio_b = await queries.model_token_ratio(conn, model_b, n=30)
+            ratio_a = await queries.model_token_ratio(conn, model_a)
+            ratio_b = await queries.model_token_ratio(conn, model_b)
         assert ratio_a == pytest.approx(1.5)
         assert ratio_b == pytest.approx(1.2)
 
@@ -162,22 +162,41 @@ class TestModelTokenRatioSQL:
         model = f"test-model-{uuid.uuid4().hex[:8]}"
         session_a = await harness.start("seed-a")
         session_b = await harness.start("seed-b")
-        for _ in range(15):
+        for _ in range(2):
             await _seed_valid_span(
                 harness, session_a.id, model=model, local_tokens=100, input_tokens=150
             )
-        for _ in range(15):
+        for _ in range(3):
             await _seed_valid_span(
                 harness, session_b.id, model=model, local_tokens=100, input_tokens=150
             )
         async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(conn, model, n=30)
+            ratio = await queries.model_token_ratio(conn, model)
         assert ratio == pytest.approx(1.5)
 
-    async def test_sliding_window_discards_old_samples(self, harness: Harness) -> None:
-        """LIMIT N in the CTE keeps only the most recent N; older samples
-        with a different ratio fall out of the aggregate as traffic
-        accumulates."""
+    async def test_uses_unweighted_mean_ratio(self, harness: Harness) -> None:
+        """Point estimate and stddev describe the same unweighted
+        per-span-ratio estimator, even when span sizes skew."""
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        for _ in range(4):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=100
+            )
+        await _seed_valid_span(
+            harness, session.id, model=model, local_tokens=10_000, input_tokens=20_000
+        )
+
+        async with harness._pool.acquire() as conn:
+            ratio = await queries.model_token_ratio(conn, model, k_bucket=0.001)
+
+        # Unweighted mean = (1 + 1 + 1 + 1 + 2) / 5 = 1.2.
+        # Weighted SUM(input)/SUM(local) would be ~1.96, which this must not return.
+        assert ratio == pytest.approx(1.2)
+
+    async def test_lifetime_aggregate_retains_old_samples(self, harness: Harness) -> None:
+        """All historical calibration samples for the model contribute to
+        the aggregate; older samples do not fall out of a LIMIT-N window."""
         model = f"test-model-{uuid.uuid4().hex[:8]}"
         session = await harness.start("seed")
         # Older regime: ratio 2.0.
@@ -191,11 +210,37 @@ class TestModelTokenRatioSQL:
                 harness, session.id, model=model, local_tokens=100, input_tokens=150
             )
         async with harness._pool.acquire() as conn:
-            # n=30 → only the newer regime counts.
-            assert await queries.model_token_ratio(conn, model, n=30) == pytest.approx(1.5)
-            # n=60 → both regimes count:
-            # total_actual = 30*200 + 30*150 = 10500; total_local = 60*100 = 6000.
-            assert await queries.model_token_ratio(conn, model, n=60) == pytest.approx(1.75)
+            # Use a narrow bucket here to isolate lifetime aggregation:
+            # mean_ratio = mean([2.0] * 30 + [1.5] * 30) = 1.75.
+            assert await queries.model_token_ratio(conn, model, k_bucket=0.001) == pytest.approx(
+                1.75
+            )
+
+    async def test_bucket_shrinks_as_sample_count_grows(self, harness: Harness) -> None:
+        """With the same underlying ratio distribution, standard-error
+        bucketing gets narrower as n grows."""
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        for input_tokens in (140, 160, 140, 160, 140):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=input_tokens
+            )
+        async with harness._pool.acquire() as conn:
+            coarse_ratio = await queries.model_token_ratio(conn, model)
+
+        for _ in range(3):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=140
+            )
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=160
+            )
+
+        queries._clear_model_token_ratio_cache()
+        async with harness._pool.acquire() as conn:
+            tighter_ratio = await queries.model_token_ratio(conn, model)
+
+        assert abs(tighter_ratio - 1.5) < abs(coarse_ratio - 1.5)
 
     async def test_zero_local_tokens_excluded(self, harness: Harness) -> None:
         """The WHERE clause filters ``(data->>'local_tokens')::bigint > 0``
@@ -208,11 +253,11 @@ class TestModelTokenRatioSQL:
             await _seed_valid_span(
                 harness, session.id, model=model, local_tokens=0, input_tokens=999
             )
-        # 30 valid.
-        for _ in range(30):
+        # 5 valid.
+        for _ in range(5):
             await _seed_valid_span(
                 harness, session.id, model=model, local_tokens=100, input_tokens=150
             )
         async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(conn, model, n=30)
+            ratio = await queries.model_token_ratio(conn, model)
         assert ratio == pytest.approx(1.5)

--- a/tests/unit/test_model_token_ratio.py
+++ b/tests/unit/test_model_token_ratio.py
@@ -1,10 +1,11 @@
 """Unit tests for :func:`aios.db.queries.model_token_ratio`.
 
 The SQL itself — partial-index coverage, JSON extraction, is_error
-filter, model-string partitioning, and LIMIT-based sliding window — is
-exercised against a real Postgres in
+filter, model-string partitioning, and lifetime aggregation — is exercised
+against a real Postgres in
 ``tests/e2e/test_model_token_ratio_sql.py``.  These tests pin the
-Python-side contract only: below-N fallback and the SUM/SUM arithmetic.
+Python-side contract only: insufficient-sample fallback, AVG/STDDEV
+arithmetic, and standard-error bucketing.
 """
 
 from __future__ import annotations
@@ -13,16 +14,26 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from aios.db.queries import model_token_ratio
+from aios.db.queries import _clear_model_token_ratio_cache, model_token_ratio
 
 
-def _mock_conn(*, k: int, total_actual: int, total_local: int) -> MagicMock:
+@pytest.fixture(autouse=True)
+def _clear_ratio_cache() -> None:
+    _clear_model_token_ratio_cache()
+
+
+def _mock_conn(
+    *,
+    n: int,
+    mean_ratio: float,
+    stddev_ratio: float,
+) -> MagicMock:
     conn = MagicMock()
     conn.fetchrow = AsyncMock(
         return_value={
-            "k": k,
-            "total_actual": total_actual,
-            "total_local": total_local,
+            "n": n,
+            "mean_ratio": mean_ratio,
+            "stddev_ratio": stddev_ratio,
         }
     )
     return conn
@@ -30,53 +41,78 @@ def _mock_conn(*, k: int, total_actual: int, total_local: int) -> MagicMock:
 
 class TestModelTokenRatio:
     @pytest.mark.asyncio
-    async def test_below_n_returns_1(self) -> None:
-        conn = _mock_conn(k=29, total_actual=15_000, total_local=10_000)
-        ratio = await model_token_ratio(conn, "model-x", n=30)
+    async def test_below_min_samples_returns_1(self) -> None:
+        conn = _mock_conn(n=4, mean_ratio=1.5, stddev_ratio=0.0)
+        ratio = await model_token_ratio(conn, "model-x")
         assert ratio == 1.0
 
     @pytest.mark.asyncio
-    async def test_at_n_returns_sum_ratio(self) -> None:
-        # 30 spans, actual sums to 1.5x the local sum -> R = 1.5 exactly.
-        conn = _mock_conn(k=30, total_actual=1_500, total_local=1_000)
-        ratio = await model_token_ratio(conn, "model-x", n=30)
+    async def test_min_samples_returns_mean_ratio_quantized_to_floor_bucket(self) -> None:
+        # Zero observed spread uses the 0.001 floor bucket.  The raw ratio
+        # 1.5004 rounds to the nearest floor bucket: 1.500.
+        conn = _mock_conn(n=5, mean_ratio=1.5004, stddev_ratio=0.0)
+        ratio = await model_token_ratio(conn, "model-x")
         assert ratio == pytest.approx(1.5)
 
     @pytest.mark.asyncio
-    async def test_above_n_returns_sum_ratio(self) -> None:
-        # LIMIT in the SQL caps the sample set at n; the helper trusts the
-        # row it got back.  Just verify the division when k >= n.
-        conn = _mock_conn(k=100, total_actual=11_824, total_local=10_000)
-        ratio = await model_token_ratio(conn, "model-x", n=100)
-        assert ratio == pytest.approx(1.1824)
+    async def test_standard_error_bucket_controls_quantization(self) -> None:
+        # raw=1.44, stddev=0.15, n=9 -> SE=0.05, bucket=0.1.
+        conn = _mock_conn(n=9, mean_ratio=1.44, stddev_ratio=0.15)
+        ratio = await model_token_ratio(conn, "model-x")
+        assert ratio == pytest.approx(1.4)
 
     @pytest.mark.asyncio
-    async def test_default_n_is_30(self) -> None:
-        # k=29 with no explicit n: 30-default returns 1.0.
-        conn = _mock_conn(k=29, total_actual=1_500, total_local=1_000)
-        assert await model_token_ratio(conn, "model-x") == 1.0
-        # k=30 activates the default threshold.
-        conn2 = _mock_conn(k=30, total_actual=1_500, total_local=1_000)
-        assert await model_token_ratio(conn2, "model-x") == pytest.approx(1.5)
+    async def test_k_bucket_tunes_standard_error_width(self) -> None:
+        # raw=1.44, stddev=0.15, n=9.  k=1 halves the bucket to 0.05,
+        # so the same aggregate rounds closer to the raw value.
+        conn = _mock_conn(n=9, mean_ratio=1.44, stddev_ratio=0.15)
+        ratio = await model_token_ratio(conn, "model-x", k_bucket=1.0)
+        assert ratio == pytest.approx(1.45)
 
     @pytest.mark.asyncio
-    async def test_passes_model_and_n_to_query(self) -> None:
-        conn = _mock_conn(k=0, total_actual=0, total_local=0)
-        await model_token_ratio(conn, "anthropic/claude-sonnet-4-6", n=200)
+    async def test_passes_model_to_query(self) -> None:
+        conn = _mock_conn(n=0, mean_ratio=0.0, stddev_ratio=0.0)
+        await model_token_ratio(conn, "anthropic/claude-sonnet-4-6")
         args = conn.fetchrow.await_args
         assert args is not None
-        # Positional args after the SQL string: (model, n)
+        # Positional args after the SQL string: (model,)
         assert args.args[1] == "anthropic/claude-sonnet-4-6"
-        assert args.args[2] == 200
 
     @pytest.mark.asyncio
     async def test_sql_does_not_sum_cache_fields(self) -> None:
         """Regression: summing ``cache_*`` breakdown fields with
         ``input_tokens`` double-counts and roughly doubles R on
         cache-hot workloads."""
-        conn = _mock_conn(k=0, total_actual=0, total_local=0)
-        await model_token_ratio(conn, "model-x", n=1)
+        conn = _mock_conn(n=0, mean_ratio=0.0, stddev_ratio=0.0)
+        await model_token_ratio(conn, "model-x")
         sql = conn.fetchrow.await_args.args[0]
-        assert sql.count("'input_tokens'") == 1
         assert "cache_read_input_tokens" not in sql
         assert "cache_creation_input_tokens" not in sql
+        assert "LIMIT" not in sql
+        assert "AVG(" in sql
+        assert "SUM(it)" not in sql
+
+    @pytest.mark.asyncio
+    async def test_invalid_bucket_rejected(self) -> None:
+        conn = _mock_conn(n=5, mean_ratio=1.5, stddev_ratio=0.0)
+        with pytest.raises(ValueError, match="k_bucket must be positive"):
+            await model_token_ratio(conn, "model-x", k_bucket=0.0)
+
+    @pytest.mark.asyncio
+    async def test_min_ratio_clamp(self) -> None:
+        conn = _mock_conn(n=5, mean_ratio=0.0001, stddev_ratio=0.0)
+        assert await model_token_ratio(conn, "model-x") == pytest.approx(0.5)
+
+    @pytest.mark.asyncio
+    async def test_two_high_spread_samples_stay_neutral(self) -> None:
+        conn = _mock_conn(n=2, mean_ratio=1.5, stddev_ratio=10.0)
+        assert await model_token_ratio(conn, "model-x") == 1.0
+
+    @pytest.mark.asyncio
+    async def test_calibrated_ratio_is_cached(self) -> None:
+        conn = _mock_conn(n=5, mean_ratio=1.5, stddev_ratio=0.0)
+        assert await model_token_ratio(conn, "model-cache") == pytest.approx(1.5)
+
+        conn.fetchrow = AsyncMock(return_value={"n": 5, "mean_ratio": 2.0, "stddev_ratio": 0.0})
+        assert await model_token_ratio(conn, "model-cache") == pytest.approx(1.5)
+        conn.fetchrow.assert_not_awaited()

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -21,8 +21,8 @@ class _FakeConn:
     """Minimal asyncpg.Connection stand-in.
 
     ``fetchval`` serves ``_latest_cumulative_tokens`` (total local tokens).
-    ``fetchrow`` serves ``model_token_ratio`` (the ``SELECT k, total_actual,
-    total_local`` row).  ``fetch`` captures the bounded range scan's args so
+    ``fetchrow`` serves ``model_token_ratio`` (the lifetime calibration
+    aggregate row).  ``fetch`` captures the bounded range scan's args so
     tests can assert the computed ``drop_local``.
     """
 
@@ -30,15 +30,15 @@ class _FakeConn:
         self,
         *,
         total_local: int | None,
-        ratio_k: int,
-        ratio_actual: int,
-        ratio_local: int,
+        ratio_n: int,
+        ratio_mean: float,
+        ratio_stddev: float = 0.0,
     ) -> None:
         self.total_local = total_local
         self.ratio_row = {
-            "k": ratio_k,
-            "total_actual": ratio_actual,
-            "total_local": ratio_local,
+            "n": ratio_n,
+            "mean_ratio": ratio_mean,
+            "stddev_ratio": ratio_stddev,
         }
         self.fetch_calls: list[tuple[Any, ...]] = []
 
@@ -58,6 +58,7 @@ def _stub_read_message_events(monkeypatch: pytest.MonkeyPatch) -> None:
     """Short-circuit ``read_message_events`` so no real DB is hit when the
     code path falls back to 'load everything'.  We sentinel its return so
     tests can detect the fallback."""
+    queries._clear_model_token_ratio_cache()
     monkeypatch.setattr(
         queries,
         "read_message_events",
@@ -67,7 +68,7 @@ def _stub_read_message_events(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 async def test_no_cumulative_falls_back_to_full_read() -> None:
-    conn = _FakeConn(total_local=None, ratio_k=0, ratio_actual=0, ratio_local=0)
+    conn = _FakeConn(total_local=None, ratio_n=0, ratio_mean=0.0)
     result = await queries.read_windowed_events(
         conn, "sess_x", window_min=1_000, window_max=2_000, model="m", overhead_local=0
     )
@@ -76,15 +77,15 @@ async def test_no_cumulative_falls_back_to_full_read() -> None:
 
 
 @pytest.mark.asyncio
-async def test_below_n_ratio_1_matches_today() -> None:
+async def test_insufficient_ratio_1_matches_today() -> None:
     """Load-bearing backward-compatibility fence.  Do not delete.
 
-    While model_token_ratio is still warming up (or on a model the DB has
-    never seen), it returns 1.0 and ``read_windowed_events`` must behave
+    While model_token_ratio has too few samples (or on a model the
+    DB has never seen), it returns 1.0 and ``read_windowed_events`` must behave
     byte-identically to the pre-ratio chunked-snap algorithm — otherwise
     the "gradual rollout" rollout property breaks.  This test pins that.
     """
-    conn = _FakeConn(total_local=3_000, ratio_k=10, ratio_actual=0, ratio_local=0)
+    conn = _FakeConn(total_local=3_000, ratio_n=4, ratio_mean=0.0)
     # window_min=1000, window_max=2000 → chunk size 1000.
     # total=3000 → overshoot 1000 → drop 1000 (one chunk).
     await queries.read_windowed_events(
@@ -106,7 +107,7 @@ async def test_ratio_above_1_drops_more() -> None:
     overshoot=250 → drop_effective=1000.
     drop_local = ceil(1000 / 1.5) = 667.
     """
-    conn = _FakeConn(total_local=1_500, ratio_k=100, ratio_actual=150, ratio_local=100)
+    conn = _FakeConn(total_local=1_500, ratio_n=5, ratio_mean=1.5)
     await queries.read_windowed_events(
         conn, "sess_x", window_min=1_000, window_max=2_000, model="m", overhead_local=0
     )
@@ -117,7 +118,7 @@ async def test_ratio_above_1_drops_more() -> None:
 @pytest.mark.asyncio
 async def test_ratio_below_1_drops_fewer() -> None:
     """ratio=0.5 deflates total_effective below window_max → no drop."""
-    conn = _FakeConn(total_local=3_000, ratio_k=100, ratio_actual=50, ratio_local=100)
+    conn = _FakeConn(total_local=3_000, ratio_n=5, ratio_mean=0.5)
     result = await queries.read_windowed_events(
         conn, "sess_x", window_min=1_000, window_max=2_000, model="m", overhead_local=0
     )


### PR DESCRIPTION
## Summary

- Replace the recent-N `model_token_ratio` sliding window with a lifetime per-model aggregate.
- Use an internally consistent unweighted estimator: `AVG(input/local)` with matching `STDDEV(input/local)` standard-error bucketing.
- Add guardrails from #168: `MIN_SAMPLES = 5`, `MIN_RATIO = 0.5`, a 0.001 bucket floor, and a 60s process-local cache for mature calibrations.
- Update unit and Postgres-backed E2E coverage for insufficient samples, unweighted aggregation, bucket shrinkage, ratio clamping, caching, and windowing callers.

## Root Cause

The old ratio query recalculated R from the most recent 30 successful `model_request_end` spans. Small changes in that sliding sample could move `drop_local` in `read_windowed_events`, shifting the kept-event boundary and invalidating provider prefix cache on otherwise steady turns.

## Validation

- `uv run ruff check src/aios/db/queries.py tests/unit/test_model_token_ratio.py tests/unit/test_windowed_ratio.py tests/e2e/test_model_token_ratio_sql.py`
- `uv run pytest tests/unit/test_model_token_ratio.py tests/unit/test_windowed_ratio.py tests/e2e/test_model_token_ratio_sql.py tests/e2e/test_windowing_overhead.py`
- `uv run mypy src/aios/db/queries.py`
- 100K-row throwaway Postgres `EXPLAIN (ANALYZE, BUFFERS)`: cold aggregate uses `events_model_request_end_calibration_idx`, scans 100,000 rows, execution time 45.404 ms, all 4,782 blocks cache-hit.
- Same 100K fixture through `model_token_ratio`: cold call 42.747 ms; 1,000 hot cached calls 1.320 ms total, average 0.001320 ms/call.
- commit hook: full ruff, full mypy, full unit suite (`904 passed`)

Fixes #168.