### PR TITLE
fix(connector): bugs surfaced by live migration on PR #213 stack

### DIFF
--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -58,7 +58,7 @@ config under the standard prefix.
 
 `aios worker` boots, spawns the signal subprocess, runs `signal-cli
 daemon`, and reports the discovered accounts on
-`aios connector accounts signal`.
+`aios connectors accounts signal`.
 
 ### 4. Attach connections to sessions
 

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -46,7 +46,7 @@ process — one bot's PTB `Application` crashing doesn't affect siblings.
 
 `aios worker` boots, spawns one telegram subprocess per instance, and
 each runs `Bot.get_me()` to identify itself.  Verify with
-`aios connector list`.
+`aios connectors list`.
 
 ### 4. Attach connections to sessions
 

--- a/packages/aios-connector/README.md
+++ b/packages/aios-connector/README.md
@@ -8,7 +8,7 @@ supervises.  It exposes:
 - **Inbound notifications** (`notifications/aios/inbound`) carrying user
   messages from the underlying platform into aios sessions.
 - **Account snapshots** (`notifications/aios/accounts`) the operator
-  surfaces in `aios connector list`.
+  surfaces in `aios connectors list`.
 
 ## Quickstart
 

--- a/packages/aios-connector/aios_connector/base.py
+++ b/packages/aios-connector/aios_connector/base.py
@@ -589,7 +589,7 @@ class Connector:
             ctx = request_ctx.get()
         except LookupError:
             return None
-        meta: RequestParams.Meta | None = getattr(ctx.request, "meta", None) if ctx else None
+        meta: RequestParams.Meta | None = ctx.meta if ctx else None
         if meta is None:
             return None
         extra = getattr(meta, "model_extra", None) or {}

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import re
 from functools import lru_cache
 from pathlib import Path
-from typing import Annotated, NamedTuple
+from typing import Annotated, Literal, NamedTuple
 
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
@@ -273,6 +273,21 @@ class Settings(BaseSettings):
         "doesn't compose well with that shape under the ``AIOS_`` env prefix; "
         "a flat ``AIOS_CONNECTORS_AUTO_CREATE='{\"signal\":false}'`` is "
         "operationally equivalent and easier to override from systemd / env.",
+    )
+
+    default_mcp_permission_policy: Literal["always_allow", "always_ask"] | None = Field(
+        default=None,
+        description="Fallback permission policy for MCP tools whose server "
+        "has no matching ``mcp_toolset`` entry on the calling agent. "
+        "When unset (the default), unmounted MCP toolsets gate on "
+        "``always_ask`` confirmation — the safe default that protects "
+        "against connector-mounted tools the agent never opted into. "
+        "Operators in trusted environments can set this to "
+        "``always_allow`` so connector tools dispatch immediately on any "
+        "session that has the connection attached, without per-agent "
+        "``mcp_toolset`` declarations.  Explicit per-toolset policies on "
+        "``agent.tools`` always win — this only changes the fallback "
+        "for unmounted servers.",
     )
 
     # ── observability ──────────────────────────────────────────────────────

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -162,11 +162,21 @@ class ConnectorState:
         return instance_label(self.connector, self.instance)
 
     def snapshot(self) -> dict[str, Any]:
+        """Build the admin-facing dict for ``connector_status`` / GET ``/v1/connectors``.
+
+        ``instructions`` is intentionally absent.  The MCP server's
+        ``InitializeResult.instructions`` is consumed for model context
+        via :func:`aios.harness.loop.discover_session_mcp_tools` (which
+        re-fetches it directly), not via this snapshot.  Including it
+        here previously broke ``connector_status``: the task pg_notifies
+        the JSON-encoded snapshot, and Postgres NOTIFY caps payloads at
+        8000 bytes — a signal connector serving N phones with their
+        contacts and groups easily exceeded that.
+        """
         return {
             "connector": self.connector,
             "instance": self.instance,
             "status": self.status,
-            "instructions": self.instructions,
             "accounts": list(self.accounts),
             "last_error": self.last_error,
             "recent_drops": dict(self.drops),

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -40,6 +40,45 @@ re-spawn.  After ``_CIRCUIT_THRESHOLD`` failures within
 ``_CIRCUIT_WINDOW``, the loop stops respawning and the connector
 reports ``circuit_open`` until the worker is restarted — operator can
 fix the connector or its config and restart the worker.
+
+Architectural constraint
+------------------------
+
+This module currently lives in the ``aios worker`` process and bakes in
+the single-worker invariant: the worker's ``pg_try_advisory_lock``
+refuses a second concurrent ``aios worker`` so the connector supervisor
+has exclusive ownership of stdio handles, restart bookkeeping, and the
+in-memory account map.  That's fine today (one worker comfortably
+multiplexes hundreds of in-flight session-step coroutines on the
+asyncio loop), but it's a real architectural ceiling for horizontal
+scaling — any future need for multiple workers would force connector
+supervision into a separate ``aios connectors`` process.
+
+To preserve that option without committing to it, this module's public
+surface is intentionally narrow:
+
+* :class:`ConnectorSubprocessRegistry` — entry-point lookup, lifecycle
+  bookkeeping, and the ``account → instance`` routing map.  External
+  consumers should reach for ``state``, ``states_for_connector``,
+  ``snapshot_all``, ``get_session``, ``dispatch_call``, and
+  ``dispatch_call_for_account`` only.
+
+* The procrastinate ``connector_call`` task in
+  :mod:`aios.harness.connector_tasks` is the canonical IPC primitive
+  for cross-process calls into the supervisor.  When the API process
+  needs supervisor data it goes through that task, not by importing
+  the registry.
+
+* The one in-process call site that bypasses the procrastinate IPC is
+  the outbound MCP dispatcher in :mod:`aios.harness.tool_dispatch`,
+  justified there as the per-tool-call hot path where ~50-200ms of
+  procrastinate round-trip would dominate the latency budget.
+
+If new functionality on the supervisor is tempted to add another
+in-process consumer that imports the registry directly, prefer
+defining a procrastinate task in ``connector_tasks.py`` and routing
+new callers through it.  Same end behaviour today; one less call site
+to migrate the day the supervisor splits out.
 """
 
 from __future__ import annotations

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -451,28 +451,24 @@ async def _run_session_step_body(
     tool_calls: list[dict[str, Any]] = assistant_msg.get("tool_calls") or []
 
     if tool_calls:
-        from aios.tools.registry import registry as tool_registry
-
         immediate: list[dict[str, Any]] = []
         mcp_immediate: list[dict[str, Any]] = []
         needs_confirm: list[dict[str, Any]] = []
         custom: list[dict[str, Any]] = []
+        unknown_mcp: list[dict[str, Any]] = []
 
         for tc in tool_calls:
-            name = _tc_name(tc)
-            if _is_mcp_tool(name):
-                # MCP tools default to always_ask (unlike built-in always_allow).
-                perm = resolve_mcp_permission(name, agent.tools)
-                if perm == "always_allow":
-                    mcp_immediate.append(tc)
-                else:
-                    needs_confirm.append(tc)
-            elif not tool_registry.has(name):
-                custom.append(tc)
-            elif resolve_permission(name, agent.tools) == "always_ask":
-                needs_confirm.append(tc)
-            else:
+            kind = _classify_tool_call(tc, agent, mcp_server_map)
+            if kind == "immediate":
                 immediate.append(tc)
+            elif kind == "mcp_immediate":
+                mcp_immediate.append(tc)
+            elif kind == "needs_confirm":
+                needs_confirm.append(tc)
+            elif kind == "custom":
+                custom.append(tc)
+            else:  # "unknown_mcp"
+                unknown_mcp.append(tc)
 
         if immediate:
             launch_tool_calls(pool, session_id, immediate)
@@ -483,19 +479,29 @@ async def _run_session_step_body(
                 tool_names=[_tc_name(tc) for tc in immediate],
             )
 
-        if mcp_immediate:
+        # Unknown-MCP tools route through the regular MCP dispatcher,
+        # bypassing the permission gate.  ``_execute_mcp_tool_async``
+        # already detects unknown servers and appends a tool_error
+        # event (``mcp_tool.server_not_found``); the prior code path
+        # parked the session in ``requires_action`` and dispatched
+        # only after a confirmation, which never came.  Routing them
+        # to immediate dispatch lets the model see the error in the
+        # next step and self-correct.
+        immediate_mcp = mcp_immediate + unknown_mcp
+        if immediate_mcp:
             launch_mcp_tool_calls(
                 pool,
                 session_id,
-                mcp_immediate,
+                immediate_mcp,
                 mcp_server_map,
                 focal_channel=session.focal_channel,
             )
             log.info(
                 "step.mcp_tools_launched",
                 session_id=session_id,
-                count=len(mcp_immediate),
-                tool_names=[_tc_name(tc) for tc in mcp_immediate],
+                count=len(immediate_mcp),
+                tool_names=[_tc_name(tc) for tc in immediate_mcp],
+                unknown_count=len(unknown_mcp),
             )
 
         if needs_confirm or custom:
@@ -604,6 +610,74 @@ def _tc_name(tc: dict[str, Any]) -> str:
 def _is_mcp_tool(name: str) -> bool:
     """Return True if the tool name is an MCP-namespaced tool."""
     return name.startswith("mcp__")
+
+
+def _is_known_mcp_server(server_name: str, mcp_server_map: dict[str, str]) -> bool:
+    """Return True if ``server_name`` resolves to a registered MCP server.
+
+    A server is "known" if either:
+
+    * It's a connector instance currently registered with the
+      :class:`~aios.harness.connector_supervisor.ConnectorSubprocessRegistry`,
+      or
+    * It appears in ``mcp_server_map`` (the agent-declared HTTP MCP
+      servers, keyed by ``McpServerSpec.name``).
+
+    Used by :func:`_classify_tool_call` to short-circuit hallucinated
+    tool names before the permission gate, so the model gets a tool
+    error in one turn instead of parking in ``requires_action`` forever
+    waiting on a confirmation that would dispatch into
+    ``mcp_tool.server_not_found`` anyway.
+    """
+    registry = runtime.connector_subprocess_registry
+    if registry is not None and registry.states_for_connector(server_name):
+        return True
+    return server_name in mcp_server_map
+
+
+def _classify_tool_call(
+    tool_call: dict[str, Any],
+    agent: Any,
+    mcp_server_map: dict[str, str],
+) -> str:
+    """Classify a tool call into a dispatch bucket.
+
+    Returns one of:
+
+    * ``"immediate"`` — built-in tool, run synchronously.
+    * ``"mcp_immediate"`` — known MCP tool, ``always_allow``.
+    * ``"needs_confirm"`` — built-in or MCP tool gated on
+      ``always_ask`` confirmation.
+    * ``"custom"`` — client-executed custom tool (the harness holds
+      the call until the client posts a tool-result).
+    * ``"unknown_mcp"`` — MCP-namespaced tool whose server is not
+      registered.  Routed to immediate tool-error so the model can
+      self-correct rather than parking in ``requires_action``.
+    """
+    from aios.tools.registry import registry as tool_registry
+
+    function = tool_call.get("function") or {}
+    name: str = function.get("name") or ""
+
+    if _is_mcp_tool(name):
+        try:
+            server_name = name.split("__", 2)[1]
+        except IndexError:
+            server_name = ""
+        if not server_name or not _is_known_mcp_server(server_name, mcp_server_map):
+            return "unknown_mcp"
+        perm = resolve_mcp_permission(name, agent.tools)
+        if perm == "always_allow":
+            return "mcp_immediate"
+        return "needs_confirm"
+
+    if not tool_registry.has(name):
+        return "custom"
+
+    if resolve_permission(name, agent.tools) == "always_ask":
+        return "needs_confirm"
+
+    return "immediate"
 
 
 def resolve_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -22,7 +22,7 @@ and proceeds.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from aios.db.sse_lock import has_subscriber
 from aios.harness import runtime
@@ -635,11 +635,16 @@ def _is_known_mcp_server(server_name: str, mcp_server_map: dict[str, str]) -> bo
     return server_name in mcp_server_map
 
 
+type ToolDispatchKind = Literal[
+    "immediate", "mcp_immediate", "needs_confirm", "custom", "unknown_mcp"
+]
+
+
 def _classify_tool_call(
     tool_call: dict[str, Any],
     agent: Any,
     mcp_server_map: dict[str, str],
-) -> str:
+) -> ToolDispatchKind:
     """Classify a tool call into a dispatch bucket.
 
     Returns one of:
@@ -654,6 +659,7 @@ def _classify_tool_call(
       registered.  Routed to immediate tool-error so the model can
       self-correct rather than parking in ``requires_action``.
     """
+    from aios.harness.tool_dispatch import _parse_mcp_tool_name
     from aios.tools.registry import registry as tool_registry
 
     function = tool_call.get("function") or {}
@@ -661,10 +667,10 @@ def _classify_tool_call(
 
     if _is_mcp_tool(name):
         try:
-            server_name = name.split("__", 2)[1]
-        except IndexError:
-            server_name = ""
-        if not server_name or not _is_known_mcp_server(server_name, mcp_server_map):
+            server_name, _ = _parse_mcp_tool_name(name)
+        except ValueError:
+            return "unknown_mcp"
+        if not _is_known_mcp_server(server_name, mcp_server_map):
             return "unknown_mcp"
         perm = resolve_mcp_permission(name, agent.tools)
         if perm is None:

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -667,6 +667,15 @@ def _classify_tool_call(
         if not server_name or not _is_known_mcp_server(server_name, mcp_server_map):
             return "unknown_mcp"
         perm = resolve_mcp_permission(name, agent.tools)
+        if perm is None:
+            # Fallback to the operator-configured default for unmounted
+            # toolsets (``AIOS_DEFAULT_MCP_PERMISSION_POLICY``).  Unset
+            # → ``always_ask`` (safe default); explicit per-toolset
+            # policies on ``agent.tools`` always win and are returned
+            # above without reaching this branch.
+            from aios.config import get_settings
+
+            perm = get_settings().default_mcp_permission_policy
         if perm == "always_allow":
             return "mcp_immediate"
         return "needs_confirm"

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -405,6 +405,18 @@ async def _execute_mcp_tool_async(
         # an agent's ``mcp_servers`` entry would be ambiguous.  We
         # resolve in favor of the connector — connectors are first-class
         # in the redesign (#200), HTTP MCP servers are agent-scoped.
+        #
+        # This is the one in-process call site that imports the
+        # supervisor registry directly (rather than going through a
+        # procrastinate task in ``aios.harness.connector_tasks``).
+        # Justified because every outbound MCP tool call is hot-path:
+        # the procrastinate round-trip would add ~50-200ms per call.
+        # New supervisor consumers should NOT add direct-import call
+        # sites here — define a task in ``connector_tasks.py`` and
+        # dispatch through it.  Same behaviour today, one less site
+        # to migrate the day the supervisor splits into a separate
+        # ``aios connectors`` process (see ``connector_supervisor``
+        # module docstring's "Architectural constraint" section).
         connector_registry = runtime.connector_subprocess_registry
         connector_instances = (
             connector_registry.states_for_connector(server_name)

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -412,18 +412,36 @@ async def _execute_mcp_tool_async(
             else []
         )
         if connector_registry is not None and connector_instances:
+            # Resolve which account the call is targeting.  Tools that
+            # take ``account`` as an explicit arg (cross-chat ops like
+            # ``list_chats``) get it from there; focal-required tools
+            # (``signal_send``, ``telegram_send``) get it from the
+            # focal-channel ``_meta`` suffix's first segment.
             account_arg = arguments.get("account")
             if isinstance(account_arg, str):
+                account_for_routing: str | None = account_arg
+            elif suffix is not None:
+                account_for_routing = suffix.partition("/")[0] or None
+            else:
+                account_for_routing = None
+
+            # Authorize the call regardless of how the account was
+            # resolved.  The pre-fix version only ran this check for
+            # the explicit-arg path; focal-routed dispatch sailed
+            # through unauthorized, letting any session that could
+            # ``switch_channel`` to a connector's chat send via that
+            # connector — see PR #214 #39.
+            if account_for_routing is not None:
                 from aios.services import connections as connections_service
 
                 authorized = await connections_service.validate_account_for_session(
-                    pool, session_id, connector=server_name, account=account_arg
+                    pool, session_id, connector=server_name, account=account_for_routing
                 )
                 if not authorized:
                     bound_log.warning(
                         "mcp_tool.account_not_authorized",
                         server_name=server_name,
-                        account=account_arg,
+                        account=account_for_routing,
                     )
                     is_error = True
                     await _append_tool_result(
@@ -432,16 +450,13 @@ async def _execute_mcp_tool_async(
                         call_id,
                         name,
                         error=(
-                            f"account {account_arg!r} on connector {server_name!r} is not "
-                            "attached to this session or one that spawned it"
+                            f"account {account_for_routing!r} on connector "
+                            f"{server_name!r} is not attached to this session "
+                            "or one that spawned it"
                         ),
                     )
                     return
-                account_for_routing: str | None = account_arg
-            elif suffix is not None:
-                account_for_routing = suffix.partition("/")[0] or None
-            else:
-                account_for_routing = None
+
             if account_for_routing is not None:
                 result = await connector_registry.dispatch_call_for_account(
                     server_name, account_for_routing, tool_name, arguments, meta=meta

--- a/src/aios/mcp/stdio_transport.py
+++ b/src/aios/mcp/stdio_transport.py
@@ -114,7 +114,13 @@ def _redact_secrets(line: str) -> str:
     parse log formats; it just matches well-known credential shapes.
     Add new patterns here as connectors that leak their own
     credentials are surfaced.
+
+    The substring fast-path skips the regex on the ~all-of-stderr
+    that doesn't mention ``/bot``; matters for high-frequency emitters
+    like PTB's ``getUpdates`` polling loop.
     """
+    if "/bot" not in line:
+        return line
     return _BOT_TOKEN_RE.sub("/bot<redacted>", line)
 
 

--- a/src/aios/mcp/stdio_transport.py
+++ b/src/aios/mcp/stdio_transport.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import re
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -91,6 +92,32 @@ class ConnectorSpec:
     cwd: Path | None = None
 
 
+# Patterns matching credentials that connector libraries embed in URL
+# paths and routinely log via their HTTP clients (e.g. python-telegram-bot
+# delegates to httpx, whose default logger emits the full request URL
+# including the bot token).  We redact at emission time rather than
+# upstream-filtering each library because stderr is a multi-source pipe
+# and the supervisor has no per-line knowledge of which library produced
+# each line.
+#
+# Telegram bot tokens have the shape ``<bot_id>:<32+ alphanum-_-_>``, used
+# as a path segment after ``/bot``.  The redaction preserves the URL
+# shape so the operator can still see *which* request was made (and
+# spot, e.g., a getUpdates polling loop) without exposing the token.
+_BOT_TOKEN_RE = re.compile(r"/bot\d+:[A-Za-z0-9_\-]+")
+
+
+def _redact_secrets(line: str) -> str:
+    """Strip embedded secrets from a stderr line before logging.
+
+    The redaction is deliberately conservative — it doesn't try to
+    parse log formats; it just matches well-known credential shapes.
+    Add new patterns here as connectors that leak their own
+    credentials are surfaced.
+    """
+    return _BOT_TOKEN_RE.sub("/bot<redacted>", line)
+
+
 async def _pump_stderr(connector_name: str, read_fd: int) -> None:
     """Read connector stderr via ``loop.add_reader`` and emit lines as structlog events.
 
@@ -129,7 +156,7 @@ async def _pump_stderr(connector_name: str, read_fd: int) -> None:
             if line:
                 bound.info(
                     "connector.stderr",
-                    line=line.decode("utf-8", errors="replace"),
+                    line=_redact_secrets(line.decode("utf-8", errors="replace")),
                 )
 
     loop.add_reader(read_fd, on_readable)
@@ -140,7 +167,7 @@ async def _pump_stderr(connector_name: str, read_fd: int) -> None:
         if pending:
             bound.info(
                 "connector.stderr",
-                line=pending.decode("utf-8", errors="replace"),
+                line=_redact_secrets(pending.decode("utf-8", errors="replace")),
             )
         with contextlib.suppress(OSError):
             os.close(read_fd)

--- a/tests/e2e/test_connector_inbound.py
+++ b/tests/e2e/test_connector_inbound.py
@@ -667,7 +667,6 @@ class TestRegistryIsolation:
                 "connector": "echo",
                 "instance": "echo",
                 "status": "starting",
-                "instructions": None,
                 "accounts": [],
                 "last_error": None,
                 "recent_drops": {},

--- a/tests/e2e/test_focal_required_dispatch.py
+++ b/tests/e2e/test_focal_required_dispatch.py
@@ -1,0 +1,148 @@
+"""E2E: outbound focal-required MCP dispatch through the aios-connector SDK.
+
+Closes the test gap that allowed the SDK ``ctx.meta`` bug into PR #211.
+That bug was on the SDK's *receive* path: the harness sent
+``_meta.aios.focal_channel_path`` correctly over JSON-RPC, but
+``_focal_from_request_meta`` read ``ctx.request.meta`` (which is None
+on a ``CallToolRequest``) instead of ``ctx.meta`` (where the lowlevel
+server stashes the parsed meta).  Every focal-required tool call
+failed with ``"aios should inject _meta.aios.focal_channel_path"``
+even when aios *had* injected it.
+
+PR #211's e2e tests covered the inbound path
+(``test_connector_inbound.py``) and the supervisor's bare dispatch
+mechanics (``test_connector_supervisor.py`` against a hand-written
+fixture that bypasses the SDK).  Neither exercised an outbound
+focal-required tool dispatched through a *real* aios-connector
+subprocess — the SDK code path that was broken.
+
+This test spawns ``python -m aios_echo`` as a real subprocess (using
+the SDK's framing end-to-end), sets a focal channel suffix on the
+``call_tool`` ``_meta``, and asserts the tool result reflects the
+account/chat_id the SDK extracted.  Without the ``ctx.meta`` fix it
+returns a tool error; with it, the round-trip succeeds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+
+from aios.config import ConnectorInstance, Settings
+from aios.harness.connector_supervisor import ConnectorSubprocessRegistry
+from aios.mcp.stdio_transport import ConnectorSpec
+
+
+def _aios_echo_specs() -> list[tuple[ConnectorInstance, ConnectorSpec]]:
+    """Spawn ``python -m aios_echo`` — the workspace's reference SDK example.
+
+    Unlike ``tests.fixtures.echo_connector`` (hand-written against the
+    raw MCP SDK), ``aios_echo`` uses the public ``aios_connector.Connector``
+    base class.  The SDK's ``_focal_from_request_meta`` runs in the
+    spawned subprocess; this is the code path the test exercises.
+    """
+    return [
+        (
+            ConnectorInstance(connector="echo", instance="echo"),
+            ConnectorSpec(
+                name="echo",
+                command=sys.executable,
+                args=["-m", "aios_echo"],
+            ),
+        )
+    ]
+
+
+async def _wait_for(predicate: Any, *, max_wait_s: float = 10.0) -> None:
+    deadline = asyncio.get_event_loop().time() + max_wait_s
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"predicate {predicate!r} did not become true within {max_wait_s}s")
+
+
+class TestFocalRequiredDispatch:
+    """``mcp__echo__echo`` is ``@focal_required``; it MUST receive the
+    SDK-extracted ``account`` and ``chat_id`` derived from
+    ``_meta.aios.focal_channel_path`` rather than failing with
+    ``"aios should inject _meta.aios.focal_channel_path"``.
+    """
+
+    async def test_focal_meta_round_trips_to_focal_required_tool(self) -> None:
+        registry = ConnectorSubprocessRegistry(_aios_echo_specs(), settings=Settings())
+        await registry.start()
+        try:
+            session = await asyncio.wait_for(registry.get_session("echo", "echo"), timeout=15.0)
+
+            # Wait until the SDK has finished its post-init handshake and the
+            # accounts snapshot is in.  ``aios_echo``'s ``discover_accounts``
+            # advertises ``echo-1`` and ``echo-2``.
+            state = registry.state("echo", "echo")
+            assert state is not None
+
+            await _wait_for(
+                lambda: any(a.get("id") == "echo-1" for a in state.accounts),
+                max_wait_s=15.0,
+            )
+
+            # Dispatch through the same code path the harness uses:
+            # ``ClientSession.call_tool(name, arguments, meta=...)``.  The
+            # account+chat_id segments mirror what
+            # ``aios.harness.tool_dispatch`` builds from the session's
+            # focal_channel for outbound calls.
+            result = await asyncio.wait_for(
+                session.call_tool(
+                    "echo",
+                    {"text": "hello"},
+                    meta={"aios.focal_channel_path": "echo-1/chat-42"},
+                ),
+                timeout=10.0,
+            )
+
+            # Without the SDK fix, isError=True with content like:
+            # "tool 'echo' requires a focal channel — aios should inject ..."
+            assert not result.isError, (
+                f"focal-required tool should not error when _meta is set; got: "
+                f"{[c.text for c in result.content if hasattr(c, 'text')]}"
+            )
+
+            # The SDK-extracted account/chat_id must round-trip through the
+            # tool's return value.
+            assert result.content
+            text_blocks = [c.text for c in result.content if hasattr(c, "text")]
+            payload = " ".join(text_blocks)
+            assert "echo-1" in payload, f"account not in result payload: {payload!r}"
+            assert "chat-42" in payload, f"chat_id not in result payload: {payload!r}"
+        finally:
+            await registry.shutdown()
+
+    async def test_missing_focal_meta_returns_tool_error(self) -> None:
+        """Negative case: with no ``_meta``, the SDK raises a tool-level
+        error message — proves the focal-meta plumbing is the load-bearing
+        path (i.e. the success above isn't passing for some unrelated
+        reason).
+        """
+        registry = ConnectorSubprocessRegistry(_aios_echo_specs(), settings=Settings())
+        await registry.start()
+        try:
+            session = await asyncio.wait_for(registry.get_session("echo", "echo"), timeout=15.0)
+            state = registry.state("echo", "echo")
+            assert state is not None
+            await _wait_for(lambda: bool(state.accounts), max_wait_s=15.0)
+
+            result = await asyncio.wait_for(
+                session.call_tool("echo", {"text": "hello"}),  # no meta
+                timeout=10.0,
+            )
+
+            # The SDK's @focal_required guard surfaces as a tool-level
+            # error rather than a transport exception.
+            text_blocks = [c.text for c in result.content if hasattr(c, "text")]
+            payload = " ".join(text_blocks)
+            assert "focal_channel_path" in payload or "focal channel" in payload, (
+                f"expected focal-channel error, got: {payload!r}"
+            )
+        finally:
+            await registry.shutdown()

--- a/tests/unit/test_config_connectors.py
+++ b/tests/unit/test_config_connectors.py
@@ -74,8 +74,9 @@ class TestParseConnectorEntry:
 class TestConnectorsEnabledValidator:
     """The Settings field validator wraps the parser per entry."""
 
-    def test_empty_default(self) -> None:
-        s = Settings(**_BASE_KWARGS)
+    def test_empty_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AIOS_CONNECTORS_ENABLED", raising=False)
+        s = Settings(_env_file=None, **_BASE_KWARGS)
         assert s.connectors_enabled == []
         assert s.connector_instances() == []
 

--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -304,6 +304,49 @@ class TestDropCounter:
         assert state.snapshot()["recent_drops"] == {}
 
 
+class TestSnapshotSize:
+    """``ConnectorState.snapshot()`` is consumed by ``connector_status``,
+    which sends the JSON-encoded result via ``pg_notify``.  Postgres
+    NOTIFY caps payloads at 8000 bytes — large server-side
+    ``InitializeResult.instructions`` (signal with N phones, each with
+    per-account contacts and groups) easily exceeded this and crashed
+    the admin RPC.
+
+    The fix: instructions stay on the state for in-process consumers
+    (the model-context discovery path uses
+    :func:`discover_session_mcp_tools` directly, not the snapshot) but
+    are kept out of the admin-facing snapshot.
+    """
+
+    def _registry_with_state(self) -> tuple[Any, Any]:
+        from aios.config import Settings
+        from aios.harness.connector_supervisor import (
+            ConnectorState,
+            ConnectorSubprocessRegistry,
+        )
+
+        registry = ConnectorSubprocessRegistry([], settings=Settings())
+        spec = ConnectorSpec(name="echo", command="x", args=[])
+        state = ConnectorState(connector="echo", instance="echo", spec=spec)
+        registry._states[("echo", "echo")] = state
+        return registry, state
+
+    def test_snapshot_omits_large_instructions(self) -> None:
+        """A 6KB instructions block must not appear in the snapshot — the
+        admin RPC is the one consumer of ``snapshot()`` and Postgres
+        NOTIFY cannot carry it."""
+        import json
+
+        _, state = self._registry_with_state()
+        state.instructions = "x" * 6000
+
+        snap = state.snapshot()
+        assert "instructions" not in snap
+        # End-to-end size assertion: serialized snapshot fits comfortably
+        # under the 8000-byte NOTIFY cap.
+        assert len(json.dumps(snap)) < 8000
+
+
 class TestInboundMalformed:
     """Malformed inbound payloads count as ``malformed`` drops, never crash.
 

--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -271,6 +271,36 @@ class TestPumpStderrLineExtraction:
                 os.close(write_fd)
         assert captured == ["trailing-no-newline"]
 
+    async def test_telegram_bot_token_redacted_from_url(self) -> None:
+        """PTB's httpx logger writes ``https://api.telegram.org/bot<TOKEN>/...``
+        URLs to stderr.  The pump must redact the token before emitting
+        ``connector.stderr`` events — otherwise the bot token lives in
+        ``/tmp/aios-worker.log`` and anyone with log access can extract it.
+        """
+        captured: list[str] = []
+        read_fd, write_fd = os.pipe()
+        token = "8116307959:AAFv1He6CZ-tpGun19CTp1tjbBoWtJrGrL8"
+        try:
+            pump = asyncio.create_task(_pump_stderr("test_conn", read_fd))
+            with mock_log_capture(captured):
+                os.write(
+                    write_fd,
+                    f'HTTP Request: POST https://api.telegram.org/bot{token}/getMe "HTTP/1.1 200 OK"\n'.encode(),
+                )
+                await asyncio.sleep(0.05)
+                os.close(write_fd)
+                write_fd = -1
+                await asyncio.wait_for(pump, timeout=1.0)
+        finally:
+            if write_fd != -1:
+                os.close(write_fd)
+        assert len(captured) == 1
+        line = captured[0]
+        assert token not in line, "bot token must be redacted from stderr line"
+        # Existing path structure preserved — only the token is masked.
+        assert "/getMe" in line
+        assert "api.telegram.org" in line
+
 
 class TestDropCounter:
     """Drop counters bump per reason and surface in :meth:`snapshot`.

--- a/tests/unit/test_loop_default_mcp_policy.py
+++ b/tests/unit/test_loop_default_mcp_policy.py
@@ -1,0 +1,124 @@
+"""Unit tests for ``AIOS_DEFAULT_MCP_PERMISSION_POLICY``.
+
+The setting overrides the harness's hardcoded ``None → always_ask``
+fallback when an MCP-namespaced tool has no matching ``mcp_toolset``
+on the agent.
+
+Default (unset): preserves current behaviour — unmounted toolsets gate
+on confirmation.
+
+When set to ``always_allow``: trusted-environment ergonomics — tools
+mounted by attached connectors dispatch immediately without requiring
+the agent author to declare an ``mcp_toolset`` per connector.
+
+Explicit per-toolset policies still win — this only changes the
+fallback for unmounted/unspecified servers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aios.harness import loop, runtime
+from aios.models.agents import (
+    McpPermissionPolicy,
+    McpServerSpec,
+    McpToolsetConfig,
+    ToolSpec,
+)
+
+
+def _agent(*tools: ToolSpec, server_names: tuple[str, ...] = ()) -> MagicMock:
+    agent = MagicMock()
+    agent.mcp_servers = [
+        McpServerSpec(name=name, url="https://example.com/mcp", type="url") for name in server_names
+    ]
+    agent.tools = list(tools)
+    return agent
+
+
+class TestDefaultMcpPolicy:
+    """``_classify_tool_call`` consults the env-level fallback policy."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        registry = MagicMock()
+        registry.states_for_connector.return_value = [MagicMock()]
+        monkeypatch.setattr(runtime, "connector_subprocess_registry", registry)
+
+    def test_unset_default_falls_back_to_always_ask(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unmounted MCP toolset with no env override gates on confirmation."""
+        from aios.config import Settings, get_settings
+
+        monkeypatch.setattr(
+            "aios.config.get_settings",
+            lambda: Settings(default_mcp_permission_policy=None),
+        )
+        get_settings.cache_clear()
+
+        agent = _agent()  # no mcp_toolset
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc1",
+                "function": {"name": "mcp__telegram__telegram_send", "arguments": "{}"},
+            },
+            agent=agent,
+            mcp_server_map={},
+        )
+        assert kind == "needs_confirm"
+
+    def test_env_default_always_allow_skips_gate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``AIOS_DEFAULT_MCP_PERMISSION_POLICY=always_allow`` lets unmounted
+        toolsets dispatch immediately."""
+        from aios.config import Settings
+
+        monkeypatch.setattr(
+            "aios.config.get_settings",
+            lambda: Settings(default_mcp_permission_policy="always_allow"),
+        )
+
+        agent = _agent()  # no mcp_toolset
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc2",
+                "function": {"name": "mcp__telegram__telegram_send", "arguments": "{}"},
+            },
+            agent=agent,
+            mcp_server_map={},
+        )
+        assert kind == "mcp_immediate"
+
+    def test_explicit_toolset_policy_overrides_env_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the agent declares an mcp_toolset with ``always_ask``, it wins
+        over the env-level default."""
+        from aios.config import Settings
+
+        monkeypatch.setattr(
+            "aios.config.get_settings",
+            lambda: Settings(default_mcp_permission_policy="always_allow"),
+        )
+
+        agent = _agent(
+            ToolSpec(
+                type="mcp_toolset",
+                mcp_server_name="telegram",
+                enabled=True,
+                default_config=McpToolsetConfig(
+                    enabled=True,
+                    permission_policy=McpPermissionPolicy(type="always_ask"),
+                ),
+            ),
+        )
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc3",
+                "function": {"name": "mcp__telegram__telegram_send", "arguments": "{}"},
+            },
+            agent=agent,
+            mcp_server_map={},
+        )
+        assert kind == "needs_confirm"

--- a/tests/unit/test_loop_unknown_mcp_tool.py
+++ b/tests/unit/test_loop_unknown_mcp_tool.py
@@ -1,0 +1,129 @@
+"""Unit test for unknown-MCP-tool handling.
+
+The bug: the harness pattern-matches ``mcp__<server>__<tool>`` then
+calls ``resolve_mcp_permission`` to choose a gate, never checking that
+the named server is actually registered (as a connector instance OR as
+one of the agent's HTTP MCP servers).  When the model hallucinates an
+old or made-up MCP tool name, the harness:
+
+  1. Returns ``None`` from ``resolve_mcp_permission`` (no toolset match).
+  2. Caller defaults to ``always_ask``.
+  3. Session parks in ``requires_action`` waiting for a confirmation
+     that, if granted, would dispatch into ``mcp_tool.server_not_found``
+     anyway.
+
+Demonstrated live during PR #213 testing: the model parroted
+``mcp__conn_<id>__signal_send`` from prior conversation context (the
+pre-PR4 namespace) — the ``conn_<id>`` server doesn't exist anymore,
+but the harness gated the call instead of erroring.
+
+This test pins the contract: an MCP tool whose server is not known
+must be classified ``unknown_mcp`` (immediate tool-error route), not
+``needs_confirm``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aios.harness import loop, runtime
+from aios.models.agents import McpServerSpec, ToolSpec
+
+
+def _agent_with_mcp_toolset(server_name: str) -> MagicMock:
+    """Build a minimal agent stand-in with one mcp_toolset entry."""
+    agent = MagicMock()
+    agent.mcp_servers = [McpServerSpec(name=server_name, url="https://example.com/mcp", type="url")]
+    agent.tools = [
+        ToolSpec(
+            type="mcp_toolset",
+            mcp_server_name=server_name,
+            enabled=True,
+        )
+    ]
+    return agent
+
+
+class TestClassifyMcpTool:
+    """``loop._classify_tool_call`` must reject unknown-server MCP names."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default to no connector registry (HTTP-only path)."""
+        monkeypatch.setattr(runtime, "connector_subprocess_registry", None)
+
+    def test_unknown_server_classified_as_unknown_mcp(self) -> None:
+        """``mcp__nonexistent__foo`` against an agent with no matching server
+        must classify as ``unknown_mcp`` so the harness emits an immediate
+        tool error instead of gating on confirmation.
+        """
+        agent = _agent_with_mcp_toolset("github")
+        # mcp_server_map mirrors what the dispatch path consults: name → URL
+        # for HTTP MCP servers the agent declared.
+        mcp_server_map = {"github": "https://api.githubcopilot.com/mcp/"}
+
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc1",
+                "function": {"name": "mcp__nonexistent__foo", "arguments": "{}"},
+            },
+            agent=agent,
+            mcp_server_map=mcp_server_map,
+        )
+        assert kind == "unknown_mcp"
+
+    def test_known_http_mcp_server_classified_normally(self) -> None:
+        """Known HTTP MCP server falls into the existing buckets."""
+        agent = _agent_with_mcp_toolset("github")
+        mcp_server_map = {"github": "https://api.githubcopilot.com/mcp/"}
+
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc2",
+                "function": {"name": "mcp__github__create_issue", "arguments": "{}"},
+            },
+            agent=agent,
+            mcp_server_map=mcp_server_map,
+        )
+        assert kind in {"mcp_immediate", "needs_confirm"}
+
+    def test_known_connector_classified_normally(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Connector-registered server (no entry in mcp_server_map) is known."""
+        agent = _agent_with_mcp_toolset("telegram")
+        mcp_server_map: dict[str, str] = {}
+
+        registry = MagicMock()
+        registry.states_for_connector.return_value = [MagicMock()]
+        monkeypatch.setattr(runtime, "connector_subprocess_registry", registry)
+
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc3",
+                "function": {"name": "mcp__telegram__telegram_send", "arguments": "{}"},
+            },
+            agent=agent,
+            mcp_server_map=mcp_server_map,
+        )
+        assert kind in {"mcp_immediate", "needs_confirm"}
+
+    def test_old_pre_pr4_conn_id_namespace_is_unknown(self) -> None:
+        """Pre-PR4 ``mcp__conn_<id>__<tool>`` names hallucinated by models
+        with stale conversation context must error immediately, not gate.
+        """
+        agent = _agent_with_mcp_toolset("github")
+        mcp_server_map = {"github": "https://api.githubcopilot.com/mcp/"}
+
+        kind = loop._classify_tool_call(
+            tool_call={
+                "id": "tc4",
+                "function": {
+                    "name": "mcp__conn_01KQS3BK4J7Y1ER372VJGBMCF8__signal_send",
+                    "arguments": "{}",
+                },
+            },
+            agent=agent,
+            mcp_server_map=mcp_server_map,
+        )
+        assert kind == "unknown_mcp"

--- a/tests/unit/test_tool_dispatch_focal_auth.py
+++ b/tests/unit/test_tool_dispatch_focal_auth.py
@@ -1,0 +1,145 @@
+"""Unit test for focal-route authorization in MCP outbound dispatch.
+
+The bug: when a model calls a connector tool that takes ``account`` from
+the focal channel meta (rather than as an explicit arg), the dispatch
+path skipped ``validate_account_for_session`` entirely.  Result: a
+session attached to one connector could send via *any* attached
+connector simply by switching focal to a channel address it didn't own.
+
+Demonstrated live during PR #213 migration testing: the factchecker
+session (telegram-only) ghost-wrote a "Testing Signal send" message
+into the Metals and AI Signal group despite having no signal
+connection attached.
+
+This test pins down the expected behaviour: focal-route dispatch MUST
+call ``validate_account_for_session`` and short-circuit with a
+tool_error if the session isn't authorized for the focal account.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.harness import runtime, tool_dispatch
+from aios.services import connections as connections_service
+from aios.services import sessions as sessions_service
+
+
+def _make_call(name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "id": "tc1",
+        "function": {
+            "name": name,
+            "arguments": json.dumps(arguments or {}),
+        },
+    }
+
+
+@pytest.fixture
+def mock_connector_registry(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Stand in for runtime.connector_subprocess_registry with a single signal instance."""
+    registry = MagicMock()
+    state = MagicMock()
+    state.instance = "signal"
+    state.connector = "signal"
+    registry.states_for_connector.return_value = [state]
+    registry.dispatch_call_for_account = AsyncMock(return_value={"sent_at_ms": 1})
+    registry.dispatch_call = AsyncMock(return_value={"sent_at_ms": 1})
+    monkeypatch.setattr(runtime, "connector_subprocess_registry", registry)
+    return registry
+
+
+@pytest.fixture
+def silenced_appenders(monkeypatch: pytest.MonkeyPatch) -> dict[str, AsyncMock]:
+    """Replace sessions_service.append_event with an AsyncMock that records calls.
+
+    Return value is a stand-in Event with ``.id`` and ``.seq`` so the
+    tool_dispatch code reading ``span_start.id`` etc. doesn't blow up.
+    """
+    fake_event = MagicMock()
+    fake_event.id = "evt_test"
+    fake_event.seq = 1
+
+    append = AsyncMock(return_value=fake_event)
+    monkeypatch.setattr(sessions_service, "append_event", append)
+    monkeypatch.setattr(tool_dispatch.sessions_service, "append_event", append)
+
+    # _trigger_sweep imports sweep lazily; stub at the tool_dispatch level.
+    sweep = AsyncMock(return_value=None)
+    monkeypatch.setattr(tool_dispatch, "_trigger_sweep", sweep)
+
+    return {"append_event": append, "sweep": sweep}
+
+
+class TestFocalRouteAuthorization:
+    """``_execute_mcp_tool_async`` must validate focal-derived accounts."""
+
+    async def test_focal_routed_unauthorized_account_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_connector_registry: MagicMock,
+        silenced_appenders: dict[str, AsyncMock],
+    ) -> None:
+        """Session with no signal attachment cannot send via focal-routed signal_send.
+
+        Reproduces the live PR #213 finding: factchecker (telegram-only)
+        ghost-writing into a Signal group via focal-route bypass.
+        """
+        validate = AsyncMock(return_value=False)  # session NOT authorized
+        monkeypatch.setattr(connections_service, "validate_account_for_session", validate)
+
+        pool = MagicMock()
+        await tool_dispatch._execute_mcp_tool_async(
+            pool=pool,
+            session_id="sess_factchecker",
+            call=_make_call("mcp__signal__signal_send", {"text": "ghost write"}),
+            mcp_server_map={},
+            focal_channel="signal/some-account-uuid/some-chat-id",
+        )
+
+        # Authorization MUST have been checked for the focal-derived account.
+        validate.assert_awaited_once()
+        assert validate.await_args is not None
+        kwargs = validate.await_args.kwargs
+        assert kwargs.get("connector") == "signal"
+        assert kwargs.get("account") == "some-account-uuid"
+
+        # Dispatch MUST NOT have been called.
+        mock_connector_registry.dispatch_call_for_account.assert_not_awaited()
+        mock_connector_registry.dispatch_call.assert_not_awaited()
+
+        # A tool_error event MUST have been appended.
+        append_calls = silenced_appenders["append_event"].await_args_list
+        message_calls = [c for c in append_calls if len(c.args) >= 3 and c.args[2] == "message"]
+        assert message_calls, "expected at least one 'message' append (the error)"
+        last_message = message_calls[-1].args[3]
+        assert last_message.get("role") == "tool"
+        assert last_message.get("is_error") is True
+        content = json.loads(last_message.get("content", "{}"))
+        assert "not attached" in content.get("error", "")
+
+    async def test_focal_routed_authorized_account_dispatches(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_connector_registry: MagicMock,
+        silenced_appenders: dict[str, AsyncMock],
+    ) -> None:
+        """Session WITH attached connection on focal account dispatches normally."""
+        validate = AsyncMock(return_value=True)  # session IS authorized
+        monkeypatch.setattr(connections_service, "validate_account_for_session", validate)
+
+        pool = MagicMock()
+        await tool_dispatch._execute_mcp_tool_async(
+            pool=pool,
+            session_id="sess_factchecker",
+            call=_make_call("mcp__signal__signal_send", {"text": "legit"}),
+            mcp_server_map={},
+            focal_channel="signal/owned-account/some-chat-id",
+        )
+
+        validate.assert_awaited_once()
+        mock_connector_registry.dispatch_call_for_account.assert_awaited_once()


### PR DESCRIPTION
## Summary

Stacked on PR #213 (multi-account/multi-instance, `wt/scalable-finding-ember`).
Bugs found while migrating Tom's running aios setup (Signal + Telegram)
onto the PR #205 → #210 → #211 → #213 stack with both connectors live.

Some fixes already in this PR; the remainder are listed below as TODO
and will be added as commits before this PR exits draft.

## Done in this PR (so far)

- **`fix(connector-sdk)`** — `_focal_from_request_meta` was reading
  `ctx.request.meta` (raw `CallToolRequest` body, no `.meta` attribute)
  instead of `ctx.meta` (where the MCP lowlevel server stashes the
  parsed `_meta`).  Every focal-required tool call failed with
  `"aios should inject _meta.aios.focal_channel_path"` even when the
  harness *had* injected it.  Wire format + harness side were both
  correct; only the SDK read path was wrong.
- **`test(config)`** — `test_empty_default` reads `.env` via
  pydantic-settings.  Any operator with `AIOS_CONNECTORS_ENABLED` set
  broke the test.  Now passes `_env_file=None` and uses
  `monkeypatch.delenv` to isolate.

## TODO before exiting draft

1. **`fix(harness)` per-session attachment check on focal-routed accounts**
   — `tool_dispatch.py:395-437` runs `validate_account_for_session` only
   when `account` is a tool-arg.  For focal-required tools (signal_send,
   telegram_send) account is derived from `_meta.aios.focal_channel_path`
   and dispatched without validation.  Demonstrated live: factchecker
   ghost-wrote `"Testing Signal send on new architecture"` into the
   Metals and AI Signal group despite having no signal connection
   attached.  Lift the check above the `if account_arg is str` branch.

2. **`fix(connector-supervisor)` redact bot token from stderr pump** —
   PTB's httpx logs request URLs `https://api.telegram.org/bot<TOKEN>/...`.
   Supervisor's `connector.stderr` event captures verbatim, so the bot
   token lives in `/tmp/aios-worker.log`.  Redact `bot<token>/` segments
   in the stderr pump or filter PTB's httpx logger upstream.

3. **`fix(connector-supervisor)` drop `instructions` from admin snapshot** —
   `pg_notify` payload caps at 8KB.  Signal's snapshot (groups + contacts
   × phones in the model-context instructions block) blows past it,
   leading to `asyncpg.InvalidParameterValueError: payload string too long`
   on every `connector_status` task.  Affects `aios connectors list`.
   `instructions` is a model-context concept; the admin RPC doesn't need it.

4. **`fix(harness)` validate MCP tool exists before any permission lookup** —
   the harness only namespace-pattern-matches `mcp__<server>__<tool>`,
   then calls `resolve_mcp_permission` (returns `None` on miss → caller
   defaults to `always_ask`), then parks the session in
   `requires_action`.  Result: a hallucinated tool name (e.g. an old
   `mcp__conn_<id>__signal_send` from prior conversation context) gates
   forever waiting for confirmation that should never come.  Validate
   against the union of `connector_subprocess_registry` ∪
   `agent.mcp_servers` ∪ discovered tool list before any policy lookup;
   on miss, append immediate tool error so the model self-corrects.

5. **`feat(config)` `AIOS_DEFAULT_MCP_PERMISSION_POLICY` env override** —
   for unmounted MCP toolsets, the harness defaults to `always_ask`.
   That's the right safe default but operator-hostile in trusted dev
   setups.  Add an env-level override that replaces the
   `None → always_ask` fallback (explicit per-toolset policies still
   win — this only changes the default for unmounted/unspecified).

6. **`docs(connector-supervisor)` strategically-placed comments** —
   per design discussion: docstring on `connector_supervisor.py`
   documenting the architectural constraint (lift-able into a separate
   `aios connectors` process if multi-worker scaling matters), plus a
   call-site note in `tool_dispatch.py` at the in-process supervisor
   call steering future additions to the procrastinate `connector_call`
   task.

7. **`test(e2e)` outbound focal-required MCP dispatch** — closes the test
   gap that let #1 (the SDK ctx.meta bug) merge in PR #211.  Exercises
   a session calling a focal-required connector tool with the focal
   channel set and asserts the tool sees the account/chat_id from `_meta`.

8. **`docs(plan)` align `aios connectors` (impl) with the PR4 plan** —
   plan documented `aios connector list` (singular), code is
   `aios connectors list` (plural).  Cosmetic.

## Followup issues (NOT in this PR)

- **Per-chat session routing was deleted by #205 but is a real use case.**
  Operator wanted "Metals chat → factchecker session, QA + DM →
  JN session" on one Signal account.  Old `channel_bindings` supported
  this; #200 deliberately collapsed it.  Neither `single_session` nor
  `per_chat` recovers the pattern (`per_chat` auto-spawns *new* sessions
  from a template; doesn't bind to an existing session).  Will file as
  a separate issue against #200.

## Operator notes (PR description, not code)

- **Migration env-var rename is loud.**  `AIOS_TELEGRAM_BOT_TOKEN`,
  `AIOS_SIGNAL_PHONES`, `AIOS_SIGNAL_CONFIG_DIR`,
  `AIOS_CONNECTORS_ENABLED` are all new shapes vs the pre-PR3 connector
  invocations.  Pre-existing operators must migrate their env.
- **Stale alembic stamp recovery is non-obvious.**  If `alembic_version`
  was bumped to `0026` without the migration actually running (botched
  prior test), 0026 isn't robust to partial-state re-run and fails with
  `DependentObjectsStillExist`.  Manual cleanup: `alembic stamp 0025`
  + drop the partially-created new objects + `alembic upgrade head`.
- **Signal `signal_send` returns inconsistent shapes.**  Sometimes
  `{"sent_at_ms": <int>}`, sometimes `{"status": "ok"}`.  Different
  signal-cli RPC response paths.  Worth pinning down for predictability.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 996 passed (the test_config fix)
- [ ] Each subsequent commit revalidates all three plus the relevant e2e
- [x] **Manual smoke** completed: full migration of running aios setup
  onto PR #213 + this stack.  Telegram inbound + outbound, Signal
  inbound + outbound, all working.  Demonstrated factchecker session
  ghost-writing into Signal (the auth gap fix #1 above closes this).

## Stack

- PR #205 → #210 → #211 → #213 → **this PR**
- Base: `wt/scalable-finding-ember` (PR #213's head)

🤖 Generated with [Claude Code](https://claude.com/claude-code)