### PR TITLE
[codex] Drop MCP fields from connections

### DIFF
--- a/migrations/versions/0026_drop_connection_mcp_fields.py
+++ b/migrations/versions/0026_drop_connection_mcp_fields.py
@@ -1,0 +1,29 @@
+"""Drop MCP config fields from connections.
+
+Connections now carry only inbound channel-account identity. MCP server
+configuration and credentials live on agents and session vaults.
+
+Revision ID: 0026
+Revises: 0025
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0026"
+down_revision: str = "0025"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE connections DROP COLUMN vault_id")
+    op.execute("ALTER TABLE connections DROP COLUMN mcp_url")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE connections ADD COLUMN mcp_url text")
+    op.execute("ALTER TABLE connections ADD COLUMN vault_id text REFERENCES vaults(id)")

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -36,8 +36,6 @@ async def create(body: ConnectionCreate, pool: PoolDep, _auth: AuthDep) -> Conne
         pool,
         connector=body.connector,
         account=body.account,
-        mcp_url=body.mcp_url,
-        vault_id=body.vault_id,
         metadata=body.metadata,
     )
 
@@ -66,13 +64,9 @@ async def get(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Connection:
 async def update(
     connection_id: str, body: ConnectionUpdate, pool: PoolDep, _auth: AuthDep
 ) -> Connection:
-    from aios.db.queries import _UNSET
-
     return await service.update_connection(
         pool,
         connection_id,
-        mcp_url=body.mcp_url if "mcp_url" in body.model_fields_set else _UNSET,
-        vault_id=body.vault_id if "vault_id" in body.model_fields_set else _UNSET,
         metadata=body.metadata,
     )
 

--- a/src/aios/cli/commands/connections.py
+++ b/src/aios/cli/commands/connections.py
@@ -66,13 +66,6 @@ def create(
     account: Annotated[
         str | None, typer.Option("--account", help="Account identifier (e.g. bot uuid).")
     ] = None,
-    mcp_url: Annotated[
-        str | None,
-        typer.Option("--mcp-url", help="Legacy MCP URL field; not used for runtime discovery."),
-    ] = None,
-    vault_id: Annotated[
-        str | None, typer.Option("--vault-id", help="Legacy MCP credential vault id.")
-    ] = None,
     metadata_json: Annotated[
         str | None,
         typer.Option("--metadata-json", help="JSON object of connection metadata."),
@@ -83,7 +76,7 @@ def create(
 ) -> None:
     def _run() -> int | None:
         ergonomic: dict[str, Any] | None = None
-        if any(v is not None for v in (connector, account, mcp_url, vault_id, metadata_json)):
+        if any(v is not None for v in (connector, account, metadata_json)):
             missing = [
                 name
                 for name, v in (
@@ -99,10 +92,6 @@ def create(
                 "connector": connector,
                 "account": account,
             }
-            if mcp_url is not None:
-                ergonomic["mcp_url"] = mcp_url
-            if vault_id is not None:
-                ergonomic["vault_id"] = vault_id
             if metadata_json is not None:
                 try:
                     ergonomic["metadata"] = load_json_object(metadata_json, "--metadata-json")

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2016,8 +2016,6 @@ def _row_to_connection(row: asyncpg.Record) -> Connection:
         id=row["id"],
         connector=row["connector"],
         account=row["account"],
-        mcp_url=row["mcp_url"],
-        vault_id=row["vault_id"],
         metadata=metadata,
         created_at=row["created_at"],
         updated_at=row["updated_at"],
@@ -2030,8 +2028,6 @@ async def insert_connection(
     *,
     connector: str,
     account: str,
-    mcp_url: str | None,
-    vault_id: str | None,
     metadata: dict[str, Any],
 ) -> Connection:
     new_id = make_id(CONNECTION)
@@ -2039,26 +2035,19 @@ async def insert_connection(
     try:
         row = await conn.fetchrow(
             """
-            INSERT INTO connections (id, connector, account, mcp_url, vault_id, metadata)
-            VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+            INSERT INTO connections (id, connector, account, metadata)
+            VALUES ($1, $2, $3, $4::jsonb)
             RETURNING *
             """,
             new_id,
             connector,
             account,
-            mcp_url,
-            vault_id,
             metadata_json,
         )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
             f"a connection for ({connector!r}, {account!r}) already exists",
             detail={"connector": connector, "account": account},
-        ) from exc
-    except asyncpg.ForeignKeyViolationError as exc:
-        raise NotFoundError(
-            f"vault {vault_id} not found",
-            detail={"vault_id": vault_id},
         ) from exc
     assert row is not None
     return _row_to_connection(row)
@@ -2096,18 +2085,10 @@ async def update_connection(
     conn: asyncpg.Connection[Any],
     connection_id: str,
     *,
-    mcp_url: str | None = _UNSET,
-    vault_id: str | None = _UNSET,
     metadata: dict[str, Any] | None = None,
 ) -> Connection:
     sets: list[str] = []
     args: list[Any] = [connection_id]
-    if mcp_url is not _UNSET:
-        args.append(mcp_url)
-        sets.append(f"mcp_url = ${len(args)}")
-    if vault_id is not _UNSET:
-        args.append(vault_id)
-        sets.append(f"vault_id = ${len(args)}")
     if metadata is not None:
         args.append(json.dumps(metadata))
         sets.append(f"metadata = ${len(args)}::jsonb")
@@ -2115,13 +2096,7 @@ async def update_connection(
         return await get_connection(conn, connection_id)
     sets.append("updated_at = now()")
     sql = f"UPDATE connections SET {', '.join(sets)} WHERE id = $1 RETURNING *"
-    try:
-        row = await conn.fetchrow(sql, *args)
-    except asyncpg.ForeignKeyViolationError as exc:
-        raise NotFoundError(
-            "vault not found",
-            detail={"vault_id": vault_id},
-        ) from exc
+    row = await conn.fetchrow(sql, *args)
     if row is None:
         raise NotFoundError(
             f"connection {connection_id} not found",

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -7,10 +7,6 @@ inbound channel router. The address scheme used by the routing layer is::
 
 where ``path`` is whatever sub-segments the connector emits for inbound
 messages (typically a chat or thread id).
-
-``mcp_url`` / ``vault_id`` are optional compatibility fields for older
-connection records. Runtime MCP discovery uses normal agent
-``mcp_servers`` and session vaults for credentials.
 """
 
 from __future__ import annotations
@@ -18,7 +14,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # Connection ids use this prefix. The stable id is also used as the
 # per-connection instruction alias key when connector MCP instructions are
@@ -39,8 +35,6 @@ class ConnectionCreate(BaseModel):
 
     connector: str = Field(min_length=1, max_length=64)
     account: str = Field(min_length=1, max_length=256)
-    mcp_url: str | None = Field(default=None, min_length=1)
-    vault_id: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("connector", "account")
@@ -50,24 +44,15 @@ class ConnectionCreate(BaseModel):
             raise ValueError("must not contain '/'")
         return v
 
-    @model_validator(mode="after")
-    def _legacy_mcp_pair(self) -> ConnectionCreate:
-        if (self.mcp_url is None) != (self.vault_id is None):
-            raise ValueError("mcp_url and vault_id must be provided together")
-        return self
-
 
 class ConnectionUpdate(BaseModel):
     """Request body for ``PUT /v1/connections/{id}``.
 
-    ``connector`` and ``account`` are immutable after creation. Explicit
-    ``null`` for a legacy MCP field clears it; omitting the field preserves it.
+    ``connector`` and ``account`` are immutable after creation.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    mcp_url: str | None = Field(default=None, min_length=1)
-    vault_id: str | None = None
     metadata: dict[str, Any] | None = None
 
 
@@ -77,8 +62,6 @@ class Connection(BaseModel):
     id: str
     connector: str
     account: str
-    mcp_url: str | None = None
-    vault_id: str | None = None
     metadata: dict[str, Any]
     created_at: datetime
     updated_at: datetime

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -24,8 +24,6 @@ async def create_connection(
     *,
     connector: str,
     account: str,
-    mcp_url: str | None = None,
-    vault_id: str | None = None,
     metadata: dict[str, Any],
 ) -> Connection:
     async with pool.acquire() as conn:
@@ -33,8 +31,6 @@ async def create_connection(
             conn,
             connector=connector,
             account=account,
-            mcp_url=mcp_url,
-            vault_id=vault_id,
             metadata=metadata,
         )
 
@@ -55,16 +51,12 @@ async def update_connection(
     pool: asyncpg.Pool[Any],
     connection_id: str,
     *,
-    mcp_url: str | None = queries._UNSET,
-    vault_id: str | None = queries._UNSET,
     metadata: dict[str, Any] | None = None,
 ) -> Connection:
     async with pool.acquire() as conn:
         return await queries.update_connection(
             conn,
             connection_id,
-            mcp_url=mcp_url,
-            vault_id=vault_id,
             metadata=metadata,
         )
 

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -95,8 +95,6 @@ async def _setup_inbound(pool: Any, agent_id: str, env_id: str, vault_id: str) -
         pool,
         connector="signal",
         account=f"focal-{_uniq()}",
-        mcp_url="https://m",
-        vault_id=vault_id,
         metadata={},
     )
     await ch_svc.create_routing_rule(
@@ -1057,8 +1055,6 @@ class TestTailBlockInStep:
             runtime_pool,
             connector="signal",
             account=account,
-            mcp_url="https://m",
-            vault_id=vault_id,
             metadata={},
         )
         await ch_svc.create_routing_rule(
@@ -1114,8 +1110,6 @@ class TestTailBlockInStep:
             runtime_pool,
             connector="signal",
             account=account,
-            mcp_url="https://m",
-            vault_id=vault_id,
             metadata={},
         )
         await ch_svc.create_routing_rule(

--- a/tests/e2e/test_migration_0019.py
+++ b/tests/e2e/test_migration_0019.py
@@ -180,6 +180,19 @@ class TestSchemaShape:
             )
             assert col is None, "address column should be dropped"
 
+    async def test_connection_mcp_columns_dropped(self, pool: Any) -> None:
+        """Connections are channel-account identity only at head."""
+        async with pool.acquire() as conn:
+            cols = await conn.fetch(
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_name = 'connections'
+                  AND column_name IN ('mcp_url', 'vault_id')
+                """
+            )
+            assert cols == []
+
     async def test_indexes_after_migration(self, pool: Any) -> None:
         """Old globally-unique indexes are gone; composite per-connection uniques exist."""
         async with pool.acquire() as conn:

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -72,7 +72,7 @@ async def vault_id(pool: Any) -> str:
 
 
 @pytest.fixture
-async def connection(pool: Any, vault_id: str) -> Any:
+async def connection(pool: Any) -> Any:
     """Fresh signal connection per test.  Rules are scoped to this
     connection's id; addresses constructed against ``connection.connector``
     + ``connection.account``.
@@ -83,8 +83,6 @@ async def connection(pool: Any, vault_id: str) -> Any:
         pool,
         connector="signal",
         account=f"t-{_uniq()}",
-        mcp_url="https://mcp.example.com",
-        vault_id=vault_id,
         metadata={},
     )
 
@@ -104,25 +102,19 @@ class TestConnectionCRUD:
         )
         assert c.id.startswith("conn_")
         assert c.connector == "signal"
-        assert c.mcp_url is None
-        assert c.vault_id is None
         assert c.metadata == {"region": "us"}
         assert c.archived_at is None
 
         fetched = await svc.get_connection(pool, c.id)
         assert fetched.id == c.id
-        assert fetched.mcp_url is None
-        assert fetched.vault_id is None
 
-    async def test_create_and_get(self, pool: Any, vault_id: str) -> None:
+    async def test_create_and_get(self, pool: Any) -> None:
         from aios.services import connections as svc
 
         c = await svc.create_connection(
             pool,
             connector="signal",
             account=f"test-{_uniq()}",
-            mcp_url="https://mcp.example.com",
-            vault_id=vault_id,
             metadata={"region": "us"},
         )
         assert c.id.startswith("conn_")
@@ -133,7 +125,7 @@ class TestConnectionCRUD:
         fetched = await svc.get_connection(pool, c.id)
         assert fetched.id == c.id
 
-    async def test_unique_per_connector_account(self, pool: Any, vault_id: str) -> None:
+    async def test_unique_per_connector_account(self, pool: Any) -> None:
         from aios.services import connections as svc
 
         account = f"dup-{_uniq()}"
@@ -141,8 +133,6 @@ class TestConnectionCRUD:
             pool,
             connector="signal",
             account=account,
-            mcp_url="https://m1",
-            vault_id=vault_id,
             metadata={},
         )
         with pytest.raises(ConflictError):
@@ -150,41 +140,22 @@ class TestConnectionCRUD:
                 pool,
                 connector="signal",
                 account=account,
-                mcp_url="https://m2",
-                vault_id=vault_id,
                 metadata={},
             )
 
-    async def test_update_mcp_url(self, pool: Any, vault_id: str) -> None:
+    async def test_update_metadata(self, pool: Any) -> None:
         from aios.services import connections as svc
 
         c = await svc.create_connection(
             pool,
             connector="signal",
             account=f"upd-{_uniq()}",
-            mcp_url="https://old",
-            vault_id=vault_id,
             metadata={},
         )
-        updated = await svc.update_connection(pool, c.id, mcp_url="https://new")
-        assert updated.mcp_url == "https://new"
+        updated = await svc.update_connection(pool, c.id, metadata={"region": "us"})
+        assert updated.metadata == {"region": "us"}
 
-    async def test_clear_legacy_mcp_fields(self, pool: Any, vault_id: str) -> None:
-        from aios.services import connections as svc
-
-        c = await svc.create_connection(
-            pool,
-            connector="signal",
-            account=f"clear-{_uniq()}",
-            mcp_url="https://old",
-            vault_id=vault_id,
-            metadata={},
-        )
-        updated = await svc.update_connection(pool, c.id, mcp_url=None, vault_id=None)
-        assert updated.mcp_url is None
-        assert updated.vault_id is None
-
-    async def test_archive(self, pool: Any, vault_id: str) -> None:
+    async def test_archive(self, pool: Any) -> None:
         from aios.services import connections as svc
 
         account = f"arch-{_uniq()}"
@@ -192,8 +163,6 @@ class TestConnectionCRUD:
             pool,
             connector="signal",
             account=account,
-            mcp_url="https://m",
-            vault_id=vault_id,
             metadata={},
         )
         archived = await svc.archive_connection(pool, c.id)
@@ -203,8 +172,6 @@ class TestConnectionCRUD:
             pool,
             connector="signal",
             account=account,
-            mcp_url="https://m2",
-            vault_id=vault_id,
             metadata={},
         )
 
@@ -212,8 +179,8 @@ class TestConnectionCRUD:
         self, pool: Any, agent_id: str, env_id: str, connection: Any
     ) -> None:
         """A connection with an active binding can't be archived — doing so
-        would drop MCP tools from any live session bound to channels under
-        that connection.
+        would break inbound routing for any live session bound to channels
+        under that connection.
         """
         from aios.services import channels as ch_svc
         from aios.services import connections as svc
@@ -241,19 +208,6 @@ class TestConnectionCRUD:
         await ch_svc.archive_binding(pool, binding.id)
         archived = await svc.archive_connection(pool, connection.id)
         assert archived.archived_at is not None
-
-    async def test_unknown_vault(self, pool: Any) -> None:
-        from aios.services import connections as svc
-
-        with pytest.raises(NotFoundError):
-            await svc.create_connection(
-                pool,
-                connector="signal",
-                account=f"novault-{_uniq()}",
-                mcp_url="https://m",
-                vault_id="vlt_nonexistent",
-                metadata={},
-            )
 
 
 # ─── routing rule CRUD ──────────────────────────────────────────────────────
@@ -342,7 +296,7 @@ class TestRoutingRuleCRUD:
             )
 
     async def test_same_prefix_on_different_connections_allowed(
-        self, pool: Any, agent_id: str, env_id: str, vault_id: str
+        self, pool: Any, agent_id: str, env_id: str
     ) -> None:
         """Uniqueness is ``(connection_id, prefix)`` — not global."""
         from aios.services import channels as svc
@@ -352,16 +306,12 @@ class TestRoutingRuleCRUD:
             pool,
             connector="signal",
             account=f"crossA-{_uniq()}",
-            mcp_url="https://a",
-            vault_id=vault_id,
             metadata={},
         )
         c2 = await conn_svc.create_connection(
             pool,
             connector="signal",
             account=f"crossB-{_uniq()}",
-            mcp_url="https://b",
-            vault_id=vault_id,
             metadata={},
         )
         params = SessionParams(environment_id=env_id)
@@ -404,7 +354,7 @@ class TestRoutingRuleCRUD:
         assert archived.archived_at is not None
 
     async def test_wrong_connection_scope_404s(
-        self, pool: Any, agent_id: str, env_id: str, connection: Any, vault_id: str
+        self, pool: Any, agent_id: str, env_id: str, connection: Any
     ) -> None:
         """A rule on connection A isn't visible through connection B's scope."""
         from aios.services import channels as svc
@@ -421,8 +371,6 @@ class TestRoutingRuleCRUD:
             pool,
             connector="signal",
             account=f"other-{_uniq()}",
-            mcp_url="https://x",
-            vault_id=vault_id,
             metadata={},
         )
         with pytest.raises(NotFoundError):
@@ -532,7 +480,7 @@ class TestFindMatchingRule:
         assert yes_match is not None
 
     async def test_cross_connection_isolation(
-        self, pool: Any, agent_id: str, env_id: str, connection: Any, vault_id: str
+        self, pool: Any, agent_id: str, env_id: str, connection: Any
     ) -> None:
         """A rule on connection A must not match a path queried with connection B's id."""
         from aios.db import queries
@@ -550,8 +498,6 @@ class TestFindMatchingRule:
             pool,
             connector="signal",
             account=f"other-{_uniq()}",
-            mcp_url="https://x",
-            vault_id=vault_id,
             metadata={},
         )
         async with pool.acquire() as conn:
@@ -854,7 +800,7 @@ class TestNestedRoutingRulesEndpoint:
         assert r.status_code == 404
 
     async def test_rule_scoped_to_connection(
-        self, http_client: httpx.AsyncClient, agent_id: str, env_id: str, vault_id: str
+        self, http_client: httpx.AsyncClient, agent_id: str, env_id: str
     ) -> None:
         """A rule on connection A is invisible through connection B."""
         a = await http_client.post(
@@ -862,8 +808,6 @@ class TestNestedRoutingRulesEndpoint:
             json={
                 "connector": "signal",
                 "account": f"scopeA-{_uniq()}",
-                "mcp_url": "https://a",
-                "vault_id": vault_id,
             },
         )
         b = await http_client.post(
@@ -871,8 +815,6 @@ class TestNestedRoutingRulesEndpoint:
             json={
                 "connector": "signal",
                 "account": f"scopeB-{_uniq()}",
-                "mcp_url": "https://b",
-                "vault_id": vault_id,
             },
         )
         aid = a.json()["id"]
@@ -1074,7 +1016,7 @@ class TestGetConnectionsByPairs:
             rows = await queries.get_connections_by_pairs(conn, [])
         assert rows == []
 
-    async def test_returns_matching_connections(self, pool: Any, vault_id: str) -> None:
+    async def test_returns_matching_connections(self, pool: Any) -> None:
         from aios.db import queries
         from aios.services import connections as conn_svc
 
@@ -1084,16 +1026,12 @@ class TestGetConnectionsByPairs:
             pool,
             connector="signal",
             account=a,
-            mcp_url="https://m1",
-            vault_id=vault_id,
             metadata={},
         )
         c_b = await conn_svc.create_connection(
             pool,
             connector="slack",
             account=b,
-            mcp_url="https://m2",
-            vault_id=vault_id,
             metadata={},
         )
 

--- a/tests/e2e/test_step_separator.py
+++ b/tests/e2e/test_step_separator.py
@@ -18,15 +18,11 @@ class TestSeparatorAtLiteLLMBoundary:
         in place immediately before the tail block."""
         from aios.services import channels as ch_svc
         from aios.services import connections as conn_svc
-        from aios.services import vaults as vault_svc
 
-        v = await vault_svc.create_vault(harness._pool, display_name="sep-v", metadata={})
         await conn_svc.create_connection(
             harness._pool,
             connector="signal",
             account="test",
-            mcp_url="https://m",
-            vault_id=v.id,
             metadata={},
         )
 

--- a/tests/unit/cli/test_cli_connections.py
+++ b/tests/unit/cli/test_cli_connections.py
@@ -44,34 +44,6 @@ def test_create_ergonomic(mocked_cli):
     }
 
 
-def test_create_ergonomic_with_legacy_mcp_projection(mocked_cli):
-    mocked_cli.queue_response(httpx.Response(201, json={"id": "conn_new"}))
-    result = runner.invoke(
-        app,
-        [
-            "connections",
-            "create",
-            "--connector",
-            "signal",
-            "--account",
-            "acct-123",
-            "--mcp-url",
-            "http://mcp.example:9000",
-            "--vault-id",
-            "vlt_1",
-        ],
-    )
-    assert result.exit_code == 0, result.output
-    assert mocked_cli.captured.method == "POST"
-    assert mocked_cli.captured.path == "/v1/connections"
-    assert mocked_cli.captured.body == {
-        "connector": "signal",
-        "account": "acct-123",
-        "mcp_url": "http://mcp.example:9000",
-        "vault_id": "vlt_1",
-    }
-
-
 def test_create_ergonomic_with_metadata_json(mocked_cli):
     mocked_cli.queue_response(httpx.Response(201, json={"id": "conn_new"}))
     result = runner.invoke(

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -73,8 +73,6 @@ def _connection(cid: str, connector: str = "signal", account: str = "acct") -> C
         id=cid,
         connector=connector,
         account=account,
-        mcp_url="https://example.com",
-        vault_id="vlt_x",
         metadata={},
         created_at=now,
         updated_at=now,

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -31,17 +31,12 @@ def _mock_crypto_box() -> Any:
 def _connection(
     cid: str,
     connector: str = "signal",
-    *,
-    mcp_url: str | None = None,
-    vault_id: str | None = None,
 ) -> Connection:
     now = datetime(2026, 4, 16)
     return Connection(
         id=cid,
         connector=connector,
         account="acct",
-        mcp_url=mcp_url,
-        vault_id=vault_id,
         metadata={},
         created_at=now,
         updated_at=now,
@@ -111,11 +106,7 @@ class TestDiscoverSessionMcpTools:
         from aios.harness.loop import discover_session_mcp_tools
 
         connections = [
-            _connection(
-                "conn_01HQR2K7VXBZ9MNPL3WYCT8F",
-                mcp_url="https://legacy-m1",
-                vault_id="vlt_x",
-            ),
+            _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F"),
             _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8G"),
         ]
 
@@ -142,13 +133,7 @@ class TestDiscoverSessionMcpTools:
             mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
             tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
         )
-        connections = [
-            _connection(
-                "conn_01HQR2K7VXBZ9MNPL3WYCT8F",
-                mcp_url="https://legacy-m1",
-                vault_id="vlt_x",
-            )
-        ]
+        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")]
 
         async def _discover(
             url: str, name: str, _headers: dict[str, str]

--- a/tests/unit/test_routing_models.py
+++ b/tests/unit/test_routing_models.py
@@ -18,30 +18,7 @@ class TestConnectionCreate:
     def test_valid(self) -> None:
         c = ConnectionCreate(connector="signal", account="alice")
         assert c.connector == "signal"
-        assert c.mcp_url is None
-        assert c.vault_id is None
         assert c.metadata == {}
-
-    def test_valid_with_legacy_mcp_projection(self) -> None:
-        c = ConnectionCreate(
-            connector="signal",
-            account="alice",
-            mcp_url="https://mcp.example.com",
-            vault_id="vlt_abc",
-        )
-        assert c.connector == "signal"
-        assert c.metadata == {}
-
-    @pytest.mark.parametrize(
-        "kwargs",
-        [
-            {"mcp_url": "https://mcp.example.com"},
-            {"vault_id": "vlt_abc"},
-        ],
-    )
-    def test_legacy_mcp_fields_are_a_pair(self, kwargs: dict[str, str]) -> None:
-        with pytest.raises(ValidationError, match="mcp_url and vault_id"):
-            ConnectionCreate(connector="signal", account="alice", **kwargs)
 
     def test_with_metadata(self) -> None:
         c = ConnectionCreate(
@@ -80,8 +57,6 @@ class TestConnectionCreate:
 class TestConnectionUpdate:
     def test_all_optional(self) -> None:
         u = ConnectionUpdate()
-        assert u.mcp_url is None
-        assert u.vault_id is None
         assert u.metadata is None
 
     def test_rejects_connector_field(self) -> None:


### PR DESCRIPTION
Stacked on #181 (`codex/agent-mcp-only-runtime`).

## Summary

- Remove `mcp_url` and `vault_id` from connection create/update/read models, service APIs, DB queries, and CLI ergonomic flags.
- Add migration `0026` to drop `connections.mcp_url` and `connections.vault_id` now that MCP discovery/auth are agent + session-vault only.
- Update routing, focal-channel, CLI, and discovery tests to treat connections as channel-account identity only.
- Add a schema assertion that head no longer exposes connection MCP columns.

## Validation

- `uv run pytest tests/unit/test_routing_models.py tests/unit/cli/test_cli_connections.py tests/unit/test_channels_helpers.py tests/unit/test_discover_session_mcp_tools.py -q`
- `uv run pytest tests/e2e/test_routing.py -q`
- `uv run pytest tests/e2e/test_migration_0019.py -q`
- `uv run pytest tests/integration/test_migrations.py::test_migration_creates_all_tables -q`
- `uv run ruff check src tests connectors/signal/src/aios_signal/mcp.py connectors/telegram/src/aios_telegram/mcp.py migrations/versions/0025_channel_only_connections.py migrations/versions/0026_drop_connection_mcp_fields.py`
- `uv run ruff format --check src tests connectors/signal/src/aios_signal/mcp.py connectors/telegram/src/aios_telegram/mcp.py migrations/versions/0025_channel_only_connections.py migrations/versions/0026_drop_connection_mcp_fields.py`
- `uv run mypy src`
- commit hook: `ruff`, `mypy`, `pytest tests/unit -q`