### PR TITLE
fix(connector): close audit findings on PR #211 stack (#200)

### DIFF
--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -30,6 +30,7 @@ Lifecycle:
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -163,12 +164,22 @@ class SignalConnector(Connector):
                 "uuid": msg.sender_uuid,
                 "display_name": msg.sender_name or msg.sender_uuid,
             }
+            # Signal envelope timestamps are millis since epoch.  Render
+            # them as ISO-8601 UTC so the supervisor stamps a string that
+            # operators (and any future cross-platform tooling) can read
+            # without knowing the connector's source-timestamp shape.
+            timestamp_iso = (
+                datetime.fromtimestamp(msg.timestamp_ms / 1000, tz=UTC).isoformat()
+                if msg.timestamp_ms
+                else None
+            )
             await self.emit_inbound(
                 account=bot_uuid,
                 chat_id=chat_id,
                 sender=sender_payload,
                 content=content,
                 metadata=metadata,
+                timestamp=timestamp_iso,
             )
 
     # ── model-facing tools ────────────────────────────────────────────

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -171,12 +172,21 @@ class TelegramConnector(Connector):
                 "display_name": msg.sender_name or str(msg.sender_id),
             }
             metadata = build_metadata(msg, self._bot_id)
+            # Telegram message ``date`` is unix-seconds; render as
+            # ISO-8601 UTC so aios's supervisor sees the same string
+            # shape as other connectors (signal etc.).
+            timestamp_iso = (
+                datetime.fromtimestamp(msg.timestamp_ms / 1000, tz=UTC).isoformat()
+                if msg.timestamp_ms
+                else None
+            )
             await self.emit_inbound(
                 account=str(self._bot_id),
                 chat_id=str(msg.chat_id),
                 sender=sender_payload,
                 content=msg.text,
                 metadata=metadata,
+                timestamp=timestamp_iso,
             )
 
     # ── model-facing tools ────────────────────────────────────────────

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -172,9 +172,10 @@ class TelegramConnector(Connector):
                 "display_name": msg.sender_name or str(msg.sender_id),
             }
             metadata = build_metadata(msg, self._bot_id)
-            # Telegram message ``date`` is unix-seconds; render as
-            # ISO-8601 UTC so aios's supervisor sees the same string
-            # shape as other connectors (signal etc.).
+            # Telegram's ``message.date`` is unix-seconds; the parser
+            # stamps it as ``timestamp_ms``.  Render that as ISO-8601
+            # UTC so aios's supervisor sees the same string shape as
+            # other connectors (signal etc.).
             timestamp_iso = (
                 datetime.fromtimestamp(msg.timestamp_ms / 1000, tz=UTC).isoformat()
                 if msg.timestamp_ms

--- a/packages/aios-connector/README.md
+++ b/packages/aios-connector/README.md
@@ -118,7 +118,7 @@ async def discover_accounts(self) -> list[dict[str, Any]]:
 The `id` field is what aios uses as the opaque `account` segment in the
 channel address `<connector>/<account>/<chat_id>`; it's the same value
 your `emit_inbound(account=...)` calls must pass.  `display_name` and
-`metadata` are surfaced in `aios connector <name> accounts` and to
+`metadata` are surfaced in `aios connectors accounts <name>` and to
 operator-facing CLI listings.
 
 ## Entry-point factory

--- a/packages/aios-connector/README.md
+++ b/packages/aios-connector/README.md
@@ -75,20 +75,89 @@ class MyMultiConnector(Connector):
         ...
 ```
 
-### Entry-point registration
+## Lifecycle hooks
 
-Both shapes register via the `aios.connectors` entry-point group:
+The base class drives a fixed startup sequence; override the four
+hooks to slot in your platform's bookkeeping.  Order is load-bearing —
+inbounds emitted from `serve()` are blocked until the initial state has
+been pushed, so `setup()` and `discover_accounts()` are guaranteed to
+land before any inbound the model sees.
+
+| Hook | When it runs | What's allowed |
+|---|---|---|
+| `setup()` | Before MCP server start | Open daemon connections, sign in, load credentials.  Blocking here keeps the supervisor in `starting` until either this returns or the supervisor's bounded init handshake (30s) trips and respawns. |
+| `discover_accounts()` | Once, between `setup()` and server start | Return a list of account dicts (use `make_account`).  Most connectors return a one-element list for the single phone / bot the integrator owns. |
+| `serve()` | Sibling task to the MCP server, after init | Long-running background work — typically a daemon listener that calls `emit_inbound`.  Override or accept the default (parks forever). |
+| `teardown()` | Always, in `run()`'s `finally` | Close anything `setup()` opened.  Runs on normal exit, exception, and cancellation. |
+
+Readiness deferral: the SDK does NOT send `notifications/initialized`
+until `setup()` and `discover_accounts()` complete.  The supervisor's
+`get_session()` blocks on first init; aios outbound dispatch into a
+not-yet-ready connector waits, surfaces as a transport error after
+60s.
+
+## Account discovery
+
+`discover_accounts()` returns a `list[dict[str, Any]]` — a list of
+account snapshots, NOT a list of bare account-id strings.  Each entry
+must include `id` and `display_name`; arbitrary metadata may be added.
+Use the `make_account(id=..., display_name=..., metadata=...)`
+convenience builder:
+
+```python
+async def discover_accounts(self) -> list[dict[str, Any]]:
+    return [
+        make_account(
+            id=str(self._bot_id),
+            display_name=self._first_name,
+            metadata={"username": self._username},
+        )
+    ]
+```
+
+The `id` field is what aios uses as the opaque `account` segment in the
+channel address `<connector>/<account>/<chat_id>`; it's the same value
+your `emit_inbound(account=...)` calls must pass.  `display_name` and
+`metadata` are surfaced in `aios connector <name> accounts` and to
+operator-facing CLI listings.
+
+## Entry-point factory
+
+Register the connector via the `aios.connectors` entry-point group in
+your package's `pyproject.toml`.  Each entry point points at a
+`make_spec` factory function (NOT the connector class itself):
 
 ```toml
 [project.entry-points."aios.connectors"]
 my_connector = "my_package.factory:make_spec"
 ```
 
-`make_spec(name, settings)` returns an
-`aios.mcp.stdio_transport.ConnectorSpec` describing the launch command.
+The factory takes `(connector_name: str, settings)` and returns an
+`aios.mcp.stdio_transport.ConnectorSpec`:
+
+```python
+import sys
+from aios.mcp.stdio_transport import ConnectorSpec
+
+
+def make_spec(connector_name: str, settings) -> ConnectorSpec:
+    return ConnectorSpec(
+        name=connector_name,
+        command=sys.executable,
+        args=["-m", "my_package"],
+        # cwd left None → supervisor stamps a per-instance default
+    )
+```
+
 The factory stays instance-naive — the supervisor applies per-instance
-cwd + env scoping after the spec returns.  See `packages/aios-echo` for
-the canonical example.
+cwd + env scoping after the spec returns.  When the factory leaves
+`cwd` unset, the supervisor stamps `settings.connectors_dir / connector`
+(default instance) or `settings.connectors_dir / connector / instance`
+(non-default), and creates the directory at boot so first-run
+`FileNotFoundError` from `asyncio.create_subprocess_exec` is impossible.
+Factories that need a different layout can set `cwd` themselves.
+
+See `packages/aios-echo` for the canonical example.
 
 ## Multi-instance deployment
 

--- a/packages/aios-connector/aios_connector/base.py
+++ b/packages/aios-connector/aios_connector/base.py
@@ -293,23 +293,47 @@ class Connector:
 
     Lifecycle (driven by :meth:`run`):
 
-    1. ``setup()`` — open daemon connections, sign in, etc.
-    2. ``discover_accounts()`` — initial account snapshot.
-    3. Start MCP server over stdio.
+    1. ``setup()`` — open daemon connections, sign in, etc.  Runs
+       before the MCP server starts; blocking here keeps the supervisor
+       in ``starting`` until either this returns or the bounded init
+       handshake (30s) trips and respawns.
+    2. ``discover_accounts()`` — return the initial account snapshot.
+       Returns ``list[dict[str, Any]]`` (NOT a list of account-id
+       strings) — use :func:`make_account` to build entries.  The ``id``
+       field is what aios uses as the opaque ``account`` segment in
+       channel addresses.
+    3. Start MCP server over stdio.  ``notifications/initialized`` is
+       only sent after steps 1-2 complete: outbound dispatch into a
+       not-yet-ready connector therefore waits on first init rather
+       than racing past unset state.
     4. Send ``notifications/aios/accounts`` once the client is initialized.
     5. Replay unacked spool entries, then enter live mode.
-    6. ``teardown()`` on exit (normal or exception).
+    6. ``serve()`` — sibling task to the MCP server.  Default parks
+       forever; override to drive an inbound pump (signal-cli's
+       listener loop, etc.).  Calls to :meth:`emit_inbound` from here
+       block until step 5 completes so live inbounds can't race past
+       spool replay.
+    7. ``teardown()`` on exit (normal or exception, in ``run()``'s
+       ``finally``).
 
     Subclass contract:
 
     * Override ``name`` (e.g. ``"signal"``); the spool path and outbound
       channel-address prefix derive from it.
-    * Override :meth:`setup`, :meth:`discover_accounts`, :meth:`teardown`.
+    * Override :meth:`setup`, :meth:`discover_accounts`, :meth:`teardown`,
+      and (if event-driven inbound is needed) :meth:`serve`.
     * Decorate methods with :func:`tool` (and optionally
       :func:`focal_required`) to publish tools.
     * Call :meth:`emit_inbound` from your inbound pump.
-    * Optionally set ``instructions`` for a class-level
-      :class:`mcp.types.InitializeResult.instructions` block.
+    * Optionally set ``instructions`` for an
+      :class:`mcp.types.InitializeResult.instructions` block surfaced
+      to the model on every turn.
+
+    Register the connector via the ``aios.connectors`` entry-point group;
+    the entry point must point at a ``make_spec(connector_name, settings)``
+    factory that returns an
+    :class:`aios.mcp.stdio_transport.ConnectorSpec` (NOT the connector
+    class itself).  See ``packages/aios-echo`` for a minimal example.
     """
 
     name: ClassVar[str] = ""
@@ -360,6 +384,12 @@ class Connector:
         Most connectors maintain a single account (signal phone,
         telegram bot) and return a one-element list.  Use
         :func:`make_account` to build entries.
+
+        Each entry is a dict with at minimum ``id`` and ``display_name``
+        — NOT a bare account-id string.  The ``id`` field is the opaque
+        ``account`` segment aios uses in channel addresses
+        (``<connector>/<account>/<chat_id>``) and the value
+        :meth:`emit_inbound`'s ``account=`` argument must match.
         """
         return []
 
@@ -393,6 +423,7 @@ class Connector:
         content: str,
         attachments: list[dict[str, Any]] | None = None,
         metadata: dict[str, Any] | None = None,
+        timestamp: str | None = None,
     ) -> str:
         """Persist an inbound message to the spool, then push the notification.
 
@@ -404,6 +435,14 @@ class Connector:
         return value.  ``chat_id`` is the connector-specific identifier
         the model addresses via focal channel; the harness builds the
         full channel address as ``<connector>/<account>/<chat_id>``.
+
+        ``timestamp`` is an optional ISO-8601 string carrying the
+        platform's actual delivery time (Signal envelope timestamp,
+        Telegram message ``date``, etc.).  When supplied, the supervisor
+        stamps it as ``metadata.platform_timestamp`` on the appended
+        event so operators debugging "why did this arrive 30s late?"
+        can compare against the server-side ``created_at``.  Connectors
+        whose source platform doesn't carry a timestamp omit this kwarg.
         """
         if self._write_stream is None:
             raise RuntimeError(
@@ -429,6 +468,8 @@ class Connector:
             params["attachments"] = list(attachments)
         if metadata:
             params["metadata"] = dict(metadata)
+        if timestamp is not None:
+            params["timestamp"] = timestamp
 
         payload = json.dumps(params).encode("utf-8")
         self._spool.add(event_id, payload, created_at=time.time())

--- a/packages/aios-connector/tests/test_emit_inbound.py
+++ b/packages/aios-connector/tests/test_emit_inbound.py
@@ -55,6 +55,33 @@ async def test_emit_inbound_persists_then_pushes(connector: _StubConnector) -> N
     assert notification.params["account"] == "echo-1"
     assert notification.params["chat_id"] == "chat-42"
     assert notification.params["content"] == "hello"
+    # Timestamp omitted by default (not all platforms supply one).
+    assert "timestamp" not in notification.params
+
+
+async def test_emit_inbound_passes_timestamp_through(connector: _StubConnector) -> None:
+    """Optional ``timestamp=`` becomes a top-level param on the notification.
+
+    Per design §3.3: the supervisor stamps it as
+    ``metadata.platform_timestamp`` on the appended event so operators
+    can compare against the server-side ``created_at``.
+    """
+    stream = _StubStream()
+    connector._write_stream = stream  # type: ignore[assignment]
+    connector._client_initialized.set()
+    connector._initial_state_done.set()
+
+    iso = "2026-04-30T17:01:23.456+00:00"
+    await connector.emit_inbound(
+        account="echo-1",
+        chat_id="chat-42",
+        sender={"display_name": "Alice"},
+        content="ping",
+        timestamp=iso,
+    )
+
+    notification = stream.sent[0].message.root
+    assert notification.params["timestamp"] == iso
 
 
 async def test_emit_inbound_blocks_until_initial_state_done(

--- a/src/aios/api/connector_rpc.py
+++ b/src/aios/api/connector_rpc.py
@@ -1,0 +1,57 @@
+"""Shared LISTEN-then-defer-then-await helper for connector RPC round-trips.
+
+Both ``routers/connectors.py`` (admin endpoints) and ``routers/connections.py``
+(attach drift check) talk to the worker via procrastinate-job + Postgres
+NOTIFY.  This helper centralises the LISTEN-before-defer invariant and the
+timeout_s-to-408 mapping so a future change to ordering / timeout_s / queue
+plumbing lands in one place.
+
+Each caller does its own error-envelope mapping — the connectors router maps
+granular ``code`` values onto specific HTTP statuses, the drift check folds
+all error envelopes to 503 — so this helper returns the parsed envelope and
+leaves error handling to the call site.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from fastapi import HTTPException, status
+from ulid import ULID
+
+from aios.db.listen import listen_for_connector_result
+
+
+async def connector_rpc(
+    db_url: str,
+    defer: Callable[[str], Awaitable[None]],
+    *,
+    timeout_s: float,
+) -> dict[str, Any]:
+    """LISTEN-then-defer-then-await one connector RPC round-trip.
+
+    ``defer`` is the call-site closure that enqueues the matching
+    procrastinate task with the minted ``call_id``.  Order matters: LISTEN
+    must be live before ``defer`` runs, otherwise a fast worker could NOTIFY
+    before the listener is attached and we'd hang waiting for a payload
+    that's already been dropped.
+
+    Returns the parsed envelope dict.  Raises ``HTTPException(408)`` on
+    timeout_s.  Error envelopes are returned as-is for the caller to map
+    onto the right HTTP status.
+    """
+    call_id = str(ULID())
+    async with listen_for_connector_result(db_url, call_id) as queue:
+        await defer(call_id)
+        try:
+            payload = await asyncio.wait_for(queue.get(), timeout=timeout_s)
+        except TimeoutError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_408_REQUEST_TIMEOUT,
+                detail=f"worker did not respond within {timeout_s:g}s",
+            ) from exc
+    envelope: dict[str, Any] = json.loads(payload)
+    return envelope

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -20,15 +20,12 @@ admin-only endpoint is invisible.
 
 from __future__ import annotations
 
-import asyncio
-import json
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
-from ulid import ULID
 
+from aios.api.connector_rpc import connector_rpc
 from aios.api.deps import AuthDep, DbUrlDep, PoolDep
-from aios.db.listen import listen_for_connector_result
 from aios.errors import AccountDriftError
 from aios.harness.connector_tasks import defer_connector_status
 from aios.models.common import ListResponse
@@ -62,20 +59,11 @@ async def _assert_account_in_snapshot(db_url: str, *, connector: str, account: s
     (per SDK convention via :func:`aios_connector.make_account`); the
     snapshot match is on that field.
     """
-    call_id = str(ULID())
-    async with listen_for_connector_result(db_url, call_id) as queue:
-        await defer_connector_status(call_id=call_id, connector=connector)
-        try:
-            payload = await asyncio.wait_for(queue.get(), timeout=_DRIFT_CHECK_TIMEOUT_S)
-        except TimeoutError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_408_REQUEST_TIMEOUT,
-                detail=(
-                    "worker did not respond within snapshot-check window; "
-                    "retry once the worker is reachable"
-                ),
-            ) from exc
-    envelope: dict[str, Any] = json.loads(payload)
+    envelope: dict[str, Any] = await connector_rpc(
+        db_url,
+        lambda cid: defer_connector_status(call_id=cid, connector=connector),
+        timeout_s=_DRIFT_CHECK_TIMEOUT_S,
+    )
     err = envelope.get("error")
     if err:
         # Supervisor not running / connector not booted → can't tell
@@ -95,6 +83,18 @@ async def _assert_account_in_snapshot(db_url: str, *, connector: str, account: s
             ),
         )
     accounts = state.get("accounts") or []
+    if not accounts:
+        # Boot-window race: supervisor flips ``status = "running"`` after MCP
+        # ``initialize`` returns, but the SDK only emits
+        # ``notifications/aios/accounts`` once the supervisor's
+        # ``notifications/initialized`` has round-tripped — at least one stdio
+        # leg of asymmetry.  An attach during that window must be 503 (retry
+        # shortly), not 409 drift; the inbound handler exempts the same case
+        # at ``connector_supervisor._handle_inbound``.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(f"connector {connector!r} snapshot not yet populated; retry shortly"),
+        )
     known_ids = {entry.get("id") for entry in accounts if isinstance(entry, dict)}
     if account not in known_ids:
         raise AccountDriftError(
@@ -105,6 +105,15 @@ async def _assert_account_in_snapshot(db_url: str, *, connector: str, account: s
 
 @router.post("", status_code=status.HTTP_201_CREATED)
 async def create(body: ConnectionCreate, pool: PoolDep, _auth: AuthDep) -> Connection:
+    """Create a detached connection, **idempotent on ``(connector, account)``**.
+
+    Per plan decision #5, this endpoint and the supervisor's
+    auto-create-on-first-inbound path race-safely converge on a single row:
+    posting twice with the same ``(connector, account)`` returns 201 with the
+    existing row rather than 409.  The ``id`` may differ from a freshly-allocated
+    one if a concurrent writer landed first; the response always reflects the
+    canonical active row.
+    """
     return await service.create_connection(
         pool,
         connector=body.connector,

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -6,13 +6,31 @@ only on detached connections (the service layer enforces this so
 operators can't silently break inbound delivery for live single_session
 connections or orphan ``spawned_from_connection_id`` pointers on
 per_chat-spawned sessions).
+
+``attach`` validates the connection's ``account`` against the connector
+subprocess's current snapshot (audit fix #1, design §5.6) — without
+this guard an operator can permanently attach a connection for an
+account the connector no longer serves, and inbound silently drops with
+the ``account_drift`` counter ticking up.  The validation flows through
+procrastinate RPC like the rest of ``/v1/connectors/*``: API mints a
+ULID, LISTENs on ``connector_result_<call_id>``, defers
+``harness.connector_status``, awaits NOTIFY.  ~50-200ms latency on an
+admin-only endpoint is invisible.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
+import asyncio
+import json
+from typing import Any
 
-from aios.api.deps import AuthDep, PoolDep
+from fastapi import APIRouter, HTTPException, status
+from ulid import ULID
+
+from aios.api.deps import AuthDep, DbUrlDep, PoolDep
+from aios.db.listen import listen_for_connector_result
+from aios.errors import AccountDriftError
+from aios.harness.connector_tasks import defer_connector_status
 from aios.models.common import ListResponse
 from aios.models.connections import (
     Connection,
@@ -24,6 +42,65 @@ from aios.models.connections import (
 from aios.services import connections as service
 
 router = APIRouter(prefix="/v1/connections", tags=["connections"])
+
+# Snapshot lookup is cheap (worker reads in-memory state and returns) —
+# tighter than the 60s call timeout but generous enough that a busy
+# worker queue doesn't false-positive a drift error on the operator.
+_DRIFT_CHECK_TIMEOUT_S = 10.0
+
+
+async def _assert_account_in_snapshot(db_url: str, *, connector: str, account: str) -> None:
+    """Raise :class:`AccountDriftError` if ``account`` isn't in the connector's snapshot.
+
+    Treats supervisor-down (``not_ready`` / ``circuit_open``) as a
+    distinct condition: those surface as 503, not 409 — the operator
+    should retry once the connector boots, not assume drift.  The
+    ``not_enabled`` envelope from the worker means the connector isn't
+    in ``connectors_enabled`` at all and is also a 503.
+
+    The connector's account snapshot dicts each carry an ``id`` field
+    (per SDK convention via :func:`aios_connector.make_account`); the
+    snapshot match is on that field.
+    """
+    call_id = str(ULID())
+    async with listen_for_connector_result(db_url, call_id) as queue:
+        await defer_connector_status(call_id=call_id, connector=connector)
+        try:
+            payload = await asyncio.wait_for(queue.get(), timeout=_DRIFT_CHECK_TIMEOUT_S)
+        except TimeoutError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_408_REQUEST_TIMEOUT,
+                detail=(
+                    "worker did not respond within snapshot-check window; "
+                    "retry once the worker is reachable"
+                ),
+            ) from exc
+    envelope: dict[str, Any] = json.loads(payload)
+    err = envelope.get("error")
+    if err:
+        # Supervisor not running / connector not booted → can't tell
+        # whether the account is valid.  Surface as 503; the caller
+        # should retry rather than assume drift.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"connector {connector!r} snapshot unavailable: {err}",
+        )
+    state = envelope.get("connector") or {}
+    if state.get("status") != "running":
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                f"connector {connector!r} is {state.get('status')!r}; "
+                "snapshot unavailable — retry once it's running"
+            ),
+        )
+    accounts = state.get("accounts") or []
+    known_ids = {entry.get("id") for entry in accounts if isinstance(entry, dict)}
+    if account not in known_ids:
+        raise AccountDriftError(
+            f"account {account!r} is not in {connector!r}'s current snapshot",
+            detail={"connector": connector, "account": account},
+        )
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)
@@ -73,8 +150,21 @@ async def delete(connection_id: str, pool: PoolDep, _auth: AuthDep) -> None:
 
 @router.post("/{connection_id}/attach")
 async def attach(
-    connection_id: str, body: ConnectionAttach, pool: PoolDep, _auth: AuthDep
+    connection_id: str,
+    body: ConnectionAttach,
+    pool: PoolDep,
+    db_url: DbUrlDep,
+    _auth: AuthDep,
 ) -> Connection:
+    """Attach a connection to a session, after validating the account against the snapshot.
+
+    The drift check runs BEFORE the DB write so a stale account can't
+    move into ``single_session`` mode and silently swallow inbound.
+    """
+    connection = await service.get_connection(pool, connection_id)
+    await _assert_account_in_snapshot(
+        db_url, connector=connection.connector, account=connection.account
+    )
     return await service.attach_connection(pool, connection_id, session_id=body.session_id)
 
 

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -21,17 +21,14 @@ connector itself is down.
 
 from __future__ import annotations
 
-import asyncio
-import json
 from collections.abc import Awaitable, Callable
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, ConfigDict
-from ulid import ULID
 
+from aios.api.connector_rpc import connector_rpc
 from aios.api.deps import AuthDep, DbUrlDep
-from aios.db.listen import listen_for_connector_result
 from aios.harness.connector_tasks import (
     defer_connector_call,
     defer_connector_status,
@@ -52,25 +49,8 @@ class ConnectorCallBody(BaseModel):
 
 
 async def _rpc(db_url: str, defer: Callable[[str], Awaitable[None]]) -> dict[str, Any]:
-    """LISTEN-then-defer-then-await for one connector RPC round-trip.
-
-    ``defer`` is the call-site closure that enqueues the matching
-    procrastinate task with the minted ``call_id``.  Order matters:
-    LISTEN must be live before defer, otherwise a fast worker could
-    NOTIFY before the listener is attached and we'd hang waiting for
-    a payload that's already been dropped.
-    """
-    call_id = str(ULID())
-    async with listen_for_connector_result(db_url, call_id) as queue:
-        await defer(call_id)
-        try:
-            payload = await asyncio.wait_for(queue.get(), timeout=_RESULT_TIMEOUT_S)
-        except TimeoutError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_408_REQUEST_TIMEOUT,
-                detail="worker did not respond within 60s",
-            ) from exc
-    envelope: dict[str, Any] = json.loads(payload)
+    """Admin-endpoint round-trip: ``connector_rpc`` + granular error mapping."""
+    envelope = await connector_rpc(db_url, defer, timeout_s=_RESULT_TIMEOUT_S)
     _raise_for_error(envelope)
     return envelope
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2179,13 +2179,39 @@ async def insert_connection(
     account: str,
     metadata: dict[str, Any],
 ) -> Connection:
-    """Insert a detached connection (no session, no template).
+    """Insert a detached connection, idempotent on the active uniqueness key.
+
+    Per plan decision #5, both the explicit ``POST /v1/connections`` and
+    the supervisor's auto-create-on-first-inbound path race-safely
+    converge on a single row via ``INSERT ... ON CONFLICT DO NOTHING
+    RETURNING``: empty RETURNING means another writer beat us, so we
+    re-read the existing active row and hand it back.  The unique index
+    is ``(connector, account) WHERE archived_at IS NULL`` — an archived
+    row with the same pair will not collide; a fresh insert will land.
 
     Use ``attach_connection`` or ``configure_per_chat_connection`` to bind
     a routing mode after creation.
     """
     new_id = make_id(CONNECTION)
-    try:
+    row = await conn.fetchrow(
+        """
+        INSERT INTO connections (id, connector, account, metadata)
+        VALUES ($1, $2, $3, $4::jsonb)
+        ON CONFLICT (connector, account) WHERE archived_at IS NULL DO NOTHING
+        RETURNING *
+        """,
+        new_id,
+        connector,
+        account,
+        json.dumps(metadata),
+    )
+    if row is not None:
+        return _row_to_connection(row)
+    existing = await get_connection_for_account(conn, connector=connector, account=account)
+    if existing is None:
+        # CONFLICT means an active row existed at INSERT time.  If it's
+        # gone now, it was archived between the two queries — fall back
+        # to a fresh insert which the unique index now permits.
         row = await conn.fetchrow(
             """
             INSERT INTO connections (id, connector, account, metadata)
@@ -2197,13 +2223,9 @@ async def insert_connection(
             account,
             json.dumps(metadata),
         )
-    except asyncpg.UniqueViolationError as exc:
-        raise ConflictError(
-            f"an active connection for ({connector!r}, {account!r}) already exists",
-            detail={"connector": connector, "account": account},
-        ) from exc
-    assert row is not None
-    return _row_to_connection(row)
+        assert row is not None
+        return _row_to_connection(row)
+    return existing
 
 
 async def get_connection(conn: asyncpg.Connection[Any], connection_id: str) -> Connection:

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2192,40 +2192,35 @@ async def insert_connection(
     Use ``attach_connection`` or ``configure_per_chat_connection`` to bind
     a routing mode after creation.
     """
-    new_id = make_id(CONNECTION)
-    row = await conn.fetchrow(
-        """
-        INSERT INTO connections (id, connector, account, metadata)
-        VALUES ($1, $2, $3, $4::jsonb)
-        ON CONFLICT (connector, account) WHERE archived_at IS NULL DO NOTHING
-        RETURNING *
-        """,
-        new_id,
-        connector,
-        account,
-        json.dumps(metadata),
-    )
-    if row is not None:
-        return _row_to_connection(row)
-    existing = await get_connection_for_account(conn, connector=connector, account=account)
-    if existing is None:
-        # CONFLICT means an active row existed at INSERT time.  If it's
-        # gone now, it was archived between the two queries — fall back
-        # to a fresh insert which the unique index now permits.
+    # Retry loop: each iteration is INSERT-then-(if-conflict)-re-read.  Three
+    # concurrent writers + an archive-between-attempts can force a second
+    # round-trip, but the loop converges within at most two iterations under
+    # any realistic contention pattern.  The bound is defensive — three
+    # iterations is enough that exhaustion would mean the system is wedged
+    # in a hot insert/archive cycle that no retry strategy can resolve.
+    for _ in range(3):
         row = await conn.fetchrow(
             """
             INSERT INTO connections (id, connector, account, metadata)
             VALUES ($1, $2, $3, $4::jsonb)
+            ON CONFLICT (connector, account) WHERE archived_at IS NULL DO NOTHING
             RETURNING *
             """,
-            new_id,
+            make_id(CONNECTION),
             connector,
             account,
             json.dumps(metadata),
         )
-        assert row is not None
-        return _row_to_connection(row)
-    return existing
+        if row is not None:
+            return _row_to_connection(row)
+        existing = await get_connection_for_account(conn, connector=connector, account=account)
+        if existing is not None:
+            return existing
+        # Active row was archived between INSERT and re-read; loop to retry the
+        # INSERT, which the partial unique index now permits.
+    raise RuntimeError(
+        f"insert_connection({connector=}, {account=}) failed to converge after 3 attempts"
+    )
 
 
 async def get_connection(conn: asyncpg.Connection[Any], connection_id: str) -> Connection:

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -65,6 +65,20 @@ class ConflictError(AiosError):
     status_code = 409
 
 
+class AccountDriftError(ConflictError):
+    """Operator tried to attach a connection for an account the connector no longer serves.
+
+    Raised by :func:`aios.services.connections.attach_connection` when
+    the supervisor's current account snapshot doesn't include the
+    connection's ``account``.  Without this guard the attach would
+    succeed silently and inbound for that account would drop forever
+    with the ``account_drift`` reason — operator pain that's better
+    surfaced at attach time than discovered hours later.
+    """
+
+    error_type = "account_drift"
+
+
 class PayloadTooLargeError(AiosError):
     error_type = "payload_too_large"
     status_code = 413

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -96,7 +96,7 @@ from mcp.types import InitializeResult
 
 from aios.config import ConnectorInstance, Settings, parse_connector_entry
 from aios.db import queries
-from aios.errors import ConflictError, NotFoundError
+from aios.errors import NotFoundError
 from aios.harness import runtime
 from aios.harness.wake import defer_wake
 from aios.logging import get_logger
@@ -144,6 +144,7 @@ DropReason = Literal[
     "session_missing",
     "malformed",
     "payload_too_large",
+    "account_drift",
 ]
 
 
@@ -236,6 +237,14 @@ def resolve_connector_specs(settings: Settings) -> list[tuple[ConnectorInstance,
     Unknown connector names raise — the operator listed something that
     isn't installed, which should fail loudly at boot rather than
     silently skip.
+
+    Per-instance cwd defaulting + on-disk creation happen inside
+    :func:`_apply_instance_overlay`: when the factory leaves ``cwd``
+    unset, the supervisor stamps ``settings.connectors_dir / connector``
+    (or ``/connector/instance`` for non-default instances) and
+    ``mkdir -p``s the result so first boot doesn't ``FileNotFoundError``
+    from inside :func:`asyncio.create_subprocess_exec`.  Idempotent —
+    subsequent boots are no-ops.
     """
     available = {ep.name: ep for ep in entry_points(group="aios.connectors")}
     out: list[tuple[ConnectorInstance, ConnectorSpec]] = []
@@ -269,6 +278,9 @@ def _apply_instance_overlay(
     (``<connectors_dir>/<connector>/``); non-default gets a per-instance
     subdir.  Either way an explicit ``spec.cwd`` from the factory wins
     (factories that hard-code their own state-file layout opt out).
+    The resolved cwd is ``mkdir -p``'d so the first
+    :func:`asyncio.create_subprocess_exec` doesn't ``FileNotFoundError``
+    on a fresh install.
 
     env: always pass the worker's ``os.environ`` to the subprocess so
     pydantic-settings reads the same vars the operator set.  For
@@ -283,6 +295,7 @@ def _apply_instance_overlay(
         cwd = settings.connectors_dir / ci.connector
         if ci.instance != ci.connector:
             cwd = cwd / ci.instance
+    cwd.mkdir(parents=True, exist_ok=True)
     env = _build_instance_env(ci, base=spec.env)
     return replace(spec, cwd=cwd, env=env)
 
@@ -662,6 +675,12 @@ class ConnectorSubprocessRegistry:
         content = params.get("content")
         raw_metadata = params.get("metadata")
         connector_metadata = raw_metadata if isinstance(raw_metadata, dict) else None
+        # Optional ISO-8601 platform timestamp (when the source platform
+        # supplies one).  Stamped onto the appended event as
+        # ``metadata.platform_timestamp`` so operators can compare against
+        # the server-side ``created_at`` when debugging delivery latency.
+        raw_timestamp = params.get("timestamp")
+        platform_timestamp = raw_timestamp if isinstance(raw_timestamp, str) else None
 
         # event_id is checked first because it's the only thing that lets
         # us ack the spool entry — without it we can't dedup or clear,
@@ -708,6 +727,19 @@ class ConnectorSubprocessRegistry:
             return
 
         pool = runtime.require_pool()
+
+        # Drift guard: an account that's persisted in ``connections``
+        # but absent from the connector's live snapshot is a no-op
+        # delivery target — the connector can't reach it on outbound,
+        # so silently appending an event would orphan the conversation.
+        # Surface as a counter so ``aios connector list`` shows the
+        # stuck account; the operator can detach + re-attach against a
+        # known-good account.  Plan §15 lists this as a drop reason.
+        known_account_ids = {entry.get("id") for entry in state.accounts if isinstance(entry, dict)}
+        if state.accounts and account not in known_account_ids:
+            self._record_drop(state, "account_drift")
+            await self._send_ack(state, event_id)
+            return
 
         # 1. Look up connection (fresh read — no caching, since the
         #    operator may have just attached/configured the connection).
@@ -758,6 +790,7 @@ class ConnectorSubprocessRegistry:
                 content=content,
                 attachments=params.get("attachments"),
                 connector_metadata=connector_metadata,
+                platform_timestamp=platform_timestamp,
             )
         except NotFoundError:
             # The session vanished between resolution and append.
@@ -785,9 +818,10 @@ class ConnectorSubprocessRegistry:
         the surface (auto-creating a row doesn't deliver the message
         that prompted it).
 
-        ``ConflictError`` is the documented race (another handler created
-        the row first); any other failure propagates so the inbound task
-        fails and the connector replays on reconnect.
+        Race-safe via :func:`queries.insert_connection`'s
+        ``ON CONFLICT DO NOTHING RETURNING`` shape (plan decision #5);
+        a concurrent explicit POST or sibling inbound handler that
+        beat us simply hands back the existing row, no exception.
 
         No dedup-ledger row is written here on purpose: if the operator
         attaches the auto-created connection later, the connector's
@@ -801,19 +835,16 @@ class ConnectorSubprocessRegistry:
         if not self._settings.connectors_auto_create.get(state.connector, True):
             return
         pool = runtime.require_pool()
-        try:
-            async with pool.acquire() as conn:
-                await queries.insert_connection(
-                    conn, connector=state.connector, account=account, metadata={}
-                )
-                log.info(
-                    "connector.auto_create_connection",
-                    connector=state.connector,
-                    instance=state.instance,
-                    account=account,
-                )
-        except ConflictError:
-            pass
+        async with pool.acquire() as conn:
+            await queries.insert_connection(
+                conn, connector=state.connector, account=account, metadata={}
+            )
+        log.info(
+            "connector.auto_create_connection",
+            connector=state.connector,
+            instance=state.instance,
+            account=account,
+        )
 
     async def _resolve_per_chat_session(
         self,
@@ -888,6 +919,7 @@ class ConnectorSubprocessRegistry:
         content: str,
         attachments: Any,
         connector_metadata: dict[str, Any] | None,
+        platform_timestamp: str | None = None,
     ) -> None:
         """Append a user-message event AND record the dedup-ledger row.
 
@@ -903,9 +935,16 @@ class ConnectorSubprocessRegistry:
         ``message_id``, ``reply_to``; anything else the connector
         emits) is merged in BEFORE the supervisor's stamps so
         supervisor-canonical fields (``channel``, ``sender``,
-        ``attachments``) win on key conflicts.  The model relies on
-        these fields — e.g. ``signal_react`` is documented to copy
-        ``sender_uuid`` and ``timestamp_ms`` from the inbound header.
+        ``attachments``, ``platform_timestamp``) win on key conflicts.
+        The model relies on these fields — e.g. ``signal_react`` is
+        documented to copy ``sender_uuid`` and ``timestamp_ms`` from
+        the inbound header.
+
+        ``platform_timestamp`` (when supplied by the connector via the
+        SDK's ``emit_inbound(timestamp=...)`` kwarg) is the source
+        platform's actual delivery time as ISO-8601.  Server-side
+        ``created_at`` always wins for ordering invariants; this field
+        is purely a debugging aid.
         """
 
         pool = runtime.require_pool()
@@ -919,6 +958,8 @@ class ConnectorSubprocessRegistry:
             metadata["sender"] = sender_name
         if isinstance(attachments, list) and attachments:
             metadata["attachments"] = attachments
+        if platform_timestamp is not None:
+            metadata["platform_timestamp"] = platform_timestamp
         data: dict[str, Any] = {
             "role": "user",
             "content": content,

--- a/src/aios/mcp/stdio_transport.py
+++ b/src/aios/mcp/stdio_transport.py
@@ -251,9 +251,11 @@ async def open_connector_session(
 
     On exit (normal or exception), the SDK runs the spec'd shutdown:
     close stdin, wait, SIGTERM, SIGKILL.
+
+    The ``spec.cwd`` directory must already exist —
+    :func:`aios.harness.connector_supervisor.resolve_connector_specs`
+    creates it once at supervisor boot, so no per-spawn ``mkdir`` here.
     """
-    if spec.cwd is not None:
-        spec.cwd.mkdir(parents=True, exist_ok=True)
     server_params = StdioServerParameters(
         command=spec.command,
         args=list(spec.args),

--- a/tests/e2e/test_connector_inbound.py
+++ b/tests/e2e/test_connector_inbound.py
@@ -376,6 +376,104 @@ class TestAutoCreateConnection:
 
 
 @needs_docker
+class TestAccountDriftInbound:
+    """Inbound for an account absent from the supervisor snapshot drops as ``account_drift``.
+
+    Audit fix #1 / plan §15.  An attached connection whose account was
+    valid at attach time but disappeared from the snapshot (operator
+    rotated phones, signal-cli unlinked, etc.) would otherwise silently
+    accept events the connector can never reach for outbound — easier
+    to surface as a counter so the drift is visible.
+    """
+
+    async def test_inbound_for_drifted_account_drops_with_counter(self, harness: Harness) -> None:
+        agent_id, env_id = await _make_agent_and_env(harness)
+        account = _unique_account()
+        session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title="drift",
+            metadata={},
+        )
+        conn_row = await connections_service.create_connection(
+            harness._pool, connector="echo", account=account, metadata={}
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_row.id, session_id=session.id
+        )
+
+        registry = _registry()
+        # Snapshot does NOT include this account — operator drift case.
+        registry._states["echo"].accounts = [{"id": "some-other-account", "display_name": "X"}]
+        ack_view = _patch_send_ack(registry)
+        await registry._handle_inbound(
+            "echo",
+            {
+                "event_id": make_id("evt"),
+                "account": account,
+                "chat_id": "chat-x",
+                "sender": {"display_name": "Alice"},
+                "content": "should not land",
+            },
+        )
+
+        events = await harness.events(session.id)
+        user_messages = [e for e in events if e.kind == "message" and e.data.get("role") == "user"]
+        assert not any(e.data.get("content") == "should not land" for e in user_messages)
+        assert registry._states["echo"].drops["account_drift"] == 1
+        # Ack still fires so the connector clears its spool — there's
+        # no recovery from drift via replay.
+        assert len(ack_view()) == 1
+
+    async def test_inbound_when_snapshot_empty_skips_drift_check(self, harness: Harness) -> None:
+        """An empty snapshot is "unavailable", not "drift": don't false-positive.
+
+        Connector boot order can briefly leave ``state.accounts`` empty
+        before the first ``notifications/aios/accounts`` lands; flagging
+        drift in that window would corrupt the boot path.
+        """
+        agent_id, env_id = await _make_agent_and_env(harness)
+        account = _unique_account()
+        session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title="drift-empty",
+            metadata={},
+        )
+        conn_row = await connections_service.create_connection(
+            harness._pool, connector="echo", account=account, metadata={}
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_row.id, session_id=session.id
+        )
+
+        registry = _registry()
+        registry._states["echo"].accounts = []  # unavailable
+        _patch_send_ack(registry)
+        with mock.patch(
+            "aios.harness.connector_supervisor.defer_wake",
+            new=mock.AsyncMock(return_value=None),
+        ):
+            await registry._handle_inbound(
+                "echo",
+                {
+                    "event_id": make_id("evt"),
+                    "account": account,
+                    "chat_id": "chat-x",
+                    "sender": {"display_name": "Alice"},
+                    "content": "lands fine",
+                },
+            )
+
+        events = await harness.events(session.id)
+        contents = [e.data.get("content") for e in events if e.data.get("role") == "user"]
+        assert "lands fine" in contents
+        assert "account_drift" not in registry._states["echo"].drops
+
+
+@needs_docker
 class TestDedupLedger:
     async def test_replaying_same_event_id_appends_once(self, harness: Harness) -> None:
         """Two ``_handle_inbound`` calls with the same event_id yield one event.
@@ -508,6 +606,7 @@ class TestConnectorMetadataMerging:
                         "timestamp_ms": 1700000000000,
                         "reply_to": {"author_uuid": "x", "timestamp_ms": 1, "text": "?"},
                     },
+                    "timestamp": "2026-04-30T17:01:23.456+00:00",
                 },
             )
 
@@ -521,6 +620,11 @@ class TestConnectorMetadataMerging:
         # Supervisor-canonical stamps win on conflict / additive.
         assert meta["channel"] == f"echo/{account}/chat-meta"
         assert meta["sender"] == "Alice"
+        # Top-level ``timestamp`` (per design §3.3) stamped as
+        # ``metadata.platform_timestamp``.  Server-side ``created_at``
+        # remains authoritative for ordering; this is operator-debugging
+        # context only.
+        assert meta["platform_timestamp"] == "2026-04-30T17:01:23.456+00:00"
 
 
 @needs_docker

--- a/tests/unit/test_attach_drift_check.py
+++ b/tests/unit/test_attach_drift_check.py
@@ -58,7 +58,7 @@ def _patch_rpc(
     ) -> None:
         captured.append((call_id, connector))
 
-    monkeypatch.setattr("aios.api.routers.connections.listen_for_connector_result", fake_listen)
+    monkeypatch.setattr("aios.api.connector_rpc.listen_for_connector_result", fake_listen)
     monkeypatch.setattr("aios.api.routers.connections.defer_connector_status", fake_defer)
     return captured
 
@@ -99,6 +99,31 @@ class TestAssertAccountInSnapshot:
         assert exc_info.value.error_type == "account_drift"
         assert exc_info.value.detail == {"connector": "echo", "account": "vanished"}
 
+    async def test_running_with_empty_snapshot_raises_503(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Boot window: ``status == "running"`` but accounts haven't been pushed yet.
+
+        Mirrors the inbound handler's empty-snapshot exemption — without it,
+        an attach placed in this window would false-positive as drift.
+        """
+        from fastapi import HTTPException
+
+        from aios.api.routers.connections import _assert_account_in_snapshot
+
+        envelope = {
+            "connector": {
+                "name": "echo",
+                "status": "running",
+                "accounts": [],
+            }
+        }
+        _patch_rpc(monkeypatch, payload=json.dumps(envelope))
+        with pytest.raises(HTTPException) as exc_info:
+            await _assert_account_in_snapshot("postgresql://x", connector="echo", account="acct-1")
+        assert exc_info.value.status_code == 503
+        assert "not yet populated" in exc_info.value.detail
+
     async def test_connector_not_running_raises_503(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Snapshot unavailable while the connector is restarting / starting."""
         from fastapi import HTTPException
@@ -132,7 +157,7 @@ class TestAssertAccountInSnapshot:
         assert "snapshot unavailable" in exc_info.value.detail
 
     async def test_timeout_raises_408(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """No NOTIFY within the snapshot-check window → 408 with retry-friendly detail."""
+        """No NOTIFY within the snapshot-check window → 408 from the shared helper."""
         from fastapi import HTTPException
 
         from aios.api.routers.connections import _assert_account_in_snapshot
@@ -145,4 +170,4 @@ class TestAssertAccountInSnapshot:
         with pytest.raises(HTTPException) as exc_info:
             await _assert_account_in_snapshot("postgresql://x", connector="echo", account="acct-1")
         assert exc_info.value.status_code == 408
-        assert "snapshot-check window" in exc_info.value.detail
+        assert "did not respond" in exc_info.value.detail

--- a/tests/unit/test_attach_drift_check.py
+++ b/tests/unit/test_attach_drift_check.py
@@ -1,0 +1,148 @@
+"""Unit tests for ``api.routers.connections._assert_account_in_snapshot``.
+
+Validates that the attach-time drift guard (audit fix #1, design §5.6)
+correctly maps the worker's snapshot envelope onto the right HTTP
+status:
+
+* Account present in snapshot → no raise.
+* Account absent → :class:`AccountDriftError` (409 ``account_drift``).
+* Connector ``status != "running"`` → 503 (snapshot unavailable, not drift).
+* Worker error envelope → 503.
+* Timeout on the LISTEN queue → 408.
+
+Mocks :func:`listen_for_connector_result` and
+:func:`defer_connector_status` so no DB / procrastinate work runs.
+
+All ``aios.api`` imports are deferred to the test bodies because
+``aios.harness.procrastinate_app`` runs ``get_settings()`` at module
+import time and the conftest env-var fixture only fires after pytest's
+collection phase finishes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+
+
+@asynccontextmanager
+async def _fake_listen(payload: str | None) -> AsyncIterator[asyncio.Queue[str]]:
+    """Stand-in for :func:`listen_for_connector_result`.
+
+    ``payload`` is pushed onto the queue immediately so the awaiter
+    sees a NOTIFY without an actual Postgres round-trip.  ``None``
+    leaves the queue empty (forces the await to time out).
+    """
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    if payload is not None:
+        queue.put_nowait(payload)
+    yield queue
+
+
+def _patch_rpc(
+    monkeypatch: pytest.MonkeyPatch, *, payload: str | None
+) -> list[tuple[str | None, str | None]]:
+    """Wire fake LISTEN + defer; record the connector name passed to defer."""
+    captured: list[tuple[str | None, str | None]] = []
+
+    def fake_listen(_db_url: str, call_id: str) -> Any:
+        return _fake_listen(payload)
+
+    async def fake_defer(
+        *, call_id: str, connector: str | None = None, instance: str | None = None
+    ) -> None:
+        captured.append((call_id, connector))
+
+    monkeypatch.setattr("aios.api.routers.connections.listen_for_connector_result", fake_listen)
+    monkeypatch.setattr("aios.api.routers.connections.defer_connector_status", fake_defer)
+    return captured
+
+
+class TestAssertAccountInSnapshot:
+    async def test_account_present_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from aios.api.routers.connections import _assert_account_in_snapshot
+
+        envelope = {
+            "connector": {
+                "name": "echo",
+                "status": "running",
+                "accounts": [{"id": "acct-1", "display_name": "A1"}],
+            }
+        }
+        _patch_rpc(monkeypatch, payload=json.dumps(envelope))
+        # Should not raise.
+        await _assert_account_in_snapshot("postgresql://x", connector="echo", account="acct-1")
+
+    async def test_account_absent_raises_drift(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from aios.api.routers.connections import _assert_account_in_snapshot
+        from aios.errors import AccountDriftError
+
+        envelope = {
+            "connector": {
+                "name": "echo",
+                "status": "running",
+                "accounts": [{"id": "acct-1", "display_name": "A1"}],
+            }
+        }
+        _patch_rpc(monkeypatch, payload=json.dumps(envelope))
+        with pytest.raises(AccountDriftError) as exc_info:
+            await _assert_account_in_snapshot(
+                "postgresql://x", connector="echo", account="vanished"
+            )
+        # 409 with the right error type and detail bag the operator can branch on.
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.error_type == "account_drift"
+        assert exc_info.value.detail == {"connector": "echo", "account": "vanished"}
+
+    async def test_connector_not_running_raises_503(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Snapshot unavailable while the connector is restarting / starting."""
+        from fastapi import HTTPException
+
+        from aios.api.routers.connections import _assert_account_in_snapshot
+
+        envelope = {
+            "connector": {
+                "name": "echo",
+                "status": "starting",
+                "accounts": [],
+            }
+        }
+        _patch_rpc(monkeypatch, payload=json.dumps(envelope))
+        with pytest.raises(HTTPException) as exc_info:
+            await _assert_account_in_snapshot("postgresql://x", connector="echo", account="acct-1")
+        assert exc_info.value.status_code == 503
+        assert "starting" in exc_info.value.detail
+
+    async def test_worker_error_envelope_raises_503(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``not_enabled`` / ``not_ready`` envelopes from the worker → 503."""
+        from fastapi import HTTPException
+
+        from aios.api.routers.connections import _assert_account_in_snapshot
+
+        envelope = {"error": "connector 'echo' not enabled", "code": "not_enabled"}
+        _patch_rpc(monkeypatch, payload=json.dumps(envelope))
+        with pytest.raises(HTTPException) as exc_info:
+            await _assert_account_in_snapshot("postgresql://x", connector="echo", account="acct-1")
+        assert exc_info.value.status_code == 503
+        assert "snapshot unavailable" in exc_info.value.detail
+
+    async def test_timeout_raises_408(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No NOTIFY within the snapshot-check window → 408 with retry-friendly detail."""
+        from fastapi import HTTPException
+
+        from aios.api.routers.connections import _assert_account_in_snapshot
+
+        _patch_rpc(monkeypatch, payload=None)  # queue stays empty
+
+        # Tighten the timeout so the test doesn't actually wait 10 seconds.
+        monkeypatch.setattr("aios.api.routers.connections._DRIFT_CHECK_TIMEOUT_S", 0.05)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _assert_account_in_snapshot("postgresql://x", connector="echo", account="acct-1")
+        assert exc_info.value.status_code == 408
+        assert "snapshot-check window" in exc_info.value.detail

--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -113,10 +113,8 @@ class TestResolveConnectorSpecs:
             resolve_connector_specs(self._settings(enabled=["bad"]))
 
     def test_default_instance_returns_single_segment_cwd(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
-        from pathlib import Path
-
         ep = MagicMock()
         ep.name = "echo"
         ep.load.return_value = lambda name, settings: ConnectorSpec(name=name, command="/bin/echo")
@@ -124,7 +122,7 @@ class TestResolveConnectorSpecs:
             "aios.harness.connector_supervisor.entry_points",
             lambda group: [ep],
         )
-        connectors_dir = Path("/tmp/aios-connectors-test")
+        connectors_dir = tmp_path / "aios-connectors"
         specs = resolve_connector_specs(
             self._settings(enabled=["echo"], connectors_dir=connectors_dir)
         )
@@ -133,12 +131,13 @@ class TestResolveConnectorSpecs:
         assert ci.connector == "echo" and ci.instance == "echo"
         # Default-instance setups keep the PR3 single-segment path.
         assert spec.cwd == connectors_dir / "echo"
+        # Audit fix #5: resolver creates the cwd up-front so the first
+        # boot doesn't ``FileNotFoundError`` during subprocess spawn.
+        assert spec.cwd is not None and spec.cwd.is_dir()
 
     def test_non_default_instance_gets_per_instance_subdir(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
-        from pathlib import Path
-
         ep = MagicMock()
         ep.name = "telegram"
         ep.load.return_value = lambda name, settings: ConnectorSpec(name=name, command="/bin/echo")
@@ -146,7 +145,7 @@ class TestResolveConnectorSpecs:
             "aios.harness.connector_supervisor.entry_points",
             lambda group: [ep],
         )
-        connectors_dir = Path("/tmp/aios-connectors-test")
+        connectors_dir = tmp_path / "aios-connectors-test"
         specs = resolve_connector_specs(
             self._settings(enabled=["telegram:bot1"], connectors_dir=connectors_dir)
         )
@@ -154,11 +153,13 @@ class TestResolveConnectorSpecs:
         ci, spec = specs[0]
         assert ci.connector == "telegram" and ci.instance == "bot1"
         assert spec.cwd == connectors_dir / "telegram" / "bot1"
+        # Audit fix #5: resolver creates the per-instance cwd too.
+        assert spec.cwd is not None and spec.cwd.is_dir()
 
-    def test_factory_explicit_cwd_is_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from pathlib import Path
-
-        explicit = Path("/var/lib/aios/special")
+    def test_factory_explicit_cwd_is_preserved(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        explicit = tmp_path / "var-lib-aios-special"
         ep = MagicMock()
         ep.name = "echo"
         ep.load.return_value = lambda name, settings: ConnectorSpec(
@@ -170,6 +171,8 @@ class TestResolveConnectorSpecs:
         )
         specs = resolve_connector_specs(self._settings(enabled=["echo"]))
         assert specs[0][1].cwd == explicit
+        # Audit fix #5: resolver also creates the explicit path.
+        assert explicit.is_dir()
 
     def test_env_re_export_for_non_default_instance(self, monkeypatch: pytest.MonkeyPatch) -> None:
         ep = MagicMock()


### PR DESCRIPTION
## Summary

Five fixes from the three-agent audit of [#200](https://github.com/eumemic/aios/issues/200), stacked on PR #211 (PR3).  Branch is a sibling of PR #210 (PR4 multi-account).

- **Attach-time account-drift guard (critical)** — `POST /v1/connections/:id/attach` now procrastinate-RPCs `connector_status` to verify the account is in the supervisor's live snapshot before the DB write.  Stale → `409 account_drift`; connector down → `503`.  Inbound handler also drops with `account_drift` for attached accounts that have drifted out of the snapshot mid-life.
- **SDK documentation gaps** — README + base-class docstrings spell out `discover_accounts() -> list[dict]`, the `make_spec` factory pattern, and the four-hook lifecycle (`setup`/`discover_accounts`/`serve`/`teardown`) with readiness-deferral semantics.
- **`INSERT ... ON CONFLICT DO NOTHING RETURNING`** — `insert_connection` now matches plan decision #5: single round-trip happy path, idempotent re-read on conflict, no exception-handling cost on auto-create.
- **Optional `timestamp` on inbound notifications** — SDK `emit_inbound(timestamp=ISO8601)` → `metadata.platform_timestamp` on the appended event.  Signal/telegram render their existing `timestamp_ms` as ISO-8601 UTC.
- **`cwd` auto-create at supervisor boot** — `resolve_connector_specs` `mkdir -p`s each connector's `~/.aios/connectors/<name>/` so first boot doesn't `FileNotFoundError`.

## Test plan

- [x] `uv run mypy src` — clean (123 source files)
- [x] `uv run ruff check src tests packages connectors` — clean
- [x] `uv run ruff format --check ...` — clean
- [x] `uv run pytest tests/unit -q` — **977 passed** (was 972)
- [x] `uv run pytest packages/aios-connector/tests -q` — **19 passed** (was 18)
- [x] `cd connectors/signal && uv run pytest -q` — **66 passed** (unchanged)
- [x] `cd connectors/telegram && uv run pytest -q` — **17 passed** (unchanged)
- [x] `DOCKER_HOST=... uv run pytest tests/e2e/test_connector_inbound.py -q` — **14 passed** (was 12; +2 drift tests)
- [x] `DOCKER_HOST=... uv run pytest tests/e2e/test_connector_supervisor.py -q` — **4 passed** (unchanged)

## Notes for review

- Drift detection in the inbound handler treats an empty snapshot as "unavailable, skip the check" rather than drift — connectors briefly have no accounts during boot before the first `notifications/aios/accounts` arrives, and flagging drift in that window would corrupt boot delivery.  Test covers this case.
- Removed the duplicate `mkdir` from `mcp/stdio_transport.open_connector_session` (was already there from a previous PR3 commit) per the project's no-belt-and-suspenders preference: the resolver is the single source of truth.
- `insert_connection` now hands back the existing row on conflict (was `409`).  This is a small POST-semantics change but consistent with plan decision #5's intent ("first-inbound vs explicit POST race" → idempotent convergence on a single row).
- The drift check uses a 10s timeout (vs the 60s for arbitrary tool calls): snapshot lookup is cheap and a longer wait on an admin endpoint just hides backend pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)