### PR TITLE
[codex] Render MCP instructions by server

### DIFF
--- a/connectors/signal/tests/test_mcp.py
+++ b/connectors/signal/tests/test_mcp.py
@@ -362,7 +362,7 @@ def test_build_mcp_server_omits_profile_name_when_bot_not_in_contacts() -> None:
 
 def test_build_mcp_server_passes_signal_instructions() -> None:
     """The MCP server's ``instructions`` field is the transport for
-    Signal's per-connector affordance prose; aios reads it from the
+    Signal's per-server affordance prose; aios reads it from the
     ``InitializeResult`` returned by ``session.initialize()`` and
     composes it into the agent's system prompt.
     """

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -247,7 +247,7 @@ async def get_context(
     session-status bumps, event appends) are omitted; the endpoint is
     read-only.
     """
-    from aios.harness.channels import list_bindings_and_connections
+    from aios.harness.channels import list_session_bindings
     from aios.harness.step_context import compose_step_context
     from aios.models.agents import Agent, AgentVersion
     from aios.services import agents as agents_service
@@ -262,7 +262,7 @@ async def get_context(
     else:
         agent = await agents_service.get_agent(pool, session.agent_id)
 
-    bindings, connections = await list_bindings_and_connections(pool, session_id)
+    bindings = await list_session_bindings(pool, session_id)
 
     events = await service.read_windowed_events(
         pool,
@@ -278,7 +278,6 @@ async def get_context(
         session=session,
         agent=agent,
         bindings=bindings,
-        connections=connections,
         events=events,
     )
     return ContextResponse(

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2105,27 +2105,6 @@ async def update_connection(
     return _row_to_connection(row)
 
 
-async def list_connections_by_ids(
-    conn: asyncpg.Connection[Any],
-    ids: list[str],
-) -> list[Connection]:
-    """Active connections with the given ``ids``.  Empty input → no roundtrip.
-
-    Results are ordered by ``c.id`` so callers can feed them into the
-    system prompt in a stable order — prompt-cache stability depends
-    on it.  Used by :func:`aios.harness.channels.list_bindings_and_connections`
-    where the ``ids`` come from the distinct ``binding.connection_id``
-    values of a session's bindings.
-    """
-    if not ids:
-        return []
-    rows = await conn.fetch(
-        "SELECT * FROM connections WHERE id = ANY($1::text[]) AND archived_at IS NULL ORDER BY id",
-        ids,
-    )
-    return [_row_to_connection(r) for r in rows]
-
-
 async def get_connections_by_pairs(
     conn: asyncpg.Connection[Any],
     pairs: list[tuple[str, str]],
@@ -2315,8 +2294,7 @@ async def list_session_bindings(
 ) -> list[ChannelBinding]:
     """Every active binding for ``session_id``, unpaginated.
 
-    The step function consumes this in one shot (see
-    :func:`aios.harness.channels.list_bindings_and_connections`).
+    The step function consumes this in one shot when composing context.
     """
     rows = await conn.fetch(
         _BINDING_SELECT + " WHERE cb.session_id = $1 AND cb.archived_at IS NULL ORDER BY cb.id",

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -1,5 +1,5 @@
-"""Channel helpers: prompt augmentation, monologue prefix, bindings →
-connections translation, and focal-channel unread derivation.
+"""Channel helpers: prompt augmentation, monologue prefix, binding lookup,
+and focal-channel unread derivation.
 """
 
 from __future__ import annotations
@@ -11,7 +11,6 @@ import asyncpg
 
 from aios.db import queries
 from aios.models.channel_bindings import ChannelBinding
-from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX, Connection
 from aios.models.events import Event
 
 MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: "
@@ -34,8 +33,8 @@ def focal_channel_path(focal: str | None) -> str | None:
     """Return the connector-specific suffix of a focal address.
 
     The ``<connector>/<account>`` prefix is information the MCP server
-    already has (it was invoked *by* that connection), so sending it
-    would be redundant; we strip it.  For a 3-segment address like
+    already has from its own service identity and session credential, so
+    sending it would be redundant; we strip it.  For a 3-segment address like
     ``signal/<bot>/<chat>`` the suffix is just ``<chat>``.  For
     ``telegram/<bot>/<chat>/<thread>`` it's ``<chat>/<thread>``.
 
@@ -51,21 +50,10 @@ def focal_channel_path(focal: str | None) -> str | None:
     return parts[2]
 
 
-def connection_server_name(c: Connection) -> str:
-    # Stable key for rendering connector instructions per bound connection.
-    assert c.id.startswith(CONNECTION_SERVER_NAME_PREFIX)
-    return c.id
-
-
-async def list_bindings_and_connections(
-    pool: asyncpg.Pool[Any], session_id: str
-) -> tuple[list[ChannelBinding], list[Connection]]:
-    """Load the session's bindings and the distinct connections they reference."""
+async def list_session_bindings(pool: asyncpg.Pool[Any], session_id: str) -> list[ChannelBinding]:
+    """Load the session's active channel bindings for context composition."""
     async with pool.acquire() as conn:
-        bindings = await queries.list_session_bindings(conn, session_id)
-        conn_ids = sorted({b.connection_id for b in bindings})
-        connections = await queries.list_connections_by_ids(conn, conn_ids) if conn_ids else []
-    return bindings, connections
+        return await queries.list_session_bindings(conn, session_id)
 
 
 def build_focal_paradigm_block(bindings: list[ChannelBinding]) -> str:
@@ -81,7 +69,7 @@ def build_focal_paradigm_block(bindings: list[ChannelBinding]) -> str:
     Per-platform specifics (Signal markdown subset, mention syntax,
     response idioms) live in each connector and travel through the MCP
     ``InitializeResult.instructions`` field — see
-    :func:`build_connector_instructions_block`.
+    :func:`build_mcp_instructions_block`.
     """
     if not bindings:
         return ""
@@ -204,37 +192,30 @@ def build_channels_tail_block(
     return {"role": "user", "content": "\n".join(lines)}
 
 
-def build_connector_instructions_block(
+def build_mcp_instructions_block(
     instructions_by_server: dict[str, str],
-    connections: list[Connection],
 ) -> str:
-    """Render per-connector affordance prose grouped by connection.
+    """Render MCP server affordance prose in discovery order.
 
     ``instructions_by_server`` maps server_name to the server's
-    ``InitializeResult.instructions`` string. For connection-scoped
-    rendering, discovery aliases the relevant MCP server instructions under
-    ``connection_server_name(c)``. Connections are iterated in the
-    caller-supplied order so the prompt is stable across steps.
+    ``InitializeResult.instructions`` string. Discovery builds the dict in
+    agent ``mcp_servers`` order so the prompt is stable across steps.
 
-    Connections without an entry in the dict are skipped — a connector
-    that supplies no instructions contributes no block.
+    Servers without instructions are omitted by discovery and skipped here.
     """
     sections: list[str] = []
-    for c in connections:
-        name = connection_server_name(c)
-        text = instructions_by_server.get(name)
+    for server_name, text in instructions_by_server.items():
         if not text:
             continue
-        sections.append(f"## Connector: {c.connector}/{c.account}\n\n{text}")
+        sections.append(f"## MCP server: {server_name}\n\n{text}")
     return "\n\n".join(sections)
 
 
-def augment_with_connector_instructions(
+def augment_with_mcp_instructions(
     base_system: str,
     instructions_by_server: dict[str, str],
-    connections: list[Connection],
 ) -> str:
-    block = build_connector_instructions_block(instructions_by_server, connections)
+    block = build_mcp_instructions_block(instructions_by_server)
     if not block:
         return base_system
     if base_system:

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -178,9 +178,9 @@ async def _run_session_step_body(
     else:
         agent = await agents_service.get_agent(pool, session.agent_id)
 
-    from aios.harness.channels import list_bindings_and_connections
+    from aios.harness.channels import list_session_bindings
 
-    bindings, connections = await list_bindings_and_connections(pool, session_id)
+    bindings = await list_session_bindings(pool, session_id)
 
     mcp_server_map: dict[str, str] = {s.name: s.url for s in agent.mcp_servers}
     channel_context_by_server = mcp_channel_context_by_server(agent.tools)
@@ -238,7 +238,6 @@ async def _run_session_step_body(
             session=session,
             agent=agent,
             bindings=bindings,
-            connections=connections,
             events=events,
         )
     except Exception:
@@ -647,7 +646,6 @@ async def discover_session_mcp_tools(
     pool: Any,
     session_id: str,
     agent: Any,
-    connections: list[Any],
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
     """Discover MCP tools from agent-declared servers (filtered by enabled
     ``mcp_toolset`` entries).
@@ -656,35 +654,21 @@ async def discover_session_mcp_tools(
     maps ``server_name`` → the server's ``InitializeResult.instructions``
     string.  Servers that supplied no instructions (or ``""``) are
     omitted from the dict — the harness uses presence in the dict as
-    the trigger for rendering a per-connector affordance block.
-
-    ``connections`` is used only to alias connector-specific MCP
-    ``instructions`` back to bound channel accounts for prompt rendering.
-    Connections do not contribute MCP servers or credentials.
+    the trigger for rendering MCP server affordance prose.
     """
     import asyncio
 
-    from aios.harness.channels import connection_server_name
     from aios.mcp.client import discover_mcp_tools, resolve_auth_for_url
 
     servers: list[tuple[str, str]] = []
 
     enabled_server_names: set[str] = set()
-    focal_server_names: set[str] = set()
     for spec in agent.tools:
         if spec.type == "mcp_toolset" and spec.enabled and spec.mcp_server_name:
             enabled_server_names.add(spec.mcp_server_name)
-            if spec.channel_context is not None and spec.channel_context.type == "focal":
-                focal_server_names.add(spec.mcp_server_name)
     for s in agent.mcp_servers:
         if s.name in enabled_server_names:
             servers.append((s.name, s.url))
-
-    instruction_aliases: dict[str, str] = {}
-    for c in connections:
-        name = connection_server_name(c)
-        if c.connector in focal_server_names:
-            instruction_aliases[name] = c.connector
 
     if not servers:
         return [], {}
@@ -709,9 +693,6 @@ async def discover_session_mcp_tools(
         for (name, _url), (_tools, instructions) in zip(servers, results, strict=True)
         if instructions
     }
-    for alias_name, source_name in instruction_aliases.items():
-        if instructions := instructions_by_server.get(source_name):
-            instructions_by_server[alias_name] = instructions
     return tools, instructions_by_server
 
 

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -36,7 +36,6 @@ if TYPE_CHECKING:
 
     from aios.models.agents import Agent, AgentVersion
     from aios.models.channel_bindings import ChannelBinding
-    from aios.models.connections import Connection
     from aios.models.events import Event
     from aios.models.sessions import Session
     from aios.models.skills import SkillVersion
@@ -60,19 +59,17 @@ async def compose_step_context(
     session: Session,
     agent: Agent | AgentVersion,
     bindings: list[ChannelBinding],
-    connections: list[Connection],
     events: list[Event],
 ) -> StepContext:
     """Compose the chat-completions payload for a step.
 
-    Callers must have already loaded ``session`` / ``agent`` / ``bindings``
-    / ``connections`` / ``events`` so the endpoint and the worker pay
-    the same I/O cost profile.  This function adds MCP discovery and
-    skill-ref resolution on top.
+    Callers must have already loaded ``session`` / ``agent`` / ``bindings`` /
+    ``events`` so the endpoint and the worker pay the same I/O cost profile.
+    This function adds MCP discovery and skill-ref resolution on top.
     """
     from aios.harness.channels import (
-        augment_with_connector_instructions,
         augment_with_focal_paradigm,
+        augment_with_mcp_instructions,
         build_channels_tail_block,
     )
     from aios.harness.loop import (
@@ -91,10 +88,8 @@ async def compose_step_context(
         tools.append(_switch_channel_tool_spec())
 
     mcp_instructions: dict[str, str] = {}
-    if agent.mcp_servers or connections:
-        mcp_tools, mcp_instructions = await discover_session_mcp_tools(
-            pool, session_id, agent, connections
-        )
+    if agent.mcp_servers:
+        mcp_tools, mcp_instructions = await discover_session_mcp_tools(pool, session_id, agent)
         # Hide focal-channel MCP tools when focal is NULL — can't type
         # into a chat you aren't attending to.
         channel_context_by_server = mcp_channel_context_by_server(agent.tools)
@@ -108,9 +103,7 @@ async def compose_step_context(
     )
     system_prompt = augment_system_prompt(agent.system, skill_versions)
     system_prompt = augment_with_focal_paradigm(system_prompt, bindings)
-    system_prompt = augment_with_connector_instructions(
-        system_prompt, mcp_instructions, connections
-    )
+    system_prompt = augment_with_mcp_instructions(system_prompt, mcp_instructions)
 
     ctx = build_messages(events, system_prompt=system_prompt)
 

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -123,11 +123,11 @@ async def discover_mcp_tools(
       (``mcp__<server_name>__<tool_name>``).
     * ``instructions`` — the server's ``InitializeResult.instructions``
       string (per the MCP spec), or ``None`` if the server didn't supply
-      any. Used by the harness to compose per-connector affordance prose
+      any. Used by the harness to compose per-server affordance prose
       into the system prompt.
 
     On any error, logs a warning and returns ``([], None)`` — the model
-    simply doesn't see those tools (or that connector's instructions).
+    simply doesn't see those tools (or that server's instructions).
     """
     try:
         from aios.harness import runtime

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -16,11 +16,6 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-# Connection ids use this prefix. The stable id is also used as the
-# per-connection instruction alias key when connector MCP instructions are
-# rendered into a session prompt.
-CONNECTION_SERVER_NAME_PREFIX = "conn_"
-
 
 class ConnectionCreate(BaseModel):
     """Request body for ``POST /v1/connections``.

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -11,15 +11,13 @@ from typing import Any
 
 from aios.harness.channels import (
     apply_monologue_prefix,
-    augment_with_connector_instructions,
     augment_with_focal_paradigm,
+    augment_with_mcp_instructions,
     build_channels_tail_block,
-    build_connector_instructions_block,
     build_focal_paradigm_block,
-    connection_server_name,
+    build_mcp_instructions_block,
 )
 from aios.models.channel_bindings import ChannelBinding, NotificationMode
-from aios.models.connections import Connection
 from aios.models.events import Event
 
 
@@ -65,38 +63,6 @@ def _user_event(
         orig_channel=orig,
         focal_channel_at_arrival=focal_at,
     )
-
-
-def _connection(cid: str, connector: str = "signal", account: str = "acct") -> Connection:
-    now = datetime(2026, 4, 16)
-    return Connection(
-        id=cid,
-        connector=connector,
-        account=account,
-        metadata={},
-        created_at=now,
-        updated_at=now,
-    )
-
-
-# ── connection_server_name ─────────────────────────────────────────────────
-
-
-class TestConnectionServerName:
-    """Per-connection instruction aliases use the connection id directly."""
-
-    def test_uses_id_directly(self) -> None:
-        c = _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")
-        assert connection_server_name(c) == "conn_01HQR2K7VXBZ9MNPL3WYCT8F"
-
-    def test_distinct_connections_produce_distinct_names(self) -> None:
-        c1 = _connection("conn_aaa", connector="signal", account="abc_def")
-        c2 = _connection("conn_bbb", connector="signal_abc", account="def")
-        assert connection_server_name(c1) != connection_server_name(c2)
-
-    def test_is_stable_for_same_connection(self) -> None:
-        c = _connection("conn_stable")
-        assert connection_server_name(c) == connection_server_name(c)
 
 
 # ── build_focal_paradigm_block / augment_with_focal_paradigm ───────────────
@@ -145,73 +111,44 @@ class TestBuildFocalParadigmBlock:
         assert "phone down" in block.lower() or "target=null" in block
 
 
-# ── build_connector_instructions_block / augment_with_connector_instructions ──
+# ── build_mcp_instructions_block / augment_with_mcp_instructions ───────────
 
 
-class TestBuildConnectorInstructionsBlock:
+class TestBuildMcpInstructionsBlock:
     def test_empty_dict_returns_empty(self) -> None:
-        assert build_connector_instructions_block({}, []) == ""
+        assert build_mcp_instructions_block({}) == ""
 
-    def test_no_matching_connection_returns_empty(self) -> None:
-        """Instructions keyed under a server name that no connection
-        matches must NOT be rendered — we only describe the connectors
-        the session is actually bound to.
-        """
-        c = _connection("conn_aaa", connector="signal", account="alice")
-        block = build_connector_instructions_block({"conn_unknown": "stray prose"}, [c])
-        assert block == ""
-
-    def test_single_connection_renders_heading_and_body(self) -> None:
-        c = _connection("conn_aaa", connector="signal", account="alice")
-        block = build_connector_instructions_block({connection_server_name(c): "be brief"}, [c])
-        assert "## Connector: signal/alice" in block
+    def test_single_server_renders_heading_and_body(self) -> None:
+        block = build_mcp_instructions_block({"signal": "be brief"})
+        assert "## MCP server: signal" in block
         assert "be brief" in block
 
-    def test_multiple_connections_rendered_in_input_order(self) -> None:
-        """Ordering is caller-controlled — important for prompt-cache
-        stability across steps.  Test by passing two connections and
-        asserting the output order matches.
+    def test_multiple_servers_rendered_in_dict_order(self) -> None:
+        """Discovery inserts instructions in agent MCP server order, so
+        renderer order must preserve dict insertion order.
         """
-        c1 = _connection("conn_aaa", connector="signal", account="alice")
-        c2 = _connection("conn_bbb", connector="signal", account="bob")
-        instructions = {
-            connection_server_name(c1): "alice prose",
-            connection_server_name(c2): "bob prose",
-        }
-        block = build_connector_instructions_block(instructions, [c1, c2])
-        assert block.index("alice prose") < block.index("bob prose")
-        # Reverse the connections list — output order flips.
-        block_rev = build_connector_instructions_block(instructions, [c2, c1])
-        assert block_rev.index("bob prose") < block_rev.index("alice prose")
+        block = build_mcp_instructions_block({"signal": "signal prose", "github": "github prose"})
+        assert block.index("signal prose") < block.index("github prose")
 
-    def test_connection_without_instructions_skipped(self) -> None:
-        c1 = _connection("conn_aaa", connector="signal", account="alice")
-        c2 = _connection("conn_bbb", connector="signal", account="bob")
-        block = build_connector_instructions_block(
-            {connection_server_name(c2): "bob prose"}, [c1, c2]
-        )
-        assert "alice" not in block
-        assert "bob prose" in block
+    def test_empty_instruction_text_skipped(self) -> None:
+        block = build_mcp_instructions_block({"signal": "", "github": "github prose"})
+        assert "signal" not in block
+        assert "github prose" in block
 
 
-class TestAugmentWithConnectorInstructions:
+class TestAugmentWithMcpInstructions:
     def test_no_instructions_returns_base_unchanged(self) -> None:
-        c = _connection("conn_aaa")
-        assert augment_with_connector_instructions("base", {}, [c]) == "base"
+        assert augment_with_mcp_instructions("base", {}) == "base"
 
     def test_appends_block_after_base(self) -> None:
-        c = _connection("conn_aaa", connector="signal", account="alice")
-        out = augment_with_connector_instructions(
-            "base system", {connection_server_name(c): "prose"}, [c]
-        )
+        out = augment_with_mcp_instructions("base system", {"signal": "prose"})
         assert out.startswith("base system")
-        assert "## Connector: signal/alice" in out
+        assert "## MCP server: signal" in out
         assert "\n\n" in out
 
     def test_empty_base_yields_block_only(self) -> None:
-        c = _connection("conn_aaa", connector="signal", account="alice")
-        out = augment_with_connector_instructions("", {connection_server_name(c): "prose"}, [c])
-        assert out.startswith("## Connector:")
+        out = augment_with_mcp_instructions("", {"signal": "prose"})
+        assert out.startswith("## MCP server:")
         assert not out.startswith("\n")
 
 

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -1,13 +1,12 @@
 """Unit tests for discover_session_mcp_tools.
 
 Covers the collect-URLs-then-discover shape: agent-declared MCP filtered by
-enabled mcp_toolset entries. Connections are present only to alias
-connector-specific MCP instructions into connector-aware prompt blocks.
+enabled mcp_toolset entries. MCP instructions are returned under normal
+agent MCP server names.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -15,7 +14,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from aios.models.agents import McpChannelContext, McpServerSpec, ToolSpec
-from aios.models.connections import Connection
 
 
 @pytest.fixture(autouse=True)
@@ -26,21 +24,6 @@ def _mock_crypto_box() -> Any:
     with patch("aios.harness.loop.runtime.require_crypto_box") as m:
         m.return_value = object()
         yield m
-
-
-def _connection(
-    cid: str,
-    connector: str = "signal",
-) -> Connection:
-    now = datetime(2026, 4, 16)
-    return Connection(
-        id=cid,
-        connector=connector,
-        account="acct",
-        metadata={},
-        created_at=now,
-        updated_at=now,
-    )
 
 
 def _agent(
@@ -61,7 +44,6 @@ class TestDiscoverSessionMcpTools:
             pool=AsyncMock(),
             session_id="sess_x",
             agent=_agent(),
-            connections=[],
         )
         assert tools == []
         assert instructions == {}
@@ -97,43 +79,17 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
-                connections=[],
             )
         names = {t["name"] for t in tools}
         assert names == {"mcp__gh__t"}
 
-    async def test_connections_do_not_project_mcp(self) -> None:
-        from aios.harness.loop import discover_session_mcp_tools
-
-        connections = [
-            _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F"),
-            _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8G"),
-        ]
-
-        with (
-            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
-            patch("aios.mcp.client.discover_mcp_tools", new_callable=AsyncMock) as discover,
-        ):
-            tools, instructions = await discover_session_mcp_tools(
-                pool=AsyncMock(),
-                session_id="sess_x",
-                agent=_agent(),
-                connections=connections,
-            )
-
-        assert tools == []
-        assert instructions == {}
-        resolve.assert_not_called()
-        discover.assert_not_called()
-
-    async def test_agent_and_connections_discovers_only_agent_servers(self) -> None:
+    async def test_discovers_only_agent_servers(self) -> None:
         from aios.harness.loop import discover_session_mcp_tools
 
         agent = _agent(
             mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
             tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
         )
-        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")]
 
         async def _discover(
             url: str, name: str, _headers: dict[str, str]
@@ -149,12 +105,11 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
-                connections=connections,
             )
         urls = sorted(t["url"] for t in tools)
         assert urls == ["https://mcp.github"]
 
-    async def test_channel_only_connection_aliases_matching_focal_server_instructions(
+    async def test_focal_server_instructions_are_not_connection_aliased(
         self,
     ) -> None:
         from aios.harness.loop import discover_session_mcp_tools
@@ -170,7 +125,6 @@ class TestDiscoverSessionMcpTools:
                 )
             ],
         )
-        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")]
 
         async def _discover(
             url: str, name: str, _headers: dict[str, str]
@@ -186,14 +140,10 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
-                connections=connections,
             )
 
         assert tools == [{"name": "mcp__signal__t", "url": "https://m1"}]
-        assert instructions == {
-            "signal": "send via focal",
-            "conn_01HQR2K7VXBZ9MNPL3WYCT8F": "send via focal",
-        }
+        assert instructions == {"signal": "send via focal"}
 
     async def test_auth_resolved_per_url(self) -> None:
         """Each URL resolves auth independently — goes through
@@ -230,7 +180,6 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
-                connections=[],
             )
         assert seen == ["https://mcp.github"]
         assert {t["auth"] for t in tools} == {"Bearer token-for-https://mcp.github"}
@@ -239,7 +188,7 @@ class TestDiscoverSessionMcpTools:
         """Each server's ``InitializeResult.instructions`` flows into the
         returned dict under its server_name key.  Servers that supply no
         instructions are omitted — the harness uses dict membership as
-        the trigger for rendering a per-connector affordance block.
+        the trigger for rendering MCP server affordance prose.
         """
         from aios.harness.loop import discover_session_mcp_tools
 
@@ -254,7 +203,6 @@ class TestDiscoverSessionMcpTools:
                 )
             ],
         )
-        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")]
 
         async def _discover(
             url: str, name: str, _headers: dict[str, str]
@@ -270,12 +218,8 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
-                connections=connections,
             )
-        assert instructions == {
-            "signal": "## signal\n\nbe nice",
-            "conn_01HQR2K7VXBZ9MNPL3WYCT8F": "## signal\n\nbe nice",
-        }
+        assert instructions == {"signal": "## signal\n\nbe nice"}
 
     async def test_empty_string_instructions_omitted(self) -> None:
         """An empty string is treated identically to ``None`` — no
@@ -303,6 +247,5 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
-                connections=[_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")],
             )
         assert instructions == {}

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -147,11 +147,11 @@ def mock_step_dependencies() -> Any:
         # Channels helpers are imported lazily inside run_session_step —
         # patch them at their source module rather than on loop.
         patch(
-            "aios.harness.channels.list_bindings_and_connections",
-            AsyncMock(return_value=([], [])),
+            "aios.harness.channels.list_session_bindings",
+            AsyncMock(return_value=[]),
         ),
         patch(
-            "aios.harness.channels.augment_with_connector_instructions",
+            "aios.harness.channels.augment_with_mcp_instructions",
             return_value="sys",
         ),
         patch(

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -289,7 +289,7 @@ class TestDiscoverMcpTools:
         """``InitializeResult.instructions`` is the standard MCP transport
         for per-server prompt affordance prose.  The harness reads it from
         ``discover_mcp_tools``'s second return slot to compose the
-        per-connector system-prompt block.
+        per-server system-prompt block.
         """
         mock_tool = _make_mock_tool("signal_send", "Send a Signal message", {"type": "object"})
         mock_result = MagicMock()

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -173,8 +173,8 @@ class TestEntrySweepSpan:
                 AsyncMock(return_value=agent),
             ),
             patch(
-                "aios.harness.channels.list_bindings_and_connections",
-                AsyncMock(return_value=([], [])),
+                "aios.harness.channels.list_session_bindings",
+                AsyncMock(return_value=[]),
             ),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -226,8 +226,8 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value=agent),
             ),
             patch(
-                "aios.harness.channels.list_bindings_and_connections",
-                AsyncMock(return_value=([], [])),
+                "aios.harness.channels.list_session_bindings",
+                AsyncMock(return_value=[]),
             ),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",
@@ -319,8 +319,8 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value=agent),
             ),
             patch(
-                "aios.harness.channels.list_bindings_and_connections",
-                AsyncMock(return_value=([], [])),
+                "aios.harness.channels.list_session_bindings",
+                AsyncMock(return_value=[]),
             ),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",
@@ -415,8 +415,8 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value=agent),
             ),
             patch(
-                "aios.harness.channels.list_bindings_and_connections",
-                AsyncMock(return_value=([], [])),
+                "aios.harness.channels.list_session_bindings",
+                AsyncMock(return_value=[]),
             ),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",


### PR DESCRIPTION
Stacked on #182 (`codex/remove-connection-mcp-fields`).

## Summary
- Render MCP `InitializeResult.instructions` directly by agent MCP server name instead of aliasing them through `conn_*` per-connection keys.
- Remove the remaining `conn_` instruction namespace helper and unused connection-by-id lookup.
- Stop loading connection rows during worker/context composition; context now needs only channel bindings plus agent MCP config.
- Update tests and docs/comments around per-server MCP instruction rendering.

## Validation
- `uv run pytest tests/unit/test_channels_helpers.py tests/unit/test_discover_session_mcp_tools.py tests/unit/test_loop_retry.py tests/unit/test_sweep_instrumentation.py tests/unit/test_wake_instrumentation.py tests/unit/test_mcp_client.py -q`
- `uv run pytest tests/e2e/test_context_endpoint.py -q`
- `uv run ruff check src tests connectors/signal/src/aios_signal/mcp.py connectors/telegram/src/aios_telegram/mcp.py migrations/versions/0025_channel_only_connections.py migrations/versions/0026_drop_connection_mcp_fields.py`
- `uv run mypy src`
- `uv run ruff format --check src tests connectors/signal/src/aios_signal/mcp.py connectors/telegram/src/aios_telegram/mcp.py migrations/versions/0025_channel_only_connections.py migrations/versions/0026_drop_connection_mcp_fields.py`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/e2e/test_context_endpoint.py tests/e2e/test_focal_channel.py::TestMcpMetaInjection tests/e2e/test_step_separator.py -q`
- pre-commit on commit: ruff, mypy, unit tests (`896 passed`)