### PR TITLE
feat: per-worktree dev instance isolation via AIOS_INSTANCE_ID

### DIFF
--- a/src/aios/cli/app.py
+++ b/src/aios/cli/app.py
@@ -97,6 +97,7 @@ from aios.cli.commands import agents as _agents  # noqa: E402
 from aios.cli.commands import bindings as _bindings  # noqa: E402
 from aios.cli.commands import chat as _chat  # noqa: E402
 from aios.cli.commands import connections as _connections  # noqa: E402
+from aios.cli.commands import dev as _dev  # noqa: E402
 from aios.cli.commands import envs as _envs  # noqa: E402
 from aios.cli.commands import ops as _ops  # noqa: E402
 from aios.cli.commands import rules as _rules  # noqa: E402
@@ -114,6 +115,7 @@ app.add_typer(_connections.app, name="connections")
 app.add_typer(_bindings.app, name="bindings")
 app.add_typer(_rules.app, name="rules")
 app.add_typer(_envs.app, name="envs")
+app.add_typer(_dev.app, name="dev")
 
 _ops.register(app)
 _status.register(app)

--- a/src/aios/cli/commands/dev.py
+++ b/src/aios/cli/commands/dev.py
@@ -1,0 +1,582 @@
+"""``aios dev ...`` — per-worktree dev instance management.
+
+Lets each git worktree run its own isolated aios against a shared local
+Postgres. ``bootstrap`` creates a per-worktree database, picks a free port,
+writes a ``.env`` with instance-specific overrides, and runs migrations.
+``teardown`` drops the database and prunes per-instance containers.
+``status`` reports instance identity and liveness.
+
+The commands parse ``.env`` directly (rather than going through
+:class:`aios.config.Settings`) so destructive cleanup still works when the
+DB is unreachable or a secrets file is malformed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Annotated
+from urllib.parse import urlparse, urlunparse
+
+import asyncpg
+import typer
+
+from aios.cli.output import print_error, print_note
+
+# ── instance id derivation + validation ────────────────────────────────────
+
+INSTANCE_ID_PATTERN = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+# PostgreSQL identifiers are silently truncated at 63 bytes. We prefix
+# dev databases with "aios_dev_" (9 bytes), leaving 54 for the instance id.
+DB_PREFIX = "aios_dev_"
+MAX_DB_NAME_BYTES = 63
+MAX_INSTANCE_ID_LEN = MAX_DB_NAME_BYTES - len(DB_PREFIX)
+
+
+def derive_instance_id(repo_root: Path) -> str:
+    """Derive a collision-free instance id from a git repo root.
+
+    The id is always ``<sanitized-basename>_<8-char-hash>`` so that two
+    worktrees with the same basename on different paths never collide.
+    Hash input is the fully resolved path.
+
+    Output is guaranteed to match :data:`INSTANCE_ID_PATTERN` and fit
+    inside ``aios_dev_<id>`` at ≤63 bytes.
+    """
+    resolved = str(repo_root.resolve())
+    raw = repo_root.name.lower()
+    safe = re.sub(r"[^a-z0-9_]", "_", raw)
+    safe = re.sub(r"_+", "_", safe).strip("_")
+    suffix = hashlib.sha256(resolved.encode()).hexdigest()[:8]
+    if not safe or safe[0].isdigit():
+        safe = "w_" + safe
+    # 1 underscore + 8-char suffix takes 9 bytes.
+    max_prefix = MAX_INSTANCE_ID_LEN - 1 - 8
+    return f"{safe[:max_prefix]}_{suffix}"
+
+
+def validate_instance_id_for_db(instance_id: str) -> None:
+    """Validate an instance id before it flows into SQL or a docker label.
+
+    Checks the safe-char pattern and the 63-byte Postgres-identifier limit
+    (PG silently truncates beyond that, which would silently create the
+    wrong database).
+    """
+    if not INSTANCE_ID_PATTERN.fullmatch(instance_id):
+        raise ValueError(
+            f"invalid AIOS_INSTANCE_ID {instance_id!r}: must match {INSTANCE_ID_PATTERN.pattern}"
+        )
+    full = DB_PREFIX + instance_id
+    if len(full.encode()) > MAX_DB_NAME_BYTES:
+        raise ValueError(
+            f"AIOS_INSTANCE_ID {instance_id!r} produces DB name {full!r} "
+            f"({len(full)} bytes); Postgres truncates identifiers over "
+            f"{MAX_DB_NAME_BYTES} bytes"
+        )
+
+
+# ── env-file I/O ───────────────────────────────────────────────────────────
+
+_ENV_LINE_RE = re.compile(r"^\s*(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<value>.*?)\s*$")
+
+
+def parse_env_file(path: Path) -> dict[str, str]:
+    """Parse a dotenv-style file into a plain dict.
+
+    Ignores blank lines and ``#`` comments. Strips one layer of surrounding
+    single or double quotes from values. Does NOT expand ``$VAR``
+    references or perform any merging with process env — that's the caller's
+    choice. Missing files return ``{}``.
+    """
+    if not path.exists():
+        return {}
+    result: dict[str, str] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = _ENV_LINE_RE.match(line)
+        if not m:
+            continue
+        key = m.group("key")
+        value = m.group("value")
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        result[key] = value
+    return result
+
+
+def write_env_atomic(path: Path, updates: dict[str, str]) -> None:
+    """Merge ``updates`` into ``path`` and rewrite atomically.
+
+    Preserves unrelated keys and line ordering: existing lines whose keys
+    appear in ``updates`` are rewritten in place, and remaining ``updates``
+    keys are appended at the end. Comments and blank lines pass through.
+    Write goes to a tmpfile in the same directory then ``os.replace`` —
+    avoids ever leaving a half-written ``.env``.
+    """
+    existing_text = path.read_text() if path.exists() else ""
+    remaining = dict(updates)
+    new_lines: list[str] = []
+    for raw_line in existing_text.splitlines():
+        m = _ENV_LINE_RE.match(raw_line)
+        if m and m.group("key") in remaining:
+            key = m.group("key")
+            new_lines.append(f"{key}={remaining.pop(key)}")
+        else:
+            new_lines.append(raw_line)
+    for key, value in remaining.items():
+        new_lines.append(f"{key}={value}")
+    new_text = "\n".join(new_lines) + ("\n" if new_lines else "")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path_str = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(new_text)
+        os.replace(tmp_path, path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def load_instance_env(repo_root: Path) -> dict[str, str]:
+    """Read the worktree's ``.env`` and require the four instance keys.
+
+    Used by teardown/status — both need to work when ``Settings`` would
+    fail to load (e.g. broken secrets file, DB unreachable). Raises
+    ``typer.Exit(1)`` with a clear message if any required key is missing.
+    """
+    env_path = repo_root / ".env"
+    env = parse_env_file(env_path)
+    required = ("AIOS_INSTANCE_ID", "AIOS_DB_URL", "AIOS_API_PORT", "AIOS_WORKSPACE_ROOT")
+    missing = [k for k in required if k not in env]
+    if missing:
+        print_error(
+            f"{env_path} is missing required keys: {', '.join(missing)}. "
+            f"Run `aios dev bootstrap` first."
+        )
+        raise typer.Exit(1)
+    return env
+
+
+# ── URL + port helpers ─────────────────────────────────────────────────────
+
+DEFAULT_ADMIN_URL = "postgresql://aios:aios@localhost:5432/postgres"
+
+
+def derive_runtime_db_url(admin_url: str, instance_id: str) -> str:
+    """Return an AIOS_DB_URL for this instance by swapping the DB name only.
+
+    Preserves scheme, host, port, user, password, and query from the admin
+    URL. This keeps bootstrap working against non-default Postgres setups
+    (alternate ports, remote hosts, alternate credentials).
+    """
+    parsed = urlparse(admin_url)
+    db_name = DB_PREFIX + instance_id
+    return urlunparse(parsed._replace(path=f"/{db_name}"))
+
+
+def pick_free_port() -> int:
+    """Bind to port 0 on loopback, return the kernel-assigned free port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        port: int = s.getsockname()[1]
+        return port
+
+
+def port_is_open(port: int, host: str = "127.0.0.1") -> bool:
+    """Best-effort check: does something accept on ``host:port``?"""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        return s.connect_ex((host, port)) == 0
+
+
+def get_git_repo_root() -> Path:
+    """Return the current git repository top level, or raise typer.Exit(1)."""
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print_error("not inside a git repository (git rev-parse failed)")
+        raise typer.Exit(1) from None
+    return Path(out.strip())
+
+
+# ── stale-export guard ─────────────────────────────────────────────────────
+
+_STALE_EXPORT_VARS = (
+    "AIOS_DB_URL",
+    "AIOS_API_PORT",
+    "AIOS_INSTANCE_ID",
+    "AIOS_WORKSPACE_ROOT",
+)
+
+
+def warn_stale_exports() -> None:
+    """Warn if the caller's shell has aios runtime vars already exported.
+
+    Bootstrap's own subprocess uses a hermetic env so its migration is
+    never misdirected — but the user's subsequent ``aios api`` /
+    ``aios worker`` will inherit the shell's env, which beats the
+    worktree ``.env``. This is non-fatal; we just tell the user.
+    """
+    stale = [v for v in _STALE_EXPORT_VARS if v in os.environ]
+    if not stale:
+        return
+    print_note(
+        f"warning: {', '.join(stale)} is exported in your shell and will "
+        f"override the worktree .env at runtime."
+    )
+    print_note("Start a fresh shell before running `aios api` / `aios worker`, or:")
+    print_note(f"  unset {' '.join(_STALE_EXPORT_VARS)}")
+
+
+# ── admin DB ops (async helpers) ───────────────────────────────────────────
+
+
+async def _preflight_role_can_create_db(admin_url: str) -> None:
+    """Connect as the admin role and verify it can CREATE DATABASE.
+
+    A superuser bypasses the rolcreatedb flag, so either qualifier passes.
+    """
+    conn = await asyncpg.connect(admin_url)
+    try:
+        row = await conn.fetchrow(
+            "SELECT rolsuper, rolcreatedb FROM pg_roles WHERE rolname = current_user"
+        )
+    finally:
+        await conn.close()
+    if row is None or not (row["rolsuper"] or row["rolcreatedb"]):
+        raise RuntimeError(
+            "Postgres role lacks CREATEDB/SUPERUSER. Grant with: ALTER USER <role> CREATEDB;"
+        )
+
+
+async def _create_database_if_missing(admin_url: str, db_name: str) -> bool:
+    """Run ``CREATE DATABASE "<db_name>"``; treat DuplicateDatabaseError as no-op.
+
+    Returns True if the database was created, False if it already existed.
+    ``db_name`` MUST have been validated by :func:`validate_instance_id_for_db`
+    prior to this call — it flows directly into an identifier position.
+    """
+    conn = await asyncpg.connect(admin_url)
+    try:
+        try:
+            await conn.execute(f'CREATE DATABASE "{db_name}"')
+            return True
+        except asyncpg.exceptions.DuplicateDatabaseError:
+            return False
+    finally:
+        await conn.close()
+
+
+async def _drop_database(admin_url: str, db_name: str) -> None:
+    """Issue ``DROP DATABASE "<db_name>"``. Raises on any Postgres error.
+
+    If PG refuses because connections are open, the caller should catch
+    the exception and list blocking PIDs via :func:`_list_db_backends`.
+    ``db_name`` MUST be pre-validated.
+    """
+    conn = await asyncpg.connect(admin_url)
+    try:
+        await conn.execute(f'DROP DATABASE "{db_name}"')
+    finally:
+        await conn.close()
+
+
+async def _list_db_backends(admin_url: str, db_name: str) -> list[tuple[int, str]]:
+    """Return ``(pid, application_name)`` for each backend attached to ``db_name``."""
+    conn = await asyncpg.connect(admin_url)
+    try:
+        rows = await conn.fetch(
+            "SELECT pid, COALESCE(application_name, '') AS application_name "
+            "FROM pg_stat_activity "
+            "WHERE datname = $1 AND pid <> pg_backend_pid()",
+            db_name,
+        )
+    finally:
+        await conn.close()
+    return [(int(r["pid"]), str(r["application_name"])) for r in rows]
+
+
+async def _count_db_clients(db_url: str) -> int:
+    """Count backends attached to the instance DB itself (dev status).
+
+    Uses the instance DSN, not the admin DSN — ``pg_stat_activity``
+    rows for a DB are visible from within that DB. Filters out the
+    counting connection itself.
+    """
+    conn = await asyncpg.connect(db_url)
+    try:
+        result = await conn.fetchval(
+            "SELECT COUNT(*) FROM pg_stat_activity "
+            "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+        )
+    finally:
+        await conn.close()
+    return int(result or 0)
+
+
+def _resolve_admin_url(secrets: dict[str, str]) -> str:
+    """Pick the admin DSN from process env, then parsed secrets, then default."""
+    return (
+        os.environ.get("AIOS_POSTGRES_ADMIN_URL")
+        or secrets.get("AIOS_POSTGRES_ADMIN_URL")
+        or DEFAULT_ADMIN_URL
+    )
+
+
+# ── docker helpers (shell out, no Settings import) ─────────────────────────
+
+
+def _list_instance_containers(instance_id: str) -> list[str]:
+    """Return container ids matching both managed+instance labels."""
+    out = subprocess.run(
+        [
+            "docker",
+            "ps",
+            "--all",
+            "--quiet",
+            "--filter",
+            "label=aios.managed=true",
+            "--filter",
+            f"label=aios.instance_id={instance_id}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode != 0:
+        print_error(f"docker ps failed: {out.stderr.strip()}")
+        raise typer.Exit(1)
+    return [line.strip() for line in out.stdout.splitlines() if line.strip()]
+
+
+def _force_remove_containers(container_ids: list[str]) -> None:
+    if not container_ids:
+        return
+    rc = subprocess.call(
+        ["docker", "rm", "--force", *container_ids],
+        stdout=subprocess.DEVNULL,
+    )
+    if rc != 0:
+        print_error(f"docker rm --force returned exit {rc}")
+        raise typer.Exit(1)
+
+
+# ── CLI sub-app ────────────────────────────────────────────────────────────
+
+app = typer.Typer(
+    name="dev",
+    help="Manage a per-worktree aios dev instance.",
+    no_args_is_help=True,
+)
+
+
+@app.command("bootstrap", help="Create a per-worktree aios dev instance.")
+def bootstrap() -> None:
+    repo_root = get_git_repo_root()
+    instance_id = derive_instance_id(repo_root)
+    validate_instance_id_for_db(instance_id)
+    db_name = DB_PREFIX + instance_id
+
+    warn_stale_exports()
+
+    secrets_path = Path.home() / ".aios" / "secrets.env"
+    secrets = parse_env_file(secrets_path)
+    missing = [k for k in ("AIOS_API_KEY", "AIOS_VAULT_KEY") if k not in secrets]
+    if missing:
+        print_error(f"{secrets_path} is missing required keys: {', '.join(missing)}")
+        print_note("Required contents (generate values yourself):")
+        print_note("  AIOS_API_KEY=<openssl rand -hex 32>")
+        print_note("  AIOS_VAULT_KEY=<openssl rand -base64 32>")
+        print_note("Plus any provider keys (OPENROUTER_API_KEY, ANTHROPIC_API_KEY, ...).")
+        raise typer.Exit(1)
+
+    admin_url = _resolve_admin_url(secrets)
+
+    try:
+        asyncio.run(_preflight_role_can_create_db(admin_url))
+    except (asyncpg.exceptions.PostgresError, OSError, RuntimeError) as exc:
+        print_error(f"Postgres admin preflight failed: {exc}")
+        print_note(f"Admin DSN: {admin_url}")
+        raise typer.Exit(1) from exc
+
+    try:
+        created = asyncio.run(_create_database_if_missing(admin_url, db_name))
+    except asyncpg.exceptions.PostgresError as exc:
+        print_error(f"CREATE DATABASE {db_name!r} failed: {exc}")
+        raise typer.Exit(1) from exc
+    print_note(f"database: {db_name} ({'created' if created else 'already exists'})")
+
+    env_path = repo_root / ".env"
+    existing_env = parse_env_file(env_path)
+    if "AIOS_API_PORT" in existing_env:
+        port = int(existing_env["AIOS_API_PORT"])
+        if port_is_open(port):
+            print_note(f"port {port} is currently in use; keeping it since it's persisted in .env")
+    else:
+        port = pick_free_port()
+
+    workspace_root = (Path.home() / ".aios" / "workspaces" / instance_id).resolve()
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    runtime_db_url = derive_runtime_db_url(admin_url, instance_id)
+
+    write_env_atomic(
+        env_path,
+        {
+            "AIOS_INSTANCE_ID": instance_id,
+            "AIOS_DB_URL": runtime_db_url,
+            "AIOS_API_PORT": str(port),
+            "AIOS_WORKSPACE_ROOT": str(workspace_root),
+        },
+    )
+
+    # Hermetic subprocess env: explicit overrides beat any stale shell exports.
+    # Parsed secrets are passed through so the child doesn't need to re-read
+    # ~/.aios/secrets.env (which pydantic-settings resolves at class-definition
+    # time, not per-invocation).
+    migrate_env = os.environ | {
+        "AIOS_INSTANCE_ID": instance_id,
+        "AIOS_DB_URL": runtime_db_url,
+        "AIOS_API_PORT": str(port),
+        "AIOS_WORKSPACE_ROOT": str(workspace_root),
+        "AIOS_API_KEY": secrets["AIOS_API_KEY"],
+        "AIOS_VAULT_KEY": secrets["AIOS_VAULT_KEY"],
+    }
+    rc = subprocess.call(
+        ["uv", "run", "aios", "migrate"],
+        cwd=str(repo_root),
+        env=migrate_env,
+    )
+    if rc != 0:
+        print_error(f"aios migrate failed (exit {rc})")
+        raise typer.Exit(rc)
+
+    print_note("")
+    print_note(f"Bootstrapped instance={instance_id} db={db_name} port={port}")
+    print_note("")
+    print_note("IMPORTANT: start a fresh shell, or explicitly unset any stale aios vars:")
+    print_note(f"  unset {' '.join(_STALE_EXPORT_VARS)}")
+    print_note("")
+    print_note("Then activate this worktree:")
+    print_note("  set -a && source .env && set +a")
+    print_note("")
+    print_note("Run:")
+    print_note("  uv run aios api       # terminal 1")
+    print_note("  uv run aios worker    # terminal 2")
+    print_note("  uv run aios agents list")
+
+
+@app.command(
+    "teardown",
+    help="Drop this worktree's aios dev database, containers, and workspace.",
+)
+def teardown(
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", "-y", help="Skip the confirmation prompt."),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help="Bypass the API-port liveness check. Does NOT terminate DB backends.",
+        ),
+    ] = False,
+) -> None:
+    repo_root = get_git_repo_root()
+    env = load_instance_env(repo_root)
+    instance_id = env["AIOS_INSTANCE_ID"]
+    validate_instance_id_for_db(instance_id)
+    db_name = DB_PREFIX + instance_id
+    port = int(env["AIOS_API_PORT"])
+    workspace_root = Path(env["AIOS_WORKSPACE_ROOT"])
+
+    if port_is_open(port) and not force:
+        print_error(
+            f"aios api appears to be running on :{port}. "
+            f"Stop it first, or pass --force to bypass this check."
+        )
+        raise typer.Exit(1)
+
+    container_ids = _list_instance_containers(instance_id)
+
+    if not yes:
+        print_note(f"About to destroy aios dev instance {instance_id}:")
+        print_note(f"  - DROP DATABASE {db_name}")
+        print_note(f"  - remove {len(container_ids)} container(s)")
+        print_note(f"  - rm -rf {workspace_root}")
+        confirm = typer.prompt("Proceed? (yes/no)", default="no")
+        if confirm.strip().lower() not in ("yes", "y"):
+            print_note("aborted")
+            raise typer.Exit(1)
+
+    _force_remove_containers(container_ids)
+
+    secrets = parse_env_file(Path.home() / ".aios" / "secrets.env")
+    admin_url = _resolve_admin_url(secrets)
+    try:
+        asyncio.run(_drop_database(admin_url, db_name))
+    except asyncpg.exceptions.PostgresError as exc:
+        print_error(f"DROP DATABASE {db_name!r} failed: {exc}")
+        try:
+            backends = asyncio.run(_list_db_backends(admin_url, db_name))
+        except asyncpg.exceptions.PostgresError:
+            backends = []
+        if backends:
+            print_note("Blocking backends:")
+            for pid, app_name in backends:
+                print_note(f"  pid={pid} application_name={app_name!r}")
+            print_note("Stop the worker/api attached to this instance, then re-run teardown.")
+        raise typer.Exit(1) from exc
+
+    if workspace_root.exists():
+        shutil.rmtree(workspace_root)
+    print_note(f"teardown complete: instance={instance_id}")
+
+
+@app.command("status", help="Show this worktree's aios dev instance status.")
+def status() -> None:
+    repo_root = get_git_repo_root()
+    env = load_instance_env(repo_root)
+    instance_id = env["AIOS_INSTANCE_ID"]
+    validate_instance_id_for_db(instance_id)
+    db_name = DB_PREFIX + instance_id
+    port = int(env["AIOS_API_PORT"])
+    workspace_root = Path(env["AIOS_WORKSPACE_ROOT"])
+
+    print(f"instance_id:     {instance_id}")
+    print(f"database:        {db_name}")
+    print(f"api_port:        {port}")
+    print(f"workspace_root:  {workspace_root}")
+
+    container_ids = _list_instance_containers(instance_id)
+    print(f"containers:      {len(container_ids)}")
+
+    api_up = port_is_open(port)
+    print(f"api_port_open:   {api_up}")
+
+    try:
+        clients = asyncio.run(_count_db_clients(env["AIOS_DB_URL"]))
+        print(f"db_attached:     {clients}  (best-effort; any long-lived connection counts)")
+    except (asyncpg.exceptions.PostgresError, OSError) as exc:
+        print(f"db_attached:     unknown ({exc})")

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -23,10 +23,30 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_prefix="AIOS_",
-        env_file=".env",
+        # Layered: user-level shared secrets (seeded once) then per-worktree
+        # overrides. Later file wins; process env still beats both. `~` is not
+        # expanded by pydantic-settings, so we resolve Path.home() explicitly.
+        # Missing files are silently skipped.
+        env_file=(
+            str(Path.home() / ".aios" / "secrets.env"),
+            ".env",
+        ),
         env_file_encoding="utf-8",
         extra="ignore",
         case_sensitive=False,
+    )
+
+    # ── instance identity ──────────────────────────────────────────────────
+    instance_id: str = Field(
+        default="default",
+        pattern=r"^[a-z_][a-z0-9_]*$",
+        description="Distinguishes concurrent aios deployments on a shared host. "
+        "Flows into Docker container labels so each worker's orphan-reaper only "
+        "touches its own containers, and into dev-bootstrap DB naming. The "
+        "`default` value preserves pre-existing single-instance behavior; `aios "
+        "dev bootstrap` writes a unique value per git worktree. The pattern "
+        "restricts the value to chars safe for Postgres identifiers and Docker "
+        "labels.",
     )
 
     # ── auth + crypto (required) ───────────────────────────────────────────

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -31,11 +31,17 @@ from aios.sandbox.container import ContainerError, ContainerHandle
 
 log = get_logger("aios.sandbox.provisioner")
 
-# Label applied at ``docker run`` time. The worker's orphan reaper lists
-# containers with this label at startup and removes any whose session_id
-# does not match an active worker lease.
+# Labels applied at ``docker run`` time. The worker's orphan reaper lists
+# containers with the managed+instance labels at startup and removes any
+# whose session_id does not match an active worker lease.
+#
+# The instance label scopes the reaper to containers belonging to this
+# aios deployment — critical when multiple worktrees or deployed instances
+# share a Docker daemon, otherwise worker A's startup would kill worker B's
+# running sandboxes.
 MANAGED_LABEL_KEY = "aios.managed"
 MANAGED_LABEL_VALUE = "true"
+INSTANCE_LABEL_KEY = "aios.instance_id"
 SESSION_LABEL_KEY = "aios.session_id"
 
 # Well-known hosts for public package registries.  Added to the iptables
@@ -146,6 +152,8 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
         f"{workspace_path}:/workspace",
         "--label",
         f"{MANAGED_LABEL_KEY}={MANAGED_LABEL_VALUE}",
+        "--label",
+        f"{INSTANCE_LABEL_KEY}={settings.instance_id}",
         "--label",
         f"{SESSION_LABEL_KEY}={session_id}",
         "--network",
@@ -362,21 +370,27 @@ async def release(handle: ContainerHandle) -> None:
 
 
 async def list_managed_containers() -> list[tuple[str, str]]:
-    """List all containers labelled ``aios.managed=true``.
+    """List containers for this aios instance.
 
-    Returns a list of ``(container_id, session_id)`` tuples, where
-    ``session_id`` is read from the container's ``aios.session_id`` label.
-    Containers missing the session label are returned with an empty
-    string as their session_id (shouldn't happen, but we're defensive).
+    Returns ``(container_id, session_id)`` tuples for containers labelled
+    both ``aios.managed=true`` and ``aios.instance_id=<current instance>``.
+    ``session_id`` is read from the container's ``aios.session_id`` label;
+    containers missing that label are returned with an empty string
+    (shouldn't happen, but we're defensive).
 
-    Used by the worker's orphan reaper at startup.
+    Used by the worker's orphan reaper at startup. The instance filter is
+    load-bearing: without it, one worker's reaper would kill containers
+    belonging to a concurrent worker on the same Docker daemon.
     """
+    settings = get_settings()
     ps_argv = [
         "docker",
         "ps",
         "--quiet",
         "--filter",
         f"label={MANAGED_LABEL_KEY}={MANAGED_LABEL_VALUE}",
+        "--filter",
+        f"label={INSTANCE_LABEL_KEY}={settings.instance_id}",
     ]
     rc, stdout_bytes, stderr_bytes = await _run_docker(ps_argv)
     if rc != 0:

--- a/tests/unit/cli/test_cli_dev.py
+++ b/tests/unit/cli/test_cli_dev.py
@@ -1,0 +1,276 @@
+"""Tests for ``aios dev`` helpers.
+
+Focus on the pure functions whose correctness underpins the bootstrap/
+teardown pipeline. The CLI commands themselves hit Docker and Postgres,
+so they're covered by manual E2E rather than unit tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aios.cli.commands.dev import (
+    INSTANCE_ID_PATTERN,
+    MAX_DB_NAME_BYTES,
+    derive_instance_id,
+    derive_runtime_db_url,
+    parse_env_file,
+    validate_instance_id_for_db,
+    write_env_atomic,
+)
+
+# ── derive_instance_id ─────────────────────────────────────────────────────
+
+
+def test_derive_instance_id_matches_pattern(tmp_path: Path) -> None:
+    repo = tmp_path / "worktree-sleepy-forging-squirrel-wvPF4Y"
+    repo.mkdir()
+    result = derive_instance_id(repo)
+    assert INSTANCE_ID_PATTERN.fullmatch(result) is not None
+
+
+def test_derive_instance_id_same_basename_different_paths_collides_never(
+    tmp_path: Path,
+) -> None:
+    """Two worktrees both named `aios` in different parent dirs must not collide."""
+    a = tmp_path / "project-a" / "aios"
+    b = tmp_path / "project-b" / "aios"
+    a.mkdir(parents=True)
+    b.mkdir(parents=True)
+    assert derive_instance_id(a) != derive_instance_id(b)
+
+
+def test_derive_instance_id_leading_digit_gets_prefix(tmp_path: Path) -> None:
+    repo = tmp_path / "9x-branch"
+    repo.mkdir()
+    result = derive_instance_id(repo)
+    assert result.startswith("w_")
+    assert INSTANCE_ID_PATTERN.fullmatch(result) is not None
+
+
+def test_derive_instance_id_long_basename_truncates_and_stays_under_limit(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / ("worktree-" + "x" * 200)
+    repo.mkdir()
+    result = derive_instance_id(repo)
+    # Full DB name is "aios_dev_<id>"; must fit in 63 bytes.
+    assert len(("aios_dev_" + result).encode()) <= MAX_DB_NAME_BYTES
+    # And still collision-resistant — suffix is always present.
+    assert "_" in result
+    assert INSTANCE_ID_PATTERN.fullmatch(result) is not None
+
+
+def test_derive_instance_id_non_ascii_folds_to_safe_chars(tmp_path: Path) -> None:
+    repo = tmp_path / "café-branch"  # "café-branch"
+    repo.mkdir()
+    result = derive_instance_id(repo)
+    assert INSTANCE_ID_PATTERN.fullmatch(result) is not None
+
+
+def test_derive_instance_id_empty_basename_survives(tmp_path: Path) -> None:
+    """Edge case: a path whose basename sanitizes to empty still produces a valid id."""
+    repo = tmp_path / "---"
+    repo.mkdir()
+    result = derive_instance_id(repo)
+    # "---" sanitizes to "" then gets the leading-digit-guard "w_" prefix.
+    assert result.startswith("w_")
+    assert INSTANCE_ID_PATTERN.fullmatch(result) is not None
+
+
+def test_derive_instance_id_deterministic(tmp_path: Path) -> None:
+    """Same path → same id across calls (important for bootstrap idempotency)."""
+    repo = tmp_path / "worktree-x"
+    repo.mkdir()
+    assert derive_instance_id(repo) == derive_instance_id(repo)
+
+
+# ── validate_instance_id_for_db ────────────────────────────────────────────
+
+
+def test_validate_instance_id_accepts_safe_values() -> None:
+    validate_instance_id_for_db("ok")
+    validate_instance_id_for_db("a_b_123")
+    validate_instance_id_for_db("_leading_underscore_ok")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",  # empty
+        "9start",  # leading digit
+        "has-dash",  # dash
+        "has.dot",  # dot
+        "UPPER",  # uppercase
+        "has space",  # space
+        'inject"; DROP TABLE--',  # SQL injection surface
+    ],
+)
+def test_validate_instance_id_rejects_unsafe_values(bad: str) -> None:
+    with pytest.raises(ValueError, match="invalid AIOS_INSTANCE_ID"):
+        validate_instance_id_for_db(bad)
+
+
+def test_validate_instance_id_rejects_too_long() -> None:
+    """Guard against PG's 63-byte silent truncation of identifiers."""
+    # "aios_dev_" is 9 bytes; 55-char id pushes the DB name to 64 bytes.
+    too_long = "a" * 55
+    with pytest.raises(ValueError, match="truncates identifiers"):
+        validate_instance_id_for_db(too_long)
+
+
+# ── derive_runtime_db_url ──────────────────────────────────────────────────
+
+
+def test_derive_runtime_db_url_swaps_only_path() -> None:
+    admin = "postgresql://aios:secret@localhost:5432/postgres"
+    result = derive_runtime_db_url(admin, "abcd1234")
+    assert result == "postgresql://aios:secret@localhost:5432/aios_dev_abcd1234"
+
+
+def test_derive_runtime_db_url_preserves_nonstandard_port() -> None:
+    admin = "postgresql://user:pass@db.example.com:6543/postgres"
+    result = derive_runtime_db_url(admin, "inst")
+    assert result == "postgresql://user:pass@db.example.com:6543/aios_dev_inst"
+
+
+def test_derive_runtime_db_url_preserves_query_string() -> None:
+    admin = "postgresql://u:p@h:5432/postgres?sslmode=require"
+    result = derive_runtime_db_url(admin, "inst")
+    assert result == "postgresql://u:p@h:5432/aios_dev_inst?sslmode=require"
+
+
+def test_derive_runtime_db_url_ipv6_host() -> None:
+    admin = "postgresql://u:p@[::1]:5432/postgres"
+    result = derive_runtime_db_url(admin, "inst")
+    assert result == "postgresql://u:p@[::1]:5432/aios_dev_inst"
+
+
+# ── parse_env_file ─────────────────────────────────────────────────────────
+
+
+def test_parse_env_file_missing_returns_empty(tmp_path: Path) -> None:
+    assert parse_env_file(tmp_path / "does-not-exist.env") == {}
+
+
+def test_parse_env_file_basic(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    f.write_text("# comment\nFOO=bar\n\nBAZ=qux\nQUOTED=\"with spaces\"\nSINGLEQUOTED='quoted'\n")
+    assert parse_env_file(f) == {
+        "FOO": "bar",
+        "BAZ": "qux",
+        "QUOTED": "with spaces",
+        "SINGLEQUOTED": "quoted",
+    }
+
+
+def test_parse_env_file_ignores_malformed_lines(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    f.write_text("GOOD=1\nnot a key=value pair\nALSO_GOOD=2\n")
+    assert parse_env_file(f) == {"GOOD": "1", "ALSO_GOOD": "2"}
+
+
+# ── write_env_atomic ───────────────────────────────────────────────────────
+
+
+def test_write_env_atomic_creates_new_file(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    write_env_atomic(f, {"FOO": "bar", "BAZ": "qux"})
+    assert parse_env_file(f) == {"FOO": "bar", "BAZ": "qux"}
+
+
+def test_write_env_atomic_preserves_unrelated_keys(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    f.write_text("UNRELATED=keep_me\nFOO=old\n# a comment\n")
+    write_env_atomic(f, {"FOO": "new", "ADDED": "yes"})
+    parsed = parse_env_file(f)
+    assert parsed["UNRELATED"] == "keep_me"
+    assert parsed["FOO"] == "new"
+    assert parsed["ADDED"] == "yes"
+    # Comment should still be present.
+    assert "# a comment" in f.read_text()
+
+
+def test_write_env_atomic_rewrites_existing_line_in_place(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    f.write_text("A=1\nFOO=old\nB=2\n")
+    write_env_atomic(f, {"FOO": "new"})
+    # FOO stays between A and B — line order preserved.
+    lines = [line for line in f.read_text().splitlines() if line and not line.startswith("#")]
+    assert lines == ["A=1", "FOO=new", "B=2"]
+
+
+# ── Settings env_file layering ─────────────────────────────────────────────
+
+
+def test_settings_env_file_tuple_layers_and_later_wins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """secrets.env provides defaults; .env overrides; process env beats both."""
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    dotenv = tmp_path / ".env"
+    secrets.write_text(
+        "AIOS_API_KEY=from_secrets\n"
+        "AIOS_VAULT_KEY=vk_secrets\n"
+        "AIOS_DB_URL=postgresql://secrets/db\n"
+    )
+    dotenv.write_text("AIOS_DB_URL=postgresql://dotenv/db\n")
+
+    # Clear any inherited aios vars so only the files + our explicit env
+    # participate in resolution.
+    for k in list(monkeypatch._setenv.keys() if hasattr(monkeypatch, "_setenv") else []):
+        monkeypatch.delenv(k, raising=False)
+    for k in (
+        "AIOS_API_KEY",
+        "AIOS_VAULT_KEY",
+        "AIOS_DB_URL",
+        "AIOS_INSTANCE_ID",
+        "AIOS_API_PORT",
+        "AIOS_WORKSPACE_ROOT",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+    s = Settings(_env_file=(str(secrets), str(dotenv)))  # type: ignore[call-arg]
+    assert s.api_key.get_secret_value() == "from_secrets"
+    assert s.vault_key.get_secret_value() == "vk_secrets"
+    # Later file overrides earlier.
+    assert s.db_url == "postgresql://dotenv/db"
+
+    # Process env beats both files.
+    monkeypatch.setenv("AIOS_DB_URL", "postgresql://env/db")
+    s2 = Settings(_env_file=(str(secrets), str(dotenv)))  # type: ignore[call-arg]
+    assert s2.db_url == "postgresql://env/db"
+
+
+def test_settings_instance_id_defaults_to_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Backwards compat: no AIOS_INSTANCE_ID in env → "default", not an error."""
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_API_KEY=k\nAIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.delenv("AIOS_INSTANCE_ID", raising=False)
+
+    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    assert s.instance_id == "default"
+
+
+def test_settings_instance_id_rejects_unsafe_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pattern validator rejects hand-edited .env that contains unsafe chars."""
+    from pydantic import ValidationError
+
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_API_KEY=k\nAIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.setenv("AIOS_INSTANCE_ID", "bad-dash")
+
+    with pytest.raises(ValidationError):
+        Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

- Scopes the sandbox orphan-reaper by a new \`aios.instance_id\` Docker label so concurrent aios deployments on one host stop killing each other's containers. Backwards-compatible: \`instance_id\` defaults to \`\"default\"\` and the pre-existing 939-test unit suite passes with no env changes.
- Adds an \`aios dev\` CLI group (\`bootstrap\`/\`teardown\`/\`status\`) that lets each git worktree run its own isolated aios against the shared local Postgres. Bootstrap creates \`aios_dev_<instance_id>\`, probes a free port, writes \`.env\`, and runs migrations in a hermetic subprocess.
- Layers \`Settings.env_file\` as \`(~/.aios/secrets.env, .env)\` so worktrees share API/vault/provider keys once but override DB/port/instance per-directory.

## Motivation

Today, \`aios api\` + \`aios worker\` in a second worktree collides with the main repo: shared DB (event log, procrastinate queue, \`LISTEN/NOTIFY\` channels), shared API port, and — most dangerously — worker B's startup reaper filters only on \`aios.managed=true\`, so it kills worker A's live sandbox containers. This made side-by-side worktree testing painful. This PR fixes the underlying reaper hazard independently of the ergonomic layer.

## Design

Two parts, each reviewable on its own:

**Part 1 — runtime correctness:** \`src/aios/config.py\` gains \`instance_id\` (default \`\"default\"\`, pattern-validated). \`src/aios/sandbox/provisioner.py\` stamps \`aios.instance_id=<id>\` on \`docker run\` and filters the reaper \`docker ps\` on both labels.

**Part 2 — \`aios dev\` ergonomics:** new \`src/aios/cli/commands/dev.py\`. Bootstrap derives a collision-free instance id by always appending an 8-char sha256 of the resolved repo path, guards every SQL-identifier site with a regex + 63-byte PG truncation check, and uses a hermetic subprocess env for \`aios migrate\` so stale shell exports can't misdirect. Teardown refuses when the API port is still live and does NOT auto-terminate DB backends — if \`DROP DATABASE\` refuses, it lists blocking PIDs and bails.

## One-time upgrade step

Containers created before this change carry only \`aios.managed=true\`. The new reaper filter won't match them, so they'll leak until removed manually. Before upgrading, run:

\`\`\`
docker ps --filter label=aios.managed=true -q | xargs docker rm -f
\`\`\`

## Test plan

- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 939 pre-existing + 29 new = 968 pass
- [ ] Two-worktree manual E2E: bootstrap each, confirm distinct ports, distinct DBs, containers labelled by instance; kill worker A and verify reaper doesn't touch worktree B's containers; teardown cleans up both without cross-effect
- [ ] Verify \`aios api\`/\`worker\` still works in the main repo against the existing \`aios\` DB with no env changes (backwards-compat regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)