### PR TITLE
fix(harness): pass per-session locks to wake_session jobs (#192)

### DIFF
--- a/src/aios/harness/tasks.py
+++ b/src/aios/harness/tasks.py
@@ -5,18 +5,29 @@
     sweep defers one when sessions need inference. A worker picks up
     the job and runs a single inference step.
 
-    Key parameters:
+    The lock and queueing_lock are NOT set on the decorator — they are
+    passed per call from :mod:`aios.harness.wake` (``defer_wake`` and
+    ``defer_retry_wake``). Procrastinate stores the decorator's lock
+    arguments verbatim with no kwarg-template substitution, so a
+    decorator-level ``lock="{session_id}"`` would assign every job the
+    same literal lock value and serialize all sessions through one job
+    slot — the bug behind issue #192.
 
-    * ``lock="{session_id}"``: procrastinate enforces mutual exclusion via
-      a DB unique index (``WHERE status = 'doing'``). Only one step runs
-      per session at a time. The lock releases the instant the job handler
-      returns. On worker crash, procrastinate's heartbeat timeout (~30s)
-      detects the stalled worker and marks the job as failed, freeing the
-      lock.
+    Per-call values used by :mod:`aios.harness.wake`:
 
-    * ``queueing_lock="{session_id}"``: deduplicates wake jobs in ``todo``
-      status. Multiple tool completions or user messages that arrive while
-      a step is running produce at most one queued wake.
+    * ``lock=session_id``: procrastinate enforces mutual exclusion via
+      a partial unique index ``WHERE status='doing'``. With distinct
+      values per session, only one step runs per session at a time
+      while different sessions run concurrently up to
+      ``worker_concurrency``. The lock releases the instant the job
+      handler returns. On worker crash, procrastinate's heartbeat
+      timeout (~30s) detects the stalled worker and marks the job as
+      failed, freeing the lock.
+
+    * ``queueing_lock=session_id``: dedups wake jobs in ``todo`` status
+      *for the same session*. Multiple tool completions or user
+      messages that arrive while a step is running produce at most one
+      queued wake per session. Other sessions are unaffected.
 
     * ``retry=False``: failed jobs land in procrastinate's failed table.
       The periodic sweep catches sessions that need re-waking.
@@ -30,8 +41,6 @@ from aios.harness.procrastinate_app import app
 @app.task(
     name="harness.wake_session",
     queue="sessions",
-    lock="{session_id}",
-    queueing_lock="{session_id}",
     retry=False,
     pass_context=False,
 )

--- a/src/aios/harness/wake.py
+++ b/src/aios/harness/wake.py
@@ -59,10 +59,16 @@ async def defer_wake(
     if delay_seconds is not None:
         deferrer = app.configure_task(
             "harness.wake_session",
+            lock=session_id,
+            queueing_lock=session_id,
             schedule_in={"seconds": delay_seconds},
         )
     else:
-        deferrer = app.configure_task("harness.wake_session")
+        deferrer = app.configure_task(
+            "harness.wake_session",
+            lock=session_id,
+            queueing_lock=session_id,
+        )
 
     try:
         await deferrer.defer_async(**task_kwargs)
@@ -101,6 +107,8 @@ async def defer_retry_wake(
     try:
         await app.configure_task(
             "harness.wake_session",
+            lock=session_id,
+            queueing_lock=session_id,
             schedule_in={"seconds": delay_seconds},
         ).defer_async(
             session_id=session_id,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -38,6 +38,40 @@ async def _noop_defer_retry_wake(pool: Any, session_id: str, *, delay_seconds: f
     pass
 
 
+async def ensure_procrastinate_schema(aios_db_url: str) -> None:
+    """Apply procrastinate's schema to the testcontainer DB if missing.
+
+    The shared ``migrated_db_url`` only runs aios's alembic migrations;
+    tests that touch ``procrastinate_jobs`` directly (or run a worker
+    against the testcontainer) need procrastinate's tables too. The
+    module-level :mod:`aios.harness.procrastinate_app` singleton's
+    connector is fixed at import time against whatever settings were
+    active then (usually wrong in tests), so we build a temporary
+    ``App`` here.
+    """
+    import asyncpg
+    from procrastinate import App, PsycopgConnector
+
+    from aios.config import get_settings
+
+    settings = get_settings()
+    conn = await asyncpg.connect(settings.db_url)
+    try:
+        present = await conn.fetchval("SELECT to_regclass('procrastinate_jobs')")
+    finally:
+        await conn.close()
+    if present is not None:
+        return
+
+    conninfo = aios_db_url.replace("postgresql+psycopg://", "postgresql://")
+    tmp_app = App(connector=PsycopgConnector(conninfo=conninfo))
+    await tmp_app.open_async()
+    try:
+        await tmp_app.schema_manager.apply_schema_async()
+    finally:
+        await tmp_app.close_async()
+
+
 @pytest.fixture
 async def harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     """Function-scoped harness: real Postgres, scripted model, no Docker."""

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -114,21 +114,24 @@ async def _post_inbound(
 ) -> tuple[str, str, str]:
     """Resolve + append a user inbound message.
 
-    Returns ``(session_id, event_id, address)``. Bypasses the HTTP layer
-    and defer_wake so the test is DB-focused.
+    Returns ``(session_id, event_id, address)``. Bypasses the HTTP
+    layer so the test is DB-focused. Neither ``resolve_channel`` nor
+    ``append_user_message`` calls ``defer_wake``, so no mock is
+    needed — and using ``mock.patch`` here is unsafe under
+    ``asyncio.gather`` (concurrent enter/exit corrupts the saved
+    original and leaks the mock to later tests).
     """
     from aios.services import channels as ch_svc
     from aios.services import sessions as sess_svc
 
     address = f"{connection.connector}/{connection.account}/{path}"
-    with mock.patch("aios.harness.wake.defer_wake"):
-        resolution = await ch_svc.resolve_channel(pool, connection, path)
-        event = await sess_svc.append_user_message(
-            pool,
-            resolution.session_id,
-            content,
-            metadata={"channel": address},
-        )
+    resolution = await ch_svc.resolve_channel(pool, connection, path)
+    event = await sess_svc.append_user_message(
+        pool,
+        resolution.session_id,
+        content,
+        metadata={"channel": address},
+    )
     return resolution.session_id, event.id, address
 
 

--- a/tests/e2e/test_reap_stalled_jobs.py
+++ b/tests/e2e/test_reap_stalled_jobs.py
@@ -26,30 +26,12 @@ from tests.conftest import needs_docker
 
 @pytest.fixture
 async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from procrastinate import App
-
     from aios.config import get_settings
     from aios.db.pool import create_pool
+    from tests.e2e.conftest import ensure_procrastinate_schema
 
-    settings = get_settings()
-    # Ensure procrastinate's tables exist on the testcontainer DB. The
-    # shared ``migrated_db_url`` only runs aios's alembic migrations;
-    # the reaper exercises procrastinate's schema directly. We build
-    # a temporary ``App`` here rather than reuse the module-level
-    # singleton because the singleton's connector is fixed at import
-    # time against whatever settings were active then — usually wrong
-    # in tests.
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    async with p.acquire() as conn:
-        present = await conn.fetchval("SELECT to_regclass('procrastinate_jobs')")
-    if present is None:
-        conninfo = aios_env["AIOS_DB_URL"].replace("postgresql+psycopg://", "postgresql://")
-        tmp_app = App(connector=PsycopgConnector(conninfo=conninfo))
-        await tmp_app.open_async()
-        try:
-            await tmp_app.schema_manager.apply_schema_async()
-        finally:
-            await tmp_app.close_async()
+    await ensure_procrastinate_schema(aios_env["AIOS_DB_URL"])
+    p = await create_pool(get_settings().db_url, min_size=1, max_size=4)
     yield p
     await p.close()
 

--- a/tests/e2e/test_worker_concurrency.py
+++ b/tests/e2e/test_worker_concurrency.py
@@ -1,24 +1,16 @@
-"""End-to-end regression test for issue #192 — wake jobs run concurrently.
+"""Wake jobs for distinct sessions must dispatch concurrently.
 
 Exercises the full pipeline against a real Postgres testcontainer:
+``defer_wake`` writes a procrastinate job, a real worker fetches it,
+the ``wake_session`` task body invokes ``run_session_step`` (patched
+here to a sleep + counter so the test focuses on dispatch behaviour
+rather than inference).
 
-* Real ``defer_wake`` writes the procrastinate ``wake_session`` job
-  (with per-session ``lock`` and ``queueing_lock``).
-* A real procrastinate worker fetches and dispatches the jobs.
-* The ``wake_session`` task body invokes ``run_session_step`` — patched
-  here to a sleep + counter, since this test cares about *whether* the
-  worker dispatches concurrently, not what happens inside a step.
-
-Behavioural contract: deferring wake jobs for N distinct sessions in
-burst, with the worker configured at ``concurrency=C``, must produce
-peak observed concurrency equal to ``C`` (assuming N ≥ C). Implementation-
-agnostic — the test never reads ``lock`` or ``queueing_lock`` columns
-or any other procrastinate internals; it only observes the user-visible
-parallelism.
-
-If a future change re-introduces the #192 bug — by reverting per-call
-locks, by adding cross-session serialization, by accidentally narrowing
-the worker pool — peak will collapse to 1 and this test fails loudly.
+Implementation-agnostic: never reads ``lock`` / ``queueing_lock`` or
+any other procrastinate internals — only the user-visible parallelism
+property. If a future change re-serializes wakes across sessions
+(e.g. the bug that issue #192 fixed), peak collapses to 1 and this
+test fails.
 """
 
 from __future__ import annotations
@@ -37,39 +29,21 @@ from aios.services import agents as agents_service
 from aios.services import environments as environments_service
 from aios.services import sessions as sessions_service
 from tests.conftest import needs_docker
+from tests.e2e.conftest import ensure_procrastinate_schema
 
 
 @pytest.fixture
 async def real_wake_setup(aios_env: dict[str, str]) -> AsyncIterator[asyncpg.Pool[Any]]:
-    """Real Postgres pool + procrastinate schema, no harness mocks.
+    """Real pool + procrastinate schema, no harness mocks.
 
-    The standard ``harness`` fixture installs a no-op ``defer_wake``
-    so most e2e tests can drive steps deterministically. This test is
-    the one place we *want* the real ``defer_wake`` to fire — it's
-    exercising the procrastinate dispatch path end-to-end. So we
-    build a bare pool here and bootstrap procrastinate's schema.
+    The standard ``harness`` fixture installs a no-op ``defer_wake``;
+    this test is the one place we *want* the real one to fire.
     """
-    from procrastinate import App
-
     from aios.config import get_settings
     from aios.db.pool import create_pool
 
-    settings = get_settings()
-    pool = await create_pool(settings.db_url, min_size=1, max_size=8)
-
-    # Bootstrap procrastinate's schema if missing (mirrors the pattern
-    # in ``tests/e2e/test_reap_stalled_jobs.py``).
-    async with pool.acquire() as conn:
-        present = await conn.fetchval("SELECT to_regclass('procrastinate_jobs')")
-    if present is None:
-        conninfo = aios_env["AIOS_DB_URL"].replace("postgresql+psycopg://", "postgresql://")
-        tmp_app = App(connector=PsycopgConnector(conninfo=conninfo))
-        await tmp_app.open_async()
-        try:
-            await tmp_app.schema_manager.apply_schema_async()
-        finally:
-            await tmp_app.close_async()
-
+    await ensure_procrastinate_schema(aios_env["AIOS_DB_URL"])
+    pool = await create_pool(get_settings().db_url, min_size=1, max_size=8)
     try:
         yield pool
     finally:
@@ -89,30 +63,17 @@ async def _create_session(pool: asyncpg.Pool[Any], agent_id: str, env_id: str) -
 
 @needs_docker
 class TestWorkerConcurrencyE2E:
-    """Workers must dispatch wake jobs for distinct sessions concurrently."""
-
     async def test_n_sessions_dispatch_concurrently(
         self, real_wake_setup: asyncpg.Pool[Any], aios_env: dict[str, str]
     ) -> None:
-        """8 sessions, concurrency=4 ⇒ peak observed concurrency == 4.
-
-        Deferring wakes for 8 distinct ``session_id`` values and running
-        a worker at ``concurrency=4`` must saturate the worker — peak
-        observed ``run_session_step`` invocations in flight at once
-        equals the configured concurrency. The strict-serial floor that
-        #192 produced (peak == 1) is what this test guards against.
-
-        Wall-clock isn't asserted: peak alone distinguishes the failure
-        modes (peak == 1 is the bug; peak > 1 is correct dispatch). A
-        hardware-dependent timing assertion would just add flake without
-        adding signal.
-        """
         from aios.harness.procrastinate_app import app as procrastinate_app
         from aios.harness.wake import defer_wake
 
         pool = real_wake_setup
+        n_sessions = 8
+        concurrency = 4
+        per_step = 0.4
 
-        # Create one agent + environment + N sessions.
         agent = await agents_service.create_agent(
             pool,
             name="conc-test-agent",
@@ -126,15 +87,10 @@ class TestWorkerConcurrencyE2E:
         )
         env = await environments_service.create_environment(pool, name="conc-test-env")
 
-        n_sessions = 8
-        concurrency = 4
-        per_step = 0.4
+        session_ids = await asyncio.gather(
+            *(_create_session(pool, agent.id, env.id) for _ in range(n_sessions))
+        )
 
-        session_ids = [await _create_session(pool, agent.id, env.id) for _ in range(n_sessions)]
-
-        # Track in-flight steps via a shared counter. The wake_session
-        # task imports run_session_step at call time, so patching the
-        # module attribute affects every dispatched job.
         in_flight = 0
         peak = 0
 
@@ -147,10 +103,6 @@ class TestWorkerConcurrencyE2E:
             finally:
                 in_flight -= 1
 
-        # Point the procrastinate_app singleton at the testcontainer.
-        # Its connector was bound at import time to whatever DB was
-        # active then; this swap is the standard pattern (see
-        # tests/unit/test_wake_instrumentation.py).
         conninfo = aios_env["AIOS_DB_URL"].replace("postgresql+psycopg://", "postgresql://")
         new_connector = PsycopgConnector(conninfo=conninfo)
         await new_connector.open_async()
@@ -160,13 +112,13 @@ class TestWorkerConcurrencyE2E:
                 procrastinate_app.replace_connector(new_connector),
                 mock.patch("aios.harness.loop.run_session_step", fake_step),
             ):
-                # Defer one wake per session via the production code path.
-                for sid in session_ids:
-                    await defer_wake(pool, sid, cause="message")
+                await asyncio.gather(
+                    *(defer_wake(pool, sid, cause="message") for sid in session_ids)
+                )
 
-                # Run the worker until the queue drains. ``wait=False``
-                # exits when ``fetch_job`` returns ``None``; the worker's
-                # shutdown path awaits in-flight tasks before returning.
+                # ``wait=False`` exits when ``fetch_job`` returns ``None``;
+                # the worker's shutdown path awaits in-flight tasks first,
+                # so this resolves only after every job has run.
                 await procrastinate_app.run_worker_async(
                     queues=["sessions"],
                     concurrency=concurrency,
@@ -177,11 +129,4 @@ class TestWorkerConcurrencyE2E:
         finally:
             await new_connector.close_async()
 
-        assert peak == concurrency, (
-            f"peak in-flight wake_session invocations = {peak}, expected "
-            f"{concurrency} for {n_sessions} distinct sessions. The "
-            f"worker is not dispatching concurrently — likely a "
-            f"regression of issue #192 (per-session locks must come "
-            f"from defer_wake's configure_task call, not from a "
-            f"decorator-level template)."
-        )
+        assert peak == concurrency, f"peak={peak}, expected {concurrency}"

--- a/tests/e2e/test_worker_concurrency.py
+++ b/tests/e2e/test_worker_concurrency.py
@@ -1,0 +1,187 @@
+"""End-to-end regression test for issue #192 — wake jobs run concurrently.
+
+Exercises the full pipeline against a real Postgres testcontainer:
+
+* Real ``defer_wake`` writes the procrastinate ``wake_session`` job
+  (with per-session ``lock`` and ``queueing_lock``).
+* A real procrastinate worker fetches and dispatches the jobs.
+* The ``wake_session`` task body invokes ``run_session_step`` — patched
+  here to a sleep + counter, since this test cares about *whether* the
+  worker dispatches concurrently, not what happens inside a step.
+
+Behavioural contract: deferring wake jobs for N distinct sessions in
+burst, with the worker configured at ``concurrency=C``, must produce
+peak observed concurrency equal to ``C`` (assuming N ≥ C). Implementation-
+agnostic — the test never reads ``lock`` or ``queueing_lock`` columns
+or any other procrastinate internals; it only observes the user-visible
+parallelism.
+
+If a future change re-introduces the #192 bug — by reverting per-call
+locks, by adding cross-session serialization, by accidentally narrowing
+the worker pool — peak will collapse to 1 and this test fails loudly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+
+import asyncpg
+import pytest
+from procrastinate import PsycopgConnector
+
+from aios.models.agents import ToolSpec
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+from tests.conftest import needs_docker
+
+
+@pytest.fixture
+async def real_wake_setup(aios_env: dict[str, str]) -> AsyncIterator[asyncpg.Pool[Any]]:
+    """Real Postgres pool + procrastinate schema, no harness mocks.
+
+    The standard ``harness`` fixture installs a no-op ``defer_wake``
+    so most e2e tests can drive steps deterministically. This test is
+    the one place we *want* the real ``defer_wake`` to fire — it's
+    exercising the procrastinate dispatch path end-to-end. So we
+    build a bare pool here and bootstrap procrastinate's schema.
+    """
+    from procrastinate import App
+
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    pool = await create_pool(settings.db_url, min_size=1, max_size=8)
+
+    # Bootstrap procrastinate's schema if missing (mirrors the pattern
+    # in ``tests/e2e/test_reap_stalled_jobs.py``).
+    async with pool.acquire() as conn:
+        present = await conn.fetchval("SELECT to_regclass('procrastinate_jobs')")
+    if present is None:
+        conninfo = aios_env["AIOS_DB_URL"].replace("postgresql+psycopg://", "postgresql://")
+        tmp_app = App(connector=PsycopgConnector(conninfo=conninfo))
+        await tmp_app.open_async()
+        try:
+            await tmp_app.schema_manager.apply_schema_async()
+        finally:
+            await tmp_app.close_async()
+
+    try:
+        yield pool
+    finally:
+        await pool.close()
+
+
+async def _create_session(pool: asyncpg.Pool[Any], agent_id: str, env_id: str) -> str:
+    session = await sessions_service.create_session(
+        pool,
+        agent_id=agent_id,
+        environment_id=env_id,
+        title="conc-test",
+        metadata={},
+    )
+    return session.id
+
+
+@needs_docker
+class TestWorkerConcurrencyE2E:
+    """Workers must dispatch wake jobs for distinct sessions concurrently."""
+
+    async def test_n_sessions_dispatch_concurrently(
+        self, real_wake_setup: asyncpg.Pool[Any], aios_env: dict[str, str]
+    ) -> None:
+        """8 sessions, concurrency=4 ⇒ peak observed concurrency == 4.
+
+        Deferring wakes for 8 distinct ``session_id`` values and running
+        a worker at ``concurrency=4`` must saturate the worker — peak
+        observed ``run_session_step`` invocations in flight at once
+        equals the configured concurrency. The strict-serial floor that
+        #192 produced (peak == 1) is what this test guards against.
+
+        Wall-clock isn't asserted: peak alone distinguishes the failure
+        modes (peak == 1 is the bug; peak > 1 is correct dispatch). A
+        hardware-dependent timing assertion would just add flake without
+        adding signal.
+        """
+        from aios.harness.procrastinate_app import app as procrastinate_app
+        from aios.harness.wake import defer_wake
+
+        pool = real_wake_setup
+
+        # Create one agent + environment + N sessions.
+        agent = await agents_service.create_agent(
+            pool,
+            name="conc-test-agent",
+            model="fake/test",
+            system="t",
+            tools=[ToolSpec(type="bash")],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(pool, name="conc-test-env")
+
+        n_sessions = 8
+        concurrency = 4
+        per_step = 0.4
+
+        session_ids = [await _create_session(pool, agent.id, env.id) for _ in range(n_sessions)]
+
+        # Track in-flight steps via a shared counter. The wake_session
+        # task imports run_session_step at call time, so patching the
+        # module attribute affects every dispatched job.
+        in_flight = 0
+        peak = 0
+
+        async def fake_step(session_id: str, **kwargs: Any) -> None:
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            try:
+                await asyncio.sleep(per_step)
+            finally:
+                in_flight -= 1
+
+        # Point the procrastinate_app singleton at the testcontainer.
+        # Its connector was bound at import time to whatever DB was
+        # active then; this swap is the standard pattern (see
+        # tests/unit/test_wake_instrumentation.py).
+        conninfo = aios_env["AIOS_DB_URL"].replace("postgresql+psycopg://", "postgresql://")
+        new_connector = PsycopgConnector(conninfo=conninfo)
+        await new_connector.open_async()
+
+        try:
+            with (
+                procrastinate_app.replace_connector(new_connector),
+                mock.patch("aios.harness.loop.run_session_step", fake_step),
+            ):
+                # Defer one wake per session via the production code path.
+                for sid in session_ids:
+                    await defer_wake(pool, sid, cause="message")
+
+                # Run the worker until the queue drains. ``wait=False``
+                # exits when ``fetch_job`` returns ``None``; the worker's
+                # shutdown path awaits in-flight tasks before returning.
+                await procrastinate_app.run_worker_async(
+                    queues=["sessions"],
+                    concurrency=concurrency,
+                    wait=False,
+                    install_signal_handlers=False,
+                    fetch_job_polling_interval=0.1,
+                )
+        finally:
+            await new_connector.close_async()
+
+        assert peak == concurrency, (
+            f"peak in-flight wake_session invocations = {peak}, expected "
+            f"{concurrency} for {n_sessions} distinct sessions. The "
+            f"worker is not dispatching concurrently — likely a "
+            f"regression of issue #192 (per-session locks must come "
+            f"from defer_wake's configure_task call, not from a "
+            f"decorator-level template)."
+        )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 import base64
 import os
 import secrets
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from typing import Any
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from procrastinate import App
+from procrastinate.testing import InMemoryConnector
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -32,6 +34,19 @@ def _unit_env() -> Iterator[None]:
         get_settings.cache_clear()
         yield
         get_settings.cache_clear()
+
+
+@pytest.fixture
+async def in_memory_app() -> AsyncIterator[App]:
+    """Patch the aios procrastinate app to use an in-memory connector.
+
+    Tests can read ``app.connector.jobs`` directly to inspect deferred
+    job rows (lock, queueing_lock, schedule, args).
+    """
+    from aios.harness.procrastinate_app import app
+
+    with app.replace_connector(InMemoryConnector()) as patched:
+        yield patched
 
 
 def fake_pool_yielding_conn(conn: Any) -> Any:

--- a/tests/unit/test_wake.py
+++ b/tests/unit/test_wake.py
@@ -8,17 +8,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from procrastinate import App
-from procrastinate.testing import InMemoryConnector
 
 from aios.harness.wake import defer_retry_wake
-
-
-@pytest.fixture
-async def in_memory_app() -> AsyncIterator[App]:
-    from aios.harness.procrastinate_app import app
-
-    with app.replace_connector(InMemoryConnector()) as patched:
-        yield patched
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -10,21 +10,12 @@ Covers:
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import Iterator
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from procrastinate import App
-from procrastinate.testing import InMemoryConnector
-
-
-@pytest.fixture
-async def in_memory_app() -> AsyncIterator[App]:
-    from aios.harness.procrastinate_app import app
-
-    with app.replace_connector(InMemoryConnector()) as patched:
-        yield patched
 
 
 class TestE2EConftestMockSignatures:

--- a/tests/unit/test_wake_locks.py
+++ b/tests/unit/test_wake_locks.py
@@ -1,0 +1,204 @@
+"""Regression tests for issue #192 — ``defer_wake`` passes per-session locks.
+
+Lives at the unit layer because the contract being pinned is purely about
+the *values* ``defer_wake`` writes into procrastinate's ``lock`` and
+``queueing_lock`` columns. The :class:`InMemoryConnector` from
+procrastinate's test kit gives direct access to those columns without
+spinning up a database or a worker.
+
+Background: the original bug — fixed alongside these tests — was that
+``src/aios/harness/tasks.py`` declared
+``@app.task(lock="{session_id}", queueing_lock="{session_id}")``. The
+braces look like a kwarg-template placeholder, but procrastinate stores
+the string literally — there is no template substitution at any layer.
+Every wake job ended up sharing the lock value ``"{session_id}"`` and
+procrastinate's per-lock serialization (the unique partial index plus
+the ``NOT EXISTS`` clause in ``procrastinate_fetch_job_v2``) gated them
+all to one at a time, regardless of session.
+
+Fix: ``src/aios/harness/wake.py`` now passes per-session
+``lock=session_id, queueing_lock=session_id`` through
+``configure_task``. These tests pin the contract so the same regression
+can't recur:
+
+* :meth:`TestDeferWakeLockValues.test_lock_is_session_id` — single
+  defer assigns ``lock = session_id``.
+* :meth:`TestDeferWakeLockValues.test_queueing_lock_is_session_id` —
+  same for ``queueing_lock``. Together with the index, this is what
+  prevents cross-session ``AlreadyEnqueued``.
+* :meth:`TestDeferWakeCrossSessionIsolation.test_distinct_sessions_do_not_coalesce`
+  — bursty defers across N sessions all enqueue, no
+  ``AlreadyEnqueued``. This is the user-visible symptom of #192.
+* :meth:`TestDeferWakeCrossSessionIsolation.test_same_session_still_coalesces`
+  — guards against an over-zealous regression that drops the dedup.
+  Two defers for one session must still produce one queued job.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from procrastinate import App
+from procrastinate.testing import InMemoryConnector
+
+
+@pytest.fixture
+async def in_memory_app() -> AsyncIterator[App]:
+    """Patch the aios procrastinate app to use an in-memory connector.
+
+    Mirrors the fixture in ``tests/unit/test_wake_instrumentation.py``.
+    The InMemoryConnector implements the same defer/fetch interface
+    against a Python dict, so we can read job rows directly via
+    ``connector.jobs``.
+    """
+    from aios.harness.procrastinate_app import app
+
+    with app.replace_connector(InMemoryConnector()) as patched:
+        yield patched
+
+
+def _job_rows(app: App) -> list[dict]:
+    """Return the in-memory job rows. Helper so the cast lives in one place."""
+    connector = app.connector
+    assert isinstance(connector, InMemoryConnector)
+    return list(connector.jobs.values())
+
+
+class TestDeferWakeLockValues:
+    """``defer_wake`` must populate ``lock`` and ``queueing_lock`` with the
+    session_id value, not the literal template string."""
+
+    async def test_lock_is_session_id(self, in_memory_app: App) -> None:
+        """One defer ⇒ one job row with ``lock = session_id``.
+
+        The ``lock`` column drives procrastinate's ``WHERE
+        status='doing'`` partial unique index — distinct values let
+        the worker run distinct sessions concurrently up to its
+        configured concurrency.
+        """
+        from aios.harness.wake import defer_wake
+
+        pool = MagicMock()
+        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+            await defer_wake(pool, "sess_alpha", cause="message")
+
+        rows = _job_rows(in_memory_app)
+        assert len(rows) == 1
+        assert rows[0]["lock"] == "sess_alpha", (
+            f"job row's lock = {rows[0]['lock']!r}; expected 'sess_alpha'. "
+            f"defer_wake must pass lock=session_id to configure_task — "
+            f"the @app.task decorator's '{{session_id}}' is a literal "
+            f"string in procrastinate, not a kwarg template."
+        )
+
+    async def test_queueing_lock_is_session_id(self, in_memory_app: App) -> None:
+        """Same contract for ``queueing_lock``.
+
+        Without this, the partial unique index on
+        ``queueing_lock WHERE status='todo'`` coalesces defers across
+        unrelated sessions, hiding new wake events behind already-queued
+        jobs for different sessions.
+        """
+        from aios.harness.wake import defer_wake
+
+        pool = MagicMock()
+        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+            await defer_wake(pool, "sess_beta", cause="message")
+
+        rows = _job_rows(in_memory_app)
+        assert len(rows) == 1
+        assert rows[0]["queueing_lock"] == "sess_beta", (
+            f"job row's queueing_lock = {rows[0]['queueing_lock']!r}; "
+            f"expected 'sess_beta'. defer_wake must pass "
+            f"queueing_lock=session_id to configure_task."
+        )
+
+    async def test_defer_retry_wake_uses_session_id_lock(self, in_memory_app: App) -> None:
+        """The retry path has the same contract as the main defer path."""
+        from aios.harness.wake import defer_retry_wake
+
+        pool = MagicMock()
+        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+            await defer_retry_wake(pool, "sess_gamma", delay_seconds=2)
+
+        rows = _job_rows(in_memory_app)
+        assert len(rows) == 1
+        assert rows[0]["lock"] == "sess_gamma", (
+            f"defer_retry_wake's job row lock = {rows[0]['lock']!r}; "
+            f"expected 'sess_gamma'. The retry path has the same "
+            f"per-session lock contract."
+        )
+        assert rows[0]["queueing_lock"] == "sess_gamma"
+
+
+class TestDeferWakeCrossSessionIsolation:
+    """The user-visible symptom of #192: bursty defers across distinct
+    sessions must not coalesce, but bursty defers within ONE session
+    must still coalesce."""
+
+    async def test_distinct_sessions_do_not_coalesce(self, in_memory_app: App) -> None:
+        """N defers across N sessions ⇒ N queued jobs.
+
+        Mirrors issue #192's "Repro" scenario: many sessions POST
+        messages back-to-back. Each ``session_id`` owns its own
+        ``queueing_lock`` slot, so all N jobs queue up and the worker
+        can run them concurrently.
+
+        ``defer_wake`` swallows ``AlreadyEnqueued``, so a regression
+        of the original bug wouldn't raise — it would surface as
+        ``connector.jobs`` holding fewer rows than expected.
+        """
+        from aios.harness.wake import defer_wake
+
+        pool = MagicMock()
+        n = 5
+
+        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+            for i in range(n):
+                await defer_wake(pool, f"sess_{i}", cause="message")
+
+        rows = _job_rows(in_memory_app)
+        assert len(rows) == n, (
+            f"only {len(rows)}/{n} wake jobs queued — the rest were "
+            f"coalesced via queueing_lock because every defer used the "
+            f"literal lock value '{{session_id}}'. This is exactly the "
+            f"#192 symptom: under bursty load across distinct sessions, "
+            f"only one wake survives the queueing_lock dedup."
+        )
+
+        locks = sorted(row["lock"] for row in rows)
+        assert locks == [f"sess_{i}" for i in range(n)], (
+            f"lock values = {locks}; expected one per session. "
+            f"Each session must own its own lock slot for the worker "
+            f"to be able to run them concurrently."
+        )
+
+    async def test_same_session_still_coalesces(self, in_memory_app: App) -> None:
+        """Two defers for the same session ⇒ one queued job.
+
+        The whole point of the ``queueing_lock`` is that within ONE
+        session, multiple defers (user message + tool completion +
+        sweep firing in the same window) collapse into a single wake
+        — the existing queued job sees all the new events when it
+        runs. Dropping this dedup would multiply queue and step
+        traffic without adding throughput.
+        """
+        from aios.harness.wake import defer_wake
+
+        pool = MagicMock()
+
+        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+            await defer_wake(pool, "sess_x", cause="message")
+            await defer_wake(pool, "sess_x", cause="sweep")
+            await defer_wake(pool, "sess_x", cause="tool_confirmation")
+
+        rows = _job_rows(in_memory_app)
+        assert len(rows) == 1, (
+            f"got {len(rows)} jobs for one session_id; expected 1. "
+            f"Same-session defers must coalesce via queueing_lock — "
+            f"the queued wake handles all events that arrived since "
+            f"it was deferred."
+        )
+        assert rows[0]["queueing_lock"] == "sess_x"

--- a/tests/unit/test_wake_locks.py
+++ b/tests/unit/test_wake_locks.py
@@ -1,83 +1,30 @@
-"""Regression tests for issue #192 — ``defer_wake`` passes per-session locks.
+"""Pin per-session ``lock`` and ``queueing_lock`` on wake_session jobs.
 
-Lives at the unit layer because the contract being pinned is purely about
-the *values* ``defer_wake`` writes into procrastinate's ``lock`` and
-``queueing_lock`` columns. The :class:`InMemoryConnector` from
-procrastinate's test kit gives direct access to those columns without
-spinning up a database or a worker.
-
-Background: the original bug — fixed alongside these tests — was that
-``src/aios/harness/tasks.py`` declared
-``@app.task(lock="{session_id}", queueing_lock="{session_id}")``. The
-braces look like a kwarg-template placeholder, but procrastinate stores
-the string literally — there is no template substitution at any layer.
-Every wake job ended up sharing the lock value ``"{session_id}"`` and
-procrastinate's per-lock serialization (the unique partial index plus
-the ``NOT EXISTS`` clause in ``procrastinate_fetch_job_v2``) gated them
-all to one at a time, regardless of session.
-
-Fix: ``src/aios/harness/wake.py`` now passes per-session
-``lock=session_id, queueing_lock=session_id`` through
-``configure_task``. These tests pin the contract so the same regression
-can't recur:
-
-* :meth:`TestDeferWakeLockValues.test_lock_is_session_id` — single
-  defer assigns ``lock = session_id``.
-* :meth:`TestDeferWakeLockValues.test_queueing_lock_is_session_id` —
-  same for ``queueing_lock``. Together with the index, this is what
-  prevents cross-session ``AlreadyEnqueued``.
-* :meth:`TestDeferWakeCrossSessionIsolation.test_distinct_sessions_do_not_coalesce`
-  — bursty defers across N sessions all enqueue, no
-  ``AlreadyEnqueued``. This is the user-visible symptom of #192.
-* :meth:`TestDeferWakeCrossSessionIsolation.test_same_session_still_coalesces`
-  — guards against an over-zealous regression that drops the dedup.
-  Two defers for one session must still produce one queued job.
+Procrastinate stores the ``@app.task(lock=...)`` decorator argument
+verbatim — there is no kwarg-template substitution. So a decorator-level
+``lock="{session_id}"`` would assign every wake job the same literal
+lock value and procrastinate's per-lock serialization (the unique
+partial indexes on ``lock``/``queueing_lock``) would gate all wakes to
+one at a time across sessions. ``defer_wake`` therefore must pass the
+real ``session_id`` per call to ``configure_task``.
 """
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from procrastinate import App
 from procrastinate.testing import InMemoryConnector
 
 
-@pytest.fixture
-async def in_memory_app() -> AsyncIterator[App]:
-    """Patch the aios procrastinate app to use an in-memory connector.
-
-    Mirrors the fixture in ``tests/unit/test_wake_instrumentation.py``.
-    The InMemoryConnector implements the same defer/fetch interface
-    against a Python dict, so we can read job rows directly via
-    ``connector.jobs``.
-    """
-    from aios.harness.procrastinate_app import app
-
-    with app.replace_connector(InMemoryConnector()) as patched:
-        yield patched
-
-
 def _job_rows(app: App) -> list[dict]:
-    """Return the in-memory job rows. Helper so the cast lives in one place."""
     connector = app.connector
     assert isinstance(connector, InMemoryConnector)
     return list(connector.jobs.values())
 
 
 class TestDeferWakeLockValues:
-    """``defer_wake`` must populate ``lock`` and ``queueing_lock`` with the
-    session_id value, not the literal template string."""
-
     async def test_lock_is_session_id(self, in_memory_app: App) -> None:
-        """One defer ⇒ one job row with ``lock = session_id``.
-
-        The ``lock`` column drives procrastinate's ``WHERE
-        status='doing'`` partial unique index — distinct values let
-        the worker run distinct sessions concurrently up to its
-        configured concurrency.
-        """
         from aios.harness.wake import defer_wake
 
         pool = MagicMock()
@@ -86,21 +33,9 @@ class TestDeferWakeLockValues:
 
         rows = _job_rows(in_memory_app)
         assert len(rows) == 1
-        assert rows[0]["lock"] == "sess_alpha", (
-            f"job row's lock = {rows[0]['lock']!r}; expected 'sess_alpha'. "
-            f"defer_wake must pass lock=session_id to configure_task — "
-            f"the @app.task decorator's '{{session_id}}' is a literal "
-            f"string in procrastinate, not a kwarg template."
-        )
+        assert rows[0]["lock"] == "sess_alpha"
 
     async def test_queueing_lock_is_session_id(self, in_memory_app: App) -> None:
-        """Same contract for ``queueing_lock``.
-
-        Without this, the partial unique index on
-        ``queueing_lock WHERE status='todo'`` coalesces defers across
-        unrelated sessions, hiding new wake events behind already-queued
-        jobs for different sessions.
-        """
         from aios.harness.wake import defer_wake
 
         pool = MagicMock()
@@ -109,14 +44,9 @@ class TestDeferWakeLockValues:
 
         rows = _job_rows(in_memory_app)
         assert len(rows) == 1
-        assert rows[0]["queueing_lock"] == "sess_beta", (
-            f"job row's queueing_lock = {rows[0]['queueing_lock']!r}; "
-            f"expected 'sess_beta'. defer_wake must pass "
-            f"queueing_lock=session_id to configure_task."
-        )
+        assert rows[0]["queueing_lock"] == "sess_beta"
 
     async def test_defer_retry_wake_uses_session_id_lock(self, in_memory_app: App) -> None:
-        """The retry path has the same contract as the main defer path."""
         from aios.harness.wake import defer_retry_wake
 
         pool = MagicMock()
@@ -125,30 +55,17 @@ class TestDeferWakeLockValues:
 
         rows = _job_rows(in_memory_app)
         assert len(rows) == 1
-        assert rows[0]["lock"] == "sess_gamma", (
-            f"defer_retry_wake's job row lock = {rows[0]['lock']!r}; "
-            f"expected 'sess_gamma'. The retry path has the same "
-            f"per-session lock contract."
-        )
+        assert rows[0]["lock"] == "sess_gamma"
         assert rows[0]["queueing_lock"] == "sess_gamma"
 
 
 class TestDeferWakeCrossSessionIsolation:
-    """The user-visible symptom of #192: bursty defers across distinct
-    sessions must not coalesce, but bursty defers within ONE session
-    must still coalesce."""
-
     async def test_distinct_sessions_do_not_coalesce(self, in_memory_app: App) -> None:
-        """N defers across N sessions ⇒ N queued jobs.
+        """N defers for N distinct sessions ⇒ N queued jobs.
 
-        Mirrors issue #192's "Repro" scenario: many sessions POST
-        messages back-to-back. Each ``session_id`` owns its own
-        ``queueing_lock`` slot, so all N jobs queue up and the worker
-        can run them concurrently.
-
-        ``defer_wake`` swallows ``AlreadyEnqueued``, so a regression
-        of the original bug wouldn't raise — it would surface as
-        ``connector.jobs`` holding fewer rows than expected.
+        ``defer_wake`` swallows ``AlreadyEnqueued``, so a regression of
+        the original bug wouldn't raise — it would surface as fewer
+        queued jobs than sessions.
         """
         from aios.harness.wake import defer_wake
 
@@ -160,30 +77,15 @@ class TestDeferWakeCrossSessionIsolation:
                 await defer_wake(pool, f"sess_{i}", cause="message")
 
         rows = _job_rows(in_memory_app)
-        assert len(rows) == n, (
-            f"only {len(rows)}/{n} wake jobs queued — the rest were "
-            f"coalesced via queueing_lock because every defer used the "
-            f"literal lock value '{{session_id}}'. This is exactly the "
-            f"#192 symptom: under bursty load across distinct sessions, "
-            f"only one wake survives the queueing_lock dedup."
-        )
-
-        locks = sorted(row["lock"] for row in rows)
-        assert locks == [f"sess_{i}" for i in range(n)], (
-            f"lock values = {locks}; expected one per session. "
-            f"Each session must own its own lock slot for the worker "
-            f"to be able to run them concurrently."
-        )
+        assert len(rows) == n
+        assert sorted(row["lock"] for row in rows) == [f"sess_{i}" for i in range(n)]
 
     async def test_same_session_still_coalesces(self, in_memory_app: App) -> None:
-        """Two defers for the same session ⇒ one queued job.
+        """Same-session defers must still dedup to one queued wake.
 
-        The whole point of the ``queueing_lock`` is that within ONE
-        session, multiple defers (user message + tool completion +
-        sweep firing in the same window) collapse into a single wake
-        — the existing queued job sees all the new events when it
-        runs. Dropping this dedup would multiply queue and step
-        traffic without adding throughput.
+        Multiple defers within one session (user message + tool
+        completion + sweep) collapse into a single wake; the queued
+        wake handles all events that arrived since it was deferred.
         """
         from aios.harness.wake import defer_wake
 
@@ -195,10 +97,5 @@ class TestDeferWakeCrossSessionIsolation:
             await defer_wake(pool, "sess_x", cause="tool_confirmation")
 
         rows = _job_rows(in_memory_app)
-        assert len(rows) == 1, (
-            f"got {len(rows)} jobs for one session_id; expected 1. "
-            f"Same-session defers must coalesce via queueing_lock — "
-            f"the queued wake handles all events that arrived since "
-            f"it was deferred."
-        )
+        assert len(rows) == 1
         assert rows[0]["queueing_lock"] == "sess_x"


### PR DESCRIPTION
## Summary

- **Root cause**: procrastinate does NOT template-substitute `{kwarg}` in `@app.task(lock=...)` — the string is stored verbatim. So aios's `@app.task(lock="{session_id}", queueing_lock="{session_id}")` assigned every wake the same literal lock value, and procrastinate's per-lock serialization (`lock` unique on `status='doing'`, `queueing_lock` unique on `status='todo'`) gated **all** wakes to one at a time across all sessions. Under bursty load, 20 sessions queued behind one job slot at ~1 job/sec instead of saturating `worker_concurrency=4`.
- **Fix**: `defer_wake` / `defer_retry_wake` now pass `lock=session_id, queueing_lock=session_id` per call to `configure_task`. Removed the now-dead (and misleading) decorator defaults from `tasks.py`. Distinct sessions get distinct lock slots; the worker dispatches them concurrently up to `worker_concurrency`.
- **Tests**: 5 unit tests pin the column-value contract; one implementation-agnostic e2e test confirms peak observed concurrency reaches the configured value end-to-end.

## Notable

`tests/e2e/test_focal_channel.py:_post_inbound` had an unrelated, latent test-isolation bug: `with mock.patch("aios.harness.wake.defer_wake")` inside a function called via `asyncio.gather(*5)` is unsafe — concurrent enter/exit corrupts the saved original, so the mock leaks to later tests. The mock was dead code anyway (neither `resolve_channel` nor `append_user_message` call `defer_wake`). Removed it.

## Test plan

- [x] `uv run mypy src` clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` clean
- [x] `uv run pytest tests/unit -q` — 1025 passed
- [x] `DOCKER_HOST=... uv run pytest tests/e2e -q` — 285 passed (incl. new e2e fence)
- [x] e2e reproducer fails at `peak=1` with the fix reverted, passes at `peak=4` with the fix

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)