### PR TITLE
[codex] Rename MCP focal meta key

### DIFF
--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -22,21 +22,22 @@ MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: "
 SWITCH_CHANNEL_METADATA_KEY = "switch_channel"
 
 # Top-level key inside the ``_meta`` field sent on JSON-RPC MCP tool-call
-# requests when a focal channel is set. The value is the focal-channel suffix
-# (the focal channel address with its first two ``<connector>/<account>``
-# segments stripped). MCP servers that understand aios channels can split this
-# on ``/`` to recover their own per-chat identifiers; other servers ignore it.
-FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
+# requests when a focal channel is set. The value is the account-relative
+# focal channel: the stored channel address with only the leading
+# ``<connector>/`` attachment segment stripped. MCP servers that understand
+# aios channels can split this on ``/`` to recover account and chat-specific
+# identifiers; other servers ignore it.
+FOCAL_CHANNEL_META_KEY = "aios.focal_channel"
 
 
-def focal_channel_path(focal: str | None) -> str | None:
-    """Return the connector-specific suffix of a focal address.
+def focal_channel_meta_value(focal: str | None) -> str | None:
+    """Return the account-relative value for MCP focal-channel ``_meta``.
 
-    The ``<connector>/<account>`` prefix is information the MCP server
-    already has from its own service identity and session credential, so
-    sending it would be redundant; we strip it.  For a 3-segment address like
-    ``signal/<bot>/<chat>`` the suffix is just ``<chat>``.  For
-    ``telegram/<bot>/<chat>/<thread>`` it's ``<chat>/<thread>``.
+    A stored focal address is ``<connector>/<account>/<path>``. The connector
+    already knows its own attachment namespace from the MCP session, so the
+    meta value carries ``<account>/<path>``. For ``signal/<bot>/<chat>`` this
+    returns ``<bot>/<chat>``; for ``telegram/<bot>/<chat>/<thread>`` it returns
+    ``<bot>/<chat>/<thread>``.
 
     Returns ``None`` if ``focal`` is ``None`` or malformed (fewer than
     three segments) — neither should reach the dispatch path, but
@@ -45,9 +46,9 @@ def focal_channel_path(focal: str | None) -> str | None:
     if not focal:
         return None
     parts = focal.split("/", 2)
-    if len(parts) < 3 or not parts[2]:
+    if len(parts) < 3 or not parts[1] or not parts[2]:
         return None
-    return parts[2]
+    return f"{parts[1]}/{parts[2]}"
 
 
 async def list_session_bindings(pool: asyncpg.Pool[Any], session_id: str) -> list[ChannelBinding]:

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -321,7 +321,7 @@ def launch_mcp_tool_calls(
     were emitted (captured at step top in ``run_session_step`` so a
     concurrent ``switch_channel`` in the same batch cannot race the
     ``chat_id`` injection).  Passed through to each task so MCP calls can
-    stamp ``_meta`` with the suffix when a focal channel is set.
+    stamp ``_meta`` with account-relative focal-channel context when set.
     """
     _launch_tasks(
         session_id,
@@ -358,12 +358,12 @@ async def _execute_mcp_tool_async(
 ) -> None:
     """Execute one MCP tool call: connect, invoke, append result, defer wake.
 
-    When a focal channel is set, its suffix is stamped into the JSON-RPC
-    request's ``_meta`` so servers that understand aios channel context can
-    resolve channel-specific identifiers without the model having to pass
-    them explicitly.  The ``focal_channel`` snapshot is emission-time — a
-    concurrent ``switch_channel`` in the same assistant batch does not race
-    this injection.
+    When a focal channel is set, its account-relative value is stamped into
+    the JSON-RPC request's ``_meta`` so servers that understand aios channel
+    context can resolve channel-specific identifiers without the model having
+    to pass them explicitly.  The ``focal_channel`` snapshot is emission-time
+    — a concurrent ``switch_channel`` in the same assistant batch does not
+    race this injection.
     """
     call_id = call.get("id") or "unknown"
     function = call.get("function") or {}
@@ -404,12 +404,12 @@ async def _execute_mcp_tool_async(
             )
             return
 
-        from aios.harness.channels import FOCAL_CHANNEL_META_KEY, focal_channel_path
+        from aios.harness.channels import FOCAL_CHANNEL_META_KEY, focal_channel_meta_value
         from aios.mcp.client import call_mcp_tool, resolve_auth_for_url
 
-        suffix = focal_channel_path(focal_channel)
+        focal_meta = focal_channel_meta_value(focal_channel)
         meta: dict[str, Any] | None = (
-            {FOCAL_CHANNEL_META_KEY: suffix} if suffix is not None else None
+            {FOCAL_CHANNEL_META_KEY: focal_meta} if focal_meta is not None else None
         )
 
         crypto_box = runtime.require_crypto_box()

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -194,9 +194,9 @@ async def call_mcp_tool(
     ``tool_name`` is the raw MCP tool name (without the ``mcp__`` prefix).
     ``meta`` is an optional per-request metadata dict forwarded as the
     JSON-RPC request's ``_meta`` field. The harness uses it to pass
-    ``aios.focal_channel_path`` whenever the session has a focal channel,
-    without stuffing channel context into model-supplied arguments. Returns a
-    result dict with either ``content`` (success) or ``error`` (failure).
+    ``aios.focal_channel`` whenever the session has a focal channel, without
+    stuffing channel context into model-supplied arguments. Returns a result
+    dict with either ``content`` (success) or ``error`` (failure).
     """
     try:
         from aios.harness import runtime

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -826,12 +826,11 @@ class TestSwitchChannelAsEvent:
 
 
 class TestMcpMetaInjection:
-    """Channel-aware MCP toolsets receive the focal channel path via the
-    JSON-RPC ``_meta`` field, without stuffing it into arguments. Normal MCP
-    servers don't get the meta stamp.
+    """MCP tool calls receive account-relative focal-channel context via the
+    JSON-RPC ``_meta`` field, without stuffing it into arguments.
     """
 
-    async def test_channel_aware_mcp_dispatch_injects_focal_suffix_into_meta(
+    async def test_mcp_dispatch_injects_account_relative_focal_meta(
         self,
         runtime_pool: Any,
         agent_id: str,
@@ -877,14 +876,14 @@ class TestMcpMetaInjection:
                     session_id,
                     tool_call_dict,
                     mcp_server_map,
-                    focal_channel=address,  # focal=A → suffix=chat-1
+                    focal_channel=address,
                 )
 
-            # Verify call_mcp_tool was invoked with the focal suffix meta.
+            # Verify call_mcp_tool was invoked with account-relative focal meta.
             _args, kwargs = mock_call.call_args
             meta = kwargs.get("meta")
             assert isinstance(meta, dict)
-            assert meta == {"aios.focal_channel_path": "chat-1"}
+            assert meta == {"aios.focal_channel": address.split("/", 1)[1]}
         finally:
             runtime.crypto_box = prev_crypto
 
@@ -938,7 +937,7 @@ class TestMcpMetaInjection:
                 )
 
             _args, kwargs = mock_call.call_args
-            assert kwargs.get("meta") == {"aios.focal_channel_path": "chat-1"}
+            assert kwargs.get("meta") == {"aios.focal_channel": address.split("/", 1)[1]}
         finally:
             runtime.crypto_box = prev_crypto
 

--- a/tests/unit/test_channels_focal.py
+++ b/tests/unit/test_channels_focal.py
@@ -8,7 +8,7 @@ from aios.harness.channels import (
     SWITCH_CHANNEL_METADATA_KEY,
     derive_last_seen,
     derive_unread_counts,
-    focal_channel_path,
+    focal_channel_meta_value,
 )
 from aios.models.events import Event, EventKind
 
@@ -254,31 +254,31 @@ class TestDeriveUnreadCounts:
         assert counts == {"signal/a/x": 1}
 
 
-class TestFocalChannelPath:
-    """Suffix-extraction helper for MCP _meta injection (slice 6)."""
+class TestFocalChannelMetaValue:
+    """Account-relative focal-channel helper for MCP _meta injection."""
 
     def test_three_segment_address(self) -> None:
         # Signal shape: signal/<bot>/<chat_id>
-        assert focal_channel_path("signal/bot/alice") == "alice"
+        assert focal_channel_meta_value("signal/bot/alice") == "bot/alice"
 
     def test_four_segment_address_preserves_inner_slashes(self) -> None:
         # Telegram forum-thread shape: telegram/<bot>/<chat>/<thread>
-        assert focal_channel_path("telegram/bot/chat/thread") == "chat/thread"
+        assert focal_channel_meta_value("telegram/bot/chat/thread") == "bot/chat/thread"
 
     def test_deep_address_preserves_all_tail_segments(self) -> None:
-        # Defensive: connectors may use arbitrarily deep suffixes.
-        assert focal_channel_path("x/y/a/b/c") == "a/b/c"
+        # Defensive: connectors may use arbitrarily deep channel paths.
+        assert focal_channel_meta_value("x/y/a/b/c") == "y/a/b/c"
 
     def test_none_returns_none(self) -> None:
-        assert focal_channel_path(None) is None
+        assert focal_channel_meta_value(None) is None
 
     def test_empty_string_returns_none(self) -> None:
-        assert focal_channel_path("") is None
+        assert focal_channel_meta_value("") is None
 
     def test_malformed_two_segments_returns_none(self) -> None:
-        # Missing suffix — should not leak a garbled value.
-        assert focal_channel_path("signal/bot") is None
+        # Missing channel path — should not leak a garbled value.
+        assert focal_channel_meta_value("signal/bot") is None
 
     def test_trailing_slash_yields_empty_suffix_is_none(self) -> None:
-        # "signal/bot/" → 3 segments but suffix is empty → None.
-        assert focal_channel_path("signal/bot/") is None
+        # "signal/bot/" → 3 segments but channel path is empty → None.
+        assert focal_channel_meta_value("signal/bot/") is None

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -410,7 +410,7 @@ class TestCallMcpTool:
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=mock_result)
 
-        meta = {"aios.focal_channel_path": "alice"}
+        meta = {"aios.focal_channel": "acct/alice"}
 
         with (
             patch("aios.mcp.client.streamable_http_client") as mock_transport,


### PR DESCRIPTION
Stacked on #186 (`codex/apply-mcp-tool-configs`).

## Summary
- Rename the outbound MCP focal-channel `_meta` key from `aios.focal_channel_path` to `aios.focal_channel`.
- Change the meta value from connector-specific chat suffix to account-relative channel (`<account>/<path>`), matching the connector architecture v2 end-state.
- Rename the helper to `focal_channel_meta_value` and update dispatch docs/tests.

## Validation
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/e2e/test_focal_channel.py -q`
- pre-commit on commit: ruff, mypy, unit tests