### PR TITLE
[codex] Make connections channel-only by default

### DIFF
--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -76,16 +76,14 @@ as focal-channel aware:
 
 ### 4. Register the aios connection
 
-The connection is the inbound channel account. `mcp_url` and `vault_id` are
-still required by the current API for legacy compatibility; normal MCP
-discovery comes from the agent config above.
+The connection is the inbound channel account. Normal MCP discovery comes from
+the agent config above; the vault is supplied through the routing rule's
+session params.
 
 ```
 CONN=$(curl -X POST :8090/v1/connections -d "{
   \"connector\": \"signal\",
-  \"account\": \"<bot-aci-uuid-from-step-1>\",
-  \"mcp_url\": \"http://localhost:9100/mcp\",
-  \"vault_id\": \"$VLT\"
+  \"account\": \"<bot-aci-uuid-from-step-1>\"
 }" | jq -r .id)
 ```
 

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -68,16 +68,14 @@ as focal-channel aware:
 
 ### 4. Register the aios connection
 
-The connection is the inbound channel account. `mcp_url` and `vault_id` are
-still required by the current API for legacy compatibility; normal MCP
-discovery comes from the agent config above.
+The connection is the inbound channel account. Normal MCP discovery comes from
+the agent config above; the vault is supplied through the routing rule's
+session params.
 
 ```
 CONN=$(curl -X POST :8090/v1/connections -d "{
   \"connector\": \"telegram\",
-  \"account\": \"<bot-numeric-id-from-step-1>\",
-  \"mcp_url\": \"http://localhost:9200/mcp\",
-  \"vault_id\": \"$VLT\"
+  \"account\": \"<bot-numeric-id-from-step-1>\"
 }" | jq -r .id)
 ```
 

--- a/migrations/versions/0025_channel_only_connections.py
+++ b/migrations/versions/0025_channel_only_connections.py
@@ -1,0 +1,30 @@
+"""Allow connections without legacy MCP projection fields.
+
+Connections are the inbound channel-account identity. ``mcp_url`` and
+``vault_id`` are optional compatibility fields for older connection-projected
+MCP setups; normal connector MCP servers are declared on agents.
+
+Revision ID: 0025
+Revises: 0024
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0025"
+down_revision: str = "0024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE connections ALTER COLUMN mcp_url DROP NOT NULL")
+    op.execute("ALTER TABLE connections ALTER COLUMN vault_id DROP NOT NULL")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE connections ALTER COLUMN vault_id SET NOT NULL")
+    op.execute("ALTER TABLE connections ALTER COLUMN mcp_url SET NOT NULL")

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -66,11 +66,13 @@ async def get(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Connection:
 async def update(
     connection_id: str, body: ConnectionUpdate, pool: PoolDep, _auth: AuthDep
 ) -> Connection:
+    from aios.db.queries import _UNSET
+
     return await service.update_connection(
         pool,
         connection_id,
-        mcp_url=body.mcp_url,
-        vault_id=body.vault_id,
+        mcp_url=body.mcp_url if "mcp_url" in body.model_fields_set else _UNSET,
+        vault_id=body.vault_id if "vault_id" in body.model_fields_set else _UNSET,
         metadata=body.metadata,
     )
 

--- a/src/aios/cli/commands/connections.py
+++ b/src/aios/cli/commands/connections.py
@@ -1,4 +1,4 @@
-"""``aios connections ...`` — connector-instance CRUD + inbound-message helper."""
+"""``aios connections ...`` — inbound account CRUD + message helper."""
 
 from __future__ import annotations
 
@@ -18,10 +18,10 @@ from aios.cli.files import PayloadError, load_json_object, load_payload, resolve
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import run_or_die
 
-app = typer.Typer(name="connections", help="Manage connector connections.", no_args_is_help=True)
+app = typer.Typer(name="connections", help="Manage inbound channel accounts.", no_args_is_help=True)
 
-_COLS = ("id", "connector", "account", "mcp_url", "updated_at")
-_MAXW = {"connector": 20, "account": 40, "mcp_url": 40}
+_COLS = ("id", "connector", "account", "updated_at")
+_MAXW = {"connector": 20, "account": 40}
 
 
 @app.command("list")
@@ -66,9 +66,11 @@ def create(
     account: Annotated[
         str | None, typer.Option("--account", help="Account identifier (e.g. bot uuid).")
     ] = None,
-    mcp_url: Annotated[str | None, typer.Option("--mcp-url", help="MCP server URL.")] = None,
+    mcp_url: Annotated[
+        str | None, typer.Option("--mcp-url", help="Legacy connection-projected MCP URL.")
+    ] = None,
     vault_id: Annotated[
-        str | None, typer.Option("--vault-id", help="Vault id with the MCP credential.")
+        str | None, typer.Option("--vault-id", help="Legacy MCP credential vault id.")
     ] = None,
     metadata_json: Annotated[
         str | None,
@@ -80,14 +82,12 @@ def create(
 ) -> None:
     def _run() -> int | None:
         ergonomic: dict[str, Any] | None = None
-        if any(v is not None for v in (connector, account, mcp_url, vault_id)):
+        if any(v is not None for v in (connector, account, mcp_url, vault_id, metadata_json)):
             missing = [
                 name
                 for name, v in (
                     ("--connector", connector),
                     ("--account", account),
-                    ("--mcp-url", mcp_url),
-                    ("--vault-id", vault_id),
                 )
                 if v is None
             ]
@@ -97,9 +97,11 @@ def create(
             ergonomic = {
                 "connector": connector,
                 "account": account,
-                "mcp_url": mcp_url,
-                "vault_id": vault_id,
             }
+            if mcp_url is not None:
+                ergonomic["mcp_url"] = mcp_url
+            if vault_id is not None:
+                ergonomic["vault_id"] = vault_id
             if metadata_json is not None:
                 try:
                     ergonomic["metadata"] = load_json_object(metadata_json, "--metadata-json")

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2030,8 +2030,8 @@ async def insert_connection(
     *,
     connector: str,
     account: str,
-    mcp_url: str,
-    vault_id: str,
+    mcp_url: str | None,
+    vault_id: str | None,
     metadata: dict[str, Any],
 ) -> Connection:
     new_id = make_id(CONNECTION)
@@ -2096,16 +2096,16 @@ async def update_connection(
     conn: asyncpg.Connection[Any],
     connection_id: str,
     *,
-    mcp_url: str | None = None,
-    vault_id: str | None = None,
+    mcp_url: str | None = _UNSET,
+    vault_id: str | None = _UNSET,
     metadata: dict[str, Any] | None = None,
 ) -> Connection:
     sets: list[str] = []
     args: list[Any] = [connection_id]
-    if mcp_url is not None:
+    if mcp_url is not _UNSET:
         args.append(mcp_url)
         sets.append(f"mcp_url = ${len(args)}")
-    if vault_id is not None:
+    if vault_id is not _UNSET:
         args.append(vault_id)
         sets.append(f"vault_id = ${len(args)}")
     if metadata is not None:

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -211,11 +211,11 @@ def build_connector_instructions_block(
 ) -> str:
     """Render per-connector affordance prose grouped by connection.
 
-    ``instructions_by_server`` maps server_name (which for connection-
-    provided MCP servers equals ``connection_server_name(c)``) to the
-    server's ``InitializeResult.instructions`` string.  Connections are
-    iterated in the caller-supplied order so the prompt is stable
-    across steps (cache friendly).
+    ``instructions_by_server`` maps server_name to the server's
+    ``InitializeResult.instructions`` string. For connection-scoped
+    rendering, discovery aliases the relevant MCP server instructions under
+    ``connection_server_name(c)``. Connections are iterated in the
+    caller-supplied order so the prompt is stable across steps.
 
     Connections without an entry in the dict are skipped — a connector
     that supplies no instructions contributes no block.

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -47,6 +47,15 @@ log = get_logger("aios.harness.loop")
 _RETRY_BACKOFF_SECONDS: list[float] = [2, 8, 30, 120]
 
 
+def _legacy_connection_mcp(c: Any) -> tuple[str, str] | None:
+    """Return legacy connection-projected MCP config when fully present."""
+    mcp_url = getattr(c, "mcp_url", None)
+    vault_id = getattr(c, "vault_id", None)
+    if isinstance(mcp_url, str) and mcp_url and isinstance(vault_id, str) and vault_id:
+        return mcp_url, vault_id
+    return None
+
+
 def _retry_delay_for_attempt(attempt: int) -> float | None:
     """Return the backoff delay for ``attempt``, or ``None`` if the budget is spent."""
     if attempt >= len(_RETRY_BACKOFF_SECONDS):
@@ -188,13 +197,17 @@ async def _run_session_step_body(
     legacy_connection_server_names: set[str] = set()
     connection_vault_by_server: dict[str, str] = {}
     for c in connections:
-        # Compatibility projection: inbound channel accounts can still expose
-        # their MCP server until agents declare those servers directly.
+        # Compatibility projection: only rows that still carry both legacy
+        # MCP fields expose a connection-scoped server.
+        legacy_mcp = _legacy_connection_mcp(c)
+        if legacy_mcp is None:
+            continue
+        mcp_url, vault_id = legacy_mcp
         name = connection_server_name(c)
-        if name not in agent_mcp_server_names and c.mcp_url not in agent_mcp_server_urls:
-            mcp_server_map[name] = c.mcp_url
+        if name not in agent_mcp_server_names and mcp_url not in agent_mcp_server_urls:
+            mcp_server_map[name] = mcp_url
             legacy_connection_server_names.add(name)
-            connection_vault_by_server[name] = c.vault_id
+            connection_vault_by_server[name] = vault_id
     channel_context_by_server = mcp_channel_context_by_server(
         agent.tools,
         connections,
@@ -545,7 +558,7 @@ def mcp_channel_context_by_server(
 
     New code gets this from normal agent ``mcp_toolset`` declarations. The
     optional ``connections`` argument is a compatibility projection for legacy
-    channel accounts that still carry an MCP URL.
+    channel accounts that still carry an MCP URL and vault id.
     """
     contexts: dict[str, str] = {}
     for spec in agent_tools:
@@ -564,8 +577,12 @@ def mcp_channel_context_by_server(
         agent_names = agent_mcp_server_names or set()
         agent_urls = agent_mcp_server_urls or set()
         for c in connections:
+            legacy_mcp = _legacy_connection_mcp(c)
+            if legacy_mcp is None:
+                continue
+            mcp_url, _vault_id = legacy_mcp
             name = connection_server_name(c)
-            if name not in agent_names and c.mcp_url not in agent_urls:
+            if name not in agent_names and mcp_url not in agent_urls:
                 contexts.setdefault(name, "focal")
     return contexts
 
@@ -704,8 +721,8 @@ async def discover_session_mcp_tools(
     the trigger for rendering a per-connector affordance block.
 
     ``connections`` is retained as a compatibility projection for legacy
-    channel accounts that still carry MCP URLs. New integrations should
-    declare MCP servers on the agent and credentials in session vaults.
+    channel accounts that still carry MCP URL/vault pairs. New integrations
+    should declare MCP servers on the agent and credentials in session vaults.
     If a connection's URL is already declared on the agent, the normal
     agent server owns discovery and the connection projection is skipped.
     """
@@ -717,9 +734,12 @@ async def discover_session_mcp_tools(
     servers: list[tuple[str, str, str | None]] = []
 
     enabled_server_names: set[str] = set()
+    focal_server_names: set[str] = set()
     for spec in agent.tools:
         if spec.type == "mcp_toolset" and spec.enabled and spec.mcp_server_name:
             enabled_server_names.add(spec.mcp_server_name)
+            if spec.channel_context is not None and spec.channel_context.type == "focal":
+                focal_server_names.add(spec.mcp_server_name)
     agent_server_names = {s.name for s in agent.mcp_servers}
     agent_server_urls = {s.url for s in agent.mcp_servers}
     enabled_agent_server_by_url: dict[str, str] = {}
@@ -731,14 +751,20 @@ async def discover_session_mcp_tools(
     instruction_aliases: dict[str, str] = {}
     for c in connections:
         name = connection_server_name(c)
+        legacy_mcp = _legacy_connection_mcp(c)
+        if legacy_mcp is None:
+            if c.connector in focal_server_names:
+                instruction_aliases[name] = c.connector
+            continue
+        mcp_url, vault_id = legacy_mcp
         if name in agent_server_names:
             continue
-        if c.mcp_url in agent_server_urls:
-            if source_name := enabled_agent_server_by_url.get(c.mcp_url):
+        if mcp_url in agent_server_urls:
+            if source_name := enabled_agent_server_by_url.get(mcp_url):
                 instruction_aliases[name] = source_name
             continue
         else:
-            servers.append((name, c.mcp_url, c.vault_id))
+            servers.append((name, mcp_url, vault_id))
 
     if not servers:
         return [], {}

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -8,10 +8,10 @@ inbound channel router. The address scheme used by the routing layer is::
 where ``path`` is whatever sub-segments the connector emits for inbound
 messages (typically a chat or thread id).
 
-``mcp_url`` / ``vault_id`` remain on the resource as a compatibility
-projection for older connector setups. New channel-aware MCP integrations
-should declare normal agent ``mcp_servers`` and use session vaults for
-credentials.
+``mcp_url`` / ``vault_id`` are optional compatibility fields for older
+connector setups that projected MCP tools from connections. New
+channel-aware MCP integrations should leave them unset, declare normal
+agent ``mcp_servers``, and use session vaults for credentials.
 """
 
 from __future__ import annotations
@@ -19,7 +19,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Legacy prefix for MCP server names projected from connection rows. New
 # channel-aware MCP integrations should use normal agent ``mcp_servers`` plus
@@ -40,8 +40,8 @@ class ConnectionCreate(BaseModel):
 
     connector: str = Field(min_length=1, max_length=64)
     account: str = Field(min_length=1, max_length=256)
-    mcp_url: str = Field(min_length=1)
-    vault_id: str
+    mcp_url: str | None = Field(default=None, min_length=1)
+    vault_id: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("connector", "account")
@@ -51,11 +51,18 @@ class ConnectionCreate(BaseModel):
             raise ValueError("must not contain '/'")
         return v
 
+    @model_validator(mode="after")
+    def _legacy_mcp_pair(self) -> ConnectionCreate:
+        if (self.mcp_url is None) != (self.vault_id is None):
+            raise ValueError("mcp_url and vault_id must be provided together")
+        return self
+
 
 class ConnectionUpdate(BaseModel):
     """Request body for ``PUT /v1/connections/{id}``.
 
-    ``connector`` and ``account`` are immutable after creation.
+    ``connector`` and ``account`` are immutable after creation. Explicit
+    ``null`` for a legacy MCP field clears it; omitting the field preserves it.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -71,8 +78,8 @@ class Connection(BaseModel):
     id: str
     connector: str
     account: str
-    mcp_url: str
-    vault_id: str
+    mcp_url: str | None = None
+    vault_id: str | None = None
     metadata: dict[str, Any]
     created_at: datetime
     updated_at: datetime

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -4,8 +4,8 @@ Thin wrapper over :mod:`aios.db.queries`. The only business rule lives
 in :func:`archive_connection`, which refuses to archive a connection
 while channel bindings under its ``(connector, account)`` prefix are
 still active. Connection rows remain the source of inbound channel identity,
-so archiving one while bound channels are live would break routing and the
-legacy MCP projection for those sessions.
+so archiving one while bound channels are live would break routing for those
+sessions.
 """
 
 from __future__ import annotations
@@ -24,8 +24,8 @@ async def create_connection(
     *,
     connector: str,
     account: str,
-    mcp_url: str,
-    vault_id: str,
+    mcp_url: str | None = None,
+    vault_id: str | None = None,
     metadata: dict[str, Any],
 ) -> Connection:
     async with pool.acquire() as conn:
@@ -55,8 +55,8 @@ async def update_connection(
     pool: asyncpg.Pool[Any],
     connection_id: str,
     *,
-    mcp_url: str | None = None,
-    vault_id: str | None = None,
+    mcp_url: str | None = queries._UNSET,
+    vault_id: str | None = queries._UNSET,
     metadata: dict[str, Any] | None = None,
 ) -> Connection:
     async with pool.acquire() as conn:
@@ -81,7 +81,7 @@ async def archive_connection(pool: asyncpg.Pool[Any], connection_id: str) -> Con
                 f"connection {connection_id} has {active} active channel binding"
                 f"{'s' if active != 1 else ''} under {connection.connector}/"
                 f"{connection.account}; archive the bindings first to avoid "
-                f"silently dropping MCP tools from live sessions",
+                f"breaking routing for live sessions",
                 detail={
                     "id": connection_id,
                     "active_bindings": active,

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -93,6 +93,27 @@ async def connection(pool: Any, vault_id: str) -> Any:
 
 
 class TestConnectionCRUD:
+    async def test_create_channel_only_connection(self, pool: Any) -> None:
+        from aios.services import connections as svc
+
+        c = await svc.create_connection(
+            pool,
+            connector="signal",
+            account=f"channel-only-{_uniq()}",
+            metadata={"region": "us"},
+        )
+        assert c.id.startswith("conn_")
+        assert c.connector == "signal"
+        assert c.mcp_url is None
+        assert c.vault_id is None
+        assert c.metadata == {"region": "us"}
+        assert c.archived_at is None
+
+        fetched = await svc.get_connection(pool, c.id)
+        assert fetched.id == c.id
+        assert fetched.mcp_url is None
+        assert fetched.vault_id is None
+
     async def test_create_and_get(self, pool: Any, vault_id: str) -> None:
         from aios.services import connections as svc
 
@@ -147,6 +168,21 @@ class TestConnectionCRUD:
         )
         updated = await svc.update_connection(pool, c.id, mcp_url="https://new")
         assert updated.mcp_url == "https://new"
+
+    async def test_clear_legacy_mcp_fields(self, pool: Any, vault_id: str) -> None:
+        from aios.services import connections as svc
+
+        c = await svc.create_connection(
+            pool,
+            connector="signal",
+            account=f"clear-{_uniq()}",
+            mcp_url="https://old",
+            vault_id=vault_id,
+            metadata={},
+        )
+        updated = await svc.update_connection(pool, c.id, mcp_url=None, vault_id=None)
+        assert updated.mcp_url is None
+        assert updated.vault_id is None
 
     async def test_archive(self, pool: Any, vault_id: str) -> None:
         from aios.services import connections as svc
@@ -784,15 +820,13 @@ async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[http
 
 class TestNestedRoutingRulesEndpoint:
     async def test_create_and_get_nested(
-        self, http_client: httpx.AsyncClient, agent_id: str, env_id: str, vault_id: str
+        self, http_client: httpx.AsyncClient, agent_id: str, env_id: str
     ) -> None:
         r = await http_client.post(
             "/v1/connections",
             json={
                 "connector": "signal",
                 "account": f"nested-{_uniq()}",
-                "mcp_url": "https://m",
-                "vault_id": vault_id,
             },
         )
         assert r.status_code == 201, r.text
@@ -864,7 +898,7 @@ class TestInboundEndpoint:
         http_client: httpx.AsyncClient,
         agent_id: str,
         env_id: str,
-        vault_id: str,
+        _vault_id: str,
     ) -> tuple[str, str]:
         """Create a connection + catch-all rule.  Returns (connection_id, account)."""
         account = f"http-{_uniq()}"
@@ -873,8 +907,6 @@ class TestInboundEndpoint:
             json={
                 "connector": "signal",
                 "account": account,
-                "mcp_url": "https://m",
-                "vault_id": vault_id,
             },
         )
         assert r.status_code == 201, r.text
@@ -935,9 +967,7 @@ class TestInboundEndpoint:
         )
         assert r.status_code == 404
 
-    async def test_no_route_returns_404(
-        self, http_client: httpx.AsyncClient, vault_id: str
-    ) -> None:
+    async def test_no_route_returns_404(self, http_client: httpx.AsyncClient) -> None:
         """Connection exists but no rule matches the resulting path."""
         account = f"unrouted-{_uniq()}"
         r = await http_client.post(
@@ -945,8 +975,6 @@ class TestInboundEndpoint:
             json={
                 "connector": "signal",
                 "account": account,
-                "mcp_url": "https://m",
-                "vault_id": vault_id,
             },
         )
         connection_id = r.json()["id"]

--- a/tests/unit/cli/test_cli_connections.py
+++ b/tests/unit/cli/test_cli_connections.py
@@ -33,6 +33,28 @@ def test_create_ergonomic(mocked_cli):
             "signal",
             "--account",
             "acct-123",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert mocked_cli.captured.method == "POST"
+    assert mocked_cli.captured.path == "/v1/connections"
+    assert mocked_cli.captured.body == {
+        "connector": "signal",
+        "account": "acct-123",
+    }
+
+
+def test_create_ergonomic_with_legacy_mcp_projection(mocked_cli):
+    mocked_cli.queue_response(httpx.Response(201, json={"id": "conn_new"}))
+    result = runner.invoke(
+        app,
+        [
+            "connections",
+            "create",
+            "--connector",
+            "signal",
+            "--account",
+            "acct-123",
             "--mcp-url",
             "http://mcp.example:9000",
             "--vault-id",
@@ -61,10 +83,6 @@ def test_create_ergonomic_with_metadata_json(mocked_cli):
             "signal",
             "--account",
             "acct-123",
-            "--mcp-url",
-            "http://mcp/",
-            "--vault-id",
-            "vlt_1",
             "--metadata-json",
             '{"region": "us-east"}',
         ],
@@ -92,10 +110,6 @@ def test_create_rejects_mixed_sources(mocked_cli):
             "signal",
             "--account",
             "acct-1",
-            "--mcp-url",
-            "http://mcp/",
-            "--vault-id",
-            "vlt_1",
             "--data",
             "{}",
         ],

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -43,6 +43,20 @@ def _connection(cid: str, url: str) -> Connection:
     )
 
 
+def _channel_only_connection(cid: str, connector: str = "signal") -> Connection:
+    now = datetime(2026, 4, 16)
+    return Connection(
+        id=cid,
+        connector=connector,
+        account="acct",
+        mcp_url=None,
+        vault_id=None,
+        metadata={},
+        created_at=now,
+        updated_at=now,
+    )
+
+
 def _agent(
     mcp_servers: list[McpServerSpec] | None = None,
     tools: list[ToolSpec] | None = None,
@@ -135,6 +149,25 @@ class TestDiscoverSessionMcpTools:
             "mcp__conn_01HQR2K7VXBZ9MNPL3WYCT8G__t",
         }
 
+    async def test_channel_only_connections_do_not_project_mcp(self) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", new_callable=AsyncMock) as discover,
+        ):
+            tools, instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=_agent(),
+                connections=[_channel_only_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")],
+            )
+
+        assert tools == []
+        assert instructions == {}
+        resolve.assert_not_called()
+        discover.assert_not_called()
+
     async def test_agent_and_connections_combined(self) -> None:
         from aios.harness.loop import discover_session_mcp_tools
 
@@ -205,6 +238,48 @@ class TestDiscoverSessionMcpTools:
             )
 
         assert seen == [("https://m1", None)]
+        assert tools == [{"name": "mcp__signal__t", "url": "https://m1"}]
+        assert instructions == {
+            "signal": "send via focal",
+            "conn_01HQR2K7VXBZ9MNPL3WYCT8F": "send via focal",
+        }
+
+    async def test_channel_only_connection_aliases_matching_focal_server_instructions(
+        self,
+    ) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+        from aios.models.agents import McpChannelContext
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="signal", url="https://m1")],
+            tools=[
+                ToolSpec(
+                    type="mcp_toolset",
+                    enabled=True,
+                    mcp_server_name="signal",
+                    channel_context=McpChannelContext(type="focal"),
+                )
+            ],
+        )
+        connections = [_channel_only_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")]
+
+        async def _discover(
+            url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [{"name": f"mcp__{name}__t", "url": url}], "send via focal"
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            tools, instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+                connections=connections,
+            )
+
         assert tools == [{"name": "mcp__signal__t", "url": "https://m1"}]
         assert instructions == {
             "signal": "send via focal",

--- a/tests/unit/test_mcp_routing.py
+++ b/tests/unit/test_mcp_routing.py
@@ -265,3 +265,19 @@ class TestHideFocalChannelToolsWhenPhoneDown:
             agent_mcp_server_urls={"https://m1"},
         )
         assert contexts == {"signal": "focal"}
+
+    def test_channel_only_connection_does_not_add_legacy_context(self) -> None:
+        now = datetime(2026, 4, 16)
+        connection = Connection(
+            id="conn_01HQR2K7VXBZ9MNPL3WYCT8F",
+            connector="signal",
+            account="acct",
+            mcp_url=None,
+            vault_id=None,
+            metadata={},
+            created_at=now,
+            updated_at=now,
+        )
+
+        contexts = mcp_channel_context_by_server([], [connection])
+        assert contexts == {}

--- a/tests/unit/test_routing_models.py
+++ b/tests/unit/test_routing_models.py
@@ -16,6 +16,13 @@ from aios.models.routing_rules import (
 
 class TestConnectionCreate:
     def test_valid(self) -> None:
+        c = ConnectionCreate(connector="signal", account="alice")
+        assert c.connector == "signal"
+        assert c.mcp_url is None
+        assert c.vault_id is None
+        assert c.metadata == {}
+
+    def test_valid_with_legacy_mcp_projection(self) -> None:
         c = ConnectionCreate(
             connector="signal",
             account="alice",
@@ -25,12 +32,21 @@ class TestConnectionCreate:
         assert c.connector == "signal"
         assert c.metadata == {}
 
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"mcp_url": "https://mcp.example.com"},
+            {"vault_id": "vlt_abc"},
+        ],
+    )
+    def test_legacy_mcp_fields_are_a_pair(self, kwargs: dict[str, str]) -> None:
+        with pytest.raises(ValidationError, match="mcp_url and vault_id"):
+            ConnectionCreate(connector="signal", account="alice", **kwargs)
+
     def test_with_metadata(self) -> None:
         c = ConnectionCreate(
             connector="signal",
             account="alice",
-            mcp_url="https://mcp.example.com",
-            vault_id="vlt_abc",
             metadata={"source": "manual"},
         )
         assert c.metadata == {"source": "manual"}
@@ -40,19 +56,12 @@ class TestConnectionCreate:
             ConnectionCreate(
                 connector="signal",
                 account="alice",
-                mcp_url="https://m",
-                vault_id="vlt_abc",
                 bogus="x",  # type: ignore[call-arg]
             )
 
     def test_rejects_empty_connector(self) -> None:
         with pytest.raises(ValidationError):
-            ConnectionCreate(
-                connector="",
-                account="alice",
-                mcp_url="https://m",
-                vault_id="vlt_abc",
-            )
+            ConnectionCreate(connector="", account="alice")
 
     @pytest.mark.parametrize(
         ("field", "value"),
@@ -62,8 +71,6 @@ class TestConnectionCreate:
         kwargs: dict[str, str] = {
             "connector": "signal",
             "account": "alice",
-            "mcp_url": "https://m",
-            "vault_id": "vlt_abc",
         }
         kwargs[field] = value
         with pytest.raises(ValidationError, match="must not contain '/'"):


### PR DESCRIPTION
## Summary

- Make `connections.mcp_url` and `connections.vault_id` nullable legacy compatibility fields.
- Allow creating connections with only `connector` + `account` (+ metadata), and update the CLI/docs to make that the default setup.
- Keep legacy connection-projected MCP only when both legacy fields are present.
- Alias matching focal MCP server instructions back to channel-only connections, so `signal`/`telegram` agent MCP servers still contribute connector affordance prose.

## Validation

- `uv run pytest tests/unit -q`
- `uv run pytest tests/e2e/test_routing.py -q`
- `uv run pytest tests/e2e/test_focal_channel.py::TestMcpMetaInjection -q`
- `uv run pytest tests/integration/test_migrations.py::test_migration_creates_all_tables -q`
- `uv run mypy src`
- `uv run ruff check src tests connectors/signal/src/aios_signal/mcp.py connectors/telegram/src/aios_telegram/mcp.py migrations/versions/0025_channel_only_connections.py`
- `uv run ruff format --check src tests connectors/signal/src/aios_signal/mcp.py connectors/telegram/src/aios_telegram/mcp.py migrations/versions/0025_channel_only_connections.py`

Stacked on #175 / `codex/channel-aware-mcp`.