### PR TITLE
[codex] Apply MCP toolset configs

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -32,7 +32,7 @@ from aios.harness.tokens import approx_tokens
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
 from aios.harness.wake import defer_retry_wake
 from aios.logging import get_logger
-from aios.models.agents import ToolSpec
+from aios.models.agents import McpToolConfig, ToolSpec
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
 
@@ -549,6 +549,14 @@ def _is_mcp_tool(name: str) -> bool:
     return name.startswith("mcp__")
 
 
+def _parse_mcp_tool_name(name: str) -> tuple[str, str] | None:
+    """Parse ``mcp__<server_name>__<tool_name>`` into its parts."""
+    parts = name.split("__", 2)
+    if len(parts) < 3 or not parts[1] or not parts[2]:
+        return None
+    return parts[1], parts[2]
+
+
 def resolve_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
     """Look up the permission policy for a built-in or custom tool by name."""
     for spec in agent_tools:
@@ -558,29 +566,86 @@ def resolve_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
     return None
 
 
+def _enabled_mcp_toolsets_by_server(agent_tools: list[ToolSpec]) -> dict[str, ToolSpec]:
+    """Return enabled MCP toolset specs keyed by server name."""
+    toolsets: dict[str, ToolSpec] = {}
+    for spec in agent_tools:
+        if (
+            spec.type == "mcp_toolset"
+            and spec.enabled
+            and spec.mcp_server_name
+            and spec.mcp_server_name not in toolsets
+        ):
+            toolsets[spec.mcp_server_name] = spec
+    return toolsets
+
+
+def _mcp_tool_config(spec: ToolSpec, tool_name: str) -> McpToolConfig | None:
+    for cfg in spec.configs or []:
+        if cfg.name == tool_name:
+            return cfg
+    return None
+
+
+def _is_mcp_tool_enabled(name: str, spec: ToolSpec) -> bool:
+    parsed = _parse_mcp_tool_name(name)
+    if parsed is None:
+        return False
+    server_name, tool_name = parsed
+    if server_name != spec.mcp_server_name:
+        return False
+    tool_cfg = _mcp_tool_config(spec, tool_name)
+    if tool_cfg is not None:
+        return tool_cfg.enabled
+    default_cfg = spec.default_config
+    if default_cfg is not None:
+        return default_cfg.enabled
+    return True
+
+
+def _filter_mcp_tools_for_toolset(
+    mcp_tools: list[dict[str, Any]],
+    spec: ToolSpec,
+) -> list[dict[str, Any]]:
+    filtered: list[dict[str, Any]] = []
+    for tool in mcp_tools:
+        name = tool.get("function", {}).get("name") or tool.get("name")
+        if isinstance(name, str) and _is_mcp_tool_enabled(name, spec):
+            filtered.append(tool)
+    return filtered
+
+
 def resolve_mcp_permission(
     name: str,
     agent_tools: list[ToolSpec],
 ) -> str | None:
     """Look up the permission policy for an MCP tool.
 
-    Finds the ``mcp_toolset`` entry whose
-    ``mcp_server_name`` matches the server portion of the namespaced
-    tool name, then returns the ``default_config.permission_policy.type``
-    or ``None`` (which callers treat as ``always_ask``).
+    Finds the enabled ``mcp_toolset`` entry whose ``mcp_server_name`` matches
+    the server portion of the namespaced tool name. Per-tool config overrides
+    the toolset default, and ``None`` means callers treat the call as
+    ``always_ask``.
 
     MCP tools do not gain implicit permissions from channel/focal behavior;
     operators grant execution policy through normal MCP toolset config.
     """
-    server_name = name.split("__", 2)[1]
-    for spec in agent_tools:
-        if spec.type == "mcp_toolset" and spec.mcp_server_name == server_name:
-            cfg = spec.default_config
-            if cfg and cfg.permission_policy:
-                return cfg.permission_policy.type
-            if spec.permission:
-                return spec.permission
-            return None
+    parsed = _parse_mcp_tool_name(name)
+    if parsed is None:
+        return None
+    server_name, tool_name = parsed
+    spec = _enabled_mcp_toolsets_by_server(agent_tools).get(server_name)
+    if spec is None:
+        return None
+
+    tool_cfg = _mcp_tool_config(spec, tool_name)
+    if tool_cfg is not None and tool_cfg.permission_policy is not None:
+        return tool_cfg.permission_policy.type
+
+    cfg = spec.default_config
+    if cfg and cfg.permission_policy:
+        return cfg.permission_policy.type
+    if spec.permission:
+        return spec.permission
     return None
 
 
@@ -590,7 +655,7 @@ async def discover_session_mcp_tools(
     agent: Any,
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
     """Discover MCP tools from agent-declared servers (filtered by enabled
-    ``mcp_toolset`` entries).
+    ``mcp_toolset`` entries and their default/per-tool enabled settings).
 
     Returns ``(tools, instructions_by_server)`` where the second element
     maps ``server_name`` → the server's ``InitializeResult.instructions``
@@ -602,15 +667,13 @@ async def discover_session_mcp_tools(
 
     from aios.mcp.client import discover_mcp_tools, resolve_auth_for_url
 
-    servers: list[tuple[str, str]] = []
+    servers: list[tuple[str, str, ToolSpec]] = []
 
-    enabled_server_names: set[str] = set()
-    for spec in agent.tools:
-        if spec.type == "mcp_toolset" and spec.enabled and spec.mcp_server_name:
-            enabled_server_names.add(spec.mcp_server_name)
+    toolsets_by_server = _enabled_mcp_toolsets_by_server(agent.tools)
     for s in agent.mcp_servers:
-        if s.name in enabled_server_names:
-            servers.append((s.name, s.url))
+        spec = toolsets_by_server.get(s.name)
+        if spec is not None:
+            servers.append((s.name, s.url, spec))
 
     if not servers:
         return [], {}
@@ -626,13 +689,15 @@ async def discover_session_mcp_tools(
         )
         return await discover_mcp_tools(url, name, headers)
 
-    results = await asyncio.gather(*[_discover_one(n, u) for n, u in servers])
+    results = await asyncio.gather(*[_discover_one(n, u) for n, u, _spec in servers])
     tools: list[dict[str, Any]] = [
-        tool for (tool_list, _instructions) in results for tool in tool_list
+        tool
+        for (_name, _url, spec), (tool_list, _instructions) in zip(servers, results, strict=True)
+        for tool in _filter_mcp_tools_for_toolset(tool_list, spec)
     ]
     instructions_by_server: dict[str, str] = {
         name: instructions
-        for (name, _url), (_tools, instructions) in zip(servers, results, strict=True)
+        for (name, _url, _spec), (_tools, instructions) in zip(servers, results, strict=True)
         if instructions
     }
     return tools, instructions_by_server

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from aios.models.agents import McpServerSpec, ToolSpec
+from aios.models.agents import McpServerSpec, McpToolConfig, McpToolsetConfig, ToolSpec
 
 
 @pytest.fixture(autouse=True)
@@ -82,6 +82,141 @@ class TestDiscoverSessionMcpTools:
             )
         names = {t["name"] for t in tools}
         assert names == {"mcp__gh__t"}
+
+    async def test_default_config_can_disable_discovered_tools(self) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
+            tools=[
+                ToolSpec(
+                    type="mcp_toolset",
+                    enabled=True,
+                    mcp_server_name="gh",
+                    default_config=McpToolsetConfig(enabled=False),
+                )
+            ],
+        )
+
+        async def _discover(
+            _url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [{"name": f"mcp__{name}__create_issue"}], None
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            tools, _instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+            )
+
+        assert tools == []
+
+    async def test_per_tool_config_overrides_default_enabled(self) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
+            tools=[
+                ToolSpec(
+                    type="mcp_toolset",
+                    enabled=True,
+                    mcp_server_name="gh",
+                    default_config=McpToolsetConfig(enabled=False),
+                    configs=[McpToolConfig(name="create_issue", enabled=True)],
+                )
+            ],
+        )
+
+        async def _discover(
+            _url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [
+                {"name": f"mcp__{name}__create_issue"},
+                {"name": f"mcp__{name}__delete_repo"},
+            ], None
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            tools, _instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+            )
+
+        assert tools == [{"name": "mcp__gh__create_issue"}]
+
+    async def test_per_tool_config_can_disable_one_tool(self) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
+            tools=[
+                ToolSpec(
+                    type="mcp_toolset",
+                    enabled=True,
+                    mcp_server_name="gh",
+                    configs=[McpToolConfig(name="delete_repo", enabled=False)],
+                )
+            ],
+        )
+
+        async def _discover(
+            _url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [
+                {"name": f"mcp__{name}__create_issue"},
+                {"name": f"mcp__{name}__delete_repo"},
+            ], None
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            tools, _instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+            )
+
+        assert tools == [{"name": "mcp__gh__create_issue"}]
+
+    async def test_drops_tools_with_mismatched_server_namespace(self) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
+            tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
+        )
+
+        async def _discover(
+            _url: str, _name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [
+                {"name": "mcp__gh__create_issue"},
+                {"name": "mcp__slack__send_message"},
+            ], None
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            tools, _instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+            )
+
+        assert tools == [{"name": "mcp__gh__create_issue"}]
 
     async def test_discovers_only_agent_servers(self) -> None:
         from aios.harness.loop import discover_session_mcp_tools

--- a/tests/unit/test_mcp_routing.py
+++ b/tests/unit/test_mcp_routing.py
@@ -9,6 +9,7 @@ from aios.harness.loop import (
 )
 from aios.models.agents import (
     McpPermissionPolicy,
+    McpToolConfig,
     McpToolsetConfig,
     ToolSpec,
 )
@@ -70,6 +71,55 @@ class TestResolveMcpPermission:
             ),
         ]
         assert resolve_mcp_permission("mcp__github__create_issue", tools) == "always_ask"
+
+    def test_per_tool_permission_overrides_default_config(self) -> None:
+        tools = [
+            ToolSpec(
+                type="mcp_toolset",
+                mcp_server_name="github",
+                default_config=McpToolsetConfig(
+                    permission_policy=McpPermissionPolicy(type="always_ask"),
+                ),
+                configs=[
+                    McpToolConfig(
+                        name="create_issue",
+                        permission_policy=McpPermissionPolicy(type="always_allow"),
+                    )
+                ],
+            ),
+        ]
+        assert resolve_mcp_permission("mcp__github__create_issue", tools) == "always_allow"
+
+    def test_unmatched_per_tool_permission_falls_back_to_default_config(self) -> None:
+        tools = [
+            ToolSpec(
+                type="mcp_toolset",
+                mcp_server_name="github",
+                default_config=McpToolsetConfig(
+                    permission_policy=McpPermissionPolicy(type="always_ask"),
+                ),
+                configs=[
+                    McpToolConfig(
+                        name="delete_repo",
+                        permission_policy=McpPermissionPolicy(type="always_allow"),
+                    )
+                ],
+            ),
+        ]
+        assert resolve_mcp_permission("mcp__github__create_issue", tools) == "always_ask"
+
+    def test_disabled_toolset_does_not_supply_permission(self) -> None:
+        tools = [
+            ToolSpec(
+                type="mcp_toolset",
+                enabled=False,
+                mcp_server_name="github",
+                default_config=McpToolsetConfig(
+                    permission_policy=McpPermissionPolicy(type="always_allow"),
+                ),
+            ),
+        ]
+        assert resolve_mcp_permission("mcp__github__create_issue", tools) is None
 
     def test_no_default_config_returns_flat_permission(self) -> None:
         """Falls back to ToolSpec.permission when no default_config."""


### PR DESCRIPTION
Stacked on #185 (`codex/drop-mcp-channel-context`).

## Summary
- Apply `McpToolsetConfig.enabled` and per-tool `McpToolConfig.enabled` when filtering discovered MCP tools.
- Apply per-tool MCP permission policies before server defaults, then fall back to legacy flat toolset permission.
- Ignore disabled MCP toolset entries for permission resolution and discovery.
- Reject discovered MCP tools whose namespace does not match the server being filtered.
- Add focused tests for default-disabled toolsets, per-tool visibility overrides, per-tool permission overrides, and mismatched tool namespaces.

## Validation
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/e2e/test_context_endpoint.py -q`
- pre-commit on commit: ruff, mypy, unit tests