### PR TITLE
feat(connector): multi-account + multi-instance support (#200, PR4/4)

### DIFF
--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -97,17 +97,6 @@ That env var is removed cleanly — set `AIOS_SIGNAL_PHONES=+1...` (a
 one-element CSV) for an equivalent single-phone deployment.  Multi-
 phone setups become `AIOS_SIGNAL_PHONES=+1...,+2...`.
 
-## Multi-phone scaling note
-
-The connector publishes one `## Your identity on this Signal account`
-+ groups roster section per registered phone in the
-`InitializeResult.instructions` block.  That block is part of every
-session step's system prompt, so prompt size grows linearly with the
-number of phones — at 5-10 phones with rich group rosters the
-inflation is visible in inference cost.  For high-fanout deployments,
-consider splitting into multiple `signal:<instance>` instances each
-serving a small phone set rather than one instance with all phones.
-
 ## Out of scope for v1
 
 - Attachments (inbound messages with attachments are posted text-only with `[attachment: <name> (<mime>)]` markers; `signal_send` has no attachment parameter).

--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -97,6 +97,17 @@ That env var is removed cleanly — set `AIOS_SIGNAL_PHONES=+1...` (a
 one-element CSV) for an equivalent single-phone deployment.  Multi-
 phone setups become `AIOS_SIGNAL_PHONES=+1...,+2...`.
 
+## Multi-phone scaling note
+
+The connector publishes one `## Your identity on this Signal account`
++ groups roster section per registered phone in the
+`InitializeResult.instructions` block.  That block is part of every
+session step's system prompt, so prompt size grows linearly with the
+number of phones — at 5-10 phones with rich group rosters the
+inflation is visible in inference cost.  For high-fanout deployments,
+consider splitting into multiple `signal:<instance>` instances each
+serving a small phone set rather than one instance with all phones.
+
 ## Out of scope for v1
 
 - Attachments (inbound messages with attachments are posted text-only with `[attachment: <name> (<mime>)]` markers; `signal_send` has no attachment parameter).

--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -1,139 +1,101 @@
 # aios-signal
 
-Signal connector for [aios](../../README.md). One long-running process per
-Signal account — wraps `signal-cli` in daemon mode, ingests inbound messages
-into aios via `POST /v1/connections/{id}/messages`, and serves an MCP server
-exposing `signal_send`, `signal_react`, `signal_read_receipt` tools that the
-aios worker calls back into.
+Signal connector for [aios](../../README.md). Wraps `signal-cli` in
+multi-account daemon mode and surfaces it as an MCP stdio server that
+the aios worker spawns and supervises.  One `signal-cli daemon`
+process serves N registered phones natively (no `-a` flag); every RPC
+call routes via the `account` field in its params.
 
 ## Prerequisites
 
 - Python ≥ 3.13
-- [signal-cli](https://github.com/AsamK/signal-cli) ≥ 0.13.x (provides the JSON-RPC `listAccounts`, `send`, `sendReaction`, `sendReceipt` methods, and `--receive-mode=on-connection`)
+- [signal-cli](https://github.com/AsamK/signal-cli) ≥ 0.13.x (the
+  multi-account JSON-RPC daemon mode is documented in
+  `signal-cli-jsonrpc.5.adoc` upstream)
 - A JRE available to signal-cli
-- A running aios instance you can point at (Phase 1 routing infra required)
-
-## Install
-
-Pip-installable standalone:
-
-```
-pip install ./connectors/signal
-```
-
-Or as a uv workspace member (already wired from the repo root):
-
-```
-uv sync --all-packages --dev
-```
+- A running aios worker that includes `signal` (or `signal:<instance>`)
+  in its `connectors_enabled` list
 
 ## Operator walkthrough
 
-### 1. Register the Signal account
+### 1. Register the Signal account(s)
 
 ```
-signal-cli -a +15551234567 register --captcha signalcaptcha://...
-signal-cli -a +15551234567 verify 123456
+signal-cli --config ~/.aios/connectors/signal -a +15551234567 register --captcha signalcaptcha://...
+signal-cli --config ~/.aios/connectors/signal -a +15551234567 verify 123456
 ```
 
-Grab the bot's ACI UUID — you'll need it for the routing rule:
+Repeat for each phone number you want this connector instance to serve.
+All registered accounts share one `--config` directory.
 
-```
-signal-cli -a +15551234567 listAccounts
-```
+### 2. Configure the worker's connector instance
 
-### 2. Create an aios vault + credential for the MCP token
+In the worker's environment:
 
-```
-VLT=$(curl -X POST :8090/v1/vaults -d '{"display_name": "Signal personal"}' | jq -r .id)
-
-curl -X POST :8090/v1/vaults/$VLT/credentials -d '{
-  "mcp_server_url": "http://localhost:9100/mcp",
-  "auth_type": "static_bearer",
-  "token": "supersecret"
-}'
+```bash
+AIOS_CONNECTORS_ENABLED=signal                   # default-instance shape
+AIOS_SIGNAL_PHONES=+15551234567,+15559876543     # CSV — both phones served by one daemon
+AIOS_SIGNAL_CONFIG_DIR=~/.aios/connectors/signal
 ```
 
-### 3. Register the aios connection
+For multi-instance deployments (e.g., separate config dirs for
+unrelated bots), use the `<connector>:<instance>` syntax and scope env
+vars by instance:
 
-```
-curl -X POST :8090/v1/connections -d "{
-  \"connector\": \"signal\",
-  \"account\": \"<bot-aci-uuid-from-step-1>\",
-  \"mcp_url\": \"http://localhost:9100/mcp\",
-  \"vault_id\": \"$VLT\"
-}"
-```
-
-### 4. Start the connector
-
-```
-export AIOS_URL=http://localhost:8090
-export AIOS_API_KEY=...
-export AIOS_CONNECTION_ID=conn_...
-export AIOS_SIGNAL_MCP_TOKEN=supersecret
-
-python -m aios_signal start \
-  --phone +15551234567 \
-  --config-dir ~/.config/signal-cli
+```bash
+AIOS_CONNECTORS_ENABLED=signal:personal,signal:work
+AIOS_SIGNAL_PERSONAL_PHONES=+15551234567
+AIOS_SIGNAL_PERSONAL_CONFIG_DIR=~/.aios/connectors/signal-personal
+AIOS_SIGNAL_WORK_PHONES=+15559876543,+15558887777
+AIOS_SIGNAL_WORK_CONFIG_DIR=~/.aios/connectors/signal-work
 ```
 
-All settings can also be passed via env vars. Full list via `python -m aios_signal start --help`.
+The supervisor re-exports `AIOS_SIGNAL_<INSTANCE>_*` as
+`AIOS_SIGNAL_*` inside each subprocess so the connector reads its
+config under the standard prefix.
 
-### 5. Add a routing rule
+### 3. Restart the worker
+
+`aios worker` boots, spawns the signal subprocess, runs `signal-cli
+daemon`, and reports the discovered accounts on
+`aios connector accounts signal`.
+
+### 4. Attach connections to sessions
+
+For each phone the connector serves, attach the auto-created
+`(connector=signal, account=<bot_uuid>)` connection to a session:
 
 ```
-curl -X POST :8090/v1/routing-rules -d '{
-  "prefix": "signal/<bot-aci-uuid>",
-  "target": "agent:<agent-id>",
-  "session_params": {"environment_id": "<env-id>"}
-}'
+aios connections list --connector=signal
+aios connections attach <conn_id> --session=<session_id>
 ```
 
-The prefix uses the **bot's** ACI UUID (from step 1), not the counterparty's.
+Or configure per-chat session spawning via a session template
+(`aios connections configure-per-chat <conn_id> --template=<tpl_id>`).
 
-### 6. DM your bot — the agent replies
+### 5. DM the bot — the agent replies
 
-DM the bot's phone number from another Signal client. Watch the aios event
-log: the inbound message shows up with `metadata.channel` set, a session is
-created on first inbound, and the agent's `signal_send` call delivers the
-reply back to Signal.
-
-**Phase-2 dependency:** step 6 works end-to-end only once Phase 2 (#31) has
-merged — Phase 2 wires connection-provided MCP servers into the worker's
-tool discovery. Until then the connector runs fine and ingests messages, but
-the agent can't see the `signal_send` tool.
+Inbound messages on each phone route to its connection's session.
+The agent's `signal_send` and `signal_react` tools take `account` +
+`chat_id` from the focal channel meta; aios injects them automatically
+when the session has a focal channel set via `switch_channel`.
 
 ## Configuration reference
 
-| Flag | Env var | Default | Description |
-|---|---|---|---|
-| `--phone` | `AIOS_SIGNAL_PHONE` | required | E.164 phone number |
-| `--config-dir` | `AIOS_SIGNAL_CONFIG_DIR` | required | signal-cli config directory |
-| `--signal-cli-bin` | `AIOS_SIGNAL_CLI_BIN` | `signal-cli` | Path to signal-cli binary |
-| `--daemon-port` | `AIOS_SIGNAL_DAEMON_PORT` | `7583` | TCP port for signal-cli daemon |
-| `--aios-url` | `AIOS_URL` | required | Base URL of aios API |
-| `--aios-api-key` | `AIOS_API_KEY` | required | Bearer token for aios API |
-| `--aios-connection-id` | `AIOS_CONNECTION_ID` | required | ID of the pre-registered connection |
-| `--mcp-bind` | `AIOS_SIGNAL_MCP_BIND` | `127.0.0.1:9100` | Host:port for MCP server |
-| `--mcp-token` | `AIOS_SIGNAL_MCP_TOKEN` | required | Token MCP clients must present |
+| Env var | Default | Description |
+|---|---|---|
+| `AIOS_SIGNAL_PHONES` | required | CSV of E.164 phone numbers; all must be registered in `AIOS_SIGNAL_CONFIG_DIR` |
+| `AIOS_SIGNAL_CONFIG_DIR` | required | signal-cli config directory; account database lives here |
+| `AIOS_SIGNAL_CLI_BIN` | `signal-cli` | Path to signal-cli binary |
+| `AIOS_SIGNAL_DAEMON_HOST` | `127.0.0.1` | Internal TCP host for signal-cli daemon |
+| `AIOS_SIGNAL_DAEMON_PORT` | `7583` | Internal TCP port for signal-cli daemon |
 
-## Architecture
+## Migration from single-phone PR3
 
-`app.run()` wires three tasks under a single `asyncio.TaskGroup`:
-
-1. **`SignalDaemon`** — subprocess lifecycle for `signal-cli daemon`. Drains
-   stdout/stderr, polls TCP readiness via `listAccounts`, discovers the bot's
-   own ACI UUID by matching `--phone` against `listAccounts` output.
-2. **`InboundPump`** — drains the daemon's persistent listener connection,
-   parses each envelope into an `InboundMessage`, and POSTs to aios with
-   the metadata envelope specified in #33.
-3. **MCP server** — FastMCP on uvicorn, bearer-auth-gated, exposing
-   `signal_send`, `signal_react`, `signal_read_receipt`.
-
-**Crash-is-fatal.** Any task failure propagates through the TaskGroup and
-exits the process non-zero. There is no auto-reconnect. Run under systemd
-(`Restart=on-failure`) or Docker (`restart: unless-stopped`).
+Pre-this-PR signal connectors used `AIOS_SIGNAL_PHONE` (singular).
+That env var is removed cleanly — set `AIOS_SIGNAL_PHONES=+1...` (a
+one-element CSV) for an equivalent single-phone deployment.  Multi-
+phone setups become `AIOS_SIGNAL_PHONES=+1...,+2...`.
 
 ## Out of scope for v1
 
@@ -143,29 +105,13 @@ exits the process non-zero. There is no auto-reconnect. Run under systemd
 - Typing indicators.
 - Message editing / deletion.
 - Automated registration.
-- Auto-reconnect on signal-cli crash.
-
-## Troubleshooting
-
-- **`signal.bot_uuid.not_found`**: `signal-cli listAccounts` returned no
-  entry matching `--phone`. Re-run registration (step 1).
-- **`signal.daemon.crashed`**: signal-cli exited unexpectedly. Check the
-  logs for the `signal.daemon.stderr` events immediately preceding. Common
-  causes: stale session state, JRE absent, port already in use.
-- **MCP calls returning 401**: the `--mcp-token` on the connector doesn't
-  match the `token` stored in the aios vault's credential for this
-  connection. They must match exactly.
-- **Inbound messages never appear in aios**: check the connector logs for
-  `ingest.client_error` (malformed payload — likely a connector bug) or
-  `ingest.retries_exhausted` (aios was unreachable long enough to exhaust
-  the 1/2/4/8s backoff).
 
 ## Development
 
 From `connectors/signal/`:
 
 ```
-uv run pytest -q           # unit + integration, ~1.5s, no Docker / no signal-cli
+uv run pytest -q           # unit, ~1.5s, no Docker / no signal-cli
 uv run mypy src tests      # strict
 uv run ruff check src tests
 uv run ruff format --check src tests

--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -58,7 +58,7 @@ config under the standard prefix.
 
 `aios worker` boots, spawns the signal subprocess, runs `signal-cli
 daemon`, and reports the discovered accounts on
-`aios connector accounts signal`.
+`aios connectors accounts signal`.
 
 ### 4. Attach connections to sessions
 

--- a/connectors/signal/src/aios_signal/config.py
+++ b/connectors/signal/src/aios_signal/config.py
@@ -10,6 +10,12 @@ MCP bind/token are also gone — the MCP server now runs over stdio
 (no HTTP bind, no bearer token).  Daemon host/port are still
 configurable since signal-cli's TCP daemon is internal to this
 subprocess and operators may need to avoid local port collisions.
+
+Multi-account: ``phones`` is a CSV of registered numbers (e.g.
+``AIOS_SIGNAL_PHONES=+1555,+1666``).  signal-cli's daemon is launched
+without ``-a`` so it serves all registered accounts; every RPC call
+includes the target account in its params.  Single-phone setups still
+work — set ``AIOS_SIGNAL_PHONES=+1555`` (a one-element list).
 """
 
 from __future__ import annotations
@@ -27,7 +33,7 @@ class Settings(BaseSettings):
     )
 
     # Signal / daemon
-    phone: str
+    phones: list[str]
     config_dir: Path
     cli_bin: str = "signal-cli"
     daemon_host: str = "127.0.0.1"

--- a/connectors/signal/src/aios_signal/config.py
+++ b/connectors/signal/src/aios_signal/config.py
@@ -21,8 +21,10 @@ work — set ``AIOS_SIGNAL_PHONES=+1555`` (a one-element list).
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Annotated
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -32,9 +34,19 @@ class Settings(BaseSettings):
         populate_by_name=True,
     )
 
-    # Signal / daemon
-    phones: list[str]
+    # Signal / daemon — ``Annotated[..., NoDecode]`` skips pydantic-settings'
+    # default JSON parsing for ``list[str]`` env vars so the
+    # :meth:`_split_csv` validator below sees the raw env string.
+    phones: Annotated[list[str], NoDecode]
     config_dir: Path
     cli_bin: str = "signal-cli"
     daemon_host: str = "127.0.0.1"
     daemon_port: int = 7583
+
+    @field_validator("phones", mode="before")
+    @classmethod
+    def _split_csv(cls, value: object) -> object:
+        """Accept ``AIOS_SIGNAL_PHONES=+1,+2`` env strings as well as JSON arrays."""
+        if isinstance(value, str):
+            return [s.strip() for s in value.split(",") if s.strip()]
+        return value

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -4,20 +4,27 @@ Replaces the pre-PR3 FastMCP HTTP server + ingest-HTTP-POST architecture
 with a single :class:`aios_connector.Connector` subclass communicating
 with aios over stdio MCP.
 
+Multi-account: one signal-cli daemon serves N registered phones (multi-
+account mode, no ``-a`` flag).  The connector aggregates per-phone
+identity (uuid + contacts + groups) and routes every send / react RPC
+through the explicit ``account`` param.  Single-phone setups still
+work — set ``AIOS_SIGNAL_PHONES`` to a one-element list.
+
 Lifecycle:
 
 * :meth:`setup` opens :class:`SignalDaemon` (which spawns ``signal-cli
-  daemon`` and waits for TCP readiness), discovers the bot UUID, and
-  loads contacts + groups for display-name resolution.
-* :meth:`discover_accounts` returns one account entry — Signal connectors
-  are single-bot by design.
-* :meth:`serve` drives the inbound pump: drains messages from
-  ``daemon.listener``, parses them, and calls :meth:`emit_inbound` for
-  each one.  Spool durability + dedup ledger are handled by the SDK.
+  daemon`` in multi-account mode and waits for TCP readiness),
+  discovers the per-phone bot UUIDs, and loads contacts + groups for
+  every account.
+* :meth:`discover_accounts` returns one entry per configured phone.
+* :meth:`serve` drives the inbound pump: drains ``(account, envelope)``
+  pairs from ``daemon.listener``, parses them with the right per-phone
+  bot UUID, and calls :meth:`emit_inbound` with the matching account.
+  Spool durability + dedup ledger are handled by the SDK.
 * :meth:`teardown` closes the daemon (SIGTERM → grace → SIGKILL).
 * The two model-facing tools, ``signal_send`` and ``signal_react``,
-  use :func:`focal_required` so the focal channel suffix is parsed
-  out of ``_meta`` and bound to the ``focal`` kwarg.
+  use :func:`focal_required` to receive ``account`` and ``chat_id``
+  from ``_meta.aios.focal_channel_path`` and route the RPC accordingly.
 """
 
 from __future__ import annotations
@@ -46,13 +53,19 @@ class SignalConnector(Connector):
         super().__init__()
         self._cfg = cfg
         self._daemon: SignalDaemon | None = None
-        self._bot_uuid: str | None = None
-        self._contact_names: dict[str, str] = {}
+        # Phone → bot UUID, populated during setup() from accounts.json.
+        self._bot_uuids: dict[str, str] = {}
+        # Convenience reverse map: UUID → phone, used in the inbound pump
+        # to look up the bot identity for a per-account envelope parse.
+        self._uuid_to_phone: dict[str, str] = {}
+        # Contacts + group rosters are per-account because each phone has
+        # its own contact store and group memberships in signal-cli.
+        self._contact_names_by_account: dict[str, dict[str, str]] = {}
 
     # ── lifecycle ─────────────────────────────────────────────────────
 
     async def setup(self) -> None:
-        """Open the signal-cli daemon and load contacts + groups.
+        """Open the signal-cli daemon and load contacts + groups for every phone.
 
         signal-cli takes 5+ seconds to come up; the supervisor's bounded
         init handshake (30s) accommodates this.  The SDK doesn't
@@ -61,43 +74,52 @@ class SignalConnector(Connector):
         calls against an unready daemon.
         """
         self._daemon = await SignalDaemon(
-            phone=self._cfg.phone,
+            phones=self._cfg.phones,
             config_dir=self._cfg.config_dir,
             cli_bin=self._cfg.cli_bin,
             host=self._cfg.daemon_host,
             port=self._cfg.daemon_port,
         ).__aenter__()
-        self._bot_uuid = await self._daemon.discover_bot_uuid()
-        self._contact_names = await self._daemon.list_contacts()
-        groups = await self._daemon.list_groups()
-        # Build a runtime instructions block that captures the bot's
-        # identity, contacts, and groups.  Set on the instance (not the
-        # class) so a second connector instance in tests doesn't see
-        # leakage from the first.
-        self.instructions = build_instructions(
-            bot_uuid=self._bot_uuid,
-            phone=self._cfg.phone,
-            profile_name=self._contact_names.get(self._bot_uuid),
-            groups=groups,
-            contact_names=self._contact_names,
-        )
-        log.info(
-            "signal.ready",
-            bot_uuid=self._bot_uuid,
-            phone=self._cfg.phone,
-            contacts=len(self._contact_names),
-            groups=len(groups),
-        )
+        self._bot_uuids = await self._daemon.discover_bot_uuids()
+        self._uuid_to_phone = {uuid: phone for phone, uuid in self._bot_uuids.items()}
+        # Load per-account contacts + groups in series — N is small
+        # (typically 1-3 phones) and parallel listContacts calls would
+        # race for the daemon's contact-store lock without measurable
+        # speedup at this scale.
+        instructions_sections: list[str] = []
+        for phone, bot_uuid in self._bot_uuids.items():
+            contact_names = await self._daemon.list_contacts(account=phone)
+            self._contact_names_by_account[phone] = contact_names
+            groups = await self._daemon.list_groups(account=phone)
+            section = build_instructions(
+                bot_uuid=bot_uuid,
+                phone=phone,
+                profile_name=contact_names.get(bot_uuid),
+                groups=groups,
+                contact_names=contact_names,
+            )
+            instructions_sections.append(section)
+            log.info(
+                "signal.account.ready",
+                bot_uuid=bot_uuid,
+                phone=phone,
+                contacts=len(contact_names),
+                groups=len(groups),
+            )
+        # Concatenate per-account sections.  build_instructions already
+        # produces a self-contained block per account; joining with a
+        # blank line gives the agent clearly delimited identities.
+        self.instructions = "\n\n".join(instructions_sections) if instructions_sections else None
 
     async def discover_accounts(self) -> list[dict[str, Any]]:
-        assert self._bot_uuid is not None, "setup() must run before discover_accounts()"
-        profile_name = self._contact_names.get(self._bot_uuid)
+        assert self._bot_uuids, "setup() must run before discover_accounts()"
         return [
             make_account(
-                id=self._bot_uuid,
-                display_name=profile_name or self._cfg.phone,
-                metadata={"phone": self._cfg.phone},
+                id=bot_uuid,
+                display_name=self._contact_names_by_account.get(phone, {}).get(bot_uuid, phone),
+                metadata={"phone": phone},
             )
+            for phone, bot_uuid in self._bot_uuids.items()
         ]
 
     async def teardown(self) -> None:
@@ -106,31 +128,43 @@ class SignalConnector(Connector):
             self._daemon = None
 
     async def serve(self) -> None:
-        """Drain inbound envelopes from signal-cli and emit them to aios.
+        """Drain ``(account, envelope)`` pairs from signal-cli and emit to aios.
 
-        Falls back on signal-cli's contact store when an envelope's
-        ``sourceName`` is empty — Signal's UI resolves names via
-        profiles the envelope doesn't carry.
+        Per-account routing: the listener stamps every receive
+        notification with the phone the message arrived on; we look up
+        the matching bot UUID and pass it to ``parse_envelope`` so
+        self-message detection works correctly across all configured
+        accounts.  Falls back on each account's contact store when an
+        envelope's ``sourceName`` is empty.
         """
         assert self._daemon is not None, "setup() must run before serve()"
-        assert self._bot_uuid is not None
-        async for envelope in self._daemon.listener.messages():
-            msg = parse_envelope(envelope, bot_account_uuid=self._bot_uuid)
+        async for account, envelope in self._daemon.listener.messages():
+            phone = account.strip()
+            bot_uuid = self._bot_uuids.get(phone)
+            if bot_uuid is None:
+                # Notification for an account we didn't register — most
+                # likely operator added a phone via signal-cli directly
+                # without restarting the connector.  Drop with a warning;
+                # otherwise self-message filtering would misbehave.
+                log.warning("signal.inbound.unknown_account", account=phone)
+                continue
+            msg = parse_envelope(envelope, bot_account_uuid=bot_uuid)
             if msg is None:
                 continue
+            contact_names = self._contact_names_by_account.get(phone, {})
             if msg.sender_name is None:
-                resolved = self._contact_names.get(msg.sender_uuid)
+                resolved = contact_names.get(msg.sender_uuid)
                 if resolved:
                     msg = replace(msg, sender_name=resolved)
             chat_id = encode_chat_id(msg.raw_chat_id, msg.chat_type)
             content = build_content_text(msg)
-            metadata = build_metadata(msg, chat_id, self._bot_uuid)
+            metadata = build_metadata(msg, chat_id, bot_uuid)
             sender_payload: dict[str, Any] = {
                 "uuid": msg.sender_uuid,
                 "display_name": msg.sender_name or msg.sender_uuid,
             }
             await self.emit_inbound(
-                account=self._bot_uuid,
+                account=bot_uuid,
                 chat_id=chat_id,
                 sender=sender_payload,
                 content=content,
@@ -141,18 +175,22 @@ class SignalConnector(Connector):
 
     @tool()
     @focal_required
-    async def signal_send(self, text: str, *, focal: str) -> dict[str, Any]:
+    async def signal_send(self, text: str, *, account: str, chat_id: str) -> dict[str, Any]:
         """Send a text message to your focal Signal chat.
 
-        The chat id is taken implicitly from your focal channel —
-        aios injects it via the JSON-RPC ``_meta`` field on each call.
-        Set focal with the built-in ``switch_channel`` tool.
+        The account (your bot UUID) and chat id are taken implicitly
+        from your focal channel — aios injects them via the JSON-RPC
+        ``_meta`` field on each call.  Set focal with the built-in
+        ``switch_channel`` tool.
 
         Args:
             text: Message body. Markdown is converted to Signal text styles.
         """
         assert self._daemon is not None
-        params = _build_send_params(focal, text)
+        phone = self._uuid_to_phone.get(account)
+        if phone is None:
+            raise ValueError(f"signal_send: unknown account {account!r}")
+        params = _build_send_params(phone, chat_id, text)
         result = await self._daemon.rpc.call("send", params)
         ts = _extract_timestamp(result)
         return {"sent_at_ms": ts} if ts is not None else {"status": "ok"}
@@ -165,12 +203,14 @@ class SignalConnector(Connector):
         target_timestamp_ms: int,
         emoji: str,
         *,
-        focal: str,
+        account: str,
+        chat_id: str,
     ) -> dict[str, Any]:
         """React to a message in your focal Signal chat with an emoji.
 
-        The chat id is taken implicitly from your focal channel — aios
-        injects it via the JSON-RPC ``_meta`` field on each call.
+        The account (your bot UUID) and chat id are taken implicitly
+        from your focal channel — aios injects them via the JSON-RPC
+        ``_meta`` field on each call.
 
         The target message is identified by ``(target_author_uuid,
         target_timestamp_ms)``.  Every inbound Signal message in your
@@ -187,16 +227,19 @@ class SignalConnector(Connector):
             emoji: The reaction emoji.
         """
         assert self._daemon is not None
-        params = _build_react_params(focal, target_author_uuid, target_timestamp_ms, emoji)
+        phone = self._uuid_to_phone.get(account)
+        if phone is None:
+            raise ValueError(f"signal_react: unknown account {account!r}")
+        params = _build_react_params(phone, chat_id, target_author_uuid, target_timestamp_ms, emoji)
         await self._daemon.rpc.call("sendReaction", params)
         return {"status": "ok"}
 
 
-def _build_send_params(chat_id: str, text: str) -> dict[str, Any]:
-    """Translate ``(chat_id, text)`` into signal-cli ``send`` params."""
+def _build_send_params(account_phone: str, chat_id: str, text: str) -> dict[str, Any]:
+    """Translate ``(account_phone, chat_id, text)`` into signal-cli ``send`` params."""
     chat_type, raw_id = decode_chat_id(chat_id)
     stripped, styles = convert_markdown_to_signal_styles(text)
-    params: dict[str, Any] = {"message": stripped}
+    params: dict[str, Any] = {"account": account_phone, "message": stripped}
     if styles:
         params["textStyles"] = styles
     if chat_type == "group":
@@ -207,6 +250,7 @@ def _build_send_params(chat_id: str, text: str) -> dict[str, Any]:
 
 
 def _build_react_params(
+    account_phone: str,
     chat_id: str,
     target_author_uuid: str,
     target_timestamp_ms: int,
@@ -215,6 +259,7 @@ def _build_react_params(
     """Translate a react request into signal-cli ``sendReaction`` params."""
     chat_type, raw_id = decode_chat_id(chat_id)
     params: dict[str, Any] = {
+        "account": account_phone,
         "emoji": emoji,
         "targetAuthor": target_author_uuid,
         "targetTimestamp": target_timestamp_ms,

--- a/connectors/signal/src/aios_signal/daemon.py
+++ b/connectors/signal/src/aios_signal/daemon.py
@@ -36,6 +36,7 @@ class GroupInfo:
     name: str
     member_uuids: list[str]
 
+
 log = structlog.get_logger(__name__)
 
 READY_POLL_ATTEMPTS = 150  # 150 attempts @ 200ms = 30s total
@@ -46,16 +47,25 @@ SHUTDOWN_GRACE_S = 5.0
 
 
 class SignalDaemon:
+    """Manages a single signal-cli daemon serving one or more accounts.
+
+    Multi-account: launched without ``-a`` so signal-cli serves every
+    registered account in ``config_dir/data/accounts.json``.  RPC calls
+    must include ``account`` in their params; receive notifications
+    carry ``params.account`` so callers know which phone the inbound
+    arrived on (see :meth:`RpcListener.messages`).
+    """
+
     def __init__(
         self,
         *,
-        phone: str,
+        phones: list[str],
         config_dir: Path,
         cli_bin: str,
         host: str,
         port: int,
     ) -> None:
-        self.phone = phone
+        self.phones = phones
         self.config_dir = config_dir
         self.cli_bin = cli_bin
         self.host = host
@@ -93,7 +103,7 @@ class SignalDaemon:
             try:
                 await asyncio.wait_for(self._proc.wait(), timeout=SHUTDOWN_GRACE_S)
             except TimeoutError:
-                log.warning("signal.daemon.sigkill", phone=self.phone)
+                log.warning("signal.daemon.sigkill", phones=self.phones)
                 with contextlib.suppress(ProcessLookupError):
                     self._proc.kill()
                 await self._proc.wait()
@@ -105,12 +115,15 @@ class SignalDaemon:
         self._drain_tasks.clear()
 
     async def _spawn(self) -> None:
+        # Multi-account daemon: no ``-a`` flag.  signal-cli will serve
+        # every account registered in ``config_dir/data/accounts.json``;
+        # callers route via ``account`` in RPC params.  Single-phone
+        # setups still benefit from the same shape (one-element phones
+        # list) — uniform code path beats a special case.
         args = [
             self.cli_bin,
             "--config",
             str(self.config_dir),
-            "-a",
-            self.phone,
             "-o",
             "json",
             "--trust-new-identities",
@@ -120,7 +133,7 @@ class SignalDaemon:
             f"{self.host}:{self.port}",
             "--receive-mode=on-connection",
         ]
-        log.info("signal.daemon.spawn", phone=self.phone, host=self.host, port=self.port)
+        log.info("signal.daemon.spawn", phones=self.phones, host=self.host, port=self.port)
         self._proc = await _spawn_subprocess(args)
         assert self._proc.stdout is not None
         assert self._proc.stderr is not None
@@ -151,9 +164,8 @@ class SignalDaemon:
         return self._crash_future
 
     async def _wait_for_tcp(self) -> None:
-        # ``listAccounts`` is rejected when the daemon is started with ``-a``
-        # (account-scoped mode), so probe with ``version`` — always
-        # implemented, side-effect-free.
+        # ``version`` is the universal readiness probe — works in
+        # multi-account daemon mode (no ``-a``) and is side-effect-free.
         last_error: Exception | None = None
         for _ in range(READY_POLL_ATTEMPTS):
             try:
@@ -169,10 +181,20 @@ class SignalDaemon:
             f"signal-cli daemon never became ready on {self.host}:{self.port}: {last_error!r}"
         )
 
-    async def discover_bot_uuid(self) -> str:
-        # Read signal-cli's on-disk account index rather than RPCing —
-        # ``listAccounts`` is the only method that returns this info and it's
-        # unavailable in account-scoped daemon mode.
+    async def discover_bot_uuids(self) -> dict[str, str]:
+        """Return a ``{phone: uuid}`` map for every configured phone.
+
+        Reads signal-cli's on-disk account index rather than RPCing —
+        ``listAccounts`` works in multi-account daemon mode but
+        accounts.json is the same source of truth and avoids a network
+        round-trip during startup.
+
+        Raises :class:`BotAccountNotFoundError` if any configured phone
+        lacks a registered account.  Operators must register every
+        phone in ``self.phones`` (via ``signal-cli -a <phone> register``)
+        before launching the connector — surfacing the missing entry at
+        startup beats discovering it on first inbound.
+        """
         import json as _json
 
         accounts_json = self.config_dir / "data" / "accounts.json"
@@ -188,17 +210,29 @@ class SignalDaemon:
             raise BotAccountNotFoundError(
                 f"malformed signal-cli accounts file at {accounts_json}: {e}"
             ) from e
-        target = self.phone.strip()
+        registered: dict[str, str] = {}
         for entry in data.get("accounts", []):
-            if str(entry.get("number", "")).strip() == target and entry.get("uuid"):
-                uuid: str = entry["uuid"]
-                return uuid
-        raise BotAccountNotFoundError(
-            f"signal-cli has no account for {self.phone} in {accounts_json}. "
-            f"Run `signal-cli -a {self.phone} register` first."
-        )
+            number = str(entry.get("number", "")).strip()
+            uuid = entry.get("uuid")
+            if number and isinstance(uuid, str) and uuid:
+                registered[number] = uuid
+        out: dict[str, str] = {}
+        missing: list[str] = []
+        for phone in self.phones:
+            target = phone.strip()
+            uuid = registered.get(target)
+            if uuid is None:
+                missing.append(target)
+            else:
+                out[target] = uuid
+        if missing:
+            raise BotAccountNotFoundError(
+                f"signal-cli has no account for {missing!r} in {accounts_json}. "
+                f"Run `signal-cli -a <phone> register` for each missing number first."
+            )
+        return out
 
-    async def list_groups(self) -> list[GroupInfo]:
+    async def list_groups(self, *, account: str) -> list[GroupInfo]:
         """Return the bot's group memberships via signal-cli ``listGroups``.
 
         Best-effort: returns an empty list on RPC failure or malformed
@@ -210,9 +244,9 @@ class SignalDaemon:
         complete picture of "who is in this room with me."
         """
         try:
-            result = await self.rpc.call("listGroups", {})
+            result = await self.rpc.call("listGroups", {"account": account})
         except Exception:
-            log.warning("signal.list_groups.failed", exc_info=True)
+            log.warning("signal.list_groups.failed", account=account, exc_info=True)
             return []
         if not isinstance(result, list):
             return []
@@ -245,7 +279,7 @@ class SignalDaemon:
             )
         return out
 
-    async def list_contacts(self) -> dict[str, str]:
+    async def list_contacts(self, *, account: str) -> dict[str, str]:
         """Return a ``{uuid: display_name}`` map from signal-cli's contact store.
 
         signal-cli's inbound ``sourceName`` is sometimes empty (e.g. for peers
@@ -255,9 +289,11 @@ class SignalDaemon:
         Returns an empty dict on RPC failure — name resolution is best-effort.
         """
         try:
-            result = await self.rpc.call("listContacts", {"allRecipients": True})
+            result = await self.rpc.call(
+                "listContacts", {"account": account, "allRecipients": True}
+            )
         except Exception:
-            log.warning("signal.list_contacts.failed", exc_info=True)
+            log.warning("signal.list_contacts.failed", account=account, exc_info=True)
             return {}
         if not isinstance(result, list):
             return {}

--- a/connectors/signal/src/aios_signal/rpc.py
+++ b/connectors/signal/src/aios_signal/rpc.py
@@ -113,8 +113,14 @@ class RpcListener:
                 f"failed to connect listener to {self._host}:{self._port}: {e}"
             ) from e
 
-    async def messages(self) -> AsyncIterator[dict[str, Any]]:
-        """Yield envelope dicts from ``receive`` notifications.
+    async def messages(self) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+        """Yield ``(account, envelope)`` pairs from ``receive`` notifications.
+
+        In multi-account daemon mode, signal-cli stamps ``params.account``
+        on every receive notification so callers can route by phone.  We
+        require it: a notification without ``account`` is a contract
+        violation (single-account daemon mode is no longer supported by
+        this connector) and is dropped with a warning rather than guessed.
 
         Raises :class:`ListenerClosedError` when the connection drops.
         Non-``receive`` notifications and stray RPC responses are ignored.
@@ -141,9 +147,13 @@ class RpcListener:
             params = message.get("params")
             if not isinstance(params, dict):
                 continue
+            account = params.get("account")
             envelope = params.get("envelope")
+            if not isinstance(account, str) or not account:
+                log.warning("rpc.listener.missing_account", params=params)
+                continue
             if isinstance(envelope, dict):
-                yield envelope
+                yield account, envelope
 
     async def aclose(self) -> None:
         if self._writer is not None:

--- a/connectors/signal/tests/test_config.py
+++ b/connectors/signal/tests/test_config.py
@@ -1,0 +1,40 @@
+"""Tests for signal connector's pydantic Settings.
+
+The ``phones`` field accepts CSV from ``AIOS_SIGNAL_PHONES`` env vars
+via ``Annotated[..., NoDecode]`` + ``mode='before'`` validator;
+without these, pydantic-settings v2 tries to JSON-parse the env value
+and crashes the connector at startup with a ``SettingsError``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios_signal.config import Settings
+
+
+def test_csv_env_value_parses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIOS_SIGNAL_PHONES", "+15551234567,+15559876543")
+    monkeypatch.setenv("AIOS_SIGNAL_CONFIG_DIR", "/tmp/aios-signal-test")
+    s = Settings()
+    assert s.phones == ["+15551234567", "+15559876543"]
+
+
+def test_csv_env_handles_whitespace_and_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIOS_SIGNAL_PHONES", " +15551234567 , +15559876543 , ")
+    monkeypatch.setenv("AIOS_SIGNAL_CONFIG_DIR", "/tmp/aios-signal-test")
+    s = Settings()
+    assert s.phones == ["+15551234567", "+15559876543"]
+
+
+def test_single_phone_csv_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIOS_SIGNAL_PHONES", "+15551234567")
+    monkeypatch.setenv("AIOS_SIGNAL_CONFIG_DIR", "/tmp/aios-signal-test")
+    s = Settings()
+    assert s.phones == ["+15551234567"]
+
+
+def test_constructor_kwarg_takes_list_directly() -> None:
+    """Constructor kwargs (used by tests) bypass the CSV-split path."""
+    s = Settings(phones=["+15551234567"], config_dir="/tmp/aios-signal-test")  # type: ignore[arg-type]
+    assert s.phones == ["+15551234567"]

--- a/connectors/signal/tests/test_daemon.py
+++ b/connectors/signal/tests/test_daemon.py
@@ -1,9 +1,13 @@
 """Unit tests for pure helpers in daemon.py.
 
-``discover_bot_uuid`` reads ``accounts.json`` from the config dir
+``discover_bot_uuids`` reads ``accounts.json`` from the config dir
 (signal-cli's on-disk account index) rather than RPC-ing
-``listAccounts`` — the latter is not implemented in account-scoped
-daemon mode, see the Signal smoke test findings.
+``listAccounts`` — both work in multi-account daemon mode but
+accounts.json avoids a startup network round-trip.
+
+Multi-account: returns a ``{phone: uuid}`` map for every configured
+phone; raises if any phone is unregistered (operator must register
+each before launching the connector).
 """
 
 from __future__ import annotations
@@ -23,9 +27,9 @@ def _write_accounts(config_dir: Path, accounts: list[dict[str, Any]]) -> None:
     (config_dir / "data" / "accounts.json").write_text(json.dumps({"accounts": accounts}))
 
 
-def _daemon(phone: str, config_dir: Path) -> SignalDaemon:
+def _daemon(phones: list[str], config_dir: Path) -> SignalDaemon:
     return SignalDaemon(
-        phone=phone,
+        phones=phones,
         config_dir=config_dir,
         cli_bin="signal-cli",
         host="127.0.0.1",
@@ -33,7 +37,7 @@ def _daemon(phone: str, config_dir: Path) -> SignalDaemon:
     )
 
 
-async def test_discover_bot_uuid_match(tmp_path: Path) -> None:
+async def test_discover_bot_uuids_single_phone(tmp_path: Path) -> None:
     _write_accounts(
         tmp_path,
         [
@@ -41,40 +45,64 @@ async def test_discover_bot_uuid_match(tmp_path: Path) -> None:
             {"number": "+15552222222", "uuid": "uuid-b"},
         ],
     )
-    d = _daemon("+15552222222", tmp_path)
-    assert await d.discover_bot_uuid() == "uuid-b"
+    d = _daemon(["+15552222222"], tmp_path)
+    assert await d.discover_bot_uuids() == {"+15552222222": "uuid-b"}
 
 
-async def test_discover_bot_uuid_normalizes_whitespace(tmp_path: Path) -> None:
+async def test_discover_bot_uuids_multiple_phones(tmp_path: Path) -> None:
+    _write_accounts(
+        tmp_path,
+        [
+            {"number": "+15551111111", "uuid": "uuid-a"},
+            {"number": "+15552222222", "uuid": "uuid-b"},
+            {"number": "+15553333333", "uuid": "uuid-c"},
+        ],
+    )
+    d = _daemon(["+15551111111", "+15553333333"], tmp_path)
+    assert await d.discover_bot_uuids() == {
+        "+15551111111": "uuid-a",
+        "+15553333333": "uuid-c",
+    }
+
+
+async def test_discover_bot_uuids_normalizes_whitespace(tmp_path: Path) -> None:
     _write_accounts(tmp_path, [{"number": "  +15551234567 ", "uuid": "abc"}])
-    d = _daemon("+15551234567", tmp_path)
-    assert await d.discover_bot_uuid() == "abc"
+    d = _daemon(["+15551234567"], tmp_path)
+    assert await d.discover_bot_uuids() == {"+15551234567": "abc"}
 
 
-async def test_discover_bot_uuid_no_match_raises(tmp_path: Path) -> None:
+async def test_discover_bot_uuids_missing_phone_raises(tmp_path: Path) -> None:
     _write_accounts(tmp_path, [{"number": "+15551111111", "uuid": "uuid-a"}])
-    d = _daemon("+15559999999", tmp_path)
-    with pytest.raises(BotAccountNotFoundError):
-        await d.discover_bot_uuid()
+    d = _daemon(["+15559999999"], tmp_path)
+    with pytest.raises(BotAccountNotFoundError, match=r"\+15559999999"):
+        await d.discover_bot_uuids()
 
 
-async def test_discover_bot_uuid_empty_list_raises(tmp_path: Path) -> None:
+async def test_discover_bot_uuids_partial_match_raises(tmp_path: Path) -> None:
+    """One missing phone fails the whole call — surfaces all missing at once."""
+    _write_accounts(tmp_path, [{"number": "+15551111111", "uuid": "uuid-a"}])
+    d = _daemon(["+15551111111", "+15559999999"], tmp_path)
+    with pytest.raises(BotAccountNotFoundError, match=r"\+15559999999"):
+        await d.discover_bot_uuids()
+
+
+async def test_discover_bot_uuids_empty_accounts_raises(tmp_path: Path) -> None:
     _write_accounts(tmp_path, [])
-    d = _daemon("+15550000000", tmp_path)
+    d = _daemon(["+15550000000"], tmp_path)
     with pytest.raises(BotAccountNotFoundError):
-        await d.discover_bot_uuid()
+        await d.discover_bot_uuids()
 
 
-async def test_discover_bot_uuid_missing_accounts_file_raises(tmp_path: Path) -> None:
+async def test_discover_bot_uuids_missing_accounts_file_raises(tmp_path: Path) -> None:
     # No accounts.json at all.
-    d = _daemon("+15550000000", tmp_path)
+    d = _daemon(["+15550000000"], tmp_path)
     with pytest.raises(BotAccountNotFoundError):
-        await d.discover_bot_uuid()
+        await d.discover_bot_uuids()
 
 
-async def test_discover_bot_uuid_malformed_accounts_file_raises(tmp_path: Path) -> None:
+async def test_discover_bot_uuids_malformed_accounts_file_raises(tmp_path: Path) -> None:
     (tmp_path / "data").mkdir(parents=True, exist_ok=True)
     (tmp_path / "data" / "accounts.json").write_text("{not valid json")
-    d = _daemon("+15550000000", tmp_path)
+    d = _daemon(["+15550000000"], tmp_path)
     with pytest.raises(BotAccountNotFoundError):
-        await d.discover_bot_uuid()
+        await d.discover_bot_uuids()

--- a/connectors/signal/tests/test_list_groups.py
+++ b/connectors/signal/tests/test_list_groups.py
@@ -14,7 +14,7 @@ def _make_daemon() -> SignalDaemon:
     from pathlib import Path
 
     return SignalDaemon(
-        phone="+15550001111",
+        phones=["+15550001111"],
         config_dir=Path("/tmp/aios-signal-test"),
         cli_bin="signal-cli",
         host="127.0.0.1",
@@ -45,7 +45,7 @@ class TestListGroups:
             ]
         )
 
-        groups = await daemon.list_groups()
+        groups = await daemon.list_groups(account="+15550001111")
 
         assert len(groups) == 2
         assert groups[0] == GroupInfo(
@@ -65,12 +65,12 @@ class TestListGroups:
     async def test_empty_list_when_rpc_fails(self) -> None:
         daemon = _make_daemon()
         daemon.rpc.call = AsyncMock(side_effect=RuntimeError("rpc broken"))  # type: ignore[method-assign]
-        assert await daemon.list_groups() == []
+        assert await daemon.list_groups(account="+15550001111") == []
 
     async def test_empty_list_when_rpc_returns_non_list(self) -> None:
         daemon = _make_daemon()
         daemon.rpc.call = AsyncMock(return_value={"unexpected": "shape"})  # type: ignore[method-assign]
-        assert await daemon.list_groups() == []
+        assert await daemon.list_groups(account="+15550001111") == []
 
     async def test_skips_malformed_entries(self) -> None:
         daemon = _make_daemon()
@@ -83,7 +83,7 @@ class TestListGroups:
                 {"id": "skip-no-members", "name": "no members"},
             ]
         )
-        groups = await daemon.list_groups()
+        groups = await daemon.list_groups(account="+15550001111")
         # Only the valid entry survives.
         assert len(groups) == 1
         assert groups[0].id == "valid="

--- a/connectors/signal/tests/test_rpc.py
+++ b/connectors/signal/tests/test_rpc.py
@@ -80,13 +80,21 @@ async def test_rpc_client_timeout() -> None:
             await client.call("slow")
 
 
-async def test_rpc_listener_yields_receive_envelopes() -> None:
+async def test_rpc_listener_yields_account_envelope_pairs() -> None:
+    """In multi-account daemon mode every receive notification carries
+    ``params.account`` — the listener exposes it alongside the envelope
+    so the connector can route inbound to the right per-phone bot UUID.
+    """
+
     async def handler(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
         for i in range(3):
             notification = {
                 "jsonrpc": "2.0",
                 "method": "receive",
-                "params": {"envelope": {"timestamp": i, "sourceUuid": f"u{i}"}},
+                "params": {
+                    "account": f"+155500000{i:02d}",
+                    "envelope": {"timestamp": i, "sourceUuid": f"u{i}"},
+                },
             }
             w.write(json.dumps(notification).encode() + b"\n")
             await w.drain()
@@ -96,32 +104,44 @@ async def test_rpc_listener_yields_receive_envelopes() -> None:
     async with server:
         listener = RpcListener("127.0.0.1", port)
         await listener.connect()
-        envelopes: list[dict[str, Any]] = []
+        pairs: list[tuple[str, dict[str, Any]]] = []
         with pytest.raises(ListenerClosedError):
-            async for env in _take_then_wait(listener.messages()):
-                envelopes.append(env)
-        assert len(envelopes) == 3
-        assert envelopes[0]["sourceUuid"] == "u0"
+            async for pair in _take_then_wait(listener.messages()):
+                pairs.append(pair)
+        assert len(pairs) == 3
+        assert pairs[0] == ("+15550000000", {"timestamp": 0, "sourceUuid": "u0"})
+        assert pairs[2] == ("+15550000002", {"timestamp": 2, "sourceUuid": "u2"})
         await listener.aclose()
 
 
 async def _take_then_wait(
-    it: AsyncIterator[dict[str, Any]],
-) -> AsyncIterator[dict[str, Any]]:
-    async for env in it:
-        yield env
+    it: AsyncIterator[tuple[str, dict[str, Any]]],
+) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+    async for pair in it:
+        yield pair
 
 
-async def test_rpc_listener_ignores_non_receive() -> None:
+async def test_rpc_listener_drops_notifications_without_account() -> None:
+    """Multi-account contract violation: a receive without ``account`` is
+    a connector-side bug (signal-cli stamps it in multi-account mode).
+    Drop with a warning rather than guessing.
+    """
+
     async def handler(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
-        # Stray RPC response, non-receive notification, then a real receive.
+        # Stray RPC response, non-receive notification, receive WITHOUT
+        # account (must be dropped), and finally a real receive WITH account.
         for msg in [
             {"jsonrpc": "2.0", "id": 99, "result": {"ignored": True}},
             {"jsonrpc": "2.0", "method": "other", "params": {}},
             {
                 "jsonrpc": "2.0",
                 "method": "receive",
-                "params": {"envelope": {"timestamp": 1}},
+                "params": {"envelope": {"timestamp": 1}},  # no account
+            },
+            {
+                "jsonrpc": "2.0",
+                "method": "receive",
+                "params": {"account": "+15550001111", "envelope": {"timestamp": 2}},
             },
         ]:
             w.write(json.dumps(msg).encode() + b"\n")
@@ -132,11 +152,12 @@ async def test_rpc_listener_ignores_non_receive() -> None:
     async with server:
         listener = RpcListener("127.0.0.1", port)
         await listener.connect()
-        envelopes: list[dict[str, Any]] = []
+        pairs: list[tuple[str, dict[str, Any]]] = []
         with pytest.raises(ListenerClosedError):
-            async for env in listener.messages():
-                envelopes.append(env)
-        assert envelopes == [{"timestamp": 1}]
+            async for pair in listener.messages():
+                pairs.append(pair)
+        # Only the well-formed receive survives.
+        assert pairs == [("+15550001111", {"timestamp": 2})]
         await listener.aclose()
 
 

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -46,7 +46,7 @@ process — one bot's PTB `Application` crashing doesn't affect siblings.
 
 `aios worker` boots, spawns one telegram subprocess per instance, and
 each runs `Bot.get_me()` to identify itself.  Verify with
-`aios connector list`.
+`aios connectors list`.
 
 ### 4. Attach connections to sessions
 

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -1,119 +1,80 @@
 # aios-telegram
 
-Telegram connector for [aios](../../README.md). One long-running process per
-Telegram bot — ingests inbound messages into aios via
-`POST /v1/connections/{id}/messages`, and serves an MCP server exposing a
-`telegram_send` tool that the aios worker calls back into.
+Telegram connector for [aios](../../README.md).  Per-account paradigm:
+each Telegram bot token is a distinct platform identity (PTB's
+`Application` is bound 1:1 to a token), so this connector runs as one
+subprocess per bot.  Operators deploy multiple bots by listing
+multiple instances under one connector type at the supervisor.
 
 ## Prerequisites
 
 - Python ≥ 3.13
 - A Telegram bot token (talk to [@BotFather](https://t.me/BotFather))
-- A running aios instance with the connector/channel routing infra
-
-## Install
-
-Pip-installable standalone:
-
-```
-pip install ./connectors/telegram
-```
-
-Or as a uv workspace member (already wired from the repo root):
-
-```
-uv sync --all-packages --dev
-```
+- A running aios worker that includes `telegram` (or
+  `telegram:<instance>`) in its `connectors_enabled` list
 
 ## Operator walkthrough
 
-### 1. Create the bot
+### 1. Create the bot(s)
 
-Message [@BotFather](https://t.me/BotFather) on Telegram: `/newbot`. Copy
-the token. Learn the bot's numeric id by running a throwaway script
-(`curl https://api.telegram.org/bot<TOKEN>/getMe`) — you'll need it for
-the routing rule.
+Message [@BotFather](https://t.me/BotFather) on Telegram: `/newbot`.
+Copy the token.  Repeat for each bot you want to deploy.
 
-### 2. Create an aios vault + credential for the MCP token
+### 2. Configure the worker's connector instance(s)
 
-```
-VLT=$(curl -X POST :8090/v1/vaults -d '{"display_name": "Telegram personal"}' | jq -r .id)
+Single bot — default-instance shape:
 
-curl -X POST :8090/v1/vaults/$VLT/credentials -d '{
-  "mcp_server_url": "http://localhost:9200/mcp",
-  "auth_type": "static_bearer",
-  "token": "supersecret"
-}'
+```bash
+AIOS_CONNECTORS_ENABLED=telegram
+AIOS_TELEGRAM_BOT_TOKEN=123456:AA...
 ```
 
-### 3. Register the aios connection
+Multiple bots — explicit instances with scoped env:
 
-```
-curl -X POST :8090/v1/connections -d "{
-  \"connector\": \"telegram\",
-  \"account\": \"<bot-numeric-id-from-step-1>\",
-  \"mcp_url\": \"http://localhost:9200/mcp\",
-  \"vault_id\": \"$VLT\"
-}"
+```bash
+AIOS_CONNECTORS_ENABLED=telegram:support,telegram:alerts
+AIOS_TELEGRAM_SUPPORT_BOT_TOKEN=111:BB...   # → AIOS_TELEGRAM_BOT_TOKEN inside support
+AIOS_TELEGRAM_ALERTS_BOT_TOKEN=222:CC...    # → AIOS_TELEGRAM_BOT_TOKEN inside alerts
 ```
 
-### 4. Start the connector
+The supervisor re-exports `AIOS_TELEGRAM_<INSTANCE>_*` as
+`AIOS_TELEGRAM_*` inside each subprocess so the connector reads its
+config under the standard prefix.  Each instance runs as its own OS
+process — one bot's PTB `Application` crashing doesn't affect siblings.
+
+### 3. Restart the worker
+
+`aios worker` boots, spawns one telegram subprocess per instance, and
+each runs `Bot.get_me()` to identify itself.  Verify with
+`aios connector list`.
+
+### 4. Attach connections to sessions
+
+For each bot the connector serves, attach the auto-created
+`(connector=telegram, account=<bot_id>)` connection to a session:
 
 ```
-export AIOS_URL=http://localhost:8090
-export AIOS_API_KEY=...
-export AIOS_CONNECTION_ID=conn_...
-export AIOS_TELEGRAM_MCP_TOKEN=supersecret
-
-python -m aios_telegram start --bot-token 123456:AA...
+aios connections list --connector=telegram
+aios connections attach <conn_id> --session=<session_id>
 ```
 
-All settings can also be passed via env vars. Full list via
-`python -m aios_telegram start --help`.
+### 5. DM the bot — the agent replies
 
-### 5. Add a routing rule
-
-```
-curl -X POST :8090/v1/routing-rules -d '{
-  "prefix": "telegram/<bot-numeric-id>",
-  "target": "agent:<agent-id>",
-  "session_params": {"environment_id": "<env-id>"}
-}'
-```
-
-### 6. DM the bot — the agent replies
-
-DM the bot from a Telegram client. Watch the aios event log: the inbound
-message shows up with `metadata.channel` set, a session is created on
-first inbound, and the agent's `telegram_send` call delivers the reply
-back to Telegram.
+Inbound messages on each bot route to its connection's session.  The
+agent's `telegram_send` tool takes only `chat_id` from the focal
+channel meta; aios injects it automatically when the session has a
+focal channel set via `switch_channel`.
 
 ## Configuration reference
 
-| Flag | Env var | Default | Description |
-|---|---|---|---|
-| `--bot-token` | `AIOS_TELEGRAM_BOT_TOKEN` | required | Bot token from BotFather |
-| `--aios-url` | `AIOS_URL` | required | Base URL of aios API |
-| `--aios-api-key` | `AIOS_API_KEY` | required | Bearer token for aios API |
-| `--aios-connection-id` | `AIOS_CONNECTION_ID` | required | ID of the pre-registered connection |
-| `--mcp-bind` | `AIOS_TELEGRAM_MCP_BIND` | `127.0.0.1:9200` | Host:port for MCP server |
-| `--mcp-token` | `AIOS_TELEGRAM_MCP_TOKEN` | required | Token MCP clients must present |
+| Env var | Default | Description |
+|---|---|---|
+| `AIOS_TELEGRAM_BOT_TOKEN` | required | Bot token from BotFather |
 
-## Architecture
-
-`app.run()` wires two tasks under a single `asyncio.TaskGroup`:
-
-1. **PTB `Application`** — python-telegram-bot's asyncio Application drives
-   the update loop (long polling). Discovers the bot's numeric id via
-   `getMe` on startup. Every incoming message is parsed into an
-   `InboundMessage` and posted to aios via
-   `POST /v1/connections/{id}/messages`.
-2. **MCP server** — FastMCP on uvicorn, bearer-auth-gated, exposing
-   `telegram_send`.
-
-**Crash-is-fatal.** Any task failure propagates through the TaskGroup and
-exits the process non-zero. There is no auto-reconnect. Run under systemd
-(`Restart=on-failure`) or Docker (`restart: unless-stopped`).
+When deploying multiple instances, set
+`AIOS_TELEGRAM_<INSTANCE_UPPER>_BOT_TOKEN` for each instance (e.g.
+`AIOS_TELEGRAM_SUPPORT_BOT_TOKEN`).  Instance names match
+`^[a-z][a-z0-9_]*$`.
 
 ## Out of scope for v1
 
@@ -125,24 +86,13 @@ exits the process non-zero. There is no auto-reconnect. Run under systemd
 - Forum topics (`message_thread_id`) — ignored; every message treated as
   top-level in the chat.
 - Webhook mode — polling only.
-- Markdown rendering — plain text only. The agent's `**bold**` will render
-  literally until a v2 adds MarkdownV2 escaping.
-- Message splitting — Telegram's 4096-char limit surfaces as a Bad Request
-  the model must handle by retrying shorter.
-- User allowlist — routing rules gate access server-side.
-- Auto-reconnect on Telegram outage.
-
-## Troubleshooting
-
-- **MCP calls returning 401**: the `--mcp-token` on the connector doesn't
-  match the `token` stored in the aios vault's credential for this
-  connection.
-- **Inbound messages never appear in aios**: check the connector logs for
-  `ingest.client_error` (malformed payload — likely a connector bug) or
-  `ingest.retries_exhausted` (aios was unreachable long enough to exhaust
-  the 1/2/4/8s backoff).
-- **`Unauthorized` from Telegram on startup**: the bot token is wrong or
-  revoked. Re-check with BotFather.
+- Markdown rendering — plain text only.  The agent's `**bold**` will
+  render literally until a v2 adds MarkdownV2 escaping.
+- Message splitting — Telegram's 4096-char limit surfaces as a Bad
+  Request the model must handle by retrying shorter.
+- User allowlist — connection attachments gate access server-side.
+- Auto-reconnect on Telegram outage (the supervisor restarts the whole
+  subprocess on PTB exit).
 
 ## Development
 

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -4,18 +4,28 @@ Replaces the pre-PR3 FastMCP HTTP server + ingest-HTTP-POST architecture
 with a single :class:`aios_connector.Connector` subclass communicating
 with aios over stdio MCP.
 
+Per-account paradigm: each Telegram bot token is a distinct platform
+identity (PTB's :class:`Application` is bound 1:1 to a token), so this
+connector is single-bot by design.  Operators deploy multiple bots by
+listing multiple instances under the same connector type (e.g.
+``connectors_enabled=telegram:support,telegram:alerts`` with
+``AIOS_TELEGRAM_SUPPORT_BOT_TOKEN`` / ``AIOS_TELEGRAM_ALERTS_BOT_TOKEN``).
+The supervisor spawns one subprocess per instance; each runs one PTB
+``Application`` and reports a single account.
+
 Lifecycle:
 
 * :meth:`setup` initializes the python-telegram-bot ``Application`` and
   discovers the bot's identity via ``Bot.get_me()`` (numeric id +
   ``first_name`` + optional ``@username``).
-* :meth:`discover_accounts` returns the bot account.
+* :meth:`discover_accounts` returns the one bot account.
 * :meth:`serve` starts PTB's long-polling loop and routes inbound
   messages to :meth:`emit_inbound`.  PTB runs its own background tasks;
   we just install a handler that funnels into :meth:`emit_inbound`.
 * :meth:`teardown` stops polling and shuts down the application cleanly.
 * The single model-facing tool ``telegram_send`` uses :func:`focal_required`
-  to receive the focal chat id from ``_meta``.
+  with only ``chat_id`` in its signature — the SDK injects nothing else,
+  so connector code stays focused on the per-bot logic.
 """
 
 from __future__ import annotations
@@ -173,7 +183,7 @@ class TelegramConnector(Connector):
 
     @tool()
     @focal_required
-    async def telegram_send(self, text: str, *, focal: str) -> dict[str, Any]:
+    async def telegram_send(self, text: str, *, chat_id: str) -> dict[str, Any]:
         """Send a text message to your focal Telegram chat.
 
         The chat id is taken implicitly from your focal channel — aios
@@ -185,10 +195,10 @@ class TelegramConnector(Connector):
         """
         assert self._application is not None
         try:
-            chat_id = int(focal)
+            chat_id_int = int(chat_id)
         except ValueError as e:
-            raise ValueError(f"telegram chat_id must be an integer; got {focal!r}") from e
-        sent = await self._application.bot.send_message(chat_id=chat_id, text=text)
+            raise ValueError(f"telegram chat_id must be an integer; got {chat_id!r}") from e
+        sent = await self._application.bot.send_message(chat_id=chat_id_int, text=text)
         return {"message_id": sent.message_id}
 
 

--- a/packages/aios-connector/README.md
+++ b/packages/aios-connector/README.md
@@ -8,7 +8,7 @@ supervises.  It exposes:
 - **Inbound notifications** (`notifications/aios/inbound`) carrying user
   messages from the underlying platform into aios sessions.
 - **Account snapshots** (`notifications/aios/accounts`) the operator
-  surfaces in `aios connector list`.
+  surfaces in `aios connectors list`.
 
 ## Quickstart
 

--- a/packages/aios-connector/README.md
+++ b/packages/aios-connector/README.md
@@ -12,6 +12,17 @@ supervises.  It exposes:
 
 ## Quickstart
 
+A connector subprocess can serve one account or many — pick whichever
+shape matches your platform.  The SDK introspects each tool method's
+signature and injects only what's declared.
+
+### Single-account connector (one bot per process)
+
+Use this shape for platforms where each account is a distinct process
+identity (Telegram bots, Discord bots).  Operators deploy multiple
+accounts by listing multiple instances under one connector type
+(see "Multi-instance deployment" below).
+
 ```python
 from typing import Any
 
@@ -20,32 +31,53 @@ from aios_connector import Connector, focal_required, make_account, tool
 
 class MyConnector(Connector):
     name = "my_connector"
-    instructions = "Brief platform-specific guidance for the model."
-
-    async def setup(self) -> None:
-        # Open daemon connections, load credentials, etc.
-        ...
 
     async def discover_accounts(self) -> list[dict[str, Any]]:
-        return [make_account(id="acct-1", display_name="My Account")]
+        return [make_account(id="acct-1", display_name="My Bot")]
 
     @tool()
     @focal_required
-    async def my_send(self, text: str, *, focal: str) -> dict[str, Any]:
-        """Send `text` to the focal chat.
-
-        `focal` is the chat-id; aios injects it from
-        `_meta.aios.focal_channel_path` at dispatch time.
-        """
-        ...
-
-    async def teardown(self) -> None:
-        # Close daemon connections.
+    async def my_send(self, text: str, *, chat_id: str) -> dict[str, Any]:
+        """Send `text` to the focal chat.  `chat_id` is injected from
+        `_meta.aios.focal_channel_path`."""
         ...
 ```
 
-Register the connector via the `aios.connectors` entry-point group in
-your package's `pyproject.toml`:
+### Multi-account connector (one process serves N accounts)
+
+Use this shape for platforms whose daemon natively dispatches by
+account (signal-cli, Matrix homeserver bridges).  `discover_accounts`
+returns N entries; tool methods that target a specific chat declare
+`account` in their signature so the SDK passes both account and chat
+parts of the focal-channel path.
+
+```python
+class MyMultiConnector(Connector):
+    name = "my_multi"
+
+    async def discover_accounts(self) -> list[dict[str, Any]]:
+        return [
+            make_account(id="acct-1", display_name="Account One"),
+            make_account(id="acct-2", display_name="Account Two"),
+        ]
+
+    @tool()
+    @focal_required
+    async def my_send(self, text: str, *, account: str, chat_id: str) -> dict[str, Any]:
+        """Both `account` and `chat_id` are injected from
+        `_meta.aios.focal_channel_path` (split on the first `/`)."""
+        ...
+
+    @tool()
+    async def list_chats(self, account: str) -> list[dict[str, Any]]:
+        """Non-focal tools that take `account` keep it as a model-visible
+        argument — the model passes it explicitly per design §3.4."""
+        ...
+```
+
+### Entry-point registration
+
+Both shapes register via the `aios.connectors` entry-point group:
 
 ```toml
 [project.entry-points."aios.connectors"]
@@ -54,7 +86,33 @@ my_connector = "my_package.factory:make_spec"
 
 `make_spec(name, settings)` returns an
 `aios.mcp.stdio_transport.ConnectorSpec` describing the launch command.
-See `packages/aios-echo` for the canonical example.
+The factory stays instance-naive — the supervisor applies per-instance
+cwd + env scoping after the spec returns.  See `packages/aios-echo` for
+the canonical example.
+
+## Multi-instance deployment
+
+Operators run multiple instances of one connector type by listing them
+in `connectors_enabled` with a `<connector>:<instance>` syntax:
+
+```bash
+AIOS_CONNECTORS_ENABLED=telegram:support,telegram:alerts,signal:main
+AIOS_TELEGRAM_SUPPORT_BOT_TOKEN=xxx     # → AIOS_TELEGRAM_BOT_TOKEN inside support
+AIOS_TELEGRAM_ALERTS_BOT_TOKEN=yyy      # → AIOS_TELEGRAM_BOT_TOKEN inside alerts
+AIOS_SIGNAL_MAIN_PHONES=+1555,+1666     # → AIOS_SIGNAL_PHONES inside main
+AIOS_SIGNAL_MAIN_CONFIG_DIR=/var/aios/signal
+```
+
+The supervisor re-exports `AIOS_<CONNECTOR>_<INSTANCE>_*` env vars as
+`AIOS_<CONNECTOR>_*` inside each subprocess so connector code reads
+its config under the standard prefix and stays instance-naive.  When
+`<instance>` is omitted (e.g. `connectors_enabled=telegram`), the
+default-instance shape applies: instance defaults to the connector
+name, env vars are inherited unscoped, and cwd is the single-segment
+`<connectors_dir>/<connector>/`.
+
+Instance names match `^[a-z][a-z0-9_]*$` so the env-var re-export
+stays POSIX-valid.
 
 ## Durability
 

--- a/packages/aios-connector/aios_connector/base.py
+++ b/packages/aios-connector/aios_connector/base.py
@@ -73,6 +73,14 @@ class ToolDescriptor:
     ``__init__``.  ``input_schema`` is the JSON Schema published in the
     ``tools/list`` response; the SDK builds it from the function's
     type hints (Python types → JSON Schema primitives).
+
+    ``focal_kwargs`` records which subset of ``{"account", "chat_id"}``
+    the tool method declared in its signature.  At dispatch time the SDK
+    splits the focal-channel path on the first ``/`` and injects only
+    those kwargs the method asked for — connectors that serve a single
+    account omit ``account`` from their signature and pay no
+    multi-account routing cost.  The frozenset is computed once at
+    registration so dispatch doesn't re-introspect on every call.
     """
 
     name: str
@@ -80,9 +88,15 @@ class ToolDescriptor:
     input_schema: dict[str, Any]
     fn: ToolFn
     focal_required: bool = False
+    focal_kwargs: frozenset[str] = frozenset()
 
 
 _TOOL_ATTR = "__aios_connector_tool__"
+
+# Kwargs the SDK injects from the focal-channel path on
+# ``@focal_required`` tools.  Tool methods opt in by listing them in
+# their signature; the SDK passes only the ones present.
+_FOCAL_INJECTED_KWARGS = frozenset({"account", "chat_id"})
 
 
 def tool(
@@ -97,12 +111,19 @@ def tool(
     the description; its parameter type hints become the JSON Schema
     properties.  Self isn't included in the schema.
 
-    Stack with :func:`focal_required` to inject the chat-id parsed
-    from ``_meta.aios.focal_channel_path``::
+    Stack with :func:`focal_required` to receive the focal-channel
+    parts as kwargs.  Declare whichever subset of ``account`` and
+    ``chat_id`` your tool needs::
 
-        @tool
+        # Multi-account connector — route by account
+        @tool()
         @focal_required
-        async def signal_send(self, text: str, *, focal: str) -> dict[str, Any]: ...
+        async def signal_send(self, text: str, *, account: str, chat_id: str): ...
+
+        # Single-account connector — chat is enough
+        @tool()
+        @focal_required
+        async def telegram_send(self, text: str, *, chat_id: str): ...
     """
 
     def decorate(fn: ToolFn) -> ToolFn:
@@ -113,13 +134,23 @@ def tool(
                 f"@tool {tool_name!r} needs a docstring or explicit description= "
                 "(MCP exposes the description to the model)"
             )
-        schema = _build_input_schema(fn)
+        is_focal = bool(getattr(fn, "__aios_focal_required__", False))
+        focal_kwargs = _detect_focal_kwargs(fn) if is_focal else frozenset()
+        if is_focal and not focal_kwargs:
+            raise ValueError(
+                f"@focal_required tool {tool_name!r} must declare at least one of "
+                f"{{account, chat_id}} as a kwarg — the SDK injects what's "
+                "present in the signature, and a tool that wants neither "
+                "shouldn't be focal-required"
+            )
+        schema = _build_input_schema(fn, focal_required=is_focal)
         descriptor = ToolDescriptor(
             name=tool_name,
             description=description or doc,
             input_schema=schema,
             fn=fn,
-            focal_required=getattr(fn, "__aios_focal_required__", False),
+            focal_required=is_focal,
+            focal_kwargs=focal_kwargs,
         )
         setattr(fn, _TOOL_ATTR, descriptor)
         return fn
@@ -130,10 +161,13 @@ def tool(
 def focal_required(fn: ToolFn) -> ToolFn:
     """Decorator marking a tool as requiring a focal channel.
 
-    The MCP request's ``_meta.aios.focal_channel_path`` is parsed and
-    passed as the ``focal`` keyword argument (a string — the chat-id /
-    suffix the harness stamps).  Calls without focal raise so the
-    model sees a tool error rather than a silent fallback.
+    The harness's ``_meta.aios.focal_channel_path`` carries the
+    connector-relative focal address (``<account>/<chat_id>`` or
+    ``<account>/<chat_id>/<thread>`` for nested forms).  The SDK splits
+    on the first ``/`` and injects ``account`` and/or ``chat_id`` based
+    on which the tool method declares in its signature.  Calls without
+    focal raise so the model sees a tool error rather than a silent
+    fallback.
 
     Apply BELOW :func:`tool` so the descriptor's ``focal_required``
     flag is set before the tool registration reads it.
@@ -142,7 +176,27 @@ def focal_required(fn: ToolFn) -> ToolFn:
     return fn
 
 
-def _build_input_schema(fn: ToolFn) -> dict[str, Any]:
+def _detect_focal_kwargs(fn: ToolFn) -> frozenset[str]:
+    """Return the subset of :data:`_FOCAL_INJECTED_KWARGS` ``fn`` declares.
+
+    Looks at named parameters (positional-or-keyword, keyword-only).
+    ``**kwargs`` catches don't count — the SDK injects only what the
+    signature explicitly names so connector authors who type-check their
+    tools see missing parameters at static-analysis time.
+    """
+    import inspect
+
+    sig = inspect.signature(fn)
+    found: set[str] = set()
+    for param_name, param in sig.parameters.items():
+        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            continue
+        if param_name in _FOCAL_INJECTED_KWARGS:
+            found.add(param_name)
+    return frozenset(found)
+
+
+def _build_input_schema(fn: ToolFn, *, focal_required: bool) -> dict[str, Any]:
     """Generate a JSON Schema for ``fn``'s non-self parameters.
 
     Walks the resolved type hints (so ``from __future__ import
@@ -150,8 +204,11 @@ def _build_input_schema(fn: ToolFn) -> dict[str, Any]:
     primitives to the JSON Schema equivalents.  Optional parameters
     (defaulting to anything) are non-required; the rest are required.
 
-    ``focal`` is a SDK-injected kwarg — not a model-visible argument —
-    so it's excluded from the schema regardless of typing.
+    When ``focal_required=True``, ``account`` and ``chat_id`` are
+    SDK-injected from the focal-channel meta and are excluded from the
+    model-facing schema.  Non-focal tools that take ``account`` (e.g.
+    ``list_chats(account: str)`` per design §3.4) keep it as a
+    model-visible argument.
     """
     import inspect
 
@@ -165,7 +222,9 @@ def _build_input_schema(fn: ToolFn) -> dict[str, Any]:
     properties: dict[str, dict[str, Any]] = {}
     required: list[str] = []
     for param_name, param in sig.parameters.items():
-        if param_name == "self" or param_name == "focal":
+        if param_name == "self":
+            continue
+        if focal_required and param_name in _FOCAL_INJECTED_KWARGS:
             continue
         if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
             continue
@@ -494,10 +553,14 @@ class Connector:
     ) -> list[TextContent]:
         """Dispatch a tool, parsing focal meta if the descriptor opted in.
 
-        :func:`focal_required` tools fail loudly when the meta key is
-        missing — the agent shouldn't reach a focal-required tool
-        without focal set, so any absence is a bug to surface, not a
-        condition to fall back on.
+        For ``@focal_required`` tools: split the focal path on the first
+        ``/`` (yielding ``account`` and the chat-id portion, which may
+        itself contain further ``/``-separated thread/sub-chat segments)
+        and inject only the kwargs the tool method's signature declared
+        (per ``descriptor.focal_kwargs``).  Tools fail loudly when the
+        meta key is missing — the agent shouldn't reach a focal-required
+        tool without focal set, so any absence is a bug to surface, not
+        a condition to fall back on.
         """
         kwargs = dict(arguments)
         if descriptor.focal_required:
@@ -507,7 +570,11 @@ class Connector:
                     f"tool {descriptor.name!r} requires a focal channel — "
                     "aios should inject _meta.aios.focal_channel_path"
                 )
-            kwargs["focal"] = focal
+            account, _, chat_id = focal.partition("/")
+            if "account" in descriptor.focal_kwargs:
+                kwargs["account"] = account
+            if "chat_id" in descriptor.focal_kwargs:
+                kwargs["chat_id"] = chat_id
 
         result = await descriptor.fn(self, **kwargs)
         if isinstance(result, list) and all(isinstance(x, TextContent) for x in result):

--- a/packages/aios-connector/aios_connector/base.py
+++ b/packages/aios-connector/aios_connector/base.py
@@ -59,7 +59,11 @@ _INBOUND_METHOD = f"{_AIOS_NOTIFICATION_PREFIX}inbound"
 
 # MCP ``_meta`` key the harness stamps for outbound tool calls when
 # the calling session has a focal channel set.  Value is the channel
-# address with its ``<connector>/<account>`` prefix stripped.
+# address with only its leading ``<connector>/`` segment stripped, so
+# the connector receives ``<account>/<chat_id>`` (or
+# ``<account>/<chat_id>/<thread>`` for nested forms).  The base class
+# splits on the first ``/`` to expose ``account`` and ``chat_id`` to
+# focal-required tool methods.
 _FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
 ToolFn = Callable[..., Awaitable[Any]]

--- a/packages/aios-connector/aios_connector/base.py
+++ b/packages/aios-connector/aios_connector/base.py
@@ -589,7 +589,7 @@ class Connector:
             ctx = request_ctx.get()
         except LookupError:
             return None
-        meta: RequestParams.Meta | None = getattr(ctx.request, "meta", None) if ctx else None
+        meta: RequestParams.Meta | None = ctx.meta if ctx else None
         if meta is None:
             return None
         extra = getattr(meta, "model_extra", None) or {}

--- a/packages/aios-connector/aios_connector/base.py
+++ b/packages/aios-connector/aios_connector/base.py
@@ -25,6 +25,7 @@ The class wires three bits the lowlevel MCP SDK leaves to integrators:
 
 from __future__ import annotations
 
+import inspect
 import json
 import time
 from collections.abc import Awaitable, Callable
@@ -179,21 +180,10 @@ def focal_required(fn: ToolFn) -> ToolFn:
 def _detect_focal_kwargs(fn: ToolFn) -> frozenset[str]:
     """Return the subset of :data:`_FOCAL_INJECTED_KWARGS` ``fn`` declares.
 
-    Looks at named parameters (positional-or-keyword, keyword-only).
-    ``**kwargs`` catches don't count — the SDK injects only what the
-    signature explicitly names so connector authors who type-check their
-    tools see missing parameters at static-analysis time.
+    `account` and `chat_id` can't appear as ``**kwargs`` catches — the
+    intersection naturally only matches named parameters.
     """
-    import inspect
-
-    sig = inspect.signature(fn)
-    found: set[str] = set()
-    for param_name, param in sig.parameters.items():
-        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
-            continue
-        if param_name in _FOCAL_INJECTED_KWARGS:
-            found.add(param_name)
-    return frozenset(found)
+    return frozenset(inspect.signature(fn).parameters) & _FOCAL_INJECTED_KWARGS
 
 
 def _build_input_schema(fn: ToolFn, *, focal_required: bool) -> dict[str, Any]:
@@ -210,8 +200,6 @@ def _build_input_schema(fn: ToolFn, *, focal_required: bool) -> dict[str, Any]:
     ``list_chats(account: str)`` per design §3.4) keep it as a
     model-visible argument.
     """
-    import inspect
-
     sig = inspect.signature(fn)
     # Fail loudly here: an unresolvable hint at decoration time means
     # the connector author has a forward-reference / circular-import

--- a/packages/aios-connector/tests/test_decorators.py
+++ b/packages/aios-connector/tests/test_decorators.py
@@ -1,13 +1,14 @@
 """@tool / @focal_required decorator tests.
 
 These exercise the static surface — schema generation, descriptor
-attachment, focal flag — without spinning up an MCP server.
-End-to-end dispatch is covered by the e2e suite via the echo
-connector.
+attachment, focal flag, signature-inspection-driven focal kwargs —
+without spinning up an MCP server.  End-to-end dispatch is covered
+by the e2e suite via the echo connector.
 """
 
 from __future__ import annotations
 
+import pytest
 from aios_connector import Connector, focal_required, make_account, tool
 from aios_connector.base import _TOOL_ATTR, ToolDescriptor
 
@@ -27,9 +28,26 @@ class _FixtureConnector(Connector):
 
     @tool()
     @focal_required
-    async def needs_focal(self, *, focal: str) -> dict[str, str]:
-        """Tool requiring focal channel injection."""
-        return {"focal": focal}
+    async def single_account_focal(self, *, chat_id: str) -> dict[str, str]:
+        """Single-account focal tool — chat_id only, no account kwarg."""
+        return {"chat_id": chat_id}
+
+    @tool()
+    @focal_required
+    async def multi_account_focal(self, *, account: str, chat_id: str) -> dict[str, str]:
+        """Multi-account focal tool — both account and chat_id injected."""
+        return {"account": account, "chat_id": chat_id}
+
+    @tool()
+    @focal_required
+    async def account_only_focal(self, *, account: str) -> dict[str, str]:
+        """Focal tool taking only account (uncommon but supported)."""
+        return {"account": account}
+
+    @tool()
+    async def explicit_account_arg(self, account: str) -> dict[str, str]:
+        """Non-focal tool with model-visible account arg (per design §3.4)."""
+        return {"account": account}
 
     @tool(name="renamed")
     async def actually_called_renamed(self) -> dict[str, str]:
@@ -58,17 +76,43 @@ def test_with_args_schema_required_and_optional() -> None:
     assert descriptor.input_schema["required"] == ["text"]
 
 
-def test_focal_required_flag() -> None:
-    descriptor = _descriptor(_FixtureConnector.needs_focal)
+def test_single_account_focal_kwargs() -> None:
+    descriptor = _descriptor(_FixtureConnector.single_account_focal)
     assert descriptor.focal_required is True
-    # The injected focal kwarg must NOT appear in the published schema —
-    # only model-supplied args do.
-    assert "focal" not in descriptor.input_schema["properties"]
+    assert descriptor.focal_kwargs == frozenset({"chat_id"})
+    # Both injected kwargs are excluded from the schema since focal_required.
+    assert "chat_id" not in descriptor.input_schema["properties"]
+    assert "account" not in descriptor.input_schema["properties"]
+
+
+def test_multi_account_focal_kwargs() -> None:
+    descriptor = _descriptor(_FixtureConnector.multi_account_focal)
+    assert descriptor.focal_required is True
+    assert descriptor.focal_kwargs == frozenset({"account", "chat_id"})
+    assert descriptor.input_schema["properties"] == {}
+
+
+def test_account_only_focal_kwargs() -> None:
+    descriptor = _descriptor(_FixtureConnector.account_only_focal)
+    assert descriptor.focal_required is True
+    assert descriptor.focal_kwargs == frozenset({"account"})
+
+
+def test_non_focal_account_arg_stays_in_schema() -> None:
+    """Per design §3.4: non-focal tools like list_chats(account: str) keep
+    account as a model-visible argument."""
+    descriptor = _descriptor(_FixtureConnector.explicit_account_arg)
+    assert descriptor.focal_required is False
+    assert descriptor.focal_kwargs == frozenset()
+    properties = descriptor.input_schema["properties"]
+    assert properties["account"] == {"type": "string"}
+    assert descriptor.input_schema["required"] == ["account"]
 
 
 def test_non_focal_tool_has_focal_required_false() -> None:
     descriptor = _descriptor(_FixtureConnector.no_args)
     assert descriptor.focal_required is False
+    assert descriptor.focal_kwargs == frozenset()
 
 
 def test_explicit_name_overrides_method_name() -> None:
@@ -76,12 +120,40 @@ def test_explicit_name_overrides_method_name() -> None:
     assert descriptor.name == "renamed"
 
 
+def test_focal_required_without_injectable_kwarg_raises() -> None:
+    """A @focal_required tool with neither account nor chat_id is a bug.
+
+    The SDK injects only what's in the signature; a tool that wants
+    neither shouldn't be focal-required (use @tool() alone instead).
+    """
+    with pytest.raises(ValueError, match="must declare at least one of"):
+
+        class _BadConnector(Connector):  # pyright: ignore[reportUnusedClass]
+            name = "_bad"
+
+            @tool()
+            @focal_required
+            async def empty_focal(self, text: str) -> dict[str, str]:
+                """Mistakenly focal-required without injectable kwarg."""
+                return {"text": text}
+
+
 def test_collect_tools_picks_up_all_decorated(tmp_path: object) -> None:
     from pathlib import Path
 
     connector = _FixtureConnector(spool_dir=Path(str(tmp_path)))
     names = sorted(t.name for t in connector._tools)
-    assert names == sorted(["no_args", "with_args", "needs_focal", "renamed"])
+    assert names == sorted(
+        [
+            "no_args",
+            "with_args",
+            "single_account_focal",
+            "multi_account_focal",
+            "account_only_focal",
+            "explicit_account_arg",
+            "renamed",
+        ]
+    )
 
 
 def test_make_account_minimal() -> None:

--- a/packages/aios-connector/tests/test_invoke_tool.py
+++ b/packages/aios-connector/tests/test_invoke_tool.py
@@ -1,0 +1,114 @@
+"""Dispatch-side tests for ``Connector._invoke_tool`` focal injection.
+
+Exercises the signature-inspection branch end-to-end without a live MCP
+server: stub out ``_focal_from_request_meta`` to return a known path,
+invoke ``_invoke_tool`` directly, and assert the right kwargs reach the
+tool method.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from aios_connector import Connector, focal_required, tool
+from aios_connector.base import _TOOL_ATTR, ToolDescriptor
+
+
+class _DispatchFixture(Connector):
+    name = "_dispatch_fixture"
+
+    @tool()
+    @focal_required
+    async def chat_only(self, *, chat_id: str) -> dict[str, str]:
+        """Single-account: chat_id only."""
+        return {"chat_id": chat_id}
+
+    @tool()
+    @focal_required
+    async def both(self, *, account: str, chat_id: str) -> dict[str, str]:
+        """Multi-account: both injected."""
+        return {"account": account, "chat_id": chat_id}
+
+    @tool()
+    @focal_required
+    async def account_only(self, *, account: str) -> dict[str, str]:
+        """Account only: chat_id ignored."""
+        return {"account": account}
+
+    @tool()
+    async def non_focal(self, text: str) -> dict[str, str]:
+        """No focal injection."""
+        return {"text": text}
+
+
+def _descriptor_for(fn: object) -> ToolDescriptor:
+    descriptor = getattr(fn, _TOOL_ATTR, None)
+    assert isinstance(descriptor, ToolDescriptor)
+    return descriptor
+
+
+def _decode(content_list: list[Any]) -> dict[str, Any]:
+    """Pull the JSON-encoded result back out of the TextContent envelope."""
+    assert len(content_list) == 1
+    payload = json.loads(content_list[0].text)
+    assert isinstance(payload, dict)
+    return payload
+
+
+@pytest.fixture
+def fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> _DispatchFixture:
+    connector = _DispatchFixture(spool_dir=tmp_path)
+    return connector
+
+
+def _stub_focal(connector: _DispatchFixture, value: str | None) -> None:
+    """Replace ``_focal_from_request_meta`` to return ``value`` verbatim."""
+    connector._focal_from_request_meta = lambda: value  # type: ignore[method-assign]
+
+
+async def test_chat_only_receives_chat_id(fixture: _DispatchFixture) -> None:
+    _stub_focal(fixture, "echo-1/chat-42")
+    descriptor = _descriptor_for(_DispatchFixture.chat_only)
+    result = _decode(await fixture._invoke_tool(descriptor, {}))
+    # Account part is silently dropped because the method didn't ask for it.
+    assert result == {"chat_id": "chat-42"}
+
+
+async def test_both_receives_account_and_chat(fixture: _DispatchFixture) -> None:
+    _stub_focal(fixture, "echo-1/chat-42")
+    descriptor = _descriptor_for(_DispatchFixture.both)
+    result = _decode(await fixture._invoke_tool(descriptor, {}))
+    assert result == {"account": "echo-1", "chat_id": "chat-42"}
+
+
+async def test_account_only_drops_chat(fixture: _DispatchFixture) -> None:
+    _stub_focal(fixture, "echo-1/chat-42")
+    descriptor = _descriptor_for(_DispatchFixture.account_only)
+    result = _decode(await fixture._invoke_tool(descriptor, {}))
+    assert result == {"account": "echo-1"}
+
+
+async def test_nested_chat_path_kept_intact(fixture: _DispatchFixture) -> None:
+    """Telegram forum-thread style: chat_id contains a slash."""
+    _stub_focal(fixture, "bot-12/group-7/thread-3")
+    descriptor = _descriptor_for(_DispatchFixture.both)
+    result = _decode(await fixture._invoke_tool(descriptor, {}))
+    assert result == {"account": "bot-12", "chat_id": "group-7/thread-3"}
+
+
+async def test_focal_required_without_meta_raises(fixture: _DispatchFixture) -> None:
+    _stub_focal(fixture, None)
+    descriptor = _descriptor_for(_DispatchFixture.both)
+    with pytest.raises(ValueError, match="requires a focal channel"):
+        await fixture._invoke_tool(descriptor, {})
+
+
+async def test_non_focal_tool_ignores_meta(fixture: _DispatchFixture) -> None:
+    """A tool without @focal_required gets no focal kwargs even if meta is set."""
+    _stub_focal(fixture, "echo-1/chat-42")  # would inject if focal-required
+    descriptor = _descriptor_for(_DispatchFixture.non_focal)
+    result = _decode(await fixture._invoke_tool(descriptor, {"text": "hi"}))
+    assert result == {"text": "hi"}

--- a/packages/aios-echo/aios_echo/connector.py
+++ b/packages/aios-echo/aios_echo/connector.py
@@ -1,9 +1,9 @@
 """Echo connector class.
 
 Subclasses :class:`aios_connector.Connector` to demonstrate the SDK's
-shape: account snapshot, two model-facing tools, and one tool that
-synthesizes an inbound message so tests can exercise
-spool→append→ack without a real platform daemon.
+shape: multi-account snapshot, model-facing tools that route by
+account, and one tool that synthesizes an inbound message so tests can
+exercise spool→append→ack without a real platform daemon.
 """
 
 from __future__ import annotations
@@ -16,10 +16,19 @@ from aios_connector import Connector, focal_required, make_account, tool
 class EchoConnector(Connector):
     name = "echo"
     version = "0.1.0"
-    instructions = "Echo connector. Use `ping` to verify wiring; `echo` to round-trip text."
+    instructions = (
+        "Echo connector. Use `ping` to verify wiring; `echo` to round-trip text "
+        "(routes by account); `trigger_inbound` to synthesize an inbound message."
+    )
 
     async def discover_accounts(self) -> list[dict[str, Any]]:
-        return [make_account(id="echo-1", display_name="Echo Account One")]
+        # Two accounts so the multi-account focal-injection path is exercised
+        # by default — single-account topology is the degenerate case (still
+        # supported via SingleAccount-style tool sigs without the account kwarg).
+        return [
+            make_account(id="echo-1", display_name="Echo Account One"),
+            make_account(id="echo-2", display_name="Echo Account Two"),
+        ]
 
     @tool()
     async def ping(self) -> dict[str, Any]:
@@ -28,14 +37,14 @@ class EchoConnector(Connector):
 
     @tool()
     @focal_required
-    async def echo(self, text: str, *, focal: str) -> dict[str, Any]:
-        """Echo ``text`` back to the caller, tagged with the focal chat id.
+    async def echo(self, text: str, *, account: str, chat_id: str) -> dict[str, Any]:
+        """Echo ``text`` back to the caller, tagged with the focal chat id and account.
 
-        Demonstrates :func:`focal_required` — the connector author writes the
-        method as if ``focal`` is a normal kwarg, and the SDK lifts it from
-        ``_meta.aios.focal_channel_path`` at dispatch time.
+        Demonstrates the multi-account focal-injection path: the SDK lifts
+        ``account`` and ``chat_id`` from ``_meta.aios.focal_channel_path`` at
+        dispatch time and the connector routes by account internally.
         """
-        return {"text": text, "focal": focal}
+        return {"text": text, "account": account, "chat_id": chat_id}
 
     @tool()
     async def trigger_inbound(

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -81,6 +81,7 @@ _CODE_TO_STATUS: dict[str, int] = {
     "circuit_open": status.HTTP_503_SERVICE_UNAVAILABLE,
     "transport_error": status.HTTP_503_SERVICE_UNAVAILABLE,
     "tool_error": status.HTTP_502_BAD_GATEWAY,
+    "ambiguous_instance": status.HTTP_409_CONFLICT,
 }
 
 

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -105,24 +105,62 @@ def _raise_for_error(envelope: dict[str, Any]) -> None:
 
 @router.get("")
 async def list_(db_url: DbUrlDep, _auth: AuthDep) -> dict[str, Any]:
-    return await _rpc(db_url, lambda cid: defer_connector_status(call_id=cid, name=None))
+    """Snapshot every enabled connector instance."""
+    return await _rpc(
+        db_url, lambda cid: defer_connector_status(call_id=cid, connector=None, instance=None)
+    )
 
 
-@router.get("/{name}/accounts")
-async def list_accounts(name: str, db_url: DbUrlDep, _auth: AuthDep) -> dict[str, Any]:
-    envelope = await _rpc(db_url, lambda cid: defer_connector_status(call_id=cid, name=name))
-    connector = envelope["connector"]
-    return {"name": connector["name"], "accounts": connector["accounts"]}
+@router.get("/{connector}")
+async def list_for_connector(connector: str, db_url: DbUrlDep, _auth: AuthDep) -> dict[str, Any]:
+    """Snapshot every instance of one connector type."""
+    return await _rpc(
+        db_url,
+        lambda cid: defer_connector_status(call_id=cid, connector=connector, instance=None),
+    )
 
 
-@router.get("/{name}/tools")
-async def list_tools(name: str, db_url: DbUrlDep, _auth: AuthDep) -> dict[str, Any]:
-    return await _rpc(db_url, lambda cid: defer_connector_tools(call_id=cid, name=name))
+@router.get("/{connector}/{instance}")
+async def get_instance(
+    connector: str, instance: str, db_url: DbUrlDep, _auth: AuthDep
+) -> dict[str, Any]:
+    """Snapshot a single ``(connector, instance)`` pair."""
+    return await _rpc(
+        db_url,
+        lambda cid: defer_connector_status(call_id=cid, connector=connector, instance=instance),
+    )
 
 
-@router.post("/{name}/call")
+@router.get("/{connector}/{instance}/accounts")
+async def list_accounts(
+    connector: str, instance: str, db_url: DbUrlDep, _auth: AuthDep
+) -> dict[str, Any]:
+    envelope = await _rpc(
+        db_url,
+        lambda cid: defer_connector_status(call_id=cid, connector=connector, instance=instance),
+    )
+    snapshot = envelope["connector"]
+    return {
+        "connector": snapshot["connector"],
+        "instance": snapshot["instance"],
+        "accounts": snapshot["accounts"],
+    }
+
+
+@router.get("/{connector}/{instance}/tools")
+async def list_tools(
+    connector: str, instance: str, db_url: DbUrlDep, _auth: AuthDep
+) -> dict[str, Any]:
+    return await _rpc(
+        db_url,
+        lambda cid: defer_connector_tools(call_id=cid, connector=connector, instance=instance),
+    )
+
+
+@router.post("/{connector}/{instance}/call")
 async def call(
-    name: str,
+    connector: str,
+    instance: str,
     body: ConnectorCallBody,
     db_url: DbUrlDep,
     _auth: AuthDep,
@@ -131,7 +169,8 @@ async def call(
         db_url,
         lambda cid: defer_connector_call(
             call_id=cid,
-            name=name,
+            connector=connector,
+            instance=instance,
             tool=body.tool,
             arguments=body.arguments,
             meta=body.meta,

--- a/src/aios/cli/commands/connectors.py
+++ b/src/aios/cli/commands/connectors.py
@@ -7,17 +7,16 @@ subcommand expects a JSON payload of shape ``{"tool": str,
 "arguments": dict, "meta": dict | null}``.
 
 Multi-instance: most commands take ``<connector> [<instance>]``
-positional args.  When the operator omits ``<instance>`` and the
-connector type has exactly one configured instance, that instance is
-used; if multiple are configured the CLI errors out with a list and
-the operator must specify.  This sugar lives in the CLI only — the
-API + procrastinate task layer always require explicit pairs.
+positional args.  When the operator omits ``<instance>``, the CLI
+passes the ``_`` sentinel to the API; the worker auto-resolves it to
+the sole enabled instance, or returns 409 with the list if multiple
+are configured.  One round-trip either way.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated
 
 import typer
 
@@ -32,31 +31,10 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
-
-def _resolve_instance(ctx: typer.Context, connector: str, instance: str | None) -> str:
-    """Auto-resolve instance when only one of this connector type is configured.
-
-    Lists the connector's instances via ``GET /v1/connectors/<connector>``.
-    If exactly one, return its instance name.  If multiple, raise typer
-    Exit with a list so the operator picks explicitly.  If none, the
-    enclosing API call will surface the not-enabled error itself.
-    """
-    if instance is not None:
-        return instance
-    client = just_client(ctx)
-    with client:
-        obj = client.request("GET", f"/v1/connectors/{connector}")
-    instances: list[dict[str, Any]] = obj.get("connectors", []) if isinstance(obj, dict) else []
-    names = [entry.get("instance") for entry in instances if isinstance(entry, dict)]
-    if len(names) == 1 and isinstance(names[0], str):
-        return names[0]
-    if not names:
-        raise typer.Exit(code=1)
-    print_error(
-        f"connector {connector!r} has multiple instances ({', '.join(str(n) for n in names)}); "
-        "specify one explicitly"
-    )
-    raise typer.Exit(code=2)
+# Mirrors ``aios.harness.connector_tasks.DEFAULT_INSTANCE_SENTINEL`` —
+# the CLI doesn't import from the worker module directly because the
+# CLI ships in environments without the harness installed.
+_DEFAULT_INSTANCE = "_"
 
 
 @app.command("list")
@@ -97,10 +75,11 @@ def accounts(
     instance: Annotated[str | None, typer.Argument()] = None,
 ) -> None:
     def _run() -> None:
-        resolved = _resolve_instance(ctx, connector, instance)
         client = just_client(ctx)
         with client:
-            obj = client.request("GET", f"/v1/connectors/{connector}/{resolved}/accounts")
+            obj = client.request(
+                "GET", f"/v1/connectors/{connector}/{instance or _DEFAULT_INSTANCE}/accounts"
+            )
         render_single(obj)
 
     run_or_die(_run)
@@ -113,10 +92,11 @@ def tools(
     instance: Annotated[str | None, typer.Argument()] = None,
 ) -> None:
     def _run() -> None:
-        resolved = _resolve_instance(ctx, connector, instance)
         client = just_client(ctx)
         with client:
-            obj = client.request("GET", f"/v1/connectors/{connector}/{resolved}/tools")
+            obj = client.request(
+                "GET", f"/v1/connectors/{connector}/{instance or _DEFAULT_INSTANCE}/tools"
+            )
         render_single(obj)
 
     run_or_die(_run)
@@ -137,11 +117,12 @@ def call(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
-        resolved = _resolve_instance(ctx, connector, instance)
         client = just_client(ctx)
         with client:
             obj = client.request(
-                "POST", f"/v1/connectors/{connector}/{resolved}/call", json_body=payload
+                "POST",
+                f"/v1/connectors/{connector}/{instance or _DEFAULT_INSTANCE}/call",
+                json_body=payload,
             )
         render_single(obj)
         return None

--- a/src/aios/cli/commands/connectors.py
+++ b/src/aios/cli/commands/connectors.py
@@ -5,12 +5,19 @@ flow through the API process, which procrastinate-RPCs into the
 worker (see :mod:`aios.api.routers.connectors`).  The ``call``
 subcommand expects a JSON payload of shape ``{"tool": str,
 "arguments": dict, "meta": dict | null}``.
+
+Multi-instance: most commands take ``<connector> [<instance>]``
+positional args.  When the operator omits ``<instance>`` and the
+connector type has exactly one configured instance, that instance is
+used; if multiple are configured the CLI errors out with a list and
+the operator must specify.  This sugar lives in the CLI only — the
+API + procrastinate task layer always require explicit pairs.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 
@@ -26,6 +33,32 @@ app = typer.Typer(
 )
 
 
+def _resolve_instance(ctx: typer.Context, connector: str, instance: str | None) -> str:
+    """Auto-resolve instance when only one of this connector type is configured.
+
+    Lists the connector's instances via ``GET /v1/connectors/<connector>``.
+    If exactly one, return its instance name.  If multiple, raise typer
+    Exit with a list so the operator picks explicitly.  If none, the
+    enclosing API call will surface the not-enabled error itself.
+    """
+    if instance is not None:
+        return instance
+    client = just_client(ctx)
+    with client:
+        obj = client.request("GET", f"/v1/connectors/{connector}")
+    instances: list[dict[str, Any]] = obj.get("connectors", []) if isinstance(obj, dict) else []
+    names = [entry.get("instance") for entry in instances if isinstance(entry, dict)]
+    if len(names) == 1 and isinstance(names[0], str):
+        return names[0]
+    if not names:
+        raise typer.Exit(code=1)
+    print_error(
+        f"connector {connector!r} has multiple instances ({', '.join(str(n) for n in names)}); "
+        "specify one explicitly"
+    )
+    raise typer.Exit(code=2)
+
+
 @app.command("list")
 def list_(ctx: typer.Context) -> None:
     def _run() -> None:
@@ -37,23 +70,53 @@ def list_(ctx: typer.Context) -> None:
     run_or_die(_run)
 
 
-@app.command("accounts")
-def accounts(ctx: typer.Context, name: str) -> None:
+@app.command("get")
+def get(
+    ctx: typer.Context,
+    connector: str,
+    instance: Annotated[str | None, typer.Argument()] = None,
+) -> None:
+    """Show all instances of a connector type, or one specific instance."""
+
     def _run() -> None:
         client = just_client(ctx)
+        path = f"/v1/connectors/{connector}"
+        if instance is not None:
+            path = f"{path}/{instance}"
         with client:
-            obj = client.request("GET", f"/v1/connectors/{name}/accounts")
+            obj = client.request("GET", path)
+        render_single(obj)
+
+    run_or_die(_run)
+
+
+@app.command("accounts")
+def accounts(
+    ctx: typer.Context,
+    connector: str,
+    instance: Annotated[str | None, typer.Argument()] = None,
+) -> None:
+    def _run() -> None:
+        resolved = _resolve_instance(ctx, connector, instance)
+        client = just_client(ctx)
+        with client:
+            obj = client.request("GET", f"/v1/connectors/{connector}/{resolved}/accounts")
         render_single(obj)
 
     run_or_die(_run)
 
 
 @app.command("tools")
-def tools(ctx: typer.Context, name: str) -> None:
+def tools(
+    ctx: typer.Context,
+    connector: str,
+    instance: Annotated[str | None, typer.Argument()] = None,
+) -> None:
     def _run() -> None:
+        resolved = _resolve_instance(ctx, connector, instance)
         client = just_client(ctx)
         with client:
-            obj = client.request("GET", f"/v1/connectors/{name}/tools")
+            obj = client.request("GET", f"/v1/connectors/{connector}/{resolved}/tools")
         render_single(obj)
 
     run_or_die(_run)
@@ -62,7 +125,8 @@ def tools(ctx: typer.Context, name: str) -> None:
 @app.command("call", help="Invoke a connector tool by name (admin escape hatch).")
 def call(
     ctx: typer.Context,
-    name: str,
+    connector: str,
+    instance: Annotated[str | None, typer.Argument()] = None,
     file: Annotated[Path | None, typer.Option("--file")] = None,
     stdin: Annotated[bool, typer.Option("--stdin")] = False,
     data: Annotated[str | None, typer.Option("--data")] = None,
@@ -73,9 +137,12 @@ def call(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
+        resolved = _resolve_instance(ctx, connector, instance)
         client = just_client(ctx)
         with client:
-            obj = client.request("POST", f"/v1/connectors/{name}/call", json_body=payload)
+            obj = client.request(
+                "POST", f"/v1/connectors/{connector}/{resolved}/call", json_body=payload
+            )
         render_single(obj)
         return None
 

--- a/src/aios/cli/commands/connectors.py
+++ b/src/aios/cli/commands/connectors.py
@@ -24,17 +24,13 @@ from aios.cli.commands._shared import just_client, render_single
 from aios.cli.files import PayloadError, load_payload
 from aios.cli.output import print_error
 from aios.cli.runtime import run_or_die
+from aios.config import DEFAULT_INSTANCE_SENTINEL
 
 app = typer.Typer(
     name="connectors",
     help="Inspect connector subprocesses (admin).",
     no_args_is_help=True,
 )
-
-# Mirrors ``aios.harness.connector_tasks.DEFAULT_INSTANCE_SENTINEL`` —
-# the CLI doesn't import from the worker module directly because the
-# CLI ships in environments without the harness installed.
-_DEFAULT_INSTANCE = "_"
 
 
 @app.command("list")
@@ -78,7 +74,8 @@ def accounts(
         client = just_client(ctx)
         with client:
             obj = client.request(
-                "GET", f"/v1/connectors/{connector}/{instance or _DEFAULT_INSTANCE}/accounts"
+                "GET",
+                f"/v1/connectors/{connector}/{instance or DEFAULT_INSTANCE_SENTINEL}/accounts",
             )
         render_single(obj)
 
@@ -95,7 +92,7 @@ def tools(
         client = just_client(ctx)
         with client:
             obj = client.request(
-                "GET", f"/v1/connectors/{connector}/{instance or _DEFAULT_INSTANCE}/tools"
+                "GET", f"/v1/connectors/{connector}/{instance or DEFAULT_INSTANCE_SENTINEL}/tools"
             )
         render_single(obj)
 
@@ -121,7 +118,7 @@ def call(
         with client:
             obj = client.request(
                 "POST",
-                f"/v1/connectors/{connector}/{instance or _DEFAULT_INSTANCE}/call",
+                f"/v1/connectors/{connector}/{instance or DEFAULT_INSTANCE_SENTINEL}/call",
                 json_body=payload,
             )
         render_single(obj)

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 import re
 from functools import lru_cache
 from pathlib import Path
-from typing import NamedTuple
+from typing import Annotated, NamedTuple
 
 from pydantic import Field, SecretStr, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 # Instance names: stricter than ``Settings.instance_id`` (which allows a
 # leading underscore for Postgres identifier compatibility) because the
@@ -187,7 +187,13 @@ class Settings(BaseSettings):
     )
 
     # ── connectors ─────────────────────────────────────────────────────────
-    connectors_enabled: list[str] = Field(
+    # ``Annotated[..., NoDecode]`` tells pydantic-settings v2 to skip its
+    # default JSON parsing for ``list[str]`` env vars so the
+    # :meth:`_split_csv` validator below receives the raw string and can
+    # split on commas.  Without ``NoDecode`` the env source tries
+    # ``json.loads("signal:main,telegram:bot1")`` and raises
+    # ``SettingsError`` before the validator runs.
+    connectors_enabled: Annotated[list[str], NoDecode] = Field(
         default_factory=list,
         description="Connector instances the worker should spawn at startup, "
         "as a CSV of ``<connector>[:<instance>]`` entries (e.g. "
@@ -208,6 +214,21 @@ class Settings(BaseSettings):
         "for non-default instances, so spool databases and other state files "
         "live next to each connector subprocess.",
     )
+
+    @field_validator("connectors_enabled", mode="before")
+    @classmethod
+    def _split_csv(cls, value: object) -> object:
+        """Accept CSV env strings (``"signal:main,telegram:bot1"``) as well as JSON arrays.
+
+        Pydantic-settings v2 only auto-parses JSON for ``list[str]``
+        env vars; without this hook ``AIOS_CONNECTORS_ENABLED='a,b'``
+        fails at startup with a SettingsError, contradicting the
+        documented CSV format.  Constructor kwargs (``Settings(connectors_enabled=[...])``)
+        bypass this branch and continue to take a list directly.
+        """
+        if isinstance(value, str):
+            return [s.strip() for s in value.split(",") if s.strip()]
+        return value
 
     @field_validator("connectors_enabled")
     @classmethod

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -22,6 +22,16 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 # ``AIOS_SIGNAL__BOT_TOKEN`` if leading underscores were allowed.
 _INSTANCE_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
+# Sentinel ``instance`` value the CLI / API passes when the operator
+# omits the instance segment.  The worker resolves it to the sole
+# enabled instance of that connector type, or returns an
+# ``ambiguous_instance`` error envelope.  Distinct from any valid
+# instance name (which must match :data:`_INSTANCE_NAME_RE`).  Lives
+# here rather than in ``aios.harness.connector_tasks`` so the CLI can
+# import it without triggering the harness's procrastinate-app load
+# (which requires ``db_url`` and other worker-only settings).
+DEFAULT_INSTANCE_SENTINEL = "_"
+
 
 class ConnectorInstance(NamedTuple):
     """Parsed ``connectors_enabled`` entry.

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -7,11 +7,57 @@ rather than touching ``os.environ`` directly.
 
 from __future__ import annotations
 
+import re
 from functools import lru_cache
 from pathlib import Path
+from typing import NamedTuple
 
-from pydantic import Field, SecretStr
+from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Instance names match the same shape as Postgres identifiers so the
+# AIOS_<CONNECTOR_UPPER>_<INSTANCE_UPPER>_* env-var re-export the
+# supervisor performs for non-default instances stays POSIX-valid.
+# Letters/digits/underscore only; lowercase enforced; must start with a letter.
+_INSTANCE_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+class ConnectorInstance(NamedTuple):
+    """Parsed ``connectors_enabled`` entry.
+
+    ``connector`` is the entry-point name (e.g. ``"signal"``).
+    ``instance`` is operator-supplied (e.g. ``"main"``); defaults to the
+    connector name when omitted in the env value.  The supervisor uses
+    ``(connector, instance)`` as the registry key so multiple instances
+    of the same connector type can run side-by-side as separate
+    subprocesses.
+    """
+
+    connector: str
+    instance: str
+
+
+def parse_connector_entry(raw: str) -> ConnectorInstance:
+    """Parse one ``<connector>[:<instance>]`` ``connectors_enabled`` entry.
+
+    Default instance = connector name when ``:`` is omitted (so a
+    single-instance setup like ``connectors_enabled=signal`` continues to
+    work without per-instance env scoping).  Both halves must match
+    :data:`_INSTANCE_NAME_RE` so the env-var re-export stays POSIX-valid.
+    """
+    if ":" in raw:
+        connector, _, instance = raw.partition(":")
+    else:
+        connector = raw
+        instance = raw
+    if not _INSTANCE_NAME_RE.match(connector):
+        raise ValueError(f"connector name {connector!r} must match ^[a-z][a-z0-9_]*$")
+    if not _INSTANCE_NAME_RE.match(instance):
+        raise ValueError(
+            f"instance name {instance!r} must match ^[a-z][a-z0-9_]*$ "
+            f"(letters/digits/underscore only; lowercase; must start with a letter)"
+        )
+    return ConnectorInstance(connector=connector, instance=instance)
 
 
 class Settings(BaseSettings):
@@ -132,19 +178,56 @@ class Settings(BaseSettings):
     # ── connectors ─────────────────────────────────────────────────────────
     connectors_enabled: list[str] = Field(
         default_factory=list,
-        description="Connector names the worker should spawn at startup. Each "
-        "name is resolved against the ``aios.connectors`` Python entry-point "
-        "group; the resolved spec describes how to launch the subprocess. "
-        "Empty (the default) means the worker boots no connector children — "
-        "operator opts in explicitly.",
+        description="Connector instances the worker should spawn at startup, "
+        "as a CSV of ``<connector>[:<instance>]`` entries (e.g. "
+        "``signal:main,telegram:support,telegram:alerts``).  When ``:`` is "
+        "omitted, instance defaults to the connector name (so a single-instance "
+        "deployment can write ``connectors_enabled=signal,telegram``).  Each "
+        "connector name is resolved against the ``aios.connectors`` Python "
+        "entry-point group; the resolved spec describes how to launch the "
+        "subprocess.  Multiple instances of the same connector type are "
+        "permitted — each gets its own subprocess and per-instance env scope.  "
+        "Empty (the default) means the worker boots no connector children.",
     )
     connectors_dir: Path = Field(
         default=Path.home() / ".aios" / "connectors",
         description="Per-connector working-directory root. The supervisor cd's "
-        "into ``<connectors_dir>/<name>/`` before spawning the subprocess so "
-        "spool databases and other state files live next to the connector "
-        "rather than in the worker's CWD.",
+        "into ``<connectors_dir>/<connector>/`` for default-instance setups "
+        "(``instance == connector``) and ``<connectors_dir>/<connector>/<instance>/`` "
+        "for non-default instances, so spool databases and other state files "
+        "live next to each connector subprocess.",
     )
+
+    @field_validator("connectors_enabled")
+    @classmethod
+    def _validate_connectors_enabled(cls, value: list[str]) -> list[str]:
+        """Reject malformed entries and duplicate ``(connector, instance)`` pairs.
+
+        Validation runs ``parse_connector_entry`` for each value to surface
+        bad characters early; the parsed list is recomputed lazily in
+        :meth:`connector_instances` rather than stored, so the public
+        attribute stays a plain ``list[str]`` for env-CSV ergonomics.
+        """
+        seen: set[tuple[str, str]] = set()
+        for raw in value:
+            parsed = parse_connector_entry(raw)
+            key = (parsed.connector, parsed.instance)
+            if key in seen:
+                raise ValueError(
+                    f"duplicate connector instance {parsed.connector}:{parsed.instance} "
+                    f"in connectors_enabled"
+                )
+            seen.add(key)
+        return value
+
+    def connector_instances(self) -> list[ConnectorInstance]:
+        """Return ``connectors_enabled`` parsed into ``(connector, instance)`` pairs.
+
+        Cheap to recompute (one regex per entry); not cached because
+        ``Settings`` instances are themselves cached at the module level.
+        """
+        return [parse_connector_entry(raw) for raw in self.connectors_enabled]
+
     connectors_auto_create: dict[str, bool] = Field(
         default_factory=dict,
         description="Per-connector ``auto_create_connections`` knob (plan §13). "

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import re
 from functools import lru_cache
 from pathlib import Path
-from typing import Annotated, NamedTuple
+from typing import Annotated, Literal, NamedTuple
 
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
@@ -273,6 +273,21 @@ class Settings(BaseSettings):
         "doesn't compose well with that shape under the ``AIOS_`` env prefix; "
         "a flat ``AIOS_CONNECTORS_AUTO_CREATE='{\"signal\":false}'`` is "
         "operationally equivalent and easier to override from systemd / env.",
+    )
+
+    default_mcp_permission_policy: Literal["always_allow", "always_ask"] | None = Field(
+        default=None,
+        description="Fallback permission policy for MCP tools whose server "
+        "has no matching ``mcp_toolset`` entry on the calling agent. "
+        "When unset (the default), unmounted MCP toolsets gate on "
+        "``always_ask`` confirmation — the safe default that protects "
+        "against connector-mounted tools the agent never opted into. "
+        "Operators in trusted environments can set this to "
+        "``always_allow`` so connector tools dispatch immediately on any "
+        "session that has the connection attached, without per-agent "
+        "``mcp_toolset`` declarations.  Explicit per-toolset policies on "
+        "``agent.tools`` always win — this only changes the fallback "
+        "for unmounted servers.",
     )
 
     # ── observability ──────────────────────────────────────────────────────

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -15,10 +15,11 @@ from typing import NamedTuple
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# Instance names match the same shape as Postgres identifiers so the
-# AIOS_<CONNECTOR_UPPER>_<INSTANCE_UPPER>_* env-var re-export the
-# supervisor performs for non-default instances stays POSIX-valid.
-# Letters/digits/underscore only; lowercase enforced; must start with a letter.
+# Instance names: stricter than ``Settings.instance_id`` (which allows a
+# leading underscore for Postgres identifier compatibility) because the
+# supervisor's AIOS_<CONNECTOR_UPPER>_<INSTANCE_UPPER>_* env-var
+# re-export would produce double-underscore POSIX env names like
+# ``AIOS_SIGNAL__BOT_TOKEN`` if leading underscores were allowed.
 _INSTANCE_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -25,8 +25,10 @@ SWITCH_CHANNEL_METADATA_KEY = "switch_channel"
 
 # Top-level key inside the ``_meta`` field sent on JSON-RPC tool-call
 # requests to MCP servers.  The value is the focal-channel suffix (the
-# focal channel address with its first two ``<connector>/<account>``
-# segments stripped, since the connector already knows its own identity).
+# focal channel address with its leading ``<connector>/`` segment
+# stripped, since the connector already knows its own identity).  The
+# ``<account>`` segment is preserved so multi-account connectors can
+# route by account; single-account connectors take the chat suffix only.
 # Stamped on outbound MCP requests whenever the calling session has a
 # focal channel set; servers that don't care ignore unknown ``_meta``
 # keys per the MCP spec.
@@ -34,24 +36,26 @@ FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
 
 def focal_channel_path(focal: str | None) -> str | None:
-    """Return the connector-specific suffix of a focal address.
+    """Return the connector-relative suffix of a focal address.
 
-    The ``<connector>/<account>`` prefix is information the MCP server
-    already has (it was invoked *by* that connection), so sending it
-    would be redundant; we strip it.  For a 3-segment address like
-    ``signal/<bot>/<chat>`` the suffix is just ``<chat>``.  For
-    ``telegram/<bot>/<chat>/<thread>`` it's ``<chat>/<thread>``.
+    The leading ``<connector>/`` segment is implicit (the MCP server was
+    invoked by aios; it knows its own name).  The suffix is
+    ``<account>/<chat>`` for a 3-segment address like
+    ``signal/<bot>/<chat>``, ``<account>/<chat>/<thread>`` for nested
+    forms.  The SDK splits on the first ``/`` to expose ``account`` and
+    ``chat_id`` to focal-required tools.
 
     Returns ``None`` if ``focal`` is ``None`` or malformed (fewer than
-    three segments) — neither should reach the dispatch path, but
-    degrading gracefully avoids leaking garbled metadata to connectors.
+    three segments, or empty chat_id) — neither should reach the
+    dispatch path, but degrading gracefully avoids leaking garbled
+    metadata to connectors.
     """
     if not focal:
         return None
-    parts = focal.split("/", 2)
+    parts = focal.split("/")
     if len(parts) < 3 or not parts[2]:
         return None
-    return parts[2]
+    return "/".join(parts[1:])
 
 
 def build_focal_paradigm_block(channels: list[str]) -> str:

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -173,6 +173,16 @@ class ConnectorState:
         }
 
 
+def _sibling_instances(parsed: list[ConnectorInstance], connector: str, instance: str) -> set[str]:
+    """Return instance names of OTHER instances of the same connector type.
+
+    Used to filter sibling-scoped env vars out of each subprocess's env
+    so a wedged connector that iterates ``os.environ`` can't expose
+    sibling tokens.
+    """
+    return {ci.instance for ci in parsed if ci.connector == connector and ci.instance != instance}
+
+
 def resolve_connector_specs(settings: Settings) -> list[tuple[ConnectorInstance, ConnectorSpec]]:
     """Resolve ``connectors_enabled`` into ``(instance, spec)`` pairs.
 
@@ -189,9 +199,9 @@ def resolve_connector_specs(settings: Settings) -> list[tuple[ConnectorInstance,
     silently skip.
     """
     available = {ep.name: ep for ep in entry_points(group="aios.connectors")}
+    parsed = [parse_connector_entry(raw) for raw in settings.connectors_enabled]
     out: list[tuple[ConnectorInstance, ConnectorSpec]] = []
-    for raw in settings.connectors_enabled:
-        ci = parse_connector_entry(raw)
+    for raw, ci in zip(settings.connectors_enabled, parsed, strict=True):
         ep = available.get(ci.connector)
         if ep is None:
             raise RuntimeError(
@@ -206,13 +216,18 @@ def resolve_connector_specs(settings: Settings) -> list[tuple[ConnectorInstance,
                 f"entry point aios.connectors:{ci.connector} returned "
                 f"{type(spec).__name__!r}, expected ConnectorSpec"
             )
-        spec = _apply_instance_overlay(spec, ci, settings)
+        siblings = _sibling_instances(parsed, ci.connector, ci.instance)
+        spec = _apply_instance_overlay(spec, ci, settings, siblings=siblings)
         out.append((ci, spec))
     return out
 
 
 def _apply_instance_overlay(
-    spec: ConnectorSpec, ci: ConnectorInstance, settings: Settings
+    spec: ConnectorSpec,
+    ci: ConnectorInstance,
+    settings: Settings,
+    *,
+    siblings: set[str],
 ) -> ConnectorSpec:
     """Layer per-instance cwd + env on top of a factory-returned spec.
 
@@ -228,17 +243,26 @@ def _apply_instance_overlay(
     connector subprocess code stays instance-naive — it just reads
     config under the standard prefix.  Single-instance deployments use
     the unscoped vars directly with no transform.
+
+    ``siblings`` is the set of other instance names for the same
+    connector type; their scoped env vars are stripped so each
+    subprocess sees only its own credentials.
     """
     cwd = spec.cwd
     if cwd is None:
         cwd = settings.connectors_dir / ci.connector
         if ci.instance != ci.connector:
             cwd = cwd / ci.instance
-    env = _build_instance_env(ci, base=spec.env)
+    env = _build_instance_env(ci, base=spec.env, siblings=siblings)
     return replace(spec, cwd=cwd, env=env)
 
 
-def _build_instance_env(ci: ConnectorInstance, *, base: dict[str, str] | None) -> dict[str, str]:
+def _build_instance_env(
+    ci: ConnectorInstance,
+    *,
+    base: dict[str, str] | None,
+    siblings: set[str],
+) -> dict[str, str]:
     """Construct the env dict for a connector subprocess.
 
     Starts from ``os.environ`` (so the subprocess inherits operator-set
@@ -247,7 +271,10 @@ def _build_instance_env(ci: ConnectorInstance, *, base: dict[str, str] | None) -
     non-default instances — re-exports
     ``AIOS_<CONN_UPPER>_<INST_UPPER>_<FIELD>`` as
     ``AIOS_<CONN_UPPER>_<FIELD>`` so the connector reads its config
-    under the standard prefix.
+    under the standard prefix.  ``siblings``-scoped vars are stripped
+    from the resulting env so each subprocess sees only its own
+    credentials (a wedged or chatty connector that iterates
+    ``os.environ`` won't surface sibling tokens).
 
     The re-export overrides any unscoped value: an operator running
     ``connectors_enabled=telegram:bot1,telegram:bot2`` with both
@@ -261,11 +288,22 @@ def _build_instance_env(ci: ConnectorInstance, *, base: dict[str, str] | None) -
         env.update(base)
     if ci.instance == ci.connector:
         return env
-    scope_prefix = f"AIOS_{ci.connector.upper()}_{ci.instance.upper()}_"
-    target_prefix = f"AIOS_{ci.connector.upper()}_"
+    connector_prefix = f"AIOS_{ci.connector.upper()}_"
+    scope_prefix = f"{connector_prefix}{ci.instance.upper()}_"
+    # Re-export our own scoped vars under the standard prefix.
     for key, value in list(env.items()):
         if key.startswith(scope_prefix):
-            env[target_prefix + key[len(scope_prefix) :]] = value
+            env[connector_prefix + key[len(scope_prefix) :]] = value
+    # Strip sibling-scoped vars so credentials don't leak across
+    # subprocesses.  We only remove vars whose leading segment matches
+    # a known sibling instance name from ``connectors_enabled`` —
+    # plain connector-scoped fields like ``AIOS_TELEGRAM_BOT_TOKEN`` (no
+    # instance segment) are kept as the legacy fallback.
+    if siblings:
+        sibling_prefixes = tuple(f"{connector_prefix}{s.upper()}_" for s in siblings)
+        for key in list(env.keys()):
+            if key.startswith(sibling_prefixes):
+                env.pop(key, None)
     return env
 
 
@@ -590,7 +628,9 @@ class ConnectorSubprocessRegistry:
         INSERT runs in the same transaction as ``append_event`` so a
         replayed inbound (same ULID after worker SIGKILL) hits
         ``ON CONFLICT DO NOTHING`` and the txn rolls back without a
-        second event row.  Ack runs after commit, fire-and-forget — a
+        second event row.  Ack runs after commit and is awaited inline
+        (see :meth:`_send_ack` — bounded by ``_DISPATCH_TIMEOUT_S`` so
+        a wedged connector pins the inbound task for at most 60 s); a
         failed ack just means the connector replays again on its next
         reconnect, where the ledger conflict path takes over.
 
@@ -834,13 +874,15 @@ class ConnectorSubprocessRegistry:
         content: str,
         attachments: Any,
         connector_metadata: dict[str, Any] | None,
-    ) -> bool:
+    ) -> None:
         """Append a user-message event AND record the dedup-ledger row.
 
-        Both writes run in one transaction.  Returns ``True`` if the
-        event was appended, ``False`` on dedup (already-processed
-        inbound replayed by the connector).  Raises :class:`NotFoundError`
-        if the target session vanished between resolution and append.
+        Both writes run in one transaction.  Silently returns on dedup
+        (already-processed inbound replayed by the connector) — the
+        ``_DedupRollback`` path logs at INFO and the caller proceeds to
+        defer a wake regardless (idempotent via procrastinate's
+        queueing_lock).  Raises :class:`NotFoundError` if the target
+        session vanished between resolution and append.
 
         Connector-supplied metadata (signal's ``sender_uuid``,
         ``timestamp_ms``, ``reply_to``, ``reaction``; telegram's
@@ -894,8 +936,6 @@ class ConnectorSubprocessRegistry:
                 connector=connector_name,
                 event_id=event_id,
             )
-            return False
-        return True
 
     async def _send_ack(self, state: ConnectorState, event_id: str) -> None:
         """Send ``aios_inbound_ack`` to clear the spool of the originating instance.

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -162,11 +162,21 @@ class ConnectorState:
         return instance_label(self.connector, self.instance)
 
     def snapshot(self) -> dict[str, Any]:
+        """Build the admin-facing dict for ``connector_status`` / GET ``/v1/connectors``.
+
+        ``instructions`` is intentionally absent.  The MCP server's
+        ``InitializeResult.instructions`` is consumed for model context
+        via :func:`aios.harness.loop.discover_session_mcp_tools` (which
+        re-fetches it directly), not via this snapshot.  Including it
+        here previously broke ``connector_status``: the task pg_notifies
+        the JSON-encoded snapshot, and Postgres NOTIFY caps payloads at
+        8000 bytes — a signal connector serving N phones with their
+        contacts and groups easily exceeded that.
+        """
         return {
             "connector": self.connector,
             "instance": self.instance,
             "status": self.status,
-            "instructions": self.instructions,
             "accounts": list(self.accounts),
             "last_error": self.last_error,
             "recent_drops": dict(self.drops),

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -40,6 +40,45 @@ re-spawn.  After ``_CIRCUIT_THRESHOLD`` failures within
 ``_CIRCUIT_WINDOW``, the loop stops respawning and the connector
 reports ``circuit_open`` until the worker is restarted — operator can
 fix the connector or its config and restart the worker.
+
+Architectural constraint
+------------------------
+
+This module currently lives in the ``aios worker`` process and bakes in
+the single-worker invariant: the worker's ``pg_try_advisory_lock``
+refuses a second concurrent ``aios worker`` so the connector supervisor
+has exclusive ownership of stdio handles, restart bookkeeping, and the
+in-memory account map.  That's fine today (one worker comfortably
+multiplexes hundreds of in-flight session-step coroutines on the
+asyncio loop), but it's a real architectural ceiling for horizontal
+scaling — any future need for multiple workers would force connector
+supervision into a separate ``aios connectors`` process.
+
+To preserve that option without committing to it, this module's public
+surface is intentionally narrow:
+
+* :class:`ConnectorSubprocessRegistry` — entry-point lookup, lifecycle
+  bookkeeping, and the ``account → instance`` routing map.  External
+  consumers should reach for ``state``, ``states_for_connector``,
+  ``snapshot_all``, ``get_session``, ``dispatch_call``, and
+  ``dispatch_call_for_account`` only.
+
+* The procrastinate ``connector_call`` task in
+  :mod:`aios.harness.connector_tasks` is the canonical IPC primitive
+  for cross-process calls into the supervisor.  When the API process
+  needs supervisor data it goes through that task, not by importing
+  the registry.
+
+* The one in-process call site that bypasses the procrastinate IPC is
+  the outbound MCP dispatcher in :mod:`aios.harness.tool_dispatch`,
+  justified there as the per-tool-call hot path where ~50-200ms of
+  procrastinate round-trip would dominate the latency budget.
+
+If new functionality on the supervisor is tempted to add another
+in-process consumer that imports the registry directly, prefer
+defining a procrastinate task in ``connector_tasks.py`` and routing
+new callers through it.  Same end behaviour today; one less call site
+to migrate the day the supervisor splits out.
 """
 
 from __future__ import annotations

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -108,6 +108,16 @@ DropReason = Literal[
 ]
 
 
+def instance_label(connector: str, instance: str) -> str:
+    """Human-readable identifier for ``(connector, instance)``.
+
+    Collapses ``signal:signal`` to ``signal`` for default-instance
+    setups so single-instance deployments don't get a confusing
+    redundant suffix in logs, snapshots, and error envelopes.
+    """
+    return connector if connector == instance else f"{connector}:{instance}"
+
+
 @dataclass
 class ConnectorState:
     """Live state for one connector subprocess instance.
@@ -149,15 +159,7 @@ class ConnectorState:
 
     @property
     def label(self) -> str:
-        """Human-readable identifier for logs and snapshots.
-
-        ``signal:main`` for explicit instances; ``signal`` (no suffix)
-        for default-instance setups so single-instance deployments don't
-        get a confusing redundant ``signal:signal`` everywhere.
-        """
-        if self.instance == self.connector:
-            return self.connector
-        return f"{self.connector}:{self.instance}"
+        return instance_label(self.connector, self.instance)
 
     def snapshot(self) -> dict[str, Any]:
         return {
@@ -355,6 +357,18 @@ class ConnectorSubprocessRegistry:
         """All ``ConnectorState``s for instances of one connector type."""
         return [s for (c, _i), s in self._states.items() if c == connector]
 
+    def resolve_default_instance(self, connector: str) -> str | None:
+        """Return the sole instance name for ``connector``, or ``None``.
+
+        Used by the procrastinate tasks to auto-resolve the ``_`` sentinel
+        that the CLI passes when the operator omits ``<instance>``.
+        Returns ``None`` for both "no instances enabled" and "multiple
+        instances enabled" — callers distinguish via
+        :meth:`states_for_connector`.
+        """
+        states = self.states_for_connector(connector)
+        return states[0].instance if len(states) == 1 else None
+
     def snapshot_all(self) -> list[dict[str, Any]]:
         return [s.snapshot() for s in self._states.values()]
 
@@ -401,7 +415,7 @@ class ConnectorSubprocessRegistry:
         instance stuck in ``starting`` doesn't pin the worker
         indefinitely; downstream the call itself shares the same bound.
         """
-        label = f"{connector}:{instance}"
+        label = instance_label(connector, instance)
         try:
             session = await asyncio.wait_for(
                 self.get_session(connector, instance), timeout=_DISPATCH_TIMEOUT_S
@@ -475,6 +489,12 @@ class ConnectorSubprocessRegistry:
         connector, instance = key
         state = self._states[key]
         if method == "notifications/aios/accounts":
+            # Each fresh accounts payload is the connector's authoritative
+            # statement of its account set; clear any prior accounts-payload-
+            # derived ``last_error`` (malformed payload, account conflict)
+            # before re-evaluating.  Subprocess-state errors (crashes) are
+            # set in ``_supervisor_loop`` and not affected here.
+            state.last_error = None
             raw_accounts = (params or {}).get("accounts")
             if isinstance(raw_accounts, list):
                 state.accounts = list(raw_accounts)
@@ -617,7 +637,7 @@ class ConnectorSubprocessRegistry:
                 ],
             )
             self._record_drop(state, "malformed")
-            await self._send_ack(connector, instance, event_id)
+            await self._send_ack(state, event_id)
             return
 
         if len(content) > MAX_USER_MESSAGE_CHARS:
@@ -630,7 +650,7 @@ class ConnectorSubprocessRegistry:
                 limit=MAX_USER_MESSAGE_CHARS,
             )
             self._record_drop(state, "payload_too_large")
-            await self._send_ack(connector, instance, event_id)
+            await self._send_ack(state, event_id)
             return
 
         pool = runtime.require_pool()
@@ -646,7 +666,7 @@ class ConnectorSubprocessRegistry:
             # Even if auto-create succeeds, this inbound is dropped:
             # the freshly-detached connection has no session to deliver
             # to.  Operator must explicitly attach / configure-per-chat.
-            await self._send_ack(connector, instance, event_id)
+            await self._send_ack(state, event_id)
             return
 
         # 2. Branch on routing mode.
@@ -664,12 +684,12 @@ class ConnectorSubprocessRegistry:
             )
         else:
             self._record_drop(state, "detached")
-            await self._send_ack(connector, instance, event_id)
+            await self._send_ack(state, event_id)
             return
 
         if target_session_id is None:
             # Per-chat resolution already recorded the drop reason.
-            await self._send_ack(connector, instance, event_id)
+            await self._send_ack(state, event_id)
             return
 
         # 3. Append event + ledger row in the same transaction.
@@ -688,7 +708,7 @@ class ConnectorSubprocessRegistry:
         except NotFoundError:
             # The session vanished between resolution and append.
             self._record_drop(state, "session_missing")
-            await self._send_ack(connector, instance, event_id)
+            await self._send_ack(state, event_id)
             return
 
         # 4. Outside the transaction: defer wake unconditionally.
@@ -699,7 +719,7 @@ class ConnectorSubprocessRegistry:
         # Failures propagate so the inbound task fails and the connector
         # replays on reconnect, where this same path can re-run.
         await defer_wake(pool, target_session_id, cause="inbound")
-        await self._send_ack(connector, instance, event_id)
+        await self._send_ack(state, event_id)
 
     async def _auto_create_or_drop(self, state: ConnectorState, *, account: str) -> None:
         """Insert a detached connection if ``auto_create_connections`` is on.
@@ -877,7 +897,7 @@ class ConnectorSubprocessRegistry:
             return False
         return True
 
-    async def _send_ack(self, connector: str, instance: str, event_id: str) -> None:
+    async def _send_ack(self, state: ConnectorState, event_id: str) -> None:
         """Send ``aios_inbound_ack`` to clear the spool of the originating instance.
 
         Awaited inline so :meth:`shutdown` waits for in-flight acks
@@ -887,13 +907,13 @@ class ConnectorSubprocessRegistry:
         we log but don't retry to avoid pinning a wedged connector.
         """
         result = await self.dispatch_call(
-            connector, instance, "aios_inbound_ack", {"event_id": event_id}
+            state.connector, state.instance, "aios_inbound_ack", {"event_id": event_id}
         )
         if "error" in result:
             log.info(
                 "connector.inbound_ack_failed",
-                connector=connector,
-                instance=instance,
+                connector=state.connector,
+                instance=state.instance,
                 event_id=event_id,
                 error=result["error"],
             )

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -1,20 +1,38 @@
 """Connector subprocess supervisor.
 
 Worker-scoped registry that owns the persistent stdio MCP sessions for
-every entry in ``settings.connectors_enabled``.  Holds three things:
+every connector instance in ``settings.connectors_enabled``.  Holds
+three things:
 
-* A long-lived asyncio task per connector that opens the subprocess,
-  runs ``initialize()``, validates the ``experimental.aios/connector``
-  capability, and stays parked on a shutdown event so the
-  :class:`~mcp.client.session.ClientSession` (and the underlying
-  subprocess) stay alive until the worker exits.
-* In-memory state per connector: the live session handle, the most
-  recent account snapshot received via ``notifications/aios/accounts``,
-  status (running / restarting / circuit_open), and the running backoff.
+* A long-lived asyncio task per ``(connector, instance)`` pair that
+  opens the subprocess, runs ``initialize()``, validates the
+  ``experimental.aios/connector`` capability, and stays parked on a
+  shutdown event so the :class:`~mcp.client.session.ClientSession`
+  (and the underlying subprocess) stay alive until the worker exits.
+* In-memory state per ``(connector, instance)``: the live session
+  handle, the most recent account snapshot received via
+  ``notifications/aios/accounts``, status (running / restarting /
+  circuit_open), and the running backoff.
+* An ``account → instance`` routing map maintained from the per-instance
+  account snapshots.  Outbound calls referencing a ``(connector,
+  account)`` pair dispatch to the owning instance via this map.
 * Two outbound entry points: :meth:`get_session` for code that needs to
   build its own request (used by the harness's outbound MCP dispatch)
   and :meth:`dispatch_call` for the procrastinate ``connector_call``
-  task that backs the API's ``POST /v1/connectors/:name/call``.
+  task that backs the API's
+  ``POST /v1/connectors/:connector/:instance/call``.
+
+Multi-instance: ``connectors_enabled`` accepts ``<connector>[:<instance>]``
+entries.  Default instance = connector name when ``:`` is omitted, so
+single-instance setups (``connectors_enabled=signal``) continue to work
+without per-instance scoping.  Per-instance:
+
+* cwd is ``<connectors_dir>/<connector>/`` for default instances,
+  ``<connectors_dir>/<connector>/<instance>/`` for non-default — keeps
+  PR3's spool location stable for single-instance deployments.
+* env is the parent's ``os.environ`` for default instances; for
+  non-default, ``AIOS_<CONN>_<INST>_*`` vars are re-exported as
+  ``AIOS_<CONN>_*`` so connector subprocess code stays instance-naive.
 
 Restart semantics: on subprocess crash, sleep ``backoff`` seconds (5s
 initial, doubles each consecutive failure, capped at 5 min) then
@@ -27,6 +45,7 @@ fix the connector or its config and restart the worker.
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from collections import Counter, deque
 from dataclasses import dataclass, field, replace
@@ -36,7 +55,7 @@ from typing import Any, Literal
 from mcp.client.session import ClientSession
 from mcp.types import InitializeResult
 
-from aios.config import Settings
+from aios.config import ConnectorInstance, Settings, parse_connector_entry
 from aios.db import queries
 from aios.errors import ConflictError, NotFoundError
 from aios.harness import runtime
@@ -91,7 +110,7 @@ DropReason = Literal[
 
 @dataclass
 class ConnectorState:
-    """Live state for one connector subprocess.
+    """Live state for one connector subprocess instance.
 
     ``status`` is what GET ``/v1/connectors`` reports back.
     ``accounts`` is a list of account dicts (shape opaque to aios; the
@@ -100,9 +119,15 @@ class ConnectorState:
     counter surfaced as ``recent_drops`` in :meth:`snapshot` so
     operators see at-a-glance from ``aios connector list`` whether
     inbound traffic is landing — plan §15.
+
+    ``connector`` and ``instance`` together identify the subprocess.
+    For single-instance deployments they're equal (default-instance
+    convention); for multi-instance setups the operator picks the
+    instance name explicitly.
     """
 
-    name: str
+    connector: str
+    instance: str
     spec: ConnectorSpec
     status: ConnectorStatus = "starting"
     instructions: str | None = None
@@ -117,9 +142,27 @@ class ConnectorState:
     # is the awaitable handle for first-init wait.
     ready: asyncio.Event = field(default_factory=asyncio.Event)
 
+    @property
+    def key(self) -> tuple[str, str]:
+        """Compound registry key — used as the dict key in ``_states``."""
+        return (self.connector, self.instance)
+
+    @property
+    def label(self) -> str:
+        """Human-readable identifier for logs and snapshots.
+
+        ``signal:main`` for explicit instances; ``signal`` (no suffix)
+        for default-instance setups so single-instance deployments don't
+        get a confusing redundant ``signal:signal`` everywhere.
+        """
+        if self.instance == self.connector:
+            return self.connector
+        return f"{self.connector}:{self.instance}"
+
     def snapshot(self) -> dict[str, Any]:
         return {
-            "name": self.name,
+            "connector": self.connector,
+            "instance": self.instance,
             "status": self.status,
             "instructions": self.instructions,
             "accounts": list(self.accounts),
@@ -128,41 +171,100 @@ class ConnectorState:
         }
 
 
-def resolve_connector_specs(settings: Settings) -> list[ConnectorSpec]:
-    """Resolve ``connectors_enabled`` against the ``aios.connectors`` entry-point group.
+def resolve_connector_specs(settings: Settings) -> list[tuple[ConnectorInstance, ConnectorSpec]]:
+    """Resolve ``connectors_enabled`` into ``(instance, spec)`` pairs.
 
-    Each entry point's ``load()`` must return a callable that accepts
-    ``(connector_name, settings)`` and returns a :class:`ConnectorSpec`.
-    Unknown names raise — the operator listed something that isn't
-    installed, which should fail loudly at boot rather than silently
-    skip.
+    Each entry-point factory's ``load()`` must return a callable that
+    accepts ``(connector_name, settings)`` and returns a
+    :class:`ConnectorSpec`.  Factories stay instance-naive — the
+    supervisor wraps the spec with per-instance cwd + env after the
+    factory call (so a future connector that needs to vary its
+    ``command`` by instance is the only kind that would force the
+    factory contract to grow an ``instance`` parameter).
 
-    Defaults the spec's cwd to ``settings.connectors_dir / name`` when
-    the factory leaves it unset, so connectors land their state files
-    (PR3's spool, signal-cli's data dir) under the operator-controlled
-    root by default per plan decision #11.  Factories that need a
-    different layout can override by setting ``cwd`` themselves.
+    Unknown connector names raise — the operator listed something that
+    isn't installed, which should fail loudly at boot rather than
+    silently skip.
     """
     available = {ep.name: ep for ep in entry_points(group="aios.connectors")}
-    specs: list[ConnectorSpec] = []
-    for name in settings.connectors_enabled:
-        ep = available.get(name)
+    out: list[tuple[ConnectorInstance, ConnectorSpec]] = []
+    for raw in settings.connectors_enabled:
+        ci = parse_connector_entry(raw)
+        ep = available.get(ci.connector)
         if ep is None:
             raise RuntimeError(
-                f"connector {name!r} listed in connectors_enabled but no "
-                f"aios.connectors entry point with that name is installed"
+                f"connector {ci.connector!r} listed in connectors_enabled (entry "
+                f"{raw!r}) but no aios.connectors entry point with that name is "
+                f"installed"
             )
         factory = ep.load()
-        spec = factory(name, settings)
+        spec = factory(ci.connector, settings)
         if not isinstance(spec, ConnectorSpec):
             raise RuntimeError(
-                f"entry point aios.connectors:{name} returned {type(spec).__name__!r}, "
-                f"expected ConnectorSpec"
+                f"entry point aios.connectors:{ci.connector} returned "
+                f"{type(spec).__name__!r}, expected ConnectorSpec"
             )
-        if spec.cwd is None:
-            spec = replace(spec, cwd=settings.connectors_dir / name)
-        specs.append(spec)
-    return specs
+        spec = _apply_instance_overlay(spec, ci, settings)
+        out.append((ci, spec))
+    return out
+
+
+def _apply_instance_overlay(
+    spec: ConnectorSpec, ci: ConnectorInstance, settings: Settings
+) -> ConnectorSpec:
+    """Layer per-instance cwd + env on top of a factory-returned spec.
+
+    cwd: default-instance keeps the PR3 single-segment path
+    (``<connectors_dir>/<connector>/``); non-default gets a per-instance
+    subdir.  Either way an explicit ``spec.cwd`` from the factory wins
+    (factories that hard-code their own state-file layout opt out).
+
+    env: always pass the worker's ``os.environ`` to the subprocess so
+    pydantic-settings reads the same vars the operator set.  For
+    non-default instances, also re-export
+    ``AIOS_<CONN_UPPER>_<INST_UPPER>_*`` as ``AIOS_<CONN_UPPER>_*`` so
+    connector subprocess code stays instance-naive — it just reads
+    config under the standard prefix.  Single-instance deployments use
+    the unscoped vars directly with no transform.
+    """
+    cwd = spec.cwd
+    if cwd is None:
+        cwd = settings.connectors_dir / ci.connector
+        if ci.instance != ci.connector:
+            cwd = cwd / ci.instance
+    env = _build_instance_env(ci, base=spec.env)
+    return replace(spec, cwd=cwd, env=env)
+
+
+def _build_instance_env(ci: ConnectorInstance, *, base: dict[str, str] | None) -> dict[str, str]:
+    """Construct the env dict for a connector subprocess.
+
+    Starts from ``os.environ`` (so the subprocess inherits operator-set
+    config), layers the factory-supplied ``base`` on top (factory wins
+    over inherited if both set the same key), and finally — for
+    non-default instances — re-exports
+    ``AIOS_<CONN_UPPER>_<INST_UPPER>_<FIELD>`` as
+    ``AIOS_<CONN_UPPER>_<FIELD>`` so the connector reads its config
+    under the standard prefix.
+
+    The re-export overrides any unscoped value: an operator running
+    ``connectors_enabled=telegram:bot1,telegram:bot2`` with both
+    ``AIOS_TELEGRAM_BOT_TOKEN`` (legacy unscoped) and
+    ``AIOS_TELEGRAM_BOT1_BOT_TOKEN`` should see ``bot1`` use the
+    scoped value, never the unscoped fallback (which would map two
+    instances to the same bot).
+    """
+    env: dict[str, str] = dict(os.environ)
+    if base:
+        env.update(base)
+    if ci.instance == ci.connector:
+        return env
+    scope_prefix = f"AIOS_{ci.connector.upper()}_{ci.instance.upper()}_"
+    target_prefix = f"AIOS_{ci.connector.upper()}_"
+    for key, value in list(env.items()):
+        if key.startswith(scope_prefix):
+            env[target_prefix + key[len(scope_prefix) :]] = value
+    return env
 
 
 class ConnectorSubprocessRegistry:
@@ -173,32 +275,46 @@ class ConnectorSubprocessRegistry:
     (registered at import time) can reach it.
 
     Thread/loop model: single asyncio event loop, one task per
-    connector, no shared mutable state across loops.
+    ``(connector, instance)``, no shared mutable state across loops.
     """
 
-    def __init__(self, specs: list[ConnectorSpec], *, settings: Settings) -> None:
+    def __init__(
+        self,
+        specs: list[tuple[ConnectorInstance, ConnectorSpec]],
+        *,
+        settings: Settings,
+    ) -> None:
         self._settings = settings
-        self._states: dict[str, ConnectorState] = {
-            s.name: ConnectorState(name=s.name, spec=s) for s in specs
+        self._states: dict[tuple[str, str], ConnectorState] = {
+            (ci.connector, ci.instance): ConnectorState(
+                connector=ci.connector, instance=ci.instance, spec=spec
+            )
+            for ci, spec in specs
         }
-        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._tasks: dict[tuple[str, str], asyncio.Task[None]] = {}
         # Inbound handler tasks: spawned per-notification so the splitter
         # task in :func:`open_connector_session` doesn't pause receive
         # while a single inbound walks the DB + sends the ack.  Tracked
         # so :meth:`shutdown` can wait them out cleanly.
         self._inbound_tasks: set[asyncio.Task[None]] = set()
+        # ``(connector, account)`` → instance.  Rebuilt per-instance on
+        # every ``notifications/aios/accounts``: clear all entries
+        # pointing at the reporting instance, then insert from the new
+        # snapshot.  This keeps removed accounts from leaving stale
+        # entries pointing at the instance that used to serve them.
+        self._account_to_instance: dict[tuple[str, str], str] = {}
         self._shutdown = asyncio.Event()
 
     @property
-    def names(self) -> list[str]:
+    def keys(self) -> list[tuple[str, str]]:
         return list(self._states.keys())
 
     async def start(self) -> None:
-        """Spawn one supervisor task per connector. Returns immediately."""
-        for name in self._states:
-            self._tasks[name] = asyncio.create_task(
-                self._supervisor_loop(name),
-                name=f"connector_supervisor:{name}",
+        """Spawn one supervisor task per ``(connector, instance)`` pair."""
+        for key, state in self._states.items():
+            self._tasks[key] = asyncio.create_task(
+                self._supervisor_loop(key),
+                name=f"connector_supervisor:{state.label}",
             )
 
     async def shutdown(self) -> None:
@@ -218,11 +334,13 @@ class ConnectorSubprocessRegistry:
         for task in self._tasks.values():
             task.cancel()
         results = await asyncio.gather(*self._tasks.values(), return_exceptions=True)
-        for name, result in zip(self._tasks.keys(), results, strict=True):
+        for key, result in zip(self._tasks.keys(), results, strict=True):
             if isinstance(result, BaseException) and not isinstance(result, asyncio.CancelledError):
+                connector, instance = key
                 log.warning(
                     "connector_supervisor.task_failed",
-                    connector=name,
+                    connector=connector,
+                    instance=instance,
                     error=f"{type(result).__name__}: {result}",
                 )
         self._tasks.clear()
@@ -230,61 +348,73 @@ class ConnectorSubprocessRegistry:
             await asyncio.gather(*self._inbound_tasks, return_exceptions=True)
             self._inbound_tasks.clear()
 
-    def state(self, name: str) -> ConnectorState | None:
-        return self._states.get(name)
+    def state(self, connector: str, instance: str) -> ConnectorState | None:
+        return self._states.get((connector, instance))
+
+    def states_for_connector(self, connector: str) -> list[ConnectorState]:
+        """All ``ConnectorState``s for instances of one connector type."""
+        return [s for (c, _i), s in self._states.items() if c == connector]
 
     def snapshot_all(self) -> list[dict[str, Any]]:
         return [s.snapshot() for s in self._states.values()]
 
-    async def get_session(self, name: str) -> ClientSession:
-        """Return the live session for ``name``, blocking until first init.
+    def lookup_instance_for_account(self, connector: str, account: str) -> str | None:
+        """Return which instance serves ``(connector, account)`` per the routing map."""
+        return self._account_to_instance.get((connector, account))
 
-        Raises :class:`ConnectorNotEnabled` if the name isn't in the
+    async def get_session(self, connector: str, instance: str) -> ClientSession:
+        """Return the live session for ``(connector, instance)``.
+
+        Raises :class:`ConnectorNotEnabled` if the pair isn't in the
         configured set or :class:`CircuitOpen` if the supervisor loop
         gave up.  Otherwise blocks indefinitely on first init — wrap
         the call in :func:`asyncio.wait_for` if you need a deadline
         (the dispatch path here does so via :data:`_DISPATCH_TIMEOUT_S`).
         """
-        state = self._states.get(name)
+        state = self._states.get((connector, instance))
         if state is None:
-            raise ConnectorNotEnabled(name)
+            raise ConnectorNotEnabled(f"{connector}:{instance}")
         if state.status == "circuit_open":
-            raise CircuitOpen(name)
+            raise CircuitOpen(state.label)
         await state.ready.wait()
         if state.session is None:
-            raise ConnectorNotReady(name)
+            raise ConnectorNotReady(state.label)
         return state.session
 
     async def dispatch_call(
         self,
-        name: str,
+        connector: str,
+        instance: str,
         tool: str,
         arguments: dict[str, Any],
         *,
         meta: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Invoke a tool on the named connector.
+        """Invoke a tool on the named ``(connector, instance)``.
 
         Returns the raw MCP-call response shape: ``{"content": str}`` on
         success, ``{"error": str}`` on tool error or transport failure.
         Mirrors :func:`aios.mcp.client.call_mcp_tool` so call sites can
         union the two without conditional shaping.
 
-        Bounds first-init wait by :data:`_DISPATCH_TIMEOUT_S` so a
-        connector stuck in ``starting`` doesn't pin the worker
+        Bounds first-init wait by :data:`_DISPATCH_TIMEOUT_S` so an
+        instance stuck in ``starting`` doesn't pin the worker
         indefinitely; downstream the call itself shares the same bound.
         """
+        label = f"{connector}:{instance}"
         try:
-            session = await asyncio.wait_for(self.get_session(name), timeout=_DISPATCH_TIMEOUT_S)
+            session = await asyncio.wait_for(
+                self.get_session(connector, instance), timeout=_DISPATCH_TIMEOUT_S
+            )
         except ConnectorNotEnabled:
-            return {"error": f"connector {name!r} not enabled", "code": "not_enabled"}
+            return {"error": f"connector instance {label!r} not enabled", "code": "not_enabled"}
         except CircuitOpen:
             return {
-                "error": f"connector {name!r} circuit open after repeated failures",
+                "error": f"connector instance {label!r} circuit open after repeated failures",
                 "code": "circuit_open",
             }
         except (ConnectorNotReady, TimeoutError):
-            return {"error": f"connector {name!r} not ready", "code": "not_ready"}
+            return {"error": f"connector instance {label!r} not ready", "code": "not_ready"}
 
         try:
             result = await asyncio.wait_for(
@@ -294,7 +424,8 @@ class ConnectorSubprocessRegistry:
         except Exception as err:
             log.warning(
                 "connector.call_failed",
-                connector=name,
+                connector=connector,
+                instance=instance,
                 tool=tool,
                 exc_info=True,
             )
@@ -305,20 +436,53 @@ class ConnectorSubprocessRegistry:
 
         return shape_call_result(result)
 
+    async def dispatch_call_for_account(
+        self,
+        connector: str,
+        account: str,
+        tool: str,
+        arguments: dict[str, Any],
+        *,
+        meta: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Dispatch when caller knows the account but not the instance.
+
+        Resolves the owning instance via the account → instance map
+        built from per-instance ``notifications/aios/accounts`` snapshots.
+        Returns a ``not_enabled`` envelope if no instance currently
+        serves that ``(connector, account)`` pair — covers both "operator
+        listed the account but its instance hasn't started yet" and
+        "account was reported by the connector subprocess but later
+        retracted".
+        """
+        instance = self._account_to_instance.get((connector, account))
+        if instance is None:
+            return {
+                "error": f"no instance serves account {account!r} on connector {connector!r}",
+                "code": "not_enabled",
+            }
+        return await self.dispatch_call(connector, instance, tool, arguments, meta=meta)
+
     # ── notifications ─────────────────────────────────────────────────
 
     async def _on_aios_notification(
-        self, name: str, method: str, params: dict[str, Any] | None
+        self,
+        key: tuple[str, str],
+        method: str,
+        params: dict[str, Any] | None,
     ) -> None:
-        """Route a ``notifications/aios/<...>`` payload from connector ``name``."""
-        state = self._states[name]
+        """Route a ``notifications/aios/<...>`` payload from one instance."""
+        connector, instance = key
+        state = self._states[key]
         if method == "notifications/aios/accounts":
             raw_accounts = (params or {}).get("accounts")
             if isinstance(raw_accounts, list):
                 state.accounts = list(raw_accounts)
+                self._rebuild_account_map(state, raw_accounts)
                 log.info(
                     "connector.accounts_updated",
-                    connector=name,
+                    connector=connector,
+                    instance=instance,
                     count=len(state.accounts),
                 )
             else:
@@ -330,7 +494,8 @@ class ConnectorSubprocessRegistry:
                 state.last_error = "malformed accounts payload"
                 log.warning(
                     "connector.accounts_malformed",
-                    connector=name,
+                    connector=connector,
+                    instance=instance,
                     payload_type=type(raw_accounts).__name__,
                 )
         elif method == "notifications/aios/inbound":
@@ -339,17 +504,66 @@ class ConnectorSubprocessRegistry:
             # would pause every other message (init responses, account
             # snapshots) for the duration.
             task = asyncio.create_task(
-                self._handle_inbound(name, params or {}),
-                name=f"connector_inbound:{name}",
+                self._handle_inbound(key, params or {}),
+                name=f"connector_inbound:{state.label}",
             )
             self._inbound_tasks.add(task)
             task.add_done_callback(self._inbound_tasks.discard)
         else:
-            log.info("connector.unknown_aios_notification", connector=name, method=method)
+            log.info(
+                "connector.unknown_aios_notification",
+                connector=connector,
+                instance=instance,
+                method=method,
+            )
+
+    def _rebuild_account_map(self, state: ConnectorState, raw_accounts: list[Any]) -> None:
+        """Refresh ``_account_to_instance`` for the reporting instance.
+
+        Atomic per-instance: clear all entries currently pointing at
+        ``state.instance`` for this connector, then insert from the new
+        snapshot.  Tolerates concurrent snapshots from sibling instances
+        (each only touches its own entries).
+
+        Conflict policy: if another instance of the same connector type
+        has already claimed this account, log a warning, set
+        ``state.last_error``, and DO NOT overwrite the existing claim.
+        Schema's ``UNIQUE (connector, account) WHERE archived_at IS
+        NULL`` makes operator-side double-attach impossible; this surfaces
+        the misconfig at the connector layer so it's visible in
+        ``aios connector list``.
+        """
+        connector = state.connector
+        # Clear stale claims for this instance.
+        for key in list(self._account_to_instance.keys()):
+            if key[0] == connector and self._account_to_instance[key] == state.instance:
+                del self._account_to_instance[key]
+        conflicts: list[str] = []
+        for entry in raw_accounts:
+            if not isinstance(entry, dict):
+                continue
+            account_id = entry.get("id")
+            if not isinstance(account_id, str) or not account_id:
+                continue
+            map_key = (connector, account_id)
+            existing = self._account_to_instance.get(map_key)
+            if existing is not None and existing != state.instance:
+                conflicts.append(f"{account_id!r} (already claimed by {existing!r})")
+                log.warning(
+                    "connector.account_conflict",
+                    connector=connector,
+                    instance=state.instance,
+                    other_instance=existing,
+                    account=account_id,
+                )
+                continue
+            self._account_to_instance[map_key] = state.instance
+        if conflicts:
+            state.last_error = f"account conflict with sibling instance(s): {', '.join(conflicts)}"
 
     # ── inbound dispatch ──────────────────────────────────────────────
 
-    async def _handle_inbound(self, name: str, params: dict[str, Any]) -> None:
+    async def _handle_inbound(self, key: tuple[str, str], params: dict[str, Any]) -> None:
         """Append an inbound event, dedupe via the ledger, ack the spool.
 
         Implements the crash walkthrough from plan decision #16: ledger
@@ -365,7 +579,8 @@ class ConnectorSubprocessRegistry:
         stalling the connector pipeline.
         """
 
-        state = self._states[name]
+        connector, instance = key
+        state = self._states[key]
         event_id = params.get("event_id")
         account = params.get("account")
         chat_id = params.get("chat_id")
@@ -378,17 +593,22 @@ class ConnectorSubprocessRegistry:
         # us ack the spool entry — without it we can't dedup or clear,
         # so the connector author must fix their emit shape.
         if not isinstance(event_id, str):
-            log.warning("connector.inbound_missing_event_id", connector=name)
+            log.warning(
+                "connector.inbound_missing_event_id",
+                connector=connector,
+                instance=instance,
+            )
             self._record_drop(state, "malformed")
             return
 
         if not (isinstance(account, str) and isinstance(chat_id, str) and isinstance(content, str)):
             log.warning(
                 "connector.inbound_malformed",
-                connector=name,
+                connector=connector,
+                instance=instance,
                 missing=[
-                    key
-                    for key, value in (
+                    field_name
+                    for field_name, value in (
                         ("account", account),
                         ("chat_id", chat_id),
                         ("content", content),
@@ -397,19 +617,20 @@ class ConnectorSubprocessRegistry:
                 ],
             )
             self._record_drop(state, "malformed")
-            await self._send_ack(name, event_id)
+            await self._send_ack(connector, instance, event_id)
             return
 
         if len(content) > MAX_USER_MESSAGE_CHARS:
             log.warning(
                 "connector.inbound_too_large",
-                connector=name,
+                connector=connector,
+                instance=instance,
                 account=account,
                 length=len(content),
                 limit=MAX_USER_MESSAGE_CHARS,
             )
             self._record_drop(state, "payload_too_large")
-            await self._send_ack(name, event_id)
+            await self._send_ack(connector, instance, event_id)
             return
 
         pool = runtime.require_pool()
@@ -418,14 +639,14 @@ class ConnectorSubprocessRegistry:
         #    operator may have just attached/configured the connection).
         async with pool.acquire() as conn:
             connection = await queries.get_connection_for_account(
-                conn, connector=name, account=account
+                conn, connector=connector, account=account
             )
         if connection is None:
-            await self._auto_create_or_drop(state, name=name, account=account)
+            await self._auto_create_or_drop(state, account=account)
             # Even if auto-create succeeds, this inbound is dropped:
             # the freshly-detached connection has no session to deliver
             # to.  Operator must explicitly attach / configure-per-chat.
-            await self._send_ack(name, event_id)
+            await self._send_ack(connector, instance, event_id)
             return
 
         # 2. Branch on routing mode.
@@ -437,24 +658,24 @@ class ConnectorSubprocessRegistry:
                 state,
                 connection_id=connection.id,
                 template_id=connection.session_template_id,
-                connector_name=name,
+                connector_name=connector,
                 account=account,
                 chat_id=chat_id,
             )
         else:
             self._record_drop(state, "detached")
-            await self._send_ack(name, event_id)
+            await self._send_ack(connector, instance, event_id)
             return
 
         if target_session_id is None:
             # Per-chat resolution already recorded the drop reason.
-            await self._send_ack(name, event_id)
+            await self._send_ack(connector, instance, event_id)
             return
 
         # 3. Append event + ledger row in the same transaction.
         try:
             await self._append_with_dedup(
-                connector_name=name,
+                connector_name=connector,
                 account=account,
                 event_id=event_id,
                 session_id=target_session_id,
@@ -467,7 +688,7 @@ class ConnectorSubprocessRegistry:
         except NotFoundError:
             # The session vanished between resolution and append.
             self._record_drop(state, "session_missing")
-            await self._send_ack(name, event_id)
+            await self._send_ack(connector, instance, event_id)
             return
 
         # 4. Outside the transaction: defer wake unconditionally.
@@ -478,9 +699,9 @@ class ConnectorSubprocessRegistry:
         # Failures propagate so the inbound task fails and the connector
         # replays on reconnect, where this same path can re-run.
         await defer_wake(pool, target_session_id, cause="inbound")
-        await self._send_ack(name, event_id)
+        await self._send_ack(connector, instance, event_id)
 
-    async def _auto_create_or_drop(self, state: ConnectorState, *, name: str, account: str) -> None:
+    async def _auto_create_or_drop(self, state: ConnectorState, *, account: str) -> None:
         """Insert a detached connection if ``auto_create_connections`` is on.
 
         Mirrors plan decision #13: missing pair drops the inbound
@@ -501,15 +722,20 @@ class ConnectorSubprocessRegistry:
         """
 
         self._record_drop(state, "no_connection")
-        if not self._settings.connectors_auto_create.get(name, True):
+        # ``connectors_auto_create`` is keyed by connector type, not
+        # instance — auto-create policy is per-platform.
+        if not self._settings.connectors_auto_create.get(state.connector, True):
             return
         pool = runtime.require_pool()
         try:
             async with pool.acquire() as conn:
-                await queries.insert_connection(conn, connector=name, account=account, metadata={})
+                await queries.insert_connection(
+                    conn, connector=state.connector, account=account, metadata={}
+                )
                 log.info(
                     "connector.auto_create_connection",
-                    connector=name,
+                    connector=state.connector,
+                    instance=state.instance,
                     account=account,
                 )
         except ConflictError:
@@ -651,8 +877,8 @@ class ConnectorSubprocessRegistry:
             return False
         return True
 
-    async def _send_ack(self, name: str, event_id: str) -> None:
-        """Send ``aios_inbound_ack`` to clear the connector's spool.
+    async def _send_ack(self, connector: str, instance: str, event_id: str) -> None:
+        """Send ``aios_inbound_ack`` to clear the spool of the originating instance.
 
         Awaited inline so :meth:`shutdown` waits for in-flight acks
         (or hits the 60s ``_DISPATCH_TIMEOUT_S``) before returning.
@@ -660,11 +886,14 @@ class ConnectorSubprocessRegistry:
         reconnect where the ledger conflict path catches the duplicate;
         we log but don't retry to avoid pinning a wedged connector.
         """
-        result = await self.dispatch_call(name, "aios_inbound_ack", {"event_id": event_id})
+        result = await self.dispatch_call(
+            connector, instance, "aios_inbound_ack", {"event_id": event_id}
+        )
         if "error" in result:
             log.info(
                 "connector.inbound_ack_failed",
-                connector=name,
+                connector=connector,
+                instance=instance,
                 event_id=event_id,
                 error=result["error"],
             )
@@ -674,14 +903,15 @@ class ConnectorSubprocessRegistry:
         state.drops[reason] += 1
         log.info(
             "connector.inbound_dropped",
-            connector=state.name,
+            connector=state.connector,
+            instance=state.instance,
             reason=reason,
             count=state.drops[reason],
         )
 
     # ── supervisor loop ───────────────────────────────────────────────
 
-    async def _supervisor_loop(self, name: str) -> None:
+    async def _supervisor_loop(self, key: tuple[str, str]) -> None:
         """Open subprocess, park on shutdown, restart on crash with backoff.
 
         Returns when :meth:`shutdown` flips the shutdown flag *or* the
@@ -689,11 +919,12 @@ class ConnectorSubprocessRegistry:
         reflects terminal status before this coroutine exits, so a GET
         call right after sees the right thing.
         """
-        state = self._states[name]
+        connector, instance = key
+        state = self._states[key]
         spec = state.spec
 
         async def handler(method: str, params: dict[str, Any] | None) -> None:
-            await self._on_aios_notification(name, method, params)
+            await self._on_aios_notification(key, method, params)
 
         while not self._shutdown.is_set():
             state.status = "starting"
@@ -704,7 +935,7 @@ class ConnectorSubprocessRegistry:
                     init_result,
                     closed_event,
                 ):
-                    self._validate_capability(name, init_result)
+                    self._validate_capability(state, init_result)
                     state.session = session
                     state.init_result = init_result
                     state.instructions = init_result.instructions
@@ -713,7 +944,8 @@ class ConnectorSubprocessRegistry:
                     state.ready.set()
                     log.info(
                         "connector.running",
-                        connector=name,
+                        connector=connector,
+                        instance=instance,
                         server_name=init_result.serverInfo.name,
                     )
                     # Park until shutdown OR the subprocess closes its
@@ -736,22 +968,37 @@ class ConnectorSubprocessRegistry:
                         return
                     # Subprocess closed.  Fall through to respawn.
                     state.last_error = "subprocess closed"
-                    log.warning("connector.crashed", connector=name, error=state.last_error)
+                    log.warning(
+                        "connector.crashed",
+                        connector=connector,
+                        instance=instance,
+                        error=state.last_error,
+                    )
             except asyncio.CancelledError:
                 if self._shutdown.is_set():
-                    log.info("connector.shutdown", connector=name)
+                    log.info(
+                        "connector.shutdown",
+                        connector=connector,
+                        instance=instance,
+                    )
                     return
                 # Cancellation that wasn't initiated by us — almost always
                 # the subprocess closed its end and anyio's task group
                 # propagated cancellation through ``open_connector_session``.
                 # Fall through to the crash branch and respawn.
                 state.last_error = "subprocess closed"
-                log.warning("connector.crashed", connector=name, error=state.last_error)
+                log.warning(
+                    "connector.crashed",
+                    connector=connector,
+                    instance=instance,
+                    error=state.last_error,
+                )
             except Exception as exc:
                 state.last_error = f"{type(exc).__name__}: {exc}"
                 log.warning(
                     "connector.crashed",
-                    connector=name,
+                    connector=connector,
+                    instance=instance,
                     error=state.last_error,
                     exc_info=True,
                 )
@@ -770,7 +1017,8 @@ class ConnectorSubprocessRegistry:
                 state.status = "circuit_open"
                 log.error(
                     "connector.circuit_open",
-                    connector=name,
+                    connector=connector,
+                    instance=instance,
                     failures=len(state.failures),
                     window_s=_CIRCUIT_WINDOW_S,
                 )
@@ -779,7 +1027,8 @@ class ConnectorSubprocessRegistry:
             state.status = "restarting"
             log.info(
                 "connector.restart_scheduled",
-                connector=name,
+                connector=connector,
+                instance=instance,
                 delay_s=state.backoff,
             )
             try:
@@ -790,11 +1039,11 @@ class ConnectorSubprocessRegistry:
                 pass
             state.backoff = min(state.backoff * 2, _BACKOFF_CAP_S)
 
-    def _validate_capability(self, name: str, init_result: InitializeResult) -> None:
+    def _validate_capability(self, state: ConnectorState, init_result: InitializeResult) -> None:
         """Hard-fail if the connector didn't declare ``experimental.aios/connector``."""
         experimental = init_result.capabilities.experimental or {}
         if _AIOS_EXPERIMENTAL_KEY not in experimental:
             raise RuntimeError(
-                f"connector {name!r} did not declare "
+                f"connector instance {state.label!r} did not declare "
                 f"experimental.{_AIOS_EXPERIMENTAL_KEY!r} capability"
             )

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -173,16 +173,6 @@ class ConnectorState:
         }
 
 
-def _sibling_instances(parsed: list[ConnectorInstance], connector: str, instance: str) -> set[str]:
-    """Return instance names of OTHER instances of the same connector type.
-
-    Used to filter sibling-scoped env vars out of each subprocess's env
-    so a wedged connector that iterates ``os.environ`` can't expose
-    sibling tokens.
-    """
-    return {ci.instance for ci in parsed if ci.connector == connector and ci.instance != instance}
-
-
 def resolve_connector_specs(settings: Settings) -> list[tuple[ConnectorInstance, ConnectorSpec]]:
     """Resolve ``connectors_enabled`` into ``(instance, spec)`` pairs.
 
@@ -199,9 +189,9 @@ def resolve_connector_specs(settings: Settings) -> list[tuple[ConnectorInstance,
     silently skip.
     """
     available = {ep.name: ep for ep in entry_points(group="aios.connectors")}
-    parsed = [parse_connector_entry(raw) for raw in settings.connectors_enabled]
     out: list[tuple[ConnectorInstance, ConnectorSpec]] = []
-    for raw, ci in zip(settings.connectors_enabled, parsed, strict=True):
+    for raw in settings.connectors_enabled:
+        ci = parse_connector_entry(raw)
         ep = available.get(ci.connector)
         if ep is None:
             raise RuntimeError(
@@ -216,18 +206,13 @@ def resolve_connector_specs(settings: Settings) -> list[tuple[ConnectorInstance,
                 f"entry point aios.connectors:{ci.connector} returned "
                 f"{type(spec).__name__!r}, expected ConnectorSpec"
             )
-        siblings = _sibling_instances(parsed, ci.connector, ci.instance)
-        spec = _apply_instance_overlay(spec, ci, settings, siblings=siblings)
+        spec = _apply_instance_overlay(spec, ci, settings)
         out.append((ci, spec))
     return out
 
 
 def _apply_instance_overlay(
-    spec: ConnectorSpec,
-    ci: ConnectorInstance,
-    settings: Settings,
-    *,
-    siblings: set[str],
+    spec: ConnectorSpec, ci: ConnectorInstance, settings: Settings
 ) -> ConnectorSpec:
     """Layer per-instance cwd + env on top of a factory-returned spec.
 
@@ -243,26 +228,17 @@ def _apply_instance_overlay(
     connector subprocess code stays instance-naive — it just reads
     config under the standard prefix.  Single-instance deployments use
     the unscoped vars directly with no transform.
-
-    ``siblings`` is the set of other instance names for the same
-    connector type; their scoped env vars are stripped so each
-    subprocess sees only its own credentials.
     """
     cwd = spec.cwd
     if cwd is None:
         cwd = settings.connectors_dir / ci.connector
         if ci.instance != ci.connector:
             cwd = cwd / ci.instance
-    env = _build_instance_env(ci, base=spec.env, siblings=siblings)
+    env = _build_instance_env(ci, base=spec.env)
     return replace(spec, cwd=cwd, env=env)
 
 
-def _build_instance_env(
-    ci: ConnectorInstance,
-    *,
-    base: dict[str, str] | None,
-    siblings: set[str],
-) -> dict[str, str]:
+def _build_instance_env(ci: ConnectorInstance, *, base: dict[str, str] | None) -> dict[str, str]:
     """Construct the env dict for a connector subprocess.
 
     Starts from ``os.environ`` (so the subprocess inherits operator-set
@@ -271,7 +247,7 @@ def _build_instance_env(
     non-default instances — re-exports
     ``AIOS_<CONN_UPPER>_<INST_UPPER>_<FIELD>`` as
     ``AIOS_<CONN_UPPER>_<FIELD>`` so the connector reads its config
-    under the standard prefix.  ``siblings``-scoped vars are stripped
+    under the standard prefix.
     from the resulting env so each subprocess sees only its own
     credentials (a wedged or chatty connector that iterates
     ``os.environ`` won't surface sibling tokens).
@@ -288,22 +264,11 @@ def _build_instance_env(
         env.update(base)
     if ci.instance == ci.connector:
         return env
-    connector_prefix = f"AIOS_{ci.connector.upper()}_"
-    scope_prefix = f"{connector_prefix}{ci.instance.upper()}_"
-    # Re-export our own scoped vars under the standard prefix.
+    scope_prefix = f"AIOS_{ci.connector.upper()}_{ci.instance.upper()}_"
+    target_prefix = f"AIOS_{ci.connector.upper()}_"
     for key, value in list(env.items()):
         if key.startswith(scope_prefix):
-            env[connector_prefix + key[len(scope_prefix) :]] = value
-    # Strip sibling-scoped vars so credentials don't leak across
-    # subprocesses.  We only remove vars whose leading segment matches
-    # a known sibling instance name from ``connectors_enabled`` —
-    # plain connector-scoped fields like ``AIOS_TELEGRAM_BOT_TOKEN`` (no
-    # instance segment) are kept as the legacy fallback.
-    if siblings:
-        sibling_prefixes = tuple(f"{connector_prefix}{s.upper()}_" for s in siblings)
-        for key in list(env.keys()):
-            if key.startswith(sibling_prefixes):
-                env.pop(key, None)
+            env[target_prefix + key[len(scope_prefix) :]] = value
     return env
 
 

--- a/src/aios/harness/connector_tasks.py
+++ b/src/aios/harness/connector_tasks.py
@@ -12,11 +12,9 @@ The ``/v1/connectors/...`` admin endpoints flow through procrastinate:
   ``pg_notify``'s the result envelope on the same channel.
 * The router awaits NOTIFY (60s ceiling) and returns.
 
-Multi-instance: every task takes ``(connector, instance)`` as a
-required pair.  No fallback at the task layer — auto-resolve sugar
-(single-instance case → infer instance) lives in the CLI/API layer
-only, where the user-facing ergonomics matter; tasks themselves
-require explicit pairs to keep the internal contract crisp.
+The ``_`` instance sentinel (:data:`DEFAULT_INSTANCE_SENTINEL`) lets
+the CLI omit ``<instance>`` without a separate resolve round-trip; the
+worker resolves it via :meth:`ConnectorSubprocessRegistry.resolve_default_instance`.
 
 Lock semantics:
 
@@ -48,9 +46,46 @@ log = get_logger("aios.harness.connector_tasks")
 CONNECTOR_QUEUE = "connectors"
 _TOOLS_TIMEOUT_S = 30.0
 
+# Sentinel ``instance`` value the CLI / API passes when the operator
+# omits the instance segment.  The supervisor resolves it to the sole
+# enabled instance of that connector type, or returns an ``ambiguous``
+# error envelope.  Distinct from any valid instance name (which must
+# match ``^[a-z][a-z0-9_]*$``).
+DEFAULT_INSTANCE_SENTINEL = "_"
+
 
 def _result_channel(call_id: str) -> str:
     return f"connector_result_{call_id}"
+
+
+def _resolve_instance_or_error(
+    registry: Any, connector: str, instance: str
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Translate the ``_`` sentinel to a concrete instance name.
+
+    Returns ``(resolved_instance, None)`` on success, or
+    ``(None, error_envelope)`` if the sentinel can't be resolved
+    (no instances enabled, or multiple instances and operator must
+    pick one explicitly).
+    """
+    if instance != DEFAULT_INSTANCE_SENTINEL:
+        return instance, None
+    resolved = registry.resolve_default_instance(connector)
+    if resolved is not None:
+        return resolved, None
+    states = registry.states_for_connector(connector)
+    if not states:
+        return None, {
+            "error": f"connector {connector!r} not enabled",
+            "code": "not_enabled",
+        }
+    return None, {
+        "error": (
+            f"connector {connector!r} has multiple instances "
+            f"({', '.join(s.instance for s in states)}); specify one explicitly"
+        ),
+        "code": "ambiguous_instance",
+    }
 
 
 async def _notify_result(pool: asyncpg.Pool[Any], call_id: str, payload: dict[str, Any]) -> None:
@@ -105,13 +140,18 @@ async def connector_status(
             return
         await _notify_result(pool, call_id, {"connectors": [s.snapshot() for s in states]})
         return
-    state = registry.state(connector, instance)
+    resolved, err = _resolve_instance_or_error(registry, connector, instance)
+    if err is not None:
+        await _notify_result(pool, call_id, err)
+        return
+    assert resolved is not None
+    state = registry.state(connector, resolved)
     if state is None:
         await _notify_result(
             pool,
             call_id,
             {
-                "error": f"connector instance {connector}:{instance} not enabled",
+                "error": f"connector instance {connector}:{resolved} not enabled",
                 "code": "not_enabled",
             },
         )
@@ -139,12 +179,18 @@ async def connector_tools(call_id: str, connector: str, instance: str) -> None:
         CircuitOpen,
         ConnectorNotEnabled,
         ConnectorNotReady,
+        instance_label,
     )
 
-    label = f"{connector}:{instance}"
+    resolved, err = _resolve_instance_or_error(registry, connector, instance)
+    if err is not None:
+        await _notify_result(pool, call_id, err)
+        return
+    assert resolved is not None
+    label = instance_label(connector, resolved)
     try:
         session = await asyncio.wait_for(
-            registry.get_session(connector, instance), timeout=_TOOLS_TIMEOUT_S
+            registry.get_session(connector, resolved), timeout=_TOOLS_TIMEOUT_S
         )
     except ConnectorNotEnabled:
         await _notify_result(
@@ -215,7 +261,12 @@ async def connector_call(
             pool, call_id, {"error": "worker not initialized", "code": "not_ready"}
         )
         return
-    result = await registry.dispatch_call(connector, instance, tool, arguments, meta=meta)
+    resolved, err = _resolve_instance_or_error(registry, connector, instance)
+    if err is not None:
+        await _notify_result(pool, call_id, err)
+        return
+    assert resolved is not None
+    result = await registry.dispatch_call(connector, resolved, tool, arguments, meta=meta)
     await _notify_result(pool, call_id, result)
 
 

--- a/src/aios/harness/connector_tasks.py
+++ b/src/aios/harness/connector_tasks.py
@@ -2,7 +2,7 @@
 
 The API process can't talk to connector subprocesses directly — they're
 owned by the worker via :class:`~aios.harness.connector_supervisor.ConnectorSubprocessRegistry`.
-The four ``/v1/connectors/...`` admin endpoints flow through procrastinate:
+The ``/v1/connectors/...`` admin endpoints flow through procrastinate:
 
 * The router generates a ULID ``call_id`` and ``LISTEN``s on
   ``connector_result_<call_id>`` (LISTEN-before-action invariant from
@@ -12,13 +12,20 @@ The four ``/v1/connectors/...`` admin endpoints flow through procrastinate:
   ``pg_notify``'s the result envelope on the same channel.
 * The router awaits NOTIFY (60s ceiling) and returns.
 
+Multi-instance: every task takes ``(connector, instance)`` as a
+required pair.  No fallback at the task layer — auto-resolve sugar
+(single-instance case → infer instance) lives in the CLI/API layer
+only, where the user-facing ergonomics matter; tasks themselves
+require explicit pairs to keep the internal contract crisp.
+
 Lock semantics:
 
-* ``harness.connector_call`` — ``lock="connector:{connector_name}"``
-  so concurrent tool calls against the same connector serialize.  Set
-  at defer time, not on the decorator: procrastinate stores decorator
-  lock arguments verbatim with no template substitution (same reason
-  ``harness.wake_session`` configures its lock per-call).
+* ``harness.connector_call`` —
+  ``lock="connector:{connector}:{instance}"`` so concurrent tool calls
+  against the same instance serialize but distinct instances run in
+  parallel.  Set at defer time, not on the decorator: procrastinate
+  stores decorator lock arguments verbatim with no template substitution
+  (same reason ``harness.wake_session`` configures its lock per-call).
 * ``harness.connector_status`` / ``harness.connector_tools`` — no
   procrastinate locks.  Reads are cheap, don't conflict, and the
   per-call NOTIFY channel routes results back to the right LISTENer.
@@ -57,15 +64,24 @@ async def _notify_result(pool: asyncpg.Pool[Any], call_id: str, payload: dict[st
 
 
 @app.task(name="harness.connector_status", queue=CONNECTOR_QUEUE, retry=False, pass_context=False)
-async def connector_status(call_id: str, name: str | None = None) -> None:
+async def connector_status(
+    call_id: str,
+    connector: str | None = None,
+    instance: str | None = None,
+) -> None:
     """Snapshot connector state and notify the API.
 
-    ``name=None`` returns every connector's snapshot (used by
-    ``GET /v1/connectors``).  ``name=<n>`` filters to a single
-    connector (used by ``GET /v1/connectors/:name/accounts`` and the
-    aggregate row in ``aios connector list`` when the operator targets
-    one connector).  Unknown ``name`` notifies an ``error`` envelope so
-    the router can return 404 without timing out.
+    Three call shapes:
+
+    * ``connector=None, instance=None``: every instance's snapshot (used
+      by ``GET /v1/connectors``).
+    * ``connector=<c>, instance=None``: every instance of one connector
+      type (used by ``GET /v1/connectors/<c>``).
+    * ``connector=<c>, instance=<i>``: single-instance state (used by
+      ``GET /v1/connectors/<c>/<i>`` and ``aios connector get``).
+
+    Unknown pairs notify an ``error`` envelope so the router can return
+    404 without timing out.
     """
     pool = runtime.require_pool()
     registry = runtime.connector_subprocess_registry
@@ -74,24 +90,38 @@ async def connector_status(call_id: str, name: str | None = None) -> None:
             pool, call_id, {"error": "worker not initialized", "code": "not_ready"}
         )
         return
-    if name is None:
+    if connector is None:
         snapshot = registry.snapshot_all()
         await _notify_result(pool, call_id, {"connectors": snapshot})
         return
-    state = registry.state(name)
+    if instance is None:
+        states = registry.states_for_connector(connector)
+        if not states:
+            await _notify_result(
+                pool,
+                call_id,
+                {"error": f"connector {connector!r} not enabled", "code": "not_enabled"},
+            )
+            return
+        await _notify_result(pool, call_id, {"connectors": [s.snapshot() for s in states]})
+        return
+    state = registry.state(connector, instance)
     if state is None:
         await _notify_result(
             pool,
             call_id,
-            {"error": f"connector {name!r} not enabled", "code": "not_enabled"},
+            {
+                "error": f"connector instance {connector}:{instance} not enabled",
+                "code": "not_enabled",
+            },
         )
         return
     await _notify_result(pool, call_id, {"connector": state.snapshot()})
 
 
 @app.task(name="harness.connector_tools", queue=CONNECTOR_QUEUE, retry=False, pass_context=False)
-async def connector_tools(call_id: str, name: str) -> None:
-    """List the named connector's tools and notify the API.
+async def connector_tools(call_id: str, connector: str, instance: str) -> None:
+    """List one instance's tools and notify the API.
 
     Round-trips to the subprocess (``session.list_tools()``) so a
     crashed connector surfaces as a fresh transport error rather than
@@ -111,34 +141,42 @@ async def connector_tools(call_id: str, name: str) -> None:
         ConnectorNotReady,
     )
 
+    label = f"{connector}:{instance}"
     try:
-        session = await asyncio.wait_for(registry.get_session(name), timeout=_TOOLS_TIMEOUT_S)
+        session = await asyncio.wait_for(
+            registry.get_session(connector, instance), timeout=_TOOLS_TIMEOUT_S
+        )
     except ConnectorNotEnabled:
         await _notify_result(
             pool,
             call_id,
-            {"error": f"connector {name!r} not enabled", "code": "not_enabled"},
+            {"error": f"connector instance {label!r} not enabled", "code": "not_enabled"},
         )
         return
     except CircuitOpen:
         await _notify_result(
             pool,
             call_id,
-            {"error": f"connector {name!r} circuit open", "code": "circuit_open"},
+            {"error": f"connector instance {label!r} circuit open", "code": "circuit_open"},
         )
         return
     except (ConnectorNotReady, TimeoutError):
         await _notify_result(
             pool,
             call_id,
-            {"error": f"connector {name!r} not ready", "code": "not_ready"},
+            {"error": f"connector instance {label!r} not ready", "code": "not_ready"},
         )
         return
 
     try:
         result = await asyncio.wait_for(session.list_tools(), timeout=_TOOLS_TIMEOUT_S)
     except Exception as err:
-        log.warning("connector_tools.list_failed", connector=name, exc_info=True)
+        log.warning(
+            "connector_tools.list_failed",
+            connector=connector,
+            instance=instance,
+            exc_info=True,
+        )
         await _notify_result(
             pool,
             call_id,
@@ -163,12 +201,13 @@ async def connector_tools(call_id: str, name: str) -> None:
 @app.task(name="harness.connector_call", queue=CONNECTOR_QUEUE, retry=False, pass_context=False)
 async def connector_call(
     call_id: str,
-    name: str,
+    connector: str,
+    instance: str,
     tool: str,
     arguments: dict[str, Any],
     meta: dict[str, Any] | None = None,
 ) -> None:
-    """Dispatch a tool call into the connector subprocess and notify the API."""
+    """Dispatch a tool call into the named instance and notify the API."""
     pool = runtime.require_pool()
     registry = runtime.connector_subprocess_registry
     if registry is None:
@@ -176,19 +215,20 @@ async def connector_call(
             pool, call_id, {"error": "worker not initialized", "code": "not_ready"}
         )
         return
-    result = await registry.dispatch_call(name, tool, arguments, meta=meta)
+    result = await registry.dispatch_call(connector, instance, tool, arguments, meta=meta)
     await _notify_result(pool, call_id, result)
 
 
 async def defer_connector_call(
     *,
     call_id: str,
-    name: str,
+    connector: str,
+    instance: str,
     tool: str,
     arguments: dict[str, Any],
     meta: dict[str, Any] | None = None,
 ) -> None:
-    """Enqueue a ``connector_call`` job with per-connector mutual exclusion.
+    """Enqueue a ``connector_call`` job with per-instance mutual exclusion.
 
     Only ``lock`` is set — ``queueing_lock`` would dedup pending jobs
     sharing a value, but every API request mints a fresh ``call_id``
@@ -198,24 +238,30 @@ async def defer_connector_call(
     """
     deferrer = app.configure_task(
         "harness.connector_call",
-        lock=f"connector:{name}",
+        lock=f"connector:{connector}:{instance}",
     )
     await deferrer.defer_async(
         call_id=call_id,
-        name=name,
+        connector=connector,
+        instance=instance,
         tool=tool,
         arguments=arguments,
         meta=meta,
     )
 
 
-async def defer_connector_status(*, call_id: str, name: str | None = None) -> None:
+async def defer_connector_status(
+    *,
+    call_id: str,
+    connector: str | None = None,
+    instance: str | None = None,
+) -> None:
     """Enqueue a ``connector_status`` snapshot job."""
     deferrer = app.configure_task("harness.connector_status")
-    await deferrer.defer_async(call_id=call_id, name=name)
+    await deferrer.defer_async(call_id=call_id, connector=connector, instance=instance)
 
 
-async def defer_connector_tools(*, call_id: str, name: str) -> None:
+async def defer_connector_tools(*, call_id: str, connector: str, instance: str) -> None:
     """Enqueue a ``connector_tools`` round-trip job."""
     deferrer = app.configure_task("harness.connector_tools")
-    await deferrer.defer_async(call_id=call_id, name=name)
+    await deferrer.defer_async(call_id=call_id, connector=connector, instance=instance)

--- a/src/aios/harness/connector_tasks.py
+++ b/src/aios/harness/connector_tasks.py
@@ -46,12 +46,11 @@ log = get_logger("aios.harness.connector_tasks")
 CONNECTOR_QUEUE = "connectors"
 _TOOLS_TIMEOUT_S = 30.0
 
-# Sentinel ``instance`` value the CLI / API passes when the operator
-# omits the instance segment.  The supervisor resolves it to the sole
-# enabled instance of that connector type, or returns an ``ambiguous``
-# error envelope.  Distinct from any valid instance name (which must
-# match ``^[a-z][a-z0-9_]*$``).
-DEFAULT_INSTANCE_SENTINEL = "_"
+# Re-export so worker-side callers (e.g. tests) that already import
+# from this module don't need to switch to ``aios.config``.  The
+# canonical home is ``aios.config`` because the CLI imports it without
+# triggering this module's procrastinate-app load.
+from aios.config import DEFAULT_INSTANCE_SENTINEL  # noqa: E402  (re-export)
 
 
 def _result_channel(call_id: str) -> str:
@@ -220,7 +219,7 @@ async def connector_tools(call_id: str, connector: str, instance: str) -> None:
         log.warning(
             "connector_tools.list_failed",
             connector=connector,
-            instance=instance,
+            instance=resolved,
             exc_info=True,
         )
         await _notify_result(

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -451,28 +451,24 @@ async def _run_session_step_body(
     tool_calls: list[dict[str, Any]] = assistant_msg.get("tool_calls") or []
 
     if tool_calls:
-        from aios.tools.registry import registry as tool_registry
-
         immediate: list[dict[str, Any]] = []
         mcp_immediate: list[dict[str, Any]] = []
         needs_confirm: list[dict[str, Any]] = []
         custom: list[dict[str, Any]] = []
+        unknown_mcp: list[dict[str, Any]] = []
 
         for tc in tool_calls:
-            name = _tc_name(tc)
-            if _is_mcp_tool(name):
-                # MCP tools default to always_ask (unlike built-in always_allow).
-                perm = resolve_mcp_permission(name, agent.tools)
-                if perm == "always_allow":
-                    mcp_immediate.append(tc)
-                else:
-                    needs_confirm.append(tc)
-            elif not tool_registry.has(name):
-                custom.append(tc)
-            elif resolve_permission(name, agent.tools) == "always_ask":
-                needs_confirm.append(tc)
-            else:
+            kind = _classify_tool_call(tc, agent, mcp_server_map)
+            if kind == "immediate":
                 immediate.append(tc)
+            elif kind == "mcp_immediate":
+                mcp_immediate.append(tc)
+            elif kind == "needs_confirm":
+                needs_confirm.append(tc)
+            elif kind == "custom":
+                custom.append(tc)
+            else:  # "unknown_mcp"
+                unknown_mcp.append(tc)
 
         if immediate:
             launch_tool_calls(pool, session_id, immediate)
@@ -483,19 +479,29 @@ async def _run_session_step_body(
                 tool_names=[_tc_name(tc) for tc in immediate],
             )
 
-        if mcp_immediate:
+        # Unknown-MCP tools route through the regular MCP dispatcher,
+        # bypassing the permission gate.  ``_execute_mcp_tool_async``
+        # already detects unknown servers and appends a tool_error
+        # event (``mcp_tool.server_not_found``); the prior code path
+        # parked the session in ``requires_action`` and dispatched
+        # only after a confirmation, which never came.  Routing them
+        # to immediate dispatch lets the model see the error in the
+        # next step and self-correct.
+        immediate_mcp = mcp_immediate + unknown_mcp
+        if immediate_mcp:
             launch_mcp_tool_calls(
                 pool,
                 session_id,
-                mcp_immediate,
+                immediate_mcp,
                 mcp_server_map,
                 focal_channel=session.focal_channel,
             )
             log.info(
                 "step.mcp_tools_launched",
                 session_id=session_id,
-                count=len(mcp_immediate),
-                tool_names=[_tc_name(tc) for tc in mcp_immediate],
+                count=len(immediate_mcp),
+                tool_names=[_tc_name(tc) for tc in immediate_mcp],
+                unknown_count=len(unknown_mcp),
             )
 
         if needs_confirm or custom:
@@ -604,6 +610,74 @@ def _tc_name(tc: dict[str, Any]) -> str:
 def _is_mcp_tool(name: str) -> bool:
     """Return True if the tool name is an MCP-namespaced tool."""
     return name.startswith("mcp__")
+
+
+def _is_known_mcp_server(server_name: str, mcp_server_map: dict[str, str]) -> bool:
+    """Return True if ``server_name`` resolves to a registered MCP server.
+
+    A server is "known" if either:
+
+    * It's a connector instance currently registered with the
+      :class:`~aios.harness.connector_supervisor.ConnectorSubprocessRegistry`,
+      or
+    * It appears in ``mcp_server_map`` (the agent-declared HTTP MCP
+      servers, keyed by ``McpServerSpec.name``).
+
+    Used by :func:`_classify_tool_call` to short-circuit hallucinated
+    tool names before the permission gate, so the model gets a tool
+    error in one turn instead of parking in ``requires_action`` forever
+    waiting on a confirmation that would dispatch into
+    ``mcp_tool.server_not_found`` anyway.
+    """
+    registry = runtime.connector_subprocess_registry
+    if registry is not None and registry.states_for_connector(server_name):
+        return True
+    return server_name in mcp_server_map
+
+
+def _classify_tool_call(
+    tool_call: dict[str, Any],
+    agent: Any,
+    mcp_server_map: dict[str, str],
+) -> str:
+    """Classify a tool call into a dispatch bucket.
+
+    Returns one of:
+
+    * ``"immediate"`` — built-in tool, run synchronously.
+    * ``"mcp_immediate"`` — known MCP tool, ``always_allow``.
+    * ``"needs_confirm"`` — built-in or MCP tool gated on
+      ``always_ask`` confirmation.
+    * ``"custom"`` — client-executed custom tool (the harness holds
+      the call until the client posts a tool-result).
+    * ``"unknown_mcp"`` — MCP-namespaced tool whose server is not
+      registered.  Routed to immediate tool-error so the model can
+      self-correct rather than parking in ``requires_action``.
+    """
+    from aios.tools.registry import registry as tool_registry
+
+    function = tool_call.get("function") or {}
+    name: str = function.get("name") or ""
+
+    if _is_mcp_tool(name):
+        try:
+            server_name = name.split("__", 2)[1]
+        except IndexError:
+            server_name = ""
+        if not server_name or not _is_known_mcp_server(server_name, mcp_server_map):
+            return "unknown_mcp"
+        perm = resolve_mcp_permission(name, agent.tools)
+        if perm == "always_allow":
+            return "mcp_immediate"
+        return "needs_confirm"
+
+    if not tool_registry.has(name):
+        return "custom"
+
+    if resolve_permission(name, agent.tools) == "always_ask":
+        return "needs_confirm"
+
+    return "immediate"
 
 
 def resolve_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -22,7 +22,7 @@ and proceeds.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from aios.db.sse_lock import has_subscriber
 from aios.harness import runtime
@@ -635,11 +635,16 @@ def _is_known_mcp_server(server_name: str, mcp_server_map: dict[str, str]) -> bo
     return server_name in mcp_server_map
 
 
+type ToolDispatchKind = Literal[
+    "immediate", "mcp_immediate", "needs_confirm", "custom", "unknown_mcp"
+]
+
+
 def _classify_tool_call(
     tool_call: dict[str, Any],
     agent: Any,
     mcp_server_map: dict[str, str],
-) -> str:
+) -> ToolDispatchKind:
     """Classify a tool call into a dispatch bucket.
 
     Returns one of:
@@ -654,6 +659,7 @@ def _classify_tool_call(
       registered.  Routed to immediate tool-error so the model can
       self-correct rather than parking in ``requires_action``.
     """
+    from aios.harness.tool_dispatch import _parse_mcp_tool_name
     from aios.tools.registry import registry as tool_registry
 
     function = tool_call.get("function") or {}
@@ -661,10 +667,10 @@ def _classify_tool_call(
 
     if _is_mcp_tool(name):
         try:
-            server_name = name.split("__", 2)[1]
-        except IndexError:
-            server_name = ""
-        if not server_name or not _is_known_mcp_server(server_name, mcp_server_map):
+            server_name, _ = _parse_mcp_tool_name(name)
+        except ValueError:
+            return "unknown_mcp"
+        if not _is_known_mcp_server(server_name, mcp_server_map):
             return "unknown_mcp"
         perm = resolve_mcp_permission(name, agent.tools)
         if perm is None:

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -667,6 +667,15 @@ def _classify_tool_call(
         if not server_name or not _is_known_mcp_server(server_name, mcp_server_map):
             return "unknown_mcp"
         perm = resolve_mcp_permission(name, agent.tools)
+        if perm is None:
+            # Fallback to the operator-configured default for unmounted
+            # toolsets (``AIOS_DEFAULT_MCP_PERMISSION_POLICY``).  Unset
+            # → ``always_ask`` (safe default); explicit per-toolset
+            # policies on ``agent.tools`` always win and are returned
+            # above without reaching this branch.
+            from aios.config import get_settings
+
+            perm = get_settings().default_mcp_permission_policy
         if perm == "always_allow":
             return "mcp_immediate"
         return "needs_confirm"

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -405,6 +405,18 @@ async def _execute_mcp_tool_async(
         # an agent's ``mcp_servers`` entry would be ambiguous.  We
         # resolve in favor of the connector — connectors are first-class
         # in the redesign (#200), HTTP MCP servers are agent-scoped.
+        #
+        # This is the one in-process call site that imports the
+        # supervisor registry directly (rather than going through a
+        # procrastinate task in ``aios.harness.connector_tasks``).
+        # Justified because every outbound MCP tool call is hot-path:
+        # the procrastinate round-trip would add ~50-200ms per call.
+        # New supervisor consumers should NOT add direct-import call
+        # sites here — define a task in ``connector_tasks.py`` and
+        # dispatch through it.  Same behaviour today, one less site
+        # to migrate the day the supervisor splits into a separate
+        # ``aios connectors`` process (see ``connector_supervisor``
+        # module docstring's "Architectural constraint" section).
         connector_registry = runtime.connector_subprocess_registry
         connector_instances = (
             connector_registry.states_for_connector(server_name)

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -412,18 +412,36 @@ async def _execute_mcp_tool_async(
             else []
         )
         if connector_registry is not None and connector_instances:
+            # Resolve which account the call is targeting.  Tools that
+            # take ``account`` as an explicit arg (cross-chat ops like
+            # ``list_chats``) get it from there; focal-required tools
+            # (``signal_send``, ``telegram_send``) get it from the
+            # focal-channel ``_meta`` suffix's first segment.
             account_arg = arguments.get("account")
             if isinstance(account_arg, str):
+                account_for_routing: str | None = account_arg
+            elif suffix is not None:
+                account_for_routing = suffix.partition("/")[0] or None
+            else:
+                account_for_routing = None
+
+            # Authorize the call regardless of how the account was
+            # resolved.  The pre-fix version only ran this check for
+            # the explicit-arg path; focal-routed dispatch sailed
+            # through unauthorized, letting any session that could
+            # ``switch_channel`` to a connector's chat send via that
+            # connector — see PR #214 #39.
+            if account_for_routing is not None:
                 from aios.services import connections as connections_service
 
                 authorized = await connections_service.validate_account_for_session(
-                    pool, session_id, connector=server_name, account=account_arg
+                    pool, session_id, connector=server_name, account=account_for_routing
                 )
                 if not authorized:
                     bound_log.warning(
                         "mcp_tool.account_not_authorized",
                         server_name=server_name,
-                        account=account_arg,
+                        account=account_for_routing,
                     )
                     is_error = True
                     await _append_tool_result(
@@ -432,16 +450,13 @@ async def _execute_mcp_tool_async(
                         call_id,
                         name,
                         error=(
-                            f"account {account_arg!r} on connector {server_name!r} is not "
-                            "attached to this session or one that spawned it"
+                            f"account {account_for_routing!r} on connector "
+                            f"{server_name!r} is not attached to this session "
+                            "or one that spawned it"
                         ),
                     )
                     return
-                account_for_routing: str | None = account_arg
-            elif suffix is not None:
-                account_for_routing = suffix.partition("/")[0] or None
-            else:
-                account_for_routing = None
+
             if account_for_routing is not None:
                 result = await connector_registry.dispatch_call_for_account(
                     server_name, account_for_routing, tool_name, arguments, meta=meta

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -406,8 +406,25 @@ async def _execute_mcp_tool_async(
         # resolve in favor of the connector — connectors are first-class
         # in the redesign (#200), HTTP MCP servers are agent-scoped.
         connector_registry = runtime.connector_subprocess_registry
-        if connector_registry is not None and connector_registry.state(server_name) is not None:
+        connector_instances = (
+            connector_registry.states_for_connector(server_name)
+            if connector_registry is not None
+            else []
+        )
+        if connector_registry is not None and connector_instances:
+            # Resolve which instance of this connector type handles the call.
+            # Three sources of routing info, in order:
+            #   1. explicit ``account`` arg (cross-chat / setup tools)
+            #   2. focal-channel meta — the ``<account>/<chat>`` suffix
+            #      we just stamped above; account is the part before the
+            #      first ``/``
+            #   3. single-instance shortcut for tools without account
+            #      context (e.g. ``ping``); ambiguous if more than one
+            #      instance is enabled
             account_arg = arguments.get("account")
+            account_for_routing: str | None = account_arg if isinstance(account_arg, str) else None
+            if account_for_routing is None and suffix is not None:
+                account_for_routing = suffix.partition("/")[0] or None
             if isinstance(account_arg, str):
                 from aios.services import connections as connections_service
 
@@ -432,9 +449,36 @@ async def _execute_mcp_tool_async(
                         ),
                     )
                     return
-            result = await connector_registry.dispatch_call(
-                server_name, tool_name, arguments, meta=meta
-            )
+            if account_for_routing is not None:
+                result = await connector_registry.dispatch_call_for_account(
+                    server_name, account_for_routing, tool_name, arguments, meta=meta
+                )
+            elif len(connector_instances) == 1:
+                instance = connector_instances[0].instance
+                result = await connector_registry.dispatch_call(
+                    server_name, instance, tool_name, arguments, meta=meta
+                )
+            else:
+                bound_log.warning(
+                    "mcp_tool.connector_instance_ambiguous",
+                    server_name=server_name,
+                    instance_count=len(connector_instances),
+                )
+                is_error = True
+                await _append_tool_result(
+                    pool,
+                    session_id,
+                    call_id,
+                    name,
+                    error=(
+                        f"connector {server_name!r} has multiple instances "
+                        f"({', '.join(s.instance for s in connector_instances)}) "
+                        "and the call provides no routing info (no account arg, "
+                        "no focal channel) — set focal channel via switch_channel "
+                        "or pass account= explicitly"
+                    ),
+                )
+                return
         else:
             url = mcp_server_map.get(server_name)
             if url is None:

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -412,19 +412,7 @@ async def _execute_mcp_tool_async(
             else []
         )
         if connector_registry is not None and connector_instances:
-            # Resolve which instance of this connector type handles the call.
-            # Three sources of routing info, in order:
-            #   1. explicit ``account`` arg (cross-chat / setup tools)
-            #   2. focal-channel meta — the ``<account>/<chat>`` suffix
-            #      we just stamped above; account is the part before the
-            #      first ``/``
-            #   3. single-instance shortcut for tools without account
-            #      context (e.g. ``ping``); ambiguous if more than one
-            #      instance is enabled
             account_arg = arguments.get("account")
-            account_for_routing: str | None = account_arg if isinstance(account_arg, str) else None
-            if account_for_routing is None and suffix is not None:
-                account_for_routing = suffix.partition("/")[0] or None
             if isinstance(account_arg, str):
                 from aios.services import connections as connections_service
 
@@ -449,14 +437,18 @@ async def _execute_mcp_tool_async(
                         ),
                     )
                     return
+                account_for_routing: str | None = account_arg
+            elif suffix is not None:
+                account_for_routing = suffix.partition("/")[0] or None
+            else:
+                account_for_routing = None
             if account_for_routing is not None:
                 result = await connector_registry.dispatch_call_for_account(
                     server_name, account_for_routing, tool_name, arguments, meta=meta
                 )
             elif len(connector_instances) == 1:
-                instance = connector_instances[0].instance
                 result = await connector_registry.dispatch_call(
-                    server_name, instance, tool_name, arguments, meta=meta
+                    server_name, connector_instances[0].instance, tool_name, arguments, meta=meta
                 )
             else:
                 bound_log.warning(

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -41,6 +41,7 @@ from aios.db.pool import create_pool, normalize_dsn
 from aios.harness import runtime
 from aios.harness.connector_supervisor import (
     ConnectorSubprocessRegistry,
+    instance_label,
     resolve_connector_specs,
 )
 from aios.harness.procrastinate_app import app as procrastinate_app
@@ -120,7 +121,7 @@ async def worker_main() -> None:
             "worker.startup",
             worker_id=runtime.worker_id,
             concurrency=settings.worker_concurrency,
-            connector_instances=[f"{c}:{i}" if c != i else c for c, i in connector_registry.keys],
+            connector_instances=[instance_label(c, i) for c, i in connector_registry.keys],
         )
 
         # Startup sweep:

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -120,7 +120,7 @@ async def worker_main() -> None:
             "worker.startup",
             worker_id=runtime.worker_id,
             concurrency=settings.worker_concurrency,
-            connectors=connector_registry.names,
+            connector_instances=[f"{c}:{i}" if c != i else c for c, i in connector_registry.keys],
         )
 
         # Startup sweep:

--- a/src/aios/mcp/stdio_transport.py
+++ b/src/aios/mcp/stdio_transport.py
@@ -114,7 +114,13 @@ def _redact_secrets(line: str) -> str:
     parse log formats; it just matches well-known credential shapes.
     Add new patterns here as connectors that leak their own
     credentials are surfaced.
+
+    The substring fast-path skips the regex on the ~all-of-stderr
+    that doesn't mention ``/bot``; matters for high-frequency emitters
+    like PTB's ``getUpdates`` polling loop.
     """
+    if "/bot" not in line:
+        return line
     return _BOT_TOKEN_RE.sub("/bot<redacted>", line)
 
 

--- a/src/aios/mcp/stdio_transport.py
+++ b/src/aios/mcp/stdio_transport.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import re
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -91,6 +92,32 @@ class ConnectorSpec:
     cwd: Path | None = None
 
 
+# Patterns matching credentials that connector libraries embed in URL
+# paths and routinely log via their HTTP clients (e.g. python-telegram-bot
+# delegates to httpx, whose default logger emits the full request URL
+# including the bot token).  We redact at emission time rather than
+# upstream-filtering each library because stderr is a multi-source pipe
+# and the supervisor has no per-line knowledge of which library produced
+# each line.
+#
+# Telegram bot tokens have the shape ``<bot_id>:<32+ alphanum-_-_>``, used
+# as a path segment after ``/bot``.  The redaction preserves the URL
+# shape so the operator can still see *which* request was made (and
+# spot, e.g., a getUpdates polling loop) without exposing the token.
+_BOT_TOKEN_RE = re.compile(r"/bot\d+:[A-Za-z0-9_\-]+")
+
+
+def _redact_secrets(line: str) -> str:
+    """Strip embedded secrets from a stderr line before logging.
+
+    The redaction is deliberately conservative — it doesn't try to
+    parse log formats; it just matches well-known credential shapes.
+    Add new patterns here as connectors that leak their own
+    credentials are surfaced.
+    """
+    return _BOT_TOKEN_RE.sub("/bot<redacted>", line)
+
+
 async def _pump_stderr(connector_name: str, read_fd: int) -> None:
     """Read connector stderr via ``loop.add_reader`` and emit lines as structlog events.
 
@@ -129,7 +156,7 @@ async def _pump_stderr(connector_name: str, read_fd: int) -> None:
             if line:
                 bound.info(
                     "connector.stderr",
-                    line=line.decode("utf-8", errors="replace"),
+                    line=_redact_secrets(line.decode("utf-8", errors="replace")),
                 )
 
     loop.add_reader(read_fd, on_readable)
@@ -140,7 +167,7 @@ async def _pump_stderr(connector_name: str, read_fd: int) -> None:
         if pending:
             bound.info(
                 "connector.stderr",
-                line=pending.decode("utf-8", errors="replace"),
+                line=_redact_secrets(pending.decode("utf-8", errors="replace")),
             )
         with contextlib.suppress(OSError):
             os.close(read_fd)

--- a/tests/e2e/test_connector_inbound.py
+++ b/tests/e2e/test_connector_inbound.py
@@ -106,7 +106,7 @@ def _patch_send_ack(registry: ConnectorSubprocessRegistry) -> Callable[[], list[
     """
     recorded: list[str] = []
 
-    async def fake_ack(self: Any, connector: str, instance: str, event_id: str) -> None:
+    async def fake_ack(self: Any, state: Any, event_id: str) -> None:
         recorded.append(event_id)
 
     registry._send_ack = fake_ack.__get__(registry, type(registry))  # type: ignore[method-assign]

--- a/tests/e2e/test_connector_inbound.py
+++ b/tests/e2e/test_connector_inbound.py
@@ -667,7 +667,6 @@ class TestRegistryIsolation:
                 "connector": "echo",
                 "instance": "echo",
                 "status": "starting",
-                "instructions": None,
                 "accounts": [],
                 "last_error": None,
                 "recent_drops": {},

--- a/tests/e2e/test_connector_inbound.py
+++ b/tests/e2e/test_connector_inbound.py
@@ -70,8 +70,20 @@ def _spec(name: str = "echo") -> ConnectorSpec:
 
 
 def _registry(settings: Settings | None = None, name: str = "echo") -> ConnectorSubprocessRegistry:
+    """Build a registry with one default-instance entry for tests.
+
+    Default-instance shape (``instance == connector``) keeps the
+    inbound-handler call sites simple: ``_handle_inbound((name, name),
+    params)`` mirrors what the real splitter does for single-instance
+    setups.
+    """
+    from aios.config import ConnectorInstance
+
     settings = settings or Settings()
-    return ConnectorSubprocessRegistry([_spec(name)], settings=settings)
+    return ConnectorSubprocessRegistry(
+        [(ConnectorInstance(connector=name, instance=name), _spec(name))],
+        settings=settings,
+    )
 
 
 def _unique_account(prefix: str = "acct") -> str:
@@ -94,7 +106,7 @@ def _patch_send_ack(registry: ConnectorSubprocessRegistry) -> Callable[[], list[
     """
     recorded: list[str] = []
 
-    async def fake_ack(self: Any, name: str, event_id: str) -> None:
+    async def fake_ack(self: Any, connector: str, instance: str, event_id: str) -> None:
         recorded.append(event_id)
 
     registry._send_ack = fake_ack.__get__(registry, type(registry))  # type: ignore[method-assign]
@@ -157,7 +169,7 @@ class TestSingleSessionInbound:
             new=mock.AsyncMock(return_value=None),
         ):
             await registry._handle_inbound(
-                "echo",
+                ("echo", "echo"),
                 {
                     "event_id": make_id("evt"),
                     "account": account,
@@ -172,7 +184,7 @@ class TestSingleSessionInbound:
         assert any(e.data.get("content") == "hello world" for e in user_messages)
         assert len(ack_view()) == 1
         # Drop counter never bumped on the happy path.
-        assert dict(registry._states["echo"].drops) == {}
+        assert dict(registry._states[("echo", "echo")].drops) == {}
 
 
 @needs_docker
@@ -211,7 +223,7 @@ class TestPerChatInbound:
             new=mock.AsyncMock(return_value=None),
         ):
             await registry._handle_inbound(
-                "echo",
+                ("echo", "echo"),
                 {
                     "event_id": make_id("evt"),
                     "account": account,
@@ -270,7 +282,7 @@ class TestPerChatInbound:
         ):
             for chat_id in ("chat-A", "chat-B"):
                 await registry._handle_inbound(
-                    "echo",
+                    ("echo", "echo"),
                     {
                         "event_id": make_id("evt"),
                         "account": account,
@@ -299,7 +311,7 @@ class TestDetachedConnection:
         ack_view = _patch_send_ack(registry)
         event_id = make_id("evt")
         await registry._handle_inbound(
-            "echo",
+            ("echo", "echo"),
             {
                 "event_id": event_id,
                 "account": account,
@@ -308,7 +320,7 @@ class TestDetachedConnection:
                 "content": "ignored",
             },
         )
-        assert registry._states["echo"].drops["detached"] == 1
+        assert registry._states[("echo", "echo")].drops["detached"] == 1
         # Ack still fires so connector clears the spool.
         assert ack_view() == [event_id]
 
@@ -322,7 +334,7 @@ class TestAutoCreateConnection:
         ack_view = _patch_send_ack(registry)
         event_id = make_id("evt")
         await registry._handle_inbound(
-            "echo",
+            ("echo", "echo"),
             {
                 "event_id": event_id,
                 "account": account,
@@ -331,7 +343,7 @@ class TestAutoCreateConnection:
                 "content": "ignored",
             },
         )
-        assert registry._states["echo"].drops["no_connection"] == 1
+        assert registry._states[("echo", "echo")].drops["no_connection"] == 1
         async with harness._pool.acquire() as conn:
             row = await queries.get_connection_for_account(conn, connector="echo", account=account)
             assert row is not None
@@ -347,7 +359,7 @@ class TestAutoCreateConnection:
         ack_view = _patch_send_ack(registry)
         event_id = make_id("evt")
         await registry._handle_inbound(
-            "echo",
+            ("echo", "echo"),
             {
                 "event_id": event_id,
                 "account": account,
@@ -356,7 +368,7 @@ class TestAutoCreateConnection:
                 "content": "ignored",
             },
         )
-        assert registry._states["echo"].drops["no_connection"] == 1
+        assert registry._states[("echo", "echo")].drops["no_connection"] == 1
         async with harness._pool.acquire() as conn:
             row = await queries.get_connection_for_account(conn, connector="echo", account=account)
             assert row is None
@@ -401,8 +413,8 @@ class TestDedupLedger:
             "aios.harness.connector_supervisor.defer_wake",
             new=mock.AsyncMock(return_value=None),
         ):
-            await registry._handle_inbound("echo", params)
-            await registry._handle_inbound("echo", params)
+            await registry._handle_inbound(("echo", "echo"), params)
+            await registry._handle_inbound(("echo", "echo"), params)
 
         events = await harness.events(session.id)
         matches = [e for e in events if e.data.get("content") == "once and only once"]
@@ -437,7 +449,7 @@ class TestArchivedTemplateDrop:
         ack_view = _patch_send_ack(registry)
         event_id = make_id("evt")
         await registry._handle_inbound(
-            "echo",
+            ("echo", "echo"),
             {
                 "event_id": event_id,
                 "account": account,
@@ -446,7 +458,7 @@ class TestArchivedTemplateDrop:
                 "content": "no spawn",
             },
         )
-        assert registry._states["echo"].drops["archived_template"] == 1
+        assert registry._states[("echo", "echo")].drops["archived_template"] == 1
         assert ack_view() == [event_id]
 
 
@@ -484,7 +496,7 @@ class TestConnectorMetadataMerging:
             new=mock.AsyncMock(return_value=None),
         ):
             await registry._handle_inbound(
-                "echo",
+                ("echo", "echo"),
                 {
                     "event_id": make_id("evt"),
                     "account": account,
@@ -543,7 +555,7 @@ class TestPayloadTooLarge:
         ack_view = _patch_send_ack(registry)
         event_id = make_id("evt")
         await registry._handle_inbound(
-            "echo",
+            ("echo", "echo"),
             {
                 "event_id": event_id,
                 "account": account,
@@ -553,7 +565,7 @@ class TestPayloadTooLarge:
             },
         )
 
-        assert registry._states["echo"].drops["payload_too_large"] == 1
+        assert registry._states[("echo", "echo")].drops["payload_too_large"] == 1
         assert ack_view() == [event_id]
         # No event was appended.
         events = await harness.events(session.id)
@@ -613,7 +625,7 @@ class TestDeferWakeFailureHeals:
             ),
             pytest.raises(RuntimeError, match="simulated"),
         ):
-            await registry._handle_inbound("echo", params)
+            await registry._handle_inbound(("echo", "echo"), params)
 
         # Event was committed (the txn closed before defer_wake ran).
         events_after_first = await harness.events(session.id)
@@ -631,7 +643,7 @@ class TestDeferWakeFailureHeals:
             "aios.harness.connector_supervisor.defer_wake",
             new=fake_defer_wake_ok,
         ):
-            await registry._handle_inbound("echo", params)
+            await registry._handle_inbound(("echo", "echo"), params)
 
         # Still exactly one event (dedup ledger blocked the second).
         events_after_second = await harness.events(session.id)
@@ -652,7 +664,8 @@ class TestRegistryIsolation:
         assert registry._settings.connectors_auto_create == {}
         assert registry.snapshot_all() == [
             {
-                "name": "echo",
+                "connector": "echo",
+                "instance": "echo",
                 "status": "starting",
                 "instructions": None,
                 "accounts": [],
@@ -660,3 +673,114 @@ class TestRegistryIsolation:
                 "recent_drops": {},
             }
         ]
+
+
+@needs_docker
+class TestMultiAccountInboundRouting:
+    """Multi-account: ``(connector, account)`` is the routing primitive.
+
+    A single-instance connector serving N accounts must route inbound on
+    each account to the connection attached to that account, even when
+    the same instance fans out to multiple sessions.
+    """
+
+    async def test_two_accounts_route_to_distinct_sessions(self, harness: Harness) -> None:
+        agent_id, env_id = await _make_agent_and_env(harness)
+        account_a = _unique_account("acct-a")
+        account_b = _unique_account("acct-b")
+        session_a = await sessions_service.create_session(
+            harness._pool, agent_id=agent_id, environment_id=env_id, title="A", metadata={}
+        )
+        session_b = await sessions_service.create_session(
+            harness._pool, agent_id=agent_id, environment_id=env_id, title="B", metadata={}
+        )
+        conn_a = await connections_service.create_connection(
+            harness._pool, connector="echo", account=account_a, metadata={}
+        )
+        conn_b = await connections_service.create_connection(
+            harness._pool, connector="echo", account=account_b, metadata={}
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_a.id, session_id=session_a.id
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_b.id, session_id=session_b.id
+        )
+
+        registry = _registry()
+        _patch_send_ack(registry)
+        with mock.patch(
+            "aios.harness.connector_supervisor.defer_wake",
+            new=mock.AsyncMock(return_value=None),
+        ):
+            await registry._handle_inbound(
+                ("echo", "echo"),
+                {
+                    "event_id": make_id("evt"),
+                    "account": account_a,
+                    "chat_id": "chat-A",
+                    "sender": {"display_name": "Alice"},
+                    "content": "hello A",
+                },
+            )
+            await registry._handle_inbound(
+                ("echo", "echo"),
+                {
+                    "event_id": make_id("evt"),
+                    "account": account_b,
+                    "chat_id": "chat-B",
+                    "sender": {"display_name": "Bob"},
+                    "content": "hello B",
+                },
+            )
+
+        events_a = await harness.events(session_a.id)
+        events_b = await harness.events(session_b.id)
+        # Each session sees only its own account's inbound.
+        contents_a = {
+            e.data.get("content")
+            for e in events_a
+            if e.kind == "message" and e.data.get("role") == "user"
+        }
+        contents_b = {
+            e.data.get("content")
+            for e in events_b
+            if e.kind == "message" and e.data.get("role") == "user"
+        }
+        assert "hello A" in contents_a and "hello B" not in contents_a
+        assert "hello B" in contents_b and "hello A" not in contents_b
+
+
+@needs_docker
+class TestAccountConflictRejection:
+    """Two instances of the same connector type both reporting the same
+    account: second is rejected, primary keeps the map entry."""
+
+    async def test_second_instance_rejected_with_last_error(self) -> None:
+        from aios.config import ConnectorInstance
+        from aios.harness.connector_supervisor import ConnectorState
+
+        registry = ConnectorSubprocessRegistry(
+            [
+                (ConnectorInstance("signal", "primary"), _spec("signal")),
+                (ConnectorInstance("signal", "secondary"), _spec("signal")),
+            ],
+            settings=Settings(),
+        )
+        # Bypass the supervisor loop entirely; we only exercise routing.
+        # `_states` already wired by the registry constructor.
+        await registry._on_aios_notification(
+            ("signal", "primary"),
+            "notifications/aios/accounts",
+            {"accounts": [{"id": "+15551234567", "display_name": "X"}]},
+        )
+        await registry._on_aios_notification(
+            ("signal", "secondary"),
+            "notifications/aios/accounts",
+            {"accounts": [{"id": "+15551234567", "display_name": "X-dup"}]},
+        )
+        assert registry.lookup_instance_for_account("signal", "+15551234567") == "primary"
+        secondary: ConnectorState | None = registry.state("signal", "secondary")
+        assert secondary is not None
+        assert secondary.last_error is not None
+        assert "conflict" in secondary.last_error

--- a/tests/e2e/test_connector_supervisor.py
+++ b/tests/e2e/test_connector_supervisor.py
@@ -22,24 +22,48 @@ from typing import Any
 
 import pytest
 
-from aios.config import Settings
+from aios.config import ConnectorInstance, Settings
 from aios.harness import connector_supervisor as supervisor_mod
 from aios.harness.connector_supervisor import ConnectorSubprocessRegistry
 from aios.mcp.stdio_transport import ConnectorSpec
 
 
-def _echo_spec() -> ConnectorSpec:
-    """Spawn ``python -m tests.fixtures.echo_connector`` from the current interpreter.
+def _echo_specs() -> list[tuple[ConnectorInstance, ConnectorSpec]]:
+    """Spawn ``python -m tests.fixtures.echo_connector`` as the default ``echo`` instance.
 
     Inheriting cwd from pytest puts the fixture module on ``sys.path``
     automatically.  Tracking the interpreter via ``sys.executable``
     keeps virtualenv selection consistent across CI variants.
+
+    Default-instance shape (``instance == connector``) so the tests
+    exercise the same code path as ``connectors_enabled=echo``
+    single-instance setups.
     """
-    return ConnectorSpec(
-        name="echo",
-        command=sys.executable,
-        args=["-m", "tests.fixtures.echo_connector"],
-    )
+    return [
+        (
+            ConnectorInstance(connector="echo", instance="echo"),
+            ConnectorSpec(
+                name="echo",
+                command=sys.executable,
+                args=["-m", "tests.fixtures.echo_connector"],
+            ),
+        )
+    ]
+
+
+def _multi_instance_echo_specs() -> list[tuple[ConnectorInstance, ConnectorSpec]]:
+    """Two echo instances, one connector type — exercises multi-instance keying."""
+    base_args = ["-m", "tests.fixtures.echo_connector"]
+    return [
+        (
+            ConnectorInstance(connector="echo", instance="alpha"),
+            ConnectorSpec(name="echo", command=sys.executable, args=base_args),
+        ),
+        (
+            ConnectorInstance(connector="echo", instance="beta"),
+            ConnectorSpec(name="echo", command=sys.executable, args=base_args),
+        ),
+    ]
 
 
 async def _wait_for(predicate: Any, *, max_wait_s: float = 10.0) -> None:
@@ -60,15 +84,15 @@ async def _wait_for(predicate: Any, *, max_wait_s: float = 10.0) -> None:
 class TestConnectorSupervisor:
     async def test_starts_initializes_and_emits_accounts(self) -> None:
         """Happy path: spawn, init, capability check, account snapshot, shutdown."""
-        registry = ConnectorSubprocessRegistry([_echo_spec()], settings=Settings())
+        registry = ConnectorSubprocessRegistry(_echo_specs(), settings=Settings())
         await registry.start()
         try:
-            session = await asyncio.wait_for(registry.get_session("echo"), timeout=10.0)
+            session = await asyncio.wait_for(registry.get_session("echo", "echo"), timeout=10.0)
             tools_result = await session.list_tools()
             tool_names = {t.name for t in tools_result.tools}
             assert tool_names == {"ping", "echo", "crash"}
 
-            state = registry.state("echo")
+            state = registry.state("echo", "echo")
             assert state is not None
             assert state.status == "running"
             assert state.instructions is not None
@@ -81,24 +105,24 @@ class TestConnectorSupervisor:
 
     async def test_dispatch_call_round_trip(self) -> None:
         """``dispatch_call`` returns the connector's tool result envelope."""
-        registry = ConnectorSubprocessRegistry([_echo_spec()], settings=Settings())
+        registry = ConnectorSubprocessRegistry(_echo_specs(), settings=Settings())
         await registry.start()
         try:
-            await asyncio.wait_for(registry.get_session("echo"), timeout=10.0)
-            ping = await registry.dispatch_call("echo", "ping", {})
+            await asyncio.wait_for(registry.get_session("echo", "echo"), timeout=10.0)
+            ping = await registry.dispatch_call("echo", "echo", "ping", {})
             assert ping == {"content": "pong"}
-            echoed = await registry.dispatch_call("echo", "echo", {"text": "hello"})
+            echoed = await registry.dispatch_call("echo", "echo", "echo", {"text": "hello"})
             assert echoed == {"content": "hello"}
         finally:
             await registry.shutdown()
 
     async def test_unknown_connector_returns_error_envelope(self) -> None:
-        """Calls against an un-enabled connector surface as a coded envelope."""
-        registry = ConnectorSubprocessRegistry([_echo_spec()], settings=Settings())
+        """Calls against an un-enabled instance surface as a coded envelope."""
+        registry = ConnectorSubprocessRegistry(_echo_specs(), settings=Settings())
         await registry.start()
         try:
-            await asyncio.wait_for(registry.get_session("echo"), timeout=10.0)
-            result = await registry.dispatch_call("nonexistent", "ping", {})
+            await asyncio.wait_for(registry.get_session("echo", "echo"), timeout=10.0)
+            result = await registry.dispatch_call("nonexistent", "x", "ping", {})
             assert "not enabled" in result["error"]
             assert result["code"] == "not_enabled"
         finally:
@@ -115,18 +139,18 @@ class TestConnectorSupervisor:
         session reference is still in place for a beat.
         """
         monkeypatch.setattr(supervisor_mod, "_BACKOFF_INITIAL_S", 0.5)
-        registry = ConnectorSubprocessRegistry([_echo_spec()], settings=Settings())
+        registry = ConnectorSubprocessRegistry(_echo_specs(), settings=Settings())
         await registry.start()
         try:
-            await asyncio.wait_for(registry.get_session("echo"), timeout=10.0)
-            state = registry.state("echo")
+            await asyncio.wait_for(registry.get_session("echo", "echo"), timeout=10.0)
+            state = registry.state("echo", "echo")
             assert state is not None
             await _wait_for(lambda: bool(state.accounts), max_wait_s=5.0)
             original_session = state.session
 
             # Trigger the fixture to ``os._exit(1)``.  The dispatch_call
             # surfaces the closed transport as a transport error envelope.
-            crash_result = await registry.dispatch_call("echo", "crash", {})
+            crash_result = await registry.dispatch_call("echo", "echo", "crash", {})
             assert "error" in crash_result
             assert crash_result["code"] == "transport_error"
 
@@ -141,7 +165,70 @@ class TestConnectorSupervisor:
                 max_wait_s=15.0,
             )
             # Fresh subprocess should still respond.
-            ping = await registry.dispatch_call("echo", "ping", {})
+            ping = await registry.dispatch_call("echo", "echo", "ping", {})
             assert ping == {"content": "pong"}
+        finally:
+            await registry.shutdown()
+
+
+class TestMultiInstanceSupervisor:
+    """Two instances of the same connector type spawn as independent subprocesses.
+
+    Verifies the registry's compound keying actually produces N distinct
+    supervisor tasks + sessions, and that one instance's failure doesn't
+    propagate to the sibling.
+    """
+
+    async def test_two_instances_spawn_with_distinct_sessions(self) -> None:
+        registry = ConnectorSubprocessRegistry(_multi_instance_echo_specs(), settings=Settings())
+        await registry.start()
+        try:
+            session_alpha = await asyncio.wait_for(
+                registry.get_session("echo", "alpha"), timeout=10.0
+            )
+            session_beta = await asyncio.wait_for(
+                registry.get_session("echo", "beta"), timeout=10.0
+            )
+            # Distinct OS subprocesses means distinct ClientSession objects.
+            assert session_alpha is not session_beta
+
+            # Both report as ``running`` and snapshot lists both.
+            states = registry.snapshot_all()
+            statuses = {(s["connector"], s["instance"]): s["status"] for s in states}
+            assert statuses == {("echo", "alpha"): "running", ("echo", "beta"): "running"}
+
+            # Each subprocess responds to ping independently.
+            ping_a = await registry.dispatch_call("echo", "alpha", "ping", {})
+            ping_b = await registry.dispatch_call("echo", "beta", "ping", {})
+            assert ping_a == {"content": "pong"}
+            assert ping_b == {"content": "pong"}
+        finally:
+            await registry.shutdown()
+
+    async def test_one_instance_crash_does_not_take_down_sibling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(supervisor_mod, "_BACKOFF_INITIAL_S", 0.5)
+        registry = ConnectorSubprocessRegistry(_multi_instance_echo_specs(), settings=Settings())
+        await registry.start()
+        try:
+            await asyncio.wait_for(registry.get_session("echo", "alpha"), timeout=10.0)
+            await asyncio.wait_for(registry.get_session("echo", "beta"), timeout=10.0)
+            beta_state = registry.state("echo", "beta")
+            assert beta_state is not None
+            beta_session_before = beta_state.session
+
+            # Crash alpha — beta should remain ``running`` throughout.
+            crash_result = await registry.dispatch_call("echo", "alpha", "crash", {})
+            assert crash_result["code"] == "transport_error"
+
+            # Beta's session reference must NOT change (no respawn for siblings).
+            await asyncio.sleep(0.5)
+            assert beta_state.status == "running"
+            assert beta_state.session is beta_session_before
+
+            # Beta still responds to ping while alpha is restarting.
+            ping_b = await registry.dispatch_call("echo", "beta", "ping", {})
+            assert ping_b == {"content": "pong"}
         finally:
             await registry.shutdown()

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -237,17 +237,20 @@ class TestFocalChannelE2E:
 
 
 class TestFocalChannelPathHelper:
-    """Pure unit tests for the helper that strips connector/account from
-    a focal address before injection into MCP ``_meta``.  Lives here so
-    the e2e file is the single home for focal-channel coverage; the
-    helper is otherwise covered indirectly by the dispatch path.
+    """Pure unit tests for the helper that strips the connector segment
+    from a focal address before injection into MCP ``_meta``.  Lives
+    here so the e2e file is the single home for focal-channel coverage;
+    the helper is otherwise covered indirectly by the dispatch path.
+
+    Account is preserved in the meta value so multi-account connectors
+    can route by it; single-account connectors take the chat suffix only.
     """
 
-    def test_strips_connector_and_account(self) -> None:
-        assert focal_channel_path("signal/+1/chat-a") == "chat-a"
+    def test_strips_only_connector_preserves_account(self) -> None:
+        assert focal_channel_path("signal/+1/chat-a") == "+1/chat-a"
 
     def test_preserves_trailing_segments(self) -> None:
-        assert focal_channel_path("telegram/bot/group/thread-1") == "group/thread-1"
+        assert focal_channel_path("telegram/bot/group/thread-1") == "bot/group/thread-1"
 
     def test_returns_none_when_focal_unset(self) -> None:
         assert focal_channel_path(None) is None

--- a/tests/e2e/test_focal_required_dispatch.py
+++ b/tests/e2e/test_focal_required_dispatch.py
@@ -1,0 +1,148 @@
+"""E2E: outbound focal-required MCP dispatch through the aios-connector SDK.
+
+Closes the test gap that allowed the SDK ``ctx.meta`` bug into PR #211.
+That bug was on the SDK's *receive* path: the harness sent
+``_meta.aios.focal_channel_path`` correctly over JSON-RPC, but
+``_focal_from_request_meta`` read ``ctx.request.meta`` (which is None
+on a ``CallToolRequest``) instead of ``ctx.meta`` (where the lowlevel
+server stashes the parsed meta).  Every focal-required tool call
+failed with ``"aios should inject _meta.aios.focal_channel_path"``
+even when aios *had* injected it.
+
+PR #211's e2e tests covered the inbound path
+(``test_connector_inbound.py``) and the supervisor's bare dispatch
+mechanics (``test_connector_supervisor.py`` against a hand-written
+fixture that bypasses the SDK).  Neither exercised an outbound
+focal-required tool dispatched through a *real* aios-connector
+subprocess — the SDK code path that was broken.
+
+This test spawns ``python -m aios_echo`` as a real subprocess (using
+the SDK's framing end-to-end), sets a focal channel suffix on the
+``call_tool`` ``_meta``, and asserts the tool result reflects the
+account/chat_id the SDK extracted.  Without the ``ctx.meta`` fix it
+returns a tool error; with it, the round-trip succeeds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+
+from aios.config import ConnectorInstance, Settings
+from aios.harness.connector_supervisor import ConnectorSubprocessRegistry
+from aios.mcp.stdio_transport import ConnectorSpec
+
+
+def _aios_echo_specs() -> list[tuple[ConnectorInstance, ConnectorSpec]]:
+    """Spawn ``python -m aios_echo`` — the workspace's reference SDK example.
+
+    Unlike ``tests.fixtures.echo_connector`` (hand-written against the
+    raw MCP SDK), ``aios_echo`` uses the public ``aios_connector.Connector``
+    base class.  The SDK's ``_focal_from_request_meta`` runs in the
+    spawned subprocess; this is the code path the test exercises.
+    """
+    return [
+        (
+            ConnectorInstance(connector="echo", instance="echo"),
+            ConnectorSpec(
+                name="echo",
+                command=sys.executable,
+                args=["-m", "aios_echo"],
+            ),
+        )
+    ]
+
+
+async def _wait_for(predicate: Any, *, max_wait_s: float = 10.0) -> None:
+    deadline = asyncio.get_event_loop().time() + max_wait_s
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"predicate {predicate!r} did not become true within {max_wait_s}s")
+
+
+class TestFocalRequiredDispatch:
+    """``mcp__echo__echo`` is ``@focal_required``; it MUST receive the
+    SDK-extracted ``account`` and ``chat_id`` derived from
+    ``_meta.aios.focal_channel_path`` rather than failing with
+    ``"aios should inject _meta.aios.focal_channel_path"``.
+    """
+
+    async def test_focal_meta_round_trips_to_focal_required_tool(self) -> None:
+        registry = ConnectorSubprocessRegistry(_aios_echo_specs(), settings=Settings())
+        await registry.start()
+        try:
+            session = await asyncio.wait_for(registry.get_session("echo", "echo"), timeout=15.0)
+
+            # Wait until the SDK has finished its post-init handshake and the
+            # accounts snapshot is in.  ``aios_echo``'s ``discover_accounts``
+            # advertises ``echo-1`` and ``echo-2``.
+            state = registry.state("echo", "echo")
+            assert state is not None
+
+            await _wait_for(
+                lambda: any(a.get("id") == "echo-1" for a in state.accounts),
+                max_wait_s=15.0,
+            )
+
+            # Dispatch through the same code path the harness uses:
+            # ``ClientSession.call_tool(name, arguments, meta=...)``.  The
+            # account+chat_id segments mirror what
+            # ``aios.harness.tool_dispatch`` builds from the session's
+            # focal_channel for outbound calls.
+            result = await asyncio.wait_for(
+                session.call_tool(
+                    "echo",
+                    {"text": "hello"},
+                    meta={"aios.focal_channel_path": "echo-1/chat-42"},
+                ),
+                timeout=10.0,
+            )
+
+            # Without the SDK fix, isError=True with content like:
+            # "tool 'echo' requires a focal channel — aios should inject ..."
+            assert not result.isError, (
+                f"focal-required tool should not error when _meta is set; got: "
+                f"{[c.text for c in result.content if hasattr(c, 'text')]}"
+            )
+
+            # The SDK-extracted account/chat_id must round-trip through the
+            # tool's return value.
+            assert result.content
+            text_blocks = [c.text for c in result.content if hasattr(c, "text")]
+            payload = " ".join(text_blocks)
+            assert "echo-1" in payload, f"account not in result payload: {payload!r}"
+            assert "chat-42" in payload, f"chat_id not in result payload: {payload!r}"
+        finally:
+            await registry.shutdown()
+
+    async def test_missing_focal_meta_returns_tool_error(self) -> None:
+        """Negative case: with no ``_meta``, the SDK raises a tool-level
+        error message — proves the focal-meta plumbing is the load-bearing
+        path (i.e. the success above isn't passing for some unrelated
+        reason).
+        """
+        registry = ConnectorSubprocessRegistry(_aios_echo_specs(), settings=Settings())
+        await registry.start()
+        try:
+            session = await asyncio.wait_for(registry.get_session("echo", "echo"), timeout=15.0)
+            state = registry.state("echo", "echo")
+            assert state is not None
+            await _wait_for(lambda: bool(state.accounts), max_wait_s=15.0)
+
+            result = await asyncio.wait_for(
+                session.call_tool("echo", {"text": "hello"}),  # no meta
+                timeout=10.0,
+            )
+
+            # The SDK's @focal_required guard surfaces as a tool-level
+            # error rather than a transport exception.
+            text_blocks = [c.text for c in result.content if hasattr(c, "text")]
+            payload = " ".join(text_blocks)
+            assert "focal_channel_path" in payload or "focal channel" in payload, (
+                f"expected focal-channel error, got: {payload!r}"
+            )
+        finally:
+            await registry.shutdown()

--- a/tests/unit/test_channels_focal.py
+++ b/tests/unit/test_channels_focal.py
@@ -255,19 +255,25 @@ class TestDeriveUnreadCounts:
 
 
 class TestFocalChannelPath:
-    """Suffix-extraction helper for MCP _meta injection (slice 6)."""
+    """Suffix-extraction helper for MCP _meta injection.
+
+    Strips only the leading ``<connector>/`` segment per design §3.4.
+    The ``<account>`` segment is preserved so multi-account connectors
+    can route by account; single-account connectors take the chat
+    suffix only.
+    """
 
     def test_three_segment_address(self) -> None:
-        # Signal shape: signal/<bot>/<chat_id>
-        assert focal_channel_path("signal/bot/alice") == "alice"
+        # Signal shape: signal/<bot>/<chat_id> — account preserved.
+        assert focal_channel_path("signal/bot/alice") == "bot/alice"
 
     def test_four_segment_address_preserves_inner_slashes(self) -> None:
         # Telegram forum-thread shape: telegram/<bot>/<chat>/<thread>
-        assert focal_channel_path("telegram/bot/chat/thread") == "chat/thread"
+        assert focal_channel_path("telegram/bot/chat/thread") == "bot/chat/thread"
 
     def test_deep_address_preserves_all_tail_segments(self) -> None:
         # Defensive: connectors may use arbitrarily deep suffixes.
-        assert focal_channel_path("x/y/a/b/c") == "a/b/c"
+        assert focal_channel_path("x/y/a/b/c") == "y/a/b/c"
 
     def test_none_returns_none(self) -> None:
         assert focal_channel_path(None) is None
@@ -276,9 +282,9 @@ class TestFocalChannelPath:
         assert focal_channel_path("") is None
 
     def test_malformed_two_segments_returns_none(self) -> None:
-        # Missing suffix — should not leak a garbled value.
+        # Missing chat suffix — still rejected as malformed.
         assert focal_channel_path("signal/bot") is None
 
     def test_trailing_slash_yields_empty_suffix_is_none(self) -> None:
-        # "signal/bot/" → 3 segments but suffix is empty → None.
+        # "signal/bot/" → 3 segments but chat_id is empty → None.
         assert focal_channel_path("signal/bot/") is None

--- a/tests/unit/test_config_connectors.py
+++ b/tests/unit/test_config_connectors.py
@@ -1,0 +1,109 @@
+"""Unit tests for the multi-instance ``connectors_enabled`` parser.
+
+Covers :func:`parse_connector_entry` and the
+:class:`Settings._validate_connectors_enabled` field validator that
+backs ``AIOS_CONNECTORS_ENABLED`` env parsing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aios.config import (
+    ConnectorInstance,
+    Settings,
+    parse_connector_entry,
+)
+
+# Settings has required fields (api_key, vault_key, db_url); fixtures
+# fill them with throwaway values so the validator tests can construct
+# instances without env state.
+_BASE_KWARGS = {
+    "api_key": "test-key",
+    "vault_key": "dGVzdC12YXVsdC1rZXktMzItYnl0ZXMtdGVzdC0=",
+    "db_url": "postgresql://test:test@localhost/test",
+}
+
+
+class TestParseConnectorEntry:
+    """``parse_connector_entry`` shape matrix."""
+
+    def test_default_instance_when_colon_omitted(self) -> None:
+        result = parse_connector_entry("signal")
+        assert result == ConnectorInstance(connector="signal", instance="signal")
+
+    def test_explicit_instance(self) -> None:
+        result = parse_connector_entry("telegram:support")
+        assert result == ConnectorInstance(connector="telegram", instance="support")
+
+    def test_underscore_in_names(self) -> None:
+        result = parse_connector_entry("my_connector:bot_one")
+        assert result == ConnectorInstance(connector="my_connector", instance="bot_one")
+
+    def test_digit_in_names(self) -> None:
+        result = parse_connector_entry("telegram:bot1")
+        assert result.instance == "bot1"
+
+    def test_uppercase_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"connector name 'Signal'"):
+            parse_connector_entry("Signal")
+
+    def test_uppercase_in_instance_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"instance name 'Support'"):
+            parse_connector_entry("telegram:Support")
+
+    def test_hyphen_rejected(self) -> None:
+        # Hyphens would corrupt the AIOS_<INSTANCE_UPPER>_* env-var re-export.
+        with pytest.raises(ValueError, match=r"instance name 'support-bot'"):
+            parse_connector_entry("telegram:support-bot")
+
+    def test_leading_digit_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"instance name '1bot'"):
+            parse_connector_entry("telegram:1bot")
+
+    def test_empty_instance_after_colon_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"instance name ''"):
+            parse_connector_entry("telegram:")
+
+    def test_slash_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"instance name 'a/b'"):
+            parse_connector_entry("telegram:a/b")
+
+
+class TestConnectorsEnabledValidator:
+    """The Settings field validator wraps the parser per entry."""
+
+    def test_empty_default(self) -> None:
+        s = Settings(**_BASE_KWARGS)
+        assert s.connectors_enabled == []
+        assert s.connector_instances() == []
+
+    def test_default_instance_passes(self) -> None:
+        s = Settings(connectors_enabled=["signal"], **_BASE_KWARGS)
+        assert s.connector_instances() == [ConnectorInstance(connector="signal", instance="signal")]
+
+    def test_mixed_default_and_explicit_instances(self) -> None:
+        s = Settings(
+            connectors_enabled=["signal:main", "telegram:support", "telegram:alerts"],
+            **_BASE_KWARGS,
+        )
+        parsed = s.connector_instances()
+        assert parsed == [
+            ConnectorInstance(connector="signal", instance="main"),
+            ConnectorInstance(connector="telegram", instance="support"),
+            ConnectorInstance(connector="telegram", instance="alerts"),
+        ]
+
+    def test_duplicate_instances_rejected(self) -> None:
+        with pytest.raises(ValidationError, match=r"duplicate connector instance signal:main"):
+            Settings(connectors_enabled=["signal:main", "signal:main"], **_BASE_KWARGS)
+
+    def test_default_instance_collides_with_same_explicit(self) -> None:
+        # signal == signal:signal; if both are listed it's a duplicate.
+        with pytest.raises(ValidationError, match=r"duplicate connector instance signal:signal"):
+            Settings(connectors_enabled=["signal", "signal:signal"], **_BASE_KWARGS)
+
+    def test_invalid_entry_surfaces_through_validator(self) -> None:
+        with pytest.raises(ValidationError, match=r"connector name 'Bad'"):
+            Settings(connectors_enabled=["Bad"], **_BASE_KWARGS)

--- a/tests/unit/test_config_connectors.py
+++ b/tests/unit/test_config_connectors.py
@@ -74,8 +74,9 @@ class TestParseConnectorEntry:
 class TestConnectorsEnabledValidator:
     """The Settings field validator wraps the parser per entry."""
 
-    def test_empty_default(self) -> None:
-        s = Settings(**_BASE_KWARGS)
+    def test_empty_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AIOS_CONNECTORS_ENABLED", raising=False)
+        s = Settings(_env_file=None, **_BASE_KWARGS)
         assert s.connectors_enabled == []
         assert s.connector_instances() == []
 

--- a/tests/unit/test_config_connectors.py
+++ b/tests/unit/test_config_connectors.py
@@ -107,3 +107,32 @@ class TestConnectorsEnabledValidator:
     def test_invalid_entry_surfaces_through_validator(self) -> None:
         with pytest.raises(ValidationError, match=r"connector name 'Bad'"):
             Settings(connectors_enabled=["Bad"], **_BASE_KWARGS)
+
+    def test_csv_env_value_parses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``AIOS_CONNECTORS_ENABLED=signal:main,telegram:bot1`` must parse as CSV.
+
+        Pydantic-settings v2 default-parses ``list[str]`` env vars as
+        JSON; the ``NoDecode`` annotation + ``mode='before'`` validator
+        on :class:`Settings` accepts CSV instead.  Without this, the
+        documented operator format ``AIOS_CONNECTORS_ENABLED=a,b``
+        crashes at startup with a ``SettingsError``.
+        """
+        monkeypatch.setenv("AIOS_API_KEY", _BASE_KWARGS["api_key"])
+        monkeypatch.setenv("AIOS_VAULT_KEY", _BASE_KWARGS["vault_key"])
+        monkeypatch.setenv("AIOS_DB_URL", _BASE_KWARGS["db_url"])
+        monkeypatch.setenv("AIOS_CONNECTORS_ENABLED", "signal:main,telegram:bot1")
+        s = Settings()
+        assert s.connectors_enabled == ["signal:main", "telegram:bot1"]
+        assert s.connector_instances() == [
+            ConnectorInstance(connector="signal", instance="main"),
+            ConnectorInstance(connector="telegram", instance="bot1"),
+        ]
+
+    def test_csv_env_handles_whitespace_and_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Whitespace around CSV entries is stripped; trailing commas drop empties."""
+        monkeypatch.setenv("AIOS_API_KEY", _BASE_KWARGS["api_key"])
+        monkeypatch.setenv("AIOS_VAULT_KEY", _BASE_KWARGS["vault_key"])
+        monkeypatch.setenv("AIOS_DB_URL", _BASE_KWARGS["db_url"])
+        monkeypatch.setenv("AIOS_CONNECTORS_ENABLED", " signal , telegram:bot1 , ")
+        s = Settings()
+        assert s.connectors_enabled == ["signal", "telegram:bot1"]

--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -304,6 +304,49 @@ class TestDropCounter:
         assert state.snapshot()["recent_drops"] == {}
 
 
+class TestSnapshotSize:
+    """``ConnectorState.snapshot()`` is consumed by ``connector_status``,
+    which sends the JSON-encoded result via ``pg_notify``.  Postgres
+    NOTIFY caps payloads at 8000 bytes — large server-side
+    ``InitializeResult.instructions`` (signal with N phones, each with
+    per-account contacts and groups) easily exceeded this and crashed
+    the admin RPC.
+
+    The fix: instructions stay on the state for in-process consumers
+    (the model-context discovery path uses
+    :func:`discover_session_mcp_tools` directly, not the snapshot) but
+    are kept out of the admin-facing snapshot.
+    """
+
+    def _registry_with_state(self) -> tuple[Any, Any]:
+        from aios.config import Settings
+        from aios.harness.connector_supervisor import (
+            ConnectorState,
+            ConnectorSubprocessRegistry,
+        )
+
+        registry = ConnectorSubprocessRegistry([], settings=Settings())
+        spec = ConnectorSpec(name="echo", command="x", args=[])
+        state = ConnectorState(connector="echo", instance="echo", spec=spec)
+        registry._states[("echo", "echo")] = state
+        return registry, state
+
+    def test_snapshot_omits_large_instructions(self) -> None:
+        """A 6KB instructions block must not appear in the snapshot — the
+        admin RPC is the one consumer of ``snapshot()`` and Postgres
+        NOTIFY cannot carry it."""
+        import json
+
+        _, state = self._registry_with_state()
+        state.instructions = "x" * 6000
+
+        snap = state.snapshot()
+        assert "instructions" not in snap
+        # End-to-end size assertion: serialized snapshot fits comfortably
+        # under the 8000-byte NOTIFY cap.
+        assert len(json.dumps(snap)) < 8000
+
+
 class TestInboundMalformed:
     """Malformed inbound payloads count as ``malformed`` drops, never crash.
 

--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -271,6 +271,36 @@ class TestPumpStderrLineExtraction:
                 os.close(write_fd)
         assert captured == ["trailing-no-newline"]
 
+    async def test_telegram_bot_token_redacted_from_url(self) -> None:
+        """PTB's httpx logger writes ``https://api.telegram.org/bot<TOKEN>/...``
+        URLs to stderr.  The pump must redact the token before emitting
+        ``connector.stderr`` events — otherwise the bot token lives in
+        ``/tmp/aios-worker.log`` and anyone with log access can extract it.
+        """
+        captured: list[str] = []
+        read_fd, write_fd = os.pipe()
+        token = "8116307959:AAFv1He6CZ-tpGun19CTp1tjbBoWtJrGrL8"
+        try:
+            pump = asyncio.create_task(_pump_stderr("test_conn", read_fd))
+            with mock_log_capture(captured):
+                os.write(
+                    write_fd,
+                    f'HTTP Request: POST https://api.telegram.org/bot{token}/getMe "HTTP/1.1 200 OK"\n'.encode(),
+                )
+                await asyncio.sleep(0.05)
+                os.close(write_fd)
+                write_fd = -1
+                await asyncio.wait_for(pump, timeout=1.0)
+        finally:
+            if write_fd != -1:
+                os.close(write_fd)
+        assert len(captured) == 1
+        line = captured[0]
+        assert token not in line, "bot token must be redacted from stderr line"
+        # Existing path structure preserved — only the token is masked.
+        assert "/getMe" in line
+        assert "api.telegram.org" in line
+
 
 class TestDropCounter:
     """Drop counters bump per reason and surface in :meth:`snapshot`.

--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -45,29 +45,35 @@ class TestValidateCapability:
 
         return ConnectorSubprocessRegistry([], settings=Settings())
 
+    def _state(self) -> Any:
+        from aios.harness.connector_supervisor import ConnectorState
+
+        spec = ConnectorSpec(name="echo", command="x", args=[])
+        return ConnectorState(connector="echo", instance="echo", spec=spec)
+
     def test_passes_when_aios_connector_key_present(self) -> None:
         registry = self._registry()
         init = _fake_init_result({_AIOS_EXPERIMENTAL_KEY: {}})
         # Should not raise.
-        registry._validate_capability("echo", init)
+        registry._validate_capability(self._state(), init)
 
     def test_raises_on_missing_experimental_dict(self) -> None:
         registry = self._registry()
         init = _fake_init_result(None)
         with pytest.raises(RuntimeError, match=r"experimental\..*aios/connector"):
-            registry._validate_capability("echo", init)
+            registry._validate_capability(self._state(), init)
 
     def test_raises_on_empty_experimental_dict(self) -> None:
         registry = self._registry()
         init = _fake_init_result({})
         with pytest.raises(RuntimeError, match=r"experimental\..*aios/connector"):
-            registry._validate_capability("echo", init)
+            registry._validate_capability(self._state(), init)
 
     def test_raises_when_other_experimental_keys_present(self) -> None:
         registry = self._registry()
         init = _fake_init_result({"some/other/cap": {"option": True}})
         with pytest.raises(RuntimeError, match=r"experimental\..*aios/connector"):
-            registry._validate_capability("echo", init)
+            registry._validate_capability(self._state(), init)
 
 
 class TestResolveConnectorSpecs:
@@ -106,7 +112,9 @@ class TestResolveConnectorSpecs:
         with pytest.raises(RuntimeError, match="expected ConnectorSpec"):
             resolve_connector_specs(self._settings(enabled=["bad"]))
 
-    def test_returns_spec_with_default_cwd(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_default_instance_returns_single_segment_cwd(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from pathlib import Path
 
         ep = MagicMock()
@@ -121,10 +129,31 @@ class TestResolveConnectorSpecs:
             self._settings(enabled=["echo"], connectors_dir=connectors_dir)
         )
         assert len(specs) == 1
-        assert specs[0].name == "echo"
-        # Plan #11: cwd defaults to ``connectors_dir / name`` when the
-        # factory leaves it None.
-        assert specs[0].cwd == connectors_dir / "echo"
+        ci, spec = specs[0]
+        assert ci.connector == "echo" and ci.instance == "echo"
+        # Default-instance setups keep the PR3 single-segment path.
+        assert spec.cwd == connectors_dir / "echo"
+
+    def test_non_default_instance_gets_per_instance_subdir(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pathlib import Path
+
+        ep = MagicMock()
+        ep.name = "telegram"
+        ep.load.return_value = lambda name, settings: ConnectorSpec(name=name, command="/bin/echo")
+        monkeypatch.setattr(
+            "aios.harness.connector_supervisor.entry_points",
+            lambda group: [ep],
+        )
+        connectors_dir = Path("/tmp/aios-connectors-test")
+        specs = resolve_connector_specs(
+            self._settings(enabled=["telegram:bot1"], connectors_dir=connectors_dir)
+        )
+        assert len(specs) == 1
+        ci, spec = specs[0]
+        assert ci.connector == "telegram" and ci.instance == "bot1"
+        assert spec.cwd == connectors_dir / "telegram" / "bot1"
 
     def test_factory_explicit_cwd_is_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from pathlib import Path
@@ -140,7 +169,42 @@ class TestResolveConnectorSpecs:
             lambda group: [ep],
         )
         specs = resolve_connector_specs(self._settings(enabled=["echo"]))
-        assert specs[0].cwd == explicit
+        assert specs[0][1].cwd == explicit
+
+    def test_env_re_export_for_non_default_instance(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ep = MagicMock()
+        ep.name = "telegram"
+        ep.load.return_value = lambda name, settings: ConnectorSpec(name=name, command="/bin/echo")
+        monkeypatch.setattr(
+            "aios.harness.connector_supervisor.entry_points",
+            lambda group: [ep],
+        )
+        # Scoped + unscoped vars present in parent env; the scoped value
+        # must override under AIOS_TELEGRAM_BOT_TOKEN inside the bot1
+        # subprocess's env.
+        monkeypatch.setenv("AIOS_TELEGRAM_BOT_TOKEN", "unscoped")
+        monkeypatch.setenv("AIOS_TELEGRAM_BOT1_BOT_TOKEN", "scoped-bot1")
+        specs = resolve_connector_specs(self._settings(enabled=["telegram:bot1"]))
+        _, spec = specs[0]
+        assert spec.env is not None
+        assert spec.env["AIOS_TELEGRAM_BOT_TOKEN"] == "scoped-bot1"
+
+    def test_env_passes_unscoped_for_default_instance(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ep = MagicMock()
+        ep.name = "telegram"
+        ep.load.return_value = lambda name, settings: ConnectorSpec(name=name, command="/bin/echo")
+        monkeypatch.setattr(
+            "aios.harness.connector_supervisor.entry_points",
+            lambda group: [ep],
+        )
+        monkeypatch.setenv("AIOS_TELEGRAM_BOT_TOKEN", "the-only-token")
+        specs = resolve_connector_specs(self._settings(enabled=["telegram"]))
+        _, spec = specs[0]
+        # Default-instance just inherits parent env unmodified.
+        assert spec.env is not None
+        assert spec.env["AIOS_TELEGRAM_BOT_TOKEN"] == "the-only-token"
 
 
 class TestPumpStderrLineExtraction:
@@ -223,8 +287,8 @@ class TestDropCounter:
 
         registry = ConnectorSubprocessRegistry([], settings=Settings())
         spec = ConnectorSpec(name="echo", command="x", args=[])
-        state = ConnectorState(name="echo", spec=spec)
-        registry._states["echo"] = state
+        state = ConnectorState(connector="echo", instance="echo", spec=spec)
+        registry._states[("echo", "echo")] = state
         return registry, state
 
     def test_drops_accumulate_per_reason(self) -> None:
@@ -263,7 +327,9 @@ class TestInboundMalformed:
 
         registry = ConnectorSubprocessRegistry([], settings=Settings())
         spec = ConnectorSpec(name="echo", command="x", args=[])
-        registry._states["echo"] = ConnectorState(name="echo", spec=spec)
+        registry._states[("echo", "echo")] = ConnectorState(
+            connector="echo", instance="echo", spec=spec
+        )
 
         def fake_require_pool() -> None:
             raise AssertionError("DB should not be touched on malformed payload")
@@ -275,7 +341,7 @@ class TestInboundMalformed:
 
         acked: list[str] = []
 
-        async def fake_ack(_self: object, _name: str, event_id: str) -> None:
+        async def fake_ack(_self: object, _connector: str, _instance: str, event_id: str) -> None:
             acked.append(event_id)
 
         monkeypatch.setattr(
@@ -291,10 +357,10 @@ class TestInboundMalformed:
         """Missing event_id → drop, NO ack (no id to ack against)."""
         registry, acked = await self._build_registry(monkeypatch)
         await registry._handle_inbound(
-            "echo",
+            ("echo", "echo"),
             {"account": "a", "chat_id": "c", "content": "x"},
         )
-        assert registry._states["echo"].drops["malformed"] == 1
+        assert registry._states[("echo", "echo")].drops["malformed"] == 1
         assert acked == []
 
     async def test_missing_other_field_drops_with_ack(
@@ -303,10 +369,10 @@ class TestInboundMalformed:
         """Other fields missing → drop AND ack so spool clears."""
         registry, acked = await self._build_registry(monkeypatch)
         await registry._handle_inbound(
-            "echo",
+            ("echo", "echo"),
             {"event_id": "01EVT", "account": "acct"},  # missing chat_id, content
         )
-        assert registry._states["echo"].drops["malformed"] == 1
+        assert registry._states[("echo", "echo")].drops["malformed"] == 1
         assert acked == ["01EVT"]
 
 
@@ -327,7 +393,7 @@ class TestBackoffSchedule:
         )
 
         spec = ConnectorSpec(name="echo", command="x", args=[])
-        state = ConnectorState(name="echo", spec=spec)
+        state = ConnectorState(connector="echo", instance="echo", spec=spec)
 
         # Walk the doubling chain until we hit the cap.  The supervisor
         # loop applies ``state.backoff = min(backoff * 2, cap)`` after
@@ -358,12 +424,14 @@ class TestAccountsNotificationMalformed:
 
         registry = ConnectorSubprocessRegistry([], settings=Settings())
         spec = ConnectorSpec(name="echo", command="x", args=[])
-        registry._states["echo"] = ConnectorState(name="echo", spec=spec)
+        registry._states[("echo", "echo")] = ConnectorState(
+            connector="echo", instance="echo", spec=spec
+        )
 
         await registry._on_aios_notification(
-            "echo", "notifications/aios/accounts", {"accounts": None}
+            ("echo", "echo"), "notifications/aios/accounts", {"accounts": None}
         )
-        state = registry._states["echo"]
+        state = registry._states[("echo", "echo")]
         assert state.last_error == "malformed accounts payload"
         assert state.accounts == []
 
@@ -373,16 +441,97 @@ class TestAccountsNotificationMalformed:
 
         registry = ConnectorSubprocessRegistry([], settings=Settings())
         spec = ConnectorSpec(name="echo", command="x", args=[])
-        registry._states["echo"] = ConnectorState(name="echo", spec=spec)
+        registry._states[("echo", "echo")] = ConnectorState(
+            connector="echo", instance="echo", spec=spec
+        )
 
         await registry._on_aios_notification(
-            "echo",
+            ("echo", "echo"),
             "notifications/aios/accounts",
             {"accounts": [{"id": "a", "display_name": "A"}]},
         )
-        state = registry._states["echo"]
+        state = registry._states[("echo", "echo")]
         assert state.accounts == [{"id": "a", "display_name": "A"}]
         assert state.last_error is None
+        # Account map populated for the reporting instance.
+        assert registry._account_to_instance == {("echo", "a"): "echo"}
+
+
+class TestAccountMapRebuild:
+    """``_rebuild_account_map`` clears stale claims, refuses conflicts."""
+
+    def _registry_with_two_signal_instances(self) -> ConnectorSubprocessRegistry:
+        from aios.config import Settings
+        from aios.harness.connector_supervisor import ConnectorState
+
+        registry = ConnectorSubprocessRegistry([], settings=Settings())
+        spec = ConnectorSpec(name="signal", command="x", args=[])
+        registry._states[("signal", "primary")] = ConnectorState(
+            connector="signal", instance="primary", spec=spec
+        )
+        registry._states[("signal", "secondary")] = ConnectorState(
+            connector="signal", instance="secondary", spec=spec
+        )
+        return registry
+
+    async def test_clears_stale_entries_for_reporting_instance(self) -> None:
+        """A removed account leaves no stale map entry pointing at the
+        instance that used to serve it (clear-then-insert semantics)."""
+        registry = self._registry_with_two_signal_instances()
+        # Two-account snapshot from primary.
+        await registry._on_aios_notification(
+            ("signal", "primary"),
+            "notifications/aios/accounts",
+            {
+                "accounts": [
+                    {"id": "+1111", "display_name": "A"},
+                    {"id": "+2222", "display_name": "B"},
+                ]
+            },
+        )
+        assert registry._account_to_instance == {
+            ("signal", "+1111"): "primary",
+            ("signal", "+2222"): "primary",
+        }
+        # Primary now reports only +1111 — +2222 must be cleared.
+        await registry._on_aios_notification(
+            ("signal", "primary"),
+            "notifications/aios/accounts",
+            {"accounts": [{"id": "+1111", "display_name": "A"}]},
+        )
+        assert registry._account_to_instance == {("signal", "+1111"): "primary"}
+
+    async def test_conflict_rejects_second_claim(self) -> None:
+        """Two instances claiming the same account: second is rejected,
+        last_error set, primary keeps the map entry."""
+        registry = self._registry_with_two_signal_instances()
+        await registry._on_aios_notification(
+            ("signal", "primary"),
+            "notifications/aios/accounts",
+            {"accounts": [{"id": "+1111", "display_name": "A"}]},
+        )
+        await registry._on_aios_notification(
+            ("signal", "secondary"),
+            "notifications/aios/accounts",
+            {"accounts": [{"id": "+1111", "display_name": "A-dup"}]},
+        )
+        # Primary still owns +1111; secondary's last_error surfaces the conflict.
+        assert registry._account_to_instance == {("signal", "+1111"): "primary"}
+        secondary = registry._states[("signal", "secondary")]
+        assert secondary.last_error is not None
+        assert "conflict" in secondary.last_error
+
+    async def test_lookup_instance_for_account(self) -> None:
+        """``lookup_instance_for_account`` is the public read path."""
+        registry = self._registry_with_two_signal_instances()
+        await registry._on_aios_notification(
+            ("signal", "primary"),
+            "notifications/aios/accounts",
+            {"accounts": [{"id": "+1111", "display_name": "A"}]},
+        )
+        assert registry.lookup_instance_for_account("signal", "+1111") == "primary"
+        assert registry.lookup_instance_for_account("signal", "+9999") is None
+        assert registry.lookup_instance_for_account("telegram", "+1111") is None
 
 
 class mock_log_capture:

--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -206,6 +206,35 @@ class TestResolveConnectorSpecs:
         assert spec.env is not None
         assert spec.env["AIOS_TELEGRAM_BOT_TOKEN"] == "the-only-token"
 
+    def test_env_strips_sibling_scoped_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Each subprocess sees only its own scoped vars; sibling tokens stay out.
+
+        A wedged or chatty connector that iterates ``os.environ`` for
+        debugging would otherwise expose sibling instances' credentials.
+        """
+        ep = MagicMock()
+        ep.name = "telegram"
+        ep.load.return_value = lambda name, settings: ConnectorSpec(name=name, command="/bin/echo")
+        monkeypatch.setattr(
+            "aios.harness.connector_supervisor.entry_points",
+            lambda group: [ep],
+        )
+        monkeypatch.setenv("AIOS_TELEGRAM_BOT1_BOT_TOKEN", "scoped-bot1")
+        monkeypatch.setenv("AIOS_TELEGRAM_BOT2_BOT_TOKEN", "scoped-bot2")
+        # Plain connector-prefix var (no instance segment) should
+        # survive — operator may rely on it as a default fallback.
+        monkeypatch.setenv("AIOS_TELEGRAM_BOT_TOKEN", "fallback")
+        specs = resolve_connector_specs(self._settings(enabled=["telegram:bot1", "telegram:bot2"]))
+        bot1_env = specs[0][1].env
+        bot2_env = specs[1][1].env
+        assert bot1_env is not None and bot2_env is not None
+        # bot1 sees its own re-export, NOT bot2's scoped var.
+        assert bot1_env["AIOS_TELEGRAM_BOT_TOKEN"] == "scoped-bot1"
+        assert "AIOS_TELEGRAM_BOT2_BOT_TOKEN" not in bot1_env
+        # And the reverse for bot2.
+        assert bot2_env["AIOS_TELEGRAM_BOT_TOKEN"] == "scoped-bot2"
+        assert "AIOS_TELEGRAM_BOT1_BOT_TOKEN" not in bot2_env
+
 
 class TestPumpStderrLineExtraction:
     """The stderr pump must split lines O(n) across chunk boundaries.

--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -341,7 +341,7 @@ class TestInboundMalformed:
 
         acked: list[str] = []
 
-        async def fake_ack(_self: object, _connector: str, _instance: str, event_id: str) -> None:
+        async def fake_ack(_self: object, _state: object, event_id: str) -> None:
             acked.append(event_id)
 
         monkeypatch.setattr(

--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -206,35 +206,6 @@ class TestResolveConnectorSpecs:
         assert spec.env is not None
         assert spec.env["AIOS_TELEGRAM_BOT_TOKEN"] == "the-only-token"
 
-    def test_env_strips_sibling_scoped_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Each subprocess sees only its own scoped vars; sibling tokens stay out.
-
-        A wedged or chatty connector that iterates ``os.environ`` for
-        debugging would otherwise expose sibling instances' credentials.
-        """
-        ep = MagicMock()
-        ep.name = "telegram"
-        ep.load.return_value = lambda name, settings: ConnectorSpec(name=name, command="/bin/echo")
-        monkeypatch.setattr(
-            "aios.harness.connector_supervisor.entry_points",
-            lambda group: [ep],
-        )
-        monkeypatch.setenv("AIOS_TELEGRAM_BOT1_BOT_TOKEN", "scoped-bot1")
-        monkeypatch.setenv("AIOS_TELEGRAM_BOT2_BOT_TOKEN", "scoped-bot2")
-        # Plain connector-prefix var (no instance segment) should
-        # survive — operator may rely on it as a default fallback.
-        monkeypatch.setenv("AIOS_TELEGRAM_BOT_TOKEN", "fallback")
-        specs = resolve_connector_specs(self._settings(enabled=["telegram:bot1", "telegram:bot2"]))
-        bot1_env = specs[0][1].env
-        bot2_env = specs[1][1].env
-        assert bot1_env is not None and bot2_env is not None
-        # bot1 sees its own re-export, NOT bot2's scoped var.
-        assert bot1_env["AIOS_TELEGRAM_BOT_TOKEN"] == "scoped-bot1"
-        assert "AIOS_TELEGRAM_BOT2_BOT_TOKEN" not in bot1_env
-        # And the reverse for bot2.
-        assert bot2_env["AIOS_TELEGRAM_BOT_TOKEN"] == "scoped-bot2"
-        assert "AIOS_TELEGRAM_BOT1_BOT_TOKEN" not in bot2_env
-
 
 class TestPumpStderrLineExtraction:
     """The stderr pump must split lines O(n) across chunk boundaries.

--- a/tests/unit/test_loop_default_mcp_policy.py
+++ b/tests/unit/test_loop_default_mcp_policy.py
@@ -1,0 +1,124 @@
+"""Unit tests for ``AIOS_DEFAULT_MCP_PERMISSION_POLICY``.
+
+The setting overrides the harness's hardcoded ``None → always_ask``
+fallback when an MCP-namespaced tool has no matching ``mcp_toolset``
+on the agent.
+
+Default (unset): preserves current behaviour — unmounted toolsets gate
+on confirmation.
+
+When set to ``always_allow``: trusted-environment ergonomics — tools
+mounted by attached connectors dispatch immediately without requiring
+the agent author to declare an ``mcp_toolset`` per connector.
+
+Explicit per-toolset policies still win — this only changes the
+fallback for unmounted/unspecified servers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aios.harness import loop, runtime
+from aios.models.agents import (
+    McpPermissionPolicy,
+    McpServerSpec,
+    McpToolsetConfig,
+    ToolSpec,
+)
+
+
+def _agent(*tools: ToolSpec, server_names: tuple[str, ...] = ()) -> MagicMock:
+    agent = MagicMock()
+    agent.mcp_servers = [
+        McpServerSpec(name=name, url="https://example.com/mcp", type="url") for name in server_names
+    ]
+    agent.tools = list(tools)
+    return agent
+
+
+class TestDefaultMcpPolicy:
+    """``_classify_tool_call`` consults the env-level fallback policy."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        registry = MagicMock()
+        registry.states_for_connector.return_value = [MagicMock()]
+        monkeypatch.setattr(runtime, "connector_subprocess_registry", registry)
+
+    def test_unset_default_falls_back_to_always_ask(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unmounted MCP toolset with no env override gates on confirmation."""
+        from aios.config import Settings, get_settings
+
+        monkeypatch.setattr(
+            "aios.config.get_settings",
+            lambda: Settings(default_mcp_permission_policy=None),
+        )
+        get_settings.cache_clear()
+
+        agent = _agent()  # no mcp_toolset
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc1",
+                "function": {"name": "mcp__telegram__telegram_send", "arguments": "{}"},
+            },
+            agent=agent,
+            mcp_server_map={},
+        )
+        assert kind == "needs_confirm"
+
+    def test_env_default_always_allow_skips_gate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``AIOS_DEFAULT_MCP_PERMISSION_POLICY=always_allow`` lets unmounted
+        toolsets dispatch immediately."""
+        from aios.config import Settings
+
+        monkeypatch.setattr(
+            "aios.config.get_settings",
+            lambda: Settings(default_mcp_permission_policy="always_allow"),
+        )
+
+        agent = _agent()  # no mcp_toolset
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc2",
+                "function": {"name": "mcp__telegram__telegram_send", "arguments": "{}"},
+            },
+            agent=agent,
+            mcp_server_map={},
+        )
+        assert kind == "mcp_immediate"
+
+    def test_explicit_toolset_policy_overrides_env_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the agent declares an mcp_toolset with ``always_ask``, it wins
+        over the env-level default."""
+        from aios.config import Settings
+
+        monkeypatch.setattr(
+            "aios.config.get_settings",
+            lambda: Settings(default_mcp_permission_policy="always_allow"),
+        )
+
+        agent = _agent(
+            ToolSpec(
+                type="mcp_toolset",
+                mcp_server_name="telegram",
+                enabled=True,
+                default_config=McpToolsetConfig(
+                    enabled=True,
+                    permission_policy=McpPermissionPolicy(type="always_ask"),
+                ),
+            ),
+        )
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc3",
+                "function": {"name": "mcp__telegram__telegram_send", "arguments": "{}"},
+            },
+            agent=agent,
+            mcp_server_map={},
+        )
+        assert kind == "needs_confirm"

--- a/tests/unit/test_loop_unknown_mcp_tool.py
+++ b/tests/unit/test_loop_unknown_mcp_tool.py
@@ -1,0 +1,129 @@
+"""Unit test for unknown-MCP-tool handling.
+
+The bug: the harness pattern-matches ``mcp__<server>__<tool>`` then
+calls ``resolve_mcp_permission`` to choose a gate, never checking that
+the named server is actually registered (as a connector instance OR as
+one of the agent's HTTP MCP servers).  When the model hallucinates an
+old or made-up MCP tool name, the harness:
+
+  1. Returns ``None`` from ``resolve_mcp_permission`` (no toolset match).
+  2. Caller defaults to ``always_ask``.
+  3. Session parks in ``requires_action`` waiting for a confirmation
+     that, if granted, would dispatch into ``mcp_tool.server_not_found``
+     anyway.
+
+Demonstrated live during PR #213 testing: the model parroted
+``mcp__conn_<id>__signal_send`` from prior conversation context (the
+pre-PR4 namespace) — the ``conn_<id>`` server doesn't exist anymore,
+but the harness gated the call instead of erroring.
+
+This test pins the contract: an MCP tool whose server is not known
+must be classified ``unknown_mcp`` (immediate tool-error route), not
+``needs_confirm``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aios.harness import loop, runtime
+from aios.models.agents import McpServerSpec, ToolSpec
+
+
+def _agent_with_mcp_toolset(server_name: str) -> MagicMock:
+    """Build a minimal agent stand-in with one mcp_toolset entry."""
+    agent = MagicMock()
+    agent.mcp_servers = [McpServerSpec(name=server_name, url="https://example.com/mcp", type="url")]
+    agent.tools = [
+        ToolSpec(
+            type="mcp_toolset",
+            mcp_server_name=server_name,
+            enabled=True,
+        )
+    ]
+    return agent
+
+
+class TestClassifyMcpTool:
+    """``loop._classify_tool_call`` must reject unknown-server MCP names."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default to no connector registry (HTTP-only path)."""
+        monkeypatch.setattr(runtime, "connector_subprocess_registry", None)
+
+    def test_unknown_server_classified_as_unknown_mcp(self) -> None:
+        """``mcp__nonexistent__foo`` against an agent with no matching server
+        must classify as ``unknown_mcp`` so the harness emits an immediate
+        tool error instead of gating on confirmation.
+        """
+        agent = _agent_with_mcp_toolset("github")
+        # mcp_server_map mirrors what the dispatch path consults: name → URL
+        # for HTTP MCP servers the agent declared.
+        mcp_server_map = {"github": "https://api.githubcopilot.com/mcp/"}
+
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc1",
+                "function": {"name": "mcp__nonexistent__foo", "arguments": "{}"},
+            },
+            agent=agent,
+            mcp_server_map=mcp_server_map,
+        )
+        assert kind == "unknown_mcp"
+
+    def test_known_http_mcp_server_classified_normally(self) -> None:
+        """Known HTTP MCP server falls into the existing buckets."""
+        agent = _agent_with_mcp_toolset("github")
+        mcp_server_map = {"github": "https://api.githubcopilot.com/mcp/"}
+
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc2",
+                "function": {"name": "mcp__github__create_issue", "arguments": "{}"},
+            },
+            agent=agent,
+            mcp_server_map=mcp_server_map,
+        )
+        assert kind in {"mcp_immediate", "needs_confirm"}
+
+    def test_known_connector_classified_normally(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Connector-registered server (no entry in mcp_server_map) is known."""
+        agent = _agent_with_mcp_toolset("telegram")
+        mcp_server_map: dict[str, str] = {}
+
+        registry = MagicMock()
+        registry.states_for_connector.return_value = [MagicMock()]
+        monkeypatch.setattr(runtime, "connector_subprocess_registry", registry)
+
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc3",
+                "function": {"name": "mcp__telegram__telegram_send", "arguments": "{}"},
+            },
+            agent=agent,
+            mcp_server_map=mcp_server_map,
+        )
+        assert kind in {"mcp_immediate", "needs_confirm"}
+
+    def test_old_pre_pr4_conn_id_namespace_is_unknown(self) -> None:
+        """Pre-PR4 ``mcp__conn_<id>__<tool>`` names hallucinated by models
+        with stale conversation context must error immediately, not gate.
+        """
+        agent = _agent_with_mcp_toolset("github")
+        mcp_server_map = {"github": "https://api.githubcopilot.com/mcp/"}
+
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc4",
+                "function": {
+                    "name": "mcp__conn_01KQS3BK4J7Y1ER372VJGBMCF8__signal_send",
+                    "arguments": "{}",
+                },
+            },
+            agent=agent,
+            mcp_server_map=mcp_server_map,
+        )
+        assert kind == "unknown_mcp"

--- a/tests/unit/test_tool_dispatch_focal_auth.py
+++ b/tests/unit/test_tool_dispatch_focal_auth.py
@@ -1,0 +1,145 @@
+"""Unit test for focal-route authorization in MCP outbound dispatch.
+
+The bug: when a model calls a connector tool that takes ``account`` from
+the focal channel meta (rather than as an explicit arg), the dispatch
+path skipped ``validate_account_for_session`` entirely.  Result: a
+session attached to one connector could send via *any* attached
+connector simply by switching focal to a channel address it didn't own.
+
+Demonstrated live during PR #213 migration testing: the factchecker
+session (telegram-only) ghost-wrote a "Testing Signal send" message
+into the Metals and AI Signal group despite having no signal
+connection attached.
+
+This test pins down the expected behaviour: focal-route dispatch MUST
+call ``validate_account_for_session`` and short-circuit with a
+tool_error if the session isn't authorized for the focal account.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.harness import runtime, tool_dispatch
+from aios.services import connections as connections_service
+from aios.services import sessions as sessions_service
+
+
+def _make_call(name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "id": "tc1",
+        "function": {
+            "name": name,
+            "arguments": json.dumps(arguments or {}),
+        },
+    }
+
+
+@pytest.fixture
+def mock_connector_registry(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Stand in for runtime.connector_subprocess_registry with a single signal instance."""
+    registry = MagicMock()
+    state = MagicMock()
+    state.instance = "signal"
+    state.connector = "signal"
+    registry.states_for_connector.return_value = [state]
+    registry.dispatch_call_for_account = AsyncMock(return_value={"sent_at_ms": 1})
+    registry.dispatch_call = AsyncMock(return_value={"sent_at_ms": 1})
+    monkeypatch.setattr(runtime, "connector_subprocess_registry", registry)
+    return registry
+
+
+@pytest.fixture
+def silenced_appenders(monkeypatch: pytest.MonkeyPatch) -> dict[str, AsyncMock]:
+    """Replace sessions_service.append_event with an AsyncMock that records calls.
+
+    Return value is a stand-in Event with ``.id`` and ``.seq`` so the
+    tool_dispatch code reading ``span_start.id`` etc. doesn't blow up.
+    """
+    fake_event = MagicMock()
+    fake_event.id = "evt_test"
+    fake_event.seq = 1
+
+    append = AsyncMock(return_value=fake_event)
+    monkeypatch.setattr(sessions_service, "append_event", append)
+    monkeypatch.setattr(tool_dispatch.sessions_service, "append_event", append)
+
+    # _trigger_sweep imports sweep lazily; stub at the tool_dispatch level.
+    sweep = AsyncMock(return_value=None)
+    monkeypatch.setattr(tool_dispatch, "_trigger_sweep", sweep)
+
+    return {"append_event": append, "sweep": sweep}
+
+
+class TestFocalRouteAuthorization:
+    """``_execute_mcp_tool_async`` must validate focal-derived accounts."""
+
+    async def test_focal_routed_unauthorized_account_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_connector_registry: MagicMock,
+        silenced_appenders: dict[str, AsyncMock],
+    ) -> None:
+        """Session with no signal attachment cannot send via focal-routed signal_send.
+
+        Reproduces the live PR #213 finding: factchecker (telegram-only)
+        ghost-writing into a Signal group via focal-route bypass.
+        """
+        validate = AsyncMock(return_value=False)  # session NOT authorized
+        monkeypatch.setattr(connections_service, "validate_account_for_session", validate)
+
+        pool = MagicMock()
+        await tool_dispatch._execute_mcp_tool_async(
+            pool=pool,
+            session_id="sess_factchecker",
+            call=_make_call("mcp__signal__signal_send", {"text": "ghost write"}),
+            mcp_server_map={},
+            focal_channel="signal/some-account-uuid/some-chat-id",
+        )
+
+        # Authorization MUST have been checked for the focal-derived account.
+        validate.assert_awaited_once()
+        assert validate.await_args is not None
+        kwargs = validate.await_args.kwargs
+        assert kwargs.get("connector") == "signal"
+        assert kwargs.get("account") == "some-account-uuid"
+
+        # Dispatch MUST NOT have been called.
+        mock_connector_registry.dispatch_call_for_account.assert_not_awaited()
+        mock_connector_registry.dispatch_call.assert_not_awaited()
+
+        # A tool_error event MUST have been appended.
+        append_calls = silenced_appenders["append_event"].await_args_list
+        message_calls = [c for c in append_calls if len(c.args) >= 3 and c.args[2] == "message"]
+        assert message_calls, "expected at least one 'message' append (the error)"
+        last_message = message_calls[-1].args[3]
+        assert last_message.get("role") == "tool"
+        assert last_message.get("is_error") is True
+        content = json.loads(last_message.get("content", "{}"))
+        assert "not attached" in content.get("error", "")
+
+    async def test_focal_routed_authorized_account_dispatches(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_connector_registry: MagicMock,
+        silenced_appenders: dict[str, AsyncMock],
+    ) -> None:
+        """Session WITH attached connection on focal account dispatches normally."""
+        validate = AsyncMock(return_value=True)  # session IS authorized
+        monkeypatch.setattr(connections_service, "validate_account_for_session", validate)
+
+        pool = MagicMock()
+        await tool_dispatch._execute_mcp_tool_async(
+            pool=pool,
+            session_id="sess_factchecker",
+            call=_make_call("mcp__signal__signal_send", {"text": "legit"}),
+            mcp_server_map={},
+            focal_channel="signal/owned-account/some-chat-id",
+        )
+
+        validate.assert_awaited_once()
+        mock_connector_registry.dispatch_call_for_account.assert_awaited_once()


### PR DESCRIPTION
## Summary

Closes the gap between [design §2](https://github.com/eumemic/aios/issues/200) ("Connectors can serve multiple platform accounts internally") and the PR3 implementation that pinned each connector type to one account.  Stacked on PR #211; combined merge to master per the back-to-front convention.

Two paradigms now coexist ergonomically:

- **Multi-account-per-process** (signal): one ``signal-cli daemon`` serves N phones; every RPC carries ``account`` per the [signal-cli JSON-RPC spec](https://github.com/AsamK/signal-cli/blob/master/man/signal-cli-jsonrpc.5.adoc).
- **Per-account-per-process** (telegram): each PTB ``Application`` runs in its own subprocess; operators deploy multiple bots via ``connectors_enabled=telegram:a,telegram:b``.

The SDK introspects each tool method's signature and injects ``account`` and/or ``chat_id`` based on what's declared.  Connector authors write the kwargs they need; mypy catches typos; the JSON schema published to the model excludes only what's auto-injected.

## Layered changes

- **Layer 1 — Harness focal-path strip**: ``focal_channel_path`` strips only ``<connector>/``, leaving ``<account>/<chat>`` per design §3.4.
- **Layer 2 — SDK signature inspection**: ``@focal_required`` reads parameter names at registration; dispatch splits the focal path on the first ``/`` and injects only declared kwargs.  Schema exclusion gated on ``focal_required`` — non-focal tools like ``list_chats(account: str)`` keep ``account`` model-visible.
- **Layer 3 — Supervisor multi-instance keying**: registry keyed by ``(connector, instance)``; per-instance cwd (``<connectors_dir>/<connector>/`` for default, else ``<connectors_dir>/<connector>/<instance>/``); per-instance env re-export (``AIOS_<CONN>_<INST>_*`` → ``AIOS_<CONN>_*``); ``account → instance`` map with clear-then-insert rebuild and conflict rejection.
- **Layer 4 — API + CLI**: ``/v1/connectors/{connector}/{instance}/...`` paths.  CLI passes ``_`` sentinel when operator omits instance; worker auto-resolves it via ``ConnectorSubprocessRegistry.resolve_default_instance`` — one HTTP round-trip per command.
- **Layer 5 — Config**: ``connectors_enabled`` accepts ``<connector>[:<instance>]``; instance names match ``^[a-z][a-z0-9_]*$`` (POSIX env-var-safe); duplicate pairs rejected.
- **Layer 6 — Signal multi-account**: drops ``-a`` from launch; every RPC includes ``account`` in params; ``discover_bot_uuids() -> dict[phone, uuid]``; per-account contacts/groups; instructions block sectioned per phone.
- **Layer 7 — Telegram per-instance**: ``telegram_send(text, *, chat_id)`` — no ``account`` kwarg; one PTB ``Application`` per subprocess.
- **Layer 8 — Echo multi-account**: returns 2 accounts; ``echo`` tool takes ``(account, chat_id)``.

## Migration (for operators on PR #211)

Env var renames are breaking but contained:

```bash
# Before (PR3, single-phone signal)
AIOS_SIGNAL_PHONE=+15551234567

# After (this PR, multi-phone-capable single-instance signal)
AIOS_SIGNAL_PHONES=+15551234567,+15559876543

# Multi-instance telegram (new)
AIOS_CONNECTORS_ENABLED=telegram:support,telegram:alerts
AIOS_TELEGRAM_SUPPORT_BOT_TOKEN=xxx
AIOS_TELEGRAM_ALERTS_BOT_TOKEN=yyy
```

Single-instance setups (``connectors_enabled=signal``) continue to work without per-instance env scoping — the supervisor auto-applies the default-instance convention.

## Stack-internal API refinement

The ``/v1/connectors/{connector}/...`` paths from #210/#211 never reach master before this PR lands, so the final API shape is ``/v1/connectors/{connector}/{instance}/...``.  Not a breaking change to existing master users; the ``ambiguous_instance`` error code maps to HTTP 409 for operators hitting the API directly.

## Test plan

- [x] ``uv run mypy src`` — clean (123 source files)
- [x] ``uv run ruff check src tests packages connectors`` — clean
- [x] ``uv run ruff format --check src tests packages connectors`` — 289 files clean
- [x] ``uv run pytest tests/unit -q`` — **994 passed** (was 972; +22 for config parser, signature inspection, account-map rebuild)
- [x] ``uv run pytest packages/aios-connector/tests -q`` — **28 passed** (was 16)
- [x] ``cd connectors/signal && uv run pytest tests -q`` — **68 passed** (was 66)
- [x] ``uv run --package aios-telegram pytest connectors/telegram/tests -q --rootdir=connectors/telegram`` — **17 passed**
- [x] ``DOCKER_HOST=... uv run pytest tests/e2e -q`` — **229 passed** (was 222; +7 for multi-account/multi-instance)
- [ ] Manual smoke: deploy with ``AIOS_CONNECTORS_ENABLED=signal:main,telegram:bot1,telegram:bot2``; verify ``aios connector list`` shows 3 instances; attach distinct sessions per account; verify cross-account inbound routing isolation; kill one telegram subprocess externally and verify the other stays up.

## Stack

- PR #205: schema cutover (PR1/3) — _merged into PR2's base_
- PR #210: stdio MCP transport + supervisor (PR2/3) — _merged into PR3's base_
- PR #211: inbound spool + reference SDK + signal/telegram port (PR3/3) — _this PR's base_
- **PR4 (this PR)**: multi-account + multi-instance support

Combined merge to master is back-to-front per the established convention.

## Commits

1. ``feat(connector): multi-account + multi-instance support (#200)`` — main implementation across 10 layers
2. ``refactor(connector): /simplify pass on multi-instance PR`` — 7 contained simplifications surfaced by the post-implementation review (``_`` instance sentinel, ``instance_label`` helper, ``_send_ack(state, ...)``, ``last_error`` clear-on-snapshot, ``_detect_focal_kwargs`` one-liner, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)