### PR TITLE
[codex] Drop MCP channel context config

### DIFF
--- a/migrations/versions/0027_drop_mcp_channel_context.py
+++ b/migrations/versions/0027_drop_mcp_channel_context.py
@@ -1,0 +1,51 @@
+"""Drop deprecated MCP channel_context config.
+
+The runtime injects focal-channel metadata into normal MCP calls based on
+session state, not agent toolset config. Strip the old inert field from stored
+agent JSON before the Pydantic model stops accepting it.
+
+Revision ID: 0027
+Revises: 0026
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0027"
+down_revision: str = "0026"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _strip_channel_context_sql(table: str) -> str:
+    return f"""
+        UPDATE {table}
+           SET tools = (
+               SELECT COALESCE(
+                   jsonb_agg(
+                       CASE
+                           WHEN jsonb_typeof(tool) = 'object'
+                           THEN tool - 'channel_context'
+                           ELSE tool
+                       END
+                       ORDER BY ord
+                   ),
+                   '[]'::jsonb
+               )
+                 FROM jsonb_array_elements(COALESCE(tools, '[]'::jsonb))
+                      WITH ORDINALITY AS t(tool, ord)
+           )
+    """
+
+
+def upgrade() -> None:
+    op.execute(_strip_channel_context_sql("agents"))
+    op.execute(_strip_channel_context_sql("agent_versions"))
+
+
+def downgrade() -> None:
+    # The removed JSON field was inert and cannot be reconstructed.
+    pass

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -83,20 +83,6 @@ class McpToolConfig(BaseModel):
     permission_policy: McpPermissionPolicy | None = None
 
 
-class McpChannelContext(BaseModel):
-    """Deprecated channel-context marker for older agent configs.
-
-    The runtime now injects focal-channel metadata into every MCP call when
-    the session has a focal channel, so this field is no longer used to gate
-    tool visibility, permissions, or dispatch behavior. It remains accepted on
-    ``mcp_toolset`` entries so existing stored agent JSON validates.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    type: Literal["focal"] = "focal"
-
-
 # ── Tool declaration ──────────────────────────────────────────────────────────
 
 
@@ -131,7 +117,6 @@ class ToolSpec(BaseModel):
     mcp_server_name: str | None = None
     default_config: McpToolsetConfig | None = None
     configs: list[McpToolConfig] | None = None
-    channel_context: McpChannelContext | None = None
 
     @model_validator(mode="after")
     def _check_type_fields(self) -> ToolSpec:
@@ -144,8 +129,6 @@ class ToolSpec(BaseModel):
         elif self.type == "mcp_toolset":
             if self.mcp_server_name is None:
                 raise ValueError("mcp_toolset requires mcp_server_name")
-        elif self.channel_context is not None:
-            raise ValueError("channel_context is only supported for mcp_toolset")
         return self
 
 

--- a/tests/unit/test_mcp_models.py
+++ b/tests/unit/test_mcp_models.py
@@ -8,7 +8,6 @@ import pytest
 
 from aios.models.agents import (
     AgentCreate,
-    McpChannelContext,
     McpPermissionPolicy,
     McpServerSpec,
     McpToolConfig,
@@ -84,16 +83,6 @@ class TestMcpToolConfig:
         assert cfg.enabled is True
 
 
-class TestMcpChannelContextCompat:
-    def test_focal_context_default(self) -> None:
-        ctx = McpChannelContext()
-        assert ctx.type == "focal"
-
-    def test_extra_fields_rejected(self) -> None:
-        with pytest.raises(ValueError):
-            McpChannelContext(type="focal", path="chat")  # type: ignore[call-arg]
-
-
 class TestToolSpecMcpToolset:
     def test_basic_mcp_toolset(self) -> None:
         spec = ToolSpec(type="mcp_toolset", mcp_server_name="github")
@@ -131,18 +120,13 @@ class TestToolSpecMcpToolset:
         assert len(spec.configs) == 1
         assert spec.configs[0].name == "create_issue"
 
-    def test_mcp_toolset_accepts_legacy_channel_context(self) -> None:
-        spec = ToolSpec(
-            type="mcp_toolset",
-            mcp_server_name="signal",
-            channel_context=McpChannelContext(type="focal"),
-        )
-        assert spec.channel_context is not None
-        assert spec.channel_context.type == "focal"
-
-    def test_channel_context_only_allowed_on_mcp_toolset(self) -> None:
+    def test_channel_context_is_not_part_of_mcp_toolset_schema(self) -> None:
         with pytest.raises(ValueError, match="channel_context"):
-            ToolSpec(type="bash", channel_context=McpChannelContext(type="focal"))
+            ToolSpec(
+                type="mcp_toolset",
+                mcp_server_name="signal",
+                channel_context={"type": "focal"},  # type: ignore[call-arg]
+            )
 
     def test_mcp_toolset_round_trip(self) -> None:
         spec = ToolSpec(
@@ -196,4 +180,3 @@ class TestBackwardCompat:
         assert all(s.mcp_server_name is None for s in specs)
         assert all(s.default_config is None for s in specs)
         assert all(s.configs is None for s in specs)
-        assert all(s.channel_context is None for s in specs)

--- a/tests/unit/test_mcp_routing.py
+++ b/tests/unit/test_mcp_routing.py
@@ -8,7 +8,6 @@ from aios.harness.loop import (
     resolve_mcp_permission,
 )
 from aios.models.agents import (
-    McpChannelContext,
     McpPermissionPolicy,
     McpToolsetConfig,
     ToolSpec,
@@ -90,23 +89,12 @@ class TestResolveMcpPermission:
         ]
         assert resolve_mcp_permission("mcp__github__create_issue", tools) is None
 
-    def test_channel_context_does_not_change_default_permission(self) -> None:
-        tools = [
-            ToolSpec(
-                type="mcp_toolset",
-                mcp_server_name="signal",
-                channel_context=McpChannelContext(type="focal"),
-            ),
-        ]
-        assert resolve_mcp_permission("mcp__signal__signal_send", tools) is None
-
-    def test_explicit_permission_beats_focal_default(self) -> None:
+    def test_flat_permission_applies_to_signal_server(self) -> None:
         tools = [
             ToolSpec(
                 type="mcp_toolset",
                 mcp_server_name="signal",
                 permission="always_ask",
-                channel_context=McpChannelContext(type="focal"),
             ),
         ]
         assert resolve_mcp_permission("mcp__signal__signal_send", tools) == "always_ask"


### PR DESCRIPTION
Stacked on #184 (`codex/always-inject-focal-meta`).

## Summary
- Remove `McpChannelContext` and the `ToolSpec.channel_context` field from the agent schema.
- Add migration `0027` to strip legacy `channel_context` keys from stored `agents.tools` and `agent_versions.tools` JSONB arrays before model validation sees them.
- Update MCP model/routing tests now that focal metadata is derived from session state, not toolset config.

## Validation
- `uv run alembic heads`
- `uv run alembic history -r 0025:head`
- `uv run ruff check src tests migrations/versions/0027_drop_mcp_channel_context.py`
- `uv run ruff format --check src tests migrations/versions/0027_drop_mcp_channel_context.py`
- `uv run mypy src`
- `uv run pytest tests/unit/test_mcp_models.py tests/unit/test_mcp_routing.py tests/unit/test_discover_session_mcp_tools.py tests/e2e/test_context_endpoint.py::TestContextEndpoint::test_phone_down_context_keeps_discovered_mcp_tools -q`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/e2e/test_context_endpoint.py tests/e2e/test_focal_channel.py::TestMcpMetaInjection -q`
- `uv run pytest tests/integration/test_migrations.py::test_migration_creates_all_tables -q`
- pre-commit on commit: ruff, mypy, unit tests (`888 passed`)