### PR TITLE
feat(github): add github_repository session resource

### DIFF
--- a/migrations/versions/0026_github_repositories.py
+++ b/migrations/versions/0026_github_repositories.py
@@ -1,0 +1,61 @@
+"""GitHub repository session resources.
+
+Adds a single table ``session_github_repositories``: each row is a per-session
+attachment that mounts a git repo into the sandbox at ``mount_path``. There is
+no top-level ``github_repositories`` table — the row IS the resource (parity
+with Anthropic Managed Agents, where ``github_repository`` resources only exist
+within a session).
+
+The clone token is stored encrypted via the same libsodium CryptoBox used by
+``vault_credentials`` (``ciphertext``/``nonce`` columns). It is never echoed in
+API responses; the only mutation supported is rotation via
+``POST /v1/sessions/{sid}/resources/{rid}``.
+
+Unique on ``(session_id, mount_path)`` so two repos can't fight for the same
+mount inside one container.
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-05-02
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0026"
+down_revision: str = "0025"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(r"""
+        CREATE TABLE session_github_repositories (
+            id              text PRIMARY KEY,
+            session_id      text NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            rank            integer NOT NULL,
+            repo_url        text NOT NULL,
+            mount_path      text NOT NULL,
+            ciphertext      bytea NOT NULL,
+            nonce           bytea NOT NULL,
+            created_at      timestamptz NOT NULL DEFAULT now(),
+            updated_at      timestamptz NOT NULL DEFAULT now(),
+            CHECK (mount_path ~ '^(/[^/\x00]+)+$'),
+            CHECK (mount_path !~ '(^|/)\.{1,2}(/|$)')
+        )
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX session_github_repos_mount_uniq
+            ON session_github_repositories (session_id, mount_path)
+    """)
+    op.execute("""
+        CREATE INDEX session_github_repos_by_session
+            ON session_github_repositories (session_id, rank)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS session_github_repositories")

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -19,6 +19,7 @@ from sse_starlette import EventSourceResponse
 
 from aios.api.deps import (
     AuthDep,
+    CryptoBoxDep,
     DbUrlDep,
     PoolDep,
     ProcrastinateDep,
@@ -26,15 +27,21 @@ from aios.api.deps import (
 from aios.api.sse import sse_event_stream
 from aios.db import queries
 from aios.db.listen import listen_for_events
-from aios.errors import NotFoundError
+from aios.errors import NotFoundError, ValidationError
 from aios.harness.wake import defer_wake
+from aios.ids import GITHUB_REPOSITORY, split_id
 from aios.models.common import ListResponse
 from aios.models.events import Event, EventKind
+from aios.models.github_repositories import (
+    GithubRepositoryResourceEcho,
+    GithubRepositoryUpdate,
+)
 from aios.models.sessions import (
     ContextResponse,
     Session,
     SessionCreate,
     SessionInterruptRequest,
+    SessionResourceEcho,
     SessionStatus,
     SessionUpdate,
     SessionUserMessage,
@@ -42,6 +49,7 @@ from aios.models.sessions import (
     ToolResultRequest,
     WaitResponse,
 )
+from aios.services import github_repositories as github_repo_service
 from aios.services import sessions as service
 
 router = APIRouter(prefix="/v1/sessions", tags=["sessions"])
@@ -52,6 +60,7 @@ async def create(
     body: SessionCreate,
     pool: PoolDep,
     procrastinate: ProcrastinateDep,
+    crypto_box: CryptoBoxDep,
     _auth: AuthDep,
 ) -> Session:
     session = await service.create_session(
@@ -63,6 +72,7 @@ async def create(
         metadata=body.metadata,
         vault_ids=body.vault_ids or None,
         resources=body.resources or None,
+        crypto_box=crypto_box,
         workspace_path=body.workspace_path,
         env=body.env or None,
     )
@@ -101,7 +111,13 @@ async def get(session_id: str, pool: PoolDep, _auth: AuthDep) -> Session:
 
 
 @router.put("/{session_id}")
-async def update(session_id: str, body: SessionUpdate, pool: PoolDep, _auth: AuthDep) -> Session:
+async def update(
+    session_id: str,
+    body: SessionUpdate,
+    pool: PoolDep,
+    crypto_box: CryptoBoxDep,
+    _auth: AuthDep,
+) -> Session:
     from aios.db.queries import _UNSET
 
     # Use model_fields_set to distinguish "not provided" from "explicitly null".
@@ -115,7 +131,87 @@ async def update(session_id: str, body: SessionUpdate, pool: PoolDep, _auth: Aut
         metadata=body.metadata,
         vault_ids=body.vault_ids,
         resources=body.resources,
+        crypto_box=crypto_box,
     )
+
+
+@router.get("/{session_id}/resources")
+async def list_resources(
+    session_id: str, pool: PoolDep, _auth: AuthDep
+) -> ListResponse[SessionResourceEcho]:
+    """List all resources attached to ``session_id``.
+
+    Returns the type-discriminated union of memory store and github
+    repository echoes, ordered by type (memory stores first) and rank.
+    Equivalent to reading the ``resources`` field on the full session
+    record, but cheaper if you don't need anything else.
+    """
+    # Reuse get_session for ordering + echo construction; resources are
+    # already on the returned record.
+    session = await service.get_session(pool, session_id)
+    return ListResponse[SessionResourceEcho](
+        data=session.resources, has_more=False, next_after=None
+    )
+
+
+@router.get("/{session_id}/resources/{resource_id}")
+async def get_resource(
+    session_id: str, resource_id: str, pool: PoolDep, _auth: AuthDep
+) -> GithubRepositoryResourceEcho:
+    """Fetch a single resource attached to ``session_id`` by its id.
+
+    v1 only supports ``github_repository`` (id prefix ``ghrepo_``) since
+    memory store attachments are keyed by ``(session_id, memory_store_id)``
+    and don't have a separate attachment id.
+    """
+    _require_github_resource_id(resource_id)
+    return await github_repo_service.get_resource(pool, session_id, resource_id)
+
+
+@router.post("/{session_id}/resources/{resource_id}")
+async def update_resource(
+    session_id: str,
+    resource_id: str,
+    body: GithubRepositoryUpdate,
+    pool: PoolDep,
+    crypto_box: CryptoBoxDep,
+    _auth: AuthDep,
+) -> GithubRepositoryResourceEcho:
+    """Rotate the auth token on a github_repository attachment.
+
+    The bumped ``updated_at`` propagates through the mount snapshot, so
+    the next sandbox provision recycles the container and re-clones the
+    working tree with the new token.
+    """
+    _require_github_resource_id(resource_id)
+    return await github_repo_service.rotate_token(
+        pool,
+        crypto_box,
+        session_id=session_id,
+        resource_id=resource_id,
+        new_token=body.authorization_token.get_secret_value(),
+    )
+
+
+def _require_github_resource_id(resource_id: str) -> None:
+    """Reject non-github resource ids with a useful 400 instead of a 404.
+
+    Memory store attachments don't have a separate id; pointing at a
+    ``memstore_`` here is almost always a client bug.
+    """
+    try:
+        prefix, _ = split_id(resource_id)
+    except ValueError as exc:
+        raise ValidationError(
+            f"malformed resource id: {resource_id!r}",
+            detail={"resource_id": resource_id},
+        ) from exc
+    if prefix != GITHUB_REPOSITORY:
+        raise ValidationError(
+            "only github_repository resource ids (prefix 'ghrepo_') are "
+            "supported on the per-resource sub-collection endpoints",
+            detail={"resource_id": resource_id, "prefix": prefix},
+        )
 
 
 @router.post("/{session_id}/archive")

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -35,6 +35,7 @@ from aios.ids import (
     CONNECTION,
     ENVIRONMENT,
     EVENT,
+    GITHUB_REPOSITORY,
     MEMORY,
     MEMORY_STORE,
     MEMORY_VERSION,
@@ -50,6 +51,7 @@ from aios.models.channel_bindings import ChannelBinding
 from aios.models.connections import Connection
 from aios.models.environments import Environment, EnvironmentConfig
 from aios.models.events import Event, EventKind
+from aios.models.github_repositories import GithubRepositoryResourceEcho
 from aios.models.memory_stores import (
     Actor,
     Memory,
@@ -3361,3 +3363,139 @@ async def list_session_memory_store_echoes(
         )
         for r in rows
     ]
+
+
+# GitHub repository attachments ────────────────────────────────────────────
+
+
+def _row_to_github_repo_echo(row: asyncpg.Record) -> GithubRepositoryResourceEcho:
+    return GithubRepositoryResourceEcho(
+        id=row["id"],
+        url=row["repo_url"],
+        mount_path=row["mount_path"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+async def attach_github_repos_to_session(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    entries: list[tuple[str, str, EncryptedBlob]],
+) -> None:
+    """Insert pre-encrypted github_repository attachments for a session.
+
+    ``entries`` is ``(repo_url, mount_path, encrypted_token)`` tuples in
+    rank order. Encryption is the caller's responsibility (service layer
+    holds the CryptoBox). Uniqueness on (session_id, mount_path) is
+    enforced by the partial unique index — a duplicate raises asyncpg's
+    ``UniqueViolationError`` which the service layer maps to a 4xx.
+    """
+    for rank, (repo_url, mount_path, blob) in enumerate(entries):
+        rid = make_id(GITHUB_REPOSITORY)
+        await conn.execute(
+            """
+            INSERT INTO session_github_repositories
+                (id, session_id, rank, repo_url, mount_path, ciphertext, nonce)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            """,
+            rid,
+            session_id,
+            rank,
+            repo_url,
+            mount_path,
+            blob.ciphertext,
+            blob.nonce,
+        )
+
+
+async def list_session_github_repo_echoes(
+    conn: asyncpg.Connection[Any], session_id: str
+) -> list[GithubRepositoryResourceEcho]:
+    rows = await conn.fetch(
+        "SELECT * FROM session_github_repositories WHERE session_id = $1 ORDER BY rank",
+        session_id,
+    )
+    return [_row_to_github_repo_echo(r) for r in rows]
+
+
+async def get_session_github_repo(
+    conn: asyncpg.Connection[Any], session_id: str, resource_id: str
+) -> GithubRepositoryResourceEcho:
+    row = await conn.fetchrow(
+        "SELECT * FROM session_github_repositories WHERE session_id = $1 AND id = $2",
+        session_id,
+        resource_id,
+    )
+    if row is None:
+        raise NotFoundError(
+            f"github_repository resource {resource_id} not found on session {session_id}",
+            detail={"session_id": session_id, "resource_id": resource_id},
+        )
+    return _row_to_github_repo_echo(row)
+
+
+async def get_session_github_repo_with_blob(
+    conn: asyncpg.Connection[Any], session_id: str, resource_id: str
+) -> tuple[GithubRepositoryResourceEcho, EncryptedBlob]:
+    """Read view + encrypted token blob, for the rotation path which needs
+    both."""
+    row = await conn.fetchrow(
+        "SELECT * FROM session_github_repositories WHERE session_id = $1 AND id = $2",
+        session_id,
+        resource_id,
+    )
+    if row is None:
+        raise NotFoundError(
+            f"github_repository resource {resource_id} not found on session {session_id}",
+            detail={"session_id": session_id, "resource_id": resource_id},
+        )
+    return _row_to_github_repo_echo(row), EncryptedBlob(
+        ciphertext=row["ciphertext"], nonce=row["nonce"]
+    )
+
+
+async def update_session_github_repo_blob(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    resource_id: str,
+    blob: EncryptedBlob,
+) -> GithubRepositoryResourceEcho:
+    """Replace the encrypted token blob and bump ``updated_at``.
+
+    Only the secret rotates; ``url`` and ``mount_path`` are immutable to
+    match CMA's behavior (verified by API probe — PUT returns 405,
+    DELETE returns 400, only POST with ``{authorization_token}`` is
+    accepted).
+    """
+    row = await conn.fetchrow(
+        """
+        UPDATE session_github_repositories
+        SET ciphertext = $1, nonce = $2, updated_at = now()
+        WHERE session_id = $3 AND id = $4
+        RETURNING *
+        """,
+        blob.ciphertext,
+        blob.nonce,
+        session_id,
+        resource_id,
+    )
+    if row is None:
+        raise NotFoundError(
+            f"github_repository resource {resource_id} not found on session {session_id}",
+            detail={"session_id": session_id, "resource_id": resource_id},
+        )
+    return _row_to_github_repo_echo(row)
+
+
+async def delete_session_github_repos(conn: asyncpg.Connection[Any], session_id: str) -> None:
+    """Delete all github_repository attachments for a session.
+
+    Used by the full-list-replace path on session update — paired with
+    a re-insert via :func:`attach_github_repos_to_session` inside the
+    same transaction.
+    """
+    await conn.execute(
+        "DELETE FROM session_github_repositories WHERE session_id = $1",
+        session_id,
+    )

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -80,7 +80,6 @@ async def refresh_session_mount_state(
         memory_echoes = await queries.list_session_memory_store_echoes(conn, session_id)
         github_echoes = await queries.list_session_github_repo_echoes(conn, session_id)
     runtime.set_session_memory_mounts(session_id, memory_echoes)
-    runtime.set_session_github_repos(session_id, github_echoes)
     if runtime.sandbox_registry is not None:
         await runtime.sandbox_registry.release_if_mounts_changed(
             session_id, memory_echoes, github_echoes

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -68,15 +68,24 @@ def _retry_delay_for_attempt(attempt: int) -> float | None:
 async def refresh_session_mount_state(
     pool: asyncpg.Pool[Any], session_id: str
 ) -> list[MemoryStoreResourceEcho]:
-    """Return the freshly-loaded echoes so the step body can skip a second DB query."""
+    """Refresh the cached resource echoes and the sandbox drift check.
+
+    Returns the memory echoes (used downstream for prompt augmentation).
+    Github echoes are cached and fed into the registry's drift check but
+    not returned — no current caller in the step body needs them.
+    """
     from aios.db import queries
 
     async with pool.acquire() as conn:
-        echoes = await queries.list_session_memory_store_echoes(conn, session_id)
-    runtime.set_session_memory_mounts(session_id, echoes)
+        memory_echoes = await queries.list_session_memory_store_echoes(conn, session_id)
+        github_echoes = await queries.list_session_github_repo_echoes(conn, session_id)
+    runtime.set_session_memory_mounts(session_id, memory_echoes)
+    runtime.set_session_github_repos(session_id, github_echoes)
     if runtime.sandbox_registry is not None:
-        await runtime.sandbox_registry.release_if_mounts_changed(session_id, echoes)
-    return echoes
+        await runtime.sandbox_registry.release_if_mounts_changed(
+            session_id, memory_echoes, github_echoes
+        )
+    return memory_echoes
 
 
 async def run_session_step(

--- a/src/aios/harness/runtime.py
+++ b/src/aios/harness/runtime.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from aios.crypto.vault import CryptoBox
     from aios.harness.task_registry import TaskRegistry
     from aios.mcp.pool import McpSessionPool
-    from aios.models.github_repositories import GithubRepositoryResourceEcho
     from aios.models.memory_stores import MemoryStoreResourceEcho
     from aios.sandbox.registry import SandboxRegistry
 
@@ -63,30 +62,6 @@ def get_session_memory_mounts(session_id: str) -> list[MemoryStoreResourceEcho]:
 def clear_session_memory_mounts(session_id: str) -> None:
     """Drop the cached mounts for ``session_id`` (e.g. after session unload)."""
     _session_memory_mounts.pop(session_id, None)
-
-
-# Per-session github_repository echo cache. Symmetric with the memory mount
-# cache above. Populated at the top of every step in
-# ``loop.refresh_session_mount_state`` so the sandbox registry's drift check
-# and any future github-aware tools can read the current attachment set
-# without an extra DB hit.
-_session_github_repos: dict[str, list[GithubRepositoryResourceEcho]] = {}
-
-
-def set_session_github_repos(session_id: str, echoes: list[GithubRepositoryResourceEcho]) -> None:
-    """Record the attached github repositories for ``session_id``."""
-    _session_github_repos[session_id] = list(echoes)
-
-
-def get_session_github_repos(session_id: str) -> list[GithubRepositoryResourceEcho]:
-    """Return the attached github repositories for ``session_id``, or an
-    empty list."""
-    return _session_github_repos.get(session_id, [])
-
-
-def clear_session_github_repos(session_id: str) -> None:
-    """Drop the cached github repos for ``session_id`` (e.g. after unload)."""
-    _session_github_repos.pop(session_id, None)
 
 
 # Per-session "last sha read by tool" cache: read tool stamps; write tool

--- a/src/aios/harness/runtime.py
+++ b/src/aios/harness/runtime.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from aios.crypto.vault import CryptoBox
     from aios.harness.task_registry import TaskRegistry
     from aios.mcp.pool import McpSessionPool
+    from aios.models.github_repositories import GithubRepositoryResourceEcho
     from aios.models.memory_stores import MemoryStoreResourceEcho
     from aios.sandbox.registry import SandboxRegistry
 
@@ -62,6 +63,30 @@ def get_session_memory_mounts(session_id: str) -> list[MemoryStoreResourceEcho]:
 def clear_session_memory_mounts(session_id: str) -> None:
     """Drop the cached mounts for ``session_id`` (e.g. after session unload)."""
     _session_memory_mounts.pop(session_id, None)
+
+
+# Per-session github_repository echo cache. Symmetric with the memory mount
+# cache above. Populated at the top of every step in
+# ``loop.refresh_session_mount_state`` so the sandbox registry's drift check
+# and any future github-aware tools can read the current attachment set
+# without an extra DB hit.
+_session_github_repos: dict[str, list[GithubRepositoryResourceEcho]] = {}
+
+
+def set_session_github_repos(session_id: str, echoes: list[GithubRepositoryResourceEcho]) -> None:
+    """Record the attached github repositories for ``session_id``."""
+    _session_github_repos[session_id] = list(echoes)
+
+
+def get_session_github_repos(session_id: str) -> list[GithubRepositoryResourceEcho]:
+    """Return the attached github repositories for ``session_id``, or an
+    empty list."""
+    return _session_github_repos.get(session_id, [])
+
+
+def clear_session_github_repos(session_id: str) -> None:
+    """Drop the cached github repos for ``session_id`` (e.g. after unload)."""
+    _session_github_repos.pop(session_id, None)
 
 
 # Per-session "last sha read by tool" cache: read tool stamps; write tool

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -34,6 +34,7 @@ ROUTING_RULE: Final = "rrul"
 MEMORY_STORE: Final = "memstore"
 MEMORY: Final = "mem"
 MEMORY_VERSION: Final = "memver"
+GITHUB_REPOSITORY: Final = "ghrepo"
 
 _PREFIXES: Final = frozenset(
     {
@@ -52,6 +53,7 @@ _PREFIXES: Final = frozenset(
         MEMORY_STORE,
         MEMORY,
         MEMORY_VERSION,
+        GITHUB_REPOSITORY,
     }
 )
 

--- a/src/aios/models/github_repositories.py
+++ b/src/aios/models/github_repositories.py
@@ -30,20 +30,16 @@ _MOUNT_PATH_PATTERN = r"^(/[^/\x00]+)+$"
 
 
 def _check_mount_path(path: str) -> None:
-    """Reject `.` and `..` segments and overlap with the memory mount root.
-
-    Path traversal is already blocked by the regex (the segment-pattern bans
-    NUL and slashes-within-segments), but `.` and `..` segments are still
-    syntactically valid under that regex and would let a clone escape the
-    intended host directory once the path is joined to a parent. The
-    ``/mnt/memory`` overlap check stops a github repo from shadowing or
-    being shadowed by a memory store mount in the same container.
-    """
+    """Block path-traversal segments and reserved-mount overlaps."""
     for segment in path.lstrip("/").split("/"):
         if segment in (".", ".."):
             raise ValueError(f"path segment {segment!r} is not allowed (would enable traversal)")
     if path == "/mnt/memory" or path.startswith("/mnt/memory/"):
         raise ValueError("mount_path may not overlap with the /mnt/memory tree (memory stores)")
+    if path == "/workspace":
+        raise ValueError(
+            "mount_path may not be /workspace exactly (it shadows the session workspace mount)"
+        )
 
 
 class GithubRepositoryResource(BaseModel):

--- a/src/aios/models/github_repositories.py
+++ b/src/aios/models/github_repositories.py
@@ -1,0 +1,119 @@
+"""GitHub repository session resources.
+
+Each ``github_repository`` is a per-session attachment that mounts a git repo
+into the sandbox at a user-specified ``mount_path``. Unlike memory stores,
+there is no top-level repository resource — the row in
+``session_github_repositories`` IS the resource. This mirrors Anthropic
+Managed Agents' wire shape exactly.
+
+The clone token (``authorization_token``) is write-only on every endpoint:
+required at create, settable via ``POST /v1/sessions/{sid}/resources/{rid}``
+for rotation, never echoed back in API responses. Stored encrypted at rest
+via the same libsodium CryptoBox used by ``vault_credentials``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
+
+# Cap mirrors memory_stores' MAX_STORES_PER_SESSION. There's no hard
+# resource constraint forcing a low cap; this is a sanity bound that
+# matches the existing aios convention for per-session mountable resources.
+MAX_REPOS_PER_SESSION = 8
+
+# Mount path pattern: absolute path, segments may not be empty/contain NUL.
+# Same shape as MEMORY_PATH_RE in models/memory_stores.py.
+_MOUNT_PATH_PATTERN = r"^(/[^/\x00]+)+$"
+
+
+def _check_mount_path(path: str) -> None:
+    """Reject `.` and `..` segments and overlap with the memory mount root.
+
+    Path traversal is already blocked by the regex (the segment-pattern bans
+    NUL and slashes-within-segments), but `.` and `..` segments are still
+    syntactically valid under that regex and would let a clone escape the
+    intended host directory once the path is joined to a parent. The
+    ``/mnt/memory`` overlap check stops a github repo from shadowing or
+    being shadowed by a memory store mount in the same container.
+    """
+    for segment in path.lstrip("/").split("/"):
+        if segment in (".", ".."):
+            raise ValueError(f"path segment {segment!r} is not allowed (would enable traversal)")
+    if path == "/mnt/memory" or path.startswith("/mnt/memory/"):
+        raise ValueError("mount_path may not overlap with the /mnt/memory tree (memory stores)")
+
+
+class GithubRepositoryResource(BaseModel):
+    """Item in ``Session.resources[]`` request shape (create + update).
+
+    The ``authorization_token`` is a write-only ``SecretStr`` — present on
+    request, encrypted on the way to the DB, and never returned in API
+    responses (see :class:`GithubRepositoryResourceEcho`).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["github_repository"]
+    url: str = Field(min_length=1)
+    mount_path: str = Field(min_length=2, max_length=4096, pattern=_MOUNT_PATH_PATTERN)
+    authorization_token: SecretStr
+
+    @model_validator(mode="after")
+    def _check(self) -> GithubRepositoryResource:
+        _check_mount_path(self.mount_path)
+        if not self.authorization_token.get_secret_value():
+            raise ValueError("authorization_token must be non-empty")
+        return self
+
+
+class GithubRepositoryResourceEcho(BaseModel):
+    """Read view of an attached github repository as echoed on
+    ``Session.resources`` and on the per-resource sub-collection endpoints.
+
+    Token is intentionally absent; ``id`` is the per-attachment ULID
+    (prefix ``ghrepo``) used by the rotation endpoint.
+    """
+
+    type: Literal["github_repository"] = "github_repository"
+    id: str
+    url: str
+    mount_path: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class GithubRepositoryUpdate(BaseModel):
+    """Request body for ``POST /v1/sessions/{sid}/resources/{rid}``.
+
+    Only the token rotates. ``url`` and ``mount_path`` are immutable after
+    creation — to change them, detach the resource and attach a new one.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    authorization_token: SecretStr
+
+    @model_validator(mode="after")
+    def _check(self) -> GithubRepositoryUpdate:
+        if not self.authorization_token.get_secret_value():
+            raise ValueError("authorization_token must be non-empty")
+        return self
+
+
+def validate_resources(resources: list[GithubRepositoryResource]) -> None:
+    """Cross-item invariants checked at the API boundary.
+
+    The DB has a unique index on ``(session_id, mount_path)`` so a duplicate
+    here would 500 with a constraint violation; catching it pre-DB lets us
+    return a clean 4xx with a useful message.
+    """
+    if len(resources) > MAX_REPOS_PER_SESSION:
+        raise ValueError(f"at most {MAX_REPOS_PER_SESSION} github repositories per session")
+    seen_paths: set[str] = set()
+    for resource in resources:
+        if resource.mount_path in seen_paths:
+            raise ValueError(f"duplicate mount_path {resource.mount_path!r}")
+        seen_paths.add(resource.mount_path)

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -11,17 +11,60 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from aios.models.events import Event
+from aios.models.github_repositories import (
+    MAX_REPOS_PER_SESSION,
+    GithubRepositoryResource,
+    GithubRepositoryResourceEcho,
+)
+from aios.models.github_repositories import validate_resources as _validate_github_resources
 from aios.models.memory_stores import (
     MAX_STORES_PER_SESSION,
     MemoryStoreResource,
     MemoryStoreResourceEcho,
-    validate_resources,
 )
+from aios.models.memory_stores import validate_resources as _validate_memory_resources
+
+# Discriminated union over resource types. New types extend this union.
+SessionResource = Annotated[
+    MemoryStoreResource | GithubRepositoryResource,
+    Field(discriminator="type"),
+]
+SessionResourceEcho = Annotated[
+    MemoryStoreResourceEcho | GithubRepositoryResourceEcho,
+    Field(discriminator="type"),
+]
+
+# Combined per-session cap. Each type still enforces its own narrower cap
+# inside ``_validate_session_resources`` below.
+MAX_RESOURCES_PER_SESSION = MAX_STORES_PER_SESSION + MAX_REPOS_PER_SESSION
+
+
+def split_resources_by_type(
+    resources: list[SessionResource],
+) -> tuple[list[MemoryStoreResource], list[GithubRepositoryResource]]:
+    """Partition a heterogeneous resource list by its discriminator."""
+    memory: list[MemoryStoreResource] = []
+    github: list[GithubRepositoryResource] = []
+    for r in resources:
+        if isinstance(r, MemoryStoreResource):
+            memory.append(r)
+        else:
+            github.append(r)
+    return memory, github
+
+
+def _validate_session_resources(resources: list[SessionResource]) -> None:
+    """Pre-DB cross-item validation; failures surface as 4xx instead of
+    constraint violations."""
+    memory, github = split_resources_by_type(resources)
+    _validate_memory_resources(memory)
+    _validate_github_resources(github)
+
 
 SessionStatus = Literal["pending", "running", "idle", "rescheduling", "terminated"]
 
@@ -79,15 +122,16 @@ class SessionCreate(BaseModel):
             "enqueues a wake job. Equivalent to a follow-up POST /messages."
         ),
     )
-    resources: list[MemoryStoreResource] = Field(
+    resources: list[SessionResource] = Field(
         default_factory=list,
-        max_length=MAX_STORES_PER_SESSION,
+        max_length=MAX_RESOURCES_PER_SESSION,
         description=(
-            "Memory store resources to attach. Up to "
-            f"{MAX_STORES_PER_SESSION} per session, no duplicate "
-            "memory_store_id. Mounted under /mnt/memory/<store_name>/ in "
-            "the sandbox. Use ``PUT /v1/sessions/{id}`` with ``resources`` "
-            "to attach or detach stores after creation."
+            "Resources to attach. Mix of memory stores (mounted under "
+            "/mnt/memory/<name>/) and github repositories (cloned to a "
+            "user-specified mount_path). Each type has its own per-session "
+            "cap; duplicates within a type are rejected. Use "
+            "``PUT /v1/sessions/{id}`` with ``resources`` to detach or "
+            "replace the set after creation."
         ),
     )
 
@@ -105,7 +149,7 @@ class SessionCreate(BaseModel):
 
     @model_validator(mode="after")
     def _validate_resources(self) -> SessionCreate:
-        validate_resources(self.resources)
+        _validate_session_resources(self.resources)
         return self
 
 
@@ -127,12 +171,12 @@ class SessionUpdate(BaseModel):
     title: str | None = None
     metadata: dict[str, Any] | None = None
     vault_ids: list[str] | None = None
-    resources: list[MemoryStoreResource] | None = None
+    resources: list[SessionResource] | None = None
 
     @model_validator(mode="after")
     def _validate_resources(self) -> SessionUpdate:
         if self.resources is not None:
-            validate_resources(self.resources)
+            _validate_session_resources(self.resources)
         return self
 
 
@@ -150,7 +194,7 @@ class Session(BaseModel):
     vault_ids: list[str] = Field(default_factory=list)
     last_event_seq: int
     usage: SessionUsage = Field(default_factory=SessionUsage)
-    resources: list[MemoryStoreResourceEcho] = Field(default_factory=list)
+    resources: list[SessionResourceEcho] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
     archived_at: datetime | None = None

--- a/src/aios/sandbox/container.py
+++ b/src/aios/sandbox/container.py
@@ -39,19 +39,29 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from aios.models.github_repositories import GithubRepositoryResourceEcho
     from aios.models.memory_stores import MemoryStoreResourceEcho
 
 
 def mount_snapshot_from_echoes(
-    echoes: Iterable[MemoryStoreResourceEcho],
-) -> frozenset[tuple[str, str, str]]:
+    memory_echoes: Iterable[MemoryStoreResourceEcho],
+    github_echoes: Iterable[GithubRepositoryResourceEcho],
+) -> frozenset[tuple[str, ...]]:
     """The set of inputs that determines the docker ``--volume`` argv.
 
     Order-independent so rank reorders don't trigger spurious recycles.
-    Both the provisioner (snapshot-at-provision) and the registry
-    (snapshot-at-compare) call this so the tuple shape stays in lockstep.
+    Each tuple is type-prefixed so memory and github namespaces can't
+    collide. The github tuple includes ``updated_at`` so token rotation
+    (which bumps ``updated_at``) propagates to a container recycle.
     """
-    return frozenset((e.memory_store_id, e.name, e.access) for e in echoes)
+    from aios.ids import GITHUB_REPOSITORY, MEMORY_STORE
+
+    items: set[tuple[str, ...]] = set()
+    for m in memory_echoes:
+        items.add((MEMORY_STORE, m.memory_store_id, m.name, m.access))
+    for g in github_echoes:
+        items.add((GITHUB_REPOSITORY, g.id, g.mount_path, g.updated_at.isoformat()))
+    return frozenset(items)
 
 
 @dataclass(slots=True, frozen=True)
@@ -129,7 +139,7 @@ class ContainerHandle:
         session_id: str,
         container_id: str,
         workspace_path: Path,
-        mount_snapshot: frozenset[tuple[str, str, str]] = frozenset(),
+        mount_snapshot: frozenset[tuple[str, ...]] = frozenset(),
     ) -> None:
         self.session_id = session_id
         self.container_id = container_id

--- a/src/aios/sandbox/github_clone.py
+++ b/src/aios/sandbox/github_clone.py
@@ -1,0 +1,275 @@
+"""Host-side ``git`` operations for ``github_repository`` session resources.
+
+Two host directories per attached repo:
+
+1. **Cache dir** — a bare clone shared across all sessions referencing
+   the same upstream URL, stored at
+   ``<workspace_root>/_github_repos/<sha256(repo_url)>/``. Created on
+   first use, fetched on subsequent uses (best-effort).
+
+2. **Per-session working tree** — a full checkout cloned with
+   ``--reference <cache_dir>`` so object data is shared with the cache.
+   Stored at ``<session_workspace>/_repos/<repo_id>/`` and bind-mounted
+   into the container at the user-supplied ``mount_path``.
+
+The auth token is embedded in the cloned ``origin`` URL
+(``https://x-access-token:$TOKEN@github.com/owner/repo.git``). The token
+sits in ``.git/config`` inside the per-session working tree, which is
+ephemeral and per-session.
+
+The host process running this module needs ``git`` on PATH.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import fcntl
+import hashlib
+import shutil
+from pathlib import Path
+
+from aios.logging import get_logger
+from aios.sandbox.container import ContainerError, run_subprocess_with_timeout
+from aios.sandbox.volumes import (
+    github_repo_cache_dir,
+    github_repo_cache_lock_path,
+    github_repos_cache_root,
+    session_repo_working_tree_dir,
+    session_repos_root,
+)
+
+log = get_logger("aios.sandbox.github_clone")
+
+# Bound on each ``git`` invocation. Generous because clone over a slow
+# link can legitimately take a while; tighter values cause spurious
+# failures on CI runners.
+_GIT_TIMEOUT_S = 300.0
+
+
+class GithubCloneError(Exception):
+    """Raised when a clone or fetch fails in a way the agent can't recover
+    from (e.g. invalid token, repo missing). The provisioner catches this,
+    logs a lifecycle event, and continues so the agent sees the failure
+    context without the session halting.
+    """
+
+
+def url_hash(repo_url: str) -> str:
+    """Stable cache key for a repo URL. SHA-256 over the raw URL string —
+    different mount paths share the same cache dir, since cache content
+    is just objects (which only depend on the upstream)."""
+    return hashlib.sha256(repo_url.encode("utf-8")).hexdigest()
+
+
+def _build_auth_url(repo_url: str, token: str) -> str:
+    """Embed the token in the clone URL.
+
+    Accepts ``https://github.com/owner/repo`` or
+    ``https://github.com/owner/repo.git``. Anything else is left to git
+    to reject. Format is ``https://x-access-token:$TOKEN@github.com/...``
+    which is what GitHub expects for PAT-authenticated HTTPS clones.
+    """
+    if not repo_url.startswith(("https://", "http://")):
+        raise GithubCloneError(
+            f"only https:// and http:// repo URLs are supported (got {repo_url!r})"
+        )
+    # Split on `://` once.
+    scheme, rest = repo_url.split("://", 1)
+    return f"{scheme}://x-access-token:{token}@{rest}"
+
+
+async def _run_git(argv: list[str], *, cwd: Path | None = None) -> tuple[int, bytes, bytes]:
+    """Launch ``git`` with the timeout and error semantics we rely on.
+
+    The launch itself can raise :class:`ContainerError` if the binary is
+    missing on the host. Nonzero exits are returned to the caller for
+    classification.
+    """
+    full_argv = ["git", *argv]
+    if cwd is not None:
+        full_argv = ["git", "-C", str(cwd), *argv]
+    rc, stdout, stderr, timed_out = await run_subprocess_with_timeout(
+        full_argv, timeout_s=_GIT_TIMEOUT_S
+    )
+    if timed_out:
+        raise GithubCloneError(f"git timed out after {_GIT_TIMEOUT_S}s: {' '.join(argv)}")
+    return rc, stdout, stderr
+
+
+async def ensure_cache_clone(repo_url: str, token: str) -> Path:
+    """Ensure ``<cache_root>/<url_hash>`` is a populated bare clone.
+
+    Holds a per-cache file lock so two sessions racing on first-clone
+    serialize. The loser sees the existing dir on its second check and
+    falls through to fetch.
+
+    Returns the cache dir path. Raises :class:`GithubCloneError` if the
+    initial clone fails — the caller (provisioner) logs a session.error
+    and continues.
+    """
+    github_repos_cache_root().mkdir(parents=True, exist_ok=True)
+    url_key = url_hash(repo_url)
+    cache_dir = github_repo_cache_dir(url_key)
+    lock_path = github_repo_cache_lock_path(url_key)
+
+    auth_url = _build_auth_url(repo_url, token)
+
+    def _exists() -> bool:
+        # Bare clone has HEAD at the root, not under .git/.
+        return cache_dir.exists() and (cache_dir / "HEAD").exists()
+
+    # Fast path: cache exists, just fetch (best-effort) and return.
+    if _exists():
+        await _fetch_cache(cache_dir, auth_url, repo_url)
+        return cache_dir
+
+    # Slow path: clone under a file lock so we don't race.
+    with lock_path.open("w") as lock_file:
+        await asyncio.get_event_loop().run_in_executor(
+            None, fcntl.flock, lock_file.fileno(), fcntl.LOCK_EX
+        )
+        try:
+            if _exists():
+                await _fetch_cache(cache_dir, auth_url, repo_url)
+                return cache_dir
+            # Clean any partial dir left by a crashed prior attempt.
+            if cache_dir.exists():
+                shutil.rmtree(cache_dir)
+            cache_dir.parent.mkdir(parents=True, exist_ok=True)
+            rc, _stdout, stderr = await _run_git(
+                ["clone", "--bare", auth_url, str(cache_dir)],
+            )
+            if rc != 0:
+                # Drop any partial dir so the next attempt re-clones from scratch.
+                if cache_dir.exists():
+                    shutil.rmtree(cache_dir, ignore_errors=True)
+                raise GithubCloneError(
+                    f"git clone --bare failed for {repo_url!r}: "
+                    f"{_redact_token_from_message(stderr.decode('utf-8', errors='replace'), token)}"
+                )
+            # Disable gc on the bare cache so it can't reap objects that
+            # per-session working trees alternate against.
+            await _run_git(["config", "gc.auto", "0"], cwd=cache_dir)
+            log.info(
+                "github_clone.cache_created",
+                repo_url=repo_url,
+                url_hash=url_hash(repo_url),
+            )
+            return cache_dir
+        finally:
+            await asyncio.get_event_loop().run_in_executor(
+                None, fcntl.flock, lock_file.fileno(), fcntl.LOCK_UN
+            )
+
+
+async def _fetch_cache(cache_dir: Path, auth_url: str, repo_url: str) -> None:
+    """Best-effort ``git fetch`` of the cache. Failures are logged and
+    swallowed — a stale cache still works for read; the cost of a fresh
+    push from the per-session clone is the same either way.
+    """
+    # Use --quiet and a one-shot URL override (-c remote.origin.url=...)
+    # so we don't have to mutate the cache's stored config.
+    rc, _stdout, stderr = await _run_git(
+        [
+            "-c",
+            f"remote.origin.url={auth_url}",
+            "fetch",
+            "--quiet",
+            "--prune",
+            "origin",
+        ],
+        cwd=cache_dir,
+    )
+    if rc != 0:
+        log.warning(
+            "github_clone.cache_fetch_failed",
+            repo_url=repo_url,
+            stderr=stderr.decode("utf-8", errors="replace")[:500],
+        )
+
+
+async def ensure_session_working_tree(
+    *,
+    session_id: str,
+    resource_id: str,
+    repo_url: str,
+    token: str,
+    cache_dir: Path,
+) -> Path:
+    """Create a per-session working tree from the cache, with the auth
+    token embedded in the ``origin`` URL.
+
+    Always recreates the working tree on call: that way token rotation
+    (which bumps ``updated_at`` on the resource and hence the mount
+    snapshot) takes effect on the next provision without any "is this
+    stale?" detection logic. The ``--reference`` clone is fast because
+    object data is reused from the cache.
+    """
+    work_dir = session_repo_working_tree_dir(session_id, resource_id)
+    session_repos_root(session_id).mkdir(parents=True, exist_ok=True)
+
+    if work_dir.exists():
+        shutil.rmtree(work_dir)
+
+    auth_url = _build_auth_url(repo_url, token)
+    rc, _stdout, stderr = await _run_git(
+        [
+            "clone",
+            "--reference",
+            str(cache_dir),
+            "--dissociate",  # copy needed objects into the working clone so
+            # cache GC (if it ever runs) can't break the working tree
+            auth_url,
+            str(work_dir),
+        ],
+    )
+    # Note: --dissociate copies; for max sharing we'd drop it, but then
+    # the cache must never gc and per-session deletes leak alternates.
+    # Trade some disk for safety.
+    if rc != 0:
+        if work_dir.exists():
+            shutil.rmtree(work_dir, ignore_errors=True)
+        raise GithubCloneError(
+            f"git clone --reference failed for session {session_id} repo {resource_id}: "
+            f"{_redact_token_from_message(stderr.decode('utf-8', errors='replace'), token)}"
+        )
+
+    log.info(
+        "github_clone.session_clone_created",
+        session_id=session_id,
+        resource_id=resource_id,
+        repo_url=repo_url,
+    )
+    return work_dir
+
+
+def remove_session_working_tree(session_id: str, resource_id: str) -> None:
+    """Best-effort delete of a per-session working tree. Used by the
+    full-list-replace path on session update — when a repo is detached,
+    its host dir should disappear so subsequent provisioning doesn't see
+    a stale mount."""
+    work_dir = session_repo_working_tree_dir(session_id, resource_id)
+    with contextlib.suppress(FileNotFoundError):
+        shutil.rmtree(work_dir)
+
+
+def _redact_token_from_message(msg: str, token: str) -> str:
+    """Strip the auth token from any error message before it lands in
+    a log or session event. Tokens are unique enough that simple
+    substitution is reliable.
+    """
+    if not token:
+        return msg
+    return msg.replace(token, "<redacted>")
+
+
+# Re-export for callers that catch container/git errors uniformly.
+__all__ = [
+    "ContainerError",
+    "GithubCloneError",
+    "ensure_cache_clone",
+    "ensure_session_working_tree",
+    "remove_session_working_tree",
+    "url_hash",
+]

--- a/src/aios/sandbox/github_clone.py
+++ b/src/aios/sandbox/github_clone.py
@@ -79,12 +79,14 @@ def _build_auth_url(repo_url: str, token: str) -> str:
     return f"{scheme}://x-access-token:{token}@{rest}"
 
 
-async def _run_git(argv: list[str], *, cwd: Path | None = None) -> tuple[int, bytes, bytes]:
+async def _run_git(
+    argv: list[str], *, cwd: Path | None = None, op: str = "git"
+) -> tuple[int, bytes, bytes]:
     """Launch ``git`` with the timeout and error semantics we rely on.
 
-    The launch itself can raise :class:`ContainerError` if the binary is
-    missing on the host. Nonzero exits are returned to the caller for
-    classification.
+    ``op`` is a short label used in the timeout error message — never
+    the raw argv, which carries the auth-embedded URL on clone/fetch
+    paths and would leak the token into logs and the session event log.
     """
     full_argv = ["git", *argv]
     if cwd is not None:
@@ -93,7 +95,7 @@ async def _run_git(argv: list[str], *, cwd: Path | None = None) -> tuple[int, by
         full_argv, timeout_s=_GIT_TIMEOUT_S
     )
     if timed_out:
-        raise GithubCloneError(f"git timed out after {_GIT_TIMEOUT_S}s: {' '.join(argv)}")
+        raise GithubCloneError(f"git {op} timed out after {_GIT_TIMEOUT_S}s")
     return rc, stdout, stderr
 
 
@@ -139,6 +141,7 @@ async def ensure_cache_clone(repo_url: str, token: str) -> Path:
             cache_dir.parent.mkdir(parents=True, exist_ok=True)
             rc, _stdout, stderr = await _run_git(
                 ["clone", "--bare", auth_url, str(cache_dir)],
+                op="clone --bare",
             )
             if rc != 0:
                 # Drop any partial dir so the next attempt re-clones from scratch.
@@ -150,7 +153,7 @@ async def ensure_cache_clone(repo_url: str, token: str) -> Path:
                 )
             # Disable gc on the bare cache so it can't reap objects that
             # per-session working trees alternate against.
-            await _run_git(["config", "gc.auto", "0"], cwd=cache_dir)
+            await _run_git(["config", "gc.auto", "0"], cwd=cache_dir, op="config gc.auto")
             log.info(
                 "github_clone.cache_created",
                 repo_url=repo_url,
@@ -180,6 +183,7 @@ async def _fetch_cache(cache_dir: Path, auth_url: str, repo_url: str) -> None:
             "origin",
         ],
         cwd=cache_dir,
+        op="fetch",
     )
     if rc != 0:
         log.warning(
@@ -213,20 +217,19 @@ async def ensure_session_working_tree(
         shutil.rmtree(work_dir)
 
     auth_url = _build_auth_url(repo_url, token)
+    # `--dissociate` copies needed objects into the working clone so cache
+    # GC can't break it later. We trade disk for safety.
     rc, _stdout, stderr = await _run_git(
         [
             "clone",
             "--reference",
             str(cache_dir),
-            "--dissociate",  # copy needed objects into the working clone so
-            # cache GC (if it ever runs) can't break the working tree
+            "--dissociate",
             auth_url,
             str(work_dir),
         ],
+        op="clone --reference",
     )
-    # Note: --dissociate copies; for max sharing we'd drop it, but then
-    # the cache must never gc and per-session deletes leak alternates.
-    # Trade some disk for safety.
     if rc != 0:
         if work_dir.exists():
             shutil.rmtree(work_dir, ignore_errors=True)
@@ -259,8 +262,6 @@ def _redact_token_from_message(msg: str, token: str) -> str:
     a log or session event. Tokens are unique enough that simple
     substitution is reliable.
     """
-    if not token:
-        return msg
     return msg.replace(token, "<redacted>")
 
 

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -167,9 +167,10 @@ async def _materialize_github_clones(
 
     pool = runtime.require_pool()
     crypto_box = runtime.require_crypto_box()
+    materialized: list[GithubRepositoryResourceEcho] = []
+    failures: list[tuple[GithubRepositoryResourceEcho, GithubCloneError]] = []
     async with pool.acquire() as conn:
         echoes = await queries.list_session_github_repo_echoes(conn, session_id)
-        materialized: list[GithubRepositoryResourceEcho] = []
         for echo in echoes:
             try:
                 token = await github_repo_service.get_session_token(
@@ -184,32 +185,34 @@ async def _materialize_github_clones(
                     cache_dir=cache_dir,
                 )
             except GithubCloneError as err:
-                # Append a session.error event so the agent's next step
-                # sees the failure context. Skip the working-tree mount
-                # for this repo — bind-mounting a missing dir would fail
-                # at docker run.
-                log.warning(
-                    "sandbox.github_clone_failed",
-                    session_id=session_id,
-                    resource_id=echo.id,
-                    repo_url=echo.url,
-                    error=str(err),
-                )
-                from aios.services import sessions as sessions_service
-
-                await sessions_service.append_event(
-                    pool,
-                    session_id,
-                    "lifecycle",
-                    {
-                        "event": "github_clone_failed",
-                        "resource_id": echo.id,
-                        "repo_url": echo.url,
-                        "message": str(err),
-                    },
-                )
+                failures.append((echo, err))
                 continue
             materialized.append(echo)
+
+    # Log + append failure events outside the conn block so we don't
+    # hold one connection while acquiring a second from the same pool.
+    if failures:
+        from aios.services import sessions as sessions_service
+
+        for failed_echo, failure in failures:
+            log.warning(
+                "sandbox.github_clone_failed",
+                session_id=session_id,
+                resource_id=failed_echo.id,
+                repo_url=failed_echo.url,
+                error=str(failure),
+            )
+            await sessions_service.append_event(
+                pool,
+                session_id,
+                "lifecycle",
+                {
+                    "event": "github_clone_failed",
+                    "resource_id": failed_echo.id,
+                    "repo_url": failed_echo.url,
+                    "message": str(failure),
+                },
+            )
     return materialized
 
 

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -25,12 +25,18 @@ from aios.config import get_settings
 from aios.db import queries
 from aios.logging import get_logger
 from aios.models.environments import EnvironmentConfig, LimitedNetworking
+from aios.models.github_repositories import GithubRepositoryResourceEcho
 from aios.models.memory_stores import MemoryStoreResourceEcho
 from aios.sandbox.container import (
     ContainerError,
     ContainerHandle,
     mount_snapshot_from_echoes,
     run_subprocess_with_timeout,
+)
+from aios.sandbox.github_clone import (
+    GithubCloneError,
+    ensure_cache_clone,
+    ensure_session_working_tree,
 )
 
 log = get_logger("aios.sandbox.provisioner")
@@ -141,6 +147,72 @@ async def _materialize_memory_mounts(
     return list(echoes)
 
 
+async def _materialize_github_clones(
+    session_id: str,
+) -> list[GithubRepositoryResourceEcho]:
+    """Run host-side ``git clone`` for each attached github_repository
+    and return the echo list.
+
+    Two-step per repo: ensure the bare cache (shared across sessions)
+    exists, then ``git clone --reference`` a per-session working tree
+    that the container will bind-mount. Token decryption uses the
+    worker-scoped CryptoBox.
+
+    Failures are non-fatal: a bad token or unreachable repo logs an
+    error and appends a lifecycle event so the agent can react, but
+    does not block container provisioning.
+    """
+    from aios.harness import runtime
+    from aios.services import github_repositories as github_repo_service
+
+    pool = runtime.require_pool()
+    crypto_box = runtime.require_crypto_box()
+    async with pool.acquire() as conn:
+        echoes = await queries.list_session_github_repo_echoes(conn, session_id)
+        materialized: list[GithubRepositoryResourceEcho] = []
+        for echo in echoes:
+            try:
+                token = await github_repo_service.get_session_token(
+                    conn, crypto_box, session_id, echo.id
+                )
+                cache_dir = await ensure_cache_clone(echo.url, token)
+                await ensure_session_working_tree(
+                    session_id=session_id,
+                    resource_id=echo.id,
+                    repo_url=echo.url,
+                    token=token,
+                    cache_dir=cache_dir,
+                )
+            except GithubCloneError as err:
+                # Append a session.error event so the agent's next step
+                # sees the failure context. Skip the working-tree mount
+                # for this repo — bind-mounting a missing dir would fail
+                # at docker run.
+                log.warning(
+                    "sandbox.github_clone_failed",
+                    session_id=session_id,
+                    resource_id=echo.id,
+                    repo_url=echo.url,
+                    error=str(err),
+                )
+                from aios.services import sessions as sessions_service
+
+                await sessions_service.append_event(
+                    pool,
+                    session_id,
+                    "lifecycle",
+                    {
+                        "event": "github_clone_failed",
+                        "resource_id": echo.id,
+                        "repo_url": echo.url,
+                        "message": str(err),
+                    },
+                )
+                continue
+            materialized.append(echo)
+    return materialized
+
+
 async def provision_for_session(session_id: str) -> ContainerHandle:
     """Create a fresh container for ``session_id`` and return a handle.
 
@@ -152,13 +224,18 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
     Raises :class:`ContainerError` if ``docker run`` fails for any reason
     (image missing, daemon unreachable, resource limits, ...).
     """
-    from aios.sandbox.volumes import ensure_workspace_path, memory_store_host_dir
+    from aios.sandbox.volumes import (
+        ensure_workspace_path,
+        memory_store_host_dir,
+        session_repo_working_tree_dir,
+    )
 
     settings = get_settings()
     raw_path, session_env = await _load_session_provisioning(session_id)
     workspace_path = ensure_workspace_path(raw_path)
     env_config = await _load_environment_config(session_id)
     memory_echoes = await _materialize_memory_mounts(session_id)
+    github_echoes = await _materialize_github_clones(session_id)
 
     # Merge environment-level and session-level env vars (session wins).
     merged_env: dict[str, str] = {
@@ -195,10 +272,17 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
     # ensures the kernel rejects writes (bash + tools alike); ``:rw`` is the
     # read_write default. The host source is shared across all attached
     # sessions, so a tool/API write in one session is visible to all.
-    for echo in memory_echoes:
-        host_dir = memory_store_host_dir(echo.memory_store_id)
-        mode = "ro" if echo.access == "read_only" else "rw"
-        argv.extend(["--volume", f"{host_dir}:/mnt/memory/{echo.name}:{mode}"])
+    for memory_echo in memory_echoes:
+        host_dir = memory_store_host_dir(memory_echo.memory_store_id)
+        mode = "ro" if memory_echo.access == "read_only" else "rw"
+        argv.extend(["--volume", f"{host_dir}:/mnt/memory/{memory_echo.name}:{mode}"])
+
+    # Bind-mount each successfully-cloned github repo. The per-session
+    # working tree (already populated by ``_materialize_github_clones``)
+    # is mounted at the user-supplied ``mount_path``.
+    for github_echo in github_echoes:
+        repo_host_dir = session_repo_working_tree_dir(session_id, github_echo.id)
+        argv.extend(["--volume", f"{repo_host_dir}:{github_echo.mount_path}:rw"])
 
     for key, value in merged_env.items():
         argv.extend(["--env", f"{key}={value}"])
@@ -224,7 +308,7 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
         session_id=session_id,
         container_id=container_id,
         workspace_path=workspace_path,
-        mount_snapshot=mount_snapshot_from_echoes(memory_echoes),
+        mount_snapshot=mount_snapshot_from_echoes(memory_echoes, github_echoes),
     )
 
     # Install packages while the network is still open.

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -31,6 +31,7 @@ from aios.sandbox.provisioner import release as provisioner_release
 if TYPE_CHECKING:
     import asyncpg
 
+    from aios.models.github_repositories import GithubRepositoryResourceEcho
     from aios.models.memory_stores import MemoryStoreResourceEcho
 
 log = get_logger("aios.sandbox.registry")
@@ -119,18 +120,24 @@ class SandboxRegistry:
     async def release_if_mounts_changed(
         self,
         session_id: str,
-        current_echoes: list[MemoryStoreResourceEcho],
+        memory_echoes: list[MemoryStoreResourceEcho],
+        github_echoes: list[GithubRepositoryResourceEcho],
     ) -> None:
         """Release the cached container if its mount snapshot has drifted.
 
         Acquires the per-session lock so a tool task from a prior step
         can't race with the release via ``get_or_provision``.
+
+        Drift includes: memory store attachments added/removed, github
+        repos added/removed, github token rotated (the ``updated_at``
+        timestamp on the github echo is part of the snapshot key, see
+        :func:`mount_snapshot_from_echoes`).
         """
         async with self._lock_for(session_id):
             handle = self._handles.get(session_id)
             if handle is None:
                 return
-            if handle.mount_snapshot == mount_snapshot_from_echoes(current_echoes):
+            if handle.mount_snapshot == mount_snapshot_from_echoes(memory_echoes, github_echoes):
                 return
             log.info(
                 "sandbox.released_for_mount_change",

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -86,3 +86,47 @@ def memory_store_lock_path(store_id: str) -> Path:
     writes the initial DB snapshot to the host dir. The loser observes
     the ``.materialized`` marker and skips."""
     return memory_stores_root() / f"{store_id}.lock"
+
+
+_GITHUB_REPOS_ROOT = "_github_repos"
+
+
+def github_repos_cache_root() -> Path:
+    """Return ``<workspace_root>/_github_repos`` — the parent of all
+    cache-bare-clone host directories.
+
+    Each cache dir is keyed by ``sha256(repo_url)`` so two sessions that
+    reference the same upstream repo share the object database, regardless
+    of ``mount_path``. Per-session working trees ``--reference`` this cache
+    via :func:`session_repo_working_tree_dir`.
+    """
+    return (get_settings().workspace_root / _GITHUB_REPOS_ROOT).resolve()
+
+
+def github_repo_cache_dir(url_hash: str) -> Path:
+    """Bare-clone host dir for a given repo-url hash. Pure — see
+    :mod:`aios.sandbox.github_clone` for materialization."""
+    return github_repos_cache_root() / url_hash
+
+
+def github_repo_cache_lock_path(url_hash: str) -> Path:
+    """Per-cache file lock path. Two sessions racing on first-clone of the
+    same url need to serialize so we don't run two ``git clone --bare``
+    side by side and corrupt the cache dir."""
+    return github_repos_cache_root() / f"{url_hash}.lock"
+
+
+def session_repos_root(session_id: str) -> Path:
+    """Per-session sibling of ``/workspace`` that holds working trees
+    cloned from the cache. Lives under the session's own workspace dir
+    so it goes away when the workspace is cleaned up.
+    """
+    return (workspace_dir_for(session_id) / "_repos").resolve()
+
+
+def session_repo_working_tree_dir(session_id: str, repo_id: str) -> Path:
+    """Per-session working tree for a single ``github_repository``
+    attachment. Bind-mounted into the container at the user-supplied
+    ``mount_path``.
+    """
+    return session_repos_root(session_id) / repo_id

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -116,12 +116,18 @@ def github_repo_cache_lock_path(url_hash: str) -> Path:
     return github_repos_cache_root() / f"{url_hash}.lock"
 
 
+_SESSION_REPOS_ROOT = "_session_repos"
+
+
 def session_repos_root(session_id: str) -> Path:
-    """Per-session sibling of ``/workspace`` that holds working trees
-    cloned from the cache. Lives under the session's own workspace dir
-    so it goes away when the workspace is cleaned up.
+    """Per-session host dir for github_repository working trees.
+
+    Rooted at ``<workspace_root>/_session_repos/<session_id>`` so the
+    location is independent of any user-supplied ``workspace_path``
+    override on the session — those overrides are user-managed and we
+    don't want plaintext-token ``.git/config`` files leaking into them.
     """
-    return (workspace_dir_for(session_id) / "_repos").resolve()
+    return (get_settings().workspace_root / _SESSION_REPOS_ROOT / session_id).resolve()
 
 
 def session_repo_working_tree_dir(session_id: str, repo_id: str) -> Path:

--- a/src/aios/services/github_repositories.py
+++ b/src/aios/services/github_repositories.py
@@ -1,0 +1,132 @@
+"""Business logic for github_repository session resources.
+
+Thin orchestration over :mod:`aios.db.queries` plus the libsodium CryptoBox
+for token encryption. Mirrors the structure of
+:mod:`aios.services.memory_stores` but only exposes the session-bridge
+surface — there is no top-level repository resource (each row is the
+resource).
+
+Token handling pattern (lifted from :mod:`aios.services.vaults`):
+- Create: encrypt-once at the API boundary, persist ``(ciphertext, nonce)``.
+- Rotate: decrypt-merge-encrypt within a single transaction, replacing
+  only the token while preserving ``url`` and ``mount_path``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from aios.crypto.vault import CryptoBox
+from aios.db import queries
+from aios.errors import ConflictError
+from aios.models.github_repositories import (
+    GithubRepositoryResource,
+    GithubRepositoryResourceEcho,
+)
+
+
+def _encrypt_token(crypto_box: CryptoBox, token: str) -> Any:
+    """Encrypt a github auth token. Returns an :class:`EncryptedBlob`."""
+    return crypto_box.encrypt(token)
+
+
+async def attach_to_session(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    resources: list[GithubRepositoryResource],
+    crypto_box: CryptoBox,
+) -> None:
+    """Encrypt each token and insert the attachment rows.
+
+    Caller controls the transaction so a failed attach rolls back the
+    earlier session insert (paired flow with
+    :func:`aios.services.memory_stores.attach_to_session`).
+    """
+    if not resources:
+        return
+    entries: list[tuple[str, str, Any]] = []
+    for res in resources:
+        blob = _encrypt_token(crypto_box, res.authorization_token.get_secret_value())
+        entries.append((res.url, res.mount_path, blob))
+    try:
+        await queries.attach_github_repos_to_session(conn, session_id, entries)
+    except asyncpg.UniqueViolationError as exc:
+        # Hits the (session_id, mount_path) partial unique index. Models
+        # validate this in-payload, so a hit here means the new payload
+        # collides with an EXISTING attachment in the DB. The full-list-
+        # replace path on update issues a DELETE first so this is only
+        # reachable on initial create with a programmatic bug — surface it
+        # as a 4xx rather than a 500.
+        raise ConflictError(
+            "duplicate mount_path among github_repository attachments",
+            detail={"session_id": session_id},
+        ) from exc
+
+
+async def set_session_resources(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    resources: list[GithubRepositoryResource],
+    crypto_box: CryptoBox,
+) -> None:
+    """Replace attached repositories atomically.
+
+    A failed attach rolls back the delete (parent transaction is the
+    caller's). Matches the memory-store full-list-replace semantics; the
+    aios-vs-CMA difference is documented in
+    :doc:`docs/github_repository`.
+    """
+    async with conn.transaction():
+        await queries.delete_session_github_repos(conn, session_id)
+        await attach_to_session(conn, session_id, resources, crypto_box)
+
+
+async def list_session_echoes(
+    pool: asyncpg.Pool[Any], session_id: str
+) -> list[GithubRepositoryResourceEcho]:
+    async with pool.acquire() as conn:
+        return await queries.list_session_github_repo_echoes(conn, session_id)
+
+
+async def get_resource(
+    pool: asyncpg.Pool[Any], session_id: str, resource_id: str
+) -> GithubRepositoryResourceEcho:
+    async with pool.acquire() as conn:
+        return await queries.get_session_github_repo(conn, session_id, resource_id)
+
+
+async def rotate_token(
+    pool: asyncpg.Pool[Any],
+    crypto_box: CryptoBox,
+    *,
+    session_id: str,
+    resource_id: str,
+    new_token: str,
+) -> GithubRepositoryResourceEcho:
+    """Update only the encrypted token; ``url`` and ``mount_path`` remain.
+
+    Decrypt-merge-encrypt isn't actually needed here (we store only the
+    token, not a payload of multiple fields), so this is a single
+    encrypt-then-update. The transaction guards against torn writes.
+    """
+    blob = _encrypt_token(crypto_box, new_token)
+    async with pool.acquire() as conn, conn.transaction():
+        return await queries.update_session_github_repo_blob(conn, session_id, resource_id, blob)
+
+
+async def get_session_token(
+    conn: asyncpg.Connection[Any],
+    crypto_box: CryptoBox,
+    session_id: str,
+    resource_id: str,
+) -> str:
+    """Decrypt and return the raw auth token for a single attachment.
+
+    Only callsite today: the sandbox provisioner, which builds the
+    auth-embedded clone URL. Lives here (not in queries) because it's
+    the boundary that owns the CryptoBox.
+    """
+    _, blob = await queries.get_session_github_repo_with_blob(conn, session_id, resource_id)
+    return crypto_box.decrypt(blob)

--- a/src/aios/services/github_repositories.py
+++ b/src/aios/services/github_repositories.py
@@ -25,11 +25,27 @@ from aios.models.github_repositories import (
     GithubRepositoryResource,
     GithubRepositoryResourceEcho,
 )
+from aios.sandbox.github_clone import remove_session_working_tree
 
 
 def _encrypt_token(crypto_box: CryptoBox, token: str) -> Any:
     """Encrypt a github auth token. Returns an :class:`EncryptedBlob`."""
     return crypto_box.encrypt(token)
+
+
+async def _list_attached_resource_ids(conn: asyncpg.Connection[Any], session_id: str) -> list[str]:
+    """Return the resource_ids currently attached so we can clean up
+    their on-disk working trees after the DB rows go away."""
+    echoes = await queries.list_session_github_repo_echoes(conn, session_id)
+    return [e.id for e in echoes]
+
+
+def _purge_working_trees(session_id: str, resource_ids: list[str]) -> None:
+    """Best-effort filesystem cleanup. Each detached resource's working
+    tree contains the embedded-token ``.git/config``; leaving it on disk
+    after the DB row goes away would be a slow plaintext-token leak."""
+    for rid in resource_ids:
+        remove_session_working_tree(session_id, rid)
 
 
 async def attach_to_session(
@@ -53,12 +69,11 @@ async def attach_to_session(
     try:
         await queries.attach_github_repos_to_session(conn, session_id, entries)
     except asyncpg.UniqueViolationError as exc:
-        # Hits the (session_id, mount_path) partial unique index. Models
-        # validate this in-payload, so a hit here means the new payload
-        # collides with an EXISTING attachment in the DB. The full-list-
-        # replace path on update issues a DELETE first so this is only
-        # reachable on initial create with a programmatic bug — surface it
-        # as a 4xx rather than a 500.
+        # The unique index hit means the new payload collides with an
+        # already-attached row. The model validator catches duplicates
+        # within one request, so reaching this means we're racing another
+        # writer or there's a programmatic bug somewhere upstream — a 4xx
+        # is the right surface either way.
         raise ConflictError(
             "duplicate mount_path among github_repository attachments",
             detail={"session_id": session_id},
@@ -74,13 +89,27 @@ async def set_session_resources(
     """Replace attached repositories atomically.
 
     A failed attach rolls back the delete (parent transaction is the
-    caller's). Matches the memory-store full-list-replace semantics; the
-    aios-vs-CMA difference is documented in
-    :doc:`docs/github_repository`.
+    caller's). Matches the memory-store full-list-replace semantics.
+    Working trees of detached attachments are removed from the host
+    after the DB swap commits — the per-session ``.git/config`` carries
+    the embedded auth token, so leaving them on disk after detach would
+    be a slow plaintext-token leak.
     """
     async with conn.transaction():
+        old_ids = await _list_attached_resource_ids(conn, session_id)
         await queries.delete_session_github_repos(conn, session_id)
         await attach_to_session(conn, session_id, resources, crypto_box)
+    _purge_working_trees(session_id, old_ids)
+
+
+async def detach_all_from_session(conn: asyncpg.Connection[Any], session_id: str) -> None:
+    """Detach every github_repository from a session and clean up the
+    working trees. Used by the full-list-replace path when the new
+    resource list contains no github entries."""
+    async with conn.transaction():
+        old_ids = await _list_attached_resource_ids(conn, session_id)
+        await queries.delete_session_github_repos(conn, session_id)
+    _purge_working_trees(session_id, old_ids)
 
 
 async def list_session_echoes(

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -13,12 +13,48 @@ from typing import Any
 
 import asyncpg
 
+from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.errors import PayloadTooLargeError
 from aios.models.events import Event, EventKind
-from aios.models.memory_stores import MemoryStoreResource
-from aios.models.sessions import MAX_USER_MESSAGE_CHARS, Session, SessionStatus
+from aios.models.sessions import (
+    MAX_USER_MESSAGE_CHARS,
+    Session,
+    SessionResource,
+    SessionResourceEcho,
+    SessionStatus,
+    split_resources_by_type,
+)
+from aios.services import github_repositories as github_repo_service
 from aios.services import memory_stores as memory_service
+
+
+async def _list_all_echoes(
+    conn: asyncpg.Connection[Any], session_id: str
+) -> list[SessionResourceEcho]:
+    """Memory echoes first then github echoes, each in rank order."""
+    memory_echoes = await queries.list_session_memory_store_echoes(conn, session_id)
+    github_echoes = await queries.list_session_github_repo_echoes(conn, session_id)
+    out: list[SessionResourceEcho] = []
+    out.extend(memory_echoes)
+    out.extend(github_echoes)
+    return out
+
+
+def _require_crypto_box(
+    crypto_box: CryptoBox | None,
+    github_resources: list[Any],
+) -> CryptoBox | None:
+    """Guard against attaching github_repository without a CryptoBox.
+
+    Returns the (non-None) crypto_box when github resources are present so
+    callers don't need a separate narrowing assertion.
+    """
+    if not github_resources:
+        return crypto_box
+    if crypto_box is None:
+        raise ValueError("crypto_box is required when attaching github_repository resources")
+    return crypto_box
 
 
 async def create_session(
@@ -30,7 +66,8 @@ async def create_session(
     title: str | None,
     metadata: dict[str, Any],
     vault_ids: list[str] | None = None,
-    resources: list[MemoryStoreResource] | None = None,
+    resources: list[SessionResource] | None = None,
+    crypto_box: CryptoBox | None = None,
     workspace_path: str | None = None,
     env: dict[str, str] | None = None,
 ) -> Session:
@@ -41,6 +78,10 @@ async def create_session(
     attachment runs in the same transaction as the session insert so a
     failed attach (e.g. archived store, name collision) leaves no
     orphaned session.
+
+    ``crypto_box`` is required when ``resources`` includes any
+    ``github_repository`` entries (their auth tokens are encrypted on
+    insert). Memory-store-only attachments don't need it.
     """
     async with pool.acquire() as conn, conn.transaction():
         session = await queries.insert_session(
@@ -57,8 +98,16 @@ async def create_session(
             await queries.set_session_vaults(conn, session.id, vault_ids)
             session = session.model_copy(update={"vault_ids": vault_ids})
         if resources:
-            await memory_service.attach_to_session(conn, session.id, resources)
-            echoes = await queries.list_session_memory_store_echoes(conn, session.id)
+            memory_resources, github_resources = split_resources_by_type(resources)
+            cbox = _require_crypto_box(crypto_box, github_resources)
+            if memory_resources:
+                await memory_service.attach_to_session(conn, session.id, memory_resources)
+            if github_resources:
+                assert cbox is not None  # narrowed by _require_crypto_box
+                await github_repo_service.attach_to_session(
+                    conn, session.id, github_resources, cbox
+                )
+            echoes = await _list_all_echoes(conn, session.id)
             session = session.model_copy(update={"resources": echoes})
         return session
 
@@ -67,7 +116,7 @@ async def get_session(pool: asyncpg.Pool[Any], session_id: str) -> Session:
     async with pool.acquire() as conn:
         session = await queries.get_session(conn, session_id)
         vault_ids = await queries.get_session_vault_ids(conn, session_id)
-        echoes = await queries.list_session_memory_store_echoes(conn, session_id)
+        echoes = await _list_all_echoes(conn, session_id)
         return session.model_copy(update={"vault_ids": vault_ids, "resources": echoes})
 
 
@@ -87,7 +136,7 @@ async def list_sessions(
             vault_map = await queries.batch_get_session_vault_ids(conn, [s.id for s in sessions])
             enriched: list[Session] = []
             for s in sessions:
-                echoes = await queries.list_session_memory_store_echoes(conn, s.id)
+                echoes = await _list_all_echoes(conn, s.id)
                 enriched.append(
                     s.model_copy(
                         update={
@@ -258,7 +307,8 @@ async def update_session(
     title: str | None = queries._UNSET,
     metadata: dict[str, Any] | None = None,
     vault_ids: list[str] | None = None,
-    resources: list[MemoryStoreResource] | None = None,
+    resources: list[SessionResource] | None = None,
+    crypto_box: CryptoBox | None = None,
 ) -> Session:
     # One transaction so a 4xx from resource attach (e.g. name collision)
     # rolls back the earlier title/agent/vault writes.
@@ -274,9 +324,21 @@ async def update_session(
         if vault_ids is not None:
             await queries.set_session_vaults(conn, session_id, vault_ids)
         if resources is not None:
-            await memory_service.set_session_resources(conn, session_id, resources)
+            # Wire-level semantics is full-list-replace across all
+            # resource types, so an incoming list that omits a type
+            # detaches every existing attachment of that type.
+            memory_resources, github_resources = split_resources_by_type(resources)
+            cbox = _require_crypto_box(crypto_box, github_resources)
+            await memory_service.set_session_resources(conn, session_id, memory_resources)
+            if github_resources:
+                assert cbox is not None
+                await github_repo_service.set_session_resources(
+                    conn, session_id, github_resources, cbox
+                )
+            else:
+                await queries.delete_session_github_repos(conn, session_id)
         vids = await queries.get_session_vault_ids(conn, session_id)
-        echoes = await queries.list_session_memory_store_echoes(conn, session_id)
+        echoes = await _list_all_echoes(conn, session_id)
         return session.model_copy(update={"vault_ids": vids, "resources": echoes})
 
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -41,22 +41,6 @@ async def _list_all_echoes(
     return out
 
 
-def _require_crypto_box(
-    crypto_box: CryptoBox | None,
-    github_resources: list[Any],
-) -> CryptoBox | None:
-    """Guard against attaching github_repository without a CryptoBox.
-
-    Returns the (non-None) crypto_box when github resources are present so
-    callers don't need a separate narrowing assertion.
-    """
-    if not github_resources:
-        return crypto_box
-    if crypto_box is None:
-        raise ValueError("crypto_box is required when attaching github_repository resources")
-    return crypto_box
-
-
 async def create_session(
     pool: asyncpg.Pool[Any],
     *,
@@ -99,13 +83,14 @@ async def create_session(
             session = session.model_copy(update={"vault_ids": vault_ids})
         if resources:
             memory_resources, github_resources = split_resources_by_type(resources)
-            cbox = _require_crypto_box(crypto_box, github_resources)
             if memory_resources:
                 await memory_service.attach_to_session(conn, session.id, memory_resources)
             if github_resources:
-                assert cbox is not None  # narrowed by _require_crypto_box
+                assert crypto_box is not None, (
+                    "API surface requires CryptoBox when attaching github_repository"
+                )
                 await github_repo_service.attach_to_session(
-                    conn, session.id, github_resources, cbox
+                    conn, session.id, github_resources, crypto_box
                 )
             echoes = await _list_all_echoes(conn, session.id)
             session = session.model_copy(update={"resources": echoes})
@@ -328,15 +313,16 @@ async def update_session(
             # resource types, so an incoming list that omits a type
             # detaches every existing attachment of that type.
             memory_resources, github_resources = split_resources_by_type(resources)
-            cbox = _require_crypto_box(crypto_box, github_resources)
             await memory_service.set_session_resources(conn, session_id, memory_resources)
             if github_resources:
-                assert cbox is not None
+                assert crypto_box is not None, (
+                    "API surface requires CryptoBox when attaching github_repository"
+                )
                 await github_repo_service.set_session_resources(
-                    conn, session_id, github_resources, cbox
+                    conn, session_id, github_resources, crypto_box
                 )
             else:
-                await queries.delete_session_github_repos(conn, session_id)
+                await github_repo_service.detach_all_from_session(conn, session_id)
         vids = await queries.get_session_vault_ids(conn, session_id)
         echoes = await _list_all_echoes(conn, session_id)
         return session.model_copy(update={"vault_ids": vids, "resources": echoes})

--- a/tests/e2e/test_github_repositories.py
+++ b/tests/e2e/test_github_repositories.py
@@ -1,0 +1,637 @@
+"""E2E tests for the ``github_repository`` session resource.
+
+Two layers of coverage:
+
+- ``TestApi`` — DB + FastAPI ASGI transport, no real git clone. Exercises
+  the wire surface: create-with-resource, list/get, token rotation, the
+  aios-vs-CMA departure (add/remove via session update), the per-resource
+  endpoint guarding against memory-store ids.
+- ``TestRealClone`` — real ``git`` against ``octocat/Hello-World``. Skipped
+  if ``git`` is not on PATH or the network is unreachable. Verifies the
+  cache → working-tree pipeline and that the embedded-token URL is what
+  ends up in ``.git/config``.
+
+We deliberately don't spin up a Docker sandbox here. The ``--volume`` path
+is exercised by the broader sandbox/registry tests; this file's job is to
+prove the resource lifecycle works end-to-end at the service + HTTP
+layer. A separate manual probe (documented in the plan) verifies the
+in-container experience.
+"""
+
+from __future__ import annotations
+
+import secrets
+import shutil
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import httpx
+import pytest
+
+from aios.models.agents import ToolSpec
+from aios.models.github_repositories import GithubRepositoryResource
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import github_repositories as github_service
+from aios.services import sessions as sessions_service
+
+_OCTOCAT_REPO = "https://github.com/octocat/Hello-World"
+
+
+def _uniq() -> str:
+    return secrets.token_hex(4)
+
+
+def _pat() -> str:
+    """A syntactically-plausible token for tests that don't actually clone.
+
+    The probe confirmed CMA validates only ``min_length=1`` at create
+    time; a fake token here is fine for everything except real clone."""
+    return f"ghp_test{_uniq()}{_uniq()}{_uniq()}"
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+def crypto_box(aios_env: dict[str, str]) -> Any:
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    return CryptoBox.from_base64(get_settings().vault_key.get_secret_value())
+
+
+@pytest.fixture
+async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    settings = get_settings()
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+        headers={"Authorization": f"Bearer {aios_env['AIOS_API_KEY']}"},
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def env_and_agent(pool: Any) -> tuple[str, str]:
+    """Create a fresh env + agent for one test.
+
+    The agent has no tools — we never run the loop here, just exercise
+    the resource lifecycle. Each test gets a unique pair so cross-test
+    state doesn't leak.
+    """
+    env = await environments_service.create_environment(pool, name=f"ghrepo-env-{_uniq()}")
+    agent = await agents_service.create_agent(
+        pool,
+        name=f"ghrepo-agent-{_uniq()}",
+        model="fake/test",
+        system="github_repository test",
+        tools=[ToolSpec(type="bash")],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    return env.id, agent.id
+
+
+# ─── service-layer flows ──────────────────────────────────────────────────
+
+
+class TestServiceLayer:
+    async def test_attach_round_trip(
+        self, pool: Any, crypto_box: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        env_id, agent_id = env_and_agent
+        token = _pat()
+        session = await sessions_service.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            resources=[
+                GithubRepositoryResource.model_validate(
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": token,
+                    }
+                )
+            ],
+            crypto_box=crypto_box,
+        )
+
+        assert len(session.resources) == 1
+        echo = session.resources[0]
+        assert echo.type == "github_repository"
+        assert echo.id.startswith("ghrepo_")
+        assert echo.mount_path == "/workspace/repo"
+        # Token never echoed.
+        assert "authorization_token" not in echo.model_dump()
+
+    async def test_token_decrypts_round_trip(
+        self, pool: Any, crypto_box: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        """Service-internal: provisioner needs the raw token; verify the
+        encrypt-on-create + decrypt-on-read path returns the original."""
+        env_id, agent_id = env_and_agent
+        original_token = _pat()
+        session = await sessions_service.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            resources=[
+                GithubRepositoryResource.model_validate(
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": original_token,
+                    }
+                )
+            ],
+            crypto_box=crypto_box,
+        )
+        echo = session.resources[0]
+        async with pool.acquire() as conn:
+            recovered = await github_service.get_session_token(
+                conn, crypto_box, session.id, echo.id
+            )
+        assert recovered == original_token
+
+    async def test_token_rotation_changes_blob_and_bumps_updated_at(
+        self, pool: Any, crypto_box: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        env_id, agent_id = env_and_agent
+        first_token = _pat()
+        session = await sessions_service.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            resources=[
+                GithubRepositoryResource.model_validate(
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": first_token,
+                    }
+                )
+            ],
+            crypto_box=crypto_box,
+        )
+        original_echo = session.resources[0]
+        new_token = _pat()
+        rotated = await github_service.rotate_token(
+            pool,
+            crypto_box,
+            session_id=session.id,
+            resource_id=original_echo.id,
+            new_token=new_token,
+        )
+        assert rotated.id == original_echo.id
+        assert rotated.url == original_echo.url
+        assert rotated.mount_path == original_echo.mount_path
+        assert rotated.updated_at > original_echo.updated_at
+
+        async with pool.acquire() as conn:
+            recovered = await github_service.get_session_token(
+                conn, crypto_box, session.id, original_echo.id
+            )
+        assert recovered == new_token
+        assert recovered != first_token
+
+    async def test_full_list_replace_detaches_then_reattaches(
+        self, pool: Any, crypto_box: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        """The aios departure: PUT /sessions/{id} with ``resources=[]``
+        detaches everything; with a new list, attaches that set fresh."""
+        env_id, agent_id = env_and_agent
+        session = await sessions_service.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            resources=[
+                GithubRepositoryResource.model_validate(
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": _pat(),
+                    }
+                )
+            ],
+            crypto_box=crypto_box,
+        )
+        assert len(session.resources) == 1
+
+        # Detach all.
+        cleared = await sessions_service.update_session(
+            pool, session.id, resources=[], crypto_box=crypto_box
+        )
+        assert cleared.resources == []
+
+        # Attach a fresh one.
+        re_attached = await sessions_service.update_session(
+            pool,
+            session.id,
+            resources=[
+                GithubRepositoryResource.model_validate(
+                    {
+                        "type": "github_repository",
+                        "url": "https://github.com/octocat/Spoon-Knife",
+                        "mount_path": "/workspace/spoon",
+                        "authorization_token": _pat(),
+                    }
+                )
+            ],
+            crypto_box=crypto_box,
+        )
+        assert len(re_attached.resources) == 1
+        assert re_attached.resources[0].mount_path == "/workspace/spoon"
+
+
+# ─── HTTP wire surface ─────────────────────────────────────────────────────
+
+
+async def _create_env_and_agent_via_api(client: httpx.AsyncClient) -> tuple[str, str]:
+    r = await client.post("/v1/environments", json={"name": f"ghrepo-env-{_uniq()}"})
+    assert r.status_code == 201, r.text
+    env_id = r.json()["id"]
+    r = await client.post(
+        "/v1/agents",
+        json={
+            "name": f"ghrepo-agent-{_uniq()}",
+            "model": "fake/test",
+            "system": "ghrepo http test",
+            "tools": [{"type": "bash"}],
+            "metadata": {},
+            "window_min": 50_000,
+            "window_max": 150_000,
+        },
+    )
+    assert r.status_code == 201, r.text
+    return env_id, r.json()["id"]
+
+
+class TestApi:
+    async def test_create_session_with_github_repo(self, http_client: httpx.AsyncClient) -> None:
+        env_id, agent_id = await _create_env_and_agent_via_api(http_client)
+        r = await http_client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "environment_id": env_id,
+                "metadata": {},
+                "resources": [
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": _pat(),
+                    }
+                ],
+            },
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert len(body["resources"]) == 1
+        echo = body["resources"][0]
+        assert echo["type"] == "github_repository"
+        assert echo["id"].startswith("ghrepo_")
+        assert echo["url"] == _OCTOCAT_REPO
+        assert echo["mount_path"] == "/workspace/repo"
+        assert "authorization_token" not in echo
+
+    async def test_token_required(self, http_client: httpx.AsyncClient) -> None:
+        env_id, agent_id = await _create_env_and_agent_via_api(http_client)
+        r = await http_client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "environment_id": env_id,
+                "metadata": {},
+                "resources": [
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                    }
+                ],
+            },
+        )
+        assert r.status_code == 422, r.text
+
+    async def test_empty_token_rejected(self, http_client: httpx.AsyncClient) -> None:
+        env_id, agent_id = await _create_env_and_agent_via_api(http_client)
+        r = await http_client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "environment_id": env_id,
+                "metadata": {},
+                "resources": [
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": "",
+                    }
+                ],
+            },
+        )
+        assert r.status_code == 422, r.text
+
+    async def test_list_resources_endpoint(self, http_client: httpx.AsyncClient) -> None:
+        env_id, agent_id = await _create_env_and_agent_via_api(http_client)
+        r = await http_client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "environment_id": env_id,
+                "metadata": {},
+                "resources": [
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": _pat(),
+                    }
+                ],
+            },
+        )
+        assert r.status_code == 201, r.text
+        sid = r.json()["id"]
+
+        r = await http_client.get(f"/v1/sessions/{sid}/resources")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert len(body["data"]) == 1
+        assert body["data"][0]["type"] == "github_repository"
+
+    async def test_get_single_resource(self, http_client: httpx.AsyncClient) -> None:
+        env_id, agent_id = await _create_env_and_agent_via_api(http_client)
+        r = await http_client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "environment_id": env_id,
+                "metadata": {},
+                "resources": [
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": _pat(),
+                    }
+                ],
+            },
+        )
+        sid = r.json()["id"]
+        rid = r.json()["resources"][0]["id"]
+
+        r = await http_client.get(f"/v1/sessions/{sid}/resources/{rid}")
+        assert r.status_code == 200, r.text
+        echo = r.json()
+        assert echo["id"] == rid
+        assert echo["type"] == "github_repository"
+        assert "authorization_token" not in echo
+
+    async def test_token_rotation_via_post(self, http_client: httpx.AsyncClient) -> None:
+        env_id, agent_id = await _create_env_and_agent_via_api(http_client)
+        r = await http_client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "environment_id": env_id,
+                "metadata": {},
+                "resources": [
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": _pat(),
+                    }
+                ],
+            },
+        )
+        sid = r.json()["id"]
+        original_echo = r.json()["resources"][0]
+
+        r = await http_client.post(
+            f"/v1/sessions/{sid}/resources/{original_echo['id']}",
+            json={"authorization_token": _pat()},
+        )
+        assert r.status_code == 200, r.text
+        rotated = r.json()
+        assert rotated["id"] == original_echo["id"]
+        assert rotated["url"] == original_echo["url"]
+        assert rotated["updated_at"] > original_echo["updated_at"]
+        assert "authorization_token" not in rotated
+
+    async def test_session_update_replaces_resource_list(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        env_id, agent_id = await _create_env_and_agent_via_api(http_client)
+        r = await http_client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "environment_id": env_id,
+                "metadata": {},
+                "resources": [
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": _pat(),
+                    }
+                ],
+            },
+        )
+        sid = r.json()["id"]
+
+        # Detach.
+        r = await http_client.put(f"/v1/sessions/{sid}", json={"resources": []})
+        assert r.status_code == 200, r.text
+        assert r.json()["resources"] == []
+
+        # Re-attach.
+        r = await http_client.put(
+            f"/v1/sessions/{sid}",
+            json={
+                "resources": [
+                    {
+                        "type": "github_repository",
+                        "url": "https://github.com/octocat/Spoon-Knife",
+                        "mount_path": "/workspace/spoon",
+                        "authorization_token": _pat(),
+                    }
+                ]
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert len(r.json()["resources"]) == 1
+        assert r.json()["resources"][0]["mount_path"] == "/workspace/spoon"
+
+    async def test_memstore_id_rejected_on_per_resource_endpoints(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        env_id, agent_id = await _create_env_and_agent_via_api(http_client)
+        r = await http_client.post(
+            "/v1/sessions",
+            json={"agent_id": agent_id, "environment_id": env_id, "metadata": {}},
+        )
+        sid = r.json()["id"]
+        # Use a memory store id shape with a valid 26-char Crockford-base32
+        # ULID body so it passes the malformed-id guard and falls through
+        # to the prefix-mismatch branch in ``_require_github_resource_id``.
+        # Both branches return ValidationError (422), but the message
+        # distinguishes them — assert on the prefix-mismatch text.
+        r = await http_client.get(
+            f"/v1/sessions/{sid}/resources/memstore_01H0RKEMFTPM3J3Q3WCABCDEFG"
+        )
+        assert r.status_code == 422, r.text
+        assert "ghrepo_" in r.json()["error"]["message"]
+
+
+# ─── real-network clone (octocat/Hello-World) ─────────────────────────────
+
+
+def _git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+def _network_available() -> bool:
+    """Cheap connectivity check — just resolve github.com."""
+    import socket
+
+    try:
+        socket.gethostbyname("github.com")
+        return True
+    except OSError:
+        return False
+
+
+needs_real_clone = pytest.mark.skipif(
+    not (_git_available() and _network_available()),
+    reason="needs git on PATH and reachable github.com",
+)
+
+
+@needs_real_clone
+class TestRealClone:
+    async def test_cache_clone_then_session_clone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end clone of a tiny public repo through the actual
+        ``ensure_cache_clone`` + ``ensure_session_working_tree`` helpers.
+
+        The PAT for octocat/Hello-World needs only ``public_repo`` — but
+        for unauthenticated cloning of a public repo, GitHub rejects
+        bogus PATs. We sidestep that by patching ``_build_auth_url``
+        to omit the credential entirely; the helpers don't care about
+        the URL shape, only that ``git clone`` succeeds.
+        """
+        # Point all sandbox host dirs at a tmp path so we don't pollute
+        # the real workspace_root.
+        from aios.config import get_settings
+
+        s = get_settings()
+        # Settings is cached; mutate the cached instance.
+        monkeypatch.setattr(s, "workspace_root", tmp_path)
+
+        from aios.sandbox import github_clone
+
+        # Pretend the user's token is irrelevant for a public unauth clone.
+        monkeypatch.setattr(github_clone, "_build_auth_url", lambda url, _tok: url)
+
+        cache_dir = await github_clone.ensure_cache_clone(_OCTOCAT_REPO, "ignored")
+        assert cache_dir.exists()
+        assert (cache_dir / "HEAD").exists()
+        assert (cache_dir / "objects").is_dir()
+
+        work_dir = await github_clone.ensure_session_working_tree(
+            session_id="sess_test",
+            resource_id="ghrepo_test",
+            repo_url=_OCTOCAT_REPO,
+            token="ignored",
+            cache_dir=cache_dir,
+        )
+        assert work_dir.exists()
+        # Working tree has README.
+        assert (work_dir / "README").exists()
+        # .git exists with config + HEAD.
+        assert (work_dir / ".git" / "config").exists()
+        # The remote URL in the per-session config should match what we
+        # built — no embedded token in this patched form.
+        config_text = (work_dir / ".git" / "config").read_text()
+        assert _OCTOCAT_REPO in config_text
+
+    async def test_per_session_clone_recreated_on_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Calling ``ensure_session_working_tree`` twice rms-and-re-clones
+        — that's how token rotation propagates the new auth into
+        ``.git/config`` without any "is this stale?" detection logic."""
+        from aios.config import get_settings
+
+        s = get_settings()
+        monkeypatch.setattr(s, "workspace_root", tmp_path)
+
+        from aios.sandbox import github_clone
+
+        monkeypatch.setattr(github_clone, "_build_auth_url", lambda url, _tok: url)
+
+        cache_dir = await github_clone.ensure_cache_clone(_OCTOCAT_REPO, "ignored")
+
+        work_dir = await github_clone.ensure_session_working_tree(
+            session_id="sess_a",
+            resource_id="ghrepo_a",
+            repo_url=_OCTOCAT_REPO,
+            token="t1",
+            cache_dir=cache_dir,
+        )
+        # Drop a sentinel that recreate must clobber.
+        (work_dir / "SENTINEL").write_text("sentinel\n")
+        assert (work_dir / "SENTINEL").exists()
+
+        await github_clone.ensure_session_working_tree(
+            session_id="sess_a",
+            resource_id="ghrepo_a",
+            repo_url=_OCTOCAT_REPO,
+            token="t2",
+            cache_dir=cache_dir,
+        )
+        assert not (work_dir / "SENTINEL").exists()
+        # Working tree is fresh (README still present, sentinel gone).
+        assert (work_dir / "README").exists()

--- a/tests/unit/test_github_clone_helpers.py
+++ b/tests/unit/test_github_clone_helpers.py
@@ -71,8 +71,3 @@ class TestRedactToken:
     def test_no_redaction_if_token_absent(self) -> None:
         msg = "fatal: not a git repository"
         assert _redact_token_from_message(msg, "ghp_secret") == msg
-
-    def test_empty_token_passthrough(self) -> None:
-        # Belt-and-suspenders: empty token should never reach this path,
-        # but if it does, don't naive-replace into mush.
-        assert _redact_token_from_message("hello world", "") == "hello world"

--- a/tests/unit/test_github_clone_helpers.py
+++ b/tests/unit/test_github_clone_helpers.py
@@ -1,0 +1,78 @@
+"""Unit tests for the pure helpers in :mod:`aios.sandbox.github_clone`.
+
+The async clone/fetch functions need a real ``git`` binary and disk;
+those live in ``tests/e2e/test_github_repositories.py``. This file
+covers only the logic-layer helpers: URL building, hashing, redaction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.sandbox.github_clone import (
+    GithubCloneError,
+    _build_auth_url,
+    _redact_token_from_message,
+    url_hash,
+)
+
+
+class TestBuildAuthUrl:
+    def test_https_canonical(self) -> None:
+        out = _build_auth_url("https://github.com/octocat/Hello-World", "ghp_xyz")
+        assert out == "https://x-access-token:ghp_xyz@github.com/octocat/Hello-World"
+
+    def test_https_with_dot_git_suffix(self) -> None:
+        out = _build_auth_url("https://github.com/octocat/Hello-World.git", "ghp_xyz")
+        assert out == "https://x-access-token:ghp_xyz@github.com/octocat/Hello-World.git"
+
+    def test_http_allowed_for_self_hosted(self) -> None:
+        # Some self-hosted GH servers expose HTTP only; we don't actively
+        # block it, just leave the choice to the user.
+        out = _build_auth_url("http://gh.internal/o/r", "tok")
+        assert out == "http://x-access-token:tok@gh.internal/o/r"
+
+    def test_ssh_url_rejected(self) -> None:
+        with pytest.raises(GithubCloneError, match="https://"):
+            _build_auth_url("git@github.com:o/r.git", "tok")
+
+    def test_git_protocol_rejected(self) -> None:
+        with pytest.raises(GithubCloneError, match="https://"):
+            _build_auth_url("git://github.com/o/r.git", "tok")
+
+
+class TestUrlHash:
+    def test_stable_for_same_input(self) -> None:
+        a = url_hash("https://github.com/o/r")
+        b = url_hash("https://github.com/o/r")
+        assert a == b
+
+    def test_differs_for_different_urls(self) -> None:
+        assert url_hash("https://github.com/o/r1") != url_hash("https://github.com/o/r2")
+
+    def test_returns_hex_string(self) -> None:
+        h = url_hash("https://github.com/o/r")
+        assert len(h) == 64
+        int(h, 16)  # would raise if not hex
+
+    def test_distinguishes_dot_git_suffix(self) -> None:
+        # Different cache buckets — we don't normalize, since git treats them
+        # equivalently but the user might have meant either form deliberately.
+        assert url_hash("https://github.com/o/r") != url_hash("https://github.com/o/r.git")
+
+
+class TestRedactToken:
+    def test_redacts_inline_token(self) -> None:
+        msg = "fatal: Authentication failed for ghp_secret123"
+        assert _redact_token_from_message(msg, "ghp_secret123") == (
+            "fatal: Authentication failed for <redacted>"
+        )
+
+    def test_no_redaction_if_token_absent(self) -> None:
+        msg = "fatal: not a git repository"
+        assert _redact_token_from_message(msg, "ghp_secret") == msg
+
+    def test_empty_token_passthrough(self) -> None:
+        # Belt-and-suspenders: empty token should never reach this path,
+        # but if it does, don't naive-replace into mush.
+        assert _redact_token_from_message("hello world", "") == "hello world"

--- a/tests/unit/test_github_repositories_models.py
+++ b/tests/unit/test_github_repositories_models.py
@@ -84,6 +84,14 @@ class TestGithubRepositoryResourceCreate:
         with pytest.raises(ValidationError, match="/mnt/memory"):
             _resource(mount_path="/mnt/memory")
 
+    def test_mount_path_exact_workspace_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="/workspace"):
+            _resource(mount_path="/workspace")
+
+    def test_mount_path_workspace_subdir_allowed(self) -> None:
+        r = _resource(mount_path="/workspace/repo")
+        assert r.mount_path == "/workspace/repo"
+
     def test_mount_path_with_special_chars_allowed(self) -> None:
         # Anything not /, NUL, '.', '..' is fine.
         r = _resource(mount_path="/workspace/My Repo (cloned)/v1")

--- a/tests/unit/test_github_repositories_models.py
+++ b/tests/unit/test_github_repositories_models.py
@@ -1,0 +1,175 @@
+"""Unit tests for github_repository session resource models.
+
+Mirrors the test surface of ``test_memory_stores_models.py``: every
+validation rule has a single test, no fixtures, no DB.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from aios.models.github_repositories import (
+    MAX_REPOS_PER_SESSION,
+    GithubRepositoryResource,
+    GithubRepositoryResourceEcho,
+    GithubRepositoryUpdate,
+    validate_resources,
+)
+
+
+def _resource(
+    *,
+    url: str = "https://github.com/octocat/Hello-World",
+    mount_path: str = "/workspace/repo",
+    token: str = "ghp_secret",
+) -> GithubRepositoryResource:
+    return GithubRepositoryResource(
+        type="github_repository",
+        url=url,
+        mount_path=mount_path,
+        authorization_token=SecretStr(token),
+    )
+
+
+class TestGithubRepositoryResourceCreate:
+    def test_minimal_valid(self) -> None:
+        r = _resource()
+        assert r.type == "github_repository"
+        assert r.url == "https://github.com/octocat/Hello-World"
+        assert r.mount_path == "/workspace/repo"
+        assert r.authorization_token.get_secret_value() == "ghp_secret"
+
+    def test_token_required(self) -> None:
+        with pytest.raises(ValidationError, match="authorization_token"):
+            GithubRepositoryResource(
+                type="github_repository",
+                url="https://github.com/octocat/Hello-World",
+                mount_path="/workspace/repo",
+            )  # type: ignore[call-arg]
+
+    def test_token_must_be_non_empty(self) -> None:
+        with pytest.raises(ValidationError, match="non-empty"):
+            GithubRepositoryResource(
+                type="github_repository",
+                url="https://github.com/octocat/Hello-World",
+                mount_path="/workspace/repo",
+                authorization_token=SecretStr(""),
+            )
+
+    def test_url_must_be_non_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            _resource(url="")
+
+    def test_mount_path_must_be_absolute(self) -> None:
+        with pytest.raises(ValidationError):
+            _resource(mount_path="repo")
+
+    def test_mount_path_rejects_traversal(self) -> None:
+        # The regex catches the '..' segment via the `[^/\x00]+` pattern
+        # — `..` is two dot chars which match the segment, but the
+        # post-validator catches it. Confirm both layers fire.
+        with pytest.raises(ValidationError, match="traversal"):
+            _resource(mount_path="/workspace/../etc")
+
+    def test_mount_path_rejects_dot_segment(self) -> None:
+        with pytest.raises(ValidationError, match="traversal"):
+            _resource(mount_path="/workspace/./repo")
+
+    def test_mount_path_rejects_memory_overlap(self) -> None:
+        with pytest.raises(ValidationError, match="/mnt/memory"):
+            _resource(mount_path="/mnt/memory/foo")
+
+    def test_mount_path_exact_memory_root_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="/mnt/memory"):
+            _resource(mount_path="/mnt/memory")
+
+    def test_mount_path_with_special_chars_allowed(self) -> None:
+        # Anything not /, NUL, '.', '..' is fine.
+        r = _resource(mount_path="/workspace/My Repo (cloned)/v1")
+        assert r.mount_path == "/workspace/My Repo (cloned)/v1"
+
+    def test_extra_fields_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="extra"):
+            GithubRepositoryResource.model_validate(
+                {
+                    "type": "github_repository",
+                    "url": "https://github.com/o/r",
+                    "mount_path": "/workspace/repo",
+                    "authorization_token": "ghp_x",
+                    "branch": "main",  # not in our v1 schema
+                }
+            )
+
+
+class TestGithubRepositoryUpdate:
+    def test_token_required(self) -> None:
+        with pytest.raises(ValidationError):
+            GithubRepositoryUpdate()  # type: ignore[call-arg]
+
+    def test_token_must_be_non_empty(self) -> None:
+        with pytest.raises(ValidationError, match="non-empty"):
+            GithubRepositoryUpdate(authorization_token=SecretStr(""))
+
+    def test_immutable_fields_rejected(self) -> None:
+        # url, mount_path are not in the update body — sending them is a 4xx.
+        with pytest.raises(ValidationError, match="extra"):
+            GithubRepositoryUpdate.model_validate(
+                {
+                    "authorization_token": "ghp_new",
+                    "url": "https://github.com/other/repo",
+                }
+            )
+
+
+class TestValidateResources:
+    def test_empty_list_ok(self) -> None:
+        validate_resources([])
+
+    def test_unique_mount_paths_ok(self) -> None:
+        validate_resources(
+            [
+                _resource(mount_path="/workspace/a"),
+                _resource(mount_path="/workspace/b"),
+            ]
+        )
+
+    def test_duplicate_mount_paths_rejected(self) -> None:
+        with pytest.raises(ValueError, match="duplicate mount_path"):
+            validate_resources(
+                [
+                    _resource(mount_path="/workspace/repo"),
+                    _resource(mount_path="/workspace/repo"),
+                ]
+            )
+
+    def test_over_cap_rejected(self) -> None:
+        too_many = [
+            _resource(mount_path=f"/workspace/r{i}") for i in range(MAX_REPOS_PER_SESSION + 1)
+        ]
+        with pytest.raises(ValueError, match=str(MAX_REPOS_PER_SESSION)):
+            validate_resources(too_many)
+
+
+class TestGithubRepositoryResourceEcho:
+    """The echo is what's serialized over the wire on read paths.
+
+    Token is intentionally absent; ``id`` is the per-attachment ULID.
+    """
+
+    def test_no_token_field(self) -> None:
+        echo_fields = set(GithubRepositoryResourceEcho.model_fields)
+        assert "authorization_token" not in echo_fields
+        assert {"id", "type", "url", "mount_path", "created_at", "updated_at"} <= echo_fields
+
+    def test_default_type_literal(self) -> None:
+        from datetime import UTC, datetime
+
+        e = GithubRepositoryResourceEcho(
+            id="ghrepo_01TEST",
+            url="https://github.com/o/r",
+            mount_path="/workspace/r",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        assert e.type == "github_repository"

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -197,6 +197,10 @@ class TestProvisionerDockerArgs:
                 "aios.sandbox.provisioner._materialize_memory_mounts",
                 AsyncMock(return_value=[]),
             ),
+            patch(
+                "aios.sandbox.provisioner._materialize_github_clones",
+                AsyncMock(return_value=[]),
+            ),
             patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
             patch(
                 "aios.sandbox.provisioner._install_packages",
@@ -244,6 +248,10 @@ class TestProvisionerDockerArgs:
                 "aios.sandbox.provisioner._materialize_memory_mounts",
                 AsyncMock(return_value=[]),
             ),
+            patch(
+                "aios.sandbox.provisioner._materialize_github_clones",
+                AsyncMock(return_value=[]),
+            ),
             patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
             patch("aios.sandbox.provisioner._install_packages", AsyncMock()),
             patch(
@@ -280,6 +288,10 @@ class TestProvisionerDockerArgs:
             ),
             patch(
                 "aios.sandbox.provisioner._materialize_memory_mounts",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "aios.sandbox.provisioner._materialize_github_clones",
                 AsyncMock(return_value=[]),
             ),
             patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -47,25 +47,30 @@ class TestReleaseIfMountsChanged:
         registry = SandboxRegistry()
         provisioner_release = AsyncMock()
         with patch("aios.sandbox.registry.provisioner_release", provisioner_release):
-            await registry.release_if_mounts_changed("sess_NONE", [_echo("memstore_a", "a")])
+            await registry.release_if_mounts_changed("sess_NONE", [_echo("memstore_a", "a")], [])
         provisioner_release.assert_not_awaited()
 
     async def test_identical_snapshot_does_not_release(self) -> None:
         registry = SandboxRegistry()
-        snapshot = frozenset([("memstore_a", "a", "read_write")])
+        snapshot = frozenset([("memstore", "memstore_a", "a", "read_write")])
         registry._handles["sess_X"] = _handle("sess_X", snapshot)
         registry._last_used["sess_X"] = 0.0
 
         provisioner_release = AsyncMock()
         with patch("aios.sandbox.registry.provisioner_release", provisioner_release):
-            await registry.release_if_mounts_changed("sess_X", [_echo("memstore_a", "a")])
+            await registry.release_if_mounts_changed("sess_X", [_echo("memstore_a", "a")], [])
 
         provisioner_release.assert_not_awaited()
         assert registry.peek("sess_X") is not None
 
     async def test_reorder_does_not_release(self) -> None:
         registry = SandboxRegistry()
-        snapshot = frozenset([("memstore_a", "a", "read_write"), ("memstore_b", "b", "read_only")])
+        snapshot = frozenset(
+            [
+                ("memstore", "memstore_a", "a", "read_write"),
+                ("memstore", "memstore_b", "b", "read_only"),
+            ]
+        )
         registry._handles["sess_X"] = _handle("sess_X", snapshot)
         registry._last_used["sess_X"] = 0.0
 
@@ -74,6 +79,7 @@ class TestReleaseIfMountsChanged:
             await registry.release_if_mounts_changed(
                 "sess_X",
                 [_echo("memstore_b", "b", "read_only"), _echo("memstore_a", "a")],
+                [],
             )
 
         provisioner_release.assert_not_awaited()
@@ -93,14 +99,14 @@ class TestReleaseIfMountsChanged:
         self, current_echoes: list[MemoryStoreResourceEcho], description: str
     ) -> None:
         registry = SandboxRegistry()
-        snapshot = frozenset([("memstore_a", "a", "read_write")])
+        snapshot = frozenset([("memstore", "memstore_a", "a", "read_write")])
         handle = _handle("sess_X", snapshot)
         registry._handles["sess_X"] = handle
         registry._last_used["sess_X"] = 0.0
 
         provisioner_release = AsyncMock()
         with patch("aios.sandbox.registry.provisioner_release", provisioner_release):
-            await registry.release_if_mounts_changed("sess_X", current_echoes)
+            await registry.release_if_mounts_changed("sess_X", current_echoes, [])
 
         provisioner_release.assert_awaited_once_with(handle)
         assert registry.peek("sess_X") is None
@@ -113,7 +119,7 @@ class TestReleaseIfMountsChanged:
         import asyncio
 
         registry = SandboxRegistry()
-        old_snapshot = frozenset([("memstore_a", "a", "read_write")])
+        old_snapshot = frozenset([("memstore", "memstore_a", "a", "read_write")])
         old_handle = _handle("sess_X", old_snapshot)
         registry._handles["sess_X"] = old_handle
         registry._last_used["sess_X"] = 0.0
@@ -124,7 +130,7 @@ class TestReleaseIfMountsChanged:
         async def slow_provision(_session_id: str) -> ContainerHandle:
             provision_started.set()
             await let_provision_continue.wait()
-            return _handle("sess_X", frozenset([("memstore_b", "b", "read_write")]))
+            return _handle("sess_X", frozenset([("memstore", "memstore_b", "b", "read_write")]))
 
         # Force a cache miss so get_or_provision contends for the lock.
         registry._handles.pop("sess_X")
@@ -141,7 +147,7 @@ class TestReleaseIfMountsChanged:
             # gets the lock — this models a real cycle: provision finishes,
             # then drift is detected, then release fires.
             release_task = asyncio.create_task(
-                registry.release_if_mounts_changed("sess_X", [_echo("memstore_b", "b")])
+                registry.release_if_mounts_changed("sess_X", [_echo("memstore_b", "b")], [])
             )
             # release_task is blocked on the lock provision_task is holding.
             await asyncio.sleep(0)


### PR DESCRIPTION
## Summary

- Adds the `github_repository` session resource, parity with Anthropic Managed Agents (CMA): clones a GitHub repo into the sandbox at a user-specified `mount_path` so the agent can `read`, edit, and `git push` directly with no external credential plumbing.
- Host-side cache (`<workspace_root>/_github_repos/<sha256(url)>`) shared across sessions; per-session working trees are populated via `git clone --reference --dissociate` so object data is reused without coupling lifetimes.
- Auth token is encrypted at rest via the existing libsodium `CryptoBox` (matches `vault_credentials`) and embedded in the `origin` URL — `git push` from inside the container works inline.
- Token rotation via `POST /v1/sessions/{sid}/resources/{rid}` bumps `updated_at`, which is part of the mount-snapshot key, so the next step recycles the container and re-clones with the rotated token. No "is this stale?" detection logic.

## Departures from CMA, by intent

- **Mid-session add/remove** of the `resources` field on session update (extends the memory-store full-list-replace pattern). CMA returns 400 on this — aios diverges deliberately.
- **URL-embedded token** rather than CMA's local credential proxy. Acceptable given per-session ephemeral containers.
- **No automatic git identity / GPG signing** pre-config — the agent configures these itself if it needs to commit.

## API surface

- `POST /v1/sessions` with `resources: [{type: "github_repository", url, mount_path, authorization_token}]`
- `GET /v1/sessions/{sid}/resources` — unified list across resource types
- `GET /v1/sessions/{sid}/resources/{rid}` — single resource read view (token never echoed)
- `POST /v1/sessions/{sid}/resources/{rid}` — token rotation, `authorization_token` only
- `PUT /v1/sessions/{sid}` with `resources: [...]` — add or detach (full-list-replace)

## Test plan

- [x] `uv run mypy src` clean (123 source files)
- [x] `uv run ruff check src tests` clean
- [x] `uv run ruff format --check src tests` clean
- [x] `uv run pytest tests/unit -q` — **1057 passed** (32 new across `test_github_repositories_models.py`, `test_github_clone_helpers.py`)
- [x] `uv run pytest tests/e2e -q` (with Docker) — **299 passed**, including 14 new in `test_github_repositories.py` (DB + service + ASGI HTTP layer; 2 real-clone tests against `octocat/Hello-World`)
- [ ] Manual probe inside an aios sandbox: verify `.git/config` has the embedded-token `origin`, working tree is fully checked out, `git push` succeeds against a personal test repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)