### PR TITLE
[codex] Add channel-aware MCP toolsets

### DIFF
--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -68,7 +68,6 @@ as focal-channel aware:
     {
       "type": "mcp_toolset",
       "mcp_server_name": "signal",
-      "default_config": {"permission_policy": {"type": "always_allow"}},
       "channel_context": {"type": "focal"}
     }
   ]

--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -54,23 +54,48 @@ curl -X POST :8090/v1/vaults/$VLT/credentials -d '{
 }'
 ```
 
-### 3. Register the aios connection
+### 3. Add the MCP server to your agent
+
+Add the Signal MCP server as a normal agent MCP server, and mark its toolset
+as focal-channel aware:
 
 ```
-curl -X POST :8090/v1/connections -d "{
+{
+  "mcp_servers": [
+    {"type": "url", "name": "signal", "url": "http://localhost:9100/mcp"}
+  ],
+  "tools": [
+    {
+      "type": "mcp_toolset",
+      "mcp_server_name": "signal",
+      "default_config": {"permission_policy": {"type": "always_allow"}},
+      "channel_context": {"type": "focal"}
+    }
+  ]
+}
+```
+
+### 4. Register the aios connection
+
+The connection is the inbound channel account. `mcp_url` and `vault_id` are
+still required by the current API for legacy compatibility; normal MCP
+discovery comes from the agent config above.
+
+```
+CONN=$(curl -X POST :8090/v1/connections -d "{
   \"connector\": \"signal\",
   \"account\": \"<bot-aci-uuid-from-step-1>\",
   \"mcp_url\": \"http://localhost:9100/mcp\",
   \"vault_id\": \"$VLT\"
-}"
+}" | jq -r .id)
 ```
 
-### 4. Start the connector
+### 5. Start the connector
 
 ```
 export AIOS_URL=http://localhost:8090
 export AIOS_API_KEY=...
-export AIOS_CONNECTION_ID=conn_...
+export AIOS_CONNECTION_ID=$CONN
 export AIOS_SIGNAL_MCP_TOKEN=supersecret
 
 python -m aios_signal start \
@@ -80,29 +105,25 @@ python -m aios_signal start \
 
 All settings can also be passed via env vars. Full list via `python -m aios_signal start --help`.
 
-### 5. Add a routing rule
+### 6. Add a routing rule
 
 ```
-curl -X POST :8090/v1/routing-rules -d '{
-  "prefix": "signal/<bot-aci-uuid>",
-  "target": "agent:<agent-id>",
-  "session_params": {"environment_id": "<env-id>"}
-}'
+curl -X POST :8090/v1/connections/$CONN/routing-rules -d "{
+  \"prefix\": \"\",
+  \"target\": \"agent:<agent-id>\",
+  \"session_params\": {\"environment_id\": \"<env-id>\", \"vault_ids\": [\"$VLT\"]}
+}"
 ```
 
-The prefix uses the **bot's** ACI UUID (from step 1), not the counterparty's.
+The empty prefix is the per-connection catch-all. The session vault binding is
+what gives the agent-declared Signal MCP server its bearer token.
 
-### 6. DM your bot — the agent replies
+### 7. DM your bot — the agent replies
 
 DM the bot's phone number from another Signal client. Watch the aios event
 log: the inbound message shows up with `metadata.channel` set, a session is
 created on first inbound, and the agent's `signal_send` call delivers the
 reply back to Signal.
-
-**Phase-2 dependency:** step 6 works end-to-end only once Phase 2 (#31) has
-merged — Phase 2 wires connection-provided MCP servers into the worker's
-tool discovery. Until then the connector runs fine and ingests messages, but
-the agent can't see the `signal_send` tool.
 
 ## Configuration reference
 

--- a/connectors/signal/src/aios_signal/mcp.py
+++ b/connectors/signal/src/aios_signal/mcp.py
@@ -41,12 +41,11 @@ from .rpc import RpcClient
 log = structlog.get_logger(__name__)
 
 
-# Key under a JSON-RPC tool-call request's ``_meta`` populated by the
-# aios worker when dispatching a connection-provided tool.  Its value
-# is the focal-channel path suffix — for Signal's 3-segment address
-# ``signal/<bot>/<chat>``, the suffix is just ``<chat>`` and can be
-# decoded directly as the Signal chat id.  See the aios focal-channel
-# plan + ``aios.harness.channels.FOCAL_CHANNEL_META_KEY`` for the
+# Key under a JSON-RPC tool-call request's ``_meta`` populated by the aios
+# worker when dispatching a focal-channel MCP toolset. Its value is the
+# focal-channel path suffix — for Signal's 3-segment address
+# ``signal/<bot>/<chat>``, the suffix is just ``<chat>`` and can be decoded
+# directly as the Signal chat id. See ``aios.harness.channels`` for the
 # client-side contract.
 _FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
@@ -54,13 +53,13 @@ _FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 def focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> str:
     """Extract the Signal ``chat_id`` from an MCP request's ``_meta``.
 
-    aios injects ``aios.focal_channel_path`` for connection-provided
-    tool calls; its value is the full focal-channel suffix (stripped
-    of ``<connector>/<account>``), which for a 3-segment Signal
-    address equals the chat id verbatim.  Missing / malformed meta
-    raises — the agent shouldn't be able to reach these tools without
-    a focal channel set (aios filters them out of the tool list when
-    focal is NULL), so any absence here is a real error to surface.
+    aios injects ``aios.focal_channel_path`` for focal-channel tool calls;
+    its value is the full focal-channel suffix (stripped of
+    ``<connector>/<account>``), which for a 3-segment Signal address equals
+    the chat id verbatim. Missing / malformed meta raises — the agent
+    shouldn't be able to reach these tools without a focal channel set (aios
+    filters them out of the tool list when focal is NULL), so any absence
+    here is a real error to surface.
     """
     path: Any = None
     if meta is not None:

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -60,7 +60,6 @@ as focal-channel aware:
     {
       "type": "mcp_toolset",
       "mcp_server_name": "telegram",
-      "default_config": {"permission_policy": {"type": "always_allow"}},
       "channel_context": {"type": "focal"}
     }
   ]

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -46,23 +46,48 @@ curl -X POST :8090/v1/vaults/$VLT/credentials -d '{
 }'
 ```
 
-### 3. Register the aios connection
+### 3. Add the MCP server to your agent
+
+Add the Telegram MCP server as a normal agent MCP server, and mark its toolset
+as focal-channel aware:
 
 ```
-curl -X POST :8090/v1/connections -d "{
+{
+  "mcp_servers": [
+    {"type": "url", "name": "telegram", "url": "http://localhost:9200/mcp"}
+  ],
+  "tools": [
+    {
+      "type": "mcp_toolset",
+      "mcp_server_name": "telegram",
+      "default_config": {"permission_policy": {"type": "always_allow"}},
+      "channel_context": {"type": "focal"}
+    }
+  ]
+}
+```
+
+### 4. Register the aios connection
+
+The connection is the inbound channel account. `mcp_url` and `vault_id` are
+still required by the current API for legacy compatibility; normal MCP
+discovery comes from the agent config above.
+
+```
+CONN=$(curl -X POST :8090/v1/connections -d "{
   \"connector\": \"telegram\",
   \"account\": \"<bot-numeric-id-from-step-1>\",
   \"mcp_url\": \"http://localhost:9200/mcp\",
   \"vault_id\": \"$VLT\"
-}"
+}" | jq -r .id)
 ```
 
-### 4. Start the connector
+### 5. Start the connector
 
 ```
 export AIOS_URL=http://localhost:8090
 export AIOS_API_KEY=...
-export AIOS_CONNECTION_ID=conn_...
+export AIOS_CONNECTION_ID=$CONN
 export AIOS_TELEGRAM_MCP_TOKEN=supersecret
 
 python -m aios_telegram start --bot-token 123456:AA...
@@ -71,17 +96,20 @@ python -m aios_telegram start --bot-token 123456:AA...
 All settings can also be passed via env vars. Full list via
 `python -m aios_telegram start --help`.
 
-### 5. Add a routing rule
+### 6. Add a routing rule
 
 ```
-curl -X POST :8090/v1/routing-rules -d '{
-  "prefix": "telegram/<bot-numeric-id>",
-  "target": "agent:<agent-id>",
-  "session_params": {"environment_id": "<env-id>"}
-}'
+curl -X POST :8090/v1/connections/$CONN/routing-rules -d "{
+  \"prefix\": \"\",
+  \"target\": \"agent:<agent-id>\",
+  \"session_params\": {\"environment_id\": \"<env-id>\", \"vault_ids\": [\"$VLT\"]}
+}"
 ```
 
-### 6. DM the bot — the agent replies
+The empty prefix is the per-connection catch-all. The session vault binding is
+what gives the agent-declared Telegram MCP server its bearer token.
+
+### 7. DM the bot — the agent replies
 
 DM the bot from a Telegram client. Watch the aios event log: the inbound
 message shows up with `metadata.channel` set, a session is created on

--- a/connectors/telegram/src/aios_telegram/mcp.py
+++ b/connectors/telegram/src/aios_telegram/mcp.py
@@ -32,19 +32,19 @@ from .prompts import build_instructions
 log = structlog.get_logger(__name__)
 
 
-# Key under a JSON-RPC tool-call request's ``_meta`` populated by the
-# aios worker when dispatching a connection-provided tool.  Its value
-# is the focal-channel path suffix — for Telegram's 3-segment address
-# ``telegram/<bot_id>/<chat_id>``, the suffix is just ``<chat_id>`` and
-# can be parsed as a signed integer.
+# Key under a JSON-RPC tool-call request's ``_meta`` populated by the aios
+# worker when dispatching a focal-channel MCP toolset. Its value is the
+# focal-channel path suffix — for Telegram's 3-segment address
+# ``telegram/<bot_id>/<chat_id>``, the suffix is just ``<chat_id>`` and can be
+# parsed as a signed integer.
 _FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
 
 def focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> int:
     """Extract the Telegram ``chat_id`` from an MCP request's ``_meta``.
 
-    aios injects ``aios.focal_channel_path`` for connection-provided tool
-    calls; its value is the full focal-channel suffix (stripped of
+    aios injects ``aios.focal_channel_path`` for focal-channel tool calls;
+    its value is the full focal-channel suffix (stripped of
     ``<connector>/<account>``), which for a 3-segment Telegram address
     is the decimal chat id. Missing / malformed meta raises — the agent
     shouldn't be able to reach these tools without a focal channel set

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2181,17 +2181,6 @@ async def get_connections_by_pairs(
     return [_row_to_connection(r) for r in rows]
 
 
-async def get_connection_vault_for_url(
-    conn: asyncpg.Connection[Any], mcp_server_url: str
-) -> str | None:
-    """Vault id of the active connection owning ``mcp_server_url``, else ``None``."""
-    val: str | None = await conn.fetchval(
-        "SELECT vault_id FROM connections WHERE mcp_url = $1 AND archived_at IS NULL LIMIT 1",
-        mcp_server_url,
-    )
-    return val
-
-
 async def archive_connection(conn: asyncpg.Connection[Any], connection_id: str) -> Connection:
     row = await conn.fetchrow(
         "UPDATE connections SET archived_at = now(), updated_at = now() "
@@ -2211,8 +2200,8 @@ async def count_active_bindings_for_connection(
 ) -> int:
     """Count active channel bindings owned by this connection.  Used to
     block connection archival while sessions are still reachable via
-    those bindings — archiving the connection would silently drop the
-    connection-provided MCP tools from any live session.
+    those bindings — archiving the connection would break inbound routing
+    and the legacy MCP projection for any live session.
     """
     val: int = await conn.fetchval(
         "SELECT COUNT(*) FROM channel_bindings WHERE connection_id = $1 AND archived_at IS NULL",

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -22,12 +22,11 @@ MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: "
 # per-channel ``last_seen`` watermark off successful switches.
 SWITCH_CHANNEL_METADATA_KEY = "switch_channel"
 
-# Top-level key inside the ``_meta`` field sent on JSON-RPC tool-call
-# requests to connection-provided MCP servers.  The value is the
-# focal-channel suffix (the focal channel address with its first two
-# ``<connector>/<account>`` segments stripped, since the connector
-# already knows its own connection identity).  The connector splits
-# this on ``/`` to recover its own per-chat identifiers.
+# Top-level key inside the ``_meta`` field sent on JSON-RPC tool-call requests
+# to focal-channel MCP toolsets. The value is the focal-channel suffix (the
+# focal channel address with its first two ``<connector>/<account>`` segments
+# stripped). The MCP server splits this on ``/`` to recover its own per-chat
+# identifiers.
 FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
 
@@ -53,8 +52,8 @@ def focal_channel_path(focal: str | None) -> str | None:
 
 
 def connection_server_name(c: Connection) -> str:
-    # c.id is "conn_<ULID>" — the ids.CONNECTION prefix is already the
-    # reserved namespace marker, so use it directly instead of stuttering.
+    # Legacy compatibility projection: connection rows can still be surfaced
+    # as MCP servers while integrations migrate to agent-declared MCP servers.
     assert c.id.startswith(CONNECTION_SERVER_NAME_PREFIX)
     return c.id
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -184,13 +184,14 @@ async def _run_session_step_body(
 
     mcp_server_map: dict[str, str] = {s.name: s.url for s in agent.mcp_servers}
     agent_mcp_server_names = set(mcp_server_map)
+    agent_mcp_server_urls = set(mcp_server_map.values())
     legacy_connection_server_names: set[str] = set()
     connection_vault_by_server: dict[str, str] = {}
     for c in connections:
         # Compatibility projection: inbound channel accounts can still expose
         # their MCP server until agents declare those servers directly.
         name = connection_server_name(c)
-        if name not in agent_mcp_server_names:
+        if name not in agent_mcp_server_names and c.mcp_url not in agent_mcp_server_urls:
             mcp_server_map[name] = c.mcp_url
             legacy_connection_server_names.add(name)
             connection_vault_by_server[name] = c.vault_id
@@ -198,6 +199,7 @@ async def _run_session_step_body(
         agent.tools,
         connections,
         agent_mcp_server_names=agent_mcp_server_names,
+        agent_mcp_server_urls=agent_mcp_server_urls,
     )
 
     # Read windowed message events for this session.
@@ -537,6 +539,7 @@ def mcp_channel_context_by_server(
     connections: list[Any] | None = None,
     *,
     agent_mcp_server_names: set[str] | None = None,
+    agent_mcp_server_urls: set[str] | None = None,
 ) -> dict[str, str]:
     """Return server_name -> channel context type for MCP toolsets.
 
@@ -559,9 +562,10 @@ def mcp_channel_context_by_server(
         from aios.harness.channels import connection_server_name
 
         agent_names = agent_mcp_server_names or set()
+        agent_urls = agent_mcp_server_urls or set()
         for c in connections:
             name = connection_server_name(c)
-            if name not in agent_names:
+            if name not in agent_names and c.mcp_url not in agent_urls:
                 contexts.setdefault(name, "focal")
     return contexts
 
@@ -588,22 +592,6 @@ def _hide_focal_channel_tools_when_phone_down(
             continue
         filtered.append(tool)
     return filtered
-
-
-def _hide_conn_tools_when_phone_down(
-    mcp_tools: list[dict[str, Any]], focal_channel: str | None
-) -> list[dict[str, Any]]:
-    """Backward-compatible wrapper for legacy conn-prefix MCP projections."""
-    from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
-
-    contexts = {
-        name.split("__", 2)[1]: "focal"
-        for tool in mcp_tools
-        if (name := tool.get("function", {}).get("name", "")).startswith(
-            f"mcp__{CONNECTION_SERVER_NAME_PREFIX}"
-        )
-    }
-    return _hide_focal_channel_tools_when_phone_down(mcp_tools, focal_channel, contexts)
 
 
 async def _dump_context_if_enabled(
@@ -680,7 +668,9 @@ def resolve_mcp_permission(
 
     ``always_allow_server_names`` is a compatibility hook for legacy
     connection-projected MCP servers. New channel-aware MCP should express
-    this on the agent's normal ``mcp_toolset`` config.
+    this on the agent's normal ``mcp_toolset`` config. Focal-channel MCP
+    toolsets default to ``always_allow`` because declaring channel context is
+    already the operator's trust decision for that server.
     """
     server_name = name.split("__", 2)[1]
     for spec in agent_tools:
@@ -688,7 +678,11 @@ def resolve_mcp_permission(
             cfg = spec.default_config
             if cfg and cfg.permission_policy:
                 return cfg.permission_policy.type
-            return spec.permission
+            if spec.permission:
+                return spec.permission
+            if spec.channel_context is not None and spec.channel_context.type == "focal":
+                return "always_allow"
+            return None
     if always_allow_server_names and server_name in always_allow_server_names:
         return "always_allow"
     return None
@@ -712,6 +706,8 @@ async def discover_session_mcp_tools(
     ``connections`` is retained as a compatibility projection for legacy
     channel accounts that still carry MCP URLs. New integrations should
     declare MCP servers on the agent and credentials in session vaults.
+    If a connection's URL is already declared on the agent, the normal
+    agent server owns discovery and the connection projection is skipped.
     """
     import asyncio
 
@@ -725,13 +721,23 @@ async def discover_session_mcp_tools(
         if spec.type == "mcp_toolset" and spec.enabled and spec.mcp_server_name:
             enabled_server_names.add(spec.mcp_server_name)
     agent_server_names = {s.name for s in agent.mcp_servers}
+    agent_server_urls = {s.url for s in agent.mcp_servers}
+    enabled_agent_server_by_url: dict[str, str] = {}
     for s in agent.mcp_servers:
         if s.name in enabled_server_names:
             servers.append((s.name, s.url, None))
+            enabled_agent_server_by_url.setdefault(s.url, s.name)
 
+    instruction_aliases: dict[str, str] = {}
     for c in connections:
         name = connection_server_name(c)
-        if name not in agent_server_names:
+        if name in agent_server_names:
+            continue
+        if c.mcp_url in agent_server_urls:
+            if source_name := enabled_agent_server_by_url.get(c.mcp_url):
+                instruction_aliases[name] = source_name
+            continue
+        else:
             servers.append((name, c.mcp_url, c.vault_id))
 
     if not servers:
@@ -760,6 +766,9 @@ async def discover_session_mcp_tools(
         for (name, _url, _vault_id), (_tools, instructions) in zip(servers, results, strict=True)
         if instructions
     }
+    for alias_name, source_name in instruction_aliases.items():
+        if instructions := instructions_by_server.get(source_name):
+            instructions_by_server[alias_name] = instructions
     return tools, instructions_by_server
 
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -183,8 +183,22 @@ async def _run_session_step_body(
     bindings, connections = await list_bindings_and_connections(pool, session_id)
 
     mcp_server_map: dict[str, str] = {s.name: s.url for s in agent.mcp_servers}
+    agent_mcp_server_names = set(mcp_server_map)
+    legacy_connection_server_names: set[str] = set()
+    connection_vault_by_server: dict[str, str] = {}
     for c in connections:
-        mcp_server_map[connection_server_name(c)] = c.mcp_url
+        # Compatibility projection: inbound channel accounts can still expose
+        # their MCP server until agents declare those servers directly.
+        name = connection_server_name(c)
+        if name not in agent_mcp_server_names:
+            mcp_server_map[name] = c.mcp_url
+            legacy_connection_server_names.add(name)
+            connection_vault_by_server[name] = c.vault_id
+    channel_context_by_server = mcp_channel_context_by_server(
+        agent.tools,
+        connections,
+        agent_mcp_server_names=agent_mcp_server_names,
+    )
 
     # Read windowed message events for this session.
     events = await sessions_service.read_windowed_events(
@@ -209,6 +223,8 @@ async def _run_session_step_body(
                 session_id,
                 pending_mcp,
                 mcp_server_map,
+                channel_context_by_server=channel_context_by_server,
+                connection_vault_by_server=connection_vault_by_server,
                 focal_channel=session.focal_channel,
             )
         log.info(
@@ -409,7 +425,11 @@ async def _run_session_step_body(
             name = _tc_name(tc)
             if _is_mcp_tool(name):
                 # MCP tools default to always_ask (unlike built-in always_allow).
-                perm = resolve_mcp_permission(name, agent.tools)
+                perm = resolve_mcp_permission(
+                    name,
+                    agent.tools,
+                    always_allow_server_names=legacy_connection_server_names,
+                )
                 if perm == "always_allow":
                     mcp_immediate.append(tc)
                 else:
@@ -436,6 +456,8 @@ async def _run_session_step_body(
                 session_id,
                 mcp_immediate,
                 mcp_server_map,
+                channel_context_by_server=channel_context_by_server,
+                connection_vault_by_server=connection_vault_by_server,
                 focal_channel=session.focal_channel,
             )
             log.info(
@@ -503,22 +525,85 @@ def _switch_channel_tool_spec() -> dict[str, Any]:
     }
 
 
+def _mcp_server_name_from_tool_name(name: str) -> str | None:
+    parts = name.split("__", 2)
+    if len(parts) < 3 or not parts[1] or not parts[2]:
+        return None
+    return parts[1]
+
+
+def mcp_channel_context_by_server(
+    agent_tools: list[ToolSpec],
+    connections: list[Any] | None = None,
+    *,
+    agent_mcp_server_names: set[str] | None = None,
+) -> dict[str, str]:
+    """Return server_name -> channel context type for MCP toolsets.
+
+    New code gets this from normal agent ``mcp_toolset`` declarations. The
+    optional ``connections`` argument is a compatibility projection for legacy
+    channel accounts that still carry an MCP URL.
+    """
+    contexts: dict[str, str] = {}
+    for spec in agent_tools:
+        if (
+            spec.type != "mcp_toolset"
+            or not spec.enabled
+            or not spec.mcp_server_name
+            or spec.channel_context is None
+        ):
+            continue
+        contexts[spec.mcp_server_name] = spec.channel_context.type
+
+    if connections:
+        from aios.harness.channels import connection_server_name
+
+        agent_names = agent_mcp_server_names or set()
+        for c in connections:
+            name = connection_server_name(c)
+            if name not in agent_names:
+                contexts.setdefault(name, "focal")
+    return contexts
+
+
+def _hide_focal_channel_tools_when_phone_down(
+    mcp_tools: list[dict[str, Any]],
+    focal_channel: str | None,
+    channel_context_by_server: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Filter focal-channel MCP tools out when focal is NULL.
+
+    Those tools resolve their channel path from focal (injected into
+    ``_meta`` at dispatch time); a "phone down" state has no focal to
+    inject, so the model shouldn't be offered them. Other MCP tools are
+    untouched.
+    """
+    if focal_channel is not None:
+        return mcp_tools
+    filtered: list[dict[str, Any]] = []
+    for tool in mcp_tools:
+        name = tool.get("function", {}).get("name", "")
+        server_name = _mcp_server_name_from_tool_name(name)
+        if server_name is not None and channel_context_by_server.get(server_name) == "focal":
+            continue
+        filtered.append(tool)
+    return filtered
+
+
 def _hide_conn_tools_when_phone_down(
     mcp_tools: list[dict[str, Any]], focal_channel: str | None
 ) -> list[dict[str, Any]]:
-    """Filter connection-provided MCP tools out when focal is NULL.
-
-    Those tools resolve their ``chat_id`` from focal (injected into
-    ``_meta`` at dispatch time); a "phone down" state has no focal to
-    inject, so the model shouldn't be offered them.  Agent-declared
-    MCP tools are untouched.
-    """
+    """Backward-compatible wrapper for legacy conn-prefix MCP projections."""
     from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
 
-    if focal_channel is not None:
-        return mcp_tools
-    prefix = f"mcp__{CONNECTION_SERVER_NAME_PREFIX}"
-    return [t for t in mcp_tools if not t.get("function", {}).get("name", "").startswith(prefix)]
+    contexts = {
+        name.split("__", 2)[1]: "focal"
+        for tool in mcp_tools
+        if (name := tool.get("function", {}).get("name", "")).startswith(
+            f"mcp__{CONNECTION_SERVER_NAME_PREFIX}"
+        )
+    }
+    return _hide_focal_channel_tools_when_phone_down(mcp_tools, focal_channel, contexts)
 
 
 async def _dump_context_if_enabled(
@@ -580,30 +665,32 @@ def resolve_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
     return None
 
 
-def resolve_mcp_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
+def resolve_mcp_permission(
+    name: str,
+    agent_tools: list[ToolSpec],
+    *,
+    always_allow_server_names: set[str] | None = None,
+) -> str | None:
     """Look up the permission policy for an MCP tool.
 
-    Connection-provided tools (server name in the reserved ``conn_``
-    namespace) default to ``always_allow`` — the session's channel
-    binding is already explicit routing consent; gating every reply on
-    a confirmation prompt would defeat the connector autonomy story.
-
-    For agent-declared servers, finds the ``mcp_toolset`` entry whose
+    Finds the ``mcp_toolset`` entry whose
     ``mcp_server_name`` matches the server portion of the namespaced
     tool name, then returns the ``default_config.permission_policy.type``
     or ``None`` (which callers treat as ``always_ask``).
-    """
-    from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
 
+    ``always_allow_server_names`` is a compatibility hook for legacy
+    connection-projected MCP servers. New channel-aware MCP should express
+    this on the agent's normal ``mcp_toolset`` config.
+    """
     server_name = name.split("__", 2)[1]
-    if server_name.startswith(CONNECTION_SERVER_NAME_PREFIX):
-        return "always_allow"
     for spec in agent_tools:
         if spec.type == "mcp_toolset" and spec.mcp_server_name == server_name:
             cfg = spec.default_config
             if cfg and cfg.permission_policy:
                 return cfg.permission_policy.type
             return spec.permission
+    if always_allow_server_names and server_name in always_allow_server_names:
+        return "always_allow"
     return None
 
 
@@ -614,48 +701,63 @@ async def discover_session_mcp_tools(
     connections: list[Any],
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
     """Discover MCP tools from agent-declared servers (filtered by enabled
-    ``mcp_toolset`` entries) unioned with connection-provided servers.
+    ``mcp_toolset`` entries).
 
     Returns ``(tools, instructions_by_server)`` where the second element
     maps ``server_name`` → the server's ``InitializeResult.instructions``
     string.  Servers that supplied no instructions (or ``""``) are
     omitted from the dict — the harness uses presence in the dict as
     the trigger for rendering a per-connector affordance block.
+
+    ``connections`` is retained as a compatibility projection for legacy
+    channel accounts that still carry MCP URLs. New integrations should
+    declare MCP servers on the agent and credentials in session vaults.
     """
     import asyncio
 
     from aios.harness.channels import connection_server_name
     from aios.mcp.client import discover_mcp_tools, resolve_auth_for_url
 
-    servers: list[tuple[str, str]] = []
+    servers: list[tuple[str, str, str | None]] = []
 
     enabled_server_names: set[str] = set()
     for spec in agent.tools:
         if spec.type == "mcp_toolset" and spec.enabled and spec.mcp_server_name:
             enabled_server_names.add(spec.mcp_server_name)
+    agent_server_names = {s.name for s in agent.mcp_servers}
     for s in agent.mcp_servers:
         if s.name in enabled_server_names:
-            servers.append((s.name, s.url))
+            servers.append((s.name, s.url, None))
 
     for c in connections:
-        servers.append((connection_server_name(c), c.mcp_url))
+        name = connection_server_name(c)
+        if name not in agent_server_names:
+            servers.append((name, c.mcp_url, c.vault_id))
 
     if not servers:
         return [], {}
 
     crypto_box = runtime.require_crypto_box()
 
-    async def _discover_one(name: str, url: str) -> tuple[list[dict[str, Any]], str | None]:
-        headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
+    async def _discover_one(
+        name: str, url: str, connection_vault_id: str | None
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        headers = await resolve_auth_for_url(
+            pool,
+            crypto_box,
+            session_id,
+            url,
+            connection_vault_id=connection_vault_id,
+        )
         return await discover_mcp_tools(url, name, headers)
 
-    results = await asyncio.gather(*[_discover_one(n, u) for n, u in servers])
+    results = await asyncio.gather(*[_discover_one(n, u, v) for n, u, v in servers])
     tools: list[dict[str, Any]] = [
         tool for (tool_list, _instructions) in results for tool in tool_list
     ]
     instructions_by_server: dict[str, str] = {
         name: instructions
-        for (name, _url), (_tools, instructions) in zip(servers, results, strict=True)
+        for (name, _url, _vault_id), (_tools, instructions) in zip(servers, results, strict=True)
         if instructions
     }
     return tools, instructions_by_server

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -101,6 +101,7 @@ async def compose_step_context(
             agent.tools,
             connections,
             agent_mcp_server_names={s.name for s in agent.mcp_servers},
+            agent_mcp_server_urls={s.url for s in agent.mcp_servers},
         )
         mcp_tools = _hide_focal_channel_tools_when_phone_down(
             mcp_tools, session.focal_channel, channel_context_by_server

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -76,9 +76,10 @@ async def compose_step_context(
         build_channels_tail_block,
     )
     from aios.harness.loop import (
-        _hide_conn_tools_when_phone_down,
+        _hide_focal_channel_tools_when_phone_down,
         _switch_channel_tool_spec,
         discover_session_mcp_tools,
+        mcp_channel_context_by_server,
     )
     from aios.harness.skills import augment_system_prompt
     from aios.services import skills as skills_service
@@ -94,9 +95,16 @@ async def compose_step_context(
         mcp_tools, mcp_instructions = await discover_session_mcp_tools(
             pool, session_id, agent, connections
         )
-        # Hide connection-provided MCP tools when focal is NULL — can't
-        # type into a chat you aren't attending to.
-        mcp_tools = _hide_conn_tools_when_phone_down(mcp_tools, session.focal_channel)
+        # Hide focal-channel MCP tools when focal is NULL — can't type
+        # into a chat you aren't attending to.
+        channel_context_by_server = mcp_channel_context_by_server(
+            agent.tools,
+            connections,
+            agent_mcp_server_names={s.name for s in agent.mcp_servers},
+        )
+        mcp_tools = _hide_focal_channel_tools_when_phone_down(
+            mcp_tools, session.focal_channel, channel_context_by_server
+        )
         tools.extend(mcp_tools)
 
     skill_versions = (

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -313,6 +313,8 @@ def launch_mcp_tool_calls(
     tool_calls: list[dict[str, Any]],
     mcp_server_map: dict[str, str],
     *,
+    channel_context_by_server: dict[str, str] | None = None,
+    connection_vault_by_server: dict[str, str] | None = None,
     focal_channel: str | None = None,
 ) -> None:
     """Launch MCP tool calls as asyncio tasks. Returns immediately.
@@ -320,14 +322,20 @@ def launch_mcp_tool_calls(
     ``focal_channel`` is the session's focal at the moment these calls
     were emitted (captured at step top in ``run_session_step`` so a
     concurrent ``switch_channel`` in the same batch cannot race the
-    ``chat_id`` injection).  Passed through to each task so
-    connection-provided tools can stamp ``_meta`` with the suffix.
+    ``chat_id`` injection).  Passed through to each task so channel-aware
+    MCP toolsets can stamp ``_meta`` with the suffix.
     """
     _launch_tasks(
         session_id,
         tool_calls,
         lambda call: _execute_mcp_tool_async(
-            pool, session_id, call, mcp_server_map, focal_channel=focal_channel
+            pool,
+            session_id,
+            call,
+            mcp_server_map,
+            channel_context_by_server=channel_context_by_server,
+            connection_vault_by_server=connection_vault_by_server,
+            focal_channel=focal_channel,
         ),
         prefix="mcp_tool",
     )
@@ -350,20 +358,19 @@ async def _execute_mcp_tool_async(
     call: dict[str, Any],
     mcp_server_map: dict[str, str],
     *,
+    channel_context_by_server: dict[str, str] | None = None,
+    connection_vault_by_server: dict[str, str] | None = None,
     focal_channel: str | None = None,
 ) -> None:
     """Execute one MCP tool call: connect, invoke, append result, defer wake.
 
-    For connection-provided servers (name in the reserved ``conn_``
-    namespace), the focal-channel suffix is stamped into the JSON-RPC
-    request's ``_meta`` so the connector can resolve its
-    connector-specific chat identifiers without the model having to
-    pass them explicitly.  The ``focal_channel`` snapshot is emission-
-    time — a concurrent ``switch_channel`` in the same assistant batch
-    does not race this injection.
+    For focal-channel MCP toolsets, the focal-channel suffix is stamped
+    into the JSON-RPC request's ``_meta`` so the server can resolve its
+    channel-specific identifiers without the model having to pass them
+    explicitly.  The ``focal_channel`` snapshot is emission-time — a
+    concurrent ``switch_channel`` in the same assistant batch does not
+    race this injection.
     """
-    from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
-
     call_id = call.get("id") or "unknown"
     function = call.get("function") or {}
     name: str = function.get("name") or ""
@@ -407,13 +414,14 @@ async def _execute_mcp_tool_async(
         from aios.mcp.client import call_mcp_tool, resolve_auth_for_url
 
         meta: dict[str, Any] | None = None
-        if server_name.startswith(CONNECTION_SERVER_NAME_PREFIX):
+        channel_context = (channel_context_by_server or {}).get(server_name)
+        if channel_context == "focal":
             suffix = focal_channel_path(focal_channel)
             if suffix is None:
-                # The model shouldn't be able to call a conn_* tool while
-                # focal is NULL — loop.py filters them out of the tool
-                # list in that state — but defend in depth if it slips
-                # through (stale tool_calls, etc.).
+                # The model shouldn't be able to call a focal-channel tool
+                # while focal is NULL — loop.py filters them out of the tool
+                # list in that state — but defend in depth if it slips through
+                # (stale tool_calls, etc.).
                 is_error = True
                 await _append_tool_result(
                     pool,
@@ -421,15 +429,20 @@ async def _execute_mcp_tool_async(
                     call_id,
                     name,
                     error=(
-                        "connection-provided tools require a focal channel; "
-                        "call switch_channel first"
+                        "channel-aware MCP tools require a focal channel; call switch_channel first"
                     ),
                 )
                 return
             meta = {FOCAL_CHANNEL_META_KEY: suffix}
 
         crypto_box = runtime.require_crypto_box()
-        headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
+        headers = await resolve_auth_for_url(
+            pool,
+            crypto_box,
+            session_id,
+            url,
+            connection_vault_id=(connection_vault_by_server or {}).get(server_name),
+        )
         result = await call_mcp_tool(url, headers, tool_name, arguments, meta=meta)
 
         content_str = json.dumps(result, ensure_ascii=False)

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -67,15 +67,17 @@ async def resolve_auth_for_url(
     crypto_box: CryptoBox,
     session_id: str,
     mcp_server_url: str,
+    *,
+    connection_vault_id: str | None = None,
 ) -> dict[str, str]:
     """Resolve MCP auth headers for ``mcp_server_url``.
 
-    Connection-owned URLs resolve through the connection's vault; other
-    URLs fall back to the session's bound vaults (``session_vaults``).
-    A connection that owns the URL but has no matching credential
-    returns ``{}`` rather than falling back — ownership decides the
-    source, not whether the lookup hits (prevents a misconfigured
-    connection from silently leaking a tenant-level credential).
+    Normal agent-declared MCP servers resolve through the session's bound
+    vaults (``session_vaults``). Legacy connection-projected MCP servers pass
+    ``connection_vault_id`` explicitly; that vault then owns auth resolution
+    for this call. A legacy connection vault with no matching credential
+    returns ``{}`` rather than falling back, preventing a misconfigured
+    connection from silently leaking a tenant-level credential.
 
     For ``mcp_oauth`` credentials whose ``expires_at`` falls within the
     refresh skew window, the access token is transparently refreshed
@@ -85,7 +87,6 @@ async def resolve_auth_for_url(
     to the stale token.
     """
     async with pool.acquire() as conn:
-        connection_vault_id = await queries.get_connection_vault_for_url(conn, mcp_server_url)
         if connection_vault_id is not None:
             vault_result = await queries.resolve_vault_credential(
                 conn, vault_id=connection_vault_id, mcp_server_url=mcp_server_url
@@ -207,8 +208,8 @@ async def call_mcp_tool(
     ``tool_name`` is the raw MCP tool name (without the ``mcp__`` prefix).
     ``meta`` is an optional per-request metadata dict forwarded as the
     JSON-RPC request's ``_meta`` field — used by the focal-channel
-    redesign to pass ``aios.focal_channel_path`` to connection-provided
-    MCP servers without stuffing it into arguments.  Returns a result
+    redesign to pass ``aios.focal_channel_path`` to channel-aware MCP
+    servers without stuffing it into arguments.  Returns a result
     dict with either ``content`` (success) or ``error`` (failure).
     """
     try:

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from aios.models.skills import AgentSkillRef
 
@@ -52,17 +52,6 @@ class McpServerSpec(BaseModel):
     name: str = Field(min_length=1, max_length=64)
     url: str = Field(min_length=1)
 
-    @field_validator("name")
-    @classmethod
-    def _reject_reserved_prefix(cls, v: str) -> str:
-        from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
-
-        if v.startswith(CONNECTION_SERVER_NAME_PREFIX):
-            raise ValueError(
-                f"mcp_server name prefix {CONNECTION_SERVER_NAME_PREFIX!r} is reserved"
-            )
-        return v
-
 
 # ── MCP toolset config (permission policies for discovered tools) ──────────
 
@@ -92,6 +81,19 @@ class McpToolConfig(BaseModel):
     name: str
     enabled: bool = True
     permission_policy: McpPermissionPolicy | None = None
+
+
+class McpChannelContext(BaseModel):
+    """Channel behavior for an MCP toolset.
+
+    ``type="focal"`` means tools from this server operate on the session's
+    current focal channel. The harness hides those tools when no focal channel
+    is set and injects the focal channel path into MCP request ``_meta``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["focal"] = "focal"
 
 
 # ── Tool declaration ──────────────────────────────────────────────────────────
@@ -128,6 +130,7 @@ class ToolSpec(BaseModel):
     mcp_server_name: str | None = None
     default_config: McpToolsetConfig | None = None
     configs: list[McpToolConfig] | None = None
+    channel_context: McpChannelContext | None = None
 
     @model_validator(mode="after")
     def _check_type_fields(self) -> ToolSpec:
@@ -140,6 +143,8 @@ class ToolSpec(BaseModel):
         elif self.type == "mcp_toolset":
             if self.mcp_server_name is None:
                 raise ValueError("mcp_toolset requires mcp_server_name")
+        elif self.channel_context is not None:
+            raise ValueError("channel_context is only supported for mcp_toolset")
         return self
 
 

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -1,13 +1,17 @@
 """Connection resource and inbound-message DTOs.
 
-A *connection* is a registered ``(connector, account)`` pair plus the
-MCP URL the connector exposes for the agent to send replies back through.
-The address scheme used by the routing layer is::
+A *connection* is a registered ``(connector, account)`` pair used by the
+inbound channel router. The address scheme used by the routing layer is::
 
     {connector}/{account}/{path}
 
 where ``path`` is whatever sub-segments the connector emits for inbound
 messages (typically a chat or thread id).
+
+``mcp_url`` / ``vault_id`` remain on the resource as a compatibility
+projection for older connector setups. New channel-aware MCP integrations
+should declare normal agent ``mcp_servers`` and use session vaults for
+credentials.
 """
 
 from __future__ import annotations
@@ -17,9 +21,9 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-# Reserved prefix for MCP server names derived from a connection.  Keeps
-# connection-provided servers disjoint from agent-declared ones in the
-# shared mcp_server_map.
+# Legacy prefix for MCP server names projected from connection rows. New
+# channel-aware MCP integrations should use normal agent ``mcp_servers`` plus
+# ``mcp_toolset.channel_context`` instead of relying on this namespace.
 CONNECTION_SERVER_NAME_PREFIX = "conn_"
 
 

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -3,8 +3,9 @@
 Thin wrapper over :mod:`aios.db.queries`. The only business rule lives
 in :func:`archive_connection`, which refuses to archive a connection
 while channel bindings under its ``(connector, account)`` prefix are
-still active — archiving would silently drop the connection-provided
-MCP tools from any live session bound to those channels.
+still active. Connection rows remain the source of inbound channel identity,
+so archiving one while bound channels are live would break routing and the
+legacy MCP projection for those sessions.
 """
 
 from __future__ import annotations

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -828,12 +828,12 @@ class TestSwitchChannelAsEvent:
 
 
 class TestMcpMetaInjection:
-    """Slice 6: connection-provided MCP tools receive the focal channel
-    path via the JSON-RPC ``_meta`` field, without stuffing it into
-    arguments.  Agent-declared MCP servers don't get the meta stamp.
+    """Channel-aware MCP toolsets receive the focal channel path via the
+    JSON-RPC ``_meta`` field, without stuffing it into arguments. Normal MCP
+    servers don't get the meta stamp.
     """
 
-    async def test_conn_tool_dispatch_injects_focal_suffix_into_meta(
+    async def test_channel_aware_mcp_dispatch_injects_focal_suffix_into_meta(
         self,
         runtime_pool: Any,
         agent_id: str,
@@ -854,18 +854,12 @@ class TestMcpMetaInjection:
             connection = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
             session_id, _e, address = await _post_inbound(runtime_pool, connection, "chat-1")
 
-            # The connection created by _setup_inbound has id prefix `conn_`.
-            from aios.services import connections as conn_svc
-
-            connections = await conn_svc.list_connections(runtime_pool)
-            conn = next(c for c in connections if c.connector == "signal")
-
-            mcp_server_map = {conn.id: conn.mcp_url}
+            mcp_server_map = {"signal": "https://m"}
             tool_call_dict = {
                 "id": "call_send_1",
                 "type": "function",
                 "function": {
-                    "name": f"mcp__{conn.id}__signal_send",
+                    "name": "mcp__signal__signal_send",
                     "arguments": json.dumps({"text": "hi there"}),
                 },
             }
@@ -885,6 +879,7 @@ class TestMcpMetaInjection:
                     session_id,
                     tool_call_dict,
                     mcp_server_map,
+                    channel_context_by_server={"signal": "focal"},
                     focal_channel=address,  # focal=A → suffix=chat-1
                 )
 
@@ -896,16 +891,16 @@ class TestMcpMetaInjection:
         finally:
             runtime.crypto_box = prev_crypto
 
-    async def test_agent_mcp_tool_dispatch_no_meta_stamped(
+    async def test_normal_mcp_tool_dispatch_no_meta_stamped(
         self,
         runtime_pool: Any,
         agent_id: str,
         env_id: str,
         vault_id: str,
     ) -> None:
-        """Agent-declared MCP servers (not under the conn_* prefix) don't
-        get focal meta — aios has no business telling an agent-declared
-        MCP server about the session's focal channel.
+        """MCP servers without channel_context don't get focal meta — aios
+        has no business telling unrelated MCP servers about the session's
+        focal channel.
         """
         from unittest.mock import AsyncMock, patch
 
@@ -919,7 +914,6 @@ class TestMcpMetaInjection:
             connection = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
             session_id, _e, address = await _post_inbound(runtime_pool, connection, "chat-1")
 
-            # Agent-declared server: name does NOT start with conn_.
             agent_server_name = "github"
             mcp_server_map = {agent_server_name: "https://mcp.github.com"}
             tool_call_dict = {
@@ -946,11 +940,11 @@ class TestMcpMetaInjection:
                     session_id,
                     tool_call_dict,
                     mcp_server_map,
-                    focal_channel=address,  # non-null focal, but agent server
+                    focal_channel=address,  # non-null focal, but no channel_context
                 )
 
             _args, kwargs = mock_call.call_args
-            # No meta for agent-declared MCP.
+            # No meta for ordinary MCP.
             assert kwargs.get("meta") is None
         finally:
             runtime.crypto_box = prev_crypto

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -980,7 +980,7 @@ class TestInboundEndpoint:
 
 class TestListSessionBindings:
     """Unpaginated "all bindings for this session" lookup used by the
-    step function to derive connection-provided MCP URLs.
+    step function to derive channel account context.
     """
 
     async def test_empty_when_no_bindings(self, pool: Any, agent_id: str, env_id: str) -> None:

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -85,9 +85,8 @@ def _connection(cid: str, connector: str = "signal", account: str = "acct") -> C
 
 
 class TestConnectionServerName:
-    """The connection id already starts with the reserved ``conn_``
-    prefix (via ``ids.CONNECTION``), so it doubles as the server name
-    directly — no stutter, still unambiguous by construction.
+    """The legacy connection-to-MCP projection uses the connection id directly
+    as the server name: no stutter, still unambiguous by construction.
     """
 
     def test_uses_id_directly(self) -> None:

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -1,10 +1,9 @@
 """Unit tests for discover_session_mcp_tools.
 
 Covers the collect-URLs-then-discover shape: agent-declared MCP
-(filtered by enabled mcp_toolset entries) unioned with
-connection-provided MCP (derived from session bindings → connections).
-The MCP SDK and auth lookup are both mocked; only the orchestration
-is under test here.
+(filtered by enabled mcp_toolset entries), plus the legacy compatibility
+projection from session bindings → connections. The MCP SDK and auth lookup
+are both mocked; only the orchestration is under test here.
 """
 
 from __future__ import annotations
@@ -176,10 +175,17 @@ class TestDiscoverSessionMcpTools:
         )
         connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
 
-        seen_urls: list[str] = []
+        seen: list[tuple[str, str | None]] = []
 
-        async def _fake_resolve(_pool: Any, _cb: Any, _sid: str, url: str) -> dict[str, str]:
-            seen_urls.append(url)
+        async def _fake_resolve(
+            _pool: Any,
+            _cb: Any,
+            _sid: str,
+            url: str,
+            *,
+            connection_vault_id: str | None = None,
+        ) -> dict[str, str]:
+            seen.append((url, connection_vault_id))
             return {"Authorization": f"Bearer token-for-{url}"}
 
         async def _discover(
@@ -197,7 +203,7 @@ class TestDiscoverSessionMcpTools:
                 agent=agent,
                 connections=connections,
             )
-        assert sorted(seen_urls) == ["https://m1", "https://mcp.github"]
+        assert sorted(seen) == [("https://m1", "vlt_x"), ("https://mcp.github", None)]
         auths = {t["auth"] for t in tools}
         assert auths == {
             "Bearer token-for-https://mcp.github",

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -163,6 +163,54 @@ class TestDiscoverSessionMcpTools:
         urls = sorted(t["url"] for t in tools)
         assert urls == ["https://m1", "https://mcp.github"]
 
+    async def test_agent_server_url_suppresses_legacy_connection_projection(self) -> None:
+        """If the agent declares the same MCP URL as a connection, discover it
+        once through the normal agent server namespace.
+        """
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="signal", url="https://m1")],
+            tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="signal")],
+        )
+        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
+
+        seen: list[tuple[str, str | None]] = []
+
+        async def _fake_resolve(
+            _pool: Any,
+            _cb: Any,
+            _sid: str,
+            url: str,
+            *,
+            connection_vault_id: str | None = None,
+        ) -> dict[str, str]:
+            seen.append((url, connection_vault_id))
+            return {}
+
+        async def _discover(
+            url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [{"name": f"mcp__{name}__t", "url": url}], "send via focal"
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", side_effect=_fake_resolve),
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            tools, instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+                connections=connections,
+            )
+
+        assert seen == [("https://m1", None)]
+        assert tools == [{"name": "mcp__signal__t", "url": "https://m1"}]
+        assert instructions == {
+            "signal": "send via focal",
+            "conn_01HQR2K7VXBZ9MNPL3WYCT8F": "send via focal",
+        }
+
     async def test_auth_resolved_per_url(self) -> None:
         """Each URL resolves auth independently — goes through
         resolve_auth_for_url once per server, not once per batch.

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -19,8 +19,9 @@ from tests.unit.conftest import fake_pool_yielding_conn
 
 
 class TestResolveAuthForUrl:
-    """Connection-declared credentials take precedence over session_vaults,
-    and mcp_oauth credentials are transparently refreshed when expiring.
+    """Agent MCP uses session_vaults by default; legacy connection-projected
+    MCP can pass an explicit connection vault id. OAuth credentials refresh
+    when expiring on either path.
     """
 
     @pytest.fixture
@@ -29,18 +30,16 @@ class TestResolveAuthForUrl:
 
         return CryptoBox(os.urandom(32))
 
-    # ── precedence: connection-owned URLs ─────────────────────────────────
+    # ── legacy connection-projected URLs ──────────────────────────────────
 
-    async def test_connection_url_uses_connection_vault(self, crypto_box: CryptoBox) -> None:
+    async def test_legacy_connection_projection_uses_connection_vault(
+        self, crypto_box: CryptoBox
+    ) -> None:
         payload = json.dumps({"token": "connection-token"})
         blob = crypto_box.encrypt(payload)
         pool = fake_pool_yielding_conn(MagicMock())
         with (
             patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
                 "aios.mcp.client.queries.resolve_vault_credential",
                 new_callable=AsyncMock,
             ) as v,
@@ -49,26 +48,25 @@ class TestResolveAuthForUrl:
                 new_callable=AsyncMock,
             ) as s,
         ):
-            g.return_value = "vlt_v2"
             v.return_value = (blob, "static_bearer")
             result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
+                pool,
+                crypto_box,
+                "sess_123",
+                "https://mcp.example.com",
+                connection_vault_id="vlt_v2",
             )
         assert result == {"Authorization": "Bearer connection-token"}
-        # Connection precedence: session_vaults lookup MUST NOT be consulted.
+        # Explicit connection-vault path MUST NOT consult session_vaults.
         s.assert_not_awaited()
         v.assert_awaited_once()
 
-    async def test_connection_url_missing_credential_returns_empty(
+    async def test_legacy_connection_projection_missing_credential_returns_empty(
         self, crypto_box: CryptoBox
     ) -> None:
         pool = fake_pool_yielding_conn(MagicMock())
         with (
             patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
                 "aios.mcp.client.queries.resolve_vault_credential",
                 new_callable=AsyncMock,
             ) as v,
@@ -77,33 +75,35 @@ class TestResolveAuthForUrl:
                 new_callable=AsyncMock,
             ) as s,
         ):
-            g.return_value = "vlt_v2"
             v.return_value = None
             result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
+                pool,
+                crypto_box,
+                "sess_123",
+                "https://mcp.example.com",
+                connection_vault_id="vlt_v2",
             )
         assert result == {}
-        # Still doesn't fall back — connection ownership decided the source.
+        # Still doesn't fall back — explicit connection vault decided the source.
         s.assert_not_awaited()
 
-    async def test_mcp_oauth_from_connection(self, crypto_box: CryptoBox) -> None:
+    async def test_mcp_oauth_from_legacy_connection_projection(self, crypto_box: CryptoBox) -> None:
         payload = json.dumps({"access_token": "oauth-conn-token"})
         blob = crypto_box.encrypt(payload)
         pool = fake_pool_yielding_conn(MagicMock())
         with (
             patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
                 "aios.mcp.client.queries.resolve_vault_credential",
                 new_callable=AsyncMock,
             ) as v,
         ):
-            g.return_value = "vlt_v2"
             v.return_value = (blob, "mcp_oauth")
             result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
+                pool,
+                crypto_box,
+                "sess_123",
+                "https://mcp.example.com",
+                connection_vault_id="vlt_v2",
             )
         assert result == {"Authorization": "Bearer oauth-conn-token"}
 
@@ -117,10 +117,6 @@ class TestResolveAuthForUrl:
         pool = fake_pool_yielding_conn(MagicMock())
         with (
             patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
                 "aios.mcp.client.queries.resolve_vault_credential",
                 new_callable=AsyncMock,
             ) as v,
@@ -129,7 +125,6 @@ class TestResolveAuthForUrl:
                 new_callable=AsyncMock,
             ) as s,
         ):
-            g.return_value = None
             s.return_value = (blob, "static_bearer", "vlt_s1")
             result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com"
@@ -138,19 +133,30 @@ class TestResolveAuthForUrl:
         v.assert_not_awaited()
         s.assert_awaited_once()
 
+    async def test_agent_mcp_uses_session_vault_without_connection_vault_id(
+        self, crypto_box: CryptoBox
+    ) -> None:
+        """A normal agent-declared MCP server uses session vaults by default."""
+        payload = json.dumps({"token": "session-token"})
+        blob = crypto_box.encrypt(payload)
+        pool = fake_pool_yielding_conn(MagicMock())
+        with patch(
+            "aios.mcp.client.queries.resolve_mcp_credential",
+            new_callable=AsyncMock,
+        ) as s:
+            s.return_value = (blob, "static_bearer", "vlt_s1")
+            result = await resolve_auth_for_url(
+                pool, crypto_box, "sess_123", "https://mcp.example.com"
+            )
+        assert result == {"Authorization": "Bearer session-token"}
+        s.assert_awaited_once()
+
     async def test_neither_source_returns_empty(self, crypto_box: CryptoBox) -> None:
         pool = fake_pool_yielding_conn(MagicMock())
-        with (
-            patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
-                "aios.mcp.client.queries.resolve_mcp_credential",
-                new_callable=AsyncMock,
-            ) as s,
-        ):
-            g.return_value = None
+        with patch(
+            "aios.mcp.client.queries.resolve_mcp_credential",
+            new_callable=AsyncMock,
+        ) as s:
             s.return_value = None
             result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com"
@@ -161,17 +167,10 @@ class TestResolveAuthForUrl:
         payload = json.dumps({"token": ""})
         blob = crypto_box.encrypt(payload)
         pool = fake_pool_yielding_conn(MagicMock())
-        with (
-            patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
-                "aios.mcp.client.queries.resolve_mcp_credential",
-                new_callable=AsyncMock,
-            ) as s,
-        ):
-            g.return_value = None
+        with patch(
+            "aios.mcp.client.queries.resolve_mcp_credential",
+            new_callable=AsyncMock,
+        ) as s:
             s.return_value = (blob, "static_bearer", "vlt_s1")
             result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com"
@@ -199,10 +198,6 @@ class TestResolveAuthForUrl:
         refresh_mock = AsyncMock()
         with (
             patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
                 "aios.mcp.client.queries.resolve_mcp_credential",
                 new_callable=AsyncMock,
             ) as s,
@@ -212,7 +207,6 @@ class TestResolveAuthForUrl:
             ) as v,
             patch("aios.mcp.client.refresh_credential", refresh_mock),
         ):
-            g.return_value = None
             s.return_value = (stale_blob, "mcp_oauth", "vlt_s1")
             v.return_value = (fresh_blob, "mcp_oauth")
             result = await resolve_auth_for_url(
@@ -225,9 +219,11 @@ class TestResolveAuthForUrl:
         assert kwargs["mcp_server_url"] == "https://mcp.example.com"
         assert result == {"Authorization": "Bearer fresh"}
 
-    async def test_oauth_refresh_triggered_on_connection_path(self, crypto_box: CryptoBox) -> None:
-        """Connection-owned path: refresh ALSO triggers here — the refresh
-        flow is source-agnostic, it just needs a vault_id + url pair.
+    async def test_oauth_refresh_triggered_on_legacy_connection_path(
+        self, crypto_box: CryptoBox
+    ) -> None:
+        """Legacy connection-vault path: refresh ALSO triggers here — the
+        refresh flow is source-agnostic, it just needs a vault_id + url pair.
         """
         from datetime import UTC, datetime, timedelta
 
@@ -245,20 +241,19 @@ class TestResolveAuthForUrl:
         refresh_mock = AsyncMock()
         with (
             patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
                 "aios.mcp.client.queries.resolve_vault_credential",
                 new_callable=AsyncMock,
             ) as v,
             patch("aios.mcp.client.refresh_credential", refresh_mock),
         ):
-            g.return_value = "vlt_conn"
             # Two reads: initial (stale) and post-refresh (fresh).
             v.side_effect = [(stale_blob, "mcp_oauth"), (fresh_blob, "mcp_oauth")]
             result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
+                pool,
+                crypto_box,
+                "sess_123",
+                "https://mcp.example.com",
+                connection_vault_id="vlt_conn",
             )
 
         refresh_mock.assert_awaited_once()
@@ -280,16 +275,11 @@ class TestResolveAuthForUrl:
 
         with (
             patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
                 "aios.mcp.client.queries.resolve_mcp_credential",
                 new_callable=AsyncMock,
             ) as s,
             patch("aios.mcp.client.refresh_credential", refresh_mock),
         ):
-            g.return_value = None
             s.return_value = (blob, "mcp_oauth", "vlt_s1")
             result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com"
@@ -314,10 +304,6 @@ class TestResolveAuthForUrl:
 
         with (
             patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
                 "aios.mcp.client.queries.resolve_mcp_credential",
                 new_callable=AsyncMock,
             ) as s,
@@ -327,7 +313,6 @@ class TestResolveAuthForUrl:
             ),
             pytest.raises(OAuthRefreshError),
         ):
-            g.return_value = None
             s.return_value = (blob, "mcp_oauth", "vlt_s1")
             await resolve_auth_for_url(pool, crypto_box, "sess_123", "https://mcp.example.com")
 
@@ -537,7 +522,7 @@ class TestCallMcpTool:
         """The ``meta`` kwarg on call_mcp_tool reaches session.call_tool
         as its ``meta=`` kwarg so it lands in the JSON-RPC request's
         ``_meta`` field (the transport for slice 6's focal-path
-        injection on connection-provided servers).
+        injection on channel-aware MCP servers).
         """
         mock_content = MagicMock()
         mock_content.text = "ok"

--- a/tests/unit/test_mcp_models.py
+++ b/tests/unit/test_mcp_models.py
@@ -8,6 +8,7 @@ import pytest
 
 from aios.models.agents import (
     AgentCreate,
+    McpChannelContext,
     McpPermissionPolicy,
     McpServerSpec,
     McpToolConfig,
@@ -51,30 +52,11 @@ class TestMcpServerSpec:
         restored = McpServerSpec.model_validate_json(j)
         assert restored.name == "slack"
 
-    def test_conn_prefix_reserved(self) -> None:
-        """The ``conn_`` prefix is reserved for connection-derived MCP server
-        names — agent-declared names must not collide.
+    def test_conn_prefix_is_ordinary_name(self) -> None:
+        """Connection MCP servers are now a legacy projection, not a reserved
+        server-name namespace.
         """
-        with pytest.raises(ValueError, match="conn_"):
-            McpServerSpec(name="conn_github", url="https://mcp.github.com/")
-
-    def test_conn_prefix_reserved_in_agent_create(self) -> None:
-        """Same rejection at the AgentCreate boundary (the HTTP router
-        path — JSON body → ``model_validate`` runs the field validator
-        on every nested mcp_servers entry).
-        """
-        with pytest.raises(ValueError, match="conn_"):
-            AgentCreate.model_validate(
-                {
-                    "name": "bad",
-                    "model": "openai/gpt-4o-mini",
-                    "system": "",
-                    "mcp_servers": [{"type": "url", "name": "conn_foo", "url": "https://m"}],
-                }
-            )
-
-    def test_names_without_conn_prefix_accepted(self) -> None:
-        """Names containing ``conn`` but not starting with ``conn_`` are fine."""
+        assert McpServerSpec(name="conn_github", url="https://m").name == "conn_github"
         assert McpServerSpec(name="connector", url="https://m").name == "connector"
         assert McpServerSpec(name="my_conn", url="https://m").name == "my_conn"
         assert McpServerSpec(name="conn", url="https://m").name == "conn"
@@ -102,6 +84,16 @@ class TestMcpToolConfig:
         )
         assert cfg.name == "create_issue"
         assert cfg.enabled is True
+
+
+class TestMcpChannelContext:
+    def test_focal_context_default(self) -> None:
+        ctx = McpChannelContext()
+        assert ctx.type == "focal"
+
+    def test_extra_fields_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            McpChannelContext(type="focal", path="chat")  # type: ignore[call-arg]
 
 
 class TestToolSpecMcpToolset:
@@ -140,6 +132,19 @@ class TestToolSpecMcpToolset:
         assert spec.configs is not None
         assert len(spec.configs) == 1
         assert spec.configs[0].name == "create_issue"
+
+    def test_mcp_toolset_with_channel_context(self) -> None:
+        spec = ToolSpec(
+            type="mcp_toolset",
+            mcp_server_name="signal",
+            channel_context=McpChannelContext(type="focal"),
+        )
+        assert spec.channel_context is not None
+        assert spec.channel_context.type == "focal"
+
+    def test_channel_context_only_allowed_on_mcp_toolset(self) -> None:
+        with pytest.raises(ValueError, match="channel_context"):
+            ToolSpec(type="bash", channel_context=McpChannelContext(type="focal"))
 
     def test_mcp_toolset_round_trip(self) -> None:
         spec = ToolSpec(
@@ -193,3 +198,4 @@ class TestBackwardCompat:
         assert all(s.mcp_server_name is None for s in specs)
         assert all(s.default_config is None for s in specs)
         assert all(s.configs is None for s in specs)
+        assert all(s.channel_context is None for s in specs)

--- a/tests/unit/test_mcp_routing.py
+++ b/tests/unit/test_mcp_routing.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from aios.harness.loop import (
     _hide_conn_tools_when_phone_down,
+    _hide_focal_channel_tools_when_phone_down,
     _is_mcp_tool,
     _tc_name,
+    mcp_channel_context_by_server,
     resolve_mcp_permission,
 )
 from aios.models.agents import (
+    McpChannelContext,
     McpPermissionPolicy,
     McpToolsetConfig,
     ToolSpec,
@@ -102,25 +105,21 @@ class TestResolveMcpPermission:
         ]
         assert resolve_mcp_permission("mcp__github__create_issue", tools) is None
 
-    def test_connection_provided_defaults_to_always_allow(self) -> None:
-        """Tools from connection-provided MCP servers (names with the
-        reserved ``conn_`` prefix) don't require per-call confirmation:
-        the session's channel binding is the explicit routing consent.
+    def test_legacy_connection_projection_can_default_to_always_allow(self) -> None:
+        """Legacy connection-projected servers are authorized by the runtime
+        with an explicit server-name set, not by a magic name prefix.
         """
-        # No agent-declared mcp_toolset entry references the connection —
-        # the reserved-prefix validator forbids it — so normally we'd
-        # fall through to None (= always_ask).  Connection servers are
-        # the exception.
         assert (
-            resolve_mcp_permission("mcp__conn_01HQR2K7VXBZ9MNPL3WYCT8F__send", []) == "always_allow"
+            resolve_mcp_permission(
+                "mcp__conn_01HQR2K7VXBZ9MNPL3WYCT8F__send",
+                [],
+                always_allow_server_names={"conn_01HQR2K7VXBZ9MNPL3WYCT8F"},
+            )
+            == "always_allow"
         )
 
-    def test_connection_provided_ignores_agent_overrides(self) -> None:
-        """Even if someone (somehow) had a matching mcp_toolset entry, the
-        connection branch wins — agent-declared tools can't target
-        connection-derived servers by name."""
-        # The validator prevents this from being constructible via API, but
-        # test behaviour directly in case of bypass (e.g., legacy DB rows).
+    def test_normal_toolset_policy_beats_legacy_projection(self) -> None:
+        """If an agent declares a server/toolset, that normal MCP config wins."""
         tools = [
             ToolSpec(
                 type="mcp_toolset",
@@ -130,7 +129,14 @@ class TestResolveMcpPermission:
                 ),
             ),
         ]
-        assert resolve_mcp_permission("mcp__conn_foo__send", tools) == "always_allow"
+        assert (
+            resolve_mcp_permission(
+                "mcp__conn_foo__send",
+                tools,
+                always_allow_server_names={"conn_foo"},
+            )
+            == "always_ask"
+        )
 
 
 class TestToOpenaiToolsSkipsMcpToolset:
@@ -161,36 +167,62 @@ def _tool(name: str) -> dict[str, object]:
     return {"type": "function", "function": {"name": name}}
 
 
-class TestHideConnToolsWhenPhoneDown:
-    """Slice 6: connection-provided MCP tools disappear from the model's
-    tool list when the session's focal_channel is NULL.  Agent-declared
-    MCP tools and built-ins stay visible.
+class TestHideFocalChannelToolsWhenPhoneDown:
+    """Focal-channel MCP tools disappear from the model's tool list when
+    the session's focal_channel is NULL. Other MCP tools and built-ins stay
+    visible.
     """
 
     def test_focal_set_keeps_all_tools(self) -> None:
         tools = [
-            _tool("mcp__conn_abc__signal_send"),
+            _tool("mcp__signal__signal_send"),
             _tool("mcp__github__create_issue"),
             _tool("bash"),
         ]
-        result = _hide_conn_tools_when_phone_down(tools, "signal/bot/alice")
+        result = _hide_focal_channel_tools_when_phone_down(
+            tools, "signal/bot/alice", {"signal": "focal"}
+        )
         assert result == tools
 
-    def test_focal_null_hides_conn_tools(self) -> None:
+    def test_focal_null_hides_channel_aware_tools(self) -> None:
         tools = [
-            _tool("mcp__conn_abc__signal_send"),
-            _tool("mcp__conn_abc__signal_react"),
+            _tool("mcp__signal__signal_send"),
+            _tool("mcp__signal__signal_react"),
             _tool("mcp__github__create_issue"),
             _tool("bash"),
         ]
-        result = _hide_conn_tools_when_phone_down(tools, None)
+        result = _hide_focal_channel_tools_when_phone_down(tools, None, {"signal": "focal"})
         names = [t["function"]["name"] for t in result]  # type: ignore[index]
-        assert "mcp__conn_abc__signal_send" not in names
-        assert "mcp__conn_abc__signal_react" not in names
+        assert "mcp__signal__signal_send" not in names
+        assert "mcp__signal__signal_react" not in names
         # Agent-declared MCP and built-ins survive.
         assert "mcp__github__create_issue" in names
         assert "bash" in names
 
     def test_empty_list(self) -> None:
-        assert _hide_conn_tools_when_phone_down([], None) == []
-        assert _hide_conn_tools_when_phone_down([], "signal/bot/alice") == []
+        assert _hide_focal_channel_tools_when_phone_down([], None, {}) == []
+        assert _hide_focal_channel_tools_when_phone_down([], "signal/bot/alice", {}) == []
+
+    def test_contexts_come_from_toolset_config(self) -> None:
+        contexts = mcp_channel_context_by_server(
+            [
+                ToolSpec(
+                    type="mcp_toolset",
+                    mcp_server_name="signal",
+                    channel_context=McpChannelContext(type="focal"),
+                ),
+                ToolSpec(type="mcp_toolset", mcp_server_name="github"),
+            ]
+        )
+        assert contexts == {"signal": "focal"}
+
+
+class TestLegacyHideConnToolsWhenPhoneDown:
+    def test_legacy_wrapper_still_hides_conn_prefix(self) -> None:
+        tools = [
+            _tool("mcp__conn_abc__signal_send"),
+            _tool("mcp__github__create_issue"),
+        ]
+        result = _hide_conn_tools_when_phone_down(tools, None)
+        names = [t["function"]["name"] for t in result]  # type: ignore[index]
+        assert names == ["mcp__github__create_issue"]

--- a/tests/unit/test_mcp_routing.py
+++ b/tests/unit/test_mcp_routing.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from aios.harness.loop import (
-    _hide_conn_tools_when_phone_down,
     _hide_focal_channel_tools_when_phone_down,
     _is_mcp_tool,
     _tc_name,
@@ -16,6 +17,7 @@ from aios.models.agents import (
     McpToolsetConfig,
     ToolSpec,
 )
+from aios.models.connections import Connection
 from aios.tools.registry import to_openai_tools
 
 
@@ -92,6 +94,27 @@ class TestResolveMcpPermission:
             ToolSpec(type="mcp_toolset", mcp_server_name="github"),
         ]
         assert resolve_mcp_permission("mcp__github__create_issue", tools) is None
+
+    def test_focal_channel_toolset_defaults_to_always_allow(self) -> None:
+        tools = [
+            ToolSpec(
+                type="mcp_toolset",
+                mcp_server_name="signal",
+                channel_context=McpChannelContext(type="focal"),
+            ),
+        ]
+        assert resolve_mcp_permission("mcp__signal__signal_send", tools) == "always_allow"
+
+    def test_explicit_permission_beats_focal_default(self) -> None:
+        tools = [
+            ToolSpec(
+                type="mcp_toolset",
+                mcp_server_name="signal",
+                permission="always_ask",
+                channel_context=McpChannelContext(type="focal"),
+            ),
+        ]
+        assert resolve_mcp_permission("mcp__signal__signal_send", tools) == "always_ask"
 
     def test_wrong_server_not_matched(self) -> None:
         tools = [
@@ -216,13 +239,29 @@ class TestHideFocalChannelToolsWhenPhoneDown:
         )
         assert contexts == {"signal": "focal"}
 
+    def test_agent_server_url_suppresses_legacy_connection_context(self) -> None:
+        now = datetime(2026, 4, 16)
+        connection = Connection(
+            id="conn_01HQR2K7VXBZ9MNPL3WYCT8F",
+            connector="signal",
+            account="acct",
+            mcp_url="https://m1",
+            vault_id="vlt_x",
+            metadata={},
+            created_at=now,
+            updated_at=now,
+        )
 
-class TestLegacyHideConnToolsWhenPhoneDown:
-    def test_legacy_wrapper_still_hides_conn_prefix(self) -> None:
-        tools = [
-            _tool("mcp__conn_abc__signal_send"),
-            _tool("mcp__github__create_issue"),
-        ]
-        result = _hide_conn_tools_when_phone_down(tools, None)
-        names = [t["function"]["name"] for t in result]  # type: ignore[index]
-        assert names == ["mcp__github__create_issue"]
+        contexts = mcp_channel_context_by_server(
+            [
+                ToolSpec(
+                    type="mcp_toolset",
+                    mcp_server_name="signal",
+                    channel_context=McpChannelContext(type="focal"),
+                ),
+            ],
+            [connection],
+            agent_mcp_server_names={"signal"},
+            agent_mcp_server_urls={"https://m1"},
+        )
+        assert contexts == {"signal": "focal"}


### PR DESCRIPTION
## Summary
- Add explicit `mcp_toolset.channel_context` for focal-channel MCP behavior.
- Move focal tool hiding, `_meta` injection, and auth selection off the `conn_` namespace.
- Keep connection MCP as a legacy projection while documenting agent MCP plus session vaults as the preferred connector path.

## Impact
- Agent-declared MCP servers can now participate in channel-aware Signal and Telegram flows without being special connection-owned servers.
- Normal agent MCP auth resolves through session vaults by default; legacy connection-projected servers pass an explicit connection vault id.

## Validation
- `uv run ruff check src tests connectors/signal/src/aios_signal/mcp.py connectors/telegram/src/aios_telegram/mcp.py`
- `uv run ruff format --check src tests connectors/signal/src/aios_signal/mcp.py connectors/telegram/src/aios_telegram/mcp.py`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/e2e/test_focal_channel.py::TestMcpMetaInjection -q`
- `uv run mypy src`