### PR TITLE
fix(harness): reap orphaned procrastinate jobs on worker startup + sweep

### DIFF
--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -432,6 +432,57 @@ def _group_tool_call_ids(rows: list[Any]) -> dict[str, set[str]]:
     return grouped
 
 
+# ─── procrastinate stalled-job recovery ──────────────────────────────────────
+
+
+async def reap_stalled_jobs(job_manager: Any) -> int:
+    """Mark stalled procrastinate jobs as failed.
+
+    Procrastinate runs a heartbeat lease: workers update
+    ``procrastinate_workers.last_heartbeat`` every
+    ``update_heartbeat_interval`` (default 10s).  A dead worker
+    (laptop sleep, OOM, ungraceful shutdown) stops heartbeating; its
+    row is pruned at any other worker's startup, leaving its
+    in-flight job at ``status='doing'`` with ``worker_id`` either
+    NULL (post-prune) or pointing at the missing row.  Either way the
+    job's ``lock`` (``"{session_id}"`` for aios) stays held — every
+    subsequent wake for that session sits behind it forever.
+
+    :meth:`procrastinate.manager.JobManager.get_stalled_jobs` is the
+    blessed query for this state.  Its SQL covers both shapes
+    (``worker_id IS NULL`` plus the membership join on
+    ``procrastinate_workers``), and the threshold is configurable per
+    call — we use 60s, comfortably above procrastinate's 10s
+    heartbeat interval and 30s default ``stalled_worker_timeout``.
+
+    Takes a ``job_manager`` rather than an ``App`` so tests can build
+    a fresh manager pointed at the testcontainer DB without depending
+    on the module-level ``procrastinate_app`` singleton (which fixes
+    its connector at import time).
+
+    Returns the number of jobs reaped.  Non-zero is a real signal
+    that a worker died.
+    """
+    from procrastinate.jobs import Status
+
+    stalled = list(await job_manager.get_stalled_jobs(seconds_since_heartbeat=60))
+    for job in stalled:
+        if job.id is None:
+            continue
+        await job_manager.finish_job_by_id_async(
+            job_id=job.id,
+            status=Status.FAILED,
+            delete_job=False,
+        )
+    if stalled:
+        log.warning(
+            "sweep.reaped_stalled_jobs",
+            count=len(stalled),
+            ids=[j.id for j in stalled],
+        )
+    return len(stalled)
+
+
 # ─── main entry point ────────────────────────────────────────────────────────
 
 

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -34,7 +34,10 @@ from aios.db import queries
 from aios.db.pool import create_pool
 from aios.harness import runtime
 from aios.harness.procrastinate_app import app as procrastinate_app
-from aios.harness.sweep import wake_sessions_needing_inference
+from aios.harness.sweep import (
+    reap_stalled_jobs,
+    wake_sessions_needing_inference,
+)
 from aios.harness.task_registry import TaskRegistry
 from aios.logging import configure_logging, get_logger
 from aios.mcp.pool import McpSessionPool
@@ -76,7 +79,13 @@ async def worker_main() -> None:
     sweep_task: asyncio.Task[None] | None = None
 
     try:
-        # Startup sweep: repair ghosts and wake sessions needing inference.
+        # Startup sweep:
+        #   1. Reap stalled procrastinate jobs (workers that died without
+        #      releasing their session lock — laptop sleep, OOM, crash).
+        #      Must run BEFORE the wake sweep so freshly-unblocked sessions
+        #      get re-enqueued in the same pass.
+        #   2. Repair tool-call ghosts and wake sessions needing inference.
+        await reap_stalled_jobs(procrastinate_app.job_manager)
         sweep = await wake_sessions_needing_inference(pool, task_registry)
         if sweep.woken_sessions or sweep.repaired_ghosts:
             log.info(
@@ -97,7 +106,7 @@ async def worker_main() -> None:
 
         # Start periodic sweep (every 30s).
         sweep_task = asyncio.create_task(
-            _periodic_sweep(pool, task_registry, interval=30),
+            _periodic_sweep(pool, task_registry, procrastinate_app.job_manager, interval=30),
             name="periodic_sweep",
         )
 
@@ -124,6 +133,7 @@ async def worker_main() -> None:
 async def _periodic_sweep(
     pool: asyncpg.Pool[Any],
     task_registry: TaskRegistry,
+    job_manager: Any,
     *,
     interval: int = 30,
 ) -> None:
@@ -132,6 +142,9 @@ async def _periodic_sweep(
     while True:
         await asyncio.sleep(interval)
         try:
+            # Reap stalled jobs first so any unblocked sessions get re-enqueued
+            # in the same tick (mirrors worker_main's startup sequence).
+            await reap_stalled_jobs(job_manager)
             sweep = await wake_sessions_needing_inference(pool, task_registry)
             if sweep.woken_sessions or sweep.repaired_ghosts:
                 log.info(

--- a/tests/e2e/test_reap_stalled_jobs.py
+++ b/tests/e2e/test_reap_stalled_jobs.py
@@ -1,0 +1,220 @@
+"""E2E tests for the stalled-procrastinate-job reaper.
+
+A worker process can die mid-job (laptop sleep, OOM, ungraceful shutdown)
+leaving the row at ``status='doing'``. Procrastinate's heartbeat lease
+(``procrastinate_workers.last_heartbeat``) is what we lean on to detect
+this — :meth:`procrastinate.manager.JobManager.get_stalled_jobs` returns
+``doing`` jobs whose worker has been silent for longer than the
+threshold (we use 60s).
+
+These tests pin the lease semantics end-to-end against a real
+procrastinate schema so a refactor can't quietly break recovery.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from procrastinate import PsycopgConnector
+from procrastinate.manager import JobManager
+
+from aios.harness.sweep import reap_stalled_jobs
+from tests.conftest import needs_docker
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from procrastinate import App
+
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    # Ensure procrastinate's tables exist on the testcontainer DB. The
+    # shared ``migrated_db_url`` only runs aios's alembic migrations;
+    # the reaper exercises procrastinate's schema directly. We build
+    # a temporary ``App`` here rather than reuse the module-level
+    # singleton because the singleton's connector is fixed at import
+    # time against whatever settings were active then — usually wrong
+    # in tests.
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    async with p.acquire() as conn:
+        present = await conn.fetchval("SELECT to_regclass('procrastinate_jobs')")
+    if present is None:
+        conninfo = aios_env["AIOS_DB_URL"].replace("postgresql+psycopg://", "postgresql://")
+        tmp_app = App(connector=PsycopgConnector(conninfo=conninfo))
+        await tmp_app.open_async()
+        try:
+            await tmp_app.schema_manager.apply_schema_async()
+        finally:
+            await tmp_app.close_async()
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def job_manager(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    """A fresh ``JobManager`` pointed at the testcontainer DB.
+
+    The module-level ``procrastinate_app`` singleton fixes its
+    connector at import time — by the time the fixture runs, that
+    connector is already bound to whatever settings were active at
+    import (typically the dev DB or nothing). We build a fresh
+    connector so the manager talks to the same DB the rest of the
+    test fixtures are seeding into.
+    """
+    conninfo = aios_env["AIOS_DB_URL"].replace("postgresql+psycopg://", "postgresql://")
+    connector = PsycopgConnector(conninfo=conninfo)
+    await connector.open_async()
+    try:
+        yield JobManager(connector=connector)
+    finally:
+        await connector.close_async()
+
+
+async def _insert_worker(conn: Any, *, stale_seconds: int = 0) -> int:
+    """Insert a procrastinate_workers row.
+
+    ``stale_seconds`` controls the heartbeat age — 0 means fresh,
+    >60 means past our reap threshold.
+    """
+    return int(
+        await conn.fetchval(
+            """
+            INSERT INTO procrastinate_workers (last_heartbeat)
+            VALUES (NOW() - ($1 || ' second')::interval)
+            RETURNING id
+            """,
+            str(stale_seconds),
+        )
+    )
+
+
+async def _insert_job(
+    conn: Any,
+    *,
+    status: str,
+    worker_id: int | None,
+    lock: str = "lk-test",
+    queueing_lock: str | None = "lk-test",
+) -> int:
+    """Insert a minimal procrastinate_jobs row.
+
+    Defaults match an aios wake job (per-session lock); each test
+    overrides only what it cares about.
+    """
+    return int(
+        await conn.fetchval(
+            """
+            INSERT INTO procrastinate_jobs
+                (queue_name, task_name, priority, lock, queueing_lock, args, status, worker_id, attempts)
+            VALUES ('sessions', 'harness.wake_session', 0, $1, $2, '{}'::jsonb, $3, $4, 0)
+            RETURNING id
+            """,
+            lock,
+            queueing_lock,
+            status,
+            worker_id,
+        )
+    )
+
+
+@needs_docker
+class TestReapStalledJobs:
+    async def test_reaps_doing_with_null_worker_id(self, pool: Any, job_manager: Any) -> None:
+        """``worker_id IS NULL`` is procrastinate's "worker dropped" state.
+
+        After procrastinate prunes a stalled worker from
+        ``procrastinate_workers``, any job it had ``doing`` ends up
+        with ``worker_id = NULL`` — genuinely orphaned and should be
+        reaped.
+        """
+        async with pool.acquire() as conn:
+            jid = await _insert_job(conn, status="doing", worker_id=None)
+            try:
+                reaped = await reap_stalled_jobs(job_manager)
+                row = await conn.fetchrow("SELECT status FROM procrastinate_jobs WHERE id=$1", jid)
+                assert reaped >= 1
+                assert row["status"] == "failed"
+            finally:
+                await conn.execute("DELETE FROM procrastinate_jobs WHERE id=$1", jid)
+
+    async def test_reaps_doing_with_stale_worker_heartbeat(
+        self, pool: Any, job_manager: Any
+    ) -> None:
+        """A worker whose heartbeat is older than the threshold is stalled.
+
+        This is the lease semantics: live workers extend their
+        heartbeat every ``update_heartbeat_interval``; if the worker
+        dies, the heartbeat goes stale, and ``get_stalled_jobs``
+        finds the orphan even before procrastinate's prune deletes
+        the row.
+        """
+        async with pool.acquire() as conn:
+            wid = await _insert_worker(conn, stale_seconds=120)
+            jid = await _insert_job(conn, status="doing", worker_id=wid)
+            try:
+                reaped = await reap_stalled_jobs(job_manager)
+                row = await conn.fetchrow("SELECT status FROM procrastinate_jobs WHERE id=$1", jid)
+                assert reaped >= 1
+                assert row["status"] == "failed"
+            finally:
+                await conn.execute("DELETE FROM procrastinate_jobs WHERE id=$1", jid)
+                await conn.execute("DELETE FROM procrastinate_workers WHERE id=$1", wid)
+
+    async def test_leaves_doing_with_live_worker_alone(self, pool: Any, job_manager: Any) -> None:
+        """A live worker's in-flight job MUST NOT be reaped.
+
+        The safety case — under normal load, jobs sit at
+        ``status='doing'`` while their worker is processing. The
+        lease check on ``last_heartbeat`` distinguishes legitimate
+        live work from genuinely abandoned jobs.
+        """
+        async with pool.acquire() as conn:
+            wid = await _insert_worker(conn, stale_seconds=0)
+            jid = await _insert_job(conn, status="doing", worker_id=wid)
+            try:
+                await reap_stalled_jobs(job_manager)
+                row = await conn.fetchrow("SELECT status FROM procrastinate_jobs WHERE id=$1", jid)
+                assert row["status"] == "doing"
+            finally:
+                await conn.execute("DELETE FROM procrastinate_jobs WHERE id=$1", jid)
+                await conn.execute("DELETE FROM procrastinate_workers WHERE id=$1", wid)
+
+    async def test_ignores_other_statuses(self, pool: Any, job_manager: Any) -> None:
+        """Only ``status='doing'`` is candidate for reaping.
+
+        ``todo`` jobs without a worker are normal queued state.
+        ``succeeded`` / ``failed`` are terminal. Reaping any of
+        these would corrupt history.
+        """
+        async with pool.acquire() as conn:
+            todo_id = await _insert_job(conn, status="todo", worker_id=None)
+            done_id = await _insert_job(
+                conn,
+                status="succeeded",
+                worker_id=None,
+                lock="lk-test-done",
+                queueing_lock=None,
+            )
+            try:
+                await reap_stalled_jobs(job_manager)
+                rows = await conn.fetch(
+                    "SELECT id, status FROM procrastinate_jobs WHERE id = ANY($1::bigint[])",
+                    [todo_id, done_id],
+                )
+                statuses = {r["id"]: r["status"] for r in rows}
+                assert statuses[todo_id] == "todo"
+                assert statuses[done_id] == "succeeded"
+            finally:
+                await conn.execute(
+                    "DELETE FROM procrastinate_jobs WHERE id = ANY($1::bigint[])",
+                    [todo_id, done_id],
+                )
+
+    async def test_returns_zero_when_no_stalled_jobs(self, pool: Any, job_manager: Any) -> None:
+        """Steady state: no stalled jobs, return 0."""
+        reaped = await reap_stalled_jobs(job_manager)
+        assert reaped == 0

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -279,7 +279,14 @@ class TestPeriodicSweepEmitsNoSpan:
             patch("aios.services.sessions.append_event", append_event),
             pytest.raises(StopAsyncIteration),
         ):
-            await _periodic_sweep(MagicMock(), MagicMock(), interval=30)
+            # MagicMock for the procrastinate app — `_periodic_sweep` calls
+            # `reap_stalled_jobs` first, which the test's patch list doesn't
+            # cover; an `AsyncMock`-backed `MagicMock().job_manager.get_stalled_jobs`
+            # returns a coroutine yielding the mock itself, which iterates
+            # empty. That's enough to make the call a no-op for this test.
+            app_mock = MagicMock()
+            app_mock.job_manager.get_stalled_jobs = AsyncMock(return_value=[])
+            await _periodic_sweep(MagicMock(), MagicMock(), app_mock, interval=30)
 
         # The periodic sweep must not emit any sweep_start/sweep_end spans.
         for call in append_event.await_args_list:


### PR DESCRIPTION
## Summary

Worker processes can die mid-job (laptop sleep, OOM, ungraceful shutdown) leaving the row at `status='doing'`. Procrastinate's heartbeat lease tracks worker liveness via `procrastinate_workers.last_heartbeat` (updated every `update_heartbeat_interval`, default 10s), but doesn't propagate worker death to the jobs they were running. The job's `lock` (`"{session_id}"` for aios) stays held; subsequent wakes for that session sit behind it forever.

This was today's incident: the factchecker session sat stuck for 2h53m via this exact shape. Worker died ~14:00 UTC, job 6620 stayed `doing`, the next queued wake (6621, `todo`) couldn't claim the session lock until I manually moved 6620 to `failed`.

## What this changes

Recovery uses procrastinate's blessed primitives — **no custom SQL on procrastinate's tables**. Per @eumemic's review of the previous draft of this PR, lean on the heartbeat lease that procrastinate already provides.

- **`sweep.py`** — new `reap_stalled_jobs(job_manager)` calls `JobManager.get_stalled_jobs(seconds_since_heartbeat=60)` (procrastinate's lease-aware query that handles both `worker_id IS NULL` and "worker has stale heartbeat" shapes) and transitions each job via `finish_job_by_id_async`. 60s is comfortably above procrastinate's 10s heartbeat and 30s default `stalled_worker_timeout`.
- **`worker.py`** — call the reaper at startup before the wake sweep (so freshly-unblocked sessions get woken in the same pass), and again on every periodic-sweep tick (so a worker death during steady-state operation recovers within the sweep interval, default 30s).

Live workers' in-flight jobs are preserved by procrastinate's lease semantics — `test_leaves_doing_with_live_worker_alone` pins this.

The function takes a `JobManager` rather than the procrastinate `App` so tests can build a fresh manager pointed at the testcontainer DB without depending on the module-level `procrastinate_app` singleton (which fixes its connector at import time, before test fixtures override env vars). This also fixes the CI failure on the previous draft of this PR.

## Pairs with #179

| failure mode | recovery |
|--------------|----------|
| Worker alive, external dep stalled | `asyncio.wait_for` fires → existing reschedule path (#179) |
| Worker dead, job orphaned | `get_stalled_jobs` lease query → `finish_job_by_id_async` → existing wake re-enqueues (this PR) |

## Test plan

- [x] `tests/e2e/test_reap_stalled_jobs.py` — five cases against a real procrastinate schema in the testcontainer:
  - `test_reaps_doing_with_null_worker_id` — `worker_id IS NULL` orphan, the canonical case from today's incident.
  - `test_reaps_doing_with_stale_worker_heartbeat` — the lease case proper: worker still in `procrastinate_workers` but heartbeat older than threshold.
  - `test_leaves_doing_with_live_worker_alone` — safety: a live worker's job MUST NOT be reaped.
  - `test_ignores_other_statuses` — `todo` and `succeeded` jobs are out of scope.
  - `test_returns_zero_when_no_stalled_jobs` — steady state.
- [x] `uv run pytest tests/unit -q` — 942 pass.
- [x] `uv run mypy src` — clean.
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean.
- [x] `DOCKER_HOST=... uv run pytest tests/e2e/test_reap_stalled_jobs.py -q` — 5 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)