### PR TITLE
[codex] Port Telegram to MCP inbound

### DIFF
--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -1,15 +1,14 @@
 # aios-telegram
 
 Telegram connector for [aios](../../README.md). One long-running process per
-Telegram bot — ingests inbound messages into aios via
-`POST /v1/connections/{id}/messages`, and serves an MCP server exposing a
-`telegram_send` tool that the aios worker calls back into.
+Telegram bot serves a stateful MCP server. aios uses the same MCP server for
+outbound tools (`telegram_send`) and inbound message subscriptions.
 
 ## Prerequisites
 
-- Python ≥ 3.13
+- Python >= 3.13
 - A Telegram bot token (talk to [@BotFather](https://t.me/BotFather))
-- A running aios instance with the connector/channel routing infra
+- A running aios API, worker, and inbound process.
 
 ## Install
 
@@ -31,8 +30,8 @@ uv sync --all-packages --dev
 
 Message [@BotFather](https://t.me/BotFather) on Telegram: `/newbot`. Copy
 the token. Learn the bot's numeric id by running a throwaway script
-(`curl https://api.telegram.org/bot<TOKEN>/getMe`) — you'll need it for
-the routing rule.
+(`curl https://api.telegram.org/bot<TOKEN>/getMe`). Use that numeric id as
+the vault credential `account_id`.
 
 ### 2. Create an aios vault + credential for the MCP token
 
@@ -41,6 +40,7 @@ VLT=$(curl -X POST :8090/v1/vaults -d '{"display_name": "Telegram personal"}' | 
 
 curl -X POST :8090/v1/vaults/$VLT/credentials -d '{
   "mcp_server_url": "http://localhost:9200/mcp",
+  "account_id": "<bot-numeric-id-from-step-1>",
   "auth_type": "static_bearer",
   "token": "supersecret"
 }'
@@ -67,25 +67,15 @@ Add the Telegram MCP server as a normal agent MCP server:
 }
 ```
 
-### 4. Register the aios connection
+### 4. Create a session with the Telegram vault
 
-The connection is the inbound channel account. Normal MCP discovery comes from
-the agent config above; the vault is supplied through the routing rule's
-session params.
-
-```
-CONN=$(curl -X POST :8090/v1/connections -d "{
-  \"connector\": \"telegram\",
-  \"account\": \"<bot-numeric-id-from-step-1>\"
-}" | jq -r .id)
-```
+Inbound subscriptions are session-scoped. Create or update a session for the
+agent above with `vault_ids: ["$VLT"]`. The `aios inbound` process will
+subscribe that session to the Telegram MCP server using the vault credential.
 
 ### 5. Start the connector
 
 ```
-export AIOS_URL=http://localhost:8090
-export AIOS_API_KEY=...
-export AIOS_CONNECTION_ID=$CONN
 export AIOS_TELEGRAM_MCP_TOKEN=supersecret
 
 python -m aios_telegram start --bot-token 123456:AA...
@@ -94,34 +84,24 @@ python -m aios_telegram start --bot-token 123456:AA...
 All settings can also be passed via env vars. Full list via
 `python -m aios_telegram start --help`.
 
-### 6. Add a routing rule
+### 6. Start aios inbound
 
 ```
-curl -X POST :8090/v1/connections/$CONN/routing-rules -d "{
-  \"prefix\": \"\",
-  \"target\": \"agent:<agent-id>\",
-  \"session_params\": {\"environment_id\": \"<env-id>\", \"vault_ids\": [\"$VLT\"]}
-}"
+aios inbound
 ```
-
-The empty prefix is the per-connection catch-all. The session vault binding is
-what gives the agent-declared Telegram MCP server its bearer token.
 
 ### 7. DM the bot — the agent replies
 
 DM the bot from a Telegram client. Watch the aios event log: the inbound
-message shows up with `metadata.channel` set, a session is created on
-first inbound, and the agent's `telegram_send` call delivers the reply
-back to Telegram.
+message shows up with `metadata.channel` set to
+`telegram/<bot-numeric-id>/<chat-id>`. The agent can focus that channel with
+`switch_channel`; `telegram_send` uses the focused channel via MCP `_meta`.
 
 ## Configuration reference
 
 | Flag | Env var | Default | Description |
 |---|---|---|---|
 | `--bot-token` | `AIOS_TELEGRAM_BOT_TOKEN` | required | Bot token from BotFather |
-| `--aios-url` | `AIOS_URL` | required | Base URL of aios API |
-| `--aios-api-key` | `AIOS_API_KEY` | required | Bearer token for aios API |
-| `--aios-connection-id` | `AIOS_CONNECTION_ID` | required | ID of the pre-registered connection |
 | `--mcp-bind` | `AIOS_TELEGRAM_MCP_BIND` | `127.0.0.1:9200` | Host:port for MCP server |
 | `--mcp-token` | `AIOS_TELEGRAM_MCP_TOKEN` | required | Token MCP clients must present |
 
@@ -129,13 +109,13 @@ back to Telegram.
 
 `app.run()` wires two tasks under a single `asyncio.TaskGroup`:
 
-1. **PTB `Application`** — python-telegram-bot's asyncio Application drives
+1. **PTB `Application`** - python-telegram-bot's asyncio Application drives
    the update loop (long polling). Discovers the bot's numeric id via
    `getMe` on startup. Every incoming message is parsed into an
-   `InboundMessage` and posted to aios via
-   `POST /v1/connections/{id}/messages`.
-2. **MCP server** — FastMCP on uvicorn, bearer-auth-gated, exposing
-   `telegram_send`.
+   `InboundMessage` and published to the connector-local MCP inbound broker.
+2. **MCP server** - stateful FastMCP on uvicorn, bearer-auth-gated, exposing
+   `telegram_send` and the hidden `aios_inbound_subscribe` hook used by
+   `aios inbound`.
 
 **Crash-is-fatal.** Any task failure propagates through the TaskGroup and
 exits the process non-zero. There is no auto-reconnect. Run under systemd
@@ -155,18 +135,17 @@ exits the process non-zero. There is no auto-reconnect. Run under systemd
   literally until a v2 adds MarkdownV2 escaping.
 - Message splitting — Telegram's 4096-char limit surfaces as a Bad Request
   the model must handle by retrying shorter.
-- User allowlist — routing rules gate access server-side.
+- User allowlist - session and vault selection gate which agents subscribe.
 - Auto-reconnect on Telegram outage.
 
 ## Troubleshooting
 
 - **MCP calls returning 401**: the `--mcp-token` on the connector doesn't
   match the `token` stored in the aios vault's credential for this
-  connection.
-- **Inbound messages never appear in aios**: check the connector logs for
-  `ingest.client_error` (malformed payload — likely a connector bug) or
-  `ingest.retries_exhausted` (aios was unreachable long enough to exhaust
-  the 1/2/4/8s backoff).
+  MCP server.
+- **Inbound messages never appear in aios**: check that `aios inbound` is
+  running, the session has the vault attached, and the vault credential has
+  `account_id` set to the bot numeric id.
 - **`Unauthorized` from Telegram on startup**: the bot token is wrong or
   revoked. Re-check with BotFather.
 

--- a/connectors/telegram/src/aios_telegram/__main__.py
+++ b/connectors/telegram/src/aios_telegram/__main__.py
@@ -22,9 +22,6 @@ def _build_parser() -> argparse.ArgumentParser:
 
     start = sub.add_parser("start", help="start the telegram connector")
     start.add_argument("--bot-token", help="Telegram bot token (AIOS_TELEGRAM_BOT_TOKEN)")
-    start.add_argument("--aios-url", help="aios base URL (AIOS_URL)")
-    start.add_argument("--aios-api-key", help="aios bearer token (AIOS_API_KEY)")
-    start.add_argument("--aios-connection-id", help="aios connection id (AIOS_CONNECTION_ID)")
     start.add_argument("--mcp-bind", help="MCP host:port (AIOS_TELEGRAM_MCP_BIND)")
     start.add_argument("--mcp-token", help="MCP bearer token (AIOS_TELEGRAM_MCP_TOKEN)")
     return parser
@@ -33,9 +30,6 @@ def _build_parser() -> argparse.ArgumentParser:
 def _apply_cli_overrides(args: argparse.Namespace) -> None:
     mapping = {
         "bot_token": "AIOS_TELEGRAM_BOT_TOKEN",
-        "aios_url": "AIOS_URL",
-        "aios_api_key": "AIOS_API_KEY",
-        "aios_connection_id": "AIOS_CONNECTION_ID",
         "mcp_bind": "AIOS_TELEGRAM_MCP_BIND",
         "mcp_token": "AIOS_TELEGRAM_MCP_TOKEN",
     }

--- a/connectors/telegram/src/aios_telegram/app.py
+++ b/connectors/telegram/src/aios_telegram/app.py
@@ -1,10 +1,10 @@
 """Top-level orchestration.
 
 ``run(cfg)`` supervises two tasks under one ``asyncio.TaskGroup``: the PTB
-``Application`` driving the Telegram long-polling loop and posting inbound
-messages to aios, and the MCP server serving ``telegram_send``. Any task
-failure propagates through the group and exits the process non-zero —
-operator systemd/Docker restarts.
+``Application`` driving the Telegram long-polling loop and publishing inbound
+messages to the MCP broker, and the MCP server serving ``telegram_send`` plus
+the hidden inbound subscription hook. Any task failure propagates through the
+group and exits the process non-zero — operator systemd/Docker restarts.
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ import structlog
 
 from .bot import build_application, discover_bot_identity, install_handler, run_application
 from .config import Settings
-from .ingest import IngestClient
+from .inbound import TelegramInboundBroker
 from .mcp import build_mcp_app, build_mcp_server, parse_bind, serve_mcp
 
 log = structlog.get_logger(__name__)
@@ -30,30 +30,27 @@ async def run(cfg: Settings) -> None:
         await application.shutdown()
         raise
 
-    async with IngestClient(
-        base_url=cfg.aios_url,
-        api_key=cfg.aios_api_key,
-        connection_id=cfg.aios_connection_id,
-    ) as ingest:
-        install_handler(application, bot_id=identity.id, ingest=ingest)
-        mcp_app = build_mcp_app(
-            build_mcp_server(
-                bot=application.bot,
-                bot_id=identity.id,
-                first_name=identity.first_name,
-                username=identity.username,
-            ),
-            token=cfg.mcp_token,
-        )
-        host, port = parse_bind(cfg.mcp_bind)
+    broker = TelegramInboundBroker(bot_id=identity.id)
+    install_handler(application, bot_id=identity.id, ingest=broker)
+    mcp_app = build_mcp_app(
+        build_mcp_server(
+            bot=application.bot,
+            bot_id=identity.id,
+            first_name=identity.first_name,
+            username=identity.username,
+            inbound_broker=broker,
+        ),
+        token=cfg.mcp_token,
+    )
+    host, port = parse_bind(cfg.mcp_bind)
 
-        log.info("telegram.ready", bot_id=identity.id)
+    log.info("telegram.ready", bot_id=identity.id)
 
-        try:
-            async with asyncio.TaskGroup() as tg:
-                tg.create_task(run_application(application), name="telegram-bot")
-                tg.create_task(serve_mcp(mcp_app, host=host, port=port), name="telegram-mcp")
-        except* Exception as eg:
-            # Surface the first real exception so operators see a conventional
-            # traceback rather than ExceptionGroup noise.
-            raise eg.exceptions[0] from None
+    try:
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(run_application(application), name="telegram-bot")
+            tg.create_task(serve_mcp(mcp_app, host=host, port=port), name="telegram-mcp")
+    except* Exception as eg:
+        # Surface the first real exception so operators see a conventional
+        # traceback rather than ExceptionGroup noise.
+        raise eg.exceptions[0] from None

--- a/connectors/telegram/src/aios_telegram/bot.py
+++ b/connectors/telegram/src/aios_telegram/bot.py
@@ -8,7 +8,7 @@ Three responsibilities:
    in the MCP init instructions (issue #55).  The numeric id doubles as
    the ``<account>`` segment of channel addresses.
 3. Register a single message handler that parses each incoming text
-   message and POSTs it to aios via :class:`aios_telegram.ingest.IngestClient`.
+   message and publishes it to the connector-local MCP inbound broker.
 
 Long-polling is driven by PTB's own ``Updater``; :func:`run_application`
 starts it, blocks until cancelled, then shuts down cleanly.
@@ -24,7 +24,7 @@ import structlog
 from telegram import Update
 from telegram.ext import Application, ContextTypes, MessageHandler, filters
 
-from .ingest import IngestClient, build_metadata
+from .ingest import InboundSink, build_metadata
 from .parse import parse_message
 
 log = structlog.get_logger(__name__)
@@ -76,7 +76,7 @@ def install_handler(
     application: Application,  # type: ignore[type-arg]
     *,
     bot_id: int,
-    ingest: IngestClient,
+    ingest: InboundSink,
 ) -> None:
     """Wire the parse → build_metadata → post_message pipeline onto PTB.
 

--- a/connectors/telegram/src/aios_telegram/config.py
+++ b/connectors/telegram/src/aios_telegram/config.py
@@ -1,14 +1,11 @@
 """Runtime configuration.
 
 Pydantic-settings sourcing: ``AIOS_TELEGRAM_*`` env vars for connector-specific
-settings, plus three shared aios env vars via explicit aliases
-(``AIOS_URL``, ``AIOS_API_KEY``, ``AIOS_CONNECTION_ID``). All may be
-overridden on the CLI (see ``__main__.py``).
+settings. All may be overridden on the CLI (see ``__main__.py``).
 """
 
 from __future__ import annotations
 
-from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -21,11 +18,6 @@ class Settings(BaseSettings):
 
     # Telegram
     bot_token: str
-
-    # aios side
-    aios_url: str = Field(validation_alias="AIOS_URL")
-    aios_api_key: str = Field(validation_alias="AIOS_API_KEY")
-    aios_connection_id: str = Field(validation_alias="AIOS_CONNECTION_ID")
 
     # MCP server
     mcp_bind: str = "127.0.0.1:9200"

--- a/connectors/telegram/src/aios_telegram/inbound.py
+++ b/connectors/telegram/src/aios_telegram/inbound.py
@@ -1,0 +1,207 @@
+"""Telegram-side MCP inbound broker."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+from mcp.shared.message import SessionMessage
+from mcp.types import JSONRPCMessage, JSONRPCNotification
+
+log = structlog.get_logger(__name__)
+
+NOTIFICATION_MESSAGE = "notifications/aios/inbound/message"
+NOTIFICATION_CHANNELS_SNAPSHOT = "notifications/aios/inbound/channels_snapshot"
+NOTIFICATION_CHANNELS_DELTA = "notifications/aios/inbound/channels_delta"
+NOTIFICATION_REPLAY_LOST = "notifications/aios/inbound/replay_lost"
+
+REPLAY_LIMIT = 512
+
+
+@dataclass(frozen=True, slots=True)
+class InboundEvent:
+    event_id: str
+    channel: str
+    content: str
+    metadata: dict[str, Any]
+
+
+def telegram_event_id(*, bot_id: int | str, path: str, metadata: dict[str, Any]) -> str:
+    sender = metadata.get("sender_id") or ""
+    message_id = metadata.get("message_id") or ""
+    timestamp = metadata.get("timestamp_ms") or ""
+    raw = f"{bot_id}|{path}|{sender}|{message_id}|{timestamp}"
+    return "tg_" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:32]
+
+
+class TelegramInboundBroker:
+    """Fan Telegram inbound events out to subscribed MCP sessions."""
+
+    def __init__(
+        self,
+        *,
+        bot_id: int | str,
+        initial_channels: list[dict[str, Any]] | None = None,
+        replay_limit: int = REPLAY_LIMIT,
+    ) -> None:
+        self.bot_id = str(bot_id)
+        self.replay_limit = replay_limit
+        self._subscribers: dict[int, Any] = {}
+        self._replay: deque[InboundEvent] = deque(maxlen=replay_limit)
+        self._channels: dict[str, dict[str, Any]] = {}
+        self._lock = asyncio.Lock()
+        for entry in initial_channels or []:
+            channel = entry.get("channel")
+            if isinstance(channel, str):
+                self._channels[channel] = dict(entry)
+
+    async def subscribe(
+        self,
+        *,
+        account_id: str,
+        since_event_id: str | None,
+        session: Any,
+    ) -> dict[str, Any]:
+        if account_id != self.bot_id:
+            raise ValueError(f"unknown Telegram account {account_id!r}")
+        async with self._lock:
+            self._subscribers[id(session)] = session
+            snapshot = list(self._channels.values())
+            replay = self._events_after_locked(since_event_id)
+            replay_lost = since_event_id is not None and replay is None
+
+        await self._send(
+            session,
+            NOTIFICATION_CHANNELS_SNAPSHOT,
+            {"channels": snapshot},
+        )
+        if replay_lost:
+            await self._send(
+                session,
+                NOTIFICATION_REPLAY_LOST,
+                {"since_event_id": since_event_id},
+            )
+            replay = []
+        for event in replay or []:
+            await self._send_event(session, event)
+        return {
+            "status": "subscribed",
+            "channels": len(snapshot),
+            "replayed": len(replay or []),
+            "replay_lost": replay_lost,
+        }
+
+    async def post_message(
+        self,
+        *,
+        path: str,
+        content: str,
+        metadata: dict[str, Any],
+    ) -> None:
+        event = InboundEvent(
+            event_id=telegram_event_id(bot_id=self.bot_id, path=path, metadata=metadata),
+            channel=f"{self.bot_id}/{path}",
+            content=content,
+            metadata=dict(metadata),
+        )
+        display_name = _display_name(metadata, path)
+        channel_metadata: dict[str, Any] = {
+            k: v
+            for k, v in metadata.items()
+            if k in {"chat_type", "chat_name", "sender_id", "sender_name"}
+        }
+        channel_entry: dict[str, Any] = {
+            "channel": event.channel,
+            "display_name": display_name,
+            "metadata": channel_metadata,
+        }
+
+        async with self._lock:
+            existing = self._channels.get(event.channel)
+            is_new = existing is None
+            existing_metadata = (existing or {}).get("metadata")
+            if not isinstance(existing_metadata, dict):
+                existing_metadata = {}
+            self._channels[event.channel] = {
+                **(existing or {}),
+                **channel_entry,
+                "metadata": {**existing_metadata, **channel_metadata},
+            }
+            self._replay.append(event)
+            subscribers = list(self._subscribers.values())
+
+        if is_new:
+            await self._broadcast(
+                NOTIFICATION_CHANNELS_DELTA,
+                {"upserts": [self._channels[event.channel]], "archives": []},
+                subscribers,
+            )
+        await self._broadcast_event(event, subscribers)
+
+    def _events_after_locked(self, since_event_id: str | None) -> list[InboundEvent] | None:
+        if since_event_id is None:
+            return []
+        events = list(self._replay)
+        for idx, event in enumerate(events):
+            if event.event_id == since_event_id:
+                return events[idx + 1 :]
+        return None if events else []
+
+    async def _broadcast(
+        self,
+        method: str,
+        params: dict[str, Any],
+        subscribers: list[Any],
+    ) -> None:
+        dead: list[int] = []
+        for session in subscribers:
+            try:
+                await self._send(session, method, params)
+            except Exception:
+                dead.append(id(session))
+                log.warning("telegram.inbound.send_failed", exc_info=True)
+        if dead:
+            async with self._lock:
+                for key in dead:
+                    self._subscribers.pop(key, None)
+
+    async def _broadcast_event(self, event: InboundEvent, subscribers: list[Any]) -> None:
+        dead: list[int] = []
+        for session in subscribers:
+            try:
+                await self._send_event(session, event)
+            except Exception:
+                dead.append(id(session))
+                log.warning("telegram.inbound.send_failed", exc_info=True)
+        if dead:
+            async with self._lock:
+                for key in dead:
+                    self._subscribers.pop(key, None)
+
+    async def _send_event(self, session: Any, event: InboundEvent) -> None:
+        await self._send(
+            session,
+            NOTIFICATION_MESSAGE,
+            {
+                "event_id": event.event_id,
+                "channel": event.channel,
+                "content": event.content,
+                "metadata": event.metadata,
+            },
+        )
+
+    async def _send(self, session: Any, method: str, params: dict[str, Any]) -> None:
+        notification = JSONRPCNotification(jsonrpc="2.0", method=method, params=params)
+        await session.send_message(SessionMessage(message=JSONRPCMessage(notification)))
+
+
+def _display_name(metadata: dict[str, Any], path: str) -> str:
+    for key in ("chat_name", "sender_name"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return path

--- a/connectors/telegram/src/aios_telegram/ingest.py
+++ b/connectors/telegram/src/aios_telegram/ingest.py
@@ -1,18 +1,15 @@
-"""aios ingest client.
+"""Legacy aios HTTP ingest client and inbound metadata helpers.
 
-POSTs inbound Telegram messages to ``/v1/connections/{id}/messages``. Retries
-transient failures (network, 5xx) with exponential backoff; 4xx and
-retry-exhaustion both log and drop. Missing messages are unrecoverable
-(Telegram does not redeliver long-polling updates we've already acked by
-advancing ``offset``), but the connector advances ``offset`` only after the
-handler returns — so a crash mid-handler causes redelivery on the next run.
+Runtime inbound now publishes to the connector-local MCP broker. ``IngestClient``
+remains for coexistence tests until the legacy connection ingest path is
+removed.
 """
 
 from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any, Self
+from typing import Any, Protocol, Self
 
 import httpx
 import structlog
@@ -22,6 +19,16 @@ from .parse import InboundMessage
 log = structlog.get_logger(__name__)
 
 RETRY_DELAYS_SECONDS: tuple[float, ...] = (1.0, 2.0, 4.0, 8.0)
+
+
+class InboundSink(Protocol):
+    async def post_message(
+        self,
+        *,
+        path: str,
+        content: str,
+        metadata: dict[str, Any],
+    ) -> None: ...
 
 
 @dataclass(slots=True)

--- a/connectors/telegram/src/aios_telegram/mcp.py
+++ b/connectors/telegram/src/aios_telegram/mcp.py
@@ -16,6 +16,7 @@ import asyncio
 import contextlib
 import hmac
 import urllib.parse
+from types import MethodType
 from typing import Any
 
 import structlog
@@ -27,6 +28,7 @@ from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 from telegram import Bot
 
+from .inbound import TelegramInboundBroker
 from .prompts import build_instructions
 
 log = structlog.get_logger(__name__)
@@ -108,6 +110,7 @@ def build_mcp_server(
     bot_id: int,
     first_name: str,
     username: str | None = None,
+    inbound_broker: TelegramInboundBroker | None = None,
 ) -> FastMCP:
     mcp = FastMCP(
         "aios-telegram",
@@ -116,8 +119,27 @@ def build_mcp_server(
             first_name=first_name,
             username=username,
         ),
-        stateless_http=True,
+        stateless_http=False,
     )
+
+    if inbound_broker is not None:
+        _install_aios_inbound_capability(mcp)
+
+        @mcp.tool(
+            name="aios_inbound_subscribe",
+            description="Internal aios inbound subscription hook.",
+            meta={"aios.internal": True},
+        )
+        async def aios_inbound_subscribe(
+            account_id: str,
+            ctx: Context[Any, Any, Any],
+            since_event_id: str | None = None,
+        ) -> dict[str, Any]:
+            return await inbound_broker.subscribe(
+                account_id=account_id,
+                since_event_id=since_event_id,
+                session=ctx.session,
+            )
 
     @mcp.tool()
     async def telegram_send(text: str, ctx: Context[Any, Any, Any]) -> dict[str, Any]:
@@ -135,6 +157,26 @@ def build_mcp_server(
         return {"message_id": sent.message_id}
 
     return mcp
+
+
+def _install_aios_inbound_capability(mcp: FastMCP) -> None:
+    """Advertise the aios inbound extension in MCP initialize."""
+    server = mcp._mcp_server  # FastMCP exposes no public hook for this yet.
+    base = server.create_initialization_options
+
+    def create_initialization_options(
+        self: Any,
+        notification_options: Any | None = None,
+        experimental_capabilities: dict[str, dict[str, Any]] | None = None,
+    ) -> Any:
+        experimental = dict(experimental_capabilities or {})
+        experimental["aiosInbound"] = {
+            "version": 1,
+            "connectorId": "telegram",
+        }
+        return base(notification_options, experimental)
+
+    server.create_initialization_options = MethodType(create_initialization_options, server)  # type: ignore[method-assign]
 
 
 def build_mcp_app(mcp: FastMCP, *, token: str) -> Starlette:

--- a/connectors/telegram/tests/test_inbound.py
+++ b/connectors/telegram/tests/test_inbound.py
@@ -1,0 +1,129 @@
+"""Tests for the Telegram MCP inbound broker."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aios_telegram.inbound import (
+    NOTIFICATION_CHANNELS_DELTA,
+    NOTIFICATION_CHANNELS_SNAPSHOT,
+    NOTIFICATION_MESSAGE,
+    NOTIFICATION_REPLAY_LOST,
+    TelegramInboundBroker,
+    telegram_event_id,
+)
+
+
+class RecordingSession:
+    def __init__(self) -> None:
+        self.messages: list[Any] = []
+
+    async def send_message(self, message: Any) -> None:
+        self.messages.append(message)
+
+
+def _notification(message: Any) -> Any:
+    return message.message.root
+
+
+def test_telegram_event_id_is_deterministic() -> None:
+    metadata = {"sender_id": 123, "message_id": 7, "timestamp_ms": 1700000000000}
+    assert telegram_event_id(bot_id=999, path="123", metadata=metadata) == telegram_event_id(
+        bot_id=999,
+        path="123",
+        metadata=metadata,
+    )
+    assert telegram_event_id(bot_id=999, path="123", metadata=metadata) != telegram_event_id(
+        bot_id=999,
+        path="123",
+        metadata={**metadata, "message_id": 8},
+    )
+
+
+async def test_subscribe_snapshot_delta_and_publish_message() -> None:
+    broker = TelegramInboundBroker(
+        bot_id=999,
+        initial_channels=[{"channel": "999/123", "display_name": "Alice", "metadata": {}}],
+    )
+    session = RecordingSession()
+
+    result = await broker.subscribe(account_id="999", since_event_id=None, session=session)
+    assert result["status"] == "subscribed"
+    assert _notification(session.messages[0]).method == NOTIFICATION_CHANNELS_SNAPSHOT
+
+    await broker.post_message(
+        path="-987",
+        content="hello",
+        metadata={
+            "chat_type": "group",
+            "chat_name": "Friends",
+            "sender_id": 123,
+            "sender_name": "Alice",
+            "message_id": 1,
+            "timestamp_ms": 1700000000000,
+        },
+    )
+
+    methods = [_notification(m).method for m in session.messages]
+    assert methods[-2:] == [NOTIFICATION_CHANNELS_DELTA, NOTIFICATION_MESSAGE]
+    delta = _notification(session.messages[-2]).params
+    assert delta["upserts"][0]["channel"] == "999/-987"
+    assert delta["upserts"][0]["display_name"] == "Friends"
+    params = _notification(session.messages[-1]).params
+    assert params["channel"] == "999/-987"
+    assert params["content"] == "hello"
+    assert params["metadata"]["sender_id"] == 123
+
+
+async def test_subscribe_replays_after_cursor() -> None:
+    broker = TelegramInboundBroker(bot_id=999)
+    first_metadata = {
+        "sender_id": 123,
+        "message_id": 1,
+        "timestamp_ms": 1700000000000,
+    }
+    await broker.post_message(path="123", content="one", metadata=first_metadata)
+    first_id = telegram_event_id(bot_id=999, path="123", metadata=first_metadata)
+    await broker.post_message(
+        path="123",
+        content="two",
+        metadata={
+            "sender_id": 123,
+            "message_id": 2,
+            "timestamp_ms": 1700000001000,
+        },
+    )
+
+    session = RecordingSession()
+    await broker.subscribe(account_id="999", since_event_id=first_id, session=session)
+
+    messages = [m for m in session.messages if _notification(m).method == NOTIFICATION_MESSAGE]
+    assert len(messages) == 1
+    assert _notification(messages[0]).params["content"] == "two"
+
+
+async def test_subscribe_reports_replay_lost_for_unknown_cursor() -> None:
+    broker = TelegramInboundBroker(bot_id=999)
+    await broker.post_message(
+        path="123",
+        content="one",
+        metadata={
+            "sender_id": 123,
+            "message_id": 1,
+            "timestamp_ms": 1700000000000,
+        },
+    )
+
+    session = RecordingSession()
+    result = await broker.subscribe(account_id="999", since_event_id="missing", session=session)
+
+    assert result["replay_lost"] is True
+    assert NOTIFICATION_REPLAY_LOST in [_notification(m).method for m in session.messages]
+
+
+async def test_subscribe_rejects_wrong_account() -> None:
+    broker = TelegramInboundBroker(bot_id=999)
+    with pytest.raises(ValueError, match="unknown Telegram account"):
+        await broker.subscribe(account_id="123", since_event_id=None, session=RecordingSession())

--- a/connectors/telegram/tests/test_mcp.py
+++ b/connectors/telegram/tests/test_mcp.py
@@ -15,6 +15,7 @@ from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 from telegram import Bot, Message
 
+from aios_telegram.inbound import TelegramInboundBroker
 from aios_telegram.mcp import (
     BearerAuthMiddleware,
     build_mcp_server,
@@ -136,6 +137,50 @@ def test_build_mcp_server_omits_username_when_absent() -> None:
     assert "42" in mcp.instructions
     assert "Example" in mcp.instructions
     assert "username" not in mcp.instructions
+
+
+class TestAiosInboundExtension:
+    def test_capability_is_advertised(self) -> None:
+        bot = MagicMock(spec=Bot)
+        mcp = build_mcp_server(
+            bot=bot,
+            bot_id=BOT_ID,
+            first_name="Test",
+            username="test_bot",
+            inbound_broker=TelegramInboundBroker(bot_id=BOT_ID),
+        )
+
+        opts = mcp._mcp_server.create_initialization_options()
+
+        assert opts.capabilities.experimental == {
+            "aiosInbound": {"version": 1, "connectorId": "telegram"}
+        }
+
+    async def test_hidden_subscribe_tool_registers_session(self) -> None:
+        bot = MagicMock(spec=Bot)
+        broker = TelegramInboundBroker(bot_id=BOT_ID)
+        mcp = build_mcp_server(
+            bot=bot,
+            bot_id=BOT_ID,
+            first_name="Test",
+            username="test_bot",
+            inbound_broker=broker,
+        )
+        session = MagicMock()
+        session.send_message = AsyncMock()
+        rc = MagicMock(spec=RequestContext)
+        rc.session = session
+        ctx: Context[Any, Any, Any] = Context(request_context=rc)
+
+        result = await mcp._tool_manager.call_tool(
+            "aios_inbound_subscribe",
+            {"account_id": str(BOT_ID)},
+            ctx,
+            convert_result=True,
+        )
+
+        assert isinstance(result, tuple)
+        assert result[1]["status"] == "subscribed"
 
 
 # ─── bearer auth middleware ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Stacks on #194 and moves the Telegram connector onto the MCP inbound subscription path. Telegram now uses the same end-state connector shape as Signal: one stateful MCP server exposes outbound tools and a hidden inbound subscription hook, while the bot polling handler publishes inbound messages to a connector-local broker.

## What changed

- Add a Telegram MCP inbound broker with snapshots, deltas, replay, replay-lost notification, deterministic event IDs, and subscriber fanout.
- Switch Telegram FastMCP to stateful Streamable HTTP and advertise `experimental.aiosInbound`.
- Register hidden internal `aios_inbound_subscribe` for `aios inbound`.
- Wire the Telegram bot handler to the broker instead of the legacy HTTP ingest client.
- Remove runtime config/CLI dependence on `AIOS_URL`, `AIOS_API_KEY`, and `AIOS_CONNECTION_ID` while keeping the legacy ingest client around for coexistence tests.
- Update Telegram README for vault credential `account_id`, session vault binding, and `aios inbound`.

## Validation

- `cd connectors/telegram && uv run pytest tests -q` -> `46 passed`
- `cd connectors/telegram && uv run ruff check src tests`
- `cd connectors/telegram && uv run mypy src tests`
- `cd connectors/telegram && uv run ruff format --check src tests`
- Commit hook: root `ruff`, root `mypy src`, root unit tests -> `954 passed`