### PR TITLE
docs(context): point _ALLOWED_FIELDS at #196 for thinking_blocks rationale

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -34,6 +34,10 @@ from aios.models.events import Event
 # Chat-completions spec fields per role.  Only these are emitted in the
 # context; provider-specific extensions (reasoning_content, etc.) stay
 # in the event log but are excluded from the message list.
+#
+# `thinking_blocks` and `reasoning_content` are intentionally stripped even
+# on same-provider replays — see #196 for cost/benefit and the OpenRouter
+# transport gaps before re-litigating.
 _ALLOWED_FIELDS: dict[str, frozenset[str]] = {
     "assistant": frozenset({"role", "content", "tool_calls"}),
     "tool": frozenset({"role", "tool_call_id", "content", "name"}),


### PR DESCRIPTION
## Summary

- Adds 3 lines of comment to `_ALLOWED_FIELDS` (src/aios/harness/context.py) noting that `thinking_blocks` / `reasoning_content` are intentionally stripped on every replay, with a pointer to #196 for the cost/benefit analysis.
- Code-only delta is the comment; the substance lives on #196 and the two adjacent transport-gap issues #202 / #203.

## Why

Spent a session probing whether to ship the conditional-strip fix proposed in #196. Conclusion was **don't** — the bug is real per Anthropic's documented contract, but unmeasured in practice; the original fork-consistency motivation didn't actually improve in the author's own test; the cost is moderately invasive and there's a Claude-5 future-proofing risk; and OR-routed sessions get nothing from the fix until upstream gaps (#202, #203) close.

The `_ALLOWED_FIELDS` definition reads like a casual oversight without context. Anyone who notices the strip and is tempted to "just keep `thinking_blocks` too" will start from scratch. This breadcrumb makes the prior investigation findable in one click instead of three hours.

## What's NOT in this PR

- No code-behavior change. Same fields stripped, same context built.
- No new tests (no behavior to test).
- The `target_supports_thinking` gate proposed in #196 is **not** implemented — that's the deferred decision; this PR documents the deferral.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1020 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)