### PR TITLE
[codex] Use only agent MCP servers at runtime

### DIFF
--- a/src/aios/cli/commands/connections.py
+++ b/src/aios/cli/commands/connections.py
@@ -67,7 +67,8 @@ def create(
         str | None, typer.Option("--account", help="Account identifier (e.g. bot uuid).")
     ] = None,
     mcp_url: Annotated[
-        str | None, typer.Option("--mcp-url", help="Legacy connection-projected MCP URL.")
+        str | None,
+        typer.Option("--mcp-url", help="Legacy MCP URL field; not used for runtime discovery."),
     ] = None,
     vault_id: Annotated[
         str | None, typer.Option("--vault-id", help="Legacy MCP credential vault id.")

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2201,7 +2201,7 @@ async def count_active_bindings_for_connection(
     """Count active channel bindings owned by this connection.  Used to
     block connection archival while sessions are still reachable via
     those bindings — archiving the connection would break inbound routing
-    and the legacy MCP projection for any live session.
+    for any live session.
     """
     val: int = await conn.fetchval(
         "SELECT COUNT(*) FROM channel_bindings WHERE connection_id = $1 AND archived_at IS NULL",

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -52,8 +52,7 @@ def focal_channel_path(focal: str | None) -> str | None:
 
 
 def connection_server_name(c: Connection) -> str:
-    # Legacy compatibility projection: connection rows can still be surfaced
-    # as MCP servers while integrations migrate to agent-declared MCP servers.
+    # Stable key for rendering connector instructions per bound connection.
     assert c.id.startswith(CONNECTION_SERVER_NAME_PREFIX)
     return c.id
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -47,15 +47,6 @@ log = get_logger("aios.harness.loop")
 _RETRY_BACKOFF_SECONDS: list[float] = [2, 8, 30, 120]
 
 
-def _legacy_connection_mcp(c: Any) -> tuple[str, str] | None:
-    """Return legacy connection-projected MCP config when fully present."""
-    mcp_url = getattr(c, "mcp_url", None)
-    vault_id = getattr(c, "vault_id", None)
-    if isinstance(mcp_url, str) and mcp_url and isinstance(vault_id, str) and vault_id:
-        return mcp_url, vault_id
-    return None
-
-
 def _retry_delay_for_attempt(attempt: int) -> float | None:
     """Return the backoff delay for ``attempt``, or ``None`` if the budget is spent."""
     if attempt >= len(_RETRY_BACKOFF_SECONDS):
@@ -187,33 +178,12 @@ async def _run_session_step_body(
     else:
         agent = await agents_service.get_agent(pool, session.agent_id)
 
-    from aios.harness.channels import connection_server_name, list_bindings_and_connections
+    from aios.harness.channels import list_bindings_and_connections
 
     bindings, connections = await list_bindings_and_connections(pool, session_id)
 
     mcp_server_map: dict[str, str] = {s.name: s.url for s in agent.mcp_servers}
-    agent_mcp_server_names = set(mcp_server_map)
-    agent_mcp_server_urls = set(mcp_server_map.values())
-    legacy_connection_server_names: set[str] = set()
-    connection_vault_by_server: dict[str, str] = {}
-    for c in connections:
-        # Compatibility projection: only rows that still carry both legacy
-        # MCP fields expose a connection-scoped server.
-        legacy_mcp = _legacy_connection_mcp(c)
-        if legacy_mcp is None:
-            continue
-        mcp_url, vault_id = legacy_mcp
-        name = connection_server_name(c)
-        if name not in agent_mcp_server_names and mcp_url not in agent_mcp_server_urls:
-            mcp_server_map[name] = mcp_url
-            legacy_connection_server_names.add(name)
-            connection_vault_by_server[name] = vault_id
-    channel_context_by_server = mcp_channel_context_by_server(
-        agent.tools,
-        connections,
-        agent_mcp_server_names=agent_mcp_server_names,
-        agent_mcp_server_urls=agent_mcp_server_urls,
-    )
+    channel_context_by_server = mcp_channel_context_by_server(agent.tools)
 
     # Read windowed message events for this session.
     events = await sessions_service.read_windowed_events(
@@ -239,7 +209,6 @@ async def _run_session_step_body(
                 pending_mcp,
                 mcp_server_map,
                 channel_context_by_server=channel_context_by_server,
-                connection_vault_by_server=connection_vault_by_server,
                 focal_channel=session.focal_channel,
             )
         log.info(
@@ -440,11 +409,7 @@ async def _run_session_step_body(
             name = _tc_name(tc)
             if _is_mcp_tool(name):
                 # MCP tools default to always_ask (unlike built-in always_allow).
-                perm = resolve_mcp_permission(
-                    name,
-                    agent.tools,
-                    always_allow_server_names=legacy_connection_server_names,
-                )
+                perm = resolve_mcp_permission(name, agent.tools)
                 if perm == "always_allow":
                     mcp_immediate.append(tc)
                 else:
@@ -472,7 +437,6 @@ async def _run_session_step_body(
                 mcp_immediate,
                 mcp_server_map,
                 channel_context_by_server=channel_context_by_server,
-                connection_vault_by_server=connection_vault_by_server,
                 focal_channel=session.focal_channel,
             )
             log.info(
@@ -549,16 +513,11 @@ def _mcp_server_name_from_tool_name(name: str) -> str | None:
 
 def mcp_channel_context_by_server(
     agent_tools: list[ToolSpec],
-    connections: list[Any] | None = None,
-    *,
-    agent_mcp_server_names: set[str] | None = None,
-    agent_mcp_server_urls: set[str] | None = None,
 ) -> dict[str, str]:
     """Return server_name -> channel context type for MCP toolsets.
 
-    New code gets this from normal agent ``mcp_toolset`` declarations. The
-    optional ``connections`` argument is a compatibility projection for legacy
-    channel accounts that still carry an MCP URL and vault id.
+    Channel-aware MCP behavior is declared on normal agent ``mcp_toolset``
+    entries; connections do not contribute MCP server context.
     """
     contexts: dict[str, str] = {}
     for spec in agent_tools:
@@ -570,20 +529,6 @@ def mcp_channel_context_by_server(
         ):
             continue
         contexts[spec.mcp_server_name] = spec.channel_context.type
-
-    if connections:
-        from aios.harness.channels import connection_server_name
-
-        agent_names = agent_mcp_server_names or set()
-        agent_urls = agent_mcp_server_urls or set()
-        for c in connections:
-            legacy_mcp = _legacy_connection_mcp(c)
-            if legacy_mcp is None:
-                continue
-            mcp_url, _vault_id = legacy_mcp
-            name = connection_server_name(c)
-            if name not in agent_names and mcp_url not in agent_urls:
-                contexts.setdefault(name, "focal")
     return contexts
 
 
@@ -673,8 +618,6 @@ def resolve_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
 def resolve_mcp_permission(
     name: str,
     agent_tools: list[ToolSpec],
-    *,
-    always_allow_server_names: set[str] | None = None,
 ) -> str | None:
     """Look up the permission policy for an MCP tool.
 
@@ -683,11 +626,8 @@ def resolve_mcp_permission(
     tool name, then returns the ``default_config.permission_policy.type``
     or ``None`` (which callers treat as ``always_ask``).
 
-    ``always_allow_server_names`` is a compatibility hook for legacy
-    connection-projected MCP servers. New channel-aware MCP should express
-    this on the agent's normal ``mcp_toolset`` config. Focal-channel MCP
-    toolsets default to ``always_allow`` because declaring channel context is
-    already the operator's trust decision for that server.
+    Focal-channel MCP toolsets default to ``always_allow`` because declaring
+    channel context is already the operator's trust decision for that server.
     """
     server_name = name.split("__", 2)[1]
     for spec in agent_tools:
@@ -700,8 +640,6 @@ def resolve_mcp_permission(
             if spec.channel_context is not None and spec.channel_context.type == "focal":
                 return "always_allow"
             return None
-    if always_allow_server_names and server_name in always_allow_server_names:
-        return "always_allow"
     return None
 
 
@@ -720,18 +658,16 @@ async def discover_session_mcp_tools(
     omitted from the dict — the harness uses presence in the dict as
     the trigger for rendering a per-connector affordance block.
 
-    ``connections`` is retained as a compatibility projection for legacy
-    channel accounts that still carry MCP URL/vault pairs. New integrations
-    should declare MCP servers on the agent and credentials in session vaults.
-    If a connection's URL is already declared on the agent, the normal
-    agent server owns discovery and the connection projection is skipped.
+    ``connections`` is used only to alias connector-specific MCP
+    ``instructions`` back to bound channel accounts for prompt rendering.
+    Connections do not contribute MCP servers or credentials.
     """
     import asyncio
 
     from aios.harness.channels import connection_server_name
     from aios.mcp.client import discover_mcp_tools, resolve_auth_for_url
 
-    servers: list[tuple[str, str, str | None]] = []
+    servers: list[tuple[str, str]] = []
 
     enabled_server_names: set[str] = set()
     focal_server_names: set[str] = set()
@@ -740,56 +676,37 @@ async def discover_session_mcp_tools(
             enabled_server_names.add(spec.mcp_server_name)
             if spec.channel_context is not None and spec.channel_context.type == "focal":
                 focal_server_names.add(spec.mcp_server_name)
-    agent_server_names = {s.name for s in agent.mcp_servers}
-    agent_server_urls = {s.url for s in agent.mcp_servers}
-    enabled_agent_server_by_url: dict[str, str] = {}
     for s in agent.mcp_servers:
         if s.name in enabled_server_names:
-            servers.append((s.name, s.url, None))
-            enabled_agent_server_by_url.setdefault(s.url, s.name)
+            servers.append((s.name, s.url))
 
     instruction_aliases: dict[str, str] = {}
     for c in connections:
         name = connection_server_name(c)
-        legacy_mcp = _legacy_connection_mcp(c)
-        if legacy_mcp is None:
-            if c.connector in focal_server_names:
-                instruction_aliases[name] = c.connector
-            continue
-        mcp_url, vault_id = legacy_mcp
-        if name in agent_server_names:
-            continue
-        if mcp_url in agent_server_urls:
-            if source_name := enabled_agent_server_by_url.get(mcp_url):
-                instruction_aliases[name] = source_name
-            continue
-        else:
-            servers.append((name, mcp_url, vault_id))
+        if c.connector in focal_server_names:
+            instruction_aliases[name] = c.connector
 
     if not servers:
         return [], {}
 
     crypto_box = runtime.require_crypto_box()
 
-    async def _discover_one(
-        name: str, url: str, connection_vault_id: str | None
-    ) -> tuple[list[dict[str, Any]], str | None]:
+    async def _discover_one(name: str, url: str) -> tuple[list[dict[str, Any]], str | None]:
         headers = await resolve_auth_for_url(
             pool,
             crypto_box,
             session_id,
             url,
-            connection_vault_id=connection_vault_id,
         )
         return await discover_mcp_tools(url, name, headers)
 
-    results = await asyncio.gather(*[_discover_one(n, u, v) for n, u, v in servers])
+    results = await asyncio.gather(*[_discover_one(n, u) for n, u in servers])
     tools: list[dict[str, Any]] = [
         tool for (tool_list, _instructions) in results for tool in tool_list
     ]
     instructions_by_server: dict[str, str] = {
         name: instructions
-        for (name, _url, _vault_id), (_tools, instructions) in zip(servers, results, strict=True)
+        for (name, _url), (_tools, instructions) in zip(servers, results, strict=True)
         if instructions
     }
     for alias_name, source_name in instruction_aliases.items():

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -97,12 +97,7 @@ async def compose_step_context(
         )
         # Hide focal-channel MCP tools when focal is NULL — can't type
         # into a chat you aren't attending to.
-        channel_context_by_server = mcp_channel_context_by_server(
-            agent.tools,
-            connections,
-            agent_mcp_server_names={s.name for s in agent.mcp_servers},
-            agent_mcp_server_urls={s.url for s in agent.mcp_servers},
-        )
+        channel_context_by_server = mcp_channel_context_by_server(agent.tools)
         mcp_tools = _hide_focal_channel_tools_when_phone_down(
             mcp_tools, session.focal_channel, channel_context_by_server
         )

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -314,7 +314,6 @@ def launch_mcp_tool_calls(
     mcp_server_map: dict[str, str],
     *,
     channel_context_by_server: dict[str, str] | None = None,
-    connection_vault_by_server: dict[str, str] | None = None,
     focal_channel: str | None = None,
 ) -> None:
     """Launch MCP tool calls as asyncio tasks. Returns immediately.
@@ -334,7 +333,6 @@ def launch_mcp_tool_calls(
             call,
             mcp_server_map,
             channel_context_by_server=channel_context_by_server,
-            connection_vault_by_server=connection_vault_by_server,
             focal_channel=focal_channel,
         ),
         prefix="mcp_tool",
@@ -359,7 +357,6 @@ async def _execute_mcp_tool_async(
     mcp_server_map: dict[str, str],
     *,
     channel_context_by_server: dict[str, str] | None = None,
-    connection_vault_by_server: dict[str, str] | None = None,
     focal_channel: str | None = None,
 ) -> None:
     """Execute one MCP tool call: connect, invoke, append result, defer wake.
@@ -441,7 +438,6 @@ async def _execute_mcp_tool_async(
             crypto_box,
             session_id,
             url,
-            connection_vault_id=(connection_vault_by_server or {}).get(server_name),
         )
         result = await call_mcp_tool(url, headers, tool_name, arguments, meta=meta)
 

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -67,17 +67,12 @@ async def resolve_auth_for_url(
     crypto_box: CryptoBox,
     session_id: str,
     mcp_server_url: str,
-    *,
-    connection_vault_id: str | None = None,
 ) -> dict[str, str]:
     """Resolve MCP auth headers for ``mcp_server_url``.
 
-    Normal agent-declared MCP servers resolve through the session's bound
-    vaults (``session_vaults``). Legacy connection-projected MCP servers pass
-    ``connection_vault_id`` explicitly; that vault then owns auth resolution
-    for this call. A legacy connection vault with no matching credential
-    returns ``{}`` rather than falling back, preventing a misconfigured
-    connection from silently leaking a tenant-level credential.
+    Agent-declared MCP servers resolve through the session's bound vaults
+    (``session_vaults``). The agent chooses a tool name; the worker resolves
+    the server URL from agent config and injects the matching vault credential.
 
     For ``mcp_oauth`` credentials whose ``expires_at`` falls within the
     refresh skew window, the access token is transparently refreshed
@@ -87,19 +82,10 @@ async def resolve_auth_for_url(
     to the stale token.
     """
     async with pool.acquire() as conn:
-        if connection_vault_id is not None:
-            vault_result = await queries.resolve_vault_credential(
-                conn, vault_id=connection_vault_id, mcp_server_url=mcp_server_url
-            )
-            if vault_result is None:
-                return {}
-            blob, auth_type = vault_result
-            vault_id = connection_vault_id
-        else:
-            session_result = await queries.resolve_mcp_credential(conn, session_id, mcp_server_url)
-            if session_result is None:
-                return {}
-            blob, auth_type, vault_id = session_result
+        session_result = await queries.resolve_mcp_credential(conn, session_id, mcp_server_url)
+        if session_result is None:
+            return {}
+        blob, auth_type, vault_id = session_result
 
         if auth_type == "mcp_oauth":
             payload = json.loads(crypto_box.decrypt(blob))

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -9,9 +9,8 @@ where ``path`` is whatever sub-segments the connector emits for inbound
 messages (typically a chat or thread id).
 
 ``mcp_url`` / ``vault_id`` are optional compatibility fields for older
-connector setups that projected MCP tools from connections. New
-channel-aware MCP integrations should leave them unset, declare normal
-agent ``mcp_servers``, and use session vaults for credentials.
+connection records. Runtime MCP discovery uses normal agent
+``mcp_servers`` and session vaults for credentials.
 """
 
 from __future__ import annotations
@@ -21,9 +20,9 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-# Legacy prefix for MCP server names projected from connection rows. New
-# channel-aware MCP integrations should use normal agent ``mcp_servers`` plus
-# ``mcp_toolset.channel_context`` instead of relying on this namespace.
+# Connection ids use this prefix. The stable id is also used as the
+# per-connection instruction alias key when connector MCP instructions are
+# rendered into a session prompt.
 CONNECTION_SERVER_NAME_PREFIX = "conn_"
 
 

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -85,9 +85,7 @@ def _connection(cid: str, connector: str = "signal", account: str = "acct") -> C
 
 
 class TestConnectionServerName:
-    """The legacy connection-to-MCP projection uses the connection id directly
-    as the server name: no stutter, still unambiguous by construction.
-    """
+    """Per-connection instruction aliases use the connection id directly."""
 
     def test_uses_id_directly(self) -> None:
         c = _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -1,9 +1,8 @@
 """Unit tests for discover_session_mcp_tools.
 
-Covers the collect-URLs-then-discover shape: agent-declared MCP
-(filtered by enabled mcp_toolset entries), plus the legacy compatibility
-projection from session bindings → connections. The MCP SDK and auth lookup
-are both mocked; only the orchestration is under test here.
+Covers the collect-URLs-then-discover shape: agent-declared MCP filtered by
+enabled mcp_toolset entries. Connections are present only to alias
+connector-specific MCP instructions into connector-aware prompt blocks.
 """
 
 from __future__ import annotations
@@ -15,7 +14,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from aios.models.agents import McpServerSpec, ToolSpec
+from aios.models.agents import McpChannelContext, McpServerSpec, ToolSpec
 from aios.models.connections import Connection
 
 
@@ -29,28 +28,20 @@ def _mock_crypto_box() -> Any:
         yield m
 
 
-def _connection(cid: str, url: str) -> Connection:
-    now = datetime(2026, 4, 16)
-    return Connection(
-        id=cid,
-        connector="signal",
-        account="acct",
-        mcp_url=url,
-        vault_id="vlt_x",
-        metadata={},
-        created_at=now,
-        updated_at=now,
-    )
-
-
-def _channel_only_connection(cid: str, connector: str = "signal") -> Connection:
+def _connection(
+    cid: str,
+    connector: str = "signal",
+    *,
+    mcp_url: str | None = None,
+    vault_id: str | None = None,
+) -> Connection:
     now = datetime(2026, 4, 16)
     return Connection(
         id=cid,
         connector=connector,
         account="acct",
-        mcp_url=None,
-        vault_id=None,
+        mcp_url=mcp_url,
+        vault_id=vault_id,
         metadata={},
         created_at=now,
         updated_at=now,
@@ -116,41 +107,17 @@ class TestDiscoverSessionMcpTools:
         names = {t["name"] for t in tools}
         assert names == {"mcp__gh__t"}
 
-    async def test_connections_only(self) -> None:
+    async def test_connections_do_not_project_mcp(self) -> None:
         from aios.harness.loop import discover_session_mcp_tools
 
         connections = [
-            _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1"),
-            _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8G", "https://m2"),
+            _connection(
+                "conn_01HQR2K7VXBZ9MNPL3WYCT8F",
+                mcp_url="https://legacy-m1",
+                vault_id="vlt_x",
+            ),
+            _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8G"),
         ]
-
-        async def _discover(
-            url: str, name: str, _headers: dict[str, str]
-        ) -> tuple[list[dict[str, Any]], str | None]:
-            return [{"name": f"mcp__{name}__t", "url": url}], None
-
-        with (
-            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
-            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
-        ):
-            resolve.return_value = {}
-            tools, _instructions = await discover_session_mcp_tools(
-                pool=AsyncMock(),
-                session_id="sess_x",
-                agent=_agent(),
-                connections=connections,
-            )
-        # Each connection contributes one tool, namespaced with its id.
-        urls = {t["url"] for t in tools}
-        assert urls == {"https://m1", "https://m2"}
-        names = {t["name"] for t in tools}
-        assert names == {
-            "mcp__conn_01HQR2K7VXBZ9MNPL3WYCT8F__t",
-            "mcp__conn_01HQR2K7VXBZ9MNPL3WYCT8G__t",
-        }
-
-    async def test_channel_only_connections_do_not_project_mcp(self) -> None:
-        from aios.harness.loop import discover_session_mcp_tools
 
         with (
             patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
@@ -160,7 +127,7 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=_agent(),
-                connections=[_channel_only_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")],
+                connections=connections,
             )
 
         assert tools == []
@@ -168,14 +135,20 @@ class TestDiscoverSessionMcpTools:
         resolve.assert_not_called()
         discover.assert_not_called()
 
-    async def test_agent_and_connections_combined(self) -> None:
+    async def test_agent_and_connections_discovers_only_agent_servers(self) -> None:
         from aios.harness.loop import discover_session_mcp_tools
 
         agent = _agent(
             mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
             tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
         )
-        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
+        connections = [
+            _connection(
+                "conn_01HQR2K7VXBZ9MNPL3WYCT8F",
+                mcp_url="https://legacy-m1",
+                vault_id="vlt_x",
+            )
+        ]
 
         async def _discover(
             url: str, name: str, _headers: dict[str, str]
@@ -194,61 +167,12 @@ class TestDiscoverSessionMcpTools:
                 connections=connections,
             )
         urls = sorted(t["url"] for t in tools)
-        assert urls == ["https://m1", "https://mcp.github"]
-
-    async def test_agent_server_url_suppresses_legacy_connection_projection(self) -> None:
-        """If the agent declares the same MCP URL as a connection, discover it
-        once through the normal agent server namespace.
-        """
-        from aios.harness.loop import discover_session_mcp_tools
-
-        agent = _agent(
-            mcp_servers=[McpServerSpec(name="signal", url="https://m1")],
-            tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="signal")],
-        )
-        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
-
-        seen: list[tuple[str, str | None]] = []
-
-        async def _fake_resolve(
-            _pool: Any,
-            _cb: Any,
-            _sid: str,
-            url: str,
-            *,
-            connection_vault_id: str | None = None,
-        ) -> dict[str, str]:
-            seen.append((url, connection_vault_id))
-            return {}
-
-        async def _discover(
-            url: str, name: str, _headers: dict[str, str]
-        ) -> tuple[list[dict[str, Any]], str | None]:
-            return [{"name": f"mcp__{name}__t", "url": url}], "send via focal"
-
-        with (
-            patch("aios.mcp.client.resolve_auth_for_url", side_effect=_fake_resolve),
-            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
-        ):
-            tools, instructions = await discover_session_mcp_tools(
-                pool=AsyncMock(),
-                session_id="sess_x",
-                agent=agent,
-                connections=connections,
-            )
-
-        assert seen == [("https://m1", None)]
-        assert tools == [{"name": "mcp__signal__t", "url": "https://m1"}]
-        assert instructions == {
-            "signal": "send via focal",
-            "conn_01HQR2K7VXBZ9MNPL3WYCT8F": "send via focal",
-        }
+        assert urls == ["https://mcp.github"]
 
     async def test_channel_only_connection_aliases_matching_focal_server_instructions(
         self,
     ) -> None:
         from aios.harness.loop import discover_session_mcp_tools
-        from aios.models.agents import McpChannelContext
 
         agent = _agent(
             mcp_servers=[McpServerSpec(name="signal", url="https://m1")],
@@ -261,7 +185,7 @@ class TestDiscoverSessionMcpTools:
                 )
             ],
         )
-        connections = [_channel_only_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")]
+        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")]
 
         async def _discover(
             url: str, name: str, _headers: dict[str, str]
@@ -296,19 +220,16 @@ class TestDiscoverSessionMcpTools:
             mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
             tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
         )
-        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
 
-        seen: list[tuple[str, str | None]] = []
+        seen: list[str] = []
 
         async def _fake_resolve(
             _pool: Any,
             _cb: Any,
             _sid: str,
             url: str,
-            *,
-            connection_vault_id: str | None = None,
         ) -> dict[str, str]:
-            seen.append((url, connection_vault_id))
+            seen.append(url)
             return {"Authorization": f"Bearer token-for-{url}"}
 
         async def _discover(
@@ -324,14 +245,10 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
-                connections=connections,
+                connections=[],
             )
-        assert sorted(seen) == [("https://m1", "vlt_x"), ("https://mcp.github", None)]
-        auths = {t["auth"] for t in tools}
-        assert auths == {
-            "Bearer token-for-https://mcp.github",
-            "Bearer token-for-https://m1",
-        }
+        assert seen == ["https://mcp.github"]
+        assert {t["auth"] for t in tools} == {"Bearer token-for-https://mcp.github"}
 
     async def test_instructions_keyed_by_server_name(self) -> None:
         """Each server's ``InitializeResult.instructions`` flows into the
@@ -342,17 +259,21 @@ class TestDiscoverSessionMcpTools:
         from aios.harness.loop import discover_session_mcp_tools
 
         agent = _agent(
-            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
-            tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
+            mcp_servers=[McpServerSpec(name="signal", url="https://mcp.signal")],
+            tools=[
+                ToolSpec(
+                    type="mcp_toolset",
+                    enabled=True,
+                    mcp_server_name="signal",
+                    channel_context=McpChannelContext(type="focal"),
+                )
+            ],
         )
-        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
+        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")]
 
         async def _discover(
             url: str, name: str, _headers: dict[str, str]
         ) -> tuple[list[dict[str, Any]], str | None]:
-            # Agent server supplies nothing; connection server supplies prose.
-            if name == "gh":
-                return [], None
             return [], "## signal\n\nbe nice"
 
         with (
@@ -366,8 +287,10 @@ class TestDiscoverSessionMcpTools:
                 agent=agent,
                 connections=connections,
             )
-        # 'gh' returned None → omitted; connection returned prose → present.
-        assert instructions == {"conn_01HQR2K7VXBZ9MNPL3WYCT8F": "## signal\n\nbe nice"}
+        assert instructions == {
+            "signal": "## signal\n\nbe nice",
+            "conn_01HQR2K7VXBZ9MNPL3WYCT8F": "## signal\n\nbe nice",
+        }
 
     async def test_empty_string_instructions_omitted(self) -> None:
         """An empty string is treated identically to ``None`` — no
@@ -376,7 +299,10 @@ class TestDiscoverSessionMcpTools:
         """
         from aios.harness.loop import discover_session_mcp_tools
 
-        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="signal", url="https://mcp.signal")],
+            tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="signal")],
+        )
 
         async def _discover(
             _url: str, _name: str, _headers: dict[str, str]
@@ -391,7 +317,7 @@ class TestDiscoverSessionMcpTools:
             _tools, instructions = await discover_session_mcp_tools(
                 pool=AsyncMock(),
                 session_id="sess_x",
-                agent=_agent(),
-                connections=connections,
+                agent=agent,
+                connections=[_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")],
             )
         assert instructions == {}

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -19,95 +19,13 @@ from tests.unit.conftest import fake_pool_yielding_conn
 
 
 class TestResolveAuthForUrl:
-    """Agent MCP uses session_vaults by default; legacy connection-projected
-    MCP can pass an explicit connection vault id. OAuth credentials refresh
-    when expiring on either path.
-    """
+    """Agent MCP auth resolves through session_vaults."""
 
     @pytest.fixture
     def crypto_box(self) -> CryptoBox:
         import os
 
         return CryptoBox(os.urandom(32))
-
-    # ── legacy connection-projected URLs ──────────────────────────────────
-
-    async def test_legacy_connection_projection_uses_connection_vault(
-        self, crypto_box: CryptoBox
-    ) -> None:
-        payload = json.dumps({"token": "connection-token"})
-        blob = crypto_box.encrypt(payload)
-        pool = fake_pool_yielding_conn(MagicMock())
-        with (
-            patch(
-                "aios.mcp.client.queries.resolve_vault_credential",
-                new_callable=AsyncMock,
-            ) as v,
-            patch(
-                "aios.mcp.client.queries.resolve_mcp_credential",
-                new_callable=AsyncMock,
-            ) as s,
-        ):
-            v.return_value = (blob, "static_bearer")
-            result = await resolve_auth_for_url(
-                pool,
-                crypto_box,
-                "sess_123",
-                "https://mcp.example.com",
-                connection_vault_id="vlt_v2",
-            )
-        assert result == {"Authorization": "Bearer connection-token"}
-        # Explicit connection-vault path MUST NOT consult session_vaults.
-        s.assert_not_awaited()
-        v.assert_awaited_once()
-
-    async def test_legacy_connection_projection_missing_credential_returns_empty(
-        self, crypto_box: CryptoBox
-    ) -> None:
-        pool = fake_pool_yielding_conn(MagicMock())
-        with (
-            patch(
-                "aios.mcp.client.queries.resolve_vault_credential",
-                new_callable=AsyncMock,
-            ) as v,
-            patch(
-                "aios.mcp.client.queries.resolve_mcp_credential",
-                new_callable=AsyncMock,
-            ) as s,
-        ):
-            v.return_value = None
-            result = await resolve_auth_for_url(
-                pool,
-                crypto_box,
-                "sess_123",
-                "https://mcp.example.com",
-                connection_vault_id="vlt_v2",
-            )
-        assert result == {}
-        # Still doesn't fall back — explicit connection vault decided the source.
-        s.assert_not_awaited()
-
-    async def test_mcp_oauth_from_legacy_connection_projection(self, crypto_box: CryptoBox) -> None:
-        payload = json.dumps({"access_token": "oauth-conn-token"})
-        blob = crypto_box.encrypt(payload)
-        pool = fake_pool_yielding_conn(MagicMock())
-        with (
-            patch(
-                "aios.mcp.client.queries.resolve_vault_credential",
-                new_callable=AsyncMock,
-            ) as v,
-        ):
-            v.return_value = (blob, "mcp_oauth")
-            result = await resolve_auth_for_url(
-                pool,
-                crypto_box,
-                "sess_123",
-                "https://mcp.example.com",
-                connection_vault_id="vlt_v2",
-            )
-        assert result == {"Authorization": "Bearer oauth-conn-token"}
-
-    # ── fallback: session_vaults ──────────────────────────────────────────
 
     async def test_non_connection_url_falls_back_to_session_vaults(
         self, crypto_box: CryptoBox
@@ -133,9 +51,7 @@ class TestResolveAuthForUrl:
         v.assert_not_awaited()
         s.assert_awaited_once()
 
-    async def test_agent_mcp_uses_session_vault_without_connection_vault_id(
-        self, crypto_box: CryptoBox
-    ) -> None:
+    async def test_agent_mcp_uses_session_vault(self, crypto_box: CryptoBox) -> None:
         """A normal agent-declared MCP server uses session vaults by default."""
         payload = json.dumps({"token": "session-token"})
         blob = crypto_box.encrypt(payload)
@@ -177,7 +93,7 @@ class TestResolveAuthForUrl:
             )
         assert result == {}
 
-    # ── OAuth refresh (applies to both paths) ─────────────────────────────
+    # ── OAuth refresh ─────────────────────────────────────────────────────
 
     async def test_oauth_refresh_triggered_when_expiring(self, crypto_box: CryptoBox) -> None:
         """Session-vaults path: stale mcp_oauth token triggers refresh, then
@@ -218,47 +134,6 @@ class TestResolveAuthForUrl:
         assert kwargs["vault_id"] == "vlt_s1"
         assert kwargs["mcp_server_url"] == "https://mcp.example.com"
         assert result == {"Authorization": "Bearer fresh"}
-
-    async def test_oauth_refresh_triggered_on_legacy_connection_path(
-        self, crypto_box: CryptoBox
-    ) -> None:
-        """Legacy connection-vault path: refresh ALSO triggers here — the
-        refresh flow is source-agnostic, it just needs a vault_id + url pair.
-        """
-        from datetime import UTC, datetime, timedelta
-
-        expiring = json.dumps(
-            {
-                "access_token": "stale-conn",
-                "expires_at": (datetime.now(UTC) + timedelta(seconds=5)).isoformat(),
-            }
-        )
-        fresh = json.dumps({"access_token": "fresh-conn"})
-        stale_blob = crypto_box.encrypt(expiring)
-        fresh_blob = crypto_box.encrypt(fresh)
-        pool = fake_pool_yielding_conn(MagicMock())
-
-        refresh_mock = AsyncMock()
-        with (
-            patch(
-                "aios.mcp.client.queries.resolve_vault_credential",
-                new_callable=AsyncMock,
-            ) as v,
-            patch("aios.mcp.client.refresh_credential", refresh_mock),
-        ):
-            # Two reads: initial (stale) and post-refresh (fresh).
-            v.side_effect = [(stale_blob, "mcp_oauth"), (fresh_blob, "mcp_oauth")]
-            result = await resolve_auth_for_url(
-                pool,
-                crypto_box,
-                "sess_123",
-                "https://mcp.example.com",
-                connection_vault_id="vlt_conn",
-            )
-
-        refresh_mock.assert_awaited_once()
-        assert refresh_mock.await_args.kwargs["vault_id"] == "vlt_conn"
-        assert result == {"Authorization": "Bearer fresh-conn"}
 
     async def test_oauth_refresh_not_triggered_when_fresh(self, crypto_box: CryptoBox) -> None:
         from datetime import UTC, datetime, timedelta

--- a/tests/unit/test_mcp_models.py
+++ b/tests/unit/test_mcp_models.py
@@ -53,9 +53,7 @@ class TestMcpServerSpec:
         assert restored.name == "slack"
 
     def test_conn_prefix_is_ordinary_name(self) -> None:
-        """Connection MCP servers are now a legacy projection, not a reserved
-        server-name namespace.
-        """
+        """The conn_ prefix is not a reserved server-name namespace."""
         assert McpServerSpec(name="conn_github", url="https://m").name == "conn_github"
         assert McpServerSpec(name="connector", url="https://m").name == "connector"
         assert McpServerSpec(name="my_conn", url="https://m").name == "my_conn"

--- a/tests/unit/test_mcp_routing.py
+++ b/tests/unit/test_mcp_routing.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-
 from aios.harness.loop import (
     _hide_focal_channel_tools_when_phone_down,
     _is_mcp_tool,
@@ -17,7 +15,6 @@ from aios.models.agents import (
     McpToolsetConfig,
     ToolSpec,
 )
-from aios.models.connections import Connection
 from aios.tools.registry import to_openai_tools
 
 
@@ -128,21 +125,7 @@ class TestResolveMcpPermission:
         ]
         assert resolve_mcp_permission("mcp__github__create_issue", tools) is None
 
-    def test_legacy_connection_projection_can_default_to_always_allow(self) -> None:
-        """Legacy connection-projected servers are authorized by the runtime
-        with an explicit server-name set, not by a magic name prefix.
-        """
-        assert (
-            resolve_mcp_permission(
-                "mcp__conn_01HQR2K7VXBZ9MNPL3WYCT8F__send",
-                [],
-                always_allow_server_names={"conn_01HQR2K7VXBZ9MNPL3WYCT8F"},
-            )
-            == "always_allow"
-        )
-
-    def test_normal_toolset_policy_beats_legacy_projection(self) -> None:
-        """If an agent declares a server/toolset, that normal MCP config wins."""
+    def test_conn_prefix_is_an_ordinary_server_name(self) -> None:
         tools = [
             ToolSpec(
                 type="mcp_toolset",
@@ -156,7 +139,6 @@ class TestResolveMcpPermission:
             resolve_mcp_permission(
                 "mcp__conn_foo__send",
                 tools,
-                always_allow_server_names={"conn_foo"},
             )
             == "always_ask"
         )
@@ -238,46 +220,3 @@ class TestHideFocalChannelToolsWhenPhoneDown:
             ]
         )
         assert contexts == {"signal": "focal"}
-
-    def test_agent_server_url_suppresses_legacy_connection_context(self) -> None:
-        now = datetime(2026, 4, 16)
-        connection = Connection(
-            id="conn_01HQR2K7VXBZ9MNPL3WYCT8F",
-            connector="signal",
-            account="acct",
-            mcp_url="https://m1",
-            vault_id="vlt_x",
-            metadata={},
-            created_at=now,
-            updated_at=now,
-        )
-
-        contexts = mcp_channel_context_by_server(
-            [
-                ToolSpec(
-                    type="mcp_toolset",
-                    mcp_server_name="signal",
-                    channel_context=McpChannelContext(type="focal"),
-                ),
-            ],
-            [connection],
-            agent_mcp_server_names={"signal"},
-            agent_mcp_server_urls={"https://m1"},
-        )
-        assert contexts == {"signal": "focal"}
-
-    def test_channel_only_connection_does_not_add_legacy_context(self) -> None:
-        now = datetime(2026, 4, 16)
-        connection = Connection(
-            id="conn_01HQR2K7VXBZ9MNPL3WYCT8F",
-            connector="signal",
-            account="acct",
-            mcp_url=None,
-            vault_id=None,
-            metadata={},
-            created_at=now,
-            updated_at=now,
-        )
-
-        contexts = mcp_channel_context_by_server([], [connection])
-        assert contexts == {}


### PR DESCRIPTION
Stacked on #180 (`codex/channel-only-connections`).

## Summary

- Stop projecting MCP servers, tools, and credentials from connection rows at runtime.
- Build MCP routing and channel context only from agent-declared `mcp_servers` plus enabled `mcp_toolset` entries.
- Resolve MCP auth only through session vaults, removing the connection vault override path from discovery and dispatch.
- Keep connections as channel binding data and retain per-connection instruction aliases for focal connector MCP instructions.
- Update tests and wording around `conn_` ids, legacy connection fields, MCP auth, discovery, and permission policy.

## Validation

- `uv run pytest tests/unit/test_mcp_client.py tests/unit/test_discover_session_mcp_tools.py tests/unit/test_mcp_routing.py tests/unit/test_channels_helpers.py tests/unit/test_mcp_models.py -q`
- `uv run ruff check src tests connectors/signal/src/aios_signal/mcp.py connectors/telegram/src/aios_telegram/mcp.py migrations/versions/0025_channel_only_connections.py`
- `uv run mypy src`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/e2e/test_focal_channel.py::TestMcpMetaInjection -q`
- `uv run pytest tests/e2e/test_routing.py -q`
- `uv run pytest tests/integration/test_migrations.py::test_migration_creates_all_tables -q`