### PR TITLE
[codex] Inject focal meta for all MCP calls

### DIFF
--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -56,8 +56,7 @@ curl -X POST :8090/v1/vaults/$VLT/credentials -d '{
 
 ### 3. Add the MCP server to your agent
 
-Add the Signal MCP server as a normal agent MCP server, and mark its toolset
-as focal-channel aware:
+Add the Signal MCP server as a normal agent MCP server:
 
 ```
 {
@@ -68,7 +67,9 @@ as focal-channel aware:
     {
       "type": "mcp_toolset",
       "mcp_server_name": "signal",
-      "channel_context": {"type": "focal"}
+      "default_config": {
+        "permission_policy": {"type": "always_allow"}
+      }
     }
   ]
 }

--- a/connectors/signal/src/aios_signal/mcp.py
+++ b/connectors/signal/src/aios_signal/mcp.py
@@ -42,8 +42,8 @@ log = structlog.get_logger(__name__)
 
 
 # Key under a JSON-RPC tool-call request's ``_meta`` populated by the aios
-# worker when dispatching a focal-channel MCP toolset. Its value is the
-# focal-channel path suffix — for Signal's 3-segment address
+# worker when dispatching an MCP tool call while a focal channel is set. Its
+# value is the focal-channel path suffix — for Signal's 3-segment address
 # ``signal/<bot>/<chat>``, the suffix is just ``<chat>`` and can be decoded
 # directly as the Signal chat id. See ``aios.harness.channels`` for the
 # client-side contract.
@@ -53,13 +53,12 @@ _FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 def focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> str:
     """Extract the Signal ``chat_id`` from an MCP request's ``_meta``.
 
-    aios injects ``aios.focal_channel_path`` for focal-channel tool calls;
+    aios injects ``aios.focal_channel_path`` for MCP tool calls while focal
+    is set;
     its value is the full focal-channel suffix (stripped of
     ``<connector>/<account>``), which for a 3-segment Signal address equals
-    the chat id verbatim. Missing / malformed meta raises — the agent
-    shouldn't be able to reach these tools without a focal channel set (aios
-    filters them out of the tool list when focal is NULL), so any absence
-    here is a real error to surface.
+    the chat id verbatim. Missing / malformed meta raises so the agent sees
+    that it must focus a channel before using Signal response tools.
     """
     path: Any = None
     if meta is not None:

--- a/connectors/signal/src/aios_signal/prompts.py
+++ b/connectors/signal/src/aios_signal/prompts.py
@@ -2,8 +2,7 @@
 
 Returned in the ``InitializeResult.instructions`` field of the MCP
 ``initialize`` response; the aios harness concatenates it into the
-session's system prompt under a ``## Connector: signal/<account>``
-heading.
+session's system prompt under the Signal MCP server heading.
 
 Covers only the tools this server actually exposes — ``signal_send``,
 ``signal_react``, ``signal_read_receipt``.  Telling the model about

--- a/connectors/signal/tests/test_mcp.py
+++ b/connectors/signal/tests/test_mcp.py
@@ -172,7 +172,8 @@ async def test_signal_send_reads_focal_from_meta() -> None:
 async def test_signal_send_errors_without_meta() -> None:
     rpc = FakeRpc()
     mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
-    # No focal — aios should have filtered this tool out, but defend.
+    # No focal — aios omits focal metadata, and the connector surfaces the
+    # missing focus as a tool error.
     ctx_no_meta = _ctx_with_focal(None)
     with pytest.raises(Exception, match="focal channel"):
         await mcp._tool_manager.call_tool(

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -48,8 +48,7 @@ curl -X POST :8090/v1/vaults/$VLT/credentials -d '{
 
 ### 3. Add the MCP server to your agent
 
-Add the Telegram MCP server as a normal agent MCP server, and mark its toolset
-as focal-channel aware:
+Add the Telegram MCP server as a normal agent MCP server:
 
 ```
 {
@@ -60,7 +59,9 @@ as focal-channel aware:
     {
       "type": "mcp_toolset",
       "mcp_server_name": "telegram",
-      "channel_context": {"type": "focal"}
+      "default_config": {
+        "permission_policy": {"type": "always_allow"}
+      }
     }
   ]
 }

--- a/connectors/telegram/src/aios_telegram/mcp.py
+++ b/connectors/telegram/src/aios_telegram/mcp.py
@@ -33,8 +33,8 @@ log = structlog.get_logger(__name__)
 
 
 # Key under a JSON-RPC tool-call request's ``_meta`` populated by the aios
-# worker when dispatching a focal-channel MCP toolset. Its value is the
-# focal-channel path suffix — for Telegram's 3-segment address
+# worker when dispatching an MCP tool call while a focal channel is set. Its
+# value is the focal-channel path suffix — for Telegram's 3-segment address
 # ``telegram/<bot_id>/<chat_id>``, the suffix is just ``<chat_id>`` and can be
 # parsed as a signed integer.
 _FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
@@ -43,13 +43,12 @@ _FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 def focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> int:
     """Extract the Telegram ``chat_id`` from an MCP request's ``_meta``.
 
-    aios injects ``aios.focal_channel_path`` for focal-channel tool calls;
+    aios injects ``aios.focal_channel_path`` for MCP tool calls while focal
+    is set;
     its value is the full focal-channel suffix (stripped of
     ``<connector>/<account>``), which for a 3-segment Telegram address
-    is the decimal chat id. Missing / malformed meta raises — the agent
-    shouldn't be able to reach these tools without a focal channel set
-    (aios filters them out of the tool list when focal is NULL), so any
-    absence here is a real error to surface.
+    is the decimal chat id. Missing / malformed meta raises so the agent sees
+    that it must focus a channel before using Telegram response tools.
     """
     path: Any = None
     if meta is not None:

--- a/connectors/telegram/src/aios_telegram/prompts.py
+++ b/connectors/telegram/src/aios_telegram/prompts.py
@@ -2,8 +2,7 @@
 
 Returned in the ``InitializeResult.instructions`` field of the MCP
 ``initialize`` response; the aios harness concatenates it into the
-session's system prompt under a ``## Connector: telegram/<account>``
-heading.
+session's system prompt under the Telegram MCP server heading.
 
 Covers only the tool this server exposes — ``telegram_send``. Telling the
 model about tools that don't exist would be worse than silence.

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -21,11 +21,11 @@ MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: "
 # per-channel ``last_seen`` watermark off successful switches.
 SWITCH_CHANNEL_METADATA_KEY = "switch_channel"
 
-# Top-level key inside the ``_meta`` field sent on JSON-RPC tool-call requests
-# to focal-channel MCP toolsets. The value is the focal-channel suffix (the
-# focal channel address with its first two ``<connector>/<account>`` segments
-# stripped). The MCP server splits this on ``/`` to recover its own per-chat
-# identifiers.
+# Top-level key inside the ``_meta`` field sent on JSON-RPC MCP tool-call
+# requests when a focal channel is set. The value is the focal-channel suffix
+# (the focal channel address with its first two ``<connector>/<account>``
+# segments stripped). MCP servers that understand aios channels can split this
+# on ``/`` to recover their own per-chat identifiers; other servers ignore it.
 FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
 
@@ -101,16 +101,18 @@ def build_focal_paradigm_block(bindings: list[ChannelBinding]) -> str:
         "quoting recent messages on that channel so you can pick up "
         "the conversation in context.  Call "
         "`switch_channel(channel_id=null)` to put your phone down — "
-        "every inbound renders as a notification, connector response "
-        "tools disappear from your tool list.  Switching repeatedly "
-        "is cheap but not free: each switch's re-orient block appends "
-        "tokens to your context.\n"
+        "every inbound renders as a notification and MCP calls receive "
+        "no focal-channel metadata.  Switching repeatedly is cheap but "
+        "not free: each switch's re-orient block appends tokens to "
+        "your context.\n"
         "\n"
         "### Responding\n"
         "\n"
         "When focused on a channel, the connector's response tools "
         "(e.g. `signal_send`, `signal_react`) operate on your focal "
         "channel implicitly — no channel/chat-id argument required. "
+        "If your phone is down, switch to the intended channel before "
+        "using channel response tools. "
         "Bare assistant text is NOT delivered to any channel — it is "
         "private thinking no human sees. Prefix any such thinking with "
         f"{MONOLOGUE_PREFIX.strip()!r} so it is unambiguous in your "

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -183,8 +183,6 @@ async def _run_session_step_body(
     bindings = await list_session_bindings(pool, session_id)
 
     mcp_server_map: dict[str, str] = {s.name: s.url for s in agent.mcp_servers}
-    channel_context_by_server = mcp_channel_context_by_server(agent.tools)
-
     # Read windowed message events for this session.
     events = await sessions_service.read_windowed_events(
         pool,
@@ -208,7 +206,6 @@ async def _run_session_step_body(
                 session_id,
                 pending_mcp,
                 mcp_server_map,
-                channel_context_by_server=channel_context_by_server,
                 focal_channel=session.focal_channel,
             )
         log.info(
@@ -435,7 +432,6 @@ async def _run_session_step_body(
                 session_id,
                 mcp_immediate,
                 mcp_server_map,
-                channel_context_by_server=channel_context_by_server,
                 focal_channel=session.focal_channel,
             )
             log.info(
@@ -501,58 +497,6 @@ def _switch_channel_tool_spec() -> dict[str, Any]:
             "parameters": tool.parameters_schema,
         },
     }
-
-
-def _mcp_server_name_from_tool_name(name: str) -> str | None:
-    parts = name.split("__", 2)
-    if len(parts) < 3 or not parts[1] or not parts[2]:
-        return None
-    return parts[1]
-
-
-def mcp_channel_context_by_server(
-    agent_tools: list[ToolSpec],
-) -> dict[str, str]:
-    """Return server_name -> channel context type for MCP toolsets.
-
-    Channel-aware MCP behavior is declared on normal agent ``mcp_toolset``
-    entries; connections do not contribute MCP server context.
-    """
-    contexts: dict[str, str] = {}
-    for spec in agent_tools:
-        if (
-            spec.type != "mcp_toolset"
-            or not spec.enabled
-            or not spec.mcp_server_name
-            or spec.channel_context is None
-        ):
-            continue
-        contexts[spec.mcp_server_name] = spec.channel_context.type
-    return contexts
-
-
-def _hide_focal_channel_tools_when_phone_down(
-    mcp_tools: list[dict[str, Any]],
-    focal_channel: str | None,
-    channel_context_by_server: dict[str, str],
-) -> list[dict[str, Any]]:
-    """Filter focal-channel MCP tools out when focal is NULL.
-
-    Those tools resolve their channel path from focal (injected into
-    ``_meta`` at dispatch time); a "phone down" state has no focal to
-    inject, so the model shouldn't be offered them. Other MCP tools are
-    untouched.
-    """
-    if focal_channel is not None:
-        return mcp_tools
-    filtered: list[dict[str, Any]] = []
-    for tool in mcp_tools:
-        name = tool.get("function", {}).get("name", "")
-        server_name = _mcp_server_name_from_tool_name(name)
-        if server_name is not None and channel_context_by_server.get(server_name) == "focal":
-            continue
-        filtered.append(tool)
-    return filtered
 
 
 async def _dump_context_if_enabled(
@@ -625,8 +569,8 @@ def resolve_mcp_permission(
     tool name, then returns the ``default_config.permission_policy.type``
     or ``None`` (which callers treat as ``always_ask``).
 
-    Focal-channel MCP toolsets default to ``always_allow`` because declaring
-    channel context is already the operator's trust decision for that server.
+    MCP tools do not gain implicit permissions from channel/focal behavior;
+    operators grant execution policy through normal MCP toolset config.
     """
     server_name = name.split("__", 2)[1]
     for spec in agent_tools:
@@ -636,8 +580,6 @@ def resolve_mcp_permission(
                 return cfg.permission_policy.type
             if spec.permission:
                 return spec.permission
-            if spec.channel_context is not None and spec.channel_context.type == "focal":
-                return "always_allow"
             return None
     return None
 

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -73,10 +73,8 @@ async def compose_step_context(
         build_channels_tail_block,
     )
     from aios.harness.loop import (
-        _hide_focal_channel_tools_when_phone_down,
         _switch_channel_tool_spec,
         discover_session_mcp_tools,
-        mcp_channel_context_by_server,
     )
     from aios.harness.skills import augment_system_prompt
     from aios.services import skills as skills_service
@@ -90,12 +88,6 @@ async def compose_step_context(
     mcp_instructions: dict[str, str] = {}
     if agent.mcp_servers:
         mcp_tools, mcp_instructions = await discover_session_mcp_tools(pool, session_id, agent)
-        # Hide focal-channel MCP tools when focal is NULL — can't type
-        # into a chat you aren't attending to.
-        channel_context_by_server = mcp_channel_context_by_server(agent.tools)
-        mcp_tools = _hide_focal_channel_tools_when_phone_down(
-            mcp_tools, session.focal_channel, channel_context_by_server
-        )
         tools.extend(mcp_tools)
 
     skill_versions = (

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -313,7 +313,6 @@ def launch_mcp_tool_calls(
     tool_calls: list[dict[str, Any]],
     mcp_server_map: dict[str, str],
     *,
-    channel_context_by_server: dict[str, str] | None = None,
     focal_channel: str | None = None,
 ) -> None:
     """Launch MCP tool calls as asyncio tasks. Returns immediately.
@@ -321,8 +320,8 @@ def launch_mcp_tool_calls(
     ``focal_channel`` is the session's focal at the moment these calls
     were emitted (captured at step top in ``run_session_step`` so a
     concurrent ``switch_channel`` in the same batch cannot race the
-    ``chat_id`` injection).  Passed through to each task so channel-aware
-    MCP toolsets can stamp ``_meta`` with the suffix.
+    ``chat_id`` injection).  Passed through to each task so MCP calls can
+    stamp ``_meta`` with the suffix when a focal channel is set.
     """
     _launch_tasks(
         session_id,
@@ -332,7 +331,6 @@ def launch_mcp_tool_calls(
             session_id,
             call,
             mcp_server_map,
-            channel_context_by_server=channel_context_by_server,
             focal_channel=focal_channel,
         ),
         prefix="mcp_tool",
@@ -356,17 +354,16 @@ async def _execute_mcp_tool_async(
     call: dict[str, Any],
     mcp_server_map: dict[str, str],
     *,
-    channel_context_by_server: dict[str, str] | None = None,
     focal_channel: str | None = None,
 ) -> None:
     """Execute one MCP tool call: connect, invoke, append result, defer wake.
 
-    For focal-channel MCP toolsets, the focal-channel suffix is stamped
-    into the JSON-RPC request's ``_meta`` so the server can resolve its
-    channel-specific identifiers without the model having to pass them
-    explicitly.  The ``focal_channel`` snapshot is emission-time — a
-    concurrent ``switch_channel`` in the same assistant batch does not
-    race this injection.
+    When a focal channel is set, its suffix is stamped into the JSON-RPC
+    request's ``_meta`` so servers that understand aios channel context can
+    resolve channel-specific identifiers without the model having to pass
+    them explicitly.  The ``focal_channel`` snapshot is emission-time — a
+    concurrent ``switch_channel`` in the same assistant batch does not race
+    this injection.
     """
     call_id = call.get("id") or "unknown"
     function = call.get("function") or {}
@@ -410,27 +407,10 @@ async def _execute_mcp_tool_async(
         from aios.harness.channels import FOCAL_CHANNEL_META_KEY, focal_channel_path
         from aios.mcp.client import call_mcp_tool, resolve_auth_for_url
 
-        meta: dict[str, Any] | None = None
-        channel_context = (channel_context_by_server or {}).get(server_name)
-        if channel_context == "focal":
-            suffix = focal_channel_path(focal_channel)
-            if suffix is None:
-                # The model shouldn't be able to call a focal-channel tool
-                # while focal is NULL — loop.py filters them out of the tool
-                # list in that state — but defend in depth if it slips through
-                # (stale tool_calls, etc.).
-                is_error = True
-                await _append_tool_result(
-                    pool,
-                    session_id,
-                    call_id,
-                    name,
-                    error=(
-                        "channel-aware MCP tools require a focal channel; call switch_channel first"
-                    ),
-                )
-                return
-            meta = {FOCAL_CHANNEL_META_KEY: suffix}
+        suffix = focal_channel_path(focal_channel)
+        meta: dict[str, Any] | None = (
+            {FOCAL_CHANNEL_META_KEY: suffix} if suffix is not None else None
+        )
 
         crypto_box = runtime.require_crypto_box()
         headers = await resolve_auth_for_url(

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -193,10 +193,10 @@ async def call_mcp_tool(
 
     ``tool_name`` is the raw MCP tool name (without the ``mcp__`` prefix).
     ``meta`` is an optional per-request metadata dict forwarded as the
-    JSON-RPC request's ``_meta`` field — used by the focal-channel
-    redesign to pass ``aios.focal_channel_path`` to channel-aware MCP
-    servers without stuffing it into arguments.  Returns a result
-    dict with either ``content`` (success) or ``error`` (failure).
+    JSON-RPC request's ``_meta`` field. The harness uses it to pass
+    ``aios.focal_channel_path`` whenever the session has a focal channel,
+    without stuffing channel context into model-supplied arguments. Returns a
+    result dict with either ``content`` (success) or ``error`` (failure).
     """
     try:
         from aios.harness import runtime

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -84,11 +84,12 @@ class McpToolConfig(BaseModel):
 
 
 class McpChannelContext(BaseModel):
-    """Channel behavior for an MCP toolset.
+    """Deprecated channel-context marker for older agent configs.
 
-    ``type="focal"`` means tools from this server operate on the session's
-    current focal channel. The harness hides those tools when no focal channel
-    is set and injects the focal channel path into MCP request ``_meta``.
+    The runtime now injects focal-channel metadata into every MCP call when
+    the session has a focal channel, so this field is no longer used to gate
+    tool visibility, permissions, or dispatch behavior. It remains accepted on
+    ``mcp_toolset`` entries so existing stored agent JSON validates.
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/tests/e2e/test_context_endpoint.py
+++ b/tests/e2e/test_context_endpoint.py
@@ -185,3 +185,54 @@ class TestContextEndpoint:
             r = await http_client.get(f"/v1/sessions/{session.id}/context")
 
         assert r.status_code == 200, r.text
+
+    async def test_phone_down_context_keeps_discovered_mcp_tools(
+        self, http_client: httpx.AsyncClient, pool: Any
+    ) -> None:
+        """Phone-down suppresses focal metadata at call time, not MCP tool visibility."""
+        from aios.db import queries
+        from aios.models.agents import McpServerSpec, ToolSpec
+        from aios.services import agents as agents_svc
+        from aios.services import sessions as sessions_svc
+
+        async with pool.acquire() as conn:
+            env = await queries.insert_environment(conn, name=f"ctx-mcp-env-{_uniq()}")
+        agent = await agents_svc.create_agent(
+            pool,
+            name=f"ctx-mcp-agent-{_uniq()}",
+            model="openai/gpt-4o-mini",
+            system="",
+            tools=[ToolSpec(type="mcp_toolset", mcp_server_name="signal")],
+            mcp_servers=[McpServerSpec(name="signal", url="http://127.0.0.1:1/mcp")],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        session = await sessions_svc.create_session(
+            pool,
+            agent_id=agent.id,
+            environment_id=env.id,
+            title=None,
+            metadata={},
+        )
+        discovered = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "mcp__signal__signal_send",
+                    "description": "Send a message",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ]
+
+        with mock.patch(
+            "aios.harness.loop.discover_session_mcp_tools",
+            new=mock.AsyncMock(return_value=(discovered, {})),
+        ):
+            r = await http_client.get(f"/v1/sessions/{session.id}/context")
+
+        assert r.status_code == 200, r.text
+        names = [tool["function"]["name"] for tool in r.json()["tools"]]
+        assert "mcp__signal__signal_send" in names

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -877,7 +877,6 @@ class TestMcpMetaInjection:
                     session_id,
                     tool_call_dict,
                     mcp_server_map,
-                    channel_context_by_server={"signal": "focal"},
                     focal_channel=address,  # focal=A → suffix=chat-1
                 )
 
@@ -889,17 +888,14 @@ class TestMcpMetaInjection:
         finally:
             runtime.crypto_box = prev_crypto
 
-    async def test_normal_mcp_tool_dispatch_no_meta_stamped(
+    async def test_normal_mcp_tool_dispatch_stamps_focal_meta(
         self,
         runtime_pool: Any,
         agent_id: str,
         env_id: str,
         vault_id: str,
     ) -> None:
-        """MCP servers without channel_context don't get focal meta — aios
-        has no business telling unrelated MCP servers about the session's
-        focal channel.
-        """
+        """All MCP calls receive focal metadata when the session has focus."""
         from unittest.mock import AsyncMock, patch
 
         from aios.crypto.vault import CryptoBox
@@ -938,11 +934,63 @@ class TestMcpMetaInjection:
                     session_id,
                     tool_call_dict,
                     mcp_server_map,
-                    focal_channel=address,  # non-null focal, but no channel_context
+                    focal_channel=address,
                 )
 
             _args, kwargs = mock_call.call_args
-            # No meta for ordinary MCP.
+            assert kwargs.get("meta") == {"aios.focal_channel_path": "chat-1"}
+        finally:
+            runtime.crypto_box = prev_crypto
+
+    async def test_mcp_tool_dispatch_omits_meta_when_phone_down(
+        self,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        """Phone-down sessions still call MCP tools, just without focal metadata."""
+        from unittest.mock import AsyncMock, patch
+
+        from aios.crypto.vault import CryptoBox
+        from aios.harness import runtime
+        from aios.harness.tool_dispatch import _execute_mcp_tool_async
+
+        prev_crypto = runtime.crypto_box
+        runtime.crypto_box = CryptoBox(__import__("os").urandom(32))
+        try:
+            connection = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+            session_id, _e, _address = await _post_inbound(runtime_pool, connection, "chat-1")
+
+            mcp_server_map = {"signal": "https://m"}
+            tool_call_dict = {
+                "id": "call_send_1",
+                "type": "function",
+                "function": {
+                    "name": "mcp__signal__signal_send",
+                    "arguments": json.dumps({"text": "hi there"}),
+                },
+            }
+
+            with (
+                patch(
+                    "aios.mcp.client.resolve_auth_for_url",
+                    new=AsyncMock(return_value={}),
+                ),
+                patch(
+                    "aios.mcp.client.call_mcp_tool",
+                    new=AsyncMock(return_value={"content": "ok"}),
+                ) as mock_call,
+            ):
+                await _execute_mcp_tool_async(
+                    runtime_pool,
+                    session_id,
+                    tool_call_dict,
+                    mcp_server_map,
+                    focal_channel=None,
+                )
+
+            _args, kwargs = mock_call.call_args
             assert kwargs.get("meta") is None
         finally:
             runtime.crypto_box = prev_crypto

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from aios.models.agents import McpChannelContext, McpServerSpec, ToolSpec
+from aios.models.agents import McpServerSpec, ToolSpec
 
 
 @pytest.fixture(autouse=True)
@@ -121,7 +121,6 @@ class TestDiscoverSessionMcpTools:
                     type="mcp_toolset",
                     enabled=True,
                     mcp_server_name="signal",
-                    channel_context=McpChannelContext(type="focal"),
                 )
             ],
         )
@@ -199,7 +198,6 @@ class TestDiscoverSessionMcpTools:
                     type="mcp_toolset",
                     enabled=True,
                     mcp_server_name="signal",
-                    channel_context=McpChannelContext(type="focal"),
                 )
             ],
         )

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -396,8 +396,8 @@ class TestCallMcpTool:
     async def test_meta_forwarded_to_session_call_tool(self) -> None:
         """The ``meta`` kwarg on call_mcp_tool reaches session.call_tool
         as its ``meta=`` kwarg so it lands in the JSON-RPC request's
-        ``_meta`` field (the transport for slice 6's focal-path
-        injection on channel-aware MCP servers).
+        ``_meta`` field, which is how the harness sends focal-channel
+        context to MCP servers.
         """
         mock_content = MagicMock()
         mock_content.text = "ok"
@@ -435,8 +435,7 @@ class TestCallMcpTool:
 
     async def test_meta_defaults_to_none(self) -> None:
         """When meta is omitted, session.call_tool is called with meta=None
-        — important for agent-declared MCP servers that should stay
-        unaware of aios internal context.
+        — this is the phone-down/no-context shape.
         """
         mock_content = MagicMock()
         mock_content.text = "ok"

--- a/tests/unit/test_mcp_models.py
+++ b/tests/unit/test_mcp_models.py
@@ -84,7 +84,7 @@ class TestMcpToolConfig:
         assert cfg.enabled is True
 
 
-class TestMcpChannelContext:
+class TestMcpChannelContextCompat:
     def test_focal_context_default(self) -> None:
         ctx = McpChannelContext()
         assert ctx.type == "focal"
@@ -131,7 +131,7 @@ class TestToolSpecMcpToolset:
         assert len(spec.configs) == 1
         assert spec.configs[0].name == "create_issue"
 
-    def test_mcp_toolset_with_channel_context(self) -> None:
+    def test_mcp_toolset_accepts_legacy_channel_context(self) -> None:
         spec = ToolSpec(
             type="mcp_toolset",
             mcp_server_name="signal",

--- a/tests/unit/test_mcp_routing.py
+++ b/tests/unit/test_mcp_routing.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 from aios.harness.loop import (
-    _hide_focal_channel_tools_when_phone_down,
     _is_mcp_tool,
     _tc_name,
-    mcp_channel_context_by_server,
     resolve_mcp_permission,
 )
 from aios.models.agents import (
@@ -92,7 +90,7 @@ class TestResolveMcpPermission:
         ]
         assert resolve_mcp_permission("mcp__github__create_issue", tools) is None
 
-    def test_focal_channel_toolset_defaults_to_always_allow(self) -> None:
+    def test_channel_context_does_not_change_default_permission(self) -> None:
         tools = [
             ToolSpec(
                 type="mcp_toolset",
@@ -100,7 +98,7 @@ class TestResolveMcpPermission:
                 channel_context=McpChannelContext(type="focal"),
             ),
         ]
-        assert resolve_mcp_permission("mcp__signal__signal_send", tools) == "always_allow"
+        assert resolve_mcp_permission("mcp__signal__signal_send", tools) is None
 
     def test_explicit_permission_beats_focal_default(self) -> None:
         tools = [
@@ -166,57 +164,3 @@ class TestToOpenaiToolsSkipsMcpToolset:
         )
         assert len(result) == 1
         assert result[0]["function"]["name"] == "bash"
-
-
-def _tool(name: str) -> dict[str, object]:
-    return {"type": "function", "function": {"name": name}}
-
-
-class TestHideFocalChannelToolsWhenPhoneDown:
-    """Focal-channel MCP tools disappear from the model's tool list when
-    the session's focal_channel is NULL. Other MCP tools and built-ins stay
-    visible.
-    """
-
-    def test_focal_set_keeps_all_tools(self) -> None:
-        tools = [
-            _tool("mcp__signal__signal_send"),
-            _tool("mcp__github__create_issue"),
-            _tool("bash"),
-        ]
-        result = _hide_focal_channel_tools_when_phone_down(
-            tools, "signal/bot/alice", {"signal": "focal"}
-        )
-        assert result == tools
-
-    def test_focal_null_hides_channel_aware_tools(self) -> None:
-        tools = [
-            _tool("mcp__signal__signal_send"),
-            _tool("mcp__signal__signal_react"),
-            _tool("mcp__github__create_issue"),
-            _tool("bash"),
-        ]
-        result = _hide_focal_channel_tools_when_phone_down(tools, None, {"signal": "focal"})
-        names = [t["function"]["name"] for t in result]  # type: ignore[index]
-        assert "mcp__signal__signal_send" not in names
-        assert "mcp__signal__signal_react" not in names
-        # Agent-declared MCP and built-ins survive.
-        assert "mcp__github__create_issue" in names
-        assert "bash" in names
-
-    def test_empty_list(self) -> None:
-        assert _hide_focal_channel_tools_when_phone_down([], None, {}) == []
-        assert _hide_focal_channel_tools_when_phone_down([], "signal/bot/alice", {}) == []
-
-    def test_contexts_come_from_toolset_config(self) -> None:
-        contexts = mcp_channel_context_by_server(
-            [
-                ToolSpec(
-                    type="mcp_toolset",
-                    mcp_server_name="signal",
-                    channel_context=McpChannelContext(type="focal"),
-                ),
-                ToolSpec(type="mcp_toolset", mcp_server_name="github"),
-            ]
-        )
-        assert contexts == {"signal": "focal"}


### PR DESCRIPTION
Stacked on #183 (`codex/mcp-server-instructions`).

## Summary
- Stop using `channel_context` as a runtime switch for MCP visibility, permissions, or dispatch.
- Keep discovered MCP tools visible even when the session is phone-down; phone-down now means MCP calls receive no focal `_meta`.
- Inject `aios.focal_channel_path` into every MCP call when the session has a focal channel, so channel-aware behavior is a normal MCP call affordance rather than a special toolset lane.
- Remove the focal-tool phone-down filter and implicit focal `always_allow` permission default; connector examples now grant `always_allow` through normal MCP toolset config.
- Update focal/context e2e coverage and connector docs/comments for the new `_meta` contract.

## Validation
- `uv run ruff check src tests connectors/signal/src/aios_signal/mcp.py connectors/signal/src/aios_signal/prompts.py connectors/signal/tests/test_mcp.py connectors/telegram/src/aios_telegram/mcp.py connectors/telegram/src/aios_telegram/prompts.py`
- `uv run ruff format --check src tests connectors/signal/src/aios_signal/mcp.py connectors/signal/src/aios_signal/prompts.py connectors/signal/tests/test_mcp.py connectors/telegram/src/aios_telegram/mcp.py connectors/telegram/src/aios_telegram/prompts.py`
- `uv run mypy src`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/e2e/test_focal_channel.py -q`
- `uv run pytest tests/e2e/test_context_endpoint.py -q`
- `(cd connectors/signal && uv run pytest tests/test_mcp.py -q)`
- `(cd connectors/telegram && uv run pytest tests/test_mcp.py -q)`
- pre-commit on commit: ruff, mypy, unit tests (`892 passed`)