### PR TITLE
[codex] Add MCP inbound runtime and Signal pilot

### DIFF
--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -1,17 +1,16 @@
 # aios-signal
 
 Signal connector for [aios](../../README.md). One long-running process per
-Signal account — wraps `signal-cli` in daemon mode, ingests inbound messages
-into aios via `POST /v1/connections/{id}/messages`, and serves an MCP server
-exposing `signal_send`, `signal_react`, `signal_read_receipt` tools that the
-aios worker calls back into.
+Signal account wraps `signal-cli` in daemon mode and serves a stateful MCP
+server. aios uses the same MCP server for outbound tools (`signal_send`,
+`signal_react`) and inbound message subscriptions.
 
 ## Prerequisites
 
 - Python ≥ 3.13
 - [signal-cli](https://github.com/AsamK/signal-cli) ≥ 0.13.x (provides the JSON-RPC `listAccounts`, `send`, `sendReaction`, `sendReceipt` methods, and `--receive-mode=on-connection`)
 - A JRE available to signal-cli
-- A running aios instance you can point at (Phase 1 routing infra required)
+- A running aios API, worker, and inbound process.
 
 ## Install
 
@@ -36,7 +35,7 @@ signal-cli -a +15551234567 register --captcha signalcaptcha://...
 signal-cli -a +15551234567 verify 123456
 ```
 
-Grab the bot's ACI UUID — you'll need it for the routing rule:
+Grab the bot's ACI UUID — you'll use it as the vault credential `account_id`:
 
 ```
 signal-cli -a +15551234567 listAccounts
@@ -49,6 +48,7 @@ VLT=$(curl -X POST :8090/v1/vaults -d '{"display_name": "Signal personal"}' | jq
 
 curl -X POST :8090/v1/vaults/$VLT/credentials -d '{
   "mcp_server_url": "http://localhost:9100/mcp",
+  "account_id": "<bot-aci-uuid-from-step-1>",
   "auth_type": "static_bearer",
   "token": "supersecret"
 }'
@@ -75,25 +75,15 @@ Add the Signal MCP server as a normal agent MCP server:
 }
 ```
 
-### 4. Register the aios connection
+### 4. Create a session with the Signal vault
 
-The connection is the inbound channel account. Normal MCP discovery comes from
-the agent config above; the vault is supplied through the routing rule's
-session params.
-
-```
-CONN=$(curl -X POST :8090/v1/connections -d "{
-  \"connector\": \"signal\",
-  \"account\": \"<bot-aci-uuid-from-step-1>\"
-}" | jq -r .id)
-```
+Inbound subscriptions are session-scoped. Create or update a session for the
+agent above with `vault_ids: ["$VLT"]`. The `aios inbound` process will
+subscribe that session to the Signal MCP server using the vault credential.
 
 ### 5. Start the connector
 
 ```
-export AIOS_URL=http://localhost:8090
-export AIOS_API_KEY=...
-export AIOS_CONNECTION_ID=$CONN
 export AIOS_SIGNAL_MCP_TOKEN=supersecret
 
 python -m aios_signal start \
@@ -103,25 +93,19 @@ python -m aios_signal start \
 
 All settings can also be passed via env vars. Full list via `python -m aios_signal start --help`.
 
-### 6. Add a routing rule
+### 6. Start aios inbound
 
 ```
-curl -X POST :8090/v1/connections/$CONN/routing-rules -d "{
-  \"prefix\": \"\",
-  \"target\": \"agent:<agent-id>\",
-  \"session_params\": {\"environment_id\": \"<env-id>\", \"vault_ids\": [\"$VLT\"]}
-}"
+aios inbound
 ```
 
-The empty prefix is the per-connection catch-all. The session vault binding is
-what gives the agent-declared Signal MCP server its bearer token.
-
-### 7. DM your bot — the agent replies
+### 7. DM your bot
 
 DM the bot's phone number from another Signal client. Watch the aios event
-log: the inbound message shows up with `metadata.channel` set, a session is
-created on first inbound, and the agent's `signal_send` call delivers the
-reply back to Signal.
+log: the inbound message shows up with `metadata.channel` set to
+`signal/<bot-aci-uuid>/<chat-id>`. The agent can focus that channel with
+`switch_channel`; `signal_send` and `signal_react` use the focused channel via
+MCP `_meta`.
 
 ## Configuration reference
 
@@ -131,9 +115,6 @@ reply back to Signal.
 | `--config-dir` | `AIOS_SIGNAL_CONFIG_DIR` | required | signal-cli config directory |
 | `--signal-cli-bin` | `AIOS_SIGNAL_CLI_BIN` | `signal-cli` | Path to signal-cli binary |
 | `--daemon-port` | `AIOS_SIGNAL_DAEMON_PORT` | `7583` | TCP port for signal-cli daemon |
-| `--aios-url` | `AIOS_URL` | required | Base URL of aios API |
-| `--aios-api-key` | `AIOS_API_KEY` | required | Bearer token for aios API |
-| `--aios-connection-id` | `AIOS_CONNECTION_ID` | required | ID of the pre-registered connection |
 | `--mcp-bind` | `AIOS_SIGNAL_MCP_BIND` | `127.0.0.1:9100` | Host:port for MCP server |
 | `--mcp-token` | `AIOS_SIGNAL_MCP_TOKEN` | required | Token MCP clients must present |
 
@@ -142,13 +123,14 @@ reply back to Signal.
 `app.run()` wires three tasks under a single `asyncio.TaskGroup`:
 
 1. **`SignalDaemon`** — subprocess lifecycle for `signal-cli daemon`. Drains
-   stdout/stderr, polls TCP readiness via `listAccounts`, discovers the bot's
-   own ACI UUID by matching `--phone` against `listAccounts` output.
+   stdout/stderr, polls TCP readiness via `version`, discovers the bot's
+   own ACI UUID from signal-cli's account file.
 2. **`InboundPump`** — drains the daemon's persistent listener connection,
-   parses each envelope into an `InboundMessage`, and POSTs to aios with
-   the metadata envelope specified in #33.
-3. **MCP server** — FastMCP on uvicorn, bearer-auth-gated, exposing
-   `signal_send`, `signal_react`, `signal_read_receipt`.
+   parses each envelope into an `InboundMessage`, and publishes it to the
+   connector-local MCP inbound broker.
+3. **MCP server** — stateful FastMCP on uvicorn, bearer-auth-gated, exposing
+   `signal_send`, `signal_react`, and the hidden `aios_inbound_subscribe`
+   hook used by `aios inbound`.
 
 **Crash-is-fatal.** Any task failure propagates through the TaskGroup and
 exits the process non-zero. There is no auto-reconnect. Run under systemd
@@ -171,13 +153,11 @@ exits the process non-zero. There is no auto-reconnect. Run under systemd
 - **`signal.daemon.crashed`**: signal-cli exited unexpectedly. Check the
   logs for the `signal.daemon.stderr` events immediately preceding. Common
   causes: stale session state, JRE absent, port already in use.
-- **MCP calls returning 401**: the `--mcp-token` on the connector doesn't
-  match the `token` stored in the aios vault's credential for this
-  connection. They must match exactly.
-- **Inbound messages never appear in aios**: check the connector logs for
-  `ingest.client_error` (malformed payload — likely a connector bug) or
-  `ingest.retries_exhausted` (aios was unreachable long enough to exhaust
-  the 1/2/4/8s backoff).
+- **MCP calls returning 401**: the `--mcp-token` on the connector does not
+  match the `token` stored in the aios vault credential for this MCP server.
+- **Inbound messages never appear in aios**: check that `aios inbound` is
+  running, the session has the vault attached, and the vault credential has
+  `account_id` set to the bot ACI UUID.
 
 ## Development
 

--- a/connectors/signal/src/aios_signal/__main__.py
+++ b/connectors/signal/src/aios_signal/__main__.py
@@ -28,9 +28,6 @@ def _build_parser() -> argparse.ArgumentParser:
     start.add_argument(
         "--daemon-port", type=int, help="TCP port for signal-cli daemon (AIOS_SIGNAL_DAEMON_PORT)"
     )
-    start.add_argument("--aios-url", help="aios base URL (AIOS_URL)")
-    start.add_argument("--aios-api-key", help="aios bearer token (AIOS_API_KEY)")
-    start.add_argument("--aios-connection-id", help="aios connection id (AIOS_CONNECTION_ID)")
     start.add_argument("--mcp-bind", help="MCP host:port (AIOS_SIGNAL_MCP_BIND)")
     start.add_argument("--mcp-token", help="MCP bearer token (AIOS_SIGNAL_MCP_TOKEN)")
     return parser
@@ -42,9 +39,6 @@ def _apply_cli_overrides(args: argparse.Namespace) -> None:
         "config_dir": "AIOS_SIGNAL_CONFIG_DIR",
         "signal_cli_bin": "AIOS_SIGNAL_CLI_BIN",
         "daemon_port": "AIOS_SIGNAL_DAEMON_PORT",
-        "aios_url": "AIOS_URL",
-        "aios_api_key": "AIOS_API_KEY",
-        "aios_connection_id": "AIOS_CONNECTION_ID",
         "mcp_bind": "AIOS_SIGNAL_MCP_BIND",
         "mcp_token": "AIOS_SIGNAL_MCP_TOKEN",
     }

--- a/connectors/signal/src/aios_signal/app.py
+++ b/connectors/signal/src/aios_signal/app.py
@@ -1,7 +1,7 @@
 """Top-level orchestration.
 
 ``run(cfg)`` supervises three tasks under one ``asyncio.TaskGroup``: the
-signal-cli subprocess, the inbound pump (listener → parse → POST aios), and
+signal-cli subprocess, the inbound pump (listener → parse → MCP broker), and
 the MCP server. Any task failure propagates through the group and exits the
 process non-zero — operator systemd/Docker restarts.
 """
@@ -15,7 +15,8 @@ import structlog
 
 from .config import Settings
 from .daemon import SignalDaemon
-from .ingest import InboundPump, IngestClient
+from .inbound import SignalInboundBroker, initial_signal_channels
+from .ingest import InboundPump
 from .mcp import build_mcp_app, build_mcp_server, parse_bind, serve_mcp
 
 log = structlog.get_logger(__name__)
@@ -40,38 +41,42 @@ async def run(cfg: Settings) -> None:
             groups=len(groups),
         )
 
-        async with IngestClient(
-            base_url=cfg.aios_url,
-            api_key=cfg.aios_api_key,
-            connection_id=cfg.aios_connection_id,
-        ) as ingest:
-            pump = InboundPump(
+        broker = SignalInboundBroker(
+            bot_uuid=bot_uuid,
+            initial_channels=initial_signal_channels(
                 bot_uuid=bot_uuid,
-                ingest=ingest,
-                messages=daemon.listener.messages(),
+                groups=groups,
                 contact_names=contact_names,
-            )
-            mcp_app = build_mcp_app(
-                build_mcp_server(
-                    rpc=daemon.rpc,
-                    bot_uuid=bot_uuid,
-                    phone=cfg.phone,
-                    groups=groups,
-                    contact_names=contact_names,
-                ),
-                token=cfg.mcp_token,
-            )
-            host, port = parse_bind(cfg.mcp_bind)
+            ),
+        )
+        pump = InboundPump(
+            bot_uuid=bot_uuid,
+            ingest=broker,
+            messages=daemon.listener.messages(),
+            contact_names=contact_names,
+        )
+        mcp_app = build_mcp_app(
+            build_mcp_server(
+                rpc=daemon.rpc,
+                bot_uuid=bot_uuid,
+                phone=cfg.phone,
+                groups=groups,
+                contact_names=contact_names,
+                inbound_broker=broker,
+            ),
+            token=cfg.mcp_token,
+        )
+        host, port = parse_bind(cfg.mcp_bind)
 
-            try:
-                async with asyncio.TaskGroup() as tg:
-                    tg.create_task(pump.run(), name="signal-pump")
-                    tg.create_task(serve_mcp(mcp_app, host=host, port=port), name="signal-mcp")
-                    tg.create_task(_await_crash(daemon), name="signal-crash-watch")
-            except* Exception as eg:
-                # Surface the first real exception so operators see a conventional
-                # traceback rather than ExceptionGroup noise.
-                raise eg.exceptions[0] from None
+        try:
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(pump.run(), name="signal-pump")
+                tg.create_task(serve_mcp(mcp_app, host=host, port=port), name="signal-mcp")
+                tg.create_task(_await_crash(daemon), name="signal-crash-watch")
+        except* Exception as eg:
+            # Surface the first real exception so operators see a conventional
+            # traceback rather than ExceptionGroup noise.
+            raise eg.exceptions[0] from None
 
 
 async def _await_crash(daemon: SignalDaemon) -> None:

--- a/connectors/signal/src/aios_signal/config.py
+++ b/connectors/signal/src/aios_signal/config.py
@@ -2,15 +2,13 @@
 
 Pydantic-settings sourcing: ``AIOS_SIGNAL_*`` env vars for connector-specific
 settings, plus three shared aios env vars via explicit aliases
-(``AIOS_URL``, ``AIOS_API_KEY``, ``AIOS_CONNECTION_ID``). All may be
-overridden on the CLI (see ``__main__.py``).
+All may be overridden on the CLI (see ``__main__.py``).
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -27,11 +25,6 @@ class Settings(BaseSettings):
     cli_bin: str = "signal-cli"
     daemon_host: str = "127.0.0.1"
     daemon_port: int = 7583
-
-    # aios side
-    aios_url: str = Field(validation_alias="AIOS_URL")
-    aios_api_key: str = Field(validation_alias="AIOS_API_KEY")
-    aios_connection_id: str = Field(validation_alias="AIOS_CONNECTION_ID")
 
     # MCP server
     mcp_bind: str = "127.0.0.1:9100"

--- a/connectors/signal/src/aios_signal/inbound.py
+++ b/connectors/signal/src/aios_signal/inbound.py
@@ -1,0 +1,235 @@
+"""Signal-side MCP inbound broker."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+from mcp.shared.message import SessionMessage
+from mcp.types import JSONRPCMessage, JSONRPCNotification
+
+from .addressing import is_dm_chat_id
+from .daemon import GroupInfo
+
+log = structlog.get_logger(__name__)
+
+NOTIFICATION_MESSAGE = "notifications/aios/inbound/message"
+NOTIFICATION_CHANNELS_SNAPSHOT = "notifications/aios/inbound/channels_snapshot"
+NOTIFICATION_CHANNELS_DELTA = "notifications/aios/inbound/channels_delta"
+NOTIFICATION_REPLAY_LOST = "notifications/aios/inbound/replay_lost"
+
+REPLAY_LIMIT = 512
+
+
+@dataclass(frozen=True, slots=True)
+class InboundEvent:
+    event_id: str
+    channel: str
+    content: str
+    metadata: dict[str, Any]
+
+
+def signal_event_id(*, bot_uuid: str, path: str, metadata: dict[str, Any]) -> str:
+    sender = metadata.get("sender_uuid") or ""
+    timestamp = metadata.get("timestamp_ms") or ""
+    raw = f"{bot_uuid}|{path}|{sender}|{timestamp}"
+    return "sig_" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:32]
+
+
+def initial_signal_channels(
+    *,
+    bot_uuid: str,
+    groups: list[GroupInfo],
+    contact_names: dict[str, str],
+) -> list[dict[str, Any]]:
+    channels: list[dict[str, Any]] = []
+    for uuid, name in sorted(contact_names.items()):
+        if uuid == bot_uuid or not is_dm_chat_id(uuid):
+            continue
+        channels.append(
+            {
+                "channel": f"{bot_uuid}/{uuid}",
+                "display_name": name or uuid,
+                "metadata": {"chat_type": "dm", "sender_uuid": uuid},
+            }
+        )
+    for group in groups:
+        channels.append(
+            {
+                "channel": f"{bot_uuid}/{group.id}",
+                "display_name": group.name or group.id,
+                "metadata": {
+                    "chat_type": "group",
+                    "chat_name": group.name,
+                    "member_uuids": group.member_uuids,
+                },
+            }
+        )
+    return channels
+
+
+class SignalInboundBroker:
+    """Fan Signal inbound events out to subscribed MCP sessions."""
+
+    def __init__(
+        self,
+        *,
+        bot_uuid: str,
+        initial_channels: list[dict[str, Any]] | None = None,
+        replay_limit: int = REPLAY_LIMIT,
+    ) -> None:
+        self.bot_uuid = bot_uuid
+        self.replay_limit = replay_limit
+        self._subscribers: dict[int, Any] = {}
+        self._replay: deque[InboundEvent] = deque(maxlen=replay_limit)
+        self._channels: dict[str, dict[str, Any]] = {}
+        self._lock = asyncio.Lock()
+        for entry in initial_channels or []:
+            channel = entry.get("channel")
+            if isinstance(channel, str):
+                self._channels[channel] = dict(entry)
+
+    async def subscribe(self, *, account_id: str, since_event_id: str | None, session: Any) -> dict[str, Any]:
+        if account_id != self.bot_uuid:
+            raise ValueError(f"unknown Signal account {account_id!r}")
+        async with self._lock:
+            self._subscribers[id(session)] = session
+            snapshot = list(self._channels.values())
+            replay = self._events_after_locked(since_event_id)
+            replay_lost = since_event_id is not None and replay is None
+
+        await self._send(
+            session,
+            NOTIFICATION_CHANNELS_SNAPSHOT,
+            {"channels": snapshot},
+        )
+        if replay_lost:
+            await self._send(
+                session,
+                NOTIFICATION_REPLAY_LOST,
+                {"since_event_id": since_event_id},
+            )
+            replay = []
+        for event in replay or []:
+            await self._send_event(session, event)
+        return {
+            "status": "subscribed",
+            "channels": len(snapshot),
+            "replayed": len(replay or []),
+            "replay_lost": replay_lost,
+        }
+
+    async def post_message(
+        self,
+        *,
+        path: str,
+        content: str,
+        metadata: dict[str, Any],
+    ) -> None:
+        event = InboundEvent(
+            event_id=signal_event_id(bot_uuid=self.bot_uuid, path=path, metadata=metadata),
+            channel=f"{self.bot_uuid}/{path}",
+            content=content,
+            metadata=dict(metadata),
+        )
+        display_name = _display_name(metadata, path)
+        channel_metadata: dict[str, Any] = {
+            k: v
+            for k, v in metadata.items()
+            if k in {"chat_type", "chat_name", "sender_uuid", "sender_name"}
+        }
+        channel_entry: dict[str, Any] = {
+            "channel": event.channel,
+            "display_name": display_name,
+            "metadata": channel_metadata,
+        }
+
+        async with self._lock:
+            existing = self._channels.get(event.channel)
+            is_new = existing is None
+            existing_metadata = (existing or {}).get("metadata")
+            if not isinstance(existing_metadata, dict):
+                existing_metadata = {}
+            self._channels[event.channel] = {
+                **(existing or {}),
+                **channel_entry,
+                "metadata": {**existing_metadata, **channel_metadata},
+            }
+            self._replay.append(event)
+            subscribers = list(self._subscribers.values())
+
+        if is_new:
+            await self._broadcast(
+                NOTIFICATION_CHANNELS_DELTA,
+                {"upserts": [self._channels[event.channel]], "archives": []},
+                subscribers,
+            )
+        await self._broadcast_event(event, subscribers)
+
+    def _events_after_locked(self, since_event_id: str | None) -> list[InboundEvent] | None:
+        if since_event_id is None:
+            return []
+        events = list(self._replay)
+        for idx, event in enumerate(events):
+            if event.event_id == since_event_id:
+                return events[idx + 1 :]
+        return None if events else []
+
+    async def _broadcast(
+        self,
+        method: str,
+        params: dict[str, Any],
+        subscribers: list[Any],
+    ) -> None:
+        dead: list[int] = []
+        for session in subscribers:
+            try:
+                await self._send(session, method, params)
+            except Exception:
+                dead.append(id(session))
+                log.warning("signal.inbound.send_failed", exc_info=True)
+        if dead:
+            async with self._lock:
+                for key in dead:
+                    self._subscribers.pop(key, None)
+
+    async def _broadcast_event(self, event: InboundEvent, subscribers: list[Any]) -> None:
+        dead: list[int] = []
+        for session in subscribers:
+            try:
+                await self._send_event(session, event)
+            except Exception:
+                dead.append(id(session))
+                log.warning("signal.inbound.send_failed", exc_info=True)
+        if dead:
+            async with self._lock:
+                for key in dead:
+                    self._subscribers.pop(key, None)
+
+    async def _send_event(self, session: Any, event: InboundEvent) -> None:
+        await self._send(
+            session,
+            NOTIFICATION_MESSAGE,
+            {
+                "event_id": event.event_id,
+                "channel": event.channel,
+                "content": event.content,
+                "metadata": event.metadata,
+            },
+        )
+
+    async def _send(self, session: Any, method: str, params: dict[str, Any]) -> None:
+        notification = JSONRPCNotification(jsonrpc="2.0", method=method, params=params)
+        await session.send_message(SessionMessage(message=JSONRPCMessage(notification)))
+
+
+def _display_name(metadata: dict[str, Any], path: str) -> str:
+    for key in ("chat_name", "sender_name"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return path

--- a/connectors/signal/src/aios_signal/ingest.py
+++ b/connectors/signal/src/aios_signal/ingest.py
@@ -1,9 +1,8 @@
-"""aios ingest client + InboundPump.
+"""Legacy aios HTTP ingest client + InboundPump.
 
-POSTs inbound Signal messages to ``/v1/connections/{id}/messages``. Retries
-transient failures (network, 5xx) with exponential backoff; 4xx and
-retry-exhaustion both log and drop, and we let Signal's own redelivery on
-reconnect recover anything not acked by the daemon.
+``InboundPump`` is transport-agnostic: in the MCP inbound runtime it publishes
+to the local broker, while ``IngestClient`` remains for legacy tests and
+coexistence.
 """
 
 from __future__ import annotations
@@ -11,7 +10,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field, replace
-from typing import Any, Self
+from typing import Any, Protocol, Self
 
 import httpx
 import structlog
@@ -22,6 +21,16 @@ from .parse import InboundMessage, build_content_text, parse_envelope
 log = structlog.get_logger(__name__)
 
 RETRY_DELAYS_SECONDS: tuple[float, ...] = (1.0, 2.0, 4.0, 8.0)
+
+
+class InboundSink(Protocol):
+    async def post_message(
+        self,
+        *,
+        path: str,
+        content: str,
+        metadata: dict[str, Any],
+    ) -> None: ...
 
 
 @dataclass(slots=True)
@@ -122,7 +131,7 @@ def build_metadata(
 @dataclass(slots=True)
 class InboundPump:
     bot_uuid: str
-    ingest: IngestClient
+    ingest: InboundSink
     messages: AsyncIterator[dict[str, Any]]
     contact_names: dict[str, str] = field(default_factory=dict)
 

--- a/connectors/signal/src/aios_signal/mcp.py
+++ b/connectors/signal/src/aios_signal/mcp.py
@@ -23,6 +23,7 @@ import asyncio
 import contextlib
 import hmac
 import urllib.parse
+from types import MethodType
 from typing import Any
 
 import structlog
@@ -34,6 +35,7 @@ from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from .addressing import decode_chat_id
+from .inbound import SignalInboundBroker
 from .markdown import convert_markdown_to_signal_styles
 from .prompts import build_instructions
 from .rpc import RpcClient
@@ -155,6 +157,7 @@ def build_mcp_server(
     phone: str,
     groups: list[Any] | None = None,
     contact_names: dict[str, str] | None = None,
+    inbound_broker: SignalInboundBroker | None = None,
 ) -> FastMCP:
     # If `listContacts` included the bot's own entry, use its display
     # name as the profile_name for the identity block.  Absent when the
@@ -170,8 +173,27 @@ def build_mcp_server(
             groups=groups,
             contact_names=contact_names,
         ),
-        stateless_http=True,
+        stateless_http=False,
     )
+
+    if inbound_broker is not None:
+        _install_aios_inbound_capability(mcp)
+
+        @mcp.tool(
+            name="aios_inbound_subscribe",
+            description="Internal aios inbound subscription hook.",
+            meta={"aios.internal": True},
+        )
+        async def aios_inbound_subscribe(
+            account_id: str,
+            ctx: Context[Any, Any, Any],
+            since_event_id: str | None = None,
+        ) -> dict[str, Any]:
+            return await inbound_broker.subscribe(
+                account_id=account_id,
+                since_event_id=since_event_id,
+                session=ctx.session,
+            )
 
     @mcp.tool()
     async def signal_send(text: str, ctx: Context[Any, Any, Any]) -> dict[str, Any]:
@@ -221,6 +243,26 @@ def build_mcp_server(
         return {"status": "ok"}
 
     return mcp
+
+
+def _install_aios_inbound_capability(mcp: FastMCP) -> None:
+    """Advertise the aios inbound extension in MCP initialize."""
+    server = mcp._mcp_server  # FastMCP exposes no public hook for this yet.
+    base = server.create_initialization_options
+
+    def create_initialization_options(
+        self: Any,
+        notification_options: Any | None = None,
+        experimental_capabilities: dict[str, dict[str, Any]] | None = None,
+    ) -> Any:
+        experimental = dict(experimental_capabilities or {})
+        experimental["aiosInbound"] = {
+            "version": 1,
+            "connectorId": "signal",
+        }
+        return base(notification_options, experimental)
+
+    server.create_initialization_options = MethodType(create_initialization_options, server)  # type: ignore[method-assign]
 
 
 def build_mcp_app(mcp: FastMCP, *, token: str) -> Starlette:

--- a/connectors/signal/tests/test_inbound.py
+++ b/connectors/signal/tests/test_inbound.py
@@ -1,0 +1,108 @@
+"""Tests for the Signal MCP inbound broker."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios_signal.daemon import GroupInfo
+from aios_signal.inbound import (
+    NOTIFICATION_CHANNELS_SNAPSHOT,
+    NOTIFICATION_MESSAGE,
+    SignalInboundBroker,
+    initial_signal_channels,
+    signal_event_id,
+)
+
+
+class RecordingSession:
+    def __init__(self) -> None:
+        self.messages: list[Any] = []
+
+    async def send_message(self, message: Any) -> None:
+        self.messages.append(message)
+
+
+def _notification(message: Any) -> Any:
+    return message.message.root
+
+
+def test_initial_signal_channels_include_contacts_and_groups() -> None:
+    channels = initial_signal_channels(
+        bot_uuid="99999999-8888-7777-6666-555555555555",
+        contact_names={
+            "99999999-8888-7777-6666-555555555555": "Me",
+            "11111111-2222-3333-4444-555555555555": "Alice",
+            "not-a-uuid": "Ignored",
+        },
+        groups=[
+            GroupInfo(
+                id="group==",
+                name="Friends",
+                member_uuids=["11111111-2222-3333-4444-555555555555"],
+            )
+        ],
+    )
+
+    assert [c["channel"] for c in channels] == [
+        "99999999-8888-7777-6666-555555555555/11111111-2222-3333-4444-555555555555",
+        "99999999-8888-7777-6666-555555555555/group==",
+    ]
+
+
+def test_signal_event_id_is_deterministic() -> None:
+    metadata = {"sender_uuid": "u", "timestamp_ms": 123}
+    assert signal_event_id(bot_uuid="b", path="p", metadata=metadata) == signal_event_id(
+        bot_uuid="b", path="p", metadata=metadata
+    )
+
+
+async def test_subscribe_snapshot_and_publish_message() -> None:
+    broker = SignalInboundBroker(
+        bot_uuid="bot",
+        initial_channels=[{"channel": "bot/chat", "display_name": "Chat", "metadata": {}}],
+    )
+    session = RecordingSession()
+
+    result = await broker.subscribe(account_id="bot", since_event_id=None, session=session)
+    assert result["status"] == "subscribed"
+    assert _notification(session.messages[0]).method == NOTIFICATION_CHANNELS_SNAPSHOT
+
+    await broker.post_message(
+        path="chat",
+        content="hello",
+        metadata={"sender_uuid": "alice", "timestamp_ms": 1, "sender_name": "Alice"},
+    )
+
+    methods = [_notification(m).method for m in session.messages]
+    assert methods[-1] == NOTIFICATION_MESSAGE
+    params = _notification(session.messages[-1]).params
+    assert params["channel"] == "bot/chat"
+    assert params["content"] == "hello"
+    assert params["metadata"]["sender_uuid"] == "alice"
+
+
+async def test_subscribe_replays_after_cursor() -> None:
+    broker = SignalInboundBroker(bot_uuid="bot")
+    await broker.post_message(
+        path="chat",
+        content="one",
+        metadata={"sender_uuid": "alice", "timestamp_ms": 1},
+    )
+    first_id = signal_event_id(
+        bot_uuid="bot",
+        path="chat",
+        metadata={"sender_uuid": "alice", "timestamp_ms": 1},
+    )
+    await broker.post_message(
+        path="chat",
+        content="two",
+        metadata={"sender_uuid": "alice", "timestamp_ms": 2},
+    )
+
+    session = RecordingSession()
+    await broker.subscribe(account_id="bot", since_event_id=first_id, session=session)
+
+    messages = [m for m in session.messages if _notification(m).method == NOTIFICATION_MESSAGE]
+    assert len(messages) == 1
+    assert _notification(messages[0]).params["content"] == "two"
+

--- a/connectors/signal/tests/test_integration.py
+++ b/connectors/signal/tests/test_integration.py
@@ -1,4 +1,4 @@
-"""End-to-end integration: stubbed signal-cli + stubbed aios + real app.run.
+"""End-to-end integration: stubbed signal-cli + stubbed MCP broker + real app.run.
 
 We stub:
 
@@ -8,13 +8,13 @@ We stub:
   ``receive`` notifications on the persistent listener connection).
 - **signal-cli subprocess** — we patch :func:`_spawn_subprocess` to return a
   :class:`FakeProcess` that does nothing (the stub TCP server is all we need).
-- **aios HTTP** — we patch :class:`IngestClient` in ``app.py`` to inject an
-  :class:`httpx.MockTransport` that records every POST.
+- **MCP inbound broker** — we patch :class:`SignalInboundBroker` in ``app.py``
+  to record messages that the pump publishes.
 
 Assertions:
 
-1. An inbound envelope emitted by the stub daemon → POST observed to aios
-   with the expected shape (path, content, ``metadata.channel``).
+1. An inbound envelope emitted by the stub daemon → broker publish observed
+   with the expected shape (path, content, metadata).
 2. A ``signal_send`` tool call over real MCP streamable HTTP → stub daemon
    records a ``send`` RPC with the expected params.
 3. Closing the listener socket triggers a fatal crash → ``app.run`` raises.
@@ -30,13 +30,11 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
-import httpx
 import pytest
 
 from aios_signal import app as app_module
 from aios_signal import daemon as daemon_module
 from aios_signal.config import Settings
-from aios_signal.ingest import IngestClient
 
 BOT_UUID = "99999999-8888-7777-6666-555555555555"
 BOT_PHONE = "+15550000000"
@@ -192,30 +190,41 @@ class StubDaemon:
             self._listener_writer = None
 
 
-# ─── Stub aios ingest ───────────────────────────────────────────────────────
+# ─── Stub MCP inbound broker ────────────────────────────────────────────────
 
 
-class IngestRecorder:
+class BrokerRecorder:
     def __init__(self) -> None:
-        self.requests: list[httpx.Request] = []
-
-    async def handle(self, request: httpx.Request) -> httpx.Response:
-        self.requests.append(request)
-        return httpx.Response(201, json={"session_id": "ses_x", "event_id": "evt_x"})
+        self.messages: list[dict[str, Any]] = []
 
 
-def _make_ingest_factory(recorder: IngestRecorder):  # type: ignore[no-untyped-def]
-    class _PatchedIngest(IngestClient):
-        async def __aenter__(self) -> _PatchedIngest:
-            transport = httpx.MockTransport(recorder.handle)
-            self._client = httpx.AsyncClient(
-                base_url=self.base_url,
-                headers={"Authorization": f"Bearer {self.api_key}"},
-                transport=transport,
+def _make_broker_factory(recorder: BrokerRecorder):  # type: ignore[no-untyped-def]
+    class _PatchedBroker:
+        def __init__(self, *, bot_uuid: str, initial_channels: list[dict[str, Any]]) -> None:
+            self.bot_uuid = bot_uuid
+            self.initial_channels = initial_channels
+
+        async def post_message(
+            self,
+            *,
+            path: str,
+            content: str,
+            metadata: dict[str, Any],
+        ) -> None:
+            recorder.messages.append(
+                {"path": path, "content": content, "metadata": metadata}
             )
-            return self
 
-    return _PatchedIngest
+        async def subscribe(
+            self,
+            *,
+            account_id: str,
+            since_event_id: str | None,
+            session: Any,
+        ) -> dict[str, Any]:
+            return {"status": "subscribed", "replayed": 0}
+
+    return _PatchedBroker
 
 
 # ─── Fixtures ───────────────────────────────────────────────────────────────
@@ -237,9 +246,6 @@ def settings(tmp_path: Path, stub_daemon: StubDaemon) -> Settings:
     for k in list(os.environ):
         if k.startswith(("AIOS_", "AIOS_SIGNAL_")):
             os.environ.pop(k)
-    os.environ["AIOS_URL"] = "http://aios.stub"
-    os.environ["AIOS_API_KEY"] = "stub-key"
-    os.environ["AIOS_CONNECTION_ID"] = "conn_stub"
     os.environ["AIOS_SIGNAL_MCP_TOKEN"] = "stub-token"
 
     # Write a minimal signal-cli accounts.json so discover_bot_uuid can
@@ -287,8 +293,8 @@ async def test_end_to_end_inbound_and_crash(
     per test, and uvicorn's in-process server state doesn't always tear down
     cleanly across loops — keeping the whole flow on one loop sidesteps that.
     """
-    recorder = IngestRecorder()
-    monkeypatch.setattr(app_module, "IngestClient", _make_ingest_factory(recorder))
+    recorder = BrokerRecorder()
+    monkeypatch.setattr(app_module, "SignalInboundBroker", _make_broker_factory(recorder))
 
     envelope = {
         "sourceUuid": "11111111-2222-3333-4444-555555555555",
@@ -299,17 +305,16 @@ async def test_end_to_end_inbound_and_crash(
 
     run_task = asyncio.create_task(app_module.run(settings))
     try:
-        # Phase 1: inbound envelope arrives and is POSTed to aios.
+        # Phase 1: inbound envelope arrives and is published to the MCP broker.
         await asyncio.sleep(0.3)  # allow setup
         await stub_daemon.push_envelope(envelope)
         for _ in range(50):
-            if recorder.requests:
+            if recorder.messages:
                 break
             await asyncio.sleep(0.05)
 
-        assert len(recorder.requests) == 1
-        request = recorder.requests[0]
-        body = json.loads(request.read())
+        assert len(recorder.messages) == 1
+        body = recorder.messages[0]
         assert body["path"] == "11111111-2222-3333-4444-555555555555"
         assert body["content"] == "hello from alice"
         assert body["metadata"]["channel"] == (

--- a/connectors/signal/tests/test_mcp.py
+++ b/connectors/signal/tests/test_mcp.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -15,6 +15,7 @@ from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 
+from aios_signal.inbound import SignalInboundBroker
 from aios_signal.mcp import (
     BearerAuthMiddleware,
     _extract_timestamp,
@@ -81,6 +82,46 @@ async def _call_tool(
     structured: Any = result[1]
     assert isinstance(structured, dict)
     return structured
+
+
+class TestAiosInboundExtension:
+    def test_capability_is_advertised(self) -> None:
+        mcp = build_mcp_server(
+            rpc=cast(Any, FakeRpc()),
+            bot_uuid=BOT_UUID,
+            phone="+15550000000",
+            inbound_broker=SignalInboundBroker(bot_uuid=BOT_UUID),
+        )
+
+        opts = mcp._mcp_server.create_initialization_options()
+
+        assert opts.capabilities.experimental == {
+            "aiosInbound": {"version": 1, "connectorId": "signal"}
+        }
+
+    async def test_hidden_subscribe_tool_registers_session(self) -> None:
+        broker = SignalInboundBroker(bot_uuid=BOT_UUID)
+        mcp = build_mcp_server(
+            rpc=cast(Any, FakeRpc()),
+            bot_uuid=BOT_UUID,
+            phone="+15550000000",
+            inbound_broker=broker,
+        )
+        session = MagicMock()
+        session.send_message = AsyncMock()
+        rc = MagicMock(spec=RequestContext)
+        rc.session = session
+        ctx = Context(request_context=rc)
+
+        result = await mcp._tool_manager.call_tool(
+            "aios_inbound_subscribe",
+            {"account_id": BOT_UUID},
+            ctx,
+            convert_result=True,
+        )
+
+        assert isinstance(result, tuple)
+        assert result[1]["status"] == "subscribed"
 
 
 # ─── unit: pure helpers ─────────────────────────────────────────────────────

--- a/migrations/versions/0030_mcp_inbound_session_channels.py
+++ b/migrations/versions/0030_mcp_inbound_session_channels.py
@@ -1,0 +1,84 @@
+"""Add MCP inbound session channel state.
+
+Revision ID: 0030
+Revises: 0029
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0030"
+down_revision: str = "0029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE session_channels (
+            id                text PRIMARY KEY,
+            session_id        text NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            mcp_server_name   text NOT NULL,
+            mcp_server_url    text NOT NULL,
+            account_id        text NOT NULL,
+            path              text NOT NULL,
+            address           text NOT NULL,
+            display_name      text,
+            notification_mode text NOT NULL DEFAULT 'focal_candidate'
+                CHECK (notification_mode IN ('focal_candidate', 'silent')),
+            metadata          jsonb NOT NULL DEFAULT '{}'::jsonb,
+            last_seen_at      timestamptz NOT NULL DEFAULT now(),
+            created_at        timestamptz NOT NULL DEFAULT now(),
+            updated_at        timestamptz NOT NULL DEFAULT now(),
+            archived_at       timestamptz
+        )
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX session_channels_identity_uniq
+            ON session_channels (session_id, mcp_server_name, account_id, path)
+            WHERE archived_at IS NULL
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX session_channels_address_uniq
+            ON session_channels (session_id, address)
+            WHERE archived_at IS NULL
+    """)
+    op.execute("""
+        CREATE INDEX session_channels_session_idx
+            ON session_channels (session_id)
+            WHERE archived_at IS NULL
+    """)
+
+    op.execute("""
+        CREATE TABLE inbound_mcp_cursors (
+            session_id          text NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            mcp_server_name     text NOT NULL,
+            mcp_server_url      text NOT NULL,
+            vault_credential_id text NOT NULL REFERENCES vault_credentials(id) ON DELETE CASCADE,
+            account_id          text NOT NULL,
+            last_event_id       text,
+            updated_at          timestamptz NOT NULL DEFAULT now(),
+            PRIMARY KEY (session_id, mcp_server_name, vault_credential_id, account_id)
+        )
+    """)
+
+    op.execute("""
+        CREATE TABLE inbound_mcp_receipts (
+            session_id      text NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            mcp_server_name text NOT NULL,
+            account_id      text NOT NULL,
+            event_id        text NOT NULL,
+            event_row_id    text REFERENCES events(id) ON DELETE SET NULL,
+            created_at      timestamptz NOT NULL DEFAULT now(),
+            PRIMARY KEY (session_id, mcp_server_name, account_id, event_id)
+        )
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS inbound_mcp_receipts")
+    op.execute("DROP TABLE IF EXISTS inbound_mcp_cursors")
+    op.execute("DROP TABLE IF EXISTS session_channels")

--- a/src/aios/cli/commands/ops.py
+++ b/src/aios/cli/commands/ops.py
@@ -1,4 +1,4 @@
-"""Operator subcommands: ``api``, ``worker``, ``migrate``.
+"""Operator subcommands: ``api``, ``worker``, ``inbound``, ``migrate``.
 
 These are lifted almost verbatim from the old ``__main__.py`` implementation.
 They start long-running processes (uvicorn, procrastinate worker) or run
@@ -35,6 +35,14 @@ def _run_worker() -> int:
 
     with contextlib.suppress(KeyboardInterrupt):
         asyncio.run(worker_main())
+    return 0
+
+
+def _run_inbound() -> int:
+    from aios.inbound.runtime import inbound_main
+
+    with contextlib.suppress(KeyboardInterrupt):
+        asyncio.run(inbound_main())
     return 0
 
 
@@ -89,6 +97,10 @@ def register(app: typer.Typer) -> None:
     @app.command("worker", help="Run the aios worker (procrastinate).")
     def worker() -> None:
         raise typer.Exit(_run_worker())
+
+    @app.command("inbound", help="Run the aios MCP inbound supervisor.")
+    def inbound() -> None:
+        raise typer.Exit(_run_inbound())
 
     @app.command(
         "migrate",

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -40,6 +40,7 @@ from aios.ids import (
     MEMORY_VERSION,
     ROUTING_RULE,
     SESSION,
+    SESSION_CHANNEL,
     SKILL,
     VAULT,
     VAULT_CREDENTIAL,
@@ -50,6 +51,7 @@ from aios.models.channel_bindings import ChannelBinding
 from aios.models.connections import Connection
 from aios.models.environments import Environment, EnvironmentConfig
 from aios.models.events import Event, EventKind
+from aios.models.inbound import InboundSubscriptionSpec
 from aios.models.memory_stores import (
     Actor,
     Memory,
@@ -60,6 +62,7 @@ from aios.models.memory_stores import (
     MemoryVersion,
 )
 from aios.models.routing_rules import RoutingRule, SessionParams
+from aios.models.session_channels import SessionChannel
 from aios.models.sessions import Session, SessionStatus, SessionUsage
 from aios.models.skills import AgentSkillRef, Skill, SkillVersion
 from aios.models.vaults import Vault, VaultCredential
@@ -1882,6 +1885,322 @@ async def resolve_mcp_credential(
         str(row["auth_type"]),
         str(row["vault_id"]),
     )
+
+
+# ─── MCP inbound subscriptions and session channels ─────────────────────────
+
+
+def _row_to_session_channel(row: asyncpg.Record) -> SessionChannel:
+    metadata = _parse_jsonb(row["metadata"])
+    return SessionChannel(
+        id=row["id"],
+        session_id=row["session_id"],
+        mcp_server_name=row["mcp_server_name"],
+        mcp_server_url=row["mcp_server_url"],
+        account_id=row["account_id"],
+        path=row["path"],
+        address=row["address"],
+        display_name=row["display_name"],
+        notification_mode=row["notification_mode"],
+        metadata=metadata,
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        last_seen_at=row["last_seen_at"],
+        archived_at=row["archived_at"],
+    )
+
+
+async def upsert_session_channel(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str,
+    mcp_server_name: str,
+    mcp_server_url: str,
+    account_id: str,
+    path: str,
+    display_name: str | None = None,
+    notification_mode: str = "focal_candidate",
+    metadata: dict[str, Any] | None = None,
+) -> SessionChannel:
+    """Create or refresh a materialized channel for a session."""
+    new_id = make_id(SESSION_CHANNEL)
+    address = f"{mcp_server_name}/{account_id}/{path}"
+    metadata_json = json.dumps(metadata or {})
+    row = await conn.fetchrow(
+        """
+        INSERT INTO session_channels (
+            id, session_id, mcp_server_name, mcp_server_url, account_id, path,
+            address, display_name, notification_mode, metadata
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)
+        ON CONFLICT (session_id, mcp_server_name, account_id, path)
+            WHERE archived_at IS NULL
+        DO UPDATE SET
+            mcp_server_url = EXCLUDED.mcp_server_url,
+            address = EXCLUDED.address,
+            display_name = COALESCE(EXCLUDED.display_name, session_channels.display_name),
+            notification_mode = EXCLUDED.notification_mode,
+            metadata = session_channels.metadata || EXCLUDED.metadata,
+            last_seen_at = now(),
+            updated_at = now()
+        RETURNING *
+        """,
+        new_id,
+        session_id,
+        mcp_server_name,
+        mcp_server_url,
+        account_id,
+        path,
+        address,
+        display_name,
+        notification_mode,
+        metadata_json,
+    )
+    assert row is not None
+    return _row_to_session_channel(row)
+
+
+async def archive_session_channel(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str,
+    mcp_server_name: str,
+    account_id: str,
+    path: str,
+) -> SessionChannel | None:
+    row = await conn.fetchrow(
+        """
+        UPDATE session_channels
+           SET archived_at = now(), updated_at = now()
+         WHERE session_id = $1
+           AND mcp_server_name = $2
+           AND account_id = $3
+           AND path = $4
+           AND archived_at IS NULL
+        RETURNING *
+        """,
+        session_id,
+        mcp_server_name,
+        account_id,
+        path,
+    )
+    return _row_to_session_channel(row) if row is not None else None
+
+
+async def list_session_channels(
+    conn: asyncpg.Connection[Any], session_id: str
+) -> list[SessionChannel]:
+    rows = await conn.fetch(
+        """
+        SELECT *
+          FROM session_channels
+         WHERE session_id = $1
+           AND archived_at IS NULL
+         ORDER BY id
+        """,
+        session_id,
+    )
+    return [_row_to_session_channel(r) for r in rows]
+
+
+async def list_session_channels_and_bindings(
+    conn: asyncpg.Connection[Any], session_id: str
+) -> list[SessionChannel | ChannelBinding]:
+    """Return MCP session channels plus legacy bindings for coexistence.
+
+    If the same address appears in both places, the MCP session channel wins.
+    """
+    session_channels = await list_session_channels(conn, session_id)
+    by_address: dict[str, SessionChannel | ChannelBinding] = {
+        c.address: c for c in session_channels
+    }
+    legacy_bindings = await list_session_bindings(conn, session_id)
+    for binding in legacy_bindings:
+        by_address.setdefault(binding.address, binding)
+    return list(by_address.values())
+
+
+async def get_inbound_cursor(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str,
+    mcp_server_name: str,
+    vault_credential_id: str,
+    account_id: str,
+) -> str | None:
+    value: str | None = await conn.fetchval(
+        """
+        SELECT last_event_id
+          FROM inbound_mcp_cursors
+         WHERE session_id = $1
+           AND mcp_server_name = $2
+           AND vault_credential_id = $3
+           AND account_id = $4
+        """,
+        session_id,
+        mcp_server_name,
+        vault_credential_id,
+        account_id,
+    )
+    return value
+
+
+async def set_inbound_cursor(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str,
+    mcp_server_name: str,
+    mcp_server_url: str,
+    vault_credential_id: str,
+    account_id: str,
+    last_event_id: str | None,
+) -> None:
+    await conn.execute(
+        """
+        INSERT INTO inbound_mcp_cursors (
+            session_id, mcp_server_name, mcp_server_url, vault_credential_id,
+            account_id, last_event_id
+        )
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT (session_id, mcp_server_name, vault_credential_id, account_id)
+        DO UPDATE SET
+            mcp_server_url = EXCLUDED.mcp_server_url,
+            last_event_id = EXCLUDED.last_event_id,
+            updated_at = now()
+        """,
+        session_id,
+        mcp_server_name,
+        mcp_server_url,
+        vault_credential_id,
+        account_id,
+        last_event_id,
+    )
+
+
+async def insert_inbound_receipt(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str,
+    mcp_server_name: str,
+    account_id: str,
+    event_id: str,
+) -> bool:
+    row = await conn.fetchrow(
+        """
+        INSERT INTO inbound_mcp_receipts (
+            session_id, mcp_server_name, account_id, event_id
+        )
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT DO NOTHING
+        RETURNING event_id
+        """,
+        session_id,
+        mcp_server_name,
+        account_id,
+        event_id,
+    )
+    return row is not None
+
+
+async def set_inbound_receipt_event(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str,
+    mcp_server_name: str,
+    account_id: str,
+    event_id: str,
+    event_row_id: str,
+) -> None:
+    await conn.execute(
+        """
+        UPDATE inbound_mcp_receipts
+           SET event_row_id = $5
+         WHERE session_id = $1
+           AND mcp_server_name = $2
+           AND account_id = $3
+           AND event_id = $4
+        """,
+        session_id,
+        mcp_server_name,
+        account_id,
+        event_id,
+        event_row_id,
+    )
+
+
+async def list_inbound_subscription_specs(
+    conn: asyncpg.Connection[Any],
+) -> list[InboundSubscriptionSpec]:
+    """Return every MCP inbound subscription desired by active sessions."""
+    rows = await conn.fetch(
+        """
+        SELECT s.id AS session_id,
+               COALESCE(av.mcp_servers, a.mcp_servers) AS mcp_servers,
+               vc.id AS vault_credential_id,
+               vc.vault_id,
+               vc.mcp_server_url,
+               vc.account_id,
+               vc.auth_type,
+               vc.ciphertext,
+               vc.nonce,
+               vc.updated_at AS credential_updated_at
+          FROM sessions s
+          JOIN agents a ON a.id = s.agent_id
+          LEFT JOIN agent_versions av
+            ON av.agent_id = s.agent_id
+           AND av.version = s.agent_version
+          JOIN session_vaults sv ON sv.session_id = s.id
+          JOIN vault_credentials vc ON vc.vault_id = sv.vault_id
+         WHERE s.archived_at IS NULL
+           AND s.status <> 'terminated'
+           AND vc.archived_at IS NULL
+           AND vc.account_id IS NOT NULL
+         ORDER BY s.id, sv.rank, vc.id
+        """
+    )
+    specs: list[InboundSubscriptionSpec] = []
+    seen: set[tuple[str, str, str, str, str]] = set()
+    for row in rows:
+        mcp_servers_raw = _parse_jsonb(row["mcp_servers"]) or []
+        if not isinstance(mcp_servers_raw, list):
+            continue
+        for server in mcp_servers_raw:
+            if not isinstance(server, dict):
+                continue
+            name = server.get("name")
+            url = server.get("url")
+            if not isinstance(name, str) or not isinstance(url, str):
+                continue
+            if url != row["mcp_server_url"]:
+                continue
+            account_id = str(row["account_id"])
+            key = (
+                str(row["session_id"]),
+                name,
+                url,
+                str(row["vault_credential_id"]),
+                account_id,
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            specs.append(
+                InboundSubscriptionSpec(
+                    session_id=str(row["session_id"]),
+                    mcp_server_name=name,
+                    mcp_server_url=url,
+                    vault_id=str(row["vault_id"]),
+                    vault_credential_id=str(row["vault_credential_id"]),
+                    account_id=account_id,
+                    auth_type=str(row["auth_type"]),
+                    blob=EncryptedBlob(
+                        ciphertext=bytes(row["ciphertext"]),
+                        nonce=bytes(row["nonce"]),
+                    ),
+                    credential_updated_at=row["credential_updated_at"],
+                )
+            )
+    return specs
 
 
 # ─── skills ──────────────────────────────────────────────────────────────────

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -12,6 +12,7 @@ import asyncpg
 from aios.db import queries
 from aios.models.channel_bindings import ChannelBinding
 from aios.models.events import Event
+from aios.models.session_channels import SessionChannel
 
 MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: "
 
@@ -51,13 +52,16 @@ def focal_channel_meta_value(focal: str | None) -> str | None:
     return f"{parts[1]}/{parts[2]}"
 
 
-async def list_session_bindings(pool: asyncpg.Pool[Any], session_id: str) -> list[ChannelBinding]:
-    """Load the session's active channel bindings for context composition."""
+type ChannelState = ChannelBinding | SessionChannel
+
+
+async def list_session_bindings(pool: asyncpg.Pool[Any], session_id: str) -> list[ChannelState]:
+    """Load active MCP session channels plus legacy bindings for context composition."""
     async with pool.acquire() as conn:
-        return await queries.list_session_bindings(conn, session_id)
+        return await queries.list_session_channels_and_bindings(conn, session_id)
 
 
-def build_focal_paradigm_block(bindings: list[ChannelBinding]) -> str:
+def build_focal_paradigm_block(bindings: list[ChannelState]) -> str:
     """Generic, connector-agnostic prose introducing the focal-channel paradigm.
 
     Cache-stable: the block's text does not vary across steps, so the
@@ -128,7 +132,7 @@ def build_focal_paradigm_block(bindings: list[ChannelBinding]) -> str:
     )
 
 
-def augment_with_focal_paradigm(base_system: str, bindings: list[ChannelBinding]) -> str:
+def augment_with_focal_paradigm(base_system: str, bindings: list[ChannelState]) -> str:
     block = build_focal_paradigm_block(bindings)
     if not block:
         return base_system
@@ -137,7 +141,7 @@ def augment_with_focal_paradigm(base_system: str, bindings: list[ChannelBinding]
     return block
 
 
-def max_tail_block_local(bindings: list[ChannelBinding]) -> int:
+def max_tail_block_local(bindings: list[ChannelState]) -> int:
     """Worst-case local-token cost of :func:`build_channels_tail_block`.
 
     Called at windowing time when the *actual* tail block isn't yet
@@ -164,7 +168,7 @@ def max_tail_block_local(bindings: list[ChannelBinding]) -> int:
 
 
 def build_channels_tail_block(
-    bindings: list[ChannelBinding],
+    bindings: list[ChannelState],
     events: list[Event],
     focal_channel: str | None,
 ) -> dict[str, Any] | None:

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -38,8 +38,8 @@ from aios.tools.registry import to_openai_tools
 if TYPE_CHECKING:
     import asyncpg
 
+    from aios.harness.channels import ChannelState
     from aios.models.agents import Agent, AgentVersion
-    from aios.models.channel_bindings import ChannelBinding
     from aios.models.events import Event
     from aios.models.memory_stores import MemoryStoreResourceEcho
     from aios.models.sessions import Session
@@ -86,7 +86,7 @@ async def compute_step_prelude(
     *,
     session: Session,
     agent: Agent | AgentVersion,
-    bindings: list[ChannelBinding],
+    bindings: list[ChannelState],
     memory_store_echoes: list[MemoryStoreResourceEcho],
 ) -> StepPrelude:
     """Build the events-independent parts of the step payload.
@@ -140,7 +140,7 @@ async def compose_step_context(
     *,
     session: Session,
     agent: Agent | AgentVersion,
-    bindings: list[ChannelBinding],
+    bindings: list[ChannelState],
     prelude: StepPrelude,
     events: list[Event],
 ) -> StepContext:

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -34,6 +34,7 @@ ROUTING_RULE: Final = "rrul"
 MEMORY_STORE: Final = "memstore"
 MEMORY: Final = "mem"
 MEMORY_VERSION: Final = "memver"
+SESSION_CHANNEL: Final = "sch"
 
 _PREFIXES: Final = frozenset(
     {
@@ -52,6 +53,7 @@ _PREFIXES: Final = frozenset(
         MEMORY_STORE,
         MEMORY,
         MEMORY_VERSION,
+        SESSION_CHANNEL,
     }
 )
 

--- a/src/aios/inbound/__init__.py
+++ b/src/aios/inbound/__init__.py
@@ -1,0 +1,1 @@
+"""MCP inbound runtime."""

--- a/src/aios/inbound/protocol.py
+++ b/src/aios/inbound/protocol.py
@@ -1,0 +1,215 @@
+"""Raw MCP Streamable HTTP client for aios inbound notifications."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import AsyncExitStack, suppress
+from typing import Any
+
+import httpx
+from mcp.client.streamable_http import streamable_http_client
+from mcp.shared.message import SessionMessage
+from mcp.types import (
+    LATEST_PROTOCOL_VERSION,
+    ClientCapabilities,
+    ErrorData,
+    Implementation,
+    InitializeResult,
+    JSONRPCError,
+    JSONRPCMessage,
+    JSONRPCNotification,
+    JSONRPCRequest,
+    JSONRPCResponse,
+)
+
+INBOUND_CAPABILITY = "aiosInbound"
+INBOUND_SUBSCRIBE_TOOL = "aios_inbound_subscribe"
+NOTIFICATION_MESSAGE = "notifications/aios/inbound/message"
+NOTIFICATION_CHANNELS_SNAPSHOT = "notifications/aios/inbound/channels_snapshot"
+NOTIFICATION_CHANNELS_DELTA = "notifications/aios/inbound/channels_delta"
+NOTIFICATION_REPLAY_LOST = "notifications/aios/inbound/replay_lost"
+
+_MCP_INBOUND_TIMEOUT = httpx.Timeout(connect=10.0, read=None, write=10.0, pool=10.0)
+
+
+class JsonRpcError(RuntimeError):
+    def __init__(self, error: ErrorData) -> None:
+        super().__init__(error.message)
+        self.error = error
+
+
+class RawInboundMcpClient:
+    """Small raw JSON-RPC client that accepts aios custom notifications."""
+
+    def __init__(
+        self,
+        url: str,
+        headers: dict[str, str],
+        *,
+        client_name: str = "aios-inbound",
+        client_version: str = "0",
+    ) -> None:
+        self.url = url
+        self.headers = headers
+        self.client_name = client_name
+        self.client_version = client_version
+        self._stack: AsyncExitStack | None = None
+        self._write_stream: Any | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._next_id = 1
+        self._pending: dict[str | int, asyncio.Future[dict[str, Any]]] = {}
+        self._notifications: asyncio.Queue[JSONRPCNotification] = asyncio.Queue()
+
+    async def __aenter__(self) -> RawInboundMcpClient:
+        stack = AsyncExitStack()
+        await stack.__aenter__()
+        try:
+            http_client = await stack.enter_async_context(
+                httpx.AsyncClient(headers=self.headers, timeout=_MCP_INBOUND_TIMEOUT)
+            )
+            read_stream, write_stream, _ = await stack.enter_async_context(
+                streamable_http_client(self.url, http_client=http_client)
+            )
+            self._write_stream = write_stream
+            self._reader_task = asyncio.create_task(
+                self._read_loop(read_stream),
+                name="mcp-inbound-read-loop",
+            )
+            self._stack = stack
+        except BaseException:
+            await stack.aclose()
+            raise
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._reader_task
+            self._reader_task = None
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.cancel()
+        self._pending.clear()
+        if self._stack is not None:
+            await self._stack.aclose()
+            self._stack = None
+        self._write_stream = None
+
+    async def initialize(self) -> InitializeResult:
+        result = await self.request(
+            "initialize",
+            {
+                "protocolVersion": LATEST_PROTOCOL_VERSION,
+                "capabilities": ClientCapabilities().model_dump(
+                    by_alias=True, mode="json", exclude_none=True
+                ),
+                "clientInfo": Implementation(
+                    name=self.client_name,
+                    version=self.client_version,
+                ).model_dump(by_alias=True, mode="json", exclude_none=True),
+            },
+        )
+        await self.notify("notifications/initialized")
+        return InitializeResult.model_validate(result)
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        result = await self.request("tools/list", None)
+        tools = result.get("tools")
+        return tools if isinstance(tools, list) else []
+
+    async def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+        return await self.request(
+            "tools/call",
+            {
+                "name": name,
+                "arguments": arguments or {},
+            },
+        )
+
+    async def request(
+        self,
+        method: str,
+        params: dict[str, Any] | None,
+        *,
+        request_timeout: float = 30.0,
+    ) -> dict[str, Any]:
+        if self._write_stream is None:
+            raise RuntimeError("MCP client is not connected")
+        request_id = self._next_id
+        self._next_id += 1
+        fut: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+        self._pending[request_id] = fut
+        message = JSONRPCRequest(jsonrpc="2.0", id=request_id, method=method, params=params)
+        await self._send(JSONRPCMessage(message))
+        try:
+            return await asyncio.wait_for(fut, timeout=request_timeout)
+        finally:
+            self._pending.pop(request_id, None)
+
+    async def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        await self._send(
+            JSONRPCMessage(JSONRPCNotification(jsonrpc="2.0", method=method, params=params))
+        )
+
+    async def notifications(self) -> AsyncIterator[JSONRPCNotification]:
+        while True:
+            yield await self._notifications.get()
+
+    async def _send(self, message: JSONRPCMessage) -> None:
+        if self._write_stream is None:
+            raise RuntimeError("MCP client is not connected")
+        await self._write_stream.send(SessionMessage(message=message))
+
+    async def _read_loop(self, read_stream: Any) -> None:
+        try:
+            async for incoming in read_stream:
+                if isinstance(incoming, Exception):
+                    self._fail_pending(incoming)
+                    continue
+                root = incoming.message.root
+                if isinstance(root, JSONRPCResponse):
+                    fut = self._pending.get(root.id)
+                    if fut is not None and not fut.done():
+                        fut.set_result(root.result)
+                elif isinstance(root, JSONRPCError):
+                    fut = self._pending.get(root.id)
+                    if fut is not None and not fut.done():
+                        fut.set_exception(JsonRpcError(root.error))
+                elif isinstance(root, JSONRPCNotification):
+                    await self._notifications.put(root)
+                elif isinstance(root, JSONRPCRequest):
+                    await self._respond_method_not_found(root)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._fail_pending(exc)
+
+    def _fail_pending(self, exc: BaseException) -> None:
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.set_exception(exc)
+
+    async def _respond_method_not_found(self, request: JSONRPCRequest) -> None:
+        error = JSONRPCError(
+            jsonrpc="2.0",
+            id=request.id,
+            error=ErrorData(code=-32601, message="Method not found"),
+        )
+        await self._send(JSONRPCMessage(error))
+
+
+def has_aios_inbound_capability(init_result: InitializeResult) -> bool:
+    experimental = init_result.capabilities.experimental
+    return isinstance(experimental, dict) and INBOUND_CAPABILITY in experimental
+
+
+def find_hidden_subscribe_tool(tools: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for tool in tools:
+        if tool.get("name") != INBOUND_SUBSCRIBE_TOOL:
+            continue
+        meta = tool.get("_meta") or tool.get("meta")
+        if isinstance(meta, dict) and meta.get("aios.internal") is True:
+            return tool
+    return None

--- a/src/aios/inbound/runtime.py
+++ b/src/aios/inbound/runtime.py
@@ -1,0 +1,267 @@
+"""Long-running MCP inbound supervisor."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import Any
+
+import asyncpg
+
+from aios.crypto.vault import CryptoBox
+from aios.db import queries
+from aios.logging import get_logger
+from aios.models.inbound import InboundSubscriptionSpec
+from aios.services import inbound as inbound_service
+from aios.services.vaults import is_expiring, refresh_credential
+
+from .protocol import (
+    NOTIFICATION_CHANNELS_DELTA,
+    NOTIFICATION_CHANNELS_SNAPSHOT,
+    NOTIFICATION_MESSAGE,
+    NOTIFICATION_REPLAY_LOST,
+    RawInboundMcpClient,
+    find_hidden_subscribe_tool,
+    has_aios_inbound_capability,
+)
+
+log = get_logger("aios.inbound")
+
+POLL_INTERVAL_SECONDS = 5.0
+UNSUPPORTED_RETRY_SECONDS = 60.0
+RECONNECT_BASE_SECONDS = 1.0
+RECONNECT_MAX_SECONDS = 30.0
+
+
+class InboundSupervisor:
+    def __init__(
+        self,
+        *,
+        pool: asyncpg.Pool[Any],
+        crypto_box: CryptoBox,
+        poll_interval_seconds: float = POLL_INTERVAL_SECONDS,
+    ) -> None:
+        self.pool = pool
+        self.crypto_box = crypto_box
+        self.poll_interval_seconds = poll_interval_seconds
+        self._tasks: dict[tuple[str, str, str, str, str, str], asyncio.Task[None]] = {}
+
+    async def run_forever(self) -> None:
+        try:
+            while True:
+                await self.reconcile_once()
+                await asyncio.sleep(self.poll_interval_seconds)
+        finally:
+            await self.shutdown()
+
+    async def reconcile_once(self) -> None:
+        async with self.pool.acquire() as conn:
+            specs = await queries.list_inbound_subscription_specs(conn)
+        desired = {spec.key: spec for spec in specs}
+
+        for key, task in list(self._tasks.items()):
+            if task.done() or key not in desired:
+                if not task.done():
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+                self._tasks.pop(key, None)
+
+        for key, spec in desired.items():
+            if key in self._tasks:
+                continue
+            self._tasks[key] = asyncio.create_task(
+                self._run_subscription(spec),
+                name=f"mcp-inbound:{spec.session_id}:{spec.mcp_server_name}:{spec.account_id}",
+            )
+
+    async def shutdown(self) -> None:
+        tasks = list(self._tasks.values())
+        self._tasks.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _run_subscription(self, spec: InboundSubscriptionSpec) -> None:
+        delay = RECONNECT_BASE_SECONDS
+        while True:
+            try:
+                await self._subscription_once(spec)
+                delay = RECONNECT_BASE_SECONDS
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.warning(
+                    "inbound.subscription_failed",
+                    session_id=spec.session_id,
+                    server_name=spec.mcp_server_name,
+                    account_id=spec.account_id,
+                    exc_info=True,
+                )
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, RECONNECT_MAX_SECONDS)
+
+    async def _subscription_once(self, spec: InboundSubscriptionSpec) -> None:
+        headers = await _headers_for_spec(self.pool, self.crypto_box, spec)
+        async with self.pool.acquire() as conn:
+            since_event_id = await queries.get_inbound_cursor(
+                conn,
+                session_id=spec.session_id,
+                mcp_server_name=spec.mcp_server_name,
+                vault_credential_id=spec.vault_credential_id,
+                account_id=spec.account_id,
+            )
+
+        async with RawInboundMcpClient(spec.mcp_server_url, headers) as client:
+            init_result = await client.initialize()
+            if not has_aios_inbound_capability(init_result):
+                log.info(
+                    "inbound.unsupported_server",
+                    session_id=spec.session_id,
+                    server_name=spec.mcp_server_name,
+                    url=spec.mcp_server_url,
+                )
+                await asyncio.sleep(UNSUPPORTED_RETRY_SECONDS)
+                return
+
+            tools = await client.list_tools()
+            if find_hidden_subscribe_tool(tools) is None:
+                log.info(
+                    "inbound.subscribe_tool_missing",
+                    session_id=spec.session_id,
+                    server_name=spec.mcp_server_name,
+                    url=spec.mcp_server_url,
+                )
+                await asyncio.sleep(UNSUPPORTED_RETRY_SECONDS)
+                return
+
+            await client.call_tool(
+                "aios_inbound_subscribe",
+                {
+                    "account_id": spec.account_id,
+                    "since_event_id": since_event_id,
+                },
+            )
+            log.info(
+                "inbound.subscribed",
+                session_id=spec.session_id,
+                server_name=spec.mcp_server_name,
+                account_id=spec.account_id,
+                since_event_id=since_event_id,
+            )
+
+            async for notification in client.notifications():
+                params = notification.params if isinstance(notification.params, dict) else {}
+                await self._handle_notification(spec, notification.method, params)
+
+    async def _handle_notification(
+        self,
+        spec: InboundSubscriptionSpec,
+        method: str,
+        params: dict[str, Any],
+    ) -> None:
+        if method == NOTIFICATION_MESSAGE:
+            event_id = params.get("event_id")
+            channel = params.get("channel")
+            content = params.get("content")
+            metadata = params.get("metadata") or {}
+            if (
+                not isinstance(event_id, str)
+                or not isinstance(channel, str)
+                or not isinstance(content, str)
+            ):
+                log.warning("inbound.bad_message_notification", method=method, params=params)
+                return
+            if not isinstance(metadata, dict):
+                metadata = {}
+            await inbound_service.ingest_inbound_message(
+                self.pool,
+                spec,
+                event_id=event_id,
+                channel=channel,
+                content=content,
+                metadata=metadata,
+            )
+            return
+
+        if method == NOTIFICATION_CHANNELS_SNAPSHOT:
+            channels = params.get("channels")
+            await inbound_service.apply_channels_snapshot(
+                self.pool,
+                spec,
+                channels if isinstance(channels, list) else [],
+            )
+            return
+
+        if method == NOTIFICATION_CHANNELS_DELTA:
+            upserts = params.get("upserts") or params.get("upsert") or []
+            archives = (
+                params.get("archives") or params.get("archived") or params.get("removes") or []
+            )
+            await inbound_service.apply_channels_delta(
+                self.pool,
+                spec,
+                upserts=upserts if isinstance(upserts, list) else [],
+                archives=archives if isinstance(archives, list) else [],
+            )
+            return
+
+        if method == NOTIFICATION_REPLAY_LOST:
+            await inbound_service.record_replay_lost(self.pool, spec, params)
+            return
+
+        log.debug("inbound.unknown_notification", method=method)
+
+
+async def _headers_for_spec(
+    pool: asyncpg.Pool[Any],
+    crypto_box: CryptoBox,
+    spec: InboundSubscriptionSpec,
+) -> dict[str, str]:
+    blob = spec.blob
+    auth_type = spec.auth_type
+    payload = json.loads(crypto_box.decrypt(blob))
+    if auth_type == "mcp_oauth" and is_expiring(payload):
+        async with pool.acquire() as conn:
+            await refresh_credential(
+                crypto_box,
+                conn,
+                vault_id=spec.vault_id,
+                mcp_server_url=spec.mcp_server_url,
+            )
+            refreshed = await queries.resolve_vault_credential(
+                conn,
+                vault_id=spec.vault_id,
+                mcp_server_url=spec.mcp_server_url,
+            )
+            if refreshed is None:
+                return {}
+            blob, auth_type = refreshed
+            payload = json.loads(crypto_box.decrypt(blob))
+
+    token = str(payload.get("access_token" if auth_type == "mcp_oauth" else "token", ""))
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+async def inbound_main() -> None:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+    from aios.harness.procrastinate_app import app as procrastinate_app
+    from aios.logging import configure_logging
+
+    settings = get_settings()
+    configure_logging(settings.log_level)
+    pool = await create_pool(settings.db_url, max_size=settings.db_pool_max_size)
+    crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    await procrastinate_app.open_async()
+    supervisor = InboundSupervisor(pool=pool, crypto_box=crypto_box)
+    log.info("inbound.startup")
+    try:
+        await supervisor.run_forever()
+    finally:
+        log.info("inbound.shutdown")
+        await supervisor.shutdown()
+        await procrastinate_app.close_async()
+        await pool.close()

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -164,16 +164,25 @@ async def discover_mcp_tools(
                 session, init_result = await _open_session(url, headers, stack)
                 result = await session.list_tools()
 
-        if len(result.tools) > MAX_TOOLS_PER_SERVER:
+        visible_tools = [
+            tool
+            for tool in result.tools
+            if not (
+                isinstance(getattr(tool, "meta", None), dict)
+                and getattr(tool, "meta", {}).get("aios.internal") is True
+            )
+        ]
+
+        if len(visible_tools) > MAX_TOOLS_PER_SERVER:
             log.warning(
                 "mcp.tools_truncated",
                 server_name=server_name,
-                total=len(result.tools),
+                total=len(visible_tools),
                 limit=MAX_TOOLS_PER_SERVER,
             )
 
         tools: list[dict[str, Any]] = []
-        for tool in result.tools[:MAX_TOOLS_PER_SERVER]:
+        for tool in visible_tools[:MAX_TOOLS_PER_SERVER]:
             tools.append(
                 {
                     "type": "function",

--- a/src/aios/models/inbound.py
+++ b/src/aios/models/inbound.py
@@ -1,0 +1,34 @@
+"""Internal models for MCP inbound subscriptions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from aios.crypto.vault import EncryptedBlob
+
+
+@dataclass(frozen=True, slots=True)
+class InboundSubscriptionSpec:
+    """One session/account subscription the inbound process should maintain."""
+
+    session_id: str
+    mcp_server_name: str
+    mcp_server_url: str
+    vault_id: str
+    vault_credential_id: str
+    account_id: str
+    auth_type: str
+    blob: EncryptedBlob
+    credential_updated_at: datetime
+
+    @property
+    def key(self) -> tuple[str, str, str, str, str, str]:
+        return (
+            self.session_id,
+            self.mcp_server_name,
+            self.mcp_server_url,
+            self.vault_credential_id,
+            self.account_id,
+            self.credential_updated_at.isoformat(),
+        )

--- a/src/aios/models/session_channels.py
+++ b/src/aios/models/session_channels.py
@@ -1,0 +1,34 @@
+"""Session-owned connector channel state.
+
+``session_channels`` is the MCP-inbound replacement for legacy
+``channel_bindings``. A row records one channel that a session may focus with
+``switch_channel``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+NotificationMode = Literal["focal_candidate", "silent"]
+
+
+class SessionChannel(BaseModel):
+    """Read view of one session materialized channel."""
+
+    id: str
+    session_id: str
+    mcp_server_name: str
+    mcp_server_url: str
+    account_id: str
+    path: str
+    address: str
+    display_name: str | None = None
+    notification_mode: NotificationMode = "focal_candidate"
+    metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+    last_seen_at: datetime
+    archived_at: datetime | None = None

--- a/src/aios/services/inbound.py
+++ b/src/aios/services/inbound.py
@@ -1,0 +1,258 @@
+"""MCP inbound message ingestion and channel-state application."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from aios.db import queries
+from aios.errors import ValidationError
+from aios.harness.wake import defer_wake
+from aios.models.events import Event
+from aios.models.inbound import InboundSubscriptionSpec
+from aios.models.session_channels import SessionChannel
+
+
+def parse_account_relative_channel(channel: str, *, account_id: str) -> str:
+    """Return the path part of ``<account_id>/<path>`` after validation."""
+    account, sep, path = channel.partition("/")
+    if not sep or not account or not path:
+        raise ValidationError(
+            "inbound channel must be '<account>/<path>'",
+            detail={"channel": channel},
+        )
+    if account != account_id:
+        raise ValidationError(
+            "inbound channel account does not match credential account",
+            detail={"channel": channel, "account_id": account_id},
+        )
+    return path
+
+
+def _display_name_from_metadata(metadata: dict[str, Any]) -> str | None:
+    for key in ("chat_name", "sender_name", "display_name", "name"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+async def ingest_inbound_message(
+    pool: asyncpg.Pool[Any],
+    spec: InboundSubscriptionSpec,
+    *,
+    event_id: str,
+    channel: str,
+    content: str,
+    metadata: dict[str, Any] | None = None,
+) -> Event | None:
+    """Persist one inbound MCP message and wake the owning session.
+
+    Returns ``None`` when the connector event id has already been processed
+    for this session/subscription.
+    """
+    if not event_id:
+        raise ValidationError("inbound message missing event_id")
+    if not isinstance(content, str):
+        raise ValidationError("inbound message content must be a string")
+
+    path = parse_account_relative_channel(channel, account_id=spec.account_id)
+    address = f"{spec.mcp_server_name}/{channel}"
+    clean_metadata = dict(metadata or {})
+    clean_metadata["channel"] = address
+    clean_metadata["inbound_event_id"] = event_id
+    clean_metadata["mcp_server_name"] = spec.mcp_server_name
+    clean_metadata["mcp_server_url"] = spec.mcp_server_url
+    clean_metadata["account_id"] = spec.account_id
+
+    async with pool.acquire() as conn, conn.transaction():
+        await queries.upsert_session_channel(
+            conn,
+            session_id=spec.session_id,
+            mcp_server_name=spec.mcp_server_name,
+            mcp_server_url=spec.mcp_server_url,
+            account_id=spec.account_id,
+            path=path,
+            display_name=_display_name_from_metadata(clean_metadata),
+            metadata={
+                k: v
+                for k, v in clean_metadata.items()
+                if k
+                in {
+                    "chat_name",
+                    "sender_name",
+                    "chat_type",
+                    "display_name",
+                    "name",
+                }
+            },
+        )
+        inserted = await queries.insert_inbound_receipt(
+            conn,
+            session_id=spec.session_id,
+            mcp_server_name=spec.mcp_server_name,
+            account_id=spec.account_id,
+            event_id=event_id,
+        )
+        if not inserted:
+            return None
+        event = await queries.append_event(
+            conn,
+            session_id=spec.session_id,
+            kind="message",
+            data={"role": "user", "content": content, "metadata": clean_metadata},
+            orig_channel=address,
+        )
+        await queries.set_inbound_receipt_event(
+            conn,
+            session_id=spec.session_id,
+            mcp_server_name=spec.mcp_server_name,
+            account_id=spec.account_id,
+            event_id=event_id,
+            event_row_id=event.id,
+        )
+        await queries.set_inbound_cursor(
+            conn,
+            session_id=spec.session_id,
+            mcp_server_name=spec.mcp_server_name,
+            mcp_server_url=spec.mcp_server_url,
+            vault_credential_id=spec.vault_credential_id,
+            account_id=spec.account_id,
+            last_event_id=event_id,
+        )
+        await conn.execute(
+            "UPDATE sessions SET status = 'pending', updated_at = now() "
+            "WHERE id = $1 AND status = 'idle'",
+            spec.session_id,
+        )
+
+    await defer_wake(pool, spec.session_id, cause="inbound_message")
+    return event
+
+
+async def apply_channels_snapshot(
+    pool: asyncpg.Pool[Any],
+    spec: InboundSubscriptionSpec,
+    channels: list[Any],
+) -> list[SessionChannel]:
+    """Replace-ish channel state from a connector snapshot.
+
+    The coexistence implementation upserts channels from the snapshot but does
+    not archive omitted rows; connectors may send partial snapshots.
+    """
+    out: list[SessionChannel] = []
+    async with pool.acquire() as conn:
+        for entry in channels:
+            parsed = _parse_channel_entry(entry, account_id=spec.account_id)
+            if parsed is None:
+                continue
+            path, display_name, notification_mode, metadata = parsed
+            out.append(
+                await queries.upsert_session_channel(
+                    conn,
+                    session_id=spec.session_id,
+                    mcp_server_name=spec.mcp_server_name,
+                    mcp_server_url=spec.mcp_server_url,
+                    account_id=spec.account_id,
+                    path=path,
+                    display_name=display_name,
+                    notification_mode=notification_mode,
+                    metadata=metadata,
+                )
+            )
+    return out
+
+
+async def apply_channels_delta(
+    pool: asyncpg.Pool[Any],
+    spec: InboundSubscriptionSpec,
+    *,
+    upserts: list[Any],
+    archives: list[Any],
+) -> None:
+    async with pool.acquire() as conn:
+        for entry in upserts:
+            parsed = _parse_channel_entry(entry, account_id=spec.account_id)
+            if parsed is None:
+                continue
+            path, display_name, notification_mode, metadata = parsed
+            await queries.upsert_session_channel(
+                conn,
+                session_id=spec.session_id,
+                mcp_server_name=spec.mcp_server_name,
+                mcp_server_url=spec.mcp_server_url,
+                account_id=spec.account_id,
+                path=path,
+                display_name=display_name,
+                notification_mode=notification_mode,
+                metadata=metadata,
+            )
+        for entry in archives:
+            channel = entry.get("channel") if isinstance(entry, dict) else entry
+            if not isinstance(channel, str):
+                continue
+            path = parse_account_relative_channel(channel, account_id=spec.account_id)
+            await queries.archive_session_channel(
+                conn,
+                session_id=spec.session_id,
+                mcp_server_name=spec.mcp_server_name,
+                account_id=spec.account_id,
+                path=path,
+            )
+
+
+async def record_replay_lost(
+    pool: asyncpg.Pool[Any],
+    spec: InboundSubscriptionSpec,
+    params: dict[str, Any],
+) -> None:
+    async with pool.acquire() as conn:
+        await queries.append_event(
+            conn,
+            session_id=spec.session_id,
+            kind="span",
+            data={
+                "event": "mcp_inbound_replay_lost",
+                "mcp_server_name": spec.mcp_server_name,
+                "account_id": spec.account_id,
+                "params": params,
+            },
+        )
+        await queries.set_inbound_cursor(
+            conn,
+            session_id=spec.session_id,
+            mcp_server_name=spec.mcp_server_name,
+            mcp_server_url=spec.mcp_server_url,
+            vault_credential_id=spec.vault_credential_id,
+            account_id=spec.account_id,
+            last_event_id=None,
+        )
+
+
+def _parse_channel_entry(
+    entry: Any, *, account_id: str
+) -> tuple[str, str | None, str, dict[str, Any]] | None:
+    if isinstance(entry, str):
+        return (
+            parse_account_relative_channel(entry, account_id=account_id),
+            None,
+            "focal_candidate",
+            {},
+        )
+    if not isinstance(entry, dict):
+        return None
+    channel = entry.get("channel")
+    if not isinstance(channel, str):
+        return None
+    path = parse_account_relative_channel(channel, account_id=account_id)
+    display_name = entry.get("display_name") or entry.get("name")
+    if not isinstance(display_name, str):
+        display_name = None
+    notification_mode = entry.get("notification_mode")
+    if notification_mode not in ("focal_candidate", "silent"):
+        notification_mode = "focal_candidate"
+    metadata = entry.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    return path, display_name, notification_mode, metadata

--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -128,7 +128,7 @@ async def switch_channel_handler(session_id: str, arguments: dict[str, Any]) -> 
                 },
             )
 
-        bindings = await queries.list_session_bindings(conn, session_id)
+        bindings = await queries.list_session_channels_and_bindings(conn, session_id)
         valid_targets = {b.address for b in bindings if b.archived_at is None}
         if target not in valid_targets:
             return ToolResult(

--- a/tests/unit/test_ids.py
+++ b/tests/unit/test_ids.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 import pytest
 
-from aios.ids import AGENT, CREDENTIAL, ENVIRONMENT, EVENT, SESSION, make_id, split_id
+from aios.ids import (
+    AGENT,
+    CREDENTIAL,
+    ENVIRONMENT,
+    EVENT,
+    SESSION,
+    SESSION_CHANNEL,
+    make_id,
+    split_id,
+)
 
 
 class TestMakeId:
@@ -20,7 +29,7 @@ class TestMakeId:
 
     @pytest.mark.parametrize(
         "prefix",
-        [AGENT, ENVIRONMENT, SESSION, EVENT, CREDENTIAL],
+        [AGENT, ENVIRONMENT, SESSION, EVENT, CREDENTIAL, SESSION_CHANNEL],
     )
     def test_all_canonical_prefixes_accepted(self, prefix: str) -> None:
         result = make_id(prefix)

--- a/tests/unit/test_inbound_protocol.py
+++ b/tests/unit/test_inbound_protocol.py
@@ -1,0 +1,123 @@
+"""Unit tests for MCP inbound protocol helpers."""
+
+from __future__ import annotations
+
+import asyncio
+
+import anyio
+import pytest
+from mcp.shared.message import SessionMessage
+from mcp.types import (
+    ErrorData,
+    Implementation,
+    InitializeResult,
+    JSONRPCError,
+    JSONRPCMessage,
+    JSONRPCNotification,
+    JSONRPCResponse,
+    ServerCapabilities,
+)
+
+from aios.inbound.protocol import (
+    NOTIFICATION_MESSAGE,
+    JsonRpcError,
+    RawInboundMcpClient,
+    find_hidden_subscribe_tool,
+    has_aios_inbound_capability,
+)
+
+
+def test_detects_aios_inbound_capability() -> None:
+    result = InitializeResult(
+        protocolVersion="2025-06-18",
+        serverInfo=Implementation(name="signal", version="1"),
+        capabilities=ServerCapabilities(experimental={"aiosInbound": {"version": 1}}),
+    )
+    assert has_aios_inbound_capability(result) is True
+
+
+def test_missing_aios_inbound_capability_is_false() -> None:
+    result = InitializeResult(
+        protocolVersion="2025-06-18",
+        serverInfo=Implementation(name="other", version="1"),
+        capabilities=ServerCapabilities(),
+    )
+    assert has_aios_inbound_capability(result) is False
+
+
+def test_find_hidden_subscribe_tool_requires_internal_marker() -> None:
+    tools = [
+        {"name": "aios_inbound_subscribe", "_meta": {}},
+        {"name": "aios_inbound_subscribe", "_meta": {"aios.internal": True}},
+    ]
+    assert find_hidden_subscribe_tool(tools) == tools[1]
+
+
+async def test_raw_client_routes_response_and_custom_notification() -> None:
+    read_send, read_recv = anyio.create_memory_object_stream[SessionMessage | Exception](10)
+    write_send, write_recv = anyio.create_memory_object_stream[SessionMessage](10)
+    client = RawInboundMcpClient("http://mcp.test", {})
+    client._write_stream = write_send
+    reader = asyncio.create_task(client._read_loop(read_recv))
+    try:
+        request_task = asyncio.create_task(client.request("tools/list", None))
+        outbound = await write_recv.receive()
+        request_id = outbound.message.root.id
+
+        await read_send.send(
+            SessionMessage(
+                message=JSONRPCMessage(
+                    JSONRPCResponse(jsonrpc="2.0", id=request_id, result={"tools": []})
+                )
+            )
+        )
+        assert await request_task == {"tools": []}
+
+        await read_send.send(
+            SessionMessage(
+                message=JSONRPCMessage(
+                    JSONRPCNotification(
+                        jsonrpc="2.0",
+                        method=NOTIFICATION_MESSAGE,
+                        params={"event_id": "e1"},
+                    )
+                )
+            )
+        )
+        notification = await asyncio.wait_for(client._notifications.get(), timeout=1)
+        assert notification.method == NOTIFICATION_MESSAGE
+        assert notification.params == {"event_id": "e1"}
+    finally:
+        reader.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await reader
+
+
+async def test_raw_client_routes_jsonrpc_errors() -> None:
+    read_send, read_recv = anyio.create_memory_object_stream[SessionMessage | Exception](10)
+    write_send, write_recv = anyio.create_memory_object_stream[SessionMessage](10)
+    client = RawInboundMcpClient("http://mcp.test", {})
+    client._write_stream = write_send
+    reader = asyncio.create_task(client._read_loop(read_recv))
+    try:
+        request_task = asyncio.create_task(client.request("tools/call", {"name": "x"}))
+        outbound = await write_recv.receive()
+        request_id = outbound.message.root.id
+
+        await read_send.send(
+            SessionMessage(
+                message=JSONRPCMessage(
+                    JSONRPCError(
+                        jsonrpc="2.0",
+                        id=request_id,
+                        error=ErrorData(code=-32000, message="boom"),
+                    )
+                )
+            )
+        )
+        with pytest.raises(JsonRpcError, match="boom"):
+            await request_task
+    finally:
+        reader.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await reader

--- a/tests/unit/test_inbound_service.py
+++ b/tests/unit/test_inbound_service.py
@@ -1,0 +1,22 @@
+"""Unit tests for MCP inbound service validation helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.errors import ValidationError
+from aios.services.inbound import parse_account_relative_channel
+
+
+def test_parse_account_relative_channel_returns_path() -> None:
+    assert parse_account_relative_channel("acct/chat/1", account_id="acct") == "chat/1"
+
+
+def test_parse_account_relative_channel_rejects_wrong_account() -> None:
+    with pytest.raises(ValidationError, match="account does not match"):
+        parse_account_relative_channel("other/chat", account_id="acct")
+
+
+def test_parse_account_relative_channel_rejects_missing_path() -> None:
+    with pytest.raises(ValidationError, match="<account>/<path>"):
+        parse_account_relative_channel("acct", account_id="acct")

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -276,6 +276,32 @@ class TestDiscoverMcpTools:
         assert tools[0]["function"]["name"] == "mcp__myserver__tool_a"
         assert tools[1]["function"]["name"] == "mcp__myserver__tool_b"
 
+    async def test_discovery_filters_internal_aios_tools(self) -> None:
+        public_tool = _make_mock_tool("signal_send", "Send", {"type": "object"})
+        hidden_tool = _make_mock_tool("aios_inbound_subscribe", "Subscribe", {"type": "object"})
+        hidden_tool.meta = {"aios.internal": True}
+        mock_result = MagicMock()
+        mock_result.tools = [hidden_tool, public_tool]
+
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock(return_value=_mock_init_result())
+        mock_session.list_tools = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("aios.mcp.client.streamable_http_client") as mock_transport,
+            patch("aios.mcp.client.ClientSession") as mock_session_cls,
+        ):
+            mock_transport.return_value.__aenter__ = AsyncMock(
+                return_value=(MagicMock(), MagicMock(), MagicMock())
+            )
+            mock_transport.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            tools, _instructions = await discover_mcp_tools("https://mcp.signal/", "signal", {})
+
+        assert [t["function"]["name"] for t in tools] == ["mcp__signal__signal_send"]
+
     async def test_discovery_failure_returns_empty(self) -> None:
         with patch("aios.mcp.client.streamable_http_client") as mock_transport:
             mock_transport.return_value.__aenter__ = AsyncMock(side_effect=ConnectionError("down"))


### PR DESCRIPTION
## Summary

Adds the first end-to-end MCP inbound path for the connector redesign. This PR introduces the long-running `aios inbound` runtime, raw Streamable HTTP JSON-RPC subscription support, session-owned channel state, inbound cursors/receipts, and the Signal pilot connector implementation.

## What changed

- Add `aios inbound` to poll active sessions and subscribe to MCP servers declared on agents with bound vault credentials.
- Add raw inbound MCP protocol support for initialize, hidden subscribe tool calls, JSON-RPC responses/errors, and custom `notifications/aios/inbound/*` notifications.
- Add `session_channels`, inbound cursors, and inbound receipts as the new session-owned channel state for inbound delivery.
- Ingest inbound messages by validating account-relative channels, materializing session channels, deduping receipts, appending user events, and deferring wakes.
- Filter hidden internal MCP tools from model-visible outbound discovery.
- Convert Signal to stateful Streamable HTTP MCP inbound with subscription broker, replay buffer, channel snapshot/delta notifications, deterministic event IDs, and metadata parity tests.

## Validation

- `uv run pytest tests -q` -> `1213 passed`
- `uv run ruff check src tests`
- `uv run mypy src`
- `cd connectors/signal && uv run pytest tests -q` -> `111 passed, 2 warnings`
- `cd connectors/signal && uv run ruff check src tests`
- `cd connectors/signal && uv run mypy src`