### PR TITLE
[codex] Consolidate connector MCP refactor

### DIFF
--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -54,23 +54,46 @@ curl -X POST :8090/v1/vaults/$VLT/credentials -d '{
 }'
 ```
 
-### 3. Register the aios connection
+### 3. Add the MCP server to your agent
+
+Add the Signal MCP server as a normal agent MCP server:
 
 ```
-curl -X POST :8090/v1/connections -d "{
+{
+  "mcp_servers": [
+    {"type": "url", "name": "signal", "url": "http://localhost:9100/mcp"}
+  ],
+  "tools": [
+    {
+      "type": "mcp_toolset",
+      "mcp_server_name": "signal",
+      "default_config": {
+        "permission_policy": {"type": "always_allow"}
+      }
+    }
+  ]
+}
+```
+
+### 4. Register the aios connection
+
+The connection is the inbound channel account. Normal MCP discovery comes from
+the agent config above; the vault is supplied through the routing rule's
+session params.
+
+```
+CONN=$(curl -X POST :8090/v1/connections -d "{
   \"connector\": \"signal\",
-  \"account\": \"<bot-aci-uuid-from-step-1>\",
-  \"mcp_url\": \"http://localhost:9100/mcp\",
-  \"vault_id\": \"$VLT\"
-}"
+  \"account\": \"<bot-aci-uuid-from-step-1>\"
+}" | jq -r .id)
 ```
 
-### 4. Start the connector
+### 5. Start the connector
 
 ```
 export AIOS_URL=http://localhost:8090
 export AIOS_API_KEY=...
-export AIOS_CONNECTION_ID=conn_...
+export AIOS_CONNECTION_ID=$CONN
 export AIOS_SIGNAL_MCP_TOKEN=supersecret
 
 python -m aios_signal start \
@@ -80,29 +103,25 @@ python -m aios_signal start \
 
 All settings can also be passed via env vars. Full list via `python -m aios_signal start --help`.
 
-### 5. Add a routing rule
+### 6. Add a routing rule
 
 ```
-curl -X POST :8090/v1/routing-rules -d '{
-  "prefix": "signal/<bot-aci-uuid>",
-  "target": "agent:<agent-id>",
-  "session_params": {"environment_id": "<env-id>"}
-}'
+curl -X POST :8090/v1/connections/$CONN/routing-rules -d "{
+  \"prefix\": \"\",
+  \"target\": \"agent:<agent-id>\",
+  \"session_params\": {\"environment_id\": \"<env-id>\", \"vault_ids\": [\"$VLT\"]}
+}"
 ```
 
-The prefix uses the **bot's** ACI UUID (from step 1), not the counterparty's.
+The empty prefix is the per-connection catch-all. The session vault binding is
+what gives the agent-declared Signal MCP server its bearer token.
 
-### 6. DM your bot — the agent replies
+### 7. DM your bot — the agent replies
 
 DM the bot's phone number from another Signal client. Watch the aios event
 log: the inbound message shows up with `metadata.channel` set, a session is
 created on first inbound, and the agent's `signal_send` call delivers the
 reply back to Signal.
-
-**Phase-2 dependency:** step 6 works end-to-end only once Phase 2 (#31) has
-merged — Phase 2 wires connection-provided MCP servers into the worker's
-tool discovery. Until then the connector runs fine and ingests messages, but
-the agent can't see the `signal_send` tool.
 
 ## Configuration reference
 

--- a/connectors/signal/src/aios_signal/mcp.py
+++ b/connectors/signal/src/aios_signal/mcp.py
@@ -41,37 +41,46 @@ from .rpc import RpcClient
 log = structlog.get_logger(__name__)
 
 
-# Key under a JSON-RPC tool-call request's ``_meta`` populated by the
-# aios worker when dispatching a connection-provided tool.  Its value
-# is the focal-channel path suffix — for Signal's 3-segment address
-# ``signal/<bot>/<chat>``, the suffix is just ``<chat>`` and can be
-# decoded directly as the Signal chat id.  See the aios focal-channel
-# plan + ``aios.harness.channels.FOCAL_CHANNEL_META_KEY`` for the
-# client-side contract.
-_FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
+# Key under a JSON-RPC tool-call request's ``_meta`` populated by the aios
+# worker when dispatching an MCP tool call while a focal channel is set. Its
+# value is the account-relative focal channel: ``<bot_uuid>/<chat_id>``.
+# See ``aios.harness.channels`` for the client-side contract.
+_FOCAL_CHANNEL_META_KEY = "aios.focal_channel"
 
 
-def focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> str:
+def focal_chat_id_from_meta(
+    meta: RequestParams.Meta | None,
+    *,
+    account_id: str | None = None,
+) -> str:
     """Extract the Signal ``chat_id`` from an MCP request's ``_meta``.
 
-    aios injects ``aios.focal_channel_path`` for connection-provided
-    tool calls; its value is the full focal-channel suffix (stripped
-    of ``<connector>/<account>``), which for a 3-segment Signal
-    address equals the chat id verbatim.  Missing / malformed meta
-    raises — the agent shouldn't be able to reach these tools without
-    a focal channel set (aios filters them out of the tool list when
-    focal is NULL), so any absence here is a real error to surface.
+    aios injects ``aios.focal_channel`` for MCP tool calls while focal is set.
+    Its value is account-relative: ``<bot_uuid>/<chat_id>``. Missing,
+    malformed, or wrong-account meta raises so the agent sees that it must
+    focus a channel on this account before using Signal response tools.
     """
-    path: Any = None
+    focal_channel: Any = None
     if meta is not None:
         extra = getattr(meta, "model_extra", None) or {}
-        path = extra.get(_FOCAL_CHANNEL_META_KEY)
-    if not isinstance(path, str) or not path:
+        focal_channel = extra.get(_FOCAL_CHANNEL_META_KEY)
+    if not isinstance(focal_channel, str) or not focal_channel:
         raise ValueError(
             "signal tools require a focal channel — aios should inject "
             f"{_FOCAL_CHANNEL_META_KEY!r} in _meta when focal is set"
         )
-    return path
+    account, sep, chat_id = focal_channel.partition("/")
+    if not sep or not account or not chat_id:
+        raise ValueError(
+            "signal focal channel must be account-relative "
+            f"'<account>/<chat_id>'; got {focal_channel!r}"
+        )
+    if account_id is not None and account != account_id:
+        raise ValueError(
+            "signal focal channel belongs to a different account "
+            f"({account!r}, expected {account_id!r})"
+        )
+    return chat_id
 
 
 def build_send_params(chat_id: str, text: str) -> dict[str, Any]:
@@ -175,7 +184,7 @@ def build_mcp_server(
         Args:
             text: Message body. Markdown is converted to Signal text styles.
         """
-        chat_id = focal_chat_id_from_meta(ctx.request_context.meta)
+        chat_id = focal_chat_id_from_meta(ctx.request_context.meta, account_id=bot_uuid)
         params = build_send_params(chat_id, text)
         result = await rpc.call("send", params)
         ts = _extract_timestamp(result)
@@ -206,7 +215,7 @@ def build_mcp_server(
                 message you're reacting to.
             emoji: The reaction emoji.
         """
-        chat_id = focal_chat_id_from_meta(ctx.request_context.meta)
+        chat_id = focal_chat_id_from_meta(ctx.request_context.meta, account_id=bot_uuid)
         params = build_react_params(chat_id, target_author_uuid, target_timestamp_ms, emoji)
         await rpc.call("sendReaction", params)
         return {"status": "ok"}

--- a/connectors/signal/src/aios_signal/prompts.py
+++ b/connectors/signal/src/aios_signal/prompts.py
@@ -2,8 +2,7 @@
 
 Returned in the ``InitializeResult.instructions`` field of the MCP
 ``initialize`` response; the aios harness concatenates it into the
-session's system prompt under a ``## Connector: signal/<account>``
-heading.
+session's system prompt under the Signal MCP server heading.
 
 Covers only the tools this server actually exposes — ``signal_send``,
 ``signal_react``, ``signal_read_receipt``.  Telling the model about

--- a/connectors/signal/tests/test_mcp.py
+++ b/connectors/signal/tests/test_mcp.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import httpx
@@ -26,9 +26,11 @@ from aios_signal.mcp import (
     parse_bind,
 )
 
+BOT_UUID = "test-bot-uuid"
+
 
 def _ctx_with_focal(chat_id: str | None) -> Context[Any, Any, Any]:
-    """Build a Context carrying an ``aios.focal_channel_path`` in ``_meta``.
+    """Build a Context carrying an account-relative focal channel in ``_meta``.
 
     The ToolManager.call_tool path accepts an explicit Context; this
     lets us simulate what aios sends without going through a full
@@ -38,7 +40,7 @@ def _ctx_with_focal(chat_id: str | None) -> Context[Any, Any, Any]:
     if chat_id is None:
         rc.meta = None
     else:
-        rc.meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": chat_id})
+        rc.meta = RequestParams.Meta.model_validate({"aios.focal_channel": f"{BOT_UUID}/{chat_id}"})
     return Context(request_context=rc)
 
 
@@ -66,7 +68,7 @@ async def _call_tool(
     Goes through ``FastMCP.tool_manager.call_tool`` so the tool handler's
     ``ctx: Context`` dependency is filled in with the constructed meta.
     """
-    mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
+    mcp = build_mcp_server(rpc=cast(Any, rpc), bot_uuid=BOT_UUID, phone="+15550000000")
     result = await mcp._tool_manager.call_tool(
         name,
         args,
@@ -85,9 +87,9 @@ async def _call_tool(
 
 
 class TestFocalChatIdFromMeta:
-    def test_returns_path_when_present(self) -> None:
-        meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "chat-abc"})
-        assert focal_chat_id_from_meta(meta) == "chat-abc"
+    def test_returns_chat_id_when_present(self) -> None:
+        meta = RequestParams.Meta.model_validate({"aios.focal_channel": f"{BOT_UUID}/chat-abc"})
+        assert focal_chat_id_from_meta(meta, account_id=BOT_UUID) == "chat-abc"
 
     def test_none_meta_raises(self) -> None:
         with pytest.raises(ValueError, match="focal channel"):
@@ -99,9 +101,19 @@ class TestFocalChatIdFromMeta:
             focal_chat_id_from_meta(meta)
 
     def test_empty_string_raises(self) -> None:
-        meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": ""})
+        meta = RequestParams.Meta.model_validate({"aios.focal_channel": ""})
         with pytest.raises(ValueError, match="focal channel"):
             focal_chat_id_from_meta(meta)
+
+    def test_malformed_account_relative_value_raises(self) -> None:
+        meta = RequestParams.Meta.model_validate({"aios.focal_channel": "chat-abc"})
+        with pytest.raises(ValueError, match="account-relative"):
+            focal_chat_id_from_meta(meta, account_id=BOT_UUID)
+
+    def test_wrong_account_raises(self) -> None:
+        meta = RequestParams.Meta.model_validate({"aios.focal_channel": "other/chat-abc"})
+        with pytest.raises(ValueError, match="different account"):
+            focal_chat_id_from_meta(meta, account_id=BOT_UUID)
 
 
 class TestBuildSendParams:
@@ -171,8 +183,9 @@ async def test_signal_send_reads_focal_from_meta() -> None:
 
 async def test_signal_send_errors_without_meta() -> None:
     rpc = FakeRpc()
-    mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
-    # No focal — aios should have filtered this tool out, but defend.
+    mcp = build_mcp_server(rpc=cast(Any, rpc), bot_uuid=BOT_UUID, phone="+15550000000")
+    # No focal — aios omits focal metadata, and the connector surfaces the
+    # missing focus as a tool error.
     ctx_no_meta = _ctx_with_focal(None)
     with pytest.raises(Exception, match="focal channel"):
         await mcp._tool_manager.call_tool(
@@ -322,7 +335,7 @@ async def test_bearer_auth_rejects_non_bearer_scheme() -> None:
 
 def test_build_mcp_app_returns_starlette() -> None:
     rpc = FakeRpc()
-    mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
+    mcp = build_mcp_server(rpc=cast(Any, rpc), bot_uuid=BOT_UUID, phone="+15550000000")
     app = build_mcp_app(mcp, token="t")
     assert isinstance(app, Starlette)
 
@@ -336,13 +349,15 @@ def test_build_mcp_server_surfaces_profile_name_from_contacts() -> None:
     """
     rpc = FakeRpc()
     mcp = build_mcp_server(
-        rpc=rpc,
-        bot_uuid="test-bot-uuid",
+        rpc=cast(Any, rpc),
+        bot_uuid=BOT_UUID,
         phone="+15550000000",
-        contact_names={"test-bot-uuid": "Bot McBotface", "other-uuid": "Alice"},
-    )  # type: ignore[arg-type]
-    assert "profile_name" in mcp.instructions
-    assert "Bot McBotface" in mcp.instructions
+        contact_names={BOT_UUID: "Bot McBotface", "other-uuid": "Alice"},
+    )
+    instructions = mcp.instructions
+    assert instructions is not None
+    assert "profile_name" in instructions
+    assert "Bot McBotface" in instructions
 
 
 def test_build_mcp_server_omits_profile_name_when_bot_not_in_contacts() -> None:
@@ -352,30 +367,34 @@ def test_build_mcp_server_omits_profile_name_when_bot_not_in_contacts() -> None:
     """
     rpc = FakeRpc()
     mcp = build_mcp_server(
-        rpc=rpc,
-        bot_uuid="test-bot-uuid",
+        rpc=cast(Any, rpc),
+        bot_uuid=BOT_UUID,
         phone="+15550000000",
         contact_names={"other-uuid": "Alice"},
-    )  # type: ignore[arg-type]
-    assert "profile_name" not in mcp.instructions
+    )
+    instructions = mcp.instructions
+    assert instructions is not None
+    assert "profile_name" not in instructions
 
 
 def test_build_mcp_server_passes_signal_instructions() -> None:
     """The MCP server's ``instructions`` field is the transport for
-    Signal's per-connector affordance prose; aios reads it from the
+    Signal's per-server affordance prose; aios reads it from the
     ``InitializeResult`` returned by ``session.initialize()`` and
     composes it into the agent's system prompt.
     """
     from aios_signal.prompts import SIGNAL_SERVER_INSTRUCTIONS
 
     rpc = FakeRpc()
-    mcp = build_mcp_server(rpc=rpc, bot_uuid="test-bot-uuid", phone="+15550000000")  # type: ignore[arg-type]
+    mcp = build_mcp_server(rpc=cast(Any, rpc), bot_uuid=BOT_UUID, phone="+15550000000")
     # The static tool prose comes through verbatim — ``build_instructions``
     # prepends an identity block but doesn't rewrite the body.
-    assert SIGNAL_SERVER_INSTRUCTIONS in mcp.instructions
-    assert "signal_send" in mcp.instructions
-    assert "signal_react" in mcp.instructions
-    assert "signal_read_receipt" in mcp.instructions
+    instructions = mcp.instructions
+    assert instructions is not None
+    assert SIGNAL_SERVER_INSTRUCTIONS in instructions
+    assert "signal_send" in instructions
+    assert "signal_react" in instructions
+    assert "signal_read_receipt" in instructions
     # Identity block is present and names this bot.
-    assert "test-bot-uuid" in mcp.instructions
-    assert "+15550000000" in mcp.instructions
+    assert BOT_UUID in instructions
+    assert "+15550000000" in instructions

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -46,23 +46,46 @@ curl -X POST :8090/v1/vaults/$VLT/credentials -d '{
 }'
 ```
 
-### 3. Register the aios connection
+### 3. Add the MCP server to your agent
+
+Add the Telegram MCP server as a normal agent MCP server:
 
 ```
-curl -X POST :8090/v1/connections -d "{
+{
+  "mcp_servers": [
+    {"type": "url", "name": "telegram", "url": "http://localhost:9200/mcp"}
+  ],
+  "tools": [
+    {
+      "type": "mcp_toolset",
+      "mcp_server_name": "telegram",
+      "default_config": {
+        "permission_policy": {"type": "always_allow"}
+      }
+    }
+  ]
+}
+```
+
+### 4. Register the aios connection
+
+The connection is the inbound channel account. Normal MCP discovery comes from
+the agent config above; the vault is supplied through the routing rule's
+session params.
+
+```
+CONN=$(curl -X POST :8090/v1/connections -d "{
   \"connector\": \"telegram\",
-  \"account\": \"<bot-numeric-id-from-step-1>\",
-  \"mcp_url\": \"http://localhost:9200/mcp\",
-  \"vault_id\": \"$VLT\"
-}"
+  \"account\": \"<bot-numeric-id-from-step-1>\"
+}" | jq -r .id)
 ```
 
-### 4. Start the connector
+### 5. Start the connector
 
 ```
 export AIOS_URL=http://localhost:8090
 export AIOS_API_KEY=...
-export AIOS_CONNECTION_ID=conn_...
+export AIOS_CONNECTION_ID=$CONN
 export AIOS_TELEGRAM_MCP_TOKEN=supersecret
 
 python -m aios_telegram start --bot-token 123456:AA...
@@ -71,17 +94,20 @@ python -m aios_telegram start --bot-token 123456:AA...
 All settings can also be passed via env vars. Full list via
 `python -m aios_telegram start --help`.
 
-### 5. Add a routing rule
+### 6. Add a routing rule
 
 ```
-curl -X POST :8090/v1/routing-rules -d '{
-  "prefix": "telegram/<bot-numeric-id>",
-  "target": "agent:<agent-id>",
-  "session_params": {"environment_id": "<env-id>"}
-}'
+curl -X POST :8090/v1/connections/$CONN/routing-rules -d "{
+  \"prefix\": \"\",
+  \"target\": \"agent:<agent-id>\",
+  \"session_params\": {\"environment_id\": \"<env-id>\", \"vault_ids\": [\"$VLT\"]}
+}"
 ```
 
-### 6. DM the bot — the agent replies
+The empty prefix is the per-connection catch-all. The session vault binding is
+what gives the agent-declared Telegram MCP server its bearer token.
+
+### 7. DM the bot — the agent replies
 
 DM the bot from a Telegram client. Watch the aios event log: the inbound
 message shows up with `metadata.channel` set, a session is created on

--- a/connectors/telegram/src/aios_telegram/mcp.py
+++ b/connectors/telegram/src/aios_telegram/mcp.py
@@ -32,38 +32,48 @@ from .prompts import build_instructions
 log = structlog.get_logger(__name__)
 
 
-# Key under a JSON-RPC tool-call request's ``_meta`` populated by the
-# aios worker when dispatching a connection-provided tool.  Its value
-# is the focal-channel path suffix — for Telegram's 3-segment address
-# ``telegram/<bot_id>/<chat_id>``, the suffix is just ``<chat_id>`` and
-# can be parsed as a signed integer.
-_FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
+# Key under a JSON-RPC tool-call request's ``_meta`` populated by the aios
+# worker when dispatching an MCP tool call while a focal channel is set. Its
+# value is the account-relative focal channel: ``<bot_id>/<chat_id>``.
+_FOCAL_CHANNEL_META_KEY = "aios.focal_channel"
 
 
-def focal_chat_id_from_meta(meta: RequestParams.Meta | None) -> int:
+def focal_chat_id_from_meta(
+    meta: RequestParams.Meta | None,
+    *,
+    account_id: int | str | None = None,
+) -> int:
     """Extract the Telegram ``chat_id`` from an MCP request's ``_meta``.
 
-    aios injects ``aios.focal_channel_path`` for connection-provided tool
-    calls; its value is the full focal-channel suffix (stripped of
-    ``<connector>/<account>``), which for a 3-segment Telegram address
-    is the decimal chat id. Missing / malformed meta raises — the agent
-    shouldn't be able to reach these tools without a focal channel set
-    (aios filters them out of the tool list when focal is NULL), so any
-    absence here is a real error to surface.
+    aios injects ``aios.focal_channel`` for MCP tool calls while focal is set.
+    Its value is account-relative: ``<bot_id>/<chat_id>``. Missing, malformed,
+    wrong-account, or non-integer chat IDs raise so the agent sees that it must
+    focus a channel on this account before using Telegram response tools.
     """
-    path: Any = None
+    focal_channel: Any = None
     if meta is not None:
         extra = getattr(meta, "model_extra", None) or {}
-        path = extra.get(_FOCAL_CHANNEL_META_KEY)
-    if not isinstance(path, str) or not path:
+        focal_channel = extra.get(_FOCAL_CHANNEL_META_KEY)
+    if not isinstance(focal_channel, str) or not focal_channel:
         raise ValueError(
             "telegram tools require a focal channel — aios should inject "
             f"{_FOCAL_CHANNEL_META_KEY!r} in _meta when focal is set"
         )
+    account, sep, chat_id = focal_channel.partition("/")
+    if not sep or not account or not chat_id:
+        raise ValueError(
+            "telegram focal channel must be account-relative "
+            f"'<account>/<chat_id>'; got {focal_channel!r}"
+        )
+    if account_id is not None and account != str(account_id):
+        raise ValueError(
+            "telegram focal channel belongs to a different account "
+            f"({account!r}, expected {str(account_id)!r})"
+        )
     try:
-        return int(path)
+        return int(chat_id)
     except ValueError as e:
-        raise ValueError(f"telegram chat_id must be an integer; got {path!r}") from e
+        raise ValueError(f"telegram chat_id must be an integer; got {chat_id!r}") from e
 
 
 class BearerAuthMiddleware:
@@ -120,7 +130,7 @@ def build_mcp_server(
         Args:
             text: Message body. Plain text only — markdown is not rendered.
         """
-        chat_id = focal_chat_id_from_meta(ctx.request_context.meta)
+        chat_id = focal_chat_id_from_meta(ctx.request_context.meta, account_id=bot_id)
         sent = await bot.send_message(chat_id=chat_id, text=text)
         return {"message_id": sent.message_id}
 

--- a/connectors/telegram/src/aios_telegram/prompts.py
+++ b/connectors/telegram/src/aios_telegram/prompts.py
@@ -2,8 +2,7 @@
 
 Returned in the ``InitializeResult.instructions`` field of the MCP
 ``initialize`` response; the aios harness concatenates it into the
-session's system prompt under a ``## Connector: telegram/<account>``
-heading.
+session's system prompt under the Telegram MCP server heading.
 
 Covers only the tool this server exposes — ``telegram_send``. Telling the
 model about tools that don't exist would be worse than silence.

--- a/connectors/telegram/tests/test_mcp.py
+++ b/connectors/telegram/tests/test_mcp.py
@@ -22,13 +22,15 @@ from aios_telegram.mcp import (
     parse_bind,
 )
 
+BOT_ID = 1
+
 
 def _ctx_with_focal(chat_id: str | None) -> Context[Any, Any, Any]:
     rc = MagicMock(spec=RequestContext)
     if chat_id is None:
         rc.meta = None
     else:
-        rc.meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": chat_id})
+        rc.meta = RequestParams.Meta.model_validate({"aios.focal_channel": f"{BOT_ID}/{chat_id}"})
     return Context(request_context=rc)
 
 
@@ -36,13 +38,13 @@ def _ctx_with_focal(chat_id: str | None) -> Context[Any, Any, Any]:
 
 
 def test_focal_meta_dm_id() -> None:
-    meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "123456789"})
-    assert focal_chat_id_from_meta(meta) == 123456789
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel": f"{BOT_ID}/123456789"})
+    assert focal_chat_id_from_meta(meta, account_id=BOT_ID) == 123456789
 
 
 def test_focal_meta_group_negative_id() -> None:
-    meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "-1001234567890"})
-    assert focal_chat_id_from_meta(meta) == -1001234567890
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel": f"{BOT_ID}/-1001234567890"})
+    assert focal_chat_id_from_meta(meta, account_id=BOT_ID) == -1001234567890
 
 
 def test_focal_meta_missing_raises() -> None:
@@ -51,9 +53,21 @@ def test_focal_meta_missing_raises() -> None:
 
 
 def test_focal_meta_not_integer_raises() -> None:
-    meta = RequestParams.Meta.model_validate({"aios.focal_channel_path": "abc"})
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel": f"{BOT_ID}/abc"})
     with pytest.raises(ValueError, match="integer"):
-        focal_chat_id_from_meta(meta)
+        focal_chat_id_from_meta(meta, account_id=BOT_ID)
+
+
+def test_focal_meta_malformed_account_relative_value_raises() -> None:
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel": "123456789"})
+    with pytest.raises(ValueError, match="account-relative"):
+        focal_chat_id_from_meta(meta, account_id=BOT_ID)
+
+
+def test_focal_meta_wrong_account_raises() -> None:
+    meta = RequestParams.Meta.model_validate({"aios.focal_channel": "2/123456789"})
+    with pytest.raises(ValueError, match="different account"):
+        focal_chat_id_from_meta(meta, account_id=BOT_ID)
 
 
 # ─── telegram_send tool ─────────────────────────────────────────────────────
@@ -62,7 +76,7 @@ def test_focal_meta_not_integer_raises() -> None:
 async def _call_send(bot: Bot, text: str, *, focal: str | None) -> dict[str, Any]:
     # Identity args are required by build_mcp_server but not exercised by
     # telegram_send — dummy values keep these tool tests focused.
-    mcp = build_mcp_server(bot=bot, bot_id=1, first_name="Test", username="test_bot")
+    mcp = build_mcp_server(bot=bot, bot_id=BOT_ID, first_name="Test", username="test_bot")
     result = await mcp._tool_manager.call_tool(
         "telegram_send",
         {"text": text},

--- a/migrations/versions/0025_channel_only_connections.py
+++ b/migrations/versions/0025_channel_only_connections.py
@@ -1,0 +1,30 @@
+"""Allow connections without legacy MCP projection fields.
+
+Connections are the inbound channel-account identity. ``mcp_url`` and
+``vault_id`` are optional compatibility fields for older connection-projected
+MCP setups; normal connector MCP servers are declared on agents.
+
+Revision ID: 0025
+Revises: 0024
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0025"
+down_revision: str = "0024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE connections ALTER COLUMN mcp_url DROP NOT NULL")
+    op.execute("ALTER TABLE connections ALTER COLUMN vault_id DROP NOT NULL")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE connections ALTER COLUMN vault_id SET NOT NULL")
+    op.execute("ALTER TABLE connections ALTER COLUMN mcp_url SET NOT NULL")

--- a/migrations/versions/0026_channel_only_connections.py
+++ b/migrations/versions/0026_channel_only_connections.py
@@ -4,8 +4,8 @@ Connections are the inbound channel-account identity. ``mcp_url`` and
 ``vault_id`` are optional compatibility fields for older connection-projected
 MCP setups; normal connector MCP servers are declared on agents.
 
-Revision ID: 0025
-Revises: 0024
+Revision ID: 0026
+Revises: 0025
 """
 
 from __future__ import annotations
@@ -14,8 +14,8 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "0025"
-down_revision: str = "0024"
+revision: str = "0026"
+down_revision: str = "0025"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/migrations/versions/0026_drop_connection_mcp_fields.py
+++ b/migrations/versions/0026_drop_connection_mcp_fields.py
@@ -1,0 +1,29 @@
+"""Drop MCP config fields from connections.
+
+Connections now carry only inbound channel-account identity. MCP server
+configuration and credentials live on agents and session vaults.
+
+Revision ID: 0026
+Revises: 0025
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0026"
+down_revision: str = "0025"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE connections DROP COLUMN vault_id")
+    op.execute("ALTER TABLE connections DROP COLUMN mcp_url")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE connections ADD COLUMN mcp_url text")
+    op.execute("ALTER TABLE connections ADD COLUMN vault_id text REFERENCES vaults(id)")

--- a/migrations/versions/0027_drop_connection_mcp_fields.py
+++ b/migrations/versions/0027_drop_connection_mcp_fields.py
@@ -3,8 +3,8 @@
 Connections now carry only inbound channel-account identity. MCP server
 configuration and credentials live on agents and session vaults.
 
-Revision ID: 0026
-Revises: 0025
+Revision ID: 0027
+Revises: 0026
 """
 
 from __future__ import annotations
@@ -13,8 +13,8 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "0026"
-down_revision: str = "0025"
+revision: str = "0027"
+down_revision: str = "0026"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/migrations/versions/0027_drop_mcp_channel_context.py
+++ b/migrations/versions/0027_drop_mcp_channel_context.py
@@ -1,0 +1,51 @@
+"""Drop deprecated MCP channel_context config.
+
+The runtime injects focal-channel metadata into normal MCP calls based on
+session state, not agent toolset config. Strip the old inert field from stored
+agent JSON before the Pydantic model stops accepting it.
+
+Revision ID: 0027
+Revises: 0026
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0027"
+down_revision: str = "0026"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _strip_channel_context_sql(table: str) -> str:
+    return f"""
+        UPDATE {table}
+           SET tools = (
+               SELECT COALESCE(
+                   jsonb_agg(
+                       CASE
+                           WHEN jsonb_typeof(tool) = 'object'
+                           THEN tool - 'channel_context'
+                           ELSE tool
+                       END
+                       ORDER BY ord
+                   ),
+                   '[]'::jsonb
+               )
+                 FROM jsonb_array_elements(COALESCE(tools, '[]'::jsonb))
+                      WITH ORDINALITY AS t(tool, ord)
+           )
+    """
+
+
+def upgrade() -> None:
+    op.execute(_strip_channel_context_sql("agents"))
+    op.execute(_strip_channel_context_sql("agent_versions"))
+
+
+def downgrade() -> None:
+    # The removed JSON field was inert and cannot be reconstructed.
+    pass

--- a/migrations/versions/0028_drop_mcp_channel_context.py
+++ b/migrations/versions/0028_drop_mcp_channel_context.py
@@ -4,8 +4,8 @@ The runtime injects focal-channel metadata into normal MCP calls based on
 session state, not agent toolset config. Strip the old inert field from stored
 agent JSON before the Pydantic model stops accepting it.
 
-Revision ID: 0027
-Revises: 0026
+Revision ID: 0028
+Revises: 0027
 """
 
 from __future__ import annotations
@@ -14,8 +14,8 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "0027"
-down_revision: str = "0026"
+revision: str = "0028"
+down_revision: str = "0027"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/migrations/versions/0028_vault_credential_account_id.py
+++ b/migrations/versions/0028_vault_credential_account_id.py
@@ -1,0 +1,35 @@
+"""Add optional account identity to vault credentials.
+
+Revision ID: 0028
+Revises: 0027
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0028"
+down_revision: str = "0027"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("vault_credentials", sa.Column("account_id", sa.Text(), nullable=True))
+    op.create_check_constraint(
+        "vault_credentials_account_id_segment_ck",
+        "vault_credentials",
+        "account_id IS NULL OR (account_id <> '' AND account_id NOT LIKE '%/%')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "vault_credentials_account_id_segment_ck",
+        "vault_credentials",
+        type_="check",
+    )
+    op.drop_column("vault_credentials", "account_id")

--- a/migrations/versions/0029_vault_credential_account_id.py
+++ b/migrations/versions/0029_vault_credential_account_id.py
@@ -1,7 +1,7 @@
 """Add optional account identity to vault credentials.
 
-Revision ID: 0028
-Revises: 0027
+Revision ID: 0029
+Revises: 0028
 """
 
 from __future__ import annotations
@@ -11,8 +11,8 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0028"
-down_revision: str = "0027"
+revision: str = "0029"
+down_revision: str = "0028"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -36,8 +36,6 @@ async def create(body: ConnectionCreate, pool: PoolDep, _auth: AuthDep) -> Conne
         pool,
         connector=body.connector,
         account=body.account,
-        mcp_url=body.mcp_url,
-        vault_id=body.vault_id,
         metadata=body.metadata,
     )
 
@@ -69,8 +67,6 @@ async def update(
     return await service.update_connection(
         pool,
         connection_id,
-        mcp_url=body.mcp_url,
-        vault_id=body.vault_id,
         metadata=body.metadata,
     )
 

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -248,7 +248,7 @@ async def get_context(
     session-status bumps, event appends) are omitted; the endpoint is
     read-only.
     """
-    from aios.harness.channels import list_bindings_and_connections
+    from aios.harness.channels import list_session_bindings
     from aios.harness.step_context import compose_step_context, compute_step_prelude
     from aios.harness.tokens import approx_tokens
     from aios.models.agents import Agent, AgentVersion
@@ -264,7 +264,7 @@ async def get_context(
     else:
         agent = await agents_service.get_agent(pool, session.agent_id)
 
-    bindings, connections = await list_bindings_and_connections(pool, session_id)
+    bindings = await list_session_bindings(pool, session_id)
 
     from aios.db import queries as _queries
 
@@ -277,7 +277,6 @@ async def get_context(
         session=session,
         agent=agent,
         bindings=bindings,
-        connections=connections,
         memory_store_echoes=memory_echoes,
     )
     overhead_local = (

--- a/src/aios/cli/commands/connections.py
+++ b/src/aios/cli/commands/connections.py
@@ -1,4 +1,4 @@
-"""``aios connections ...`` — connector-instance CRUD + inbound-message helper."""
+"""``aios connections ...`` — inbound account CRUD + message helper."""
 
 from __future__ import annotations
 
@@ -18,10 +18,10 @@ from aios.cli.files import PayloadError, load_json_object, load_payload, resolve
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import run_or_die
 
-app = typer.Typer(name="connections", help="Manage connector connections.", no_args_is_help=True)
+app = typer.Typer(name="connections", help="Manage inbound channel accounts.", no_args_is_help=True)
 
-_COLS = ("id", "connector", "account", "mcp_url", "updated_at")
-_MAXW = {"connector": 20, "account": 40, "mcp_url": 40}
+_COLS = ("id", "connector", "account", "updated_at")
+_MAXW = {"connector": 20, "account": 40}
 
 
 @app.command("list")
@@ -66,10 +66,6 @@ def create(
     account: Annotated[
         str | None, typer.Option("--account", help="Account identifier (e.g. bot uuid).")
     ] = None,
-    mcp_url: Annotated[str | None, typer.Option("--mcp-url", help="MCP server URL.")] = None,
-    vault_id: Annotated[
-        str | None, typer.Option("--vault-id", help="Vault id with the MCP credential.")
-    ] = None,
     metadata_json: Annotated[
         str | None,
         typer.Option("--metadata-json", help="JSON object of connection metadata."),
@@ -80,14 +76,12 @@ def create(
 ) -> None:
     def _run() -> int | None:
         ergonomic: dict[str, Any] | None = None
-        if any(v is not None for v in (connector, account, mcp_url, vault_id)):
+        if any(v is not None for v in (connector, account, metadata_json)):
             missing = [
                 name
                 for name, v in (
                     ("--connector", connector),
                     ("--account", account),
-                    ("--mcp-url", mcp_url),
-                    ("--vault-id", vault_id),
                 )
                 if v is None
             ]
@@ -97,8 +91,6 @@ def create(
             ergonomic = {
                 "connector": connector,
                 "account": account,
-                "mcp_url": mcp_url,
-                "vault_id": vault_id,
             }
             if metadata_json is not None:
                 try:

--- a/src/aios/cli/commands/vaults.py
+++ b/src/aios/cli/commands/vaults.py
@@ -30,7 +30,7 @@ app.add_typer(credentials, name="credentials")
 # ── vaults CRUD ─────────────────────────────────────────────────────────────
 
 _VAULT_COLS = ("id", "display_name", "archived_at", "updated_at")
-_CRED_COLS = ("id", "display_name", "auth_type", "mcp_server_url", "updated_at")
+_CRED_COLS = ("id", "display_name", "auth_type", "mcp_server_url", "account_id", "updated_at")
 
 
 @app.command("list", help="List vaults.")

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1536,6 +1536,7 @@ def _row_to_vault_credential(row: asyncpg.Record) -> VaultCredential:
         vault_id=row["vault_id"],
         display_name=row["display_name"],
         mcp_server_url=row["mcp_server_url"],
+        account_id=row["account_id"],
         auth_type=row["auth_type"],
         metadata=metadata,
         created_at=row["created_at"],
@@ -1550,6 +1551,7 @@ async def insert_vault_credential(
     vault_id: str,
     display_name: str | None,
     mcp_server_url: str,
+    account_id: str | None,
     auth_type: str,
     blob: EncryptedBlob,
     metadata: dict[str, Any],
@@ -1560,16 +1562,17 @@ async def insert_vault_credential(
         row = await conn.fetchrow(
             """
             INSERT INTO vault_credentials (
-                id, vault_id, display_name, mcp_server_url,
+                id, vault_id, display_name, mcp_server_url, account_id,
                 auth_type, ciphertext, nonce, metadata
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
             RETURNING *
             """,
             new_id,
             vault_id,
             display_name,
             mcp_server_url,
+            account_id,
             auth_type,
             blob.ciphertext,
             blob.nonce,
@@ -1683,6 +1686,7 @@ async def update_vault_credential(
     *,
     blob: EncryptedBlob | None = None,
     display_name: str | None | EllipsisType = ...,
+    account_id: str | None | EllipsisType = ...,
     metadata: dict[str, Any] | None | EllipsisType = ...,
 ) -> VaultCredential:
     sets: list[str] = []
@@ -1690,6 +1694,9 @@ async def update_vault_credential(
     if display_name is not ...:
         args.append(display_name)
         sets.append(f"display_name = ${len(args)}")
+    if account_id is not ...:
+        args.append(account_id)
+        sets.append(f"account_id = ${len(args)}")
     if blob is not None:
         args.append(blob.ciphertext)
         sets.append(f"ciphertext = ${len(args)}")
@@ -2110,8 +2117,6 @@ def _row_to_connection(row: asyncpg.Record) -> Connection:
         id=row["id"],
         connector=row["connector"],
         account=row["account"],
-        mcp_url=row["mcp_url"],
-        vault_id=row["vault_id"],
         metadata=metadata,
         created_at=row["created_at"],
         updated_at=row["updated_at"],
@@ -2124,8 +2129,6 @@ async def insert_connection(
     *,
     connector: str,
     account: str,
-    mcp_url: str,
-    vault_id: str,
     metadata: dict[str, Any],
 ) -> Connection:
     new_id = make_id(CONNECTION)
@@ -2133,26 +2136,19 @@ async def insert_connection(
     try:
         row = await conn.fetchrow(
             """
-            INSERT INTO connections (id, connector, account, mcp_url, vault_id, metadata)
-            VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+            INSERT INTO connections (id, connector, account, metadata)
+            VALUES ($1, $2, $3, $4::jsonb)
             RETURNING *
             """,
             new_id,
             connector,
             account,
-            mcp_url,
-            vault_id,
             metadata_json,
         )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
             f"a connection for ({connector!r}, {account!r}) already exists",
             detail={"connector": connector, "account": account},
-        ) from exc
-    except asyncpg.ForeignKeyViolationError as exc:
-        raise NotFoundError(
-            f"vault {vault_id} not found",
-            detail={"vault_id": vault_id},
         ) from exc
     assert row is not None
     return _row_to_connection(row)
@@ -2190,18 +2186,10 @@ async def update_connection(
     conn: asyncpg.Connection[Any],
     connection_id: str,
     *,
-    mcp_url: str | None = None,
-    vault_id: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> Connection:
     sets: list[str] = []
     args: list[Any] = [connection_id]
-    if mcp_url is not None:
-        args.append(mcp_url)
-        sets.append(f"mcp_url = ${len(args)}")
-    if vault_id is not None:
-        args.append(vault_id)
-        sets.append(f"vault_id = ${len(args)}")
     if metadata is not None:
         args.append(json.dumps(metadata))
         sets.append(f"metadata = ${len(args)}::jsonb")
@@ -2209,40 +2197,13 @@ async def update_connection(
         return await get_connection(conn, connection_id)
     sets.append("updated_at = now()")
     sql = f"UPDATE connections SET {', '.join(sets)} WHERE id = $1 RETURNING *"
-    try:
-        row = await conn.fetchrow(sql, *args)
-    except asyncpg.ForeignKeyViolationError as exc:
-        raise NotFoundError(
-            "vault not found",
-            detail={"vault_id": vault_id},
-        ) from exc
+    row = await conn.fetchrow(sql, *args)
     if row is None:
         raise NotFoundError(
             f"connection {connection_id} not found",
             detail={"id": connection_id},
         )
     return _row_to_connection(row)
-
-
-async def list_connections_by_ids(
-    conn: asyncpg.Connection[Any],
-    ids: list[str],
-) -> list[Connection]:
-    """Active connections with the given ``ids``.  Empty input → no roundtrip.
-
-    Results are ordered by ``c.id`` so callers can feed them into the
-    system prompt in a stable order — prompt-cache stability depends
-    on it.  Used by :func:`aios.harness.channels.list_bindings_and_connections`
-    where the ``ids`` come from the distinct ``binding.connection_id``
-    values of a session's bindings.
-    """
-    if not ids:
-        return []
-    rows = await conn.fetch(
-        "SELECT * FROM connections WHERE id = ANY($1::text[]) AND archived_at IS NULL ORDER BY id",
-        ids,
-    )
-    return [_row_to_connection(r) for r in rows]
 
 
 async def get_connections_by_pairs(
@@ -2275,17 +2236,6 @@ async def get_connections_by_pairs(
     return [_row_to_connection(r) for r in rows]
 
 
-async def get_connection_vault_for_url(
-    conn: asyncpg.Connection[Any], mcp_server_url: str
-) -> str | None:
-    """Vault id of the active connection owning ``mcp_server_url``, else ``None``."""
-    val: str | None = await conn.fetchval(
-        "SELECT vault_id FROM connections WHERE mcp_url = $1 AND archived_at IS NULL LIMIT 1",
-        mcp_server_url,
-    )
-    return val
-
-
 async def archive_connection(conn: asyncpg.Connection[Any], connection_id: str) -> Connection:
     row = await conn.fetchrow(
         "UPDATE connections SET archived_at = now(), updated_at = now() "
@@ -2305,8 +2255,8 @@ async def count_active_bindings_for_connection(
 ) -> int:
     """Count active channel bindings owned by this connection.  Used to
     block connection archival while sessions are still reachable via
-    those bindings — archiving the connection would silently drop the
-    connection-provided MCP tools from any live session.
+    those bindings — archiving the connection would break inbound routing
+    for any live session.
     """
     val: int = await conn.fetchval(
         "SELECT COUNT(*) FROM channel_bindings WHERE connection_id = $1 AND archived_at IS NULL",
@@ -2445,8 +2395,7 @@ async def list_session_bindings(
 ) -> list[ChannelBinding]:
     """Every active binding for ``session_id``, unpaginated.
 
-    The step function consumes this in one shot (see
-    :func:`aios.harness.channels.list_bindings_and_connections`).
+    The step function consumes this in one shot when composing context.
     """
     rows = await conn.fetch(
         _BINDING_SELECT + " WHERE cb.session_id = $1 AND cb.archived_at IS NULL ORDER BY cb.id",

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -1,5 +1,5 @@
-"""Channel helpers: prompt augmentation, monologue prefix, bindings →
-connections translation, and focal-channel unread derivation.
+"""Channel helpers: prompt augmentation, monologue prefix, binding lookup,
+and focal-channel unread derivation.
 """
 
 from __future__ import annotations
@@ -11,7 +11,6 @@ import asyncpg
 
 from aios.db import queries
 from aios.models.channel_bindings import ChannelBinding
-from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX, Connection
 from aios.models.events import Event
 
 MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: "
@@ -22,23 +21,23 @@ MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: "
 # per-channel ``last_seen`` watermark off successful switches.
 SWITCH_CHANNEL_METADATA_KEY = "switch_channel"
 
-# Top-level key inside the ``_meta`` field sent on JSON-RPC tool-call
-# requests to connection-provided MCP servers.  The value is the
-# focal-channel suffix (the focal channel address with its first two
-# ``<connector>/<account>`` segments stripped, since the connector
-# already knows its own connection identity).  The connector splits
-# this on ``/`` to recover its own per-chat identifiers.
-FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
+# Top-level key inside the ``_meta`` field sent on JSON-RPC MCP tool-call
+# requests when a focal channel is set. The value is the account-relative
+# focal channel: the stored channel address with only the leading
+# ``<connector>/`` attachment segment stripped. MCP servers that understand
+# aios channels can split this on ``/`` to recover account and chat-specific
+# identifiers; other servers ignore it.
+FOCAL_CHANNEL_META_KEY = "aios.focal_channel"
 
 
-def focal_channel_path(focal: str | None) -> str | None:
-    """Return the connector-specific suffix of a focal address.
+def focal_channel_meta_value(focal: str | None) -> str | None:
+    """Return the account-relative value for MCP focal-channel ``_meta``.
 
-    The ``<connector>/<account>`` prefix is information the MCP server
-    already has (it was invoked *by* that connection), so sending it
-    would be redundant; we strip it.  For a 3-segment address like
-    ``signal/<bot>/<chat>`` the suffix is just ``<chat>``.  For
-    ``telegram/<bot>/<chat>/<thread>`` it's ``<chat>/<thread>``.
+    A stored focal address is ``<connector>/<account>/<path>``. The connector
+    already knows its own attachment namespace from the MCP session, so the
+    meta value carries ``<account>/<path>``. For ``signal/<bot>/<chat>`` this
+    returns ``<bot>/<chat>``; for ``telegram/<bot>/<chat>/<thread>`` it returns
+    ``<bot>/<chat>/<thread>``.
 
     Returns ``None`` if ``focal`` is ``None`` or malformed (fewer than
     three segments) — neither should reach the dispatch path, but
@@ -47,27 +46,15 @@ def focal_channel_path(focal: str | None) -> str | None:
     if not focal:
         return None
     parts = focal.split("/", 2)
-    if len(parts) < 3 or not parts[2]:
+    if len(parts) < 3 or not parts[1] or not parts[2]:
         return None
-    return parts[2]
+    return f"{parts[1]}/{parts[2]}"
 
 
-def connection_server_name(c: Connection) -> str:
-    # c.id is "conn_<ULID>" — the ids.CONNECTION prefix is already the
-    # reserved namespace marker, so use it directly instead of stuttering.
-    assert c.id.startswith(CONNECTION_SERVER_NAME_PREFIX)
-    return c.id
-
-
-async def list_bindings_and_connections(
-    pool: asyncpg.Pool[Any], session_id: str
-) -> tuple[list[ChannelBinding], list[Connection]]:
-    """Load the session's bindings and the distinct connections they reference."""
+async def list_session_bindings(pool: asyncpg.Pool[Any], session_id: str) -> list[ChannelBinding]:
+    """Load the session's active channel bindings for context composition."""
     async with pool.acquire() as conn:
-        bindings = await queries.list_session_bindings(conn, session_id)
-        conn_ids = sorted({b.connection_id for b in bindings})
-        connections = await queries.list_connections_by_ids(conn, conn_ids) if conn_ids else []
-    return bindings, connections
+        return await queries.list_session_bindings(conn, session_id)
 
 
 def build_focal_paradigm_block(bindings: list[ChannelBinding]) -> str:
@@ -83,7 +70,7 @@ def build_focal_paradigm_block(bindings: list[ChannelBinding]) -> str:
     Per-platform specifics (Signal markdown subset, mention syntax,
     response idioms) live in each connector and travel through the MCP
     ``InitializeResult.instructions`` field — see
-    :func:`build_connector_instructions_block`.
+    :func:`build_mcp_instructions_block`.
     """
     if not bindings:
         return ""
@@ -115,16 +102,18 @@ def build_focal_paradigm_block(bindings: list[ChannelBinding]) -> str:
         "quoting recent messages on that channel so you can pick up "
         "the conversation in context.  Call "
         "`switch_channel(channel_id=null)` to put your phone down — "
-        "every inbound renders as a notification, connector response "
-        "tools disappear from your tool list.  Switching repeatedly "
-        "is cheap but not free: each switch's re-orient block appends "
-        "tokens to your context.\n"
+        "every inbound renders as a notification and MCP calls receive "
+        "no focal-channel metadata.  Switching repeatedly is cheap but "
+        "not free: each switch's re-orient block appends tokens to "
+        "your context.\n"
         "\n"
         "### Responding\n"
         "\n"
         "When focused on a channel, the connector's response tools "
         "(e.g. `signal_send`, `signal_react`) operate on your focal "
         "channel implicitly — no channel/chat-id argument required. "
+        "If your phone is down, switch to the intended channel before "
+        "using channel response tools. "
         "Bare assistant text is NOT delivered to any channel — it is "
         "private thinking no human sees. Prefix any such thinking with "
         f"{MONOLOGUE_PREFIX.strip()!r} so it is unambiguous in your "
@@ -232,37 +221,30 @@ def build_channels_tail_block(
     return {"role": "user", "content": "\n".join(lines)}
 
 
-def build_connector_instructions_block(
+def build_mcp_instructions_block(
     instructions_by_server: dict[str, str],
-    connections: list[Connection],
 ) -> str:
-    """Render per-connector affordance prose grouped by connection.
+    """Render MCP server affordance prose in discovery order.
 
-    ``instructions_by_server`` maps server_name (which for connection-
-    provided MCP servers equals ``connection_server_name(c)``) to the
-    server's ``InitializeResult.instructions`` string.  Connections are
-    iterated in the caller-supplied order so the prompt is stable
-    across steps (cache friendly).
+    ``instructions_by_server`` maps server_name to the server's
+    ``InitializeResult.instructions`` string. Discovery builds the dict in
+    agent ``mcp_servers`` order so the prompt is stable across steps.
 
-    Connections without an entry in the dict are skipped — a connector
-    that supplies no instructions contributes no block.
+    Servers without instructions are omitted by discovery and skipped here.
     """
     sections: list[str] = []
-    for c in connections:
-        name = connection_server_name(c)
-        text = instructions_by_server.get(name)
+    for server_name, text in instructions_by_server.items():
         if not text:
             continue
-        sections.append(f"## Connector: {c.connector}/{c.account}\n\n{text}")
+        sections.append(f"## MCP server: {server_name}\n\n{text}")
     return "\n\n".join(sections)
 
 
-def augment_with_connector_instructions(
+def augment_with_mcp_instructions(
     base_system: str,
     instructions_by_server: dict[str, str],
-    connections: list[Connection],
 ) -> str:
-    block = build_connector_instructions_block(instructions_by_server, connections)
+    block = build_mcp_instructions_block(instructions_by_server)
     if not block:
         return base_system
     if base_system:

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -33,7 +33,7 @@ from aios.harness.tokens import approx_tokens
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
 from aios.harness.wake import defer_retry_wake
 from aios.logging import get_logger
-from aios.models.agents import ToolSpec
+from aios.models.agents import McpToolConfig, ToolSpec
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
 
@@ -198,13 +198,11 @@ async def _run_session_step_body(
     else:
         agent = await agents_service.get_agent(pool, session.agent_id)
 
-    from aios.harness.channels import connection_server_name, list_bindings_and_connections
+    from aios.harness.channels import list_session_bindings
 
-    bindings, connections = await list_bindings_and_connections(pool, session_id)
+    bindings = await list_session_bindings(pool, session_id)
 
     mcp_server_map: dict[str, str] = {s.name: s.url for s in agent.mcp_servers}
-    for c in connections:
-        mcp_server_map[connection_server_name(c)] = c.mcp_url
 
     # Memory store mounts: load echoes once per step. Used both for the
     # system-prompt block and (via runtime cache) by the tool intercept
@@ -225,7 +223,6 @@ async def _run_session_step_body(
         session=session,
         agent=agent,
         bindings=bindings,
-        connections=connections,
         memory_store_echoes=memory_echoes,
     )
     overhead_local = (
@@ -552,24 +549,6 @@ def _switch_channel_tool_spec() -> dict[str, Any]:
     }
 
 
-def _hide_conn_tools_when_phone_down(
-    mcp_tools: list[dict[str, Any]], focal_channel: str | None
-) -> list[dict[str, Any]]:
-    """Filter connection-provided MCP tools out when focal is NULL.
-
-    Those tools resolve their ``chat_id`` from focal (injected into
-    ``_meta`` at dispatch time); a "phone down" state has no focal to
-    inject, so the model shouldn't be offered them.  Agent-declared
-    MCP tools are untouched.
-    """
-    from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
-
-    if focal_channel is not None:
-        return mcp_tools
-    prefix = f"mcp__{CONNECTION_SERVER_NAME_PREFIX}"
-    return [t for t in mcp_tools if not t.get("function", {}).get("name", "").startswith(prefix)]
-
-
 async def _dump_context_if_enabled(
     session_id: str,
     model: str,
@@ -620,6 +599,14 @@ def _is_mcp_tool(name: str) -> bool:
     return name.startswith("mcp__")
 
 
+def _parse_mcp_tool_name(name: str) -> tuple[str, str] | None:
+    """Parse ``mcp__<server_name>__<tool_name>`` into its parts."""
+    parts = name.split("__", 2)
+    if len(parts) < 3 or not parts[1] or not parts[2]:
+        return None
+    return parts[1], parts[2]
+
+
 def resolve_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
     """Look up the permission policy for a built-in or custom tool by name."""
     for spec in agent_tools:
@@ -629,30 +616,86 @@ def resolve_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
     return None
 
 
-def resolve_mcp_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
+def _enabled_mcp_toolsets_by_server(agent_tools: list[ToolSpec]) -> dict[str, ToolSpec]:
+    """Return enabled MCP toolset specs keyed by server name."""
+    toolsets: dict[str, ToolSpec] = {}
+    for spec in agent_tools:
+        if (
+            spec.type == "mcp_toolset"
+            and spec.enabled
+            and spec.mcp_server_name
+            and spec.mcp_server_name not in toolsets
+        ):
+            toolsets[spec.mcp_server_name] = spec
+    return toolsets
+
+
+def _mcp_tool_config(spec: ToolSpec, tool_name: str) -> McpToolConfig | None:
+    for cfg in spec.configs or []:
+        if cfg.name == tool_name:
+            return cfg
+    return None
+
+
+def _is_mcp_tool_enabled(name: str, spec: ToolSpec) -> bool:
+    parsed = _parse_mcp_tool_name(name)
+    if parsed is None:
+        return False
+    server_name, tool_name = parsed
+    if server_name != spec.mcp_server_name:
+        return False
+    tool_cfg = _mcp_tool_config(spec, tool_name)
+    if tool_cfg is not None:
+        return tool_cfg.enabled
+    default_cfg = spec.default_config
+    if default_cfg is not None:
+        return default_cfg.enabled
+    return True
+
+
+def _filter_mcp_tools_for_toolset(
+    mcp_tools: list[dict[str, Any]],
+    spec: ToolSpec,
+) -> list[dict[str, Any]]:
+    filtered: list[dict[str, Any]] = []
+    for tool in mcp_tools:
+        name = tool.get("function", {}).get("name") or tool.get("name")
+        if isinstance(name, str) and _is_mcp_tool_enabled(name, spec):
+            filtered.append(tool)
+    return filtered
+
+
+def resolve_mcp_permission(
+    name: str,
+    agent_tools: list[ToolSpec],
+) -> str | None:
     """Look up the permission policy for an MCP tool.
 
-    Connection-provided tools (server name in the reserved ``conn_``
-    namespace) default to ``always_allow`` — the session's channel
-    binding is already explicit routing consent; gating every reply on
-    a confirmation prompt would defeat the connector autonomy story.
+    Finds the enabled ``mcp_toolset`` entry whose ``mcp_server_name`` matches
+    the server portion of the namespaced tool name. Per-tool config overrides
+    the toolset default, and ``None`` means callers treat the call as
+    ``always_ask``.
 
-    For agent-declared servers, finds the ``mcp_toolset`` entry whose
-    ``mcp_server_name`` matches the server portion of the namespaced
-    tool name, then returns the ``default_config.permission_policy.type``
-    or ``None`` (which callers treat as ``always_ask``).
+    MCP tools do not gain implicit permissions from channel/focal behavior;
+    operators grant execution policy through normal MCP toolset config.
     """
-    from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
+    parsed = _parse_mcp_tool_name(name)
+    if parsed is None:
+        return None
+    server_name, tool_name = parsed
+    spec = _enabled_mcp_toolsets_by_server(agent_tools).get(server_name)
+    if spec is None:
+        return None
 
-    server_name = name.split("__", 2)[1]
-    if server_name.startswith(CONNECTION_SERVER_NAME_PREFIX):
-        return "always_allow"
-    for spec in agent_tools:
-        if spec.type == "mcp_toolset" and spec.mcp_server_name == server_name:
-            cfg = spec.default_config
-            if cfg and cfg.permission_policy:
-                return cfg.permission_policy.type
-            return spec.permission
+    tool_cfg = _mcp_tool_config(spec, tool_name)
+    if tool_cfg is not None and tool_cfg.permission_policy is not None:
+        return tool_cfg.permission_policy.type
+
+    cfg = spec.default_config
+    if cfg and cfg.permission_policy:
+        return cfg.permission_policy.type
+    if spec.permission:
+        return spec.permission
     return None
 
 
@@ -660,32 +703,27 @@ async def discover_session_mcp_tools(
     pool: Any,
     session_id: str,
     agent: Any,
-    connections: list[Any],
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
     """Discover MCP tools from agent-declared servers (filtered by enabled
-    ``mcp_toolset`` entries) unioned with connection-provided servers.
+    ``mcp_toolset`` entries and their default/per-tool enabled settings).
 
     Returns ``(tools, instructions_by_server)`` where the second element
     maps ``server_name`` → the server's ``InitializeResult.instructions``
     string.  Servers that supplied no instructions (or ``""``) are
     omitted from the dict — the harness uses presence in the dict as
-    the trigger for rendering a per-connector affordance block.
+    the trigger for rendering MCP server affordance prose.
     """
-    from aios.harness.channels import connection_server_name
+    import asyncio
+
     from aios.mcp.client import discover_mcp_tools, resolve_auth_for_url
 
-    servers: list[tuple[str, str]] = []
+    servers: list[tuple[str, str, ToolSpec]] = []
 
-    enabled_server_names: set[str] = set()
-    for spec in agent.tools:
-        if spec.type == "mcp_toolset" and spec.enabled and spec.mcp_server_name:
-            enabled_server_names.add(spec.mcp_server_name)
+    toolsets_by_server = _enabled_mcp_toolsets_by_server(agent.tools)
     for s in agent.mcp_servers:
-        if s.name in enabled_server_names:
-            servers.append((s.name, s.url))
-
-    for c in connections:
-        servers.append((connection_server_name(c), c.mcp_url))
+        spec = toolsets_by_server.get(s.name)
+        if spec is not None:
+            servers.append((s.name, s.url, spec))
 
     if not servers:
         return [], {}
@@ -693,16 +731,23 @@ async def discover_session_mcp_tools(
     crypto_box = runtime.require_crypto_box()
 
     async def _discover_one(name: str, url: str) -> tuple[list[dict[str, Any]], str | None]:
-        headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
+        headers = await resolve_auth_for_url(
+            pool,
+            crypto_box,
+            session_id,
+            url,
+        )
         return await discover_mcp_tools(url, name, headers)
 
-    results = await asyncio.gather(*[_discover_one(n, u) for n, u in servers])
+    results = await asyncio.gather(*[_discover_one(n, u) for n, u, _spec in servers])
     tools: list[dict[str, Any]] = [
-        tool for (tool_list, _instructions) in results for tool in tool_list
+        tool
+        for (_name, _url, spec), (tool_list, _instructions) in zip(servers, results, strict=True)
+        for tool in _filter_mcp_tools_for_toolset(tool_list, spec)
     ]
     instructions_by_server: dict[str, str] = {
         name: instructions
-        for (name, _url), (_tools, instructions) in zip(servers, results, strict=True)
+        for (name, _url, _spec), (_tools, instructions) in zip(servers, results, strict=True)
         if instructions
     }
     return tools, instructions_by_server

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 
     from aios.models.agents import Agent, AgentVersion
     from aios.models.channel_bindings import ChannelBinding
-    from aios.models.connections import Connection
     from aios.models.events import Event
     from aios.models.memory_stores import MemoryStoreResourceEcho
     from aios.models.sessions import Session
@@ -51,8 +50,8 @@ if TYPE_CHECKING:
 class StepPrelude:
     """Events-independent portion of a step's payload.
 
-    Everything here depends only on ``agent`` / ``bindings`` /
-    ``connections`` / ``session`` — not on which events windowing picks.
+    Everything here depends only on ``agent`` / ``bindings`` / ``session`` —
+    not on which events windowing picks.
     Computed before windowing so ``read_windowed_events`` can subtract
     the overhead from the budget (see ``overhead_local`` there).
 
@@ -88,7 +87,6 @@ async def compute_step_prelude(
     session: Session,
     agent: Agent | AgentVersion,
     bindings: list[ChannelBinding],
-    connections: list[Connection],
     memory_store_echoes: list[MemoryStoreResourceEcho],
 ) -> StepPrelude:
     """Build the events-independent parts of the step payload.
@@ -99,12 +97,11 @@ async def compute_step_prelude(
     byte-identical to what it was before the split.
     """
     from aios.harness.channels import (
-        augment_with_connector_instructions,
         augment_with_focal_paradigm,
+        augment_with_mcp_instructions,
         max_tail_block_local,
     )
     from aios.harness.loop import (
-        _hide_conn_tools_when_phone_down,
         _switch_channel_tool_spec,
         discover_session_mcp_tools,
     )
@@ -119,13 +116,8 @@ async def compute_step_prelude(
         tools.append(_switch_channel_tool_spec())
 
     mcp_instructions: dict[str, str] = {}
-    if agent.mcp_servers or connections:
-        mcp_tools, mcp_instructions = await discover_session_mcp_tools(
-            pool, session_id, agent, connections
-        )
-        # Hide connection-provided MCP tools when focal is NULL — can't
-        # type into a chat you aren't attending to.
-        mcp_tools = _hide_conn_tools_when_phone_down(mcp_tools, session.focal_channel)
+    if agent.mcp_servers:
+        mcp_tools, mcp_instructions = await discover_session_mcp_tools(pool, session_id, agent)
         tools.extend(mcp_tools)
 
     skill_versions = (
@@ -133,9 +125,7 @@ async def compute_step_prelude(
     )
     system_prompt = augment_system_prompt(agent.system, skill_versions)
     system_prompt = augment_with_focal_paradigm(system_prompt, bindings)
-    system_prompt = augment_with_connector_instructions(
-        system_prompt, mcp_instructions, connections
-    )
+    system_prompt = augment_with_mcp_instructions(system_prompt, mcp_instructions)
     system_prompt = augment_with_memory_stores(system_prompt, memory_store_echoes)
 
     return StepPrelude(

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -320,14 +320,18 @@ def launch_mcp_tool_calls(
     ``focal_channel`` is the session's focal at the moment these calls
     were emitted (captured at step top in ``run_session_step`` so a
     concurrent ``switch_channel`` in the same batch cannot race the
-    ``chat_id`` injection).  Passed through to each task so
-    connection-provided tools can stamp ``_meta`` with the suffix.
+    ``chat_id`` injection).  Passed through to each task so MCP calls can
+    stamp ``_meta`` with account-relative focal-channel context when set.
     """
     _launch_tasks(
         session_id,
         tool_calls,
         lambda call: _execute_mcp_tool_async(
-            pool, session_id, call, mcp_server_map, focal_channel=focal_channel
+            pool,
+            session_id,
+            call,
+            mcp_server_map,
+            focal_channel=focal_channel,
         ),
         prefix="mcp_tool",
     )
@@ -354,16 +358,13 @@ async def _execute_mcp_tool_async(
 ) -> None:
     """Execute one MCP tool call: connect, invoke, append result, defer wake.
 
-    For connection-provided servers (name in the reserved ``conn_``
-    namespace), the focal-channel suffix is stamped into the JSON-RPC
-    request's ``_meta`` so the connector can resolve its
-    connector-specific chat identifiers without the model having to
-    pass them explicitly.  The ``focal_channel`` snapshot is emission-
-    time — a concurrent ``switch_channel`` in the same assistant batch
-    does not race this injection.
+    When a focal channel is set, its account-relative value is stamped into
+    the JSON-RPC request's ``_meta`` so servers that understand aios channel
+    context can resolve channel-specific identifiers without the model having
+    to pass them explicitly.  The ``focal_channel`` snapshot is emission-time
+    — a concurrent ``switch_channel`` in the same assistant batch does not
+    race this injection.
     """
-    from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
-
     call_id = call.get("id") or "unknown"
     function = call.get("function") or {}
     name: str = function.get("name") or ""
@@ -403,33 +404,21 @@ async def _execute_mcp_tool_async(
             )
             return
 
-        from aios.harness.channels import FOCAL_CHANNEL_META_KEY, focal_channel_path
+        from aios.harness.channels import FOCAL_CHANNEL_META_KEY, focal_channel_meta_value
         from aios.mcp.client import call_mcp_tool, resolve_auth_for_url
 
-        meta: dict[str, Any] | None = None
-        if server_name.startswith(CONNECTION_SERVER_NAME_PREFIX):
-            suffix = focal_channel_path(focal_channel)
-            if suffix is None:
-                # The model shouldn't be able to call a conn_* tool while
-                # focal is NULL — loop.py filters them out of the tool
-                # list in that state — but defend in depth if it slips
-                # through (stale tool_calls, etc.).
-                is_error = True
-                await _append_tool_result(
-                    pool,
-                    session_id,
-                    call_id,
-                    name,
-                    error=(
-                        "connection-provided tools require a focal channel; "
-                        "call switch_channel first"
-                    ),
-                )
-                return
-            meta = {FOCAL_CHANNEL_META_KEY: suffix}
+        focal_meta = focal_channel_meta_value(focal_channel)
+        meta: dict[str, Any] | None = (
+            {FOCAL_CHANNEL_META_KEY: focal_meta} if focal_meta is not None else None
+        )
 
         crypto_box = runtime.require_crypto_box()
-        headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
+        headers = await resolve_auth_for_url(
+            pool,
+            crypto_box,
+            session_id,
+            url,
+        )
         result = await call_mcp_tool(url, headers, tool_name, arguments, meta=meta)
 
         content_str = json.dumps(result, ensure_ascii=False)

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -85,12 +85,9 @@ async def resolve_auth_for_url(
 ) -> dict[str, str]:
     """Resolve MCP auth headers for ``mcp_server_url``.
 
-    Connection-owned URLs resolve through the connection's vault; other
-    URLs fall back to the session's bound vaults (``session_vaults``).
-    A connection that owns the URL but has no matching credential
-    returns ``{}`` rather than falling back — ownership decides the
-    source, not whether the lookup hits (prevents a misconfigured
-    connection from silently leaking a tenant-level credential).
+    Agent-declared MCP servers resolve through the session's bound vaults
+    (``session_vaults``). The agent chooses a tool name; the worker resolves
+    the server URL from agent config and injects the matching vault credential.
 
     For ``mcp_oauth`` credentials whose ``expires_at`` falls within the
     refresh skew window, the access token is transparently refreshed
@@ -100,20 +97,10 @@ async def resolve_auth_for_url(
     to the stale token.
     """
     async with pool.acquire() as conn:
-        connection_vault_id = await queries.get_connection_vault_for_url(conn, mcp_server_url)
-        if connection_vault_id is not None:
-            vault_result = await queries.resolve_vault_credential(
-                conn, vault_id=connection_vault_id, mcp_server_url=mcp_server_url
-            )
-            if vault_result is None:
-                return {}
-            blob, auth_type = vault_result
-            vault_id = connection_vault_id
-        else:
-            session_result = await queries.resolve_mcp_credential(conn, session_id, mcp_server_url)
-            if session_result is None:
-                return {}
-            blob, auth_type, vault_id = session_result
+        session_result = await queries.resolve_mcp_credential(conn, session_id, mcp_server_url)
+        if session_result is None:
+            return {}
+        blob, auth_type, vault_id = session_result
 
         if auth_type == "mcp_oauth":
             payload = json.loads(crypto_box.decrypt(blob))
@@ -151,11 +138,11 @@ async def discover_mcp_tools(
       (``mcp__<server_name>__<tool_name>``).
     * ``instructions`` — the server's ``InitializeResult.instructions``
       string (per the MCP spec), or ``None`` if the server didn't supply
-      any. Used by the harness to compose per-connector affordance prose
+      any. Used by the harness to compose per-server affordance prose
       into the system prompt.
 
     On any error, logs a warning and returns ``([], None)`` — the model
-    simply doesn't see those tools (or that connector's instructions).
+    simply doesn't see those tools (or that server's instructions).
     """
     try:
         from aios.harness import runtime
@@ -221,9 +208,9 @@ async def call_mcp_tool(
 
     ``tool_name`` is the raw MCP tool name (without the ``mcp__`` prefix).
     ``meta`` is an optional per-request metadata dict forwarded as the
-    JSON-RPC request's ``_meta`` field — used by the focal-channel
-    redesign to pass ``aios.focal_channel_path`` to connection-provided
-    MCP servers without stuffing it into arguments.  Returns a result
+    JSON-RPC request's ``_meta`` field. The harness uses it to pass
+    ``aios.focal_channel`` whenever the session has a focal channel, without
+    stuffing channel context into model-supplied arguments. Returns a result
     dict with either ``content`` (success) or ``error`` (failure).
     """
     try:

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from aios.models.skills import AgentSkillRef
 
@@ -51,17 +51,6 @@ class McpServerSpec(BaseModel):
     type: Literal["url"] = "url"
     name: str = Field(min_length=1, max_length=64)
     url: str = Field(min_length=1)
-
-    @field_validator("name")
-    @classmethod
-    def _reject_reserved_prefix(cls, v: str) -> str:
-        from aios.models.connections import CONNECTION_SERVER_NAME_PREFIX
-
-        if v.startswith(CONNECTION_SERVER_NAME_PREFIX):
-            raise ValueError(
-                f"mcp_server name prefix {CONNECTION_SERVER_NAME_PREFIX!r} is reserved"
-            )
-        return v
 
 
 # ── MCP toolset config (permission policies for discovered tools) ──────────

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -1,8 +1,7 @@
 """Connection resource and inbound-message DTOs.
 
-A *connection* is a registered ``(connector, account)`` pair plus the
-MCP URL the connector exposes for the agent to send replies back through.
-The address scheme used by the routing layer is::
+A *connection* is a registered ``(connector, account)`` pair used by the
+inbound channel router. The address scheme used by the routing layer is::
 
     {connector}/{account}/{path}
 
@@ -16,11 +15,6 @@ from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
-
-# Reserved prefix for MCP server names derived from a connection.  Keeps
-# connection-provided servers disjoint from agent-declared ones in the
-# shared mcp_server_map.
-CONNECTION_SERVER_NAME_PREFIX = "conn_"
 
 
 class ConnectionCreate(BaseModel):
@@ -36,8 +30,6 @@ class ConnectionCreate(BaseModel):
 
     connector: str = Field(min_length=1, max_length=64)
     account: str = Field(min_length=1, max_length=256)
-    mcp_url: str = Field(min_length=1)
-    vault_id: str
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("connector", "account")
@@ -56,8 +48,6 @@ class ConnectionUpdate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    mcp_url: str | None = Field(default=None, min_length=1)
-    vault_id: str | None = None
     metadata: dict[str, Any] | None = None
 
 
@@ -67,8 +57,6 @@ class Connection(BaseModel):
     id: str
     connector: str
     account: str
-    mcp_url: str
-    vault_id: str
     metadata: dict[str, Any]
     created_at: datetime
     updated_at: datetime

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 
 AuthType = Literal["mcp_oauth", "static_bearer"]
 
@@ -90,14 +90,16 @@ class VaultCredentialCreate(BaseModel):
     """Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
     All secret fields are write-only. The ``mcp_server_url`` is immutable
-    after creation. The service layer validates required fields per
-    ``auth_type``.
+    after creation. ``account_id`` is optional public metadata for connectors
+    that need a stable account segment in channel addresses. The service layer
+    validates required fields per ``auth_type``.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     display_name: str | None = Field(default=None, max_length=128)
     mcp_server_url: str = Field(min_length=1)
+    account_id: str | None = Field(default=None, min_length=1, max_length=256)
     auth_type: AuthType
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -114,17 +116,26 @@ class VaultCredentialCreate(BaseModel):
     # static_bearer fields
     token: SecretStr | None = None
 
+    @field_validator("account_id")
+    @classmethod
+    def _account_id_no_slash(cls, v: str | None) -> str | None:
+        if v is not None and "/" in v:
+            raise ValueError("must not contain '/'")
+        return v
+
 
 class VaultCredentialUpdate(BaseModel):
     """Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.
 
     ``mcp_server_url`` and ``auth_type`` are immutable — not accepted here.
-    Omitted secret fields are preserved (decrypt-merge-encrypt).
+    Omitted public metadata and secret fields are preserved
+    (decrypt-merge-encrypt).
     """
 
     model_config = ConfigDict(extra="forbid")
 
     display_name: str | None = Field(default=None, max_length=128)
+    account_id: str | None = Field(default=None, min_length=1, max_length=256)
     metadata: dict[str, Any] | None = None
 
     # mcp_oauth fields (all optional — omitted = preserve)
@@ -140,6 +151,13 @@ class VaultCredentialUpdate(BaseModel):
     # static_bearer
     token: SecretStr | None = None
 
+    @field_validator("account_id")
+    @classmethod
+    def _account_id_no_slash(cls, v: str | None) -> str | None:
+        if v is not None and "/" in v:
+            raise ValueError("must not contain '/'")
+        return v
+
 
 class VaultCredential(BaseModel):
     """Read view of a vault credential. Secrets are never returned."""
@@ -148,6 +166,7 @@ class VaultCredential(BaseModel):
     vault_id: str
     display_name: str | None
     mcp_server_url: str
+    account_id: str | None = None
     auth_type: AuthType
     metadata: dict[str, Any]
     created_at: datetime

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -3,8 +3,9 @@
 Thin wrapper over :mod:`aios.db.queries`. The only business rule lives
 in :func:`archive_connection`, which refuses to archive a connection
 while channel bindings under its ``(connector, account)`` prefix are
-still active — archiving would silently drop the connection-provided
-MCP tools from any live session bound to those channels.
+still active. Connection rows remain the source of inbound channel identity,
+so archiving one while bound channels are live would break routing for those
+sessions.
 """
 
 from __future__ import annotations
@@ -23,8 +24,6 @@ async def create_connection(
     *,
     connector: str,
     account: str,
-    mcp_url: str,
-    vault_id: str,
     metadata: dict[str, Any],
 ) -> Connection:
     async with pool.acquire() as conn:
@@ -32,8 +31,6 @@ async def create_connection(
             conn,
             connector=connector,
             account=account,
-            mcp_url=mcp_url,
-            vault_id=vault_id,
             metadata=metadata,
         )
 
@@ -54,16 +51,12 @@ async def update_connection(
     pool: asyncpg.Pool[Any],
     connection_id: str,
     *,
-    mcp_url: str | None = None,
-    vault_id: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> Connection:
     async with pool.acquire() as conn:
         return await queries.update_connection(
             conn,
             connection_id,
-            mcp_url=mcp_url,
-            vault_id=vault_id,
             metadata=metadata,
         )
 
@@ -80,7 +73,7 @@ async def archive_connection(pool: asyncpg.Pool[Any], connection_id: str) -> Con
                 f"connection {connection_id} has {active} active channel binding"
                 f"{'s' if active != 1 else ''} under {connection.connector}/"
                 f"{connection.account}; archive the bindings first to avoid "
-                f"silently dropping MCP tools from live sessions",
+                f"breaking routing for live sessions",
                 detail={
                     "id": connection_id,
                     "active_bindings": active,

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -25,7 +25,10 @@ async def create_connection(
     connector: str,
     account: str,
     metadata: dict[str, Any],
+    mcp_url: str | None = None,
+    vault_id: str | None = None,
 ) -> Connection:
+    _ = (mcp_url, vault_id)  # Accepted for legacy call sites during MCP-vault coexistence.
     async with pool.acquire() as conn:
         return await queries.insert_connection(
             conn,

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -368,6 +368,7 @@ async def create_vault_credential(
             vault_id=vault_id,
             display_name=body.display_name,
             mcp_server_url=body.mcp_server_url,
+            account_id=body.account_id,
             auth_type=body.auth_type,
             blob=blob,
             metadata=body.metadata,
@@ -415,6 +416,7 @@ async def update_vault_credential(
             credential_id,
             blob=new_blob,
             display_name=(body.display_name if "display_name" in body.model_fields_set else ...),
+            account_id=body.account_id if "account_id" in body.model_fields_set else ...,
             metadata=body.metadata if "metadata" in body.model_fields_set else ...,
         )
 

--- a/tests/e2e/test_context_endpoint.py
+++ b/tests/e2e/test_context_endpoint.py
@@ -185,3 +185,54 @@ class TestContextEndpoint:
             r = await http_client.get(f"/v1/sessions/{session.id}/context")
 
         assert r.status_code == 200, r.text
+
+    async def test_phone_down_context_keeps_discovered_mcp_tools(
+        self, http_client: httpx.AsyncClient, pool: Any
+    ) -> None:
+        """Phone-down suppresses focal metadata at call time, not MCP tool visibility."""
+        from aios.db import queries
+        from aios.models.agents import McpServerSpec, ToolSpec
+        from aios.services import agents as agents_svc
+        from aios.services import sessions as sessions_svc
+
+        async with pool.acquire() as conn:
+            env = await queries.insert_environment(conn, name=f"ctx-mcp-env-{_uniq()}")
+        agent = await agents_svc.create_agent(
+            pool,
+            name=f"ctx-mcp-agent-{_uniq()}",
+            model="openai/gpt-4o-mini",
+            system="",
+            tools=[ToolSpec(type="mcp_toolset", mcp_server_name="signal")],
+            mcp_servers=[McpServerSpec(name="signal", url="http://127.0.0.1:1/mcp")],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        session = await sessions_svc.create_session(
+            pool,
+            agent_id=agent.id,
+            environment_id=env.id,
+            title=None,
+            metadata={},
+        )
+        discovered = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "mcp__signal__signal_send",
+                    "description": "Send a message",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ]
+
+        with mock.patch(
+            "aios.harness.loop.discover_session_mcp_tools",
+            new=mock.AsyncMock(return_value=(discovered, {})),
+        ):
+            r = await http_client.get(f"/v1/sessions/{session.id}/context")
+
+        assert r.status_code == 200, r.text
+        names = [tool["function"]["name"] for tool in r.json()["tools"]]
+        assert "mcp__signal__signal_send" in names

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -95,8 +95,6 @@ async def _setup_inbound(pool: Any, agent_id: str, env_id: str, vault_id: str) -
         pool,
         connector="signal",
         account=f"focal-{_uniq()}",
-        mcp_url="https://m",
-        vault_id=vault_id,
         metadata={},
     )
     await ch_svc.create_routing_rule(
@@ -828,12 +826,11 @@ class TestSwitchChannelAsEvent:
 
 
 class TestMcpMetaInjection:
-    """Slice 6: connection-provided MCP tools receive the focal channel
-    path via the JSON-RPC ``_meta`` field, without stuffing it into
-    arguments.  Agent-declared MCP servers don't get the meta stamp.
+    """MCP tool calls receive account-relative focal-channel context via the
+    JSON-RPC ``_meta`` field, without stuffing it into arguments.
     """
 
-    async def test_conn_tool_dispatch_injects_focal_suffix_into_meta(
+    async def test_mcp_dispatch_injects_account_relative_focal_meta(
         self,
         runtime_pool: Any,
         agent_id: str,
@@ -854,18 +851,12 @@ class TestMcpMetaInjection:
             connection = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
             session_id, _e, address = await _post_inbound(runtime_pool, connection, "chat-1")
 
-            # The connection created by _setup_inbound has id prefix `conn_`.
-            from aios.services import connections as conn_svc
-
-            connections = await conn_svc.list_connections(runtime_pool)
-            conn = next(c for c in connections if c.connector == "signal")
-
-            mcp_server_map = {conn.id: conn.mcp_url}
+            mcp_server_map = {"signal": "https://m"}
             tool_call_dict = {
                 "id": "call_send_1",
                 "type": "function",
                 "function": {
-                    "name": f"mcp__{conn.id}__signal_send",
+                    "name": "mcp__signal__signal_send",
                     "arguments": json.dumps({"text": "hi there"}),
                 },
             }
@@ -885,28 +876,25 @@ class TestMcpMetaInjection:
                     session_id,
                     tool_call_dict,
                     mcp_server_map,
-                    focal_channel=address,  # focal=A → suffix=chat-1
+                    focal_channel=address,
                 )
 
-            # Verify call_mcp_tool was invoked with the focal suffix meta.
+            # Verify call_mcp_tool was invoked with account-relative focal meta.
             _args, kwargs = mock_call.call_args
             meta = kwargs.get("meta")
             assert isinstance(meta, dict)
-            assert meta == {"aios.focal_channel_path": "chat-1"}
+            assert meta == {"aios.focal_channel": address.split("/", 1)[1]}
         finally:
             runtime.crypto_box = prev_crypto
 
-    async def test_agent_mcp_tool_dispatch_no_meta_stamped(
+    async def test_normal_mcp_tool_dispatch_stamps_focal_meta(
         self,
         runtime_pool: Any,
         agent_id: str,
         env_id: str,
         vault_id: str,
     ) -> None:
-        """Agent-declared MCP servers (not under the conn_* prefix) don't
-        get focal meta — aios has no business telling an agent-declared
-        MCP server about the session's focal channel.
-        """
+        """All MCP calls receive focal metadata when the session has focus."""
         from unittest.mock import AsyncMock, patch
 
         from aios.crypto.vault import CryptoBox
@@ -919,7 +907,6 @@ class TestMcpMetaInjection:
             connection = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
             session_id, _e, address = await _post_inbound(runtime_pool, connection, "chat-1")
 
-            # Agent-declared server: name does NOT start with conn_.
             agent_server_name = "github"
             mcp_server_map = {agent_server_name: "https://mcp.github.com"}
             tool_call_dict = {
@@ -946,11 +933,63 @@ class TestMcpMetaInjection:
                     session_id,
                     tool_call_dict,
                     mcp_server_map,
-                    focal_channel=address,  # non-null focal, but agent server
+                    focal_channel=address,
                 )
 
             _args, kwargs = mock_call.call_args
-            # No meta for agent-declared MCP.
+            assert kwargs.get("meta") == {"aios.focal_channel": address.split("/", 1)[1]}
+        finally:
+            runtime.crypto_box = prev_crypto
+
+    async def test_mcp_tool_dispatch_omits_meta_when_phone_down(
+        self,
+        runtime_pool: Any,
+        agent_id: str,
+        env_id: str,
+        vault_id: str,
+    ) -> None:
+        """Phone-down sessions still call MCP tools, just without focal metadata."""
+        from unittest.mock import AsyncMock, patch
+
+        from aios.crypto.vault import CryptoBox
+        from aios.harness import runtime
+        from aios.harness.tool_dispatch import _execute_mcp_tool_async
+
+        prev_crypto = runtime.crypto_box
+        runtime.crypto_box = CryptoBox(__import__("os").urandom(32))
+        try:
+            connection = await _setup_inbound(runtime_pool, agent_id, env_id, vault_id)
+            session_id, _e, _address = await _post_inbound(runtime_pool, connection, "chat-1")
+
+            mcp_server_map = {"signal": "https://m"}
+            tool_call_dict = {
+                "id": "call_send_1",
+                "type": "function",
+                "function": {
+                    "name": "mcp__signal__signal_send",
+                    "arguments": json.dumps({"text": "hi there"}),
+                },
+            }
+
+            with (
+                patch(
+                    "aios.mcp.client.resolve_auth_for_url",
+                    new=AsyncMock(return_value={}),
+                ),
+                patch(
+                    "aios.mcp.client.call_mcp_tool",
+                    new=AsyncMock(return_value={"content": "ok"}),
+                ) as mock_call,
+            ):
+                await _execute_mcp_tool_async(
+                    runtime_pool,
+                    session_id,
+                    tool_call_dict,
+                    mcp_server_map,
+                    focal_channel=None,
+                )
+
+            _args, kwargs = mock_call.call_args
             assert kwargs.get("meta") is None
         finally:
             runtime.crypto_box = prev_crypto
@@ -1063,8 +1102,6 @@ class TestTailBlockInStep:
             runtime_pool,
             connector="signal",
             account=account,
-            mcp_url="https://m",
-            vault_id=vault_id,
             metadata={},
         )
         await ch_svc.create_routing_rule(
@@ -1120,8 +1157,6 @@ class TestTailBlockInStep:
             runtime_pool,
             connector="signal",
             account=account,
-            mcp_url="https://m",
-            vault_id=vault_id,
             metadata={},
         )
         await ch_svc.create_routing_rule(

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -12,7 +12,6 @@ import json
 import secrets
 from collections.abc import AsyncIterator
 from typing import Any
-from unittest import mock
 
 import pytest
 
@@ -113,20 +112,19 @@ async def _post_inbound(
     """Resolve + append a user inbound message.
 
     Returns ``(session_id, event_id, address)``. Bypasses the HTTP layer
-    and defer_wake so the test is DB-focused.
+    and uses the service layer directly so the test is DB-focused.
     """
     from aios.services import channels as ch_svc
     from aios.services import sessions as sess_svc
 
     address = f"{connection.connector}/{connection.account}/{path}"
-    with mock.patch("aios.harness.wake.defer_wake"):
-        resolution = await ch_svc.resolve_channel(pool, connection, path)
-        event = await sess_svc.append_user_message(
-            pool,
-            resolution.session_id,
-            content,
-            metadata={"channel": address},
-        )
+    resolution = await ch_svc.resolve_channel(pool, connection, path)
+    event = await sess_svc.append_user_message(
+        pool,
+        resolution.session_id,
+        content,
+        metadata={"channel": address},
+    )
     return resolution.session_id, event.id, address
 
 
@@ -1112,16 +1110,15 @@ class TestTailBlockInStep:
             session_params=SessionParams(environment_id=env_id),
         )
         address = f"signal/{account}/chat-1"
-        with mock.patch("aios.harness.wake.defer_wake"):
-            resolution = await ch_svc.resolve_channel(runtime_pool, connection, "chat-1")
-            from aios.services import sessions as sess_svc
+        resolution = await ch_svc.resolve_channel(runtime_pool, connection, "chat-1")
+        from aios.services import sessions as sess_svc
 
-            await sess_svc.append_user_message(
-                runtime_pool,
-                resolution.session_id,
-                "hi",
-                metadata={"channel": address},
-            )
+        await sess_svc.append_user_message(
+            runtime_pool,
+            resolution.session_id,
+            "hi",
+            metadata={"channel": address},
+        )
         session_id = resolution.session_id
         # Ignore the connection — the channel listing pulls from bindings.
         assert connection.id.startswith("conn_")
@@ -1168,33 +1165,32 @@ class TestTailBlockInStep:
         )
         address_a = f"signal/{account}/chat-A"
         address_b = f"signal/{account}/chat-B"
-        with mock.patch("aios.harness.wake.defer_wake"):
-            resolution_a = await ch_svc.resolve_channel(runtime_pool, connection, "chat-A")
-            session_id = resolution_a.session_id
-            await ch_svc.create_binding(runtime_pool, address=address_b, session_id=session_id)
-            # Focus on A and let one message land in A.
-            from aios.services import sessions as sess_svc
+        resolution_a = await ch_svc.resolve_channel(runtime_pool, connection, "chat-A")
+        session_id = resolution_a.session_id
+        await ch_svc.create_binding(runtime_pool, address=address_b, session_id=session_id)
+        # Focus on A and let one message land in A.
+        from aios.services import sessions as sess_svc
 
-            await _set_focal(runtime_pool, session_id, address_a)
-            await sess_svc.append_user_message(
-                runtime_pool,
-                session_id,
-                "hi from A",
-                metadata={"channel": address_a},
-            )
-            # Then two messages on B while focal is A → unread in B.
-            await sess_svc.append_user_message(
-                runtime_pool,
-                session_id,
-                "msg-b1",
-                metadata={"channel": address_b},
-            )
-            await sess_svc.append_user_message(
-                runtime_pool,
-                session_id,
-                "msg-b2",
-                metadata={"channel": address_b},
-            )
+        await _set_focal(runtime_pool, session_id, address_a)
+        await sess_svc.append_user_message(
+            runtime_pool,
+            session_id,
+            "hi from A",
+            metadata={"channel": address_a},
+        )
+        # Then two messages on B while focal is A → unread in B.
+        await sess_svc.append_user_message(
+            runtime_pool,
+            session_id,
+            "msg-b1",
+            metadata={"channel": address_b},
+        )
+        await sess_svc.append_user_message(
+            runtime_pool,
+            session_id,
+            "msg-b2",
+            metadata={"channel": address_b},
+        )
 
         # Step 1: focal=A.  Tail block should mark A as focal, show 2 unread on B.
         harness.script_model([assistant("processing")])

--- a/tests/e2e/test_migration_0019.py
+++ b/tests/e2e/test_migration_0019.py
@@ -180,6 +180,19 @@ class TestSchemaShape:
             )
             assert col is None, "address column should be dropped"
 
+    async def test_connection_mcp_columns_dropped(self, pool: Any) -> None:
+        """Connections are channel-account identity only at head."""
+        async with pool.acquire() as conn:
+            cols = await conn.fetch(
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_name = 'connections'
+                  AND column_name IN ('mcp_url', 'vault_id')
+                """
+            )
+            assert cols == []
+
     async def test_indexes_after_migration(self, pool: Any) -> None:
         """Old globally-unique indexes are gone; composite per-connection uniques exist."""
         async with pool.acquire() as conn:

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -72,7 +72,7 @@ async def vault_id(pool: Any) -> str:
 
 
 @pytest.fixture
-async def connection(pool: Any, vault_id: str) -> Any:
+async def connection(pool: Any) -> Any:
     """Fresh signal connection per test.  Rules are scoped to this
     connection's id; addresses constructed against ``connection.connector``
     + ``connection.account``.
@@ -83,8 +83,6 @@ async def connection(pool: Any, vault_id: str) -> Any:
         pool,
         connector="signal",
         account=f"t-{_uniq()}",
-        mcp_url="https://mcp.example.com",
-        vault_id=vault_id,
         metadata={},
     )
 
@@ -93,15 +91,13 @@ async def connection(pool: Any, vault_id: str) -> Any:
 
 
 class TestConnectionCRUD:
-    async def test_create_and_get(self, pool: Any, vault_id: str) -> None:
+    async def test_create_channel_only_connection(self, pool: Any) -> None:
         from aios.services import connections as svc
 
         c = await svc.create_connection(
             pool,
             connector="signal",
-            account=f"test-{_uniq()}",
-            mcp_url="https://mcp.example.com",
-            vault_id=vault_id,
+            account=f"channel-only-{_uniq()}",
             metadata={"region": "us"},
         )
         assert c.id.startswith("conn_")
@@ -112,7 +108,24 @@ class TestConnectionCRUD:
         fetched = await svc.get_connection(pool, c.id)
         assert fetched.id == c.id
 
-    async def test_unique_per_connector_account(self, pool: Any, vault_id: str) -> None:
+    async def test_create_and_get(self, pool: Any) -> None:
+        from aios.services import connections as svc
+
+        c = await svc.create_connection(
+            pool,
+            connector="signal",
+            account=f"test-{_uniq()}",
+            metadata={"region": "us"},
+        )
+        assert c.id.startswith("conn_")
+        assert c.connector == "signal"
+        assert c.metadata == {"region": "us"}
+        assert c.archived_at is None
+
+        fetched = await svc.get_connection(pool, c.id)
+        assert fetched.id == c.id
+
+    async def test_unique_per_connector_account(self, pool: Any) -> None:
         from aios.services import connections as svc
 
         account = f"dup-{_uniq()}"
@@ -120,8 +133,6 @@ class TestConnectionCRUD:
             pool,
             connector="signal",
             account=account,
-            mcp_url="https://m1",
-            vault_id=vault_id,
             metadata={},
         )
         with pytest.raises(ConflictError):
@@ -129,26 +140,22 @@ class TestConnectionCRUD:
                 pool,
                 connector="signal",
                 account=account,
-                mcp_url="https://m2",
-                vault_id=vault_id,
                 metadata={},
             )
 
-    async def test_update_mcp_url(self, pool: Any, vault_id: str) -> None:
+    async def test_update_metadata(self, pool: Any) -> None:
         from aios.services import connections as svc
 
         c = await svc.create_connection(
             pool,
             connector="signal",
             account=f"upd-{_uniq()}",
-            mcp_url="https://old",
-            vault_id=vault_id,
             metadata={},
         )
-        updated = await svc.update_connection(pool, c.id, mcp_url="https://new")
-        assert updated.mcp_url == "https://new"
+        updated = await svc.update_connection(pool, c.id, metadata={"region": "us"})
+        assert updated.metadata == {"region": "us"}
 
-    async def test_archive(self, pool: Any, vault_id: str) -> None:
+    async def test_archive(self, pool: Any) -> None:
         from aios.services import connections as svc
 
         account = f"arch-{_uniq()}"
@@ -156,8 +163,6 @@ class TestConnectionCRUD:
             pool,
             connector="signal",
             account=account,
-            mcp_url="https://m",
-            vault_id=vault_id,
             metadata={},
         )
         archived = await svc.archive_connection(pool, c.id)
@@ -167,8 +172,6 @@ class TestConnectionCRUD:
             pool,
             connector="signal",
             account=account,
-            mcp_url="https://m2",
-            vault_id=vault_id,
             metadata={},
         )
 
@@ -176,8 +179,8 @@ class TestConnectionCRUD:
         self, pool: Any, agent_id: str, env_id: str, connection: Any
     ) -> None:
         """A connection with an active binding can't be archived — doing so
-        would drop MCP tools from any live session bound to channels under
-        that connection.
+        would break inbound routing for any live session bound to channels
+        under that connection.
         """
         from aios.services import channels as ch_svc
         from aios.services import connections as svc
@@ -205,19 +208,6 @@ class TestConnectionCRUD:
         await ch_svc.archive_binding(pool, binding.id)
         archived = await svc.archive_connection(pool, connection.id)
         assert archived.archived_at is not None
-
-    async def test_unknown_vault(self, pool: Any) -> None:
-        from aios.services import connections as svc
-
-        with pytest.raises(NotFoundError):
-            await svc.create_connection(
-                pool,
-                connector="signal",
-                account=f"novault-{_uniq()}",
-                mcp_url="https://m",
-                vault_id="vlt_nonexistent",
-                metadata={},
-            )
 
 
 # ─── routing rule CRUD ──────────────────────────────────────────────────────
@@ -306,7 +296,7 @@ class TestRoutingRuleCRUD:
             )
 
     async def test_same_prefix_on_different_connections_allowed(
-        self, pool: Any, agent_id: str, env_id: str, vault_id: str
+        self, pool: Any, agent_id: str, env_id: str
     ) -> None:
         """Uniqueness is ``(connection_id, prefix)`` — not global."""
         from aios.services import channels as svc
@@ -316,16 +306,12 @@ class TestRoutingRuleCRUD:
             pool,
             connector="signal",
             account=f"crossA-{_uniq()}",
-            mcp_url="https://a",
-            vault_id=vault_id,
             metadata={},
         )
         c2 = await conn_svc.create_connection(
             pool,
             connector="signal",
             account=f"crossB-{_uniq()}",
-            mcp_url="https://b",
-            vault_id=vault_id,
             metadata={},
         )
         params = SessionParams(environment_id=env_id)
@@ -368,7 +354,7 @@ class TestRoutingRuleCRUD:
         assert archived.archived_at is not None
 
     async def test_wrong_connection_scope_404s(
-        self, pool: Any, agent_id: str, env_id: str, connection: Any, vault_id: str
+        self, pool: Any, agent_id: str, env_id: str, connection: Any
     ) -> None:
         """A rule on connection A isn't visible through connection B's scope."""
         from aios.services import channels as svc
@@ -385,8 +371,6 @@ class TestRoutingRuleCRUD:
             pool,
             connector="signal",
             account=f"other-{_uniq()}",
-            mcp_url="https://x",
-            vault_id=vault_id,
             metadata={},
         )
         with pytest.raises(NotFoundError):
@@ -496,7 +480,7 @@ class TestFindMatchingRule:
         assert yes_match is not None
 
     async def test_cross_connection_isolation(
-        self, pool: Any, agent_id: str, env_id: str, connection: Any, vault_id: str
+        self, pool: Any, agent_id: str, env_id: str, connection: Any
     ) -> None:
         """A rule on connection A must not match a path queried with connection B's id."""
         from aios.db import queries
@@ -514,8 +498,6 @@ class TestFindMatchingRule:
             pool,
             connector="signal",
             account=f"other-{_uniq()}",
-            mcp_url="https://x",
-            vault_id=vault_id,
             metadata={},
         )
         async with pool.acquire() as conn:
@@ -784,15 +766,13 @@ async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[http
 
 class TestNestedRoutingRulesEndpoint:
     async def test_create_and_get_nested(
-        self, http_client: httpx.AsyncClient, agent_id: str, env_id: str, vault_id: str
+        self, http_client: httpx.AsyncClient, agent_id: str, env_id: str
     ) -> None:
         r = await http_client.post(
             "/v1/connections",
             json={
                 "connector": "signal",
                 "account": f"nested-{_uniq()}",
-                "mcp_url": "https://m",
-                "vault_id": vault_id,
             },
         )
         assert r.status_code == 201, r.text
@@ -820,7 +800,7 @@ class TestNestedRoutingRulesEndpoint:
         assert r.status_code == 404
 
     async def test_rule_scoped_to_connection(
-        self, http_client: httpx.AsyncClient, agent_id: str, env_id: str, vault_id: str
+        self, http_client: httpx.AsyncClient, agent_id: str, env_id: str
     ) -> None:
         """A rule on connection A is invisible through connection B."""
         a = await http_client.post(
@@ -828,8 +808,6 @@ class TestNestedRoutingRulesEndpoint:
             json={
                 "connector": "signal",
                 "account": f"scopeA-{_uniq()}",
-                "mcp_url": "https://a",
-                "vault_id": vault_id,
             },
         )
         b = await http_client.post(
@@ -837,8 +815,6 @@ class TestNestedRoutingRulesEndpoint:
             json={
                 "connector": "signal",
                 "account": f"scopeB-{_uniq()}",
-                "mcp_url": "https://b",
-                "vault_id": vault_id,
             },
         )
         aid = a.json()["id"]
@@ -864,7 +840,7 @@ class TestInboundEndpoint:
         http_client: httpx.AsyncClient,
         agent_id: str,
         env_id: str,
-        vault_id: str,
+        _vault_id: str,
     ) -> tuple[str, str]:
         """Create a connection + catch-all rule.  Returns (connection_id, account)."""
         account = f"http-{_uniq()}"
@@ -873,8 +849,6 @@ class TestInboundEndpoint:
             json={
                 "connector": "signal",
                 "account": account,
-                "mcp_url": "https://m",
-                "vault_id": vault_id,
             },
         )
         assert r.status_code == 201, r.text
@@ -935,9 +909,7 @@ class TestInboundEndpoint:
         )
         assert r.status_code == 404
 
-    async def test_no_route_returns_404(
-        self, http_client: httpx.AsyncClient, vault_id: str
-    ) -> None:
+    async def test_no_route_returns_404(self, http_client: httpx.AsyncClient) -> None:
         """Connection exists but no rule matches the resulting path."""
         account = f"unrouted-{_uniq()}"
         r = await http_client.post(
@@ -945,8 +917,6 @@ class TestInboundEndpoint:
             json={
                 "connector": "signal",
                 "account": account,
-                "mcp_url": "https://m",
-                "vault_id": vault_id,
             },
         )
         connection_id = r.json()["id"]
@@ -980,7 +950,7 @@ class TestInboundEndpoint:
 
 class TestListSessionBindings:
     """Unpaginated "all bindings for this session" lookup used by the
-    step function to derive connection-provided MCP URLs.
+    step function to derive channel account context.
     """
 
     async def test_empty_when_no_bindings(self, pool: Any, agent_id: str, env_id: str) -> None:
@@ -1046,7 +1016,7 @@ class TestGetConnectionsByPairs:
             rows = await queries.get_connections_by_pairs(conn, [])
         assert rows == []
 
-    async def test_returns_matching_connections(self, pool: Any, vault_id: str) -> None:
+    async def test_returns_matching_connections(self, pool: Any) -> None:
         from aios.db import queries
         from aios.services import connections as conn_svc
 
@@ -1056,16 +1026,12 @@ class TestGetConnectionsByPairs:
             pool,
             connector="signal",
             account=a,
-            mcp_url="https://m1",
-            vault_id=vault_id,
             metadata={},
         )
         c_b = await conn_svc.create_connection(
             pool,
             connector="slack",
             account=b,
-            mcp_url="https://m2",
-            vault_id=vault_id,
             metadata={},
         )
 

--- a/tests/e2e/test_step_separator.py
+++ b/tests/e2e/test_step_separator.py
@@ -18,15 +18,11 @@ class TestSeparatorAtLiteLLMBoundary:
         in place immediately before the tail block."""
         from aios.services import channels as ch_svc
         from aios.services import connections as conn_svc
-        from aios.services import vaults as vault_svc
 
-        v = await vault_svc.create_vault(harness._pool, display_name="sep-v", metadata={})
         await conn_svc.create_connection(
             harness._pool,
             connector="signal",
             account="test",
-            mcp_url="https://m",
-            vault_id=v.id,
             metadata={},
         )
 

--- a/tests/e2e/test_vaults.py
+++ b/tests/e2e/test_vaults.py
@@ -95,6 +95,7 @@ class TestVaultCredentialCRUD:
         vault = await svc.create_vault(pool, display_name="cred-test", metadata={})
         body = VaultCredentialCreate(
             mcp_server_url="https://mcp.example.com/api",
+            account_id="signal-bot-1",
             auth_type="static_bearer",
             token=SecretStr("my-secret-token"),
         )
@@ -102,7 +103,11 @@ class TestVaultCredentialCRUD:
         assert cred.id.startswith("vcr_")
         assert cred.vault_id == vault.id
         assert cred.mcp_server_url == "https://mcp.example.com/api"
+        assert cred.account_id == "signal-bot-1"
         assert cred.auth_type == "static_bearer"
+
+        fetched = await svc.get_vault_credential(pool, vault.id, cred.id)
+        assert fetched.account_id == "signal-bot-1"
 
     async def test_secrets_not_returned(self, pool: Any, crypto_box: Any) -> None:
         """Verify that the read view never includes secret fields."""
@@ -205,13 +210,24 @@ class TestVaultCredentialCRUD:
 
         update = VaultCredentialUpdate(
             display_name="updated",
+            account_id="signal-bot-2",
             token=SecretStr("new-token"),
         )
         updated = await svc.update_vault_credential(
             pool, crypto_box, vault_id=vault.id, credential_id=cred.id, body=update
         )
         assert updated.display_name == "updated"
+        assert updated.account_id == "signal-bot-2"
         assert updated.updated_at > cred.updated_at
+
+        cleared = await svc.update_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=vault.id,
+            credential_id=cred.id,
+            body=VaultCredentialUpdate(account_id=None),
+        )
+        assert cleared.account_id is None
 
     async def test_credential_limit(self, pool: Any, crypto_box: Any) -> None:
         """Vault cannot have more than 20 active credentials."""

--- a/tests/unit/cli/test_cli_connections.py
+++ b/tests/unit/cli/test_cli_connections.py
@@ -33,10 +33,6 @@ def test_create_ergonomic(mocked_cli):
             "signal",
             "--account",
             "acct-123",
-            "--mcp-url",
-            "http://mcp.example:9000",
-            "--vault-id",
-            "vlt_1",
         ],
     )
     assert result.exit_code == 0, result.output
@@ -45,8 +41,6 @@ def test_create_ergonomic(mocked_cli):
     assert mocked_cli.captured.body == {
         "connector": "signal",
         "account": "acct-123",
-        "mcp_url": "http://mcp.example:9000",
-        "vault_id": "vlt_1",
     }
 
 
@@ -61,10 +55,6 @@ def test_create_ergonomic_with_metadata_json(mocked_cli):
             "signal",
             "--account",
             "acct-123",
-            "--mcp-url",
-            "http://mcp/",
-            "--vault-id",
-            "vlt_1",
             "--metadata-json",
             '{"region": "us-east"}',
         ],
@@ -92,10 +82,6 @@ def test_create_rejects_mixed_sources(mocked_cli):
             "signal",
             "--account",
             "acct-1",
-            "--mcp-url",
-            "http://mcp/",
-            "--vault-id",
-            "vlt_1",
             "--data",
             "{}",
         ],

--- a/tests/unit/cli/test_cli_vault_credentials.py
+++ b/tests/unit/cli/test_cli_vault_credentials.py
@@ -31,7 +31,7 @@ def test_create_via_body_file(mocked_cli, tmp_path):
     body = tmp_path / "cred.json"
     body.write_text(
         '{"display_name": "my-creds", "mcp_server_url": "http://x",'
-        ' "auth_type": "static_bearer", "token": "t"}'
+        ' "account_id": "acct-1", "auth_type": "static_bearer", "token": "t"}'
     )
     mocked_cli.queue_response(httpx.Response(201, json={"id": "cred_new"}))
     result = runner.invoke(
@@ -49,6 +49,7 @@ def test_create_via_body_file(mocked_cli, tmp_path):
     assert mocked_cli.captured.method == "POST"
     assert mocked_cli.captured.path == "/v1/vaults/vlt_1/credentials"
     assert mocked_cli.captured.body["display_name"] == "my-creds"
+    assert mocked_cli.captured.body["account_id"] == "acct-1"
     assert mocked_cli.captured.body["token"] == "t"
 
 

--- a/tests/unit/test_channels_focal.py
+++ b/tests/unit/test_channels_focal.py
@@ -8,7 +8,7 @@ from aios.harness.channels import (
     SWITCH_CHANNEL_METADATA_KEY,
     derive_last_seen,
     derive_unread_counts,
-    focal_channel_path,
+    focal_channel_meta_value,
 )
 from aios.models.events import Event, EventKind
 
@@ -254,31 +254,31 @@ class TestDeriveUnreadCounts:
         assert counts == {"signal/a/x": 1}
 
 
-class TestFocalChannelPath:
-    """Suffix-extraction helper for MCP _meta injection (slice 6)."""
+class TestFocalChannelMetaValue:
+    """Account-relative focal-channel helper for MCP _meta injection."""
 
     def test_three_segment_address(self) -> None:
         # Signal shape: signal/<bot>/<chat_id>
-        assert focal_channel_path("signal/bot/alice") == "alice"
+        assert focal_channel_meta_value("signal/bot/alice") == "bot/alice"
 
     def test_four_segment_address_preserves_inner_slashes(self) -> None:
         # Telegram forum-thread shape: telegram/<bot>/<chat>/<thread>
-        assert focal_channel_path("telegram/bot/chat/thread") == "chat/thread"
+        assert focal_channel_meta_value("telegram/bot/chat/thread") == "bot/chat/thread"
 
     def test_deep_address_preserves_all_tail_segments(self) -> None:
-        # Defensive: connectors may use arbitrarily deep suffixes.
-        assert focal_channel_path("x/y/a/b/c") == "a/b/c"
+        # Defensive: connectors may use arbitrarily deep channel paths.
+        assert focal_channel_meta_value("x/y/a/b/c") == "y/a/b/c"
 
     def test_none_returns_none(self) -> None:
-        assert focal_channel_path(None) is None
+        assert focal_channel_meta_value(None) is None
 
     def test_empty_string_returns_none(self) -> None:
-        assert focal_channel_path("") is None
+        assert focal_channel_meta_value("") is None
 
     def test_malformed_two_segments_returns_none(self) -> None:
-        # Missing suffix — should not leak a garbled value.
-        assert focal_channel_path("signal/bot") is None
+        # Missing channel path — should not leak a garbled value.
+        assert focal_channel_meta_value("signal/bot") is None
 
     def test_trailing_slash_yields_empty_suffix_is_none(self) -> None:
-        # "signal/bot/" → 3 segments but suffix is empty → None.
-        assert focal_channel_path("signal/bot/") is None
+        # "signal/bot/" → 3 segments but channel path is empty → None.
+        assert focal_channel_meta_value("signal/bot/") is None

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -11,15 +11,13 @@ from typing import Any
 
 from aios.harness.channels import (
     apply_monologue_prefix,
-    augment_with_connector_instructions,
     augment_with_focal_paradigm,
+    augment_with_mcp_instructions,
     build_channels_tail_block,
-    build_connector_instructions_block,
     build_focal_paradigm_block,
-    connection_server_name,
+    build_mcp_instructions_block,
 )
 from aios.models.channel_bindings import ChannelBinding, NotificationMode
-from aios.models.connections import Connection
 from aios.models.events import Event
 
 
@@ -65,43 +63,6 @@ def _user_event(
         orig_channel=orig,
         focal_channel_at_arrival=focal_at,
     )
-
-
-def _connection(cid: str, connector: str = "signal", account: str = "acct") -> Connection:
-    now = datetime(2026, 4, 16)
-    return Connection(
-        id=cid,
-        connector=connector,
-        account=account,
-        mcp_url="https://example.com",
-        vault_id="vlt_x",
-        metadata={},
-        created_at=now,
-        updated_at=now,
-    )
-
-
-# ── connection_server_name ─────────────────────────────────────────────────
-
-
-class TestConnectionServerName:
-    """The connection id already starts with the reserved ``conn_``
-    prefix (via ``ids.CONNECTION``), so it doubles as the server name
-    directly — no stutter, still unambiguous by construction.
-    """
-
-    def test_uses_id_directly(self) -> None:
-        c = _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F")
-        assert connection_server_name(c) == "conn_01HQR2K7VXBZ9MNPL3WYCT8F"
-
-    def test_distinct_connections_produce_distinct_names(self) -> None:
-        c1 = _connection("conn_aaa", connector="signal", account="abc_def")
-        c2 = _connection("conn_bbb", connector="signal_abc", account="def")
-        assert connection_server_name(c1) != connection_server_name(c2)
-
-    def test_is_stable_for_same_connection(self) -> None:
-        c = _connection("conn_stable")
-        assert connection_server_name(c) == connection_server_name(c)
 
 
 # ── build_focal_paradigm_block / augment_with_focal_paradigm ───────────────
@@ -150,73 +111,44 @@ class TestBuildFocalParadigmBlock:
         assert "phone down" in block.lower() or "target=null" in block
 
 
-# ── build_connector_instructions_block / augment_with_connector_instructions ──
+# ── build_mcp_instructions_block / augment_with_mcp_instructions ───────────
 
 
-class TestBuildConnectorInstructionsBlock:
+class TestBuildMcpInstructionsBlock:
     def test_empty_dict_returns_empty(self) -> None:
-        assert build_connector_instructions_block({}, []) == ""
+        assert build_mcp_instructions_block({}) == ""
 
-    def test_no_matching_connection_returns_empty(self) -> None:
-        """Instructions keyed under a server name that no connection
-        matches must NOT be rendered — we only describe the connectors
-        the session is actually bound to.
-        """
-        c = _connection("conn_aaa", connector="signal", account="alice")
-        block = build_connector_instructions_block({"conn_unknown": "stray prose"}, [c])
-        assert block == ""
-
-    def test_single_connection_renders_heading_and_body(self) -> None:
-        c = _connection("conn_aaa", connector="signal", account="alice")
-        block = build_connector_instructions_block({connection_server_name(c): "be brief"}, [c])
-        assert "## Connector: signal/alice" in block
+    def test_single_server_renders_heading_and_body(self) -> None:
+        block = build_mcp_instructions_block({"signal": "be brief"})
+        assert "## MCP server: signal" in block
         assert "be brief" in block
 
-    def test_multiple_connections_rendered_in_input_order(self) -> None:
-        """Ordering is caller-controlled — important for prompt-cache
-        stability across steps.  Test by passing two connections and
-        asserting the output order matches.
+    def test_multiple_servers_rendered_in_dict_order(self) -> None:
+        """Discovery inserts instructions in agent MCP server order, so
+        renderer order must preserve dict insertion order.
         """
-        c1 = _connection("conn_aaa", connector="signal", account="alice")
-        c2 = _connection("conn_bbb", connector="signal", account="bob")
-        instructions = {
-            connection_server_name(c1): "alice prose",
-            connection_server_name(c2): "bob prose",
-        }
-        block = build_connector_instructions_block(instructions, [c1, c2])
-        assert block.index("alice prose") < block.index("bob prose")
-        # Reverse the connections list — output order flips.
-        block_rev = build_connector_instructions_block(instructions, [c2, c1])
-        assert block_rev.index("bob prose") < block_rev.index("alice prose")
+        block = build_mcp_instructions_block({"signal": "signal prose", "github": "github prose"})
+        assert block.index("signal prose") < block.index("github prose")
 
-    def test_connection_without_instructions_skipped(self) -> None:
-        c1 = _connection("conn_aaa", connector="signal", account="alice")
-        c2 = _connection("conn_bbb", connector="signal", account="bob")
-        block = build_connector_instructions_block(
-            {connection_server_name(c2): "bob prose"}, [c1, c2]
-        )
-        assert "alice" not in block
-        assert "bob prose" in block
+    def test_empty_instruction_text_skipped(self) -> None:
+        block = build_mcp_instructions_block({"signal": "", "github": "github prose"})
+        assert "signal" not in block
+        assert "github prose" in block
 
 
-class TestAugmentWithConnectorInstructions:
+class TestAugmentWithMcpInstructions:
     def test_no_instructions_returns_base_unchanged(self) -> None:
-        c = _connection("conn_aaa")
-        assert augment_with_connector_instructions("base", {}, [c]) == "base"
+        assert augment_with_mcp_instructions("base", {}) == "base"
 
     def test_appends_block_after_base(self) -> None:
-        c = _connection("conn_aaa", connector="signal", account="alice")
-        out = augment_with_connector_instructions(
-            "base system", {connection_server_name(c): "prose"}, [c]
-        )
+        out = augment_with_mcp_instructions("base system", {"signal": "prose"})
         assert out.startswith("base system")
-        assert "## Connector: signal/alice" in out
+        assert "## MCP server: signal" in out
         assert "\n\n" in out
 
     def test_empty_base_yields_block_only(self) -> None:
-        c = _connection("conn_aaa", connector="signal", account="alice")
-        out = augment_with_connector_instructions("", {connection_server_name(c): "prose"}, [c])
-        assert out.startswith("## Connector:")
+        out = augment_with_mcp_instructions("", {"signal": "prose"})
+        assert out.startswith("## MCP server:")
         assert not out.startswith("\n")
 
 

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -1,23 +1,19 @@
 """Unit tests for discover_session_mcp_tools.
 
-Covers the collect-URLs-then-discover shape: agent-declared MCP
-(filtered by enabled mcp_toolset entries) unioned with
-connection-provided MCP (derived from session bindings → connections).
-The MCP SDK and auth lookup are both mocked; only the orchestration
-is under test here.
+Covers the collect-URLs-then-discover shape: agent-declared MCP filtered by
+enabled mcp_toolset entries. MCP instructions are returned under normal
+agent MCP server names.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from aios.models.agents import McpServerSpec, ToolSpec
-from aios.models.connections import Connection
+from aios.models.agents import McpServerSpec, McpToolConfig, McpToolsetConfig, ToolSpec
 
 
 @pytest.fixture(autouse=True)
@@ -28,20 +24,6 @@ def _mock_crypto_box() -> Any:
     with patch("aios.harness.loop.runtime.require_crypto_box") as m:
         m.return_value = object()
         yield m
-
-
-def _connection(cid: str, url: str) -> Connection:
-    now = datetime(2026, 4, 16)
-    return Connection(
-        id=cid,
-        connector="signal",
-        account="acct",
-        mcp_url=url,
-        vault_id="vlt_x",
-        metadata={},
-        created_at=now,
-        updated_at=now,
-    )
 
 
 def _agent(
@@ -62,7 +44,6 @@ class TestDiscoverSessionMcpTools:
             pool=AsyncMock(),
             session_id="sess_x",
             agent=_agent(),
-            connections=[],
         )
         assert tools == []
         assert instructions == {}
@@ -98,23 +79,29 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
-                connections=[],
             )
         names = {t["name"] for t in tools}
         assert names == {"mcp__gh__t"}
 
-    async def test_connections_only(self) -> None:
+    async def test_default_config_can_disable_discovered_tools(self) -> None:
         from aios.harness.loop import discover_session_mcp_tools
 
-        connections = [
-            _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1"),
-            _connection("conn_01HQR2K7VXBZ9MNPL3WYCT8G", "https://m2"),
-        ]
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
+            tools=[
+                ToolSpec(
+                    type="mcp_toolset",
+                    enabled=True,
+                    mcp_server_name="gh",
+                    default_config=McpToolsetConfig(enabled=False),
+                )
+            ],
+        )
 
         async def _discover(
-            url: str, name: str, _headers: dict[str, str]
+            _url: str, name: str, _headers: dict[str, str]
         ) -> tuple[list[dict[str, Any]], str | None]:
-            return [{"name": f"mcp__{name}__t", "url": url}], None
+            return [{"name": f"mcp__{name}__create_issue"}], None
 
         with (
             patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
@@ -124,26 +111,120 @@ class TestDiscoverSessionMcpTools:
             tools, _instructions = await discover_session_mcp_tools(
                 pool=AsyncMock(),
                 session_id="sess_x",
-                agent=_agent(),
-                connections=connections,
+                agent=agent,
             )
-        # Each connection contributes one tool, namespaced with its id.
-        urls = {t["url"] for t in tools}
-        assert urls == {"https://m1", "https://m2"}
-        names = {t["name"] for t in tools}
-        assert names == {
-            "mcp__conn_01HQR2K7VXBZ9MNPL3WYCT8F__t",
-            "mcp__conn_01HQR2K7VXBZ9MNPL3WYCT8G__t",
-        }
 
-    async def test_agent_and_connections_combined(self) -> None:
+        assert tools == []
+
+    async def test_per_tool_config_overrides_default_enabled(self) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
+            tools=[
+                ToolSpec(
+                    type="mcp_toolset",
+                    enabled=True,
+                    mcp_server_name="gh",
+                    default_config=McpToolsetConfig(enabled=False),
+                    configs=[McpToolConfig(name="create_issue", enabled=True)],
+                )
+            ],
+        )
+
+        async def _discover(
+            _url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [
+                {"name": f"mcp__{name}__create_issue"},
+                {"name": f"mcp__{name}__delete_repo"},
+            ], None
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            tools, _instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+            )
+
+        assert tools == [{"name": "mcp__gh__create_issue"}]
+
+    async def test_per_tool_config_can_disable_one_tool(self) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
+            tools=[
+                ToolSpec(
+                    type="mcp_toolset",
+                    enabled=True,
+                    mcp_server_name="gh",
+                    configs=[McpToolConfig(name="delete_repo", enabled=False)],
+                )
+            ],
+        )
+
+        async def _discover(
+            _url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [
+                {"name": f"mcp__{name}__create_issue"},
+                {"name": f"mcp__{name}__delete_repo"},
+            ], None
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            tools, _instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+            )
+
+        assert tools == [{"name": "mcp__gh__create_issue"}]
+
+    async def test_drops_tools_with_mismatched_server_namespace(self) -> None:
         from aios.harness.loop import discover_session_mcp_tools
 
         agent = _agent(
             mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
             tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
         )
-        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
+
+        async def _discover(
+            _url: str, _name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [
+                {"name": "mcp__gh__create_issue"},
+                {"name": "mcp__slack__send_message"},
+            ], None
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            tools, _instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+            )
+
+        assert tools == [{"name": "mcp__gh__create_issue"}]
+
+    async def test_discovers_only_agent_servers(self) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
+            tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
+        )
 
         async def _discover(
             url: str, name: str, _headers: dict[str, str]
@@ -159,10 +240,44 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
-                connections=connections,
             )
         urls = sorted(t["url"] for t in tools)
-        assert urls == ["https://m1", "https://mcp.github"]
+        assert urls == ["https://mcp.github"]
+
+    async def test_focal_server_instructions_are_not_connection_aliased(
+        self,
+    ) -> None:
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="signal", url="https://m1")],
+            tools=[
+                ToolSpec(
+                    type="mcp_toolset",
+                    enabled=True,
+                    mcp_server_name="signal",
+                )
+            ],
+        )
+
+        async def _discover(
+            url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [{"name": f"mcp__{name}__t", "url": url}], "send via focal"
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = {}
+            tools, instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+            )
+
+        assert tools == [{"name": "mcp__signal__t", "url": "https://m1"}]
+        assert instructions == {"signal": "send via focal"}
 
     async def test_auth_resolved_per_url(self) -> None:
         """Each URL resolves auth independently — goes through
@@ -174,12 +289,16 @@ class TestDiscoverSessionMcpTools:
             mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
             tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
         )
-        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
 
-        seen_urls: list[str] = []
+        seen: list[str] = []
 
-        async def _fake_resolve(_pool: Any, _cb: Any, _sid: str, url: str) -> dict[str, str]:
-            seen_urls.append(url)
+        async def _fake_resolve(
+            _pool: Any,
+            _cb: Any,
+            _sid: str,
+            url: str,
+        ) -> dict[str, str]:
+            seen.append(url)
             return {"Authorization": f"Bearer token-for-{url}"}
 
         async def _discover(
@@ -195,35 +314,32 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
-                connections=connections,
             )
-        assert sorted(seen_urls) == ["https://m1", "https://mcp.github"]
-        auths = {t["auth"] for t in tools}
-        assert auths == {
-            "Bearer token-for-https://mcp.github",
-            "Bearer token-for-https://m1",
-        }
+        assert seen == ["https://mcp.github"]
+        assert {t["auth"] for t in tools} == {"Bearer token-for-https://mcp.github"}
 
     async def test_instructions_keyed_by_server_name(self) -> None:
         """Each server's ``InitializeResult.instructions`` flows into the
         returned dict under its server_name key.  Servers that supply no
         instructions are omitted — the harness uses dict membership as
-        the trigger for rendering a per-connector affordance block.
+        the trigger for rendering MCP server affordance prose.
         """
         from aios.harness.loop import discover_session_mcp_tools
 
         agent = _agent(
-            mcp_servers=[McpServerSpec(name="gh", url="https://mcp.github")],
-            tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh")],
+            mcp_servers=[McpServerSpec(name="signal", url="https://mcp.signal")],
+            tools=[
+                ToolSpec(
+                    type="mcp_toolset",
+                    enabled=True,
+                    mcp_server_name="signal",
+                )
+            ],
         )
-        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
 
         async def _discover(
             url: str, name: str, _headers: dict[str, str]
         ) -> tuple[list[dict[str, Any]], str | None]:
-            # Agent server supplies nothing; connection server supplies prose.
-            if name == "gh":
-                return [], None
             return [], "## signal\n\nbe nice"
 
         with (
@@ -235,10 +351,8 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
-                connections=connections,
             )
-        # 'gh' returned None → omitted; connection returned prose → present.
-        assert instructions == {"conn_01HQR2K7VXBZ9MNPL3WYCT8F": "## signal\n\nbe nice"}
+        assert instructions == {"signal": "## signal\n\nbe nice"}
 
     async def test_empty_string_instructions_omitted(self) -> None:
         """An empty string is treated identically to ``None`` — no
@@ -247,7 +361,10 @@ class TestDiscoverSessionMcpTools:
         """
         from aios.harness.loop import discover_session_mcp_tools
 
-        connections = [_connection("conn_01HQR2K7VXBZ9MNPL3WYCT8F", "https://m1")]
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="signal", url="https://mcp.signal")],
+            tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="signal")],
+        )
 
         async def _discover(
             _url: str, _name: str, _headers: dict[str, str]
@@ -262,7 +379,6 @@ class TestDiscoverSessionMcpTools:
             _tools, instructions = await discover_session_mcp_tools(
                 pool=AsyncMock(),
                 session_id="sess_x",
-                agent=_agent(),
-                connections=connections,
+                agent=agent,
             )
         assert instructions == {}

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -147,11 +147,11 @@ def mock_step_dependencies() -> Any:
         # Channels helpers are imported lazily inside run_session_step —
         # patch them at their source module rather than on loop.
         patch(
-            "aios.harness.channels.list_bindings_and_connections",
-            AsyncMock(return_value=([], [])),
+            "aios.harness.channels.list_session_bindings",
+            AsyncMock(return_value=[]),
         ),
         patch(
-            "aios.harness.channels.augment_with_connector_instructions",
+            "aios.harness.channels.augment_with_mcp_instructions",
             return_value="sys",
         ),
         patch(

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -19,95 +19,13 @@ from tests.unit.conftest import fake_pool_yielding_conn
 
 
 class TestResolveAuthForUrl:
-    """Connection-declared credentials take precedence over session_vaults,
-    and mcp_oauth credentials are transparently refreshed when expiring.
-    """
+    """Agent MCP auth resolves through session_vaults."""
 
     @pytest.fixture
     def crypto_box(self) -> CryptoBox:
         import os
 
         return CryptoBox(os.urandom(32))
-
-    # ── precedence: connection-owned URLs ─────────────────────────────────
-
-    async def test_connection_url_uses_connection_vault(self, crypto_box: CryptoBox) -> None:
-        payload = json.dumps({"token": "connection-token"})
-        blob = crypto_box.encrypt(payload)
-        pool = fake_pool_yielding_conn(MagicMock())
-        with (
-            patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
-                "aios.mcp.client.queries.resolve_vault_credential",
-                new_callable=AsyncMock,
-            ) as v,
-            patch(
-                "aios.mcp.client.queries.resolve_mcp_credential",
-                new_callable=AsyncMock,
-            ) as s,
-        ):
-            g.return_value = "vlt_v2"
-            v.return_value = (blob, "static_bearer")
-            result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
-            )
-        assert result == {"Authorization": "Bearer connection-token"}
-        # Connection precedence: session_vaults lookup MUST NOT be consulted.
-        s.assert_not_awaited()
-        v.assert_awaited_once()
-
-    async def test_connection_url_missing_credential_returns_empty(
-        self, crypto_box: CryptoBox
-    ) -> None:
-        pool = fake_pool_yielding_conn(MagicMock())
-        with (
-            patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
-                "aios.mcp.client.queries.resolve_vault_credential",
-                new_callable=AsyncMock,
-            ) as v,
-            patch(
-                "aios.mcp.client.queries.resolve_mcp_credential",
-                new_callable=AsyncMock,
-            ) as s,
-        ):
-            g.return_value = "vlt_v2"
-            v.return_value = None
-            result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
-            )
-        assert result == {}
-        # Still doesn't fall back — connection ownership decided the source.
-        s.assert_not_awaited()
-
-    async def test_mcp_oauth_from_connection(self, crypto_box: CryptoBox) -> None:
-        payload = json.dumps({"access_token": "oauth-conn-token"})
-        blob = crypto_box.encrypt(payload)
-        pool = fake_pool_yielding_conn(MagicMock())
-        with (
-            patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
-                "aios.mcp.client.queries.resolve_vault_credential",
-                new_callable=AsyncMock,
-            ) as v,
-        ):
-            g.return_value = "vlt_v2"
-            v.return_value = (blob, "mcp_oauth")
-            result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
-            )
-        assert result == {"Authorization": "Bearer oauth-conn-token"}
-
-    # ── fallback: session_vaults ──────────────────────────────────────────
 
     async def test_non_connection_url_falls_back_to_session_vaults(
         self, crypto_box: CryptoBox
@@ -117,10 +35,6 @@ class TestResolveAuthForUrl:
         pool = fake_pool_yielding_conn(MagicMock())
         with (
             patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
                 "aios.mcp.client.queries.resolve_vault_credential",
                 new_callable=AsyncMock,
             ) as v,
@@ -129,7 +43,6 @@ class TestResolveAuthForUrl:
                 new_callable=AsyncMock,
             ) as s,
         ):
-            g.return_value = None
             s.return_value = (blob, "static_bearer", "vlt_s1")
             result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com"
@@ -138,19 +51,28 @@ class TestResolveAuthForUrl:
         v.assert_not_awaited()
         s.assert_awaited_once()
 
+    async def test_agent_mcp_uses_session_vault(self, crypto_box: CryptoBox) -> None:
+        """A normal agent-declared MCP server uses session vaults by default."""
+        payload = json.dumps({"token": "session-token"})
+        blob = crypto_box.encrypt(payload)
+        pool = fake_pool_yielding_conn(MagicMock())
+        with patch(
+            "aios.mcp.client.queries.resolve_mcp_credential",
+            new_callable=AsyncMock,
+        ) as s:
+            s.return_value = (blob, "static_bearer", "vlt_s1")
+            result = await resolve_auth_for_url(
+                pool, crypto_box, "sess_123", "https://mcp.example.com"
+            )
+        assert result == {"Authorization": "Bearer session-token"}
+        s.assert_awaited_once()
+
     async def test_neither_source_returns_empty(self, crypto_box: CryptoBox) -> None:
         pool = fake_pool_yielding_conn(MagicMock())
-        with (
-            patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
-                "aios.mcp.client.queries.resolve_mcp_credential",
-                new_callable=AsyncMock,
-            ) as s,
-        ):
-            g.return_value = None
+        with patch(
+            "aios.mcp.client.queries.resolve_mcp_credential",
+            new_callable=AsyncMock,
+        ) as s:
             s.return_value = None
             result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com"
@@ -161,24 +83,17 @@ class TestResolveAuthForUrl:
         payload = json.dumps({"token": ""})
         blob = crypto_box.encrypt(payload)
         pool = fake_pool_yielding_conn(MagicMock())
-        with (
-            patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
-                "aios.mcp.client.queries.resolve_mcp_credential",
-                new_callable=AsyncMock,
-            ) as s,
-        ):
-            g.return_value = None
+        with patch(
+            "aios.mcp.client.queries.resolve_mcp_credential",
+            new_callable=AsyncMock,
+        ) as s:
             s.return_value = (blob, "static_bearer", "vlt_s1")
             result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com"
             )
         assert result == {}
 
-    # ── OAuth refresh (applies to both paths) ─────────────────────────────
+    # ── OAuth refresh ─────────────────────────────────────────────────────
 
     async def test_oauth_refresh_triggered_when_expiring(self, crypto_box: CryptoBox) -> None:
         """Session-vaults path: stale mcp_oauth token triggers refresh, then
@@ -199,10 +114,6 @@ class TestResolveAuthForUrl:
         refresh_mock = AsyncMock()
         with (
             patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
                 "aios.mcp.client.queries.resolve_mcp_credential",
                 new_callable=AsyncMock,
             ) as s,
@@ -212,7 +123,6 @@ class TestResolveAuthForUrl:
             ) as v,
             patch("aios.mcp.client.refresh_credential", refresh_mock),
         ):
-            g.return_value = None
             s.return_value = (stale_blob, "mcp_oauth", "vlt_s1")
             v.return_value = (fresh_blob, "mcp_oauth")
             result = await resolve_auth_for_url(
@@ -224,46 +134,6 @@ class TestResolveAuthForUrl:
         assert kwargs["vault_id"] == "vlt_s1"
         assert kwargs["mcp_server_url"] == "https://mcp.example.com"
         assert result == {"Authorization": "Bearer fresh"}
-
-    async def test_oauth_refresh_triggered_on_connection_path(self, crypto_box: CryptoBox) -> None:
-        """Connection-owned path: refresh ALSO triggers here — the refresh
-        flow is source-agnostic, it just needs a vault_id + url pair.
-        """
-        from datetime import UTC, datetime, timedelta
-
-        expiring = json.dumps(
-            {
-                "access_token": "stale-conn",
-                "expires_at": (datetime.now(UTC) + timedelta(seconds=5)).isoformat(),
-            }
-        )
-        fresh = json.dumps({"access_token": "fresh-conn"})
-        stale_blob = crypto_box.encrypt(expiring)
-        fresh_blob = crypto_box.encrypt(fresh)
-        pool = fake_pool_yielding_conn(MagicMock())
-
-        refresh_mock = AsyncMock()
-        with (
-            patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
-                "aios.mcp.client.queries.resolve_vault_credential",
-                new_callable=AsyncMock,
-            ) as v,
-            patch("aios.mcp.client.refresh_credential", refresh_mock),
-        ):
-            g.return_value = "vlt_conn"
-            # Two reads: initial (stale) and post-refresh (fresh).
-            v.side_effect = [(stale_blob, "mcp_oauth"), (fresh_blob, "mcp_oauth")]
-            result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
-            )
-
-        refresh_mock.assert_awaited_once()
-        assert refresh_mock.await_args.kwargs["vault_id"] == "vlt_conn"
-        assert result == {"Authorization": "Bearer fresh-conn"}
 
     async def test_oauth_refresh_not_triggered_when_fresh(self, crypto_box: CryptoBox) -> None:
         from datetime import UTC, datetime, timedelta
@@ -280,16 +150,11 @@ class TestResolveAuthForUrl:
 
         with (
             patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
                 "aios.mcp.client.queries.resolve_mcp_credential",
                 new_callable=AsyncMock,
             ) as s,
             patch("aios.mcp.client.refresh_credential", refresh_mock),
         ):
-            g.return_value = None
             s.return_value = (blob, "mcp_oauth", "vlt_s1")
             result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com"
@@ -314,10 +179,6 @@ class TestResolveAuthForUrl:
 
         with (
             patch(
-                "aios.mcp.client.queries.get_connection_vault_for_url",
-                new_callable=AsyncMock,
-            ) as g,
-            patch(
                 "aios.mcp.client.queries.resolve_mcp_credential",
                 new_callable=AsyncMock,
             ) as s,
@@ -327,7 +188,6 @@ class TestResolveAuthForUrl:
             ),
             pytest.raises(OAuthRefreshError),
         ):
-            g.return_value = None
             s.return_value = (blob, "mcp_oauth", "vlt_s1")
             await resolve_auth_for_url(pool, crypto_box, "sess_123", "https://mcp.example.com")
 
@@ -429,7 +289,7 @@ class TestDiscoverMcpTools:
         """``InitializeResult.instructions`` is the standard MCP transport
         for per-server prompt affordance prose.  The harness reads it from
         ``discover_mcp_tools``'s second return slot to compose the
-        per-connector system-prompt block.
+        per-server system-prompt block.
         """
         mock_tool = _make_mock_tool("signal_send", "Send a Signal message", {"type": "object"})
         mock_result = MagicMock()
@@ -536,8 +396,8 @@ class TestCallMcpTool:
     async def test_meta_forwarded_to_session_call_tool(self) -> None:
         """The ``meta`` kwarg on call_mcp_tool reaches session.call_tool
         as its ``meta=`` kwarg so it lands in the JSON-RPC request's
-        ``_meta`` field (the transport for slice 6's focal-path
-        injection on connection-provided servers).
+        ``_meta`` field, which is how the harness sends focal-channel
+        context to MCP servers.
         """
         mock_content = MagicMock()
         mock_content.text = "ok"
@@ -550,7 +410,7 @@ class TestCallMcpTool:
         mock_session.initialize = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value=mock_result)
 
-        meta = {"aios.focal_channel_path": "alice"}
+        meta = {"aios.focal_channel": "acct/alice"}
 
         with (
             patch("aios.mcp.client.streamable_http_client") as mock_transport,
@@ -575,8 +435,7 @@ class TestCallMcpTool:
 
     async def test_meta_defaults_to_none(self) -> None:
         """When meta is omitted, session.call_tool is called with meta=None
-        — important for agent-declared MCP servers that should stay
-        unaware of aios internal context.
+        — this is the phone-down/no-context shape.
         """
         mock_content = MagicMock()
         mock_content.text = "ok"

--- a/tests/unit/test_mcp_models.py
+++ b/tests/unit/test_mcp_models.py
@@ -51,30 +51,9 @@ class TestMcpServerSpec:
         restored = McpServerSpec.model_validate_json(j)
         assert restored.name == "slack"
 
-    def test_conn_prefix_reserved(self) -> None:
-        """The ``conn_`` prefix is reserved for connection-derived MCP server
-        names — agent-declared names must not collide.
-        """
-        with pytest.raises(ValueError, match="conn_"):
-            McpServerSpec(name="conn_github", url="https://mcp.github.com/")
-
-    def test_conn_prefix_reserved_in_agent_create(self) -> None:
-        """Same rejection at the AgentCreate boundary (the HTTP router
-        path — JSON body → ``model_validate`` runs the field validator
-        on every nested mcp_servers entry).
-        """
-        with pytest.raises(ValueError, match="conn_"):
-            AgentCreate.model_validate(
-                {
-                    "name": "bad",
-                    "model": "openai/gpt-4o-mini",
-                    "system": "",
-                    "mcp_servers": [{"type": "url", "name": "conn_foo", "url": "https://m"}],
-                }
-            )
-
-    def test_names_without_conn_prefix_accepted(self) -> None:
-        """Names containing ``conn`` but not starting with ``conn_`` are fine."""
+    def test_conn_prefix_is_ordinary_name(self) -> None:
+        """The conn_ prefix is not a reserved server-name namespace."""
+        assert McpServerSpec(name="conn_github", url="https://m").name == "conn_github"
         assert McpServerSpec(name="connector", url="https://m").name == "connector"
         assert McpServerSpec(name="my_conn", url="https://m").name == "my_conn"
         assert McpServerSpec(name="conn", url="https://m").name == "conn"
@@ -140,6 +119,14 @@ class TestToolSpecMcpToolset:
         assert spec.configs is not None
         assert len(spec.configs) == 1
         assert spec.configs[0].name == "create_issue"
+
+    def test_channel_context_is_not_part_of_mcp_toolset_schema(self) -> None:
+        with pytest.raises(ValueError, match="channel_context"):
+            ToolSpec(
+                type="mcp_toolset",
+                mcp_server_name="signal",
+                channel_context={"type": "focal"},  # type: ignore[call-arg]
+            )
 
     def test_mcp_toolset_round_trip(self) -> None:
         spec = ToolSpec(

--- a/tests/unit/test_mcp_routing.py
+++ b/tests/unit/test_mcp_routing.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from aios.harness.loop import (
-    _hide_conn_tools_when_phone_down,
     _is_mcp_tool,
     _tc_name,
     resolve_mcp_permission,
 )
 from aios.models.agents import (
     McpPermissionPolicy,
+    McpToolConfig,
     McpToolsetConfig,
     ToolSpec,
 )
@@ -72,6 +72,55 @@ class TestResolveMcpPermission:
         ]
         assert resolve_mcp_permission("mcp__github__create_issue", tools) == "always_ask"
 
+    def test_per_tool_permission_overrides_default_config(self) -> None:
+        tools = [
+            ToolSpec(
+                type="mcp_toolset",
+                mcp_server_name="github",
+                default_config=McpToolsetConfig(
+                    permission_policy=McpPermissionPolicy(type="always_ask"),
+                ),
+                configs=[
+                    McpToolConfig(
+                        name="create_issue",
+                        permission_policy=McpPermissionPolicy(type="always_allow"),
+                    )
+                ],
+            ),
+        ]
+        assert resolve_mcp_permission("mcp__github__create_issue", tools) == "always_allow"
+
+    def test_unmatched_per_tool_permission_falls_back_to_default_config(self) -> None:
+        tools = [
+            ToolSpec(
+                type="mcp_toolset",
+                mcp_server_name="github",
+                default_config=McpToolsetConfig(
+                    permission_policy=McpPermissionPolicy(type="always_ask"),
+                ),
+                configs=[
+                    McpToolConfig(
+                        name="delete_repo",
+                        permission_policy=McpPermissionPolicy(type="always_allow"),
+                    )
+                ],
+            ),
+        ]
+        assert resolve_mcp_permission("mcp__github__create_issue", tools) == "always_ask"
+
+    def test_disabled_toolset_does_not_supply_permission(self) -> None:
+        tools = [
+            ToolSpec(
+                type="mcp_toolset",
+                enabled=False,
+                mcp_server_name="github",
+                default_config=McpToolsetConfig(
+                    permission_policy=McpPermissionPolicy(type="always_allow"),
+                ),
+            ),
+        ]
+        assert resolve_mcp_permission("mcp__github__create_issue", tools) is None
+
     def test_no_default_config_returns_flat_permission(self) -> None:
         """Falls back to ToolSpec.permission when no default_config."""
         tools = [
@@ -90,6 +139,16 @@ class TestResolveMcpPermission:
         ]
         assert resolve_mcp_permission("mcp__github__create_issue", tools) is None
 
+    def test_flat_permission_applies_to_signal_server(self) -> None:
+        tools = [
+            ToolSpec(
+                type="mcp_toolset",
+                mcp_server_name="signal",
+                permission="always_ask",
+            ),
+        ]
+        assert resolve_mcp_permission("mcp__signal__signal_send", tools) == "always_ask"
+
     def test_wrong_server_not_matched(self) -> None:
         tools = [
             ToolSpec(
@@ -102,25 +161,7 @@ class TestResolveMcpPermission:
         ]
         assert resolve_mcp_permission("mcp__github__create_issue", tools) is None
 
-    def test_connection_provided_defaults_to_always_allow(self) -> None:
-        """Tools from connection-provided MCP servers (names with the
-        reserved ``conn_`` prefix) don't require per-call confirmation:
-        the session's channel binding is the explicit routing consent.
-        """
-        # No agent-declared mcp_toolset entry references the connection —
-        # the reserved-prefix validator forbids it — so normally we'd
-        # fall through to None (= always_ask).  Connection servers are
-        # the exception.
-        assert (
-            resolve_mcp_permission("mcp__conn_01HQR2K7VXBZ9MNPL3WYCT8F__send", []) == "always_allow"
-        )
-
-    def test_connection_provided_ignores_agent_overrides(self) -> None:
-        """Even if someone (somehow) had a matching mcp_toolset entry, the
-        connection branch wins — agent-declared tools can't target
-        connection-derived servers by name."""
-        # The validator prevents this from being constructible via API, but
-        # test behaviour directly in case of bypass (e.g., legacy DB rows).
+    def test_conn_prefix_is_an_ordinary_server_name(self) -> None:
         tools = [
             ToolSpec(
                 type="mcp_toolset",
@@ -130,7 +171,13 @@ class TestResolveMcpPermission:
                 ),
             ),
         ]
-        assert resolve_mcp_permission("mcp__conn_foo__send", tools) == "always_allow"
+        assert (
+            resolve_mcp_permission(
+                "mcp__conn_foo__send",
+                tools,
+            )
+            == "always_ask"
+        )
 
 
 class TestToOpenaiToolsSkipsMcpToolset:
@@ -155,42 +202,3 @@ class TestToOpenaiToolsSkipsMcpToolset:
         )
         assert len(result) == 1
         assert result[0]["function"]["name"] == "bash"
-
-
-def _tool(name: str) -> dict[str, object]:
-    return {"type": "function", "function": {"name": name}}
-
-
-class TestHideConnToolsWhenPhoneDown:
-    """Slice 6: connection-provided MCP tools disappear from the model's
-    tool list when the session's focal_channel is NULL.  Agent-declared
-    MCP tools and built-ins stay visible.
-    """
-
-    def test_focal_set_keeps_all_tools(self) -> None:
-        tools = [
-            _tool("mcp__conn_abc__signal_send"),
-            _tool("mcp__github__create_issue"),
-            _tool("bash"),
-        ]
-        result = _hide_conn_tools_when_phone_down(tools, "signal/bot/alice")
-        assert result == tools
-
-    def test_focal_null_hides_conn_tools(self) -> None:
-        tools = [
-            _tool("mcp__conn_abc__signal_send"),
-            _tool("mcp__conn_abc__signal_react"),
-            _tool("mcp__github__create_issue"),
-            _tool("bash"),
-        ]
-        result = _hide_conn_tools_when_phone_down(tools, None)
-        names = [t["function"]["name"] for t in result]  # type: ignore[index]
-        assert "mcp__conn_abc__signal_send" not in names
-        assert "mcp__conn_abc__signal_react" not in names
-        # Agent-declared MCP and built-ins survive.
-        assert "mcp__github__create_issue" in names
-        assert "bash" in names
-
-    def test_empty_list(self) -> None:
-        assert _hide_conn_tools_when_phone_down([], None) == []
-        assert _hide_conn_tools_when_phone_down([], "signal/bot/alice") == []

--- a/tests/unit/test_routing_models.py
+++ b/tests/unit/test_routing_models.py
@@ -16,12 +16,7 @@ from aios.models.routing_rules import (
 
 class TestConnectionCreate:
     def test_valid(self) -> None:
-        c = ConnectionCreate(
-            connector="signal",
-            account="alice",
-            mcp_url="https://mcp.example.com",
-            vault_id="vlt_abc",
-        )
+        c = ConnectionCreate(connector="signal", account="alice")
         assert c.connector == "signal"
         assert c.metadata == {}
 
@@ -29,8 +24,6 @@ class TestConnectionCreate:
         c = ConnectionCreate(
             connector="signal",
             account="alice",
-            mcp_url="https://mcp.example.com",
-            vault_id="vlt_abc",
             metadata={"source": "manual"},
         )
         assert c.metadata == {"source": "manual"}
@@ -40,19 +33,12 @@ class TestConnectionCreate:
             ConnectionCreate(
                 connector="signal",
                 account="alice",
-                mcp_url="https://m",
-                vault_id="vlt_abc",
                 bogus="x",  # type: ignore[call-arg]
             )
 
     def test_rejects_empty_connector(self) -> None:
         with pytest.raises(ValidationError):
-            ConnectionCreate(
-                connector="",
-                account="alice",
-                mcp_url="https://m",
-                vault_id="vlt_abc",
-            )
+            ConnectionCreate(connector="", account="alice")
 
     @pytest.mark.parametrize(
         ("field", "value"),
@@ -62,8 +48,6 @@ class TestConnectionCreate:
         kwargs: dict[str, str] = {
             "connector": "signal",
             "account": "alice",
-            "mcp_url": "https://m",
-            "vault_id": "vlt_abc",
         }
         kwargs[field] = value
         with pytest.raises(ValidationError, match="must not contain '/'"):
@@ -73,8 +57,6 @@ class TestConnectionCreate:
 class TestConnectionUpdate:
     def test_all_optional(self) -> None:
         u = ConnectionUpdate()
-        assert u.mcp_url is None
-        assert u.vault_id is None
         assert u.metadata is None
 
     def test_rejects_connector_field(self) -> None:

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -173,8 +173,8 @@ class TestEntrySweepSpan:
                 AsyncMock(return_value=agent),
             ),
             patch(
-                "aios.harness.channels.list_bindings_and_connections",
-                AsyncMock(return_value=([], [])),
+                "aios.harness.channels.list_session_bindings",
+                AsyncMock(return_value=[]),
             ),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -288,6 +288,7 @@ class TestUpdateVaultCredentialCallSite:
         upd.assert_awaited_once()
         kwargs = upd.await_args.kwargs
         assert kwargs["display_name"] is ...
+        assert kwargs["account_id"] is ...
         assert kwargs["metadata"] is ...
         assert kwargs["blob"] is not None  # always re-encrypted
 
@@ -321,6 +322,37 @@ class TestUpdateVaultCredentialCallSite:
 
         kwargs = upd.await_args.kwargs
         assert kwargs["display_name"] is None  # not Ellipsis — explicitly passed
+
+    @pytest.mark.asyncio
+    async def test_passes_account_id_when_set_even_to_none(self, crypto_box: CryptoBox) -> None:
+        existing = _existing_credential()
+        existing_blob = crypto_box.encrypt(json.dumps({"access_token": "at"}))
+        conn = MagicMock()
+        pool = fake_pool_yielding_conn(conn)
+
+        with (
+            patch.object(
+                vaults_service.queries,
+                "get_vault_credential_with_blob",
+                AsyncMock(return_value=(existing, existing_blob)),
+            ),
+            patch.object(
+                vaults_service.queries,
+                "update_vault_credential",
+                AsyncMock(return_value=existing),
+            ) as upd,
+        ):
+            body = VaultCredentialUpdate(account_id=None)  # explicitly clear account identity
+            await vaults_service.update_vault_credential(
+                pool,
+                crypto_box,
+                vault_id="vlt_1",
+                credential_id="vc_1",
+                body=body,
+            )
+
+        kwargs = upd.await_args.kwargs
+        assert kwargs["account_id"] is None  # not Ellipsis — explicitly passed
 
 
 # ── OAuth refresh ────────────────────────────────────────────────────────────

--- a/tests/unit/test_vault_models.py
+++ b/tests/unit/test_vault_models.py
@@ -116,6 +116,33 @@ class TestVaultCredentialCreate:
         assert c.token is not None
         assert c.token.get_secret_value() == "my-token"
 
+    def test_account_id_valid(self) -> None:
+        c = VaultCredentialCreate(
+            mcp_server_url="https://mcp.example.com",
+            account_id="signal-bot-1",
+            auth_type="static_bearer",
+            token=SecretStr("my-token"),
+        )
+        assert c.account_id == "signal-bot-1"
+
+    def test_account_id_rejects_slash(self) -> None:
+        with pytest.raises(ValidationError, match="must not contain"):
+            VaultCredentialCreate(
+                mcp_server_url="https://mcp.example.com",
+                account_id="signal/bot",
+                auth_type="static_bearer",
+                token=SecretStr("my-token"),
+            )
+
+    def test_account_id_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            VaultCredentialCreate(
+                mcp_server_url="https://mcp.example.com",
+                account_id="",
+                auth_type="static_bearer",
+                token=SecretStr("my-token"),
+            )
+
     def test_mcp_oauth_valid(self) -> None:
         c = VaultCredentialCreate(
             mcp_server_url="https://mcp.example.com",
@@ -231,6 +258,19 @@ class TestVaultCredentialUpdate:
         assert u.token.get_secret_value() == "new-token"
         assert "token" in u.model_fields_set
         assert "access_token" not in u.model_fields_set
+
+    def test_account_id_update_can_set_or_clear(self) -> None:
+        u = VaultCredentialUpdate(account_id="signal-bot-1")
+        assert u.account_id == "signal-bot-1"
+        assert "account_id" in u.model_fields_set
+
+        clear = VaultCredentialUpdate(account_id=None)
+        assert clear.account_id is None
+        assert "account_id" in clear.model_fields_set
+
+    def test_account_id_update_rejects_slash(self) -> None:
+        with pytest.raises(ValidationError, match="must not contain"):
+            VaultCredentialUpdate(account_id="signal/bot")
 
     def test_partial_update_token_endpoint_auth(self) -> None:
         u = VaultCredentialUpdate(

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -226,8 +226,8 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value=agent),
             ),
             patch(
-                "aios.harness.channels.list_bindings_and_connections",
-                AsyncMock(return_value=([], [])),
+                "aios.harness.channels.list_session_bindings",
+                AsyncMock(return_value=[]),
             ),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",
@@ -319,8 +319,8 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value=agent),
             ),
             patch(
-                "aios.harness.channels.list_bindings_and_connections",
-                AsyncMock(return_value=([], [])),
+                "aios.harness.channels.list_session_bindings",
+                AsyncMock(return_value=[]),
             ),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",
@@ -415,8 +415,8 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value=agent),
             ),
             patch(
-                "aios.harness.channels.list_bindings_and_connections",
-                AsyncMock(return_value=([], [])),
+                "aios.harness.channels.list_session_bindings",
+                AsyncMock(return_value=[]),
             ),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",


### PR DESCRIPTION
Consolidates the previous connector/MCP PR stack (#175, #180-#189) into one PR based on current `master`.

## Summary
- Move connector outbound tools to normal agent-declared MCP servers and session vault credential auth.
- Make connection resources channel-only by removing connection-owned MCP URL/vault/tool-discovery behavior.
- Render MCP `InitializeResult.instructions` per server in the system prompt.
- Always inject account-relative `_meta.aios.focal_channel` on MCP tool calls when focal is set.
- Add per-tool MCP toolset config filtering/permission handling and `account_id` metadata on vault credentials.
- Update Signal and Telegram connector MCP handlers/docs/tests for the new focal metadata contract.

## Notes
- This intentionally preserves the existing HTTP inbound connection/routing path. The next branch should implement the inbound MCP subscription process instead of continuing small cleanup PRs.
- The squash conflict with current `master` was resolved by keeping `master`'s context prelude/window-overhead and timeout hardening, while applying the consolidated agent-MCP-only behavior.

## Validation
- `uv run ruff check`
- `git diff --cached --name-only -- '*.py' | xargs uv run ruff format --check`
- `uv run mypy src`
- `uv run pytest tests/unit -q` (`944 passed`)
- `uv run ruff check connectors/signal/src/aios_signal/mcp.py connectors/signal/tests/test_mcp.py connectors/telegram/src/aios_telegram/mcp.py connectors/telegram/tests/test_mcp.py`
- `uv run ruff format --check connectors/signal/src/aios_signal/mcp.py connectors/signal/tests/test_mcp.py connectors/telegram/src/aios_telegram/mcp.py connectors/telegram/tests/test_mcp.py`
- `(cd connectors/signal && uv run mypy src tests)`
- `(cd connectors/telegram && uv run mypy src tests)`
- `(cd connectors/signal && uv run pytest tests/test_mcp.py -q)` (`30 passed`)
- `(cd connectors/telegram && uv run pytest tests/test_mcp.py -q)` (`16 passed`)
- pre-commit on commit: ruff, mypy, unit tests (`944 passed`)