### PR TITLE
fix(harness): stub reasoning_content on assistant turns for thinking models

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -510,6 +510,29 @@ def _prune_leading_orphans(messages: list[dict[str, Any]]) -> list[dict[str, Any
     return messages[start:]
 
 
+def stub_missing_reasoning_content(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Ensure every assistant message carries ``reasoning_content``.
+
+    Thinking-mode models (DeepSeek V4 Flash, etc.) reject transcripts
+    whose assistant turns lack this field: ``The reasoning_content in the
+    thinking mode must be passed back to the API``.  Non-thinking models
+    (Anthropic / OpenAI / Gemini / Llama / DeepSeek v3 — all probed)
+    ignore the field entirely, so setting an empty stub unconditionally
+    costs nothing and lets cross-model sessions use thinking models for
+    a single turn without poisoning their replay on other providers.
+
+    Mutates messages in place and returns the list for chaining.  Skips
+    messages that already have a reasoning_content set (from a prior
+    thinking-model turn whose output we preserved opaquely in the log).
+    """
+    for msg in messages:
+        if msg.get("role") == "assistant" and "reasoning_content" not in msg:
+            msg["reasoning_content"] = ""
+    return messages
+
+
 def separate_adjacent_user_messages(
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -28,7 +28,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from aios.harness.context import build_messages, separate_adjacent_user_messages
+from aios.harness.context import (
+    build_messages,
+    separate_adjacent_user_messages,
+    stub_missing_reasoning_content,
+)
 from aios.tools.registry import to_openai_tools
 
 if TYPE_CHECKING:
@@ -165,6 +169,12 @@ async def compose_step_context(
     # Block LiteLLM's adjacent-same-role merge on Anthropic so the tail
     # isn't concatenated into the preceding user inbound.
     messages = separate_adjacent_user_messages(ctx.messages)
+
+    # Unblock thinking-mode models: DeepSeek V4 Flash rejects assistant
+    # turns without reasoning_content.  Empty stub is ignored by all
+    # non-thinking providers we've tested (Anthropic, OpenAI, Gemini,
+    # Llama, non-thinking DeepSeek).
+    stub_missing_reasoning_content(messages)
 
     return StepContext(
         model=agent.model,

--- a/tests/e2e/test_step_separator.py
+++ b/tests/e2e/test_step_separator.py
@@ -55,8 +55,14 @@ class TestSeparatorAtLiteLLMBoundary:
         assert tail_idx > 0, "tail block should not be first — there's an inbound before it"
 
         prev = msgs[tail_idx - 1]
-        assert prev == {"role": "assistant", "content": ""}, (
+        # The separator is an empty-assistant message.  ``reasoning_content``
+        # is stubbed empty too so thinking-mode providers don't reject the
+        # transcript (see ``stub_missing_reasoning_content``).
+        assert prev.get("role") == "assistant" and prev.get("content") == "", (
             f"expected empty-assistant separator before tail, got prev={prev!r}, tail={msgs[tail_idx]!r}"
+        )
+        assert prev.get("reasoning_content") == "", (
+            f"expected reasoning_content stub on separator, got prev={prev!r}"
         )
 
     async def test_no_separator_when_tail_block_absent(self, harness: Harness) -> None:

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -14,6 +14,7 @@ from aios.harness.context import (
     build_messages,
     separate_adjacent_user_messages,
     should_call_model,
+    stub_missing_reasoning_content,
 )
 from aios.models.channel_bindings import ChannelBinding
 from aios.models.events import Event
@@ -1094,6 +1095,58 @@ class TestSeparateAdjacentUserMessages:
             {"role": "assistant", "content": ""},
             {"role": "user", "content": "two"},
         ]
+
+
+class TestStubMissingReasoningContent:
+    def test_adds_empty_stub_to_assistant_without_reasoning(self) -> None:
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        stub_missing_reasoning_content(msgs)
+        assert msgs[1] == {"role": "assistant", "content": "hello", "reasoning_content": ""}
+
+    def test_preserves_existing_reasoning_content(self) -> None:
+        msgs = [
+            {"role": "assistant", "content": "ok", "reasoning_content": "deep thoughts"},
+        ]
+        stub_missing_reasoning_content(msgs)
+        assert msgs[0]["reasoning_content"] == "deep thoughts"
+
+    def test_ignores_user_messages(self) -> None:
+        msgs = [{"role": "user", "content": "hi"}]
+        stub_missing_reasoning_content(msgs)
+        assert msgs[0] == {"role": "user", "content": "hi"}
+
+    def test_ignores_tool_messages(self) -> None:
+        msgs = [{"role": "tool", "tool_call_id": "x", "content": "result"}]
+        stub_missing_reasoning_content(msgs)
+        assert msgs[0] == {"role": "tool", "tool_call_id": "x", "content": "result"}
+
+    def test_stubs_empty_assistant_separator(self) -> None:
+        """The empty-assistant separator inserted by
+        :func:`separate_adjacent_user_messages` is still an assistant
+        message and must also carry the stub."""
+        msgs = [
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "b"},
+        ]
+        stub_missing_reasoning_content(msgs)
+        assert msgs[1] == {"role": "assistant", "content": "", "reasoning_content": ""}
+
+    def test_mutates_in_place_and_returns(self) -> None:
+        msgs = [{"role": "assistant", "content": "x"}]
+        returned = stub_missing_reasoning_content(msgs)
+        assert returned is msgs
+
+    def test_handles_tool_call_assistants(self) -> None:
+        msgs = [
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "a"}]},
+        ]
+        stub_missing_reasoning_content(msgs)
+        assert msgs[0]["reasoning_content"] == ""
+        assert msgs[0]["tool_calls"] == [{"id": "a"}]
 
 
 class TestSeparateAdjacentUserMessagesPipeline:


### PR DESCRIPTION
## Summary
- Thinking-mode models (DeepSeek V4 Flash and future kin) reject transcripts whose assistant turns lack \`reasoning_content\` with: *"The reasoning_content in the thinking mode must be passed back to the API."*
- One-line fix: every assistant message sent to a model gets \`reasoning_content = ""\` if it doesn't already have one. Empty stub is tolerated by all non-thinking providers probed.

## Why it matters
A long-running session (like JN) that has ever been served by a non-thinking model accumulates assistant turns without \`reasoning_content\`. Any subsequent thinking-model call rejects the entire transcript. Without this fix, thinking models are effectively unusable in mixed-model sessions — which is most sessions in aios's design.

## Approach
New helper \`stub_missing_reasoning_content(messages)\` in \`context.py\`, called from \`compose_step_context\` immediately after \`separate_adjacent_user_messages\`. Stubs an empty string only when the field is missing — messages that already carry \`reasoning_content\` from a prior thinking-model turn are untouched. Event log stays opaque; the stub is a per-send transform, never persisted.

## Empirical safety
Probed assistant message with \`reasoning_content\` field directly via LiteLLM against each provider:

| Provider (via route) | Empty-string stub | Notes |
|---|---|---|
| Anthropic Haiku 4.5 | ✅ | Ignored |
| OpenAI gpt-4o-mini (OR) | ✅ | Ignored |
| Google Gemini 2.5 flash (OR) | ✅ | Ignored |
| Llama 3.3 70B (OR) | ✅ | Ignored |
| DeepSeek v3.1 non-thinking (OR) | ✅ | Ignored |
| DeepSeek V4 Flash thinking (OR) | ✅ | Satisfies thinking-mode requirement |

Non-empty stubs occasionally produced a LiteLLM-side \`NoneType\` error on DeepSeek V4 Flash streaming; empty string avoids it.

## Live verification
Pre-fix: JN on \`openrouter/deepseek/deepseek-v4-flash\` failed every call with the thinking-mode rejection, exhausting retry backoff.

Post-fix: JN on the same model immediately replied \`"hello from deepseek"\` to a probe under its full 110K-130K window. No other config changed. Subsequent turns continued to work in conversation.

## Test plan
- [x] \`uv run mypy src\` — clean.
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean.
- [x] \`uv run pytest tests/unit -q\` — 910 passed (+7 new \`TestStubMissingReasoningContent\` cases).
- [x] Live smoke: JN successfully conversed on DeepSeek V4 Flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)