### PR TITLE
fix(github): proxy github_repository PATs out-of-process from the sandbox (#208)

### DIFF
--- a/src/aios/sandbox/container.py
+++ b/src/aios/sandbox/container.py
@@ -41,6 +41,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from aios.models.github_repositories import GithubRepositoryResourceEcho
     from aios.models.memory_stores import MemoryStoreResourceEcho
+    from aios.sandbox.git_proxy import GitProxy
 
 
 def mount_snapshot_from_echoes(
@@ -140,11 +141,16 @@ class ContainerHandle:
         container_id: str,
         workspace_path: Path,
         mount_snapshot: frozenset[tuple[str, ...]] = frozenset(),
+        git_proxy: GitProxy | None = None,
     ) -> None:
         self.session_id = session_id
         self.container_id = container_id
         self.workspace_path = workspace_path
         self.mount_snapshot = mount_snapshot
+        # Per-session credential broker for github_repository attachments.
+        # Lifetime tied to this handle; release() in the provisioner stops
+        # it before tearing down the docker container.
+        self.git_proxy = git_proxy
 
     async def run_command(
         self,

--- a/src/aios/sandbox/container.py
+++ b/src/aios/sandbox/container.py
@@ -148,8 +148,7 @@ class ContainerHandle:
         self.workspace_path = workspace_path
         self.mount_snapshot = mount_snapshot
         # Per-session credential broker for github_repository attachments.
-        # Lifetime tied to this handle; release() in the provisioner stops
-        # it before tearing down the docker container.
+        # Held here so the handle's release path can stop it.
         self.git_proxy = git_proxy
 
     async def run_command(

--- a/src/aios/sandbox/git_proxy.py
+++ b/src/aios/sandbox/git_proxy.py
@@ -173,8 +173,9 @@ class GitProxy:
         self._serve_task = asyncio.create_task(self._server.serve(), name="git-proxy-serve")
 
         # Wait for the bind to complete and grab the port.
-        deadline = asyncio.get_event_loop().time() + _BIND_TIMEOUT_S
-        while asyncio.get_event_loop().time() < deadline:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _BIND_TIMEOUT_S
+        while loop.time() < deadline:
             await asyncio.sleep(0.01)
             if self._server.started and self._server.servers:
                 sockets = self._server.servers[0].sockets
@@ -188,14 +189,19 @@ class GitProxy:
         """Gracefully stop the server and close the httpx client."""
         if self._server is not None:
             self._server.should_exit = True
-        if self._serve_task is not None:
-            try:
-                await asyncio.wait_for(self._serve_task, timeout=5.0)
-            except TimeoutError:
+        try:
+            if self._serve_task is not None:
+                with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+                    await asyncio.wait_for(self._serve_task, timeout=5.0)
+        finally:
+            # Always cancel the serve task and close the httpx client.
+            # Skipping either on a non-timeout exception leaks the
+            # bound port and the in-memory token map.
+            if self._serve_task is not None and not self._serve_task.done():
                 self._serve_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await self._serve_task
-        await self._client.aclose()
+            await self._client.aclose()
         log.info("git_proxy.stopped", port=self._port)
 
     async def _handle(self, request: Request) -> Response:

--- a/src/aios/sandbox/git_proxy.py
+++ b/src/aios/sandbox/git_proxy.py
@@ -1,0 +1,267 @@
+"""Per-session HTTP proxy that holds GitHub PATs on the host side and
+injects them into outbound git traffic from the sandbox.
+
+The token never enters the container. The container's working tree has
+``origin = http://host.docker.internal:<port>/git/<secret>/<owner>/<repo>``;
+git speaks smart-HTTP to that URL; the proxy forwards each request to
+``https://github.com/<owner>/<repo>/...`` with the ``Authorization``
+header injected from the in-memory token map.
+
+Per session lifecycle: started by the provisioner alongside the
+container, torn down by the registry's ``release`` path. Token rotation
+is an atomic swap of the in-memory map; the existing mount-snapshot
+drift check (``updated_at`` is part of the snapshot key) also forces a
+container recycle which restarts the proxy with a fresh map, so
+correctness doesn't depend on ``update_repos``.
+
+The per-session secret in the URL path is a sanity check, not a true
+isolation primitive — the agent can read the secret from
+``.git/config`` inside the container. Its job is to limit blast radius
+if the proxy port is reachable from the wider network: a port scanner
+without the secret gets a 403, and an attacker that learned the secret
+can only proxy requests for the specific repos this session is already
+attached to (and only while the proxy is alive).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import secrets
+from collections.abc import AsyncIterator
+from urllib.parse import urlsplit
+
+import httpx
+import uvicorn
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import Response, StreamingResponse
+from starlette.routing import Route
+
+from aios.logging import get_logger
+
+log = get_logger("aios.sandbox.git_proxy")
+
+_HOP_BY_HOP_REQUEST_HEADERS: frozenset[str] = frozenset(
+    {
+        "host",
+        "authorization",
+        "connection",
+        "content-length",
+        "transfer-encoding",
+        "expect",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "upgrade",
+    }
+)
+
+_HOP_BY_HOP_RESPONSE_HEADERS: frozenset[str] = frozenset(
+    {
+        "connection",
+        "content-encoding",  # httpx auto-decodes; we re-stream the decoded body
+        "content-length",  # length changes once we drop other hop-by-hops
+        "transfer-encoding",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "upgrade",
+    }
+)
+
+# Generous bound on the upstream HTTP request — git smart HTTP can stream
+# large pack files for big pushes/pulls.
+_UPSTREAM_TIMEOUT_S = 300.0
+_BIND_TIMEOUT_S = 5.0
+
+
+def repo_key(repo_url: str) -> str:
+    """Map a github repo URL to ``owner/repo`` (no ``.git`` suffix).
+
+    Two URLs that differ only in the suffix resolve to the same token
+    so the proxy doesn't duplicate entries for the same upstream.
+    """
+    parts = urlsplit(repo_url)
+    path = parts.path.strip("/")
+    if path.endswith(".git"):
+        path = path[: -len(".git")]
+    return path
+
+
+class GitProxy:
+    """One per session; holds tokens in memory, accepts git smart-HTTP
+    requests on a random port, forwards to github.com with
+    ``Authorization`` injected.
+
+    Lifetime is bounded by the session container's lifetime: when the
+    container is released or recycled, the proxy is stopped and the
+    in-memory token map is dropped.
+    """
+
+    def __init__(self, repos: dict[str, str]) -> None:
+        # Copy so callers can't mutate the live map under us.
+        self._repos: dict[str, str] = dict(repos)
+        self._secret = secrets.token_urlsafe(32)
+        self._client = httpx.AsyncClient(timeout=_UPSTREAM_TIMEOUT_S, follow_redirects=False)
+        self._server: uvicorn.Server | None = None
+        self._serve_task: asyncio.Task[None] | None = None
+        self._port: int | None = None
+
+    @property
+    def secret(self) -> str:
+        return self._secret
+
+    @property
+    def port(self) -> int:
+        assert self._port is not None, "GitProxy.start() has not completed"
+        return self._port
+
+    def proxy_url(self, repo_url: str, *, host: str) -> str:
+        """The URL to write into a working tree's ``origin`` config so
+        git operations from inside the container route through this
+        proxy. Secret travels in the URL path; no userinfo, so git
+        won't send a Basic-auth Authorization header that we'd have to
+        strip on every request."""
+        return f"http://{host}:{self.port}/git/{self._secret}/{repo_key(repo_url)}"
+
+    def update_repos(self, repos: dict[str, str]) -> None:
+        """Atomic replacement of the token map. Called on rotation /
+        mount-set change so the proxy starts honoring the new tokens
+        immediately. The container-recycle path also handles this case
+        by restarting the proxy entirely; this method is a faster path
+        when we want to skip the recycle."""
+        self._repos = dict(repos)
+
+    async def start(self) -> None:
+        """Bind ``0.0.0.0:0`` (ephemeral port, all interfaces) and begin
+        serving. Binding to 0.0.0.0 is required for the docker container
+        to reach the proxy via ``host.docker.internal``; per-session
+        secret + per-repo path keep the blast radius bounded if the port
+        is exposed."""
+        app = Starlette(
+            routes=[
+                Route(
+                    "/git/{rest:path}",
+                    self._handle,
+                    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"],
+                )
+            ]
+        )
+        config = uvicorn.Config(
+            app,
+            host="0.0.0.0",
+            port=0,
+            log_level="error",
+            access_log=False,
+            lifespan="off",
+        )
+        self._server = uvicorn.Server(config)
+        self._serve_task = asyncio.create_task(self._server.serve(), name="git-proxy-serve")
+
+        # Wait for the bind to complete and grab the port.
+        deadline = asyncio.get_event_loop().time() + _BIND_TIMEOUT_S
+        while asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+            if self._server.started and self._server.servers:
+                sockets = self._server.servers[0].sockets
+                if sockets:
+                    self._port = sockets[0].getsockname()[1]
+                    log.info("git_proxy.started", port=self._port)
+                    return
+        raise RuntimeError(f"git proxy failed to bind within {_BIND_TIMEOUT_S}s")
+
+    async def stop(self) -> None:
+        """Gracefully stop the server and close the httpx client."""
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._serve_task is not None:
+            try:
+                await asyncio.wait_for(self._serve_task, timeout=5.0)
+            except TimeoutError:
+                self._serve_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._serve_task
+        await self._client.aclose()
+        log.info("git_proxy.stopped", port=self._port)
+
+    async def _handle(self, request: Request) -> Response:
+        # URL path: /git/<secret>/<owner>/<repo>[/<rest>]
+        rest = request.path_params["rest"]
+        parts = rest.split("/", 3)
+        if len(parts) < 3 or parts[0] != self._secret:
+            return Response(status_code=403, content=b"forbidden")
+        owner, repo = parts[1], parts[2]
+        upstream_path = parts[3] if len(parts) > 3 else ""
+        repo_no_git = repo.removesuffix(".git")
+        token = self._repos.get(f"{owner}/{repo_no_git}")
+        if token is None:
+            return Response(status_code=404, content=b"unknown repo for this proxy")
+
+        upstream_url = f"https://github.com/{owner}/{repo}"
+        if upstream_path:
+            upstream_url = f"{upstream_url}/{upstream_path}"
+        if request.url.query:
+            upstream_url = f"{upstream_url}?{request.url.query}"
+
+        fwd_headers: dict[str, str] = {}
+        for name, value in request.headers.items():
+            if name.lower() in _HOP_BY_HOP_REQUEST_HEADERS:
+                continue
+            fwd_headers[name] = value
+        # Use Basic auth with the standard "x-access-token:<pat>" form —
+        # this mirrors what `https://x-access-token:$TOKEN@github.com/...`
+        # produces and is accepted by both classic PATs and fine-grained
+        # tokens. The plain "Authorization: token <pat>" header works for
+        # classic PATs but is rejected by newer fine-grained tokens.
+        basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+        fwd_headers["Authorization"] = f"Basic {basic}"
+
+        try:
+            upstream_req = self._client.build_request(
+                request.method,
+                upstream_url,
+                headers=fwd_headers,
+                content=request.stream(),
+            )
+            upstream_resp = await self._client.send(upstream_req, stream=True)
+        except httpx.RequestError as exc:
+            log.warning(
+                "git_proxy.upstream_error",
+                upstream_url=upstream_url,
+                method=request.method,
+                error=str(exc),
+            )
+            return Response(status_code=502, content=b"upstream error")
+
+        resp_headers: dict[str, str] = {}
+        for name, value in upstream_resp.headers.items():
+            if name.lower() in _HOP_BY_HOP_RESPONSE_HEADERS:
+                continue
+            resp_headers[name] = value
+
+        async def _body() -> AsyncIterator[bytes]:
+            # ``aiter_bytes`` works whether the underlying transport
+            # streamed the body (real network) or pre-buffered it
+            # (httpx.MockTransport in tests). Content-Encoding is
+            # already stripped from ``resp_headers`` because httpx
+            # decodes here, so the client sees raw bytes consistently.
+            try:
+                async for chunk in upstream_resp.aiter_bytes():
+                    yield chunk
+            finally:
+                await upstream_resp.aclose()
+
+        return StreamingResponse(
+            _body(),
+            status_code=upstream_resp.status_code,
+            headers=resp_headers,
+        )
+
+
+__all__ = ["GitProxy", "repo_key"]

--- a/src/aios/sandbox/git_proxy.py
+++ b/src/aios/sandbox/git_proxy.py
@@ -5,14 +5,13 @@ The token never enters the container. The container's working tree has
 ``origin = http://host.docker.internal:<port>/git/<secret>/<owner>/<repo>``;
 git speaks smart-HTTP to that URL; the proxy forwards each request to
 ``https://github.com/<owner>/<repo>/...`` with the ``Authorization``
-header injected from the in-memory token map.
+header injected from the precomputed per-repo basic-auth map.
 
 Per session lifecycle: started by the provisioner alongside the
 container, torn down by the registry's ``release`` path. Token rotation
-is an atomic swap of the in-memory map; the existing mount-snapshot
-drift check (``updated_at`` is part of the snapshot key) also forces a
-container recycle which restarts the proxy with a fresh map, so
-correctness doesn't depend on ``update_repos``.
+runs through the same path as add/remove — the existing mount-snapshot
+drift check (``updated_at`` is part of the snapshot key) recycles the
+container, which restarts the proxy with a fresh map.
 
 The per-session secret in the URL path is a sanity check, not a true
 isolation primitive — the agent can read the secret from
@@ -94,6 +93,20 @@ def repo_key(repo_url: str) -> str:
     return path
 
 
+def build_basic_auth_header(token: str) -> str:
+    """The ``Authorization`` value the proxy injects on forwarded
+    requests.
+
+    Form is ``Basic base64(x-access-token:<pat>)`` — what
+    ``https://x-access-token:$TOKEN@github.com/...`` produces when git
+    parses URL userinfo. Accepted by both classic and fine-grained
+    PATs; ``Authorization: token <pat>`` works for classic but is
+    rejected by newer fine-grained tokens.
+    """
+    encoded = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+    return f"Basic {encoded}"
+
+
 class GitProxy:
     """One per session; holds tokens in memory, accepts git smart-HTTP
     requests on a random port, forwards to github.com with
@@ -105,8 +118,11 @@ class GitProxy:
     """
 
     def __init__(self, repos: dict[str, str]) -> None:
-        # Copy so callers can't mutate the live map under us.
-        self._repos: dict[str, str] = dict(repos)
+        # Precompute Basic-auth headers so each request is just a dict
+        # lookup. The raw tokens go out of scope after this constructor.
+        self._auth_headers: dict[str, str] = {
+            key: build_basic_auth_header(token) for key, token in repos.items()
+        }
         self._secret = secrets.token_urlsafe(32)
         self._client = httpx.AsyncClient(timeout=_UPSTREAM_TIMEOUT_S, follow_redirects=False)
         self._server: uvicorn.Server | None = None
@@ -129,14 +145,6 @@ class GitProxy:
         won't send a Basic-auth Authorization header that we'd have to
         strip on every request."""
         return f"http://{host}:{self.port}/git/{self._secret}/{repo_key(repo_url)}"
-
-    def update_repos(self, repos: dict[str, str]) -> None:
-        """Atomic replacement of the token map. Called on rotation /
-        mount-set change so the proxy starts honoring the new tokens
-        immediately. The container-recycle path also handles this case
-        by restarting the proxy entirely; this method is a faster path
-        when we want to skip the recycle."""
-        self._repos = dict(repos)
 
     async def start(self) -> None:
         """Bind ``0.0.0.0:0`` (ephemeral port, all interfaces) and begin
@@ -199,8 +207,8 @@ class GitProxy:
         owner, repo = parts[1], parts[2]
         upstream_path = parts[3] if len(parts) > 3 else ""
         repo_no_git = repo.removesuffix(".git")
-        token = self._repos.get(f"{owner}/{repo_no_git}")
-        if token is None:
+        auth_header = self._auth_headers.get(f"{owner}/{repo_no_git}")
+        if auth_header is None:
             return Response(status_code=404, content=b"unknown repo for this proxy")
 
         upstream_url = f"https://github.com/{owner}/{repo}"
@@ -214,13 +222,7 @@ class GitProxy:
             if name.lower() in _HOP_BY_HOP_REQUEST_HEADERS:
                 continue
             fwd_headers[name] = value
-        # Use Basic auth with the standard "x-access-token:<pat>" form —
-        # this mirrors what `https://x-access-token:$TOKEN@github.com/...`
-        # produces and is accepted by both classic PATs and fine-grained
-        # tokens. The plain "Authorization: token <pat>" header works for
-        # classic PATs but is rejected by newer fine-grained tokens.
-        basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
-        fwd_headers["Authorization"] = f"Basic {basic}"
+        fwd_headers["Authorization"] = auth_header
 
         try:
             upstream_req = self._client.build_request(

--- a/src/aios/sandbox/github_clone.py
+++ b/src/aios/sandbox/github_clone.py
@@ -12,10 +12,14 @@ Two host directories per attached repo:
    Stored at ``<session_workspace>/_repos/<repo_id>/`` and bind-mounted
    into the container at the user-supplied ``mount_path``.
 
-The auth token is embedded in the cloned ``origin`` URL
-(``https://x-access-token:$TOKEN@github.com/owner/repo.git``). The token
-sits in ``.git/config`` inside the per-session working tree, which is
-ephemeral and per-session.
+The auth token is used only on the host-side ``git clone`` invocation;
+we then ``git remote set-url origin`` the working tree to a per-session
+:class:`aios.sandbox.git_proxy.GitProxy` URL so the bind-mounted
+``.git/config`` inside the sandbox carries no credential. The proxy
+holds the token in worker-process memory and forwards smart-HTTP traffic
+to ``api.github.com`` with ``Authorization`` injected — the agent inside
+the container can ``git fetch`` / ``push`` as normal but cannot read
+the token. Cache refreshes happen on the host outside the container.
 
 The host process running this module needs ``git`` on PATH.
 """
@@ -200,9 +204,12 @@ async def ensure_session_working_tree(
     repo_url: str,
     token: str,
     cache_dir: Path,
+    proxy_url: str,
 ) -> Path:
-    """Create a per-session working tree from the cache, with the auth
-    token embedded in the ``origin`` URL.
+    """Create a per-session working tree from the cache, then rewrite
+    ``origin`` to point at the per-session ``GitProxy`` URL so the
+    bind-mounted ``.git/config`` inside the sandbox carries no
+    credential.
 
     Always recreates the working tree on call: that way token rotation
     (which bumps ``updated_at`` on the resource and hence the mount
@@ -235,6 +242,23 @@ async def ensure_session_working_tree(
             shutil.rmtree(work_dir, ignore_errors=True)
         raise GithubCloneError(
             f"git clone --reference failed for session {session_id} repo {resource_id}: "
+            f"{_redact_token_from_message(stderr.decode('utf-8', errors='replace'), token)}"
+        )
+
+    # Replace the auth-embedded origin URL with the proxy URL. The bind
+    # mount is about to expose this .git/config inside the sandbox; if we
+    # left the auth URL in place, the agent could read the PAT via
+    # `cat .git/config` or `git remote -v`.
+    rc, _stdout, stderr = await _run_git(
+        ["remote", "set-url", "origin", proxy_url],
+        cwd=work_dir,
+        op="remote set-url",
+    )
+    if rc != 0:
+        if work_dir.exists():
+            shutil.rmtree(work_dir, ignore_errors=True)
+        raise GithubCloneError(
+            f"failed to scrub origin URL for session {session_id} repo {resource_id}: "
             f"{_redact_token_from_message(stderr.decode('utf-8', errors='replace'), token)}"
         )
 

--- a/src/aios/sandbox/github_clone.py
+++ b/src/aios/sandbox/github_clone.py
@@ -17,9 +17,10 @@ we then ``git remote set-url origin`` the working tree to a per-session
 :class:`aios.sandbox.git_proxy.GitProxy` URL so the bind-mounted
 ``.git/config`` inside the sandbox carries no credential. The proxy
 holds the token in worker-process memory and forwards smart-HTTP traffic
-to ``api.github.com`` with ``Authorization`` injected — the agent inside
-the container can ``git fetch`` / ``push`` as normal but cannot read
-the token. Cache refreshes happen on the host outside the container.
+to ``github.com`` with ``Authorization`` injected — the agent inside
+the container can ``git fetch`` / ``push`` as normal but the PAT itself
+is not readable from inside the container. Cache refreshes happen on
+the host outside the container.
 
 The host process running this module needs ``git`` on PATH.
 """

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -21,6 +21,8 @@ CLI.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from aios.config import get_settings
 from aios.db import queries
 from aios.logging import get_logger
@@ -349,9 +351,9 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
     # credential proxy is running, allow outbound to its host:port too,
     # otherwise the lockdown would block all in-container git traffic.
     if needs_lockdown and isinstance(networking, LimitedNetworking):
-        extra_host_ports: list[tuple[str, int]] = []
-        if git_proxy is not None:
-            extra_host_ports.append((_PROXY_HOST_ALIAS, git_proxy.port))
+        extra_host_ports: list[tuple[str, int]] = (
+            [(_PROXY_HOST_ALIAS, git_proxy.port)] if git_proxy is not None else []
+        )
         await _apply_network_lockdown(
             handle, networking, session_id, extra_host_ports=extra_host_ports
         )
@@ -415,7 +417,7 @@ async def _install_packages(
 
 def build_iptables_script(
     allowed_hosts: set[str],
-    extra_host_ports: list[tuple[str, int]] | None = None,
+    extra_host_ports: Sequence[tuple[str, int]] = (),
 ) -> str:
     """Build a shell script that restricts outbound traffic via iptables.
 
@@ -458,7 +460,7 @@ def build_iptables_script(
         lines.append('  iptables -A OUTPUT -d "$ip" -p tcp --dport 443 -j ACCEPT')
         lines.append("done")
 
-    for host, port in extra_host_ports or []:
+    for host, port in extra_host_ports:
         lines.append("")
         lines.append(f"# Allow {host}:{port}")
         lines.append(
@@ -479,7 +481,7 @@ async def _apply_network_lockdown(
     networking: LimitedNetworking,
     session_id: str,
     *,
-    extra_host_ports: list[tuple[str, int]] | None = None,
+    extra_host_ports: Sequence[tuple[str, int]] = (),
 ) -> None:
     """Apply iptables rules to restrict outbound traffic.
 
@@ -510,7 +512,7 @@ async def _apply_network_lockdown(
             "sandbox.network_lockdown_applied",
             session_id=session_id,
             allowed_host_count=len(allowed),
-            extra_host_port_count=len(extra_host_ports or []),
+            extra_host_port_count=len(extra_host_ports),
         )
 
 

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -33,6 +33,7 @@ from aios.sandbox.container import (
     mount_snapshot_from_echoes,
     run_subprocess_with_timeout,
 )
+from aios.sandbox.git_proxy import GitProxy
 from aios.sandbox.github_clone import (
     GithubCloneError,
     ensure_cache_clone,
@@ -147,47 +148,67 @@ async def _materialize_memory_mounts(
     return list(echoes)
 
 
+_PROXY_HOST_ALIAS = "host.docker.internal"
+
+
 async def _materialize_github_clones(
     session_id: str,
-) -> list[GithubRepositoryResourceEcho]:
-    """Run host-side ``git clone`` for each attached github_repository
-    and return the echo list.
+) -> tuple[list[GithubRepositoryResourceEcho], GitProxy | None]:
+    """Decrypt tokens, start a per-session :class:`GitProxy`, then run
+    the host-side clone for each attached github_repository — rewriting
+    each working tree's ``origin`` to the proxy URL so the bind-mounted
+    ``.git/config`` inside the sandbox carries no credential.
 
-    Two-step per repo: ensure the bare cache (shared across sessions)
-    exists, then ``git clone --reference`` a per-session working tree
-    that the container will bind-mount. Token decryption uses the
-    worker-scoped CryptoBox.
+    Returns the materialized echo list and the proxy (or ``None`` when
+    the session has no github_repository attachments).
 
-    Failures are non-fatal: a bad token or unreachable repo logs an
-    error and appends a lifecycle event so the agent can react, but
-    does not block container provisioning.
+    Per-repo clone failures are non-fatal — they log + append a
+    lifecycle event and drop the repo from the materialized list (its
+    working tree won't be bind-mounted). The proxy stays alive for
+    sibling repos.
     """
     from aios.harness import runtime
+    from aios.sandbox.git_proxy import GitProxy, repo_key
     from aios.services import github_repositories as github_repo_service
 
     pool = runtime.require_pool()
     crypto_box = runtime.require_crypto_box()
-    materialized: list[GithubRepositoryResourceEcho] = []
-    failures: list[tuple[GithubRepositoryResourceEcho, GithubCloneError]] = []
+
+    # Load echoes and decrypt all tokens up front so the proxy can be
+    # initialized with the full token map before any clone runs.
     async with pool.acquire() as conn:
         echoes = await queries.list_session_github_repo_echoes(conn, session_id)
+        if not echoes:
+            return [], None
+        echo_tokens: list[tuple[GithubRepositoryResourceEcho, str]] = []
+        repos_map: dict[str, str] = {}
         for echo in echoes:
-            try:
-                token = await github_repo_service.get_session_token(
-                    conn, crypto_box, session_id, echo.id
-                )
-                cache_dir = await ensure_cache_clone(echo.url, token)
-                await ensure_session_working_tree(
-                    session_id=session_id,
-                    resource_id=echo.id,
-                    repo_url=echo.url,
-                    token=token,
-                    cache_dir=cache_dir,
-                )
-            except GithubCloneError as err:
-                failures.append((echo, err))
-                continue
-            materialized.append(echo)
+            token = await github_repo_service.get_session_token(
+                conn, crypto_box, session_id, echo.id
+            )
+            echo_tokens.append((echo, token))
+            repos_map[repo_key(echo.url)] = token
+
+    proxy = GitProxy(repos_map)
+    await proxy.start()
+
+    materialized: list[GithubRepositoryResourceEcho] = []
+    failures: list[tuple[GithubRepositoryResourceEcho, GithubCloneError]] = []
+    for echo, token in echo_tokens:
+        try:
+            cache_dir = await ensure_cache_clone(echo.url, token)
+            await ensure_session_working_tree(
+                session_id=session_id,
+                resource_id=echo.id,
+                repo_url=echo.url,
+                token=token,
+                cache_dir=cache_dir,
+                proxy_url=proxy.proxy_url(echo.url, host=_PROXY_HOST_ALIAS),
+            )
+        except GithubCloneError as err:
+            failures.append((echo, err))
+            continue
+        materialized.append(echo)
 
     # Log + append failure events outside the conn block so we don't
     # hold one connection while acquiring a second from the same pool.
@@ -213,7 +234,7 @@ async def _materialize_github_clones(
                     "message": str(failure),
                 },
             )
-    return materialized
+    return materialized, proxy
 
 
 async def provision_for_session(session_id: str) -> ContainerHandle:
@@ -238,7 +259,7 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
     workspace_path = ensure_workspace_path(raw_path)
     env_config = await _load_environment_config(session_id)
     memory_echoes = await _materialize_memory_mounts(session_id)
-    github_echoes = await _materialize_github_clones(session_id)
+    github_echoes, git_proxy = await _materialize_github_clones(session_id)
 
     # Merge environment-level and session-level env vars (session wins).
     merged_env: dict[str, str] = {
@@ -270,6 +291,12 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
         # Keep stdin open so the container doesn't exit on empty stdin.
         "--interactive",
     ]
+
+    # When a github_repository is attached, the container must be able to
+    # reach the host-side credential proxy via host.docker.internal.
+    # Auto-resolved on Docker Desktop; Linux requires the explicit alias.
+    if git_proxy is not None:
+        argv.extend(["--add-host", f"{_PROXY_HOST_ALIAS}:host-gateway"])
 
     # Bind-mount each attached memory store. ``:ro`` for read_only attaches
     # ensures the kernel rejects writes (bash + tools alike); ``:rw`` is the
@@ -312,14 +339,22 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
         container_id=container_id,
         workspace_path=workspace_path,
         mount_snapshot=mount_snapshot_from_echoes(memory_echoes, github_echoes),
+        git_proxy=git_proxy,
     )
 
     # Install packages while the network is still open.
     await _install_packages(handle, env_config, session_id)
 
-    # Apply iptables lockdown after packages are installed.
+    # Apply iptables lockdown after packages are installed. When a
+    # credential proxy is running, allow outbound to its host:port too,
+    # otherwise the lockdown would block all in-container git traffic.
     if needs_lockdown and isinstance(networking, LimitedNetworking):
-        await _apply_network_lockdown(handle, networking, session_id)
+        extra_host_ports: list[tuple[str, int]] = []
+        if git_proxy is not None:
+            extra_host_ports.append((_PROXY_HOST_ALIAS, git_proxy.port))
+        await _apply_network_lockdown(
+            handle, networking, session_id, extra_host_ports=extra_host_ports
+        )
 
     log.info(
         "sandbox.provisioned",
@@ -378,12 +413,20 @@ async def _install_packages(
 # ── network lockdown ──────────────────────────────────────────────────────────
 
 
-def build_iptables_script(allowed_hosts: set[str]) -> str:
+def build_iptables_script(
+    allowed_hosts: set[str],
+    extra_host_ports: list[tuple[str, int]] | None = None,
+) -> str:
     """Build a shell script that restricts outbound traffic via iptables.
 
     The script allows: loopback, established connections, DNS (port 53),
-    and HTTP/HTTPS (ports 80/443) to the resolved IPs of each allowed
-    host. Everything else is dropped.
+    HTTP/HTTPS (ports 80/443) to the resolved IPs of each allowed host,
+    and any additional ``(host, port)`` pairs in ``extra_host_ports``.
+    Everything else is dropped.
+
+    The extra-host-ports surface exists because the credential proxy
+    binds to a non-standard ephemeral port; without it, in-container
+    git traffic to the proxy would be dropped by the default policy.
 
     Hostnames are validated at the model layer (alphanumerics, dots, hyphens
     only) so embedding them in the script is safe.
@@ -415,6 +458,15 @@ def build_iptables_script(allowed_hosts: set[str]) -> str:
         lines.append('  iptables -A OUTPUT -d "$ip" -p tcp --dport 443 -j ACCEPT')
         lines.append("done")
 
+    for host, port in extra_host_ports or []:
+        lines.append("")
+        lines.append(f"# Allow {host}:{port}")
+        lines.append(
+            f"for ip in $(getent ahosts {host} 2>/dev/null | awk '{{print $1}}' | sort -u); do"
+        )
+        lines.append(f'  iptables -A OUTPUT -d "$ip" -p tcp --dport {port} -j ACCEPT')
+        lines.append("done")
+
     lines.append("")
     lines.append("# Drop everything else")
     lines.append("iptables -P OUTPUT DROP")
@@ -426,6 +478,8 @@ async def _apply_network_lockdown(
     handle: ContainerHandle,
     networking: LimitedNetworking,
     session_id: str,
+    *,
+    extra_host_ports: list[tuple[str, int]] | None = None,
 ) -> None:
     """Apply iptables rules to restrict outbound traffic.
 
@@ -438,7 +492,7 @@ async def _apply_network_lockdown(
     if networking.allow_package_managers:
         allowed |= PACKAGE_REGISTRY_HOSTS
 
-    script = build_iptables_script(allowed)
+    script = build_iptables_script(allowed, extra_host_ports=extra_host_ports)
     settings = get_settings()
     result = await handle.run_command(
         script, timeout_seconds=30, max_output_bytes=settings.bash_max_output_bytes
@@ -456,6 +510,7 @@ async def _apply_network_lockdown(
             "sandbox.network_lockdown_applied",
             session_id=session_id,
             allowed_host_count=len(allowed),
+            extra_host_port_count=len(extra_host_ports or []),
         )
 
 
@@ -466,7 +521,23 @@ async def release(handle: ContainerHandle) -> None:
     container in one step. If the container is already gone (daemon
     forgot it, user removed it manually), this is a no-op — we log but
     don't raise. The workspace directory on the host is NOT deleted.
+
+    The per-session credential proxy (if any) is stopped before docker
+    rm so its in-memory tokens are released as soon as the session is
+    no longer using them.
     """
+    if handle.git_proxy is not None:
+        try:
+            await handle.git_proxy.stop()
+        except Exception as err:
+            # Best-effort cleanup — never let a stuck proxy block container
+            # teardown. The server task is killed regardless on cancel.
+            log.warning(
+                "sandbox.git_proxy_stop_failed",
+                session_id=handle.session_id,
+                error=str(err),
+            )
+
     argv = ["docker", "rm", "--force", handle.container_id]
     try:
         rc, _, stderr_bytes = await _run_docker(argv)

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -22,8 +22,13 @@ CLI.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from aios.config import get_settings
+
+if TYPE_CHECKING:
+    from aios.config import Settings
 from aios.db import queries
 from aios.logging import get_logger
 from aios.models.environments import EnvironmentConfig, LimitedNetworking
@@ -250,11 +255,7 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
     Raises :class:`ContainerError` if ``docker run`` fails for any reason
     (image missing, daemon unreachable, resource limits, ...).
     """
-    from aios.sandbox.volumes import (
-        ensure_workspace_path,
-        memory_store_host_dir,
-        session_repo_working_tree_dir,
-    )
+    from aios.sandbox.volumes import ensure_workspace_path
 
     settings = get_settings()
     raw_path, session_env = await _load_session_provisioning(session_id)
@@ -263,13 +264,55 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
     memory_echoes = await _materialize_memory_mounts(session_id)
     github_echoes, git_proxy = await _materialize_github_clones(session_id)
 
-    # Merge environment-level and session-level env vars (session wins).
+    # Once the proxy is running its serve task holds an open port +
+    # in-memory token map. Anything that raises before we hand the
+    # caller a ContainerHandle (which carries the proxy and would be
+    # cleaned up by ``release``) must stop the proxy on the way out,
+    # otherwise the port and tokens leak for the worker's lifetime.
+    try:
+        return await _provision_for_session_inner(
+            session_id=session_id,
+            settings=settings,
+            workspace_path=workspace_path,
+            env_config=env_config,
+            session_env=session_env,
+            memory_echoes=memory_echoes,
+            github_echoes=github_echoes,
+            git_proxy=git_proxy,
+        )
+    except BaseException:
+        if git_proxy is not None:
+            try:
+                await git_proxy.stop()
+            except Exception as cleanup_err:
+                log.warning(
+                    "sandbox.git_proxy_cleanup_after_provision_failure",
+                    session_id=session_id,
+                    error=str(cleanup_err),
+                )
+        raise
+
+
+async def _provision_for_session_inner(
+    *,
+    session_id: str,
+    settings: Settings,
+    workspace_path: Path,
+    env_config: EnvironmentConfig | None,
+    session_env: dict[str, str],
+    memory_echoes: list[MemoryStoreResourceEcho],
+    github_echoes: list[GithubRepositoryResourceEcho],
+    git_proxy: GitProxy | None,
+) -> ContainerHandle:
+    """The body of ``provision_for_session``. Split out so the caller's
+    try/except cleanly wraps everything that might leak the proxy."""
+    from aios.sandbox.volumes import memory_store_host_dir, session_repo_working_tree_dir
+
     merged_env: dict[str, str] = {
         **(env_config.env if env_config and env_config.env else {}),
         **session_env,
     }
 
-    # Determine if the environment uses limited networking.
     networking = env_config.networking if env_config else None
     needs_lockdown = isinstance(networking, LimitedNetworking)
 
@@ -296,7 +339,8 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
 
     # When a github_repository is attached, the container must be able to
     # reach the host-side credential proxy via host.docker.internal.
-    # Auto-resolved on Docker Desktop; Linux requires the explicit alias.
+    # The explicit alias is required on Linux; on Docker Desktop the
+    # name auto-resolves but `--add-host` is harmless.
     if git_proxy is not None:
         argv.extend(["--add-host", f"{_PROXY_HOST_ALIAS}:host-gateway"])
 
@@ -309,9 +353,6 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
         mode = "ro" if memory_echo.access == "read_only" else "rw"
         argv.extend(["--volume", f"{host_dir}:/mnt/memory/{memory_echo.name}:{mode}"])
 
-    # Bind-mount each successfully-cloned github repo. The per-session
-    # working tree (already populated by ``_materialize_github_clones``)
-    # is mounted at the user-supplied ``mount_path``.
     for github_echo in github_echoes:
         repo_host_dir = session_repo_working_tree_dir(session_id, github_echo.id)
         argv.extend(["--volume", f"{repo_host_dir}:{github_echo.mount_path}:rw"])
@@ -344,19 +385,20 @@ async def provision_for_session(session_id: str) -> ContainerHandle:
         git_proxy=git_proxy,
     )
 
-    # Install packages while the network is still open.
-    await _install_packages(handle, env_config, session_id)
-
-    # Apply iptables lockdown after packages are installed. When a
-    # credential proxy is running, allow outbound to its host:port too,
-    # otherwise the lockdown would block all in-container git traffic.
-    if needs_lockdown and isinstance(networking, LimitedNetworking):
-        extra_host_ports: list[tuple[str, int]] = (
-            [(_PROXY_HOST_ALIAS, git_proxy.port)] if git_proxy is not None else []
-        )
-        await _apply_network_lockdown(
-            handle, networking, session_id, extra_host_ports=extra_host_ports
-        )
+    try:
+        await _install_packages(handle, env_config, session_id)
+        if needs_lockdown and isinstance(networking, LimitedNetworking):
+            extra_host_ports: list[tuple[str, int]] = (
+                [(_PROXY_HOST_ALIAS, git_proxy.port)] if git_proxy is not None else []
+            )
+            await _apply_network_lockdown(
+                handle, networking, session_id, extra_host_ports=extra_host_ports
+            )
+    except BaseException:
+        # Container is up but we failed to set it up. Tear it down so
+        # we don't leak a docker container alongside the proxy.
+        await release(handle)
+        raise
 
     log.info(
         "sandbox.provisioned",

--- a/tests/e2e/test_github_repositories.py
+++ b/tests/e2e/test_github_repositories.py
@@ -550,29 +550,27 @@ needs_real_clone = pytest.mark.skipif(
 
 @needs_real_clone
 class TestRealClone:
-    async def test_cache_clone_then_session_clone(
+    async def test_cache_clone_then_session_clone_origin_scrubbed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """End-to-end clone of a tiny public repo through the actual
-        ``ensure_cache_clone`` + ``ensure_session_working_tree`` helpers.
+        """End-to-end clone of a tiny public repo. After
+        ``ensure_session_working_tree``, ``.git/config`` must hold the
+        proxy URL — never the auth-embedded one. This regression-tests
+        issue #208.
 
         The PAT for octocat/Hello-World needs only ``public_repo`` — but
         for unauthenticated cloning of a public repo, GitHub rejects
-        bogus PATs. We sidestep that by patching ``_build_auth_url``
-        to omit the credential entirely; the helpers don't care about
-        the URL shape, only that ``git clone`` succeeds.
+        bogus PATs. We patch ``_build_auth_url`` to a no-op so the
+        clone is anonymous, then verify the post-clone scrub still
+        replaces ``origin`` with the proxy URL.
         """
-        # Point all sandbox host dirs at a tmp path so we don't pollute
-        # the real workspace_root.
         from aios.config import get_settings
 
         s = get_settings()
-        # Settings is cached; mutate the cached instance.
         monkeypatch.setattr(s, "workspace_root", tmp_path)
 
         from aios.sandbox import github_clone
 
-        # Pretend the user's token is irrelevant for a public unauth clone.
         monkeypatch.setattr(github_clone, "_build_auth_url", lambda url, _tok: url)
 
         cache_dir = await github_clone.ensure_cache_clone(_OCTOCAT_REPO, "ignored")
@@ -580,22 +578,25 @@ class TestRealClone:
         assert (cache_dir / "HEAD").exists()
         assert (cache_dir / "objects").is_dir()
 
+        proxy_url = "http://aios.test:9999/git/SECRET/octocat/Hello-World"
         work_dir = await github_clone.ensure_session_working_tree(
             session_id="sess_test",
             resource_id="ghrepo_test",
             repo_url=_OCTOCAT_REPO,
-            token="ignored",
+            token="REAL_TOKEN_ghp_xxxx",
             cache_dir=cache_dir,
+            proxy_url=proxy_url,
         )
         assert work_dir.exists()
-        # Working tree has README.
         assert (work_dir / "README").exists()
-        # .git exists with config + HEAD.
         assert (work_dir / ".git" / "config").exists()
-        # The remote URL in the per-session config should match what we
-        # built — no embedded token in this patched form.
+
         config_text = (work_dir / ".git" / "config").read_text()
-        assert _OCTOCAT_REPO in config_text
+        # Critical: the .git/config must NOT carry the token in any form.
+        assert "REAL_TOKEN_ghp_xxxx" not in config_text
+        assert "x-access-token" not in config_text
+        # And it MUST carry the proxy URL.
+        assert proxy_url in config_text
 
     async def test_per_session_clone_recreated_on_call(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -613,6 +614,7 @@ class TestRealClone:
         monkeypatch.setattr(github_clone, "_build_auth_url", lambda url, _tok: url)
 
         cache_dir = await github_clone.ensure_cache_clone(_OCTOCAT_REPO, "ignored")
+        proxy_url = "http://aios.test:9999/git/SECRET/octocat/Hello-World"
 
         work_dir = await github_clone.ensure_session_working_tree(
             session_id="sess_a",
@@ -620,6 +622,7 @@ class TestRealClone:
             repo_url=_OCTOCAT_REPO,
             token="t1",
             cache_dir=cache_dir,
+            proxy_url=proxy_url,
         )
         # Drop a sentinel that recreate must clobber.
         (work_dir / "SENTINEL").write_text("sentinel\n")
@@ -631,6 +634,7 @@ class TestRealClone:
             repo_url=_OCTOCAT_REPO,
             token="t2",
             cache_dir=cache_dir,
+            proxy_url=proxy_url,
         )
         assert not (work_dir / "SENTINEL").exists()
         # Working tree is fresh (README still present, sentinel gone).

--- a/tests/e2e/test_github_repositories.py
+++ b/tests/e2e/test_github_repositories.py
@@ -592,11 +592,26 @@ class TestRealClone:
         assert (work_dir / ".git" / "config").exists()
 
         config_text = (work_dir / ".git" / "config").read_text()
-        # Critical: the .git/config must NOT carry the token in any form.
-        assert "REAL_TOKEN_ghp_xxxx" not in config_text
-        assert "x-access-token" not in config_text
         # And it MUST carry the proxy URL.
         assert proxy_url in config_text
+
+        # Scan the entire .git tree (config, refs, logs/HEAD reflog,
+        # FETCH_HEAD, ORIG_HEAD, packed-refs, etc.) to catch any path
+        # where the token might leak — issue #208 was an instance of
+        # exactly this kind of "we only checked the obvious file" bug.
+        for path in (work_dir / ".git").rglob("*"):
+            if not path.is_file():
+                continue
+            try:
+                contents = path.read_bytes()
+            except OSError:
+                continue
+            assert b"REAL_TOKEN_ghp_xxxx" not in contents, (
+                f"token leaked into {path.relative_to(work_dir)}"
+            )
+            assert b"x-access-token" not in contents, (
+                f"x-access-token URL form leaked into {path.relative_to(work_dir)}"
+            )
 
     async def test_per_session_clone_recreated_on_call(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_git_proxy.py
+++ b/tests/unit/test_git_proxy.py
@@ -9,7 +9,6 @@ leave the test process. Verifies:
 - the upstream request gets the expected ``Authorization: Basic <...>``
 - hop-by-hop request and response headers are stripped
 - streamed response bodies make it back unchanged
-- ``update_repos`` swap takes effect on the next request
 - ``proxy_url`` formats correctly and ``repo_key`` normalizes ``.git``
 
 No docker, no real github, no PAT.
@@ -186,33 +185,6 @@ class TestForwarding:
                 f"http://127.0.0.1:{proxy.port}/git/{proxy.secret}/acme/foo/info/refs"
             )
             assert r.content == b"upstream-body"
-
-
-class TestUpdateRepos:
-    async def test_atomic_swap(
-        self, proxy_with_mock_upstream: tuple[GitProxy, list[httpx.Request]]
-    ) -> None:
-        proxy, captured = proxy_with_mock_upstream
-        async with httpx.AsyncClient() as client:
-            r1 = await client.get(
-                f"http://127.0.0.1:{proxy.port}/git/{proxy.secret}/acme/foo/info/refs"
-            )
-            assert r1.status_code == 200
-            assert captured[-1].headers["authorization"] == _basic_auth("ghp_TEST")
-
-            proxy.update_repos({"acme/foo": "ghp_ROTATED", "other/repo": "ghp_OTHER"})
-
-            r2 = await client.get(
-                f"http://127.0.0.1:{proxy.port}/git/{proxy.secret}/acme/foo/info/refs"
-            )
-            assert r2.status_code == 200
-            assert captured[-1].headers["authorization"] == _basic_auth("ghp_ROTATED")
-
-            r3 = await client.get(
-                f"http://127.0.0.1:{proxy.port}/git/{proxy.secret}/other/repo/info/refs"
-            )
-            assert r3.status_code == 200
-            assert captured[-1].headers["authorization"] == _basic_auth("ghp_OTHER")
 
 
 class TestUpstreamFailure:

--- a/tests/unit/test_git_proxy.py
+++ b/tests/unit/test_git_proxy.py
@@ -1,0 +1,240 @@
+"""Unit tests for the per-session git credential proxy.
+
+Boots a real ``GitProxy`` (so we exercise the actual starlette + uvicorn
+machinery), but mocks the upstream ``httpx`` transport so requests never
+leave the test process. Verifies:
+
+- 403 on a missing/wrong secret
+- 404 on a repo that isn't in the token map
+- the upstream request gets the expected ``Authorization: Basic <...>``
+- hop-by-hop request and response headers are stripped
+- streamed response bodies make it back unchanged
+- ``update_repos`` swap takes effect on the next request
+- ``proxy_url`` formats correctly and ``repo_key`` normalizes ``.git``
+
+No docker, no real github, no PAT.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+from aios.sandbox.git_proxy import GitProxy, repo_key
+
+
+def _basic_auth(token: str) -> str:
+    """The Authorization value the proxy injects when forwarding."""
+    creds = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+    return f"Basic {creds}"
+
+
+def _make_mock_transport(captured: list[httpx.Request]) -> httpx.MockTransport:
+    """Mock upstream that records every request and returns a canned 200."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "application/x-git-upload-pack-advertisement",
+                "x-github-request-id": "abc",
+                # Hop-by-hop should be stripped on the way back to the client.
+                "transfer-encoding": "chunked",
+                "connection": "keep-alive",
+            },
+            content=b"upstream-body",
+        )
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture
+async def proxy() -> AsyncIterator[GitProxy]:
+    p = GitProxy({"acme/foo": "ghp_TEST"})
+    await p.start()
+    try:
+        yield p
+    finally:
+        await p.stop()
+
+
+@pytest.fixture
+async def proxy_with_mock_upstream() -> AsyncIterator[tuple[GitProxy, list[httpx.Request]]]:
+    """Proxy whose upstream client points at a MockTransport."""
+    p = GitProxy({"acme/foo": "ghp_TEST"})
+    captured: list[httpx.Request] = []
+    # Replace the inner httpx.AsyncClient with one backed by the mock
+    # transport. This is private-attr surgery, but we deliberately want
+    # to test that the proxy uses its client correctly without requiring
+    # network egress.
+    await p._client.aclose()  # type: ignore[has-type]
+    p._client = httpx.AsyncClient(transport=_make_mock_transport(captured))  # type: ignore[has-type]
+    await p.start()
+    try:
+        yield p, captured
+    finally:
+        await p.stop()
+
+
+class TestRepoKey:
+    def test_strips_dot_git(self) -> None:
+        assert repo_key("https://github.com/acme/foo.git") == "acme/foo"
+
+    def test_no_dot_git(self) -> None:
+        assert repo_key("https://github.com/acme/foo") == "acme/foo"
+
+    def test_with_trailing_slash(self) -> None:
+        assert repo_key("https://github.com/acme/foo/") == "acme/foo"
+
+
+class TestProxyUrl:
+    async def test_format(self, proxy: GitProxy) -> None:
+        url = proxy.proxy_url("https://github.com/acme/foo.git", host="example.local")
+        assert url == f"http://example.local:{proxy.port}/git/{proxy.secret}/acme/foo"
+
+    async def test_strips_dot_git(self, proxy: GitProxy) -> None:
+        a = proxy.proxy_url("https://github.com/acme/foo.git", host="h")
+        b = proxy.proxy_url("https://github.com/acme/foo", host="h")
+        assert a == b
+
+
+class TestSecretEnforcement:
+    async def test_missing_secret_returns_403(self, proxy: GitProxy) -> None:
+        async with httpx.AsyncClient() as client:
+            r = await client.get(f"http://127.0.0.1:{proxy.port}/git/wrong/acme/foo/info/refs")
+            assert r.status_code == 403
+
+    async def test_correct_secret_unknown_repo_returns_404(self, proxy: GitProxy) -> None:
+        # Note: the upstream client isn't mocked here — we're checking the
+        # 404 short-circuits before we touch httpx, so no network egress.
+        async with httpx.AsyncClient() as client:
+            r = await client.get(
+                f"http://127.0.0.1:{proxy.port}/git/{proxy.secret}/other/repo/info/refs"
+            )
+            assert r.status_code == 404
+
+
+class TestForwarding:
+    async def test_authorization_injected(
+        self, proxy_with_mock_upstream: tuple[GitProxy, list[httpx.Request]]
+    ) -> None:
+        proxy, captured = proxy_with_mock_upstream
+        async with httpx.AsyncClient() as client:
+            r = await client.get(
+                f"http://127.0.0.1:{proxy.port}/git/{proxy.secret}/acme/foo/info/refs"
+                "?service=git-upload-pack"
+            )
+            assert r.status_code == 200
+        assert len(captured) == 1
+        upstream = captured[0]
+        assert upstream.url == "https://github.com/acme/foo/info/refs?service=git-upload-pack"
+        assert upstream.headers.get("authorization") == _basic_auth("ghp_TEST")
+
+    async def test_client_supplied_authorization_replaced_not_leaked(
+        self, proxy_with_mock_upstream: tuple[GitProxy, list[httpx.Request]]
+    ) -> None:
+        """The Authorization the client sent (e.g. from the URL's basic
+        auth) must not propagate to upstream — only our injected token
+        should appear."""
+        proxy, captured = proxy_with_mock_upstream
+        async with httpx.AsyncClient() as client:
+            await client.get(
+                f"http://127.0.0.1:{proxy.port}/git/{proxy.secret}/acme/foo/info/refs",
+                headers={
+                    "Authorization": "Basic poison",
+                    "Proxy-Authorization": "should-not-leak",
+                    "User-Agent": "git/2.40.0",
+                },
+            )
+        upstream = captured[0]
+        # Injected Authorization uses our token — the client's poisoned
+        # value didn't pass through.
+        assert upstream.headers.get("authorization") == _basic_auth("ghp_TEST")
+        # Proxy-Authorization is sensitive hop-by-hop; httpx wouldn't
+        # add it on its own, so its absence proves we stripped it.
+        assert upstream.headers.get("proxy-authorization") is None
+        # Non-hop-by-hop request headers pass through.
+        assert upstream.headers.get("user-agent") == "git/2.40.0"
+
+    async def test_non_hop_by_hop_response_headers_pass_through(
+        self, proxy_with_mock_upstream: tuple[GitProxy, list[httpx.Request]]
+    ) -> None:
+        """The response side: arbitrary upstream headers reach the client.
+
+        We don't assert the absence of ``connection`` / ``transfer-encoding``
+        on the client-facing response — uvicorn adds those on its own
+        connection. The relevant property is that meaningful upstream
+        headers (e.g. GitHub request id) reach the caller intact.
+        """
+        proxy, _ = proxy_with_mock_upstream
+        async with httpx.AsyncClient() as client:
+            r = await client.get(
+                f"http://127.0.0.1:{proxy.port}/git/{proxy.secret}/acme/foo/info/refs"
+            )
+            assert r.headers.get("x-github-request-id") == "abc"
+
+    async def test_response_body_streamed(
+        self, proxy_with_mock_upstream: tuple[GitProxy, list[httpx.Request]]
+    ) -> None:
+        proxy, _ = proxy_with_mock_upstream
+        async with httpx.AsyncClient() as client:
+            r = await client.get(
+                f"http://127.0.0.1:{proxy.port}/git/{proxy.secret}/acme/foo/info/refs"
+            )
+            assert r.content == b"upstream-body"
+
+
+class TestUpdateRepos:
+    async def test_atomic_swap(
+        self, proxy_with_mock_upstream: tuple[GitProxy, list[httpx.Request]]
+    ) -> None:
+        proxy, captured = proxy_with_mock_upstream
+        async with httpx.AsyncClient() as client:
+            r1 = await client.get(
+                f"http://127.0.0.1:{proxy.port}/git/{proxy.secret}/acme/foo/info/refs"
+            )
+            assert r1.status_code == 200
+            assert captured[-1].headers["authorization"] == _basic_auth("ghp_TEST")
+
+            proxy.update_repos({"acme/foo": "ghp_ROTATED", "other/repo": "ghp_OTHER"})
+
+            r2 = await client.get(
+                f"http://127.0.0.1:{proxy.port}/git/{proxy.secret}/acme/foo/info/refs"
+            )
+            assert r2.status_code == 200
+            assert captured[-1].headers["authorization"] == _basic_auth("ghp_ROTATED")
+
+            r3 = await client.get(
+                f"http://127.0.0.1:{proxy.port}/git/{proxy.secret}/other/repo/info/refs"
+            )
+            assert r3.status_code == 200
+            assert captured[-1].headers["authorization"] == _basic_auth("ghp_OTHER")
+
+
+class TestUpstreamFailure:
+    async def test_upstream_error_returns_502(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("simulated network error")
+
+        p = GitProxy({"acme/foo": "ghp_TEST"})
+        await p._client.aclose()  # type: ignore[has-type]
+        p._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))  # type: ignore[has-type]
+        await p.start()
+        try:
+            async with httpx.AsyncClient() as client:
+                r = await client.get(f"http://127.0.0.1:{p.port}/git/{p.secret}/acme/foo/info/refs")
+                assert r.status_code == 502
+        finally:
+            await p.stop()
+
+
+def test_module_exports() -> None:
+    """Sanity: the module's public surface is what we expect."""
+    from aios.sandbox import git_proxy
+
+    assert "GitProxy" in git_proxy.__all__
+    assert "repo_key" in git_proxy.__all__

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -199,7 +199,7 @@ class TestProvisionerDockerArgs:
             ),
             patch(
                 "aios.sandbox.provisioner._materialize_github_clones",
-                AsyncMock(return_value=[]),
+                AsyncMock(return_value=([], None)),
             ),
             patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
             patch(
@@ -250,7 +250,7 @@ class TestProvisionerDockerArgs:
             ),
             patch(
                 "aios.sandbox.provisioner._materialize_github_clones",
-                AsyncMock(return_value=[]),
+                AsyncMock(return_value=([], None)),
             ),
             patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
             patch("aios.sandbox.provisioner._install_packages", AsyncMock()),
@@ -292,7 +292,7 @@ class TestProvisionerDockerArgs:
             ),
             patch(
                 "aios.sandbox.provisioner._materialize_github_clones",
-                AsyncMock(return_value=[]),
+                AsyncMock(return_value=([], None)),
             ),
             patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
             patch("aios.sandbox.provisioner._install_packages", AsyncMock()),


### PR DESCRIPTION
## Summary

Fixes #208. PR #206 wrote `https://x-access-token:$TOKEN@github.com/owner/repo` into the bind-mounted `.git/config` and characterized that as safe because the working tree was "ephemeral and per-session." Wrong threat model — the agent IS the principal we needed to keep the token from. The factchecker session in #208 read `git remote -v`, saw the token, and propagated it to chat, the events log, and Signal client logs.

This PR restores parity with CMA's verified design: a per-session host-side credential broker that the container talks to over the docker bridge. **The token never enters the sandbox.**

## Architecture

- **New `src/aios/sandbox/git_proxy.py`** — small starlette+uvicorn app on an ephemeral port on the worker host. Holds `{owner/repo: token}` in memory. Routes `/git/<secret>/<owner>/<repo>/<rest>` to `https://github.com/<owner>/<repo>/<rest>` with `Authorization: Basic base64(x-access-token:<pat>)` injected (works for both classic and fine-grained PATs). Streams responses; strips hop-by-hop headers both directions.
- **Per-session secret** in the URL path bounds blast radius if the proxy port is reachable from the wider network. The agent CAN read the secret from `.git/config`, but at worst can only proxy GitHub for the repos this session is already attached to — strictly less than durable full-PAT exposure.
- **Provisioner** (`provision_for_session`) decrypts tokens up front, starts the `GitProxy`, host-side-clones each repo with the auth-embedded URL, then `git remote set-url origin <proxy-url>` so the bind-mounted `.git/config` carries no credential.
- **Container reaches the proxy** via `host.docker.internal`. `--add-host=host.docker.internal:host-gateway` is added unconditionally when a session has any github_repository attachment (auto on Docker Desktop, required on Linux).
- **Iptables lockdown** — `build_iptables_script` extended with `extra_host_ports`. Without this, the limited-networking default-DROP on `OUTPUT` would block in-container git traffic to the non-standard proxy port.
- **`ContainerHandle`** carries the `GitProxy`; `provisioner.release` stops it before `docker rm` so tokens are dropped from worker memory as soon as the session no longer uses them.

## Manual probe (against `eumemic/jarvis`)

| Property | Result |
|---|---|
| `cat .git/config` inside the container | Shows `origin = http://host.docker.internal:<port>/git/<secret>/eumemic/jarvis` — no token, no `x-access-token` |
| `git remote -v` inside the container | Same — token-free |
| `git fetch origin` inside the container | Succeeds via the proxy |
| `git push origin <branch>` inside the container | Succeeds via the proxy (\`* [new branch] claude-probe-… -> claude-probe-…\`) |

The probe branch was deleted via `gh api -X DELETE`.

## Test plan

- [x] `uv run mypy src` clean (124 source files)
- [x] `uv run ruff check src tests` clean
- [x] `uv run ruff format --check src tests` clean
- [x] `uv run pytest tests/unit -q` — **1072 passed** (14 new in `test_git_proxy.py`)
- [x] `uv run pytest tests/e2e -q` (with Docker) — **299 passed**, including the updated `TestRealClone.test_cache_clone_then_session_clone_origin_scrubbed` regression test that asserts no token appears in `.git/config` after `ensure_session_working_tree`
- [x] Manual probe end-to-end against `eumemic/jarvis` (results above)

## Operational note

Existing live containers from before this fix still have the auth-embedded `origin` URL until they're recycled. Pair the deploy with a **worker process restart** so all currently-cached `ContainerHandle`s are torn down; the next provisioning of any session uses the new flow.

Closes #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)