### PR TITLE
[codex] Add vault credential account identity

### DIFF
--- a/migrations/versions/0028_vault_credential_account_id.py
+++ b/migrations/versions/0028_vault_credential_account_id.py
@@ -1,0 +1,35 @@
+"""Add optional account identity to vault credentials.
+
+Revision ID: 0028
+Revises: 0027
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0028"
+down_revision: str = "0027"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("vault_credentials", sa.Column("account_id", sa.Text(), nullable=True))
+    op.create_check_constraint(
+        "vault_credentials_account_id_segment_ck",
+        "vault_credentials",
+        "account_id IS NULL OR (account_id <> '' AND account_id NOT LIKE '%/%')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "vault_credentials_account_id_segment_ck",
+        "vault_credentials",
+        type_="check",
+    )
+    op.drop_column("vault_credentials", "account_id")

--- a/src/aios/cli/commands/vaults.py
+++ b/src/aios/cli/commands/vaults.py
@@ -30,7 +30,7 @@ app.add_typer(credentials, name="credentials")
 # ── vaults CRUD ─────────────────────────────────────────────────────────────
 
 _VAULT_COLS = ("id", "display_name", "archived_at", "updated_at")
-_CRED_COLS = ("id", "display_name", "auth_type", "mcp_server_url", "updated_at")
+_CRED_COLS = ("id", "display_name", "auth_type", "mcp_server_url", "account_id", "updated_at")
 
 
 @app.command("list", help="List vaults.")

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1442,6 +1442,7 @@ def _row_to_vault_credential(row: asyncpg.Record) -> VaultCredential:
         vault_id=row["vault_id"],
         display_name=row["display_name"],
         mcp_server_url=row["mcp_server_url"],
+        account_id=row["account_id"],
         auth_type=row["auth_type"],
         metadata=metadata,
         created_at=row["created_at"],
@@ -1456,6 +1457,7 @@ async def insert_vault_credential(
     vault_id: str,
     display_name: str | None,
     mcp_server_url: str,
+    account_id: str | None,
     auth_type: str,
     blob: EncryptedBlob,
     metadata: dict[str, Any],
@@ -1466,16 +1468,17 @@ async def insert_vault_credential(
         row = await conn.fetchrow(
             """
             INSERT INTO vault_credentials (
-                id, vault_id, display_name, mcp_server_url,
+                id, vault_id, display_name, mcp_server_url, account_id,
                 auth_type, ciphertext, nonce, metadata
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
             RETURNING *
             """,
             new_id,
             vault_id,
             display_name,
             mcp_server_url,
+            account_id,
             auth_type,
             blob.ciphertext,
             blob.nonce,
@@ -1589,6 +1592,7 @@ async def update_vault_credential(
     *,
     blob: EncryptedBlob | None = None,
     display_name: str | None | EllipsisType = ...,
+    account_id: str | None | EllipsisType = ...,
     metadata: dict[str, Any] | None | EllipsisType = ...,
 ) -> VaultCredential:
     sets: list[str] = []
@@ -1596,6 +1600,9 @@ async def update_vault_credential(
     if display_name is not ...:
         args.append(display_name)
         sets.append(f"display_name = ${len(args)}")
+    if account_id is not ...:
+        args.append(account_id)
+        sets.append(f"account_id = ${len(args)}")
     if blob is not None:
         args.append(blob.ciphertext)
         sets.append(f"ciphertext = ${len(args)}")

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 
 AuthType = Literal["mcp_oauth", "static_bearer"]
 
@@ -90,14 +90,16 @@ class VaultCredentialCreate(BaseModel):
     """Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
     All secret fields are write-only. The ``mcp_server_url`` is immutable
-    after creation. The service layer validates required fields per
-    ``auth_type``.
+    after creation. ``account_id`` is optional public metadata for connectors
+    that need a stable account segment in channel addresses. The service layer
+    validates required fields per ``auth_type``.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     display_name: str | None = Field(default=None, max_length=128)
     mcp_server_url: str = Field(min_length=1)
+    account_id: str | None = Field(default=None, min_length=1, max_length=256)
     auth_type: AuthType
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -114,17 +116,26 @@ class VaultCredentialCreate(BaseModel):
     # static_bearer fields
     token: SecretStr | None = None
 
+    @field_validator("account_id")
+    @classmethod
+    def _account_id_no_slash(cls, v: str | None) -> str | None:
+        if v is not None and "/" in v:
+            raise ValueError("must not contain '/'")
+        return v
+
 
 class VaultCredentialUpdate(BaseModel):
     """Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.
 
     ``mcp_server_url`` and ``auth_type`` are immutable — not accepted here.
-    Omitted secret fields are preserved (decrypt-merge-encrypt).
+    Omitted public metadata and secret fields are preserved
+    (decrypt-merge-encrypt).
     """
 
     model_config = ConfigDict(extra="forbid")
 
     display_name: str | None = Field(default=None, max_length=128)
+    account_id: str | None = Field(default=None, min_length=1, max_length=256)
     metadata: dict[str, Any] | None = None
 
     # mcp_oauth fields (all optional — omitted = preserve)
@@ -140,6 +151,13 @@ class VaultCredentialUpdate(BaseModel):
     # static_bearer
     token: SecretStr | None = None
 
+    @field_validator("account_id")
+    @classmethod
+    def _account_id_no_slash(cls, v: str | None) -> str | None:
+        if v is not None and "/" in v:
+            raise ValueError("must not contain '/'")
+        return v
+
 
 class VaultCredential(BaseModel):
     """Read view of a vault credential. Secrets are never returned."""
@@ -148,6 +166,7 @@ class VaultCredential(BaseModel):
     vault_id: str
     display_name: str | None
     mcp_server_url: str
+    account_id: str | None = None
     auth_type: AuthType
     metadata: dict[str, Any]
     created_at: datetime

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -368,6 +368,7 @@ async def create_vault_credential(
             vault_id=vault_id,
             display_name=body.display_name,
             mcp_server_url=body.mcp_server_url,
+            account_id=body.account_id,
             auth_type=body.auth_type,
             blob=blob,
             metadata=body.metadata,
@@ -415,6 +416,7 @@ async def update_vault_credential(
             credential_id,
             blob=new_blob,
             display_name=(body.display_name if "display_name" in body.model_fields_set else ...),
+            account_id=body.account_id if "account_id" in body.model_fields_set else ...,
             metadata=body.metadata if "metadata" in body.model_fields_set else ...,
         )
 

--- a/tests/e2e/test_vaults.py
+++ b/tests/e2e/test_vaults.py
@@ -95,6 +95,7 @@ class TestVaultCredentialCRUD:
         vault = await svc.create_vault(pool, display_name="cred-test", metadata={})
         body = VaultCredentialCreate(
             mcp_server_url="https://mcp.example.com/api",
+            account_id="signal-bot-1",
             auth_type="static_bearer",
             token=SecretStr("my-secret-token"),
         )
@@ -102,7 +103,11 @@ class TestVaultCredentialCRUD:
         assert cred.id.startswith("vcr_")
         assert cred.vault_id == vault.id
         assert cred.mcp_server_url == "https://mcp.example.com/api"
+        assert cred.account_id == "signal-bot-1"
         assert cred.auth_type == "static_bearer"
+
+        fetched = await svc.get_vault_credential(pool, vault.id, cred.id)
+        assert fetched.account_id == "signal-bot-1"
 
     async def test_secrets_not_returned(self, pool: Any, crypto_box: Any) -> None:
         """Verify that the read view never includes secret fields."""
@@ -205,13 +210,24 @@ class TestVaultCredentialCRUD:
 
         update = VaultCredentialUpdate(
             display_name="updated",
+            account_id="signal-bot-2",
             token=SecretStr("new-token"),
         )
         updated = await svc.update_vault_credential(
             pool, crypto_box, vault_id=vault.id, credential_id=cred.id, body=update
         )
         assert updated.display_name == "updated"
+        assert updated.account_id == "signal-bot-2"
         assert updated.updated_at > cred.updated_at
+
+        cleared = await svc.update_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=vault.id,
+            credential_id=cred.id,
+            body=VaultCredentialUpdate(account_id=None),
+        )
+        assert cleared.account_id is None
 
     async def test_credential_limit(self, pool: Any, crypto_box: Any) -> None:
         """Vault cannot have more than 20 active credentials."""

--- a/tests/unit/cli/test_cli_vault_credentials.py
+++ b/tests/unit/cli/test_cli_vault_credentials.py
@@ -31,7 +31,7 @@ def test_create_via_body_file(mocked_cli, tmp_path):
     body = tmp_path / "cred.json"
     body.write_text(
         '{"display_name": "my-creds", "mcp_server_url": "http://x",'
-        ' "auth_type": "static_bearer", "token": "t"}'
+        ' "account_id": "acct-1", "auth_type": "static_bearer", "token": "t"}'
     )
     mocked_cli.queue_response(httpx.Response(201, json={"id": "cred_new"}))
     result = runner.invoke(
@@ -49,6 +49,7 @@ def test_create_via_body_file(mocked_cli, tmp_path):
     assert mocked_cli.captured.method == "POST"
     assert mocked_cli.captured.path == "/v1/vaults/vlt_1/credentials"
     assert mocked_cli.captured.body["display_name"] == "my-creds"
+    assert mocked_cli.captured.body["account_id"] == "acct-1"
     assert mocked_cli.captured.body["token"] == "t"
 
 

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -288,6 +288,7 @@ class TestUpdateVaultCredentialCallSite:
         upd.assert_awaited_once()
         kwargs = upd.await_args.kwargs
         assert kwargs["display_name"] is ...
+        assert kwargs["account_id"] is ...
         assert kwargs["metadata"] is ...
         assert kwargs["blob"] is not None  # always re-encrypted
 
@@ -321,6 +322,37 @@ class TestUpdateVaultCredentialCallSite:
 
         kwargs = upd.await_args.kwargs
         assert kwargs["display_name"] is None  # not Ellipsis — explicitly passed
+
+    @pytest.mark.asyncio
+    async def test_passes_account_id_when_set_even_to_none(self, crypto_box: CryptoBox) -> None:
+        existing = _existing_credential()
+        existing_blob = crypto_box.encrypt(json.dumps({"access_token": "at"}))
+        conn = MagicMock()
+        pool = fake_pool_yielding_conn(conn)
+
+        with (
+            patch.object(
+                vaults_service.queries,
+                "get_vault_credential_with_blob",
+                AsyncMock(return_value=(existing, existing_blob)),
+            ),
+            patch.object(
+                vaults_service.queries,
+                "update_vault_credential",
+                AsyncMock(return_value=existing),
+            ) as upd,
+        ):
+            body = VaultCredentialUpdate(account_id=None)  # explicitly clear account identity
+            await vaults_service.update_vault_credential(
+                pool,
+                crypto_box,
+                vault_id="vlt_1",
+                credential_id="vc_1",
+                body=body,
+            )
+
+        kwargs = upd.await_args.kwargs
+        assert kwargs["account_id"] is None  # not Ellipsis — explicitly passed
 
 
 # ── OAuth refresh ────────────────────────────────────────────────────────────

--- a/tests/unit/test_vault_models.py
+++ b/tests/unit/test_vault_models.py
@@ -116,6 +116,33 @@ class TestVaultCredentialCreate:
         assert c.token is not None
         assert c.token.get_secret_value() == "my-token"
 
+    def test_account_id_valid(self) -> None:
+        c = VaultCredentialCreate(
+            mcp_server_url="https://mcp.example.com",
+            account_id="signal-bot-1",
+            auth_type="static_bearer",
+            token=SecretStr("my-token"),
+        )
+        assert c.account_id == "signal-bot-1"
+
+    def test_account_id_rejects_slash(self) -> None:
+        with pytest.raises(ValidationError, match="must not contain"):
+            VaultCredentialCreate(
+                mcp_server_url="https://mcp.example.com",
+                account_id="signal/bot",
+                auth_type="static_bearer",
+                token=SecretStr("my-token"),
+            )
+
+    def test_account_id_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            VaultCredentialCreate(
+                mcp_server_url="https://mcp.example.com",
+                account_id="",
+                auth_type="static_bearer",
+                token=SecretStr("my-token"),
+            )
+
     def test_mcp_oauth_valid(self) -> None:
         c = VaultCredentialCreate(
             mcp_server_url="https://mcp.example.com",
@@ -231,6 +258,19 @@ class TestVaultCredentialUpdate:
         assert u.token.get_secret_value() == "new-token"
         assert "token" in u.model_fields_set
         assert "access_token" not in u.model_fields_set
+
+    def test_account_id_update_can_set_or_clear(self) -> None:
+        u = VaultCredentialUpdate(account_id="signal-bot-1")
+        assert u.account_id == "signal-bot-1"
+        assert "account_id" in u.model_fields_set
+
+        clear = VaultCredentialUpdate(account_id=None)
+        assert clear.account_id is None
+        assert "account_id" in clear.model_fields_set
+
+    def test_account_id_update_rejects_slash(self) -> None:
+        with pytest.raises(ValidationError, match="must not contain"):
+            VaultCredentialUpdate(account_id="signal/bot")
 
     def test_partial_update_token_endpoint_auth(self) -> None:
         u = VaultCredentialUpdate(


### PR DESCRIPTION
Stacked on #187 (`codex/rename-focal-mcp-meta`).

## Summary
- Add nullable `account_id` to `vault_credentials` via migration 0028, with segment validation matching channel account-address constraints.
- Expose `account_id` on vault credential create/update/read models and persist it through query/service layers.
- Include `account_id` in CLI credential list columns and JSON body tests.
- Cover create/fetch/update/clear behavior plus model validation and migration coverage.

## Validation
- `uv run ruff check src tests migrations/versions/0028_vault_credential_account_id.py`
- `uv run ruff format --check src tests migrations/versions/0028_vault_credential_account_id.py`
- `uv run mypy src`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/e2e/test_vaults.py tests/integration/test_migrations.py -q`
- pre-commit on commit: ruff, mypy, unit tests

Note: `uv run ruff format --check migrations` still reports pre-existing formatting drift in older migration files, so validation is scoped to the new migration file plus `src` and `tests`.