### PR TITLE
[codex] Update connectors for focal MCP meta

### DIFF
--- a/connectors/signal/src/aios_signal/mcp.py
+++ b/connectors/signal/src/aios_signal/mcp.py
@@ -43,33 +43,44 @@ log = structlog.get_logger(__name__)
 
 # Key under a JSON-RPC tool-call request's ``_meta`` populated by the aios
 # worker when dispatching an MCP tool call while a focal channel is set. Its
-# value is the focal-channel path suffix — for Signal's 3-segment address
-# ``signal/<bot>/<chat>``, the suffix is just ``<chat>`` and can be decoded
-# directly as the Signal chat id. See ``aios.harness.channels`` for the
-# client-side contract.
-_FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
+# value is the account-relative focal channel: ``<bot_uuid>/<chat_id>``.
+# See ``aios.harness.channels`` for the client-side contract.
+_FOCAL_CHANNEL_META_KEY = "aios.focal_channel"
 
 
-def focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> str:
+def focal_chat_id_from_meta(
+    meta: RequestParams.Meta | None,
+    *,
+    account_id: str | None = None,
+) -> str:
     """Extract the Signal ``chat_id`` from an MCP request's ``_meta``.
 
-    aios injects ``aios.focal_channel_path`` for MCP tool calls while focal
-    is set;
-    its value is the full focal-channel suffix (stripped of
-    ``<connector>/<account>``), which for a 3-segment Signal address equals
-    the chat id verbatim. Missing / malformed meta raises so the agent sees
-    that it must focus a channel before using Signal response tools.
+    aios injects ``aios.focal_channel`` for MCP tool calls while focal is set.
+    Its value is account-relative: ``<bot_uuid>/<chat_id>``. Missing,
+    malformed, or wrong-account meta raises so the agent sees that it must
+    focus a channel on this account before using Signal response tools.
     """
-    path: Any = None
+    focal_channel: Any = None
     if meta is not None:
         extra = getattr(meta, "model_extra", None) or {}
-        path = extra.get(_FOCAL_CHANNEL_META_KEY)
-    if not isinstance(path, str) or not path:
+        focal_channel = extra.get(_FOCAL_CHANNEL_META_KEY)
+    if not isinstance(focal_channel, str) or not focal_channel:
         raise ValueError(
             "signal tools require a focal channel — aios should inject "
             f"{_FOCAL_CHANNEL_META_KEY!r} in _meta when focal is set"
         )
-    return path
+    account, sep, chat_id = focal_channel.partition("/")
+    if not sep or not account or not chat_id:
+        raise ValueError(
+            "signal focal channel must be account-relative "
+            f"'<account>/<chat_id>'; got {focal_channel!r}"
+        )
+    if account_id is not None and account != account_id:
+        raise ValueError(
+            "signal focal channel belongs to a different account "
+            f"({account!r}, expected {account_id!r})"
+        )
+    return chat_id
 
 
 def build_send_params(chat_id: str, text: str) -> dict[str, Any]:
@@ -173,7 +184,7 @@ def build_mcp_server(
         Args:
             text: Message body. Markdown is converted to Signal text styles.
         """
-        chat_id = focal_chat_id_from_meta(ctx.request_context.meta)
+        chat_id = focal_chat_id_from_meta(ctx.request_context.meta, account_id=bot_uuid)
         params = build_send_params(chat_id, text)
         result = await rpc.call("send", params)
         ts = _extract_timestamp(result)
@@ -204,7 +215,7 @@ def build_mcp_server(
                 message you're reacting to.
             emoji: The reaction emoji.
         """
-        chat_id = focal_chat_id_from_meta(ctx.request_context.meta)
+        chat_id = focal_chat_id_from_meta(ctx.request_context.meta, account_id=bot_uuid)
         params = build_react_params(chat_id, target_author_uuid, target_timestamp_ms, emoji)
         await rpc.call("sendReaction", params)
         return {"status": "ok"}

--- a/connectors/signal/tests/test_mcp.py
+++ b/connectors/signal/tests/test_mcp.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import httpx
@@ -26,9 +26,11 @@ from aios_signal.mcp import (
     parse_bind,
 )
 
+BOT_UUID = "test-bot-uuid"
+
 
 def _ctx_with_focal(chat_id: str | None) -> Context[Any, Any, Any]:
-    """Build a Context carrying an ``aios.focal_channel_path`` in ``_meta``.
+    """Build a Context carrying an account-relative focal channel in ``_meta``.
 
     The ToolManager.call_tool path accepts an explicit Context; this
     lets us simulate what aios sends without going through a full
@@ -38,7 +40,7 @@ def _ctx_with_focal(chat_id: str | None) -> Context[Any, Any, Any]:
     if chat_id is None:
         rc.meta = None
     else:
-        rc.meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": chat_id})
+        rc.meta = RequestParams.Meta.model_validate({"aios.focal_channel": f"{BOT_UUID}/{chat_id}"})
     return Context(request_context=rc)
 
 
@@ -66,7 +68,7 @@ async def _call_tool(
     Goes through ``FastMCP.tool_manager.call_tool`` so the tool handler's
     ``ctx: Context`` dependency is filled in with the constructed meta.
     """
-    mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
+    mcp = build_mcp_server(rpc=cast(Any, rpc), bot_uuid=BOT_UUID, phone="+15550000000")
     result = await mcp._tool_manager.call_tool(
         name,
         args,
@@ -85,9 +87,9 @@ async def _call_tool(
 
 
 class TestFocalChatIdFromMeta:
-    def test_returns_path_when_present(self) -> None:
-        meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "chat-abc"})
-        assert focal_chat_id_from_meta(meta) == "chat-abc"
+    def test_returns_chat_id_when_present(self) -> None:
+        meta = RequestParams.Meta.model_validate({"aios.focal_channel": f"{BOT_UUID}/chat-abc"})
+        assert focal_chat_id_from_meta(meta, account_id=BOT_UUID) == "chat-abc"
 
     def test_none_meta_raises(self) -> None:
         with pytest.raises(ValueError, match="focal channel"):
@@ -99,9 +101,19 @@ class TestFocalChatIdFromMeta:
             focal_chat_id_from_meta(meta)
 
     def test_empty_string_raises(self) -> None:
-        meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": ""})
+        meta = RequestParams.Meta.model_validate({"aios.focal_channel": ""})
         with pytest.raises(ValueError, match="focal channel"):
             focal_chat_id_from_meta(meta)
+
+    def test_malformed_account_relative_value_raises(self) -> None:
+        meta = RequestParams.Meta.model_validate({"aios.focal_channel": "chat-abc"})
+        with pytest.raises(ValueError, match="account-relative"):
+            focal_chat_id_from_meta(meta, account_id=BOT_UUID)
+
+    def test_wrong_account_raises(self) -> None:
+        meta = RequestParams.Meta.model_validate({"aios.focal_channel": "other/chat-abc"})
+        with pytest.raises(ValueError, match="different account"):
+            focal_chat_id_from_meta(meta, account_id=BOT_UUID)
 
 
 class TestBuildSendParams:
@@ -171,7 +183,7 @@ async def test_signal_send_reads_focal_from_meta() -> None:
 
 async def test_signal_send_errors_without_meta() -> None:
     rpc = FakeRpc()
-    mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
+    mcp = build_mcp_server(rpc=cast(Any, rpc), bot_uuid=BOT_UUID, phone="+15550000000")
     # No focal — aios omits focal metadata, and the connector surfaces the
     # missing focus as a tool error.
     ctx_no_meta = _ctx_with_focal(None)
@@ -323,7 +335,7 @@ async def test_bearer_auth_rejects_non_bearer_scheme() -> None:
 
 def test_build_mcp_app_returns_starlette() -> None:
     rpc = FakeRpc()
-    mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
+    mcp = build_mcp_server(rpc=cast(Any, rpc), bot_uuid=BOT_UUID, phone="+15550000000")
     app = build_mcp_app(mcp, token="t")
     assert isinstance(app, Starlette)
 
@@ -337,13 +349,15 @@ def test_build_mcp_server_surfaces_profile_name_from_contacts() -> None:
     """
     rpc = FakeRpc()
     mcp = build_mcp_server(
-        rpc=rpc,
-        bot_uuid="test-bot-uuid",
+        rpc=cast(Any, rpc),
+        bot_uuid=BOT_UUID,
         phone="+15550000000",
-        contact_names={"test-bot-uuid": "Bot McBotface", "other-uuid": "Alice"},
-    )  # type: ignore[arg-type]
-    assert "profile_name" in mcp.instructions
-    assert "Bot McBotface" in mcp.instructions
+        contact_names={BOT_UUID: "Bot McBotface", "other-uuid": "Alice"},
+    )
+    instructions = mcp.instructions
+    assert instructions is not None
+    assert "profile_name" in instructions
+    assert "Bot McBotface" in instructions
 
 
 def test_build_mcp_server_omits_profile_name_when_bot_not_in_contacts() -> None:
@@ -353,12 +367,14 @@ def test_build_mcp_server_omits_profile_name_when_bot_not_in_contacts() -> None:
     """
     rpc = FakeRpc()
     mcp = build_mcp_server(
-        rpc=rpc,
-        bot_uuid="test-bot-uuid",
+        rpc=cast(Any, rpc),
+        bot_uuid=BOT_UUID,
         phone="+15550000000",
         contact_names={"other-uuid": "Alice"},
-    )  # type: ignore[arg-type]
-    assert "profile_name" not in mcp.instructions
+    )
+    instructions = mcp.instructions
+    assert instructions is not None
+    assert "profile_name" not in instructions
 
 
 def test_build_mcp_server_passes_signal_instructions() -> None:
@@ -370,13 +386,15 @@ def test_build_mcp_server_passes_signal_instructions() -> None:
     from aios_signal.prompts import SIGNAL_SERVER_INSTRUCTIONS
 
     rpc = FakeRpc()
-    mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
+    mcp = build_mcp_server(rpc=cast(Any, rpc), bot_uuid=BOT_UUID, phone="+15550000000")
     # The static tool prose comes through verbatim — ``build_instructions``
     # prepends an identity block but doesn't rewrite the body.
-    assert SIGNAL_SERVER_INSTRUCTIONS in mcp.instructions
-    assert "signal_send" in mcp.instructions
-    assert "signal_react" in mcp.instructions
-    assert "signal_read_receipt" in mcp.instructions
+    instructions = mcp.instructions
+    assert instructions is not None
+    assert SIGNAL_SERVER_INSTRUCTIONS in instructions
+    assert "signal_send" in instructions
+    assert "signal_react" in instructions
+    assert "signal_read_receipt" in instructions
     # Identity block is present and names this bot.
-    assert "test-bot-uuid" in mcp.instructions
-    assert "+15550000000" in mcp.instructions
+    assert BOT_UUID in instructions
+    assert "+15550000000" in instructions

--- a/connectors/telegram/src/aios_telegram/mcp.py
+++ b/connectors/telegram/src/aios_telegram/mcp.py
@@ -34,35 +34,46 @@ log = structlog.get_logger(__name__)
 
 # Key under a JSON-RPC tool-call request's ``_meta`` populated by the aios
 # worker when dispatching an MCP tool call while a focal channel is set. Its
-# value is the focal-channel path suffix — for Telegram's 3-segment address
-# ``telegram/<bot_id>/<chat_id>``, the suffix is just ``<chat_id>`` and can be
-# parsed as a signed integer.
-_FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
+# value is the account-relative focal channel: ``<bot_id>/<chat_id>``.
+_FOCAL_CHANNEL_META_KEY = "aios.focal_channel"
 
 
-def focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> int:
+def focal_chat_id_from_meta(
+    meta: RequestParams.Meta | None,
+    *,
+    account_id: int | str | None = None,
+) -> int:
     """Extract the Telegram ``chat_id`` from an MCP request's ``_meta``.
 
-    aios injects ``aios.focal_channel_path`` for MCP tool calls while focal
-    is set;
-    its value is the full focal-channel suffix (stripped of
-    ``<connector>/<account>``), which for a 3-segment Telegram address
-    is the decimal chat id. Missing / malformed meta raises so the agent sees
-    that it must focus a channel before using Telegram response tools.
+    aios injects ``aios.focal_channel`` for MCP tool calls while focal is set.
+    Its value is account-relative: ``<bot_id>/<chat_id>``. Missing, malformed,
+    wrong-account, or non-integer chat IDs raise so the agent sees that it must
+    focus a channel on this account before using Telegram response tools.
     """
-    path: Any = None
+    focal_channel: Any = None
     if meta is not None:
         extra = getattr(meta, "model_extra", None) or {}
-        path = extra.get(_FOCAL_CHANNEL_META_KEY)
-    if not isinstance(path, str) or not path:
+        focal_channel = extra.get(_FOCAL_CHANNEL_META_KEY)
+    if not isinstance(focal_channel, str) or not focal_channel:
         raise ValueError(
             "telegram tools require a focal channel — aios should inject "
             f"{_FOCAL_CHANNEL_META_KEY!r} in _meta when focal is set"
         )
+    account, sep, chat_id = focal_channel.partition("/")
+    if not sep or not account or not chat_id:
+        raise ValueError(
+            "telegram focal channel must be account-relative "
+            f"'<account>/<chat_id>'; got {focal_channel!r}"
+        )
+    if account_id is not None and account != str(account_id):
+        raise ValueError(
+            "telegram focal channel belongs to a different account "
+            f"({account!r}, expected {str(account_id)!r})"
+        )
     try:
-        return int(path)
+        return int(chat_id)
     except ValueError as e:
-        raise ValueError(f"telegram chat_id must be an integer; got {path!r}") from e
+        raise ValueError(f"telegram chat_id must be an integer; got {chat_id!r}") from e
 
 
 class BearerAuthMiddleware:
@@ -119,7 +130,7 @@ def build_mcp_server(
         Args:
             text: Message body. Plain text only — markdown is not rendered.
         """
-        chat_id = focal_chat_id_from_meta(ctx.request_context.meta)
+        chat_id = focal_chat_id_from_meta(ctx.request_context.meta, account_id=bot_id)
         sent = await bot.send_message(chat_id=chat_id, text=text)
         return {"message_id": sent.message_id}
 

--- a/connectors/telegram/tests/test_mcp.py
+++ b/connectors/telegram/tests/test_mcp.py
@@ -22,13 +22,15 @@ from aios_telegram.mcp import (
     parse_bind,
 )
 
+BOT_ID = 1
+
 
 def _ctx_with_focal(chat_id: str | None) -> Context[Any, Any, Any]:
     rc = MagicMock(spec=RequestContext)
     if chat_id is None:
         rc.meta = None
     else:
-        rc.meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": chat_id})
+        rc.meta = RequestParams.Meta.model_validate({"aios.focal_channel": f"{BOT_ID}/{chat_id}"})
     return Context(request_context=rc)
 
 
@@ -36,13 +38,13 @@ def _ctx_with_focal(chat_id: str | None) -> Context[Any, Any, Any]:
 
 
 def test_focal_meta_dm_id() -> None:
-    meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "123456789"})
-    assert focal_chat_id_from_meta(meta) == 123456789
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel": f"{BOT_ID}/123456789"})
+    assert focal_chat_id_from_meta(meta, account_id=BOT_ID) == 123456789
 
 
 def test_focal_meta_group_negative_id() -> None:
-    meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "-1001234567890"})
-    assert focal_chat_id_from_meta(meta) == -1001234567890
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel": f"{BOT_ID}/-1001234567890"})
+    assert focal_chat_id_from_meta(meta, account_id=BOT_ID) == -1001234567890
 
 
 def test_focal_meta_missing_raises() -> None:
@@ -51,9 +53,21 @@ def test_focal_meta_missing_raises() -> None:
 
 
 def test_focal_meta_not_integer_raises() -> None:
-    meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "abc"})
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel": f"{BOT_ID}/abc"})
     with pytest.raises(ValueError, match="integer"):
-        focal_chat_id_from_meta(meta)
+        focal_chat_id_from_meta(meta, account_id=BOT_ID)
+
+
+def test_focal_meta_malformed_account_relative_value_raises() -> None:
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel": "123456789"})
+    with pytest.raises(ValueError, match="account-relative"):
+        focal_chat_id_from_meta(meta, account_id=BOT_ID)
+
+
+def test_focal_meta_wrong_account_raises() -> None:
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel": "2/123456789"})
+    with pytest.raises(ValueError, match="different account"):
+        focal_chat_id_from_meta(meta, account_id=BOT_ID)
 
 
 # ─── telegram_send tool ─────────────────────────────────────────────────────
@@ -62,7 +76,7 @@ def test_focal_meta_not_integer_raises() -> None:
 async def _call_send(bot: Bot, text: str, *, focal: str | None) -> dict[str, Any]:
     # Identity args are required by build_mcp_server but not exercised by
     # telegram_send — dummy values keep these tool tests focused.
-    mcp = build_mcp_server(bot=bot, bot_id=1, first_name="Test", username="test_bot")
+    mcp = build_mcp_server(bot=bot, bot_id=BOT_ID, first_name="Test", username="test_bot")
     result = await mcp._tool_manager.call_tool(
         "telegram_send",
         {"text": text},


### PR DESCRIPTION
Stacked on #188 (`codex/vault-credential-account-id`).

## Summary
- Update Signal and Telegram MCP servers to read `_meta.aios.focal_channel`.
- Interpret focal metadata as account-relative (`<account>/<chat>`) and reject wrong-account metadata.
- Update connector tests for the new focal metadata shape and error handling.

## Validation
- `uv run ruff check connectors/signal/src/aios_signal/mcp.py connectors/signal/tests/test_mcp.py connectors/telegram/src/aios_telegram/mcp.py connectors/telegram/tests/test_mcp.py`
- `uv run ruff format --check connectors/signal/src/aios_signal/mcp.py connectors/signal/tests/test_mcp.py connectors/telegram/src/aios_telegram/mcp.py connectors/telegram/tests/test_mcp.py`
- `(cd connectors/signal && uv run mypy src tests)`
- `(cd connectors/telegram && uv run mypy src tests)`
- `(cd connectors/signal && uv run pytest tests/test_mcp.py -q)`
- `(cd connectors/telegram && uv run pytest tests/test_mcp.py -q)`
- pre-commit on commit: ruff, mypy, unit tests (`901 passed`)