### PR TITLE
fix(harness): bound every external await so the worker can't hang

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -16,6 +16,7 @@ prefix.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from functools import cache
 from typing import TYPE_CHECKING, Any
@@ -25,6 +26,14 @@ import litellm
 # Anthropic rejects empty text blocks that some OpenRouter models emit on
 # tool-call-only turns; modify_params tells LiteLLM to sanitize them.
 litellm.modify_params = True
+
+# Default per-call bounds. Kept here so they're visible at the wrapper boundary
+# rather than buried in defaults that drift between LiteLLM versions. Agents
+# can override either via ``litellm_extra``; the spread happens after these
+# defaults so user values win. The harness's job-level cap in ``run_session_step``
+# is the safety net if both are bypassed somehow.
+_REQUEST_TIMEOUT_S = 300.0
+_STREAM_INACTIVITY_TIMEOUT_S = 60.0
 
 if TYPE_CHECKING:
     import asyncpg
@@ -273,6 +282,7 @@ async def call_litellm(
     kwargs: dict[str, Any] = {
         "model": model,
         "messages": messages,
+        "timeout": _REQUEST_TIMEOUT_S,
     }
     if tools:
         kwargs["tools"] = tools
@@ -321,6 +331,8 @@ async def stream_litellm(
         "model": model,
         "messages": messages,
         "stream": True,
+        "timeout": _REQUEST_TIMEOUT_S,
+        "stream_timeout": _STREAM_INACTIVITY_TIMEOUT_S,
     }
     if tools:
         kwargs["tools"] = tools
@@ -331,8 +343,20 @@ async def stream_litellm(
 
     response = await litellm.acompletion(**kwargs)
 
+    # Per-chunk inactivity guard. The ``stream_timeout`` kwarg above is
+    # LiteLLM's own per-chunk bound, but its behavior varies by provider
+    # adapter. Wrapping each ``__anext__`` with our own ``wait_for`` makes
+    # the bound deterministic regardless of provider — a stalled connection
+    # raises ``TimeoutError`` after ``_STREAM_INACTIVITY_TIMEOUT_S`` rather
+    # than hanging the worker. (Required for the harness's zero-hang
+    # guarantee — see also ``run_session_step``'s job-level cap.)
     chunks: list[Any] = []
-    async for chunk in response:
+    aiter = response.__aiter__()
+    while True:
+        try:
+            chunk = await asyncio.wait_for(aiter.__anext__(), timeout=_STREAM_INACTIVITY_TIMEOUT_S)
+        except StopAsyncIteration:
+            break
         chunks.append(chunk)
         content = chunk.choices[0].delta.content
         if content:

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -21,6 +21,7 @@ and proceeds.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from aios.db.sse_lock import has_subscriber
@@ -45,6 +46,15 @@ log = get_logger("aios.harness.loop")
 
 
 _RETRY_BACKOFF_SECONDS: list[float] = [2, 8, 30, 120]
+
+# Wall-clock cap on a single ``run_session_step`` invocation. The harness's
+# zero-hang guarantee: per-call timeouts (LiteLLM, MCP, tool dispatch, etc.)
+# are the precise instruments, but if any future code path bypasses them
+# this cap fires and forces a clean rescheduling. Sized to fit the longest
+# legitimate single-turn use (300s = matches the ``_REQUEST_TIMEOUT_S`` in
+# ``completion.py`` so the model call alone can occupy almost the whole
+# budget).
+_JOB_TIMEOUT_S = 300.0
 
 
 def _retry_delay_for_attempt(attempt: int) -> float | None:
@@ -87,9 +97,19 @@ async def run_session_step(
     )
     retry_delay: float | None = None
     try:
-        retry_delay = await _run_session_step_body(
-            pool, task_registry, session_id, cause=cause, wake_reason=wake_reason
-        )
+        try:
+            retry_delay = await asyncio.wait_for(
+                _run_session_step_body(
+                    pool, task_registry, session_id, cause=cause, wake_reason=wake_reason
+                ),
+                timeout=_JOB_TIMEOUT_S,
+            )
+        except TimeoutError:
+            # Job-level safety net: a per-call timeout was missing or didn't
+            # fire. Force a reschedulable error state so the next wake can
+            # proceed (matches what the body's litellm-error handler does).
+            log.exception("step.job_timeout", session_id=session_id, timeout=_JOB_TIMEOUT_S)
+            retry_delay = await _handle_step_timeout(pool, session_id)
     finally:
         await sessions_service.append_event(
             pool,
@@ -641,8 +661,6 @@ async def discover_session_mcp_tools(
     omitted from the dict — the harness uses presence in the dict as
     the trigger for rendering a per-connector affordance block.
     """
-    import asyncio
-
     from aios.harness.channels import connection_server_name
     from aios.mcp.client import discover_mcp_tools, resolve_auth_for_url
 
@@ -731,6 +749,35 @@ async def _dispatch_confirmed_tools(
         tc for tc in asst_tool_calls if tc.get("id") in confirmed and tc.get("id") not in completed
     ]
     return pending
+
+
+async def _handle_step_timeout(pool: Any, session_id: str) -> float | None:
+    """Synthesize a reschedulable error state when the job-level cap fires.
+
+    Mirrors the rescheduling logic in the litellm-error handler so the
+    session ends each step in a clean status regardless of which path
+    surfaced the failure. Returns the retry delay (seconds) when the
+    backoff budget allows, ``None`` for a terminal failure.
+    """
+    await sessions_service.append_event(
+        pool,
+        session_id,
+        "span",
+        {"event": "step_timeout", "timeout_seconds": _JOB_TIMEOUT_S},
+    )
+    attempt = await _count_consecutive_rescheduling(pool, session_id)
+    delay = _retry_delay_for_attempt(attempt)
+    if delay is not None:
+        await sessions_service.set_session_status(
+            pool, session_id, "rescheduling", stop_reason={"type": "rescheduling"}
+        )
+        await _append_lifecycle(pool, session_id, "turn_ended", "rescheduling", "rescheduling")
+        return delay
+    await sessions_service.set_session_status(
+        pool, session_id, "idle", stop_reason={"type": "error"}
+    )
+    await _append_lifecycle(pool, session_id, "turn_ended", "idle", "error")
+    return None
 
 
 async def _count_consecutive_rescheduling(pool: Any, session_id: str) -> int:

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -14,6 +14,7 @@ as regular function-calling tools.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from contextlib import AsyncExitStack
 from typing import Any
@@ -33,6 +34,18 @@ log = get_logger("aios.mcp.client")
 
 MAX_TOOLS_PER_SERVER = 128
 
+# Per-call bound for ``session.call_tool``. The harness needs every external
+# await to have a finite ceiling so the worker can't hang on a misbehaving
+# MCP server. Mirrors the same intent as the LiteLLM call timeouts in
+# ``harness/completion.py``.
+_TOOL_CALL_TIMEOUT_S = 120.0
+
+# httpx client bounds for MCP transport. ``read`` is the longest leg —
+# tool calls that do real work (DB lookups, external APIs) commonly take
+# tens of seconds. Connect/write/pool are tight because they're network
+# fast paths.
+_MCP_HTTPX_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0)
+
 
 async def _open_session(
     url: str, headers: dict[str, str], stack: AsyncExitStack
@@ -42,7 +55,9 @@ async def _open_session(
     Returns the session along with the ``InitializeResult`` so callers can
     read server-supplied metadata (notably ``instructions``).
     """
-    http_client = await stack.enter_async_context(httpx.AsyncClient(headers=headers))
+    http_client = await stack.enter_async_context(
+        httpx.AsyncClient(headers=headers, timeout=_MCP_HTTPX_TIMEOUT)
+    )
     read_stream, write_stream, _ = await stack.enter_async_context(
         streamable_http_client(url, http_client=http_client)
     )
@@ -219,15 +234,24 @@ async def call_mcp_tool(
         if _pool is not None:
             try:
                 session, _ = await _pool.get_or_connect(url, headers)
-                result = await session.call_tool(tool_name, arguments, meta=meta)
+                result = await asyncio.wait_for(
+                    session.call_tool(tool_name, arguments, meta=meta),
+                    timeout=_TOOL_CALL_TIMEOUT_S,
+                )
             except Exception:
                 _pool.evict(url, headers)
                 session, _ = await _pool.get_or_connect(url, headers)
-                result = await session.call_tool(tool_name, arguments, meta=meta)
+                result = await asyncio.wait_for(
+                    session.call_tool(tool_name, arguments, meta=meta),
+                    timeout=_TOOL_CALL_TIMEOUT_S,
+                )
         else:
             async with AsyncExitStack() as stack:
                 session, _ = await _open_session(url, headers, stack)
-                result = await session.call_tool(tool_name, arguments, meta=meta)
+                result = await asyncio.wait_for(
+                    session.call_tool(tool_name, arguments, meta=meta),
+                    timeout=_TOOL_CALL_TIMEOUT_S,
+                )
 
         # Concatenate text content from the result.
         parts: list[str] = []

--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -33,6 +33,11 @@ from aios.logging import get_logger
 
 log = get_logger("aios.mcp.pool")
 
+# Mirrors the per-call bound used by :mod:`aios.mcp.client`. The pool's
+# pooled sessions share a connection-level timeout so a stalled MCP server
+# can't keep the worker on a dead socket indefinitely.
+_MCP_HTTPX_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0)
+
 type _PoolKey = tuple[str, str]
 
 
@@ -87,7 +92,9 @@ class McpSessionPool:
         stack: AsyncExitStack = AsyncExitStack()
         await stack.__aenter__()
         try:
-            http_client: Any = await stack.enter_async_context(httpx.AsyncClient(headers=headers))
+            http_client: Any = await stack.enter_async_context(
+                httpx.AsyncClient(headers=headers, timeout=_MCP_HTTPX_TIMEOUT)
+            )
             read_stream, write_stream, _ = await stack.enter_async_context(
                 streamable_http_client(url, http_client=http_client)
             )

--- a/tests/unit/test_completion_timeouts.py
+++ b/tests/unit/test_completion_timeouts.py
@@ -1,0 +1,175 @@
+"""Per-call timeout behavior for the LiteLLM wrappers.
+
+The harness's zero-hang guarantee depends on every external await having a
+finite ceiling.  ``stream_litellm`` is the most exposed call site: a server
+that silently stops sending chunks (laptop sleep, network blip, upstream
+provider stall) would, without per-chunk inactivity bounds, hang the
+worker for as long as the underlying HTTP layer holds the connection open.
+These tests confirm the wrapper raises ``TimeoutError`` instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from aios.harness import completion
+
+
+class _StallingResponse:
+    """Async iterator that yields one chunk then awaits forever.
+
+    Mimics a streaming model response that produced an initial token
+    burst and then stalled — the failure mode our timeout fixes.
+    """
+
+    def __init__(self) -> None:
+        self._first_yielded = False
+
+    def __aiter__(self) -> _StallingResponse:
+        return self
+
+    async def __anext__(self) -> object:
+        if not self._first_yielded:
+            self._first_yielded = True
+            return _make_chunk("hello")
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+
+def _make_chunk(text: str | None) -> object:
+    """Build the minimum shape ``stream_litellm`` reads off each chunk."""
+    from types import SimpleNamespace
+
+    delta = SimpleNamespace(content=text)
+    choice = SimpleNamespace(delta=delta)
+    return SimpleNamespace(choices=[choice])
+
+
+class _StubPool:
+    """``stream_litellm`` only uses the pool to ``pg_notify`` deltas.
+
+    A no-op pool keeps the chunk loop honest — every yielded chunk runs
+    through ``_notify_delta`` which pulls a connection.
+    """
+
+    def acquire(self) -> _StubPoolAcquire:
+        return _StubPoolAcquire()
+
+
+class _StubPoolAcquire:
+    async def __aenter__(self) -> _StubConnection:
+        return _StubConnection()
+
+    async def __aexit__(self, *args: object) -> None:
+        pass
+
+
+class _StubConnection:
+    async def execute(self, *args: object) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_stream_litellm_raises_timeout_on_stalled_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A streaming response that hangs after the first chunk must raise
+    ``TimeoutError`` once the per-chunk inactivity bound elapses."""
+    monkeypatch.setattr(completion, "_STREAM_INACTIVITY_TIMEOUT_S", 0.1)
+
+    async def fake_acompletion(**kwargs: object) -> _StallingResponse:
+        return _StallingResponse()
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+
+    with pytest.raises(TimeoutError):
+        await completion.stream_litellm(
+            model="anthropic/claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "ping"}],
+            pool=_StubPool(),  # type: ignore[arg-type]
+            session_id="sess_test",
+        )
+
+
+@pytest.mark.asyncio
+async def test_stream_litellm_passes_timeout_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defaults must reach ``litellm.acompletion``.  This is what bounds
+    the total request and the LiteLLM-side per-chunk inactivity."""
+    captured: dict[str, object] = {}
+
+    class _EmptyResponse:
+        def __aiter__(self) -> _EmptyResponse:
+            return self
+
+        async def __anext__(self) -> object:
+            raise StopAsyncIteration
+
+    async def fake_acompletion(**kwargs: object) -> _EmptyResponse:
+        captured.update(kwargs)
+        return _EmptyResponse()
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(
+        completion.litellm,
+        "stream_chunk_builder",
+        lambda chunks: {
+            "usage": {},
+            "choices": [{"message": {"role": "assistant", "content": ""}}],
+        },
+    )
+
+    await completion.stream_litellm(
+        model="anthropic/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "ping"}],
+        pool=_StubPool(),  # type: ignore[arg-type]
+        session_id="sess_test",
+    )
+
+    assert captured["timeout"] == completion._REQUEST_TIMEOUT_S
+    assert captured["stream_timeout"] == completion._STREAM_INACTIVITY_TIMEOUT_S
+
+
+@pytest.mark.asyncio
+async def test_extra_overrides_default_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents can override the default request timeout via ``litellm_extra``.
+
+    This is the documented path for legitimately long-running calls (e.g.
+    Opus 4.7 against 1M-context prompts) — the default protects all
+    sessions but motivated operators can raise the bound per-agent.
+    """
+    captured: dict[str, object] = {}
+
+    class _DictResponse(dict[str, object]):
+        """Subscriptable + ``.get`` like the real LiteLLM response dict.
+
+        ``_hidden_params`` is set in ``__init__`` so ``_extract_cost``
+        finds the empty mapping it expects — a bare dict raises
+        ``AttributeError`` on the lookup.
+        """
+
+        def __init__(self, **kwargs: object) -> None:
+            super().__init__(**kwargs)
+            self._hidden_params: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> _DictResponse:
+        captured.update(kwargs)
+        return _DictResponse(
+            choices=[{"message": {"role": "assistant", "content": ""}}],
+            usage={},
+        )
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+
+    await completion.call_litellm(
+        model="anthropic/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "ping"}],
+        extra={"timeout": 1234.0},
+    )
+
+    assert captured["timeout"] == 1234.0


### PR DESCRIPTION
## Summary

The harness had no defense against an external dependency stalling indefinitely. A laptop-sleep mid-LiteLLM-stream let one `run_session_step` invocation occupy the session lock for **2h41m** before the underlying TCP connection finally died upstream — twelve user messages stacked unprocessed, the agent appearing dead the entire time. Same shape applies to MCP calls and any future external I/O the worker grows.

This change adds defense in depth: per-call timeouts at every external await, plus a job-level safety net wrapping the whole step.

- **`completion.py`** — pass `timeout=300` (and `stream_timeout=60` on streaming) to `litellm.acompletion`. Wrap each streaming `__anext__` with `asyncio.wait_for` so the per-chunk inactivity bound is enforced regardless of LiteLLM provider-adapter behavior. Defaults placed before the `litellm_extra` spread so motivated operators (e.g. 1M-context Opus) can override per-agent.
- **`mcp/client.py`, `mcp/pool.py`** — `httpx.Timeout` on the MCP `AsyncClient` (10s connect, 120s read) and `asyncio.wait_for` around every `session.call_tool` invocation.
- **`harness/loop.py`** — wrap `_run_session_step_body` in `asyncio.wait_for(timeout=300)`. On timeout, synthesize the same reschedulable error state the litellm-error handler produces (a `step_timeout` span, a rescheduling lifecycle, and a normal retry backoff via `defer_retry_wake`). This is the cross-cutting backstop for any future call site that lacks its own bound.

Failure path is unchanged for downstream consumers: timeouts surface as `TimeoutError` → existing `except Exception` in the body catches them, or the new outer handler does → error span + reschedule via the existing backoff ladder.

## Values picked (locked with @eumemic before implementation)

| call site | bound |
|-----------|-------|
| Job-level cap (`run_session_step`) | 300s |
| Model request total | 300s |
| Model stream-chunk inactivity | 60s |
| MCP httpx (connect / read) | 10s / 120s |
| MCP `call_tool` per call | 120s |

`litellm_extra` overrides for model-call timeouts; MCP/job bounds are infra-internal.

## Investigation context

The 2h41m hang was diagnosed in #174's neighborhood (this is a separate root cause — `#174` was the OpenRouter `provider.order` issue). Span chronology that motivated the fix:

| start # | duration | err |
|---------|----------|-----|
| #2659 | 2014s (33m) | false |
| #2742 | 1729s (29m) | false |
| #2771 | 9672s (161m) | true |

Three back-to-back wildly abnormal calls before the final hang — pre-fix, "successful" but laptop-sleep-extended calls billed for the whole sleep window.

## Test plan

- [x] Run `tests/unit/test_completion_timeouts.py` — three new cases:
  - `test_stream_litellm_raises_timeout_on_stalled_stream` — yields one chunk then awaits forever, must raise `TimeoutError`.
  - `test_stream_litellm_passes_timeout_kwargs` — confirms defaults reach `litellm.acompletion`.
  - `test_extra_overrides_default_timeout` — confirms `litellm_extra` wins.
- [x] `uv run pytest tests/unit -q` — all 913 pass.
- [x] `uv run mypy src` — clean.
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean.
- [ ] Restart the dev worker and confirm normal traffic continues to flow (will do post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)