### PR TITLE
feat(connector): inbound attachment staging + sandbox bind mount + orphan GC (#216, PR1/4)

### DIFF
--- a/packages/aios-connector/aios_connector/__init__.py
+++ b/packages/aios-connector/aios_connector/__init__.py
@@ -23,15 +23,27 @@ Public API:
   ``_meta.aios.focal_channel_path`` into the ``focal`` kwarg.
 * :func:`make_account` — convenience builder for account snapshot
   entries.
+* :class:`Attachment` / :class:`AttachmentError` — inbound binary blobs
+  (photos, voice notes, documents) and the SDK-boundary validation
+  failure connectors catch.
 """
 
 from __future__ import annotations
 
 from aios_connector.base import (
+    Attachment,
+    AttachmentError,
     Connector,
     focal_required,
     make_account,
     tool,
 )
 
-__all__ = ["Connector", "focal_required", "make_account", "tool"]
+__all__ = [
+    "Attachment",
+    "AttachmentError",
+    "Connector",
+    "focal_required",
+    "make_account",
+    "tool",
+]

--- a/packages/aios-connector/aios_connector/base.py
+++ b/packages/aios-connector/aios_connector/base.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import inspect
 import json
+import os
+import stat
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -288,6 +290,61 @@ def make_account(
     return _Account(id=id, display_name=display_name, metadata=metadata or {}).as_dict()
 
 
+_MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024
+
+
+class AttachmentError(ValueError):
+    """Raised by :meth:`Attachment.as_params` when the host path is unreadable
+    or exceeds the 5 MiB SDK boundary cap.
+
+    Connector code that catches this can decide whether to skip the
+    attachment, send a placeholder text message, or fail loudly.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class Attachment:
+    """An inbound binary blob (photo, voice note, document) carried on a
+    chat message.
+
+    The connector hands aios a *host path* — bytes never traverse stdio.
+    The supervisor stages the file into the session's read-only
+    ``/mnt/attachments`` bind mount before appending the inbound event.
+    """
+
+    host_path: str
+    filename: str
+    content_type: str
+
+    def as_params(self) -> dict[str, Any]:
+        """Validate the host path and return the JSON-RPC wire dict.
+
+        Raises :class:`AttachmentError` when the file is missing or
+        exceeds the 5 MiB cap.  Stat'ing here rather than at
+        construction lets callers build :class:`Attachment` instances
+        before their backing files are fully written.
+        """
+        try:
+            st = os.stat(self.host_path)
+        except FileNotFoundError as err:
+            raise AttachmentError(
+                f"attachment host_path does not exist: {self.host_path!r}"
+            ) from err
+        if not stat.S_ISREG(st.st_mode):
+            raise AttachmentError(f"attachment host_path is not a regular file: {self.host_path!r}")
+        if st.st_size > _MAX_ATTACHMENT_BYTES:
+            raise AttachmentError(
+                f"attachment {self.filename!r} is {st.st_size} bytes; "
+                f"SDK cap is {_MAX_ATTACHMENT_BYTES} bytes (5 MiB)."
+            )
+        return {
+            "host_path": self.host_path,
+            "filename": self.filename,
+            "content_type": self.content_type,
+            "size": st.st_size,
+        }
+
+
 class Connector:
     """Base class connector authors subclass.
 
@@ -421,7 +478,7 @@ class Connector:
         chat_id: str,
         sender: dict[str, Any],
         content: str,
-        attachments: list[dict[str, Any]] | None = None,
+        attachments: list[Attachment] | None = None,
         metadata: dict[str, Any] | None = None,
         timestamp: str | None = None,
     ) -> str:
@@ -435,6 +492,15 @@ class Connector:
         return value.  ``chat_id`` is the connector-specific identifier
         the model addresses via focal channel; the harness builds the
         full channel address as ``<connector>/<account>/<chat_id>``.
+
+        ``attachments`` is an optional list of :class:`Attachment`
+        records carrying binary blobs (photos, voice notes, documents).
+        Each attachment's ``host_path`` is validated (readable, ≤5 MiB)
+        before the notification is pushed — invalid attachments raise
+        :class:`AttachmentError` and the connector decides whether to
+        skip, fall back to a text placeholder, or refuse the inbound.
+        Bytes never traverse stdio; the supervisor stages the host path
+        into the session's ``/mnt/attachments`` bind mount.
 
         ``timestamp`` is an optional ISO-8601 string carrying the
         platform's actual delivery time (Signal envelope timestamp,
@@ -465,7 +531,7 @@ class Connector:
             "content": content,
         }
         if attachments:
-            params["attachments"] = list(attachments)
+            params["attachments"] = [att.as_params() for att in attachments]
         if metadata:
             params["metadata"] = dict(metadata)
         if timestamp is not None:

--- a/packages/aios-connector/tests/test_attachment.py
+++ b/packages/aios-connector/tests/test_attachment.py
@@ -1,0 +1,92 @@
+"""SDK boundary validation for the :class:`Attachment` dataclass.
+
+The 5 MiB cap and path-readable check live at the SDK layer (not in the
+supervisor) so connector authors get a clean ``AttachmentError`` at
+``emit_inbound`` time rather than an opaque crash deep in the harness
+pipeline.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from aios_connector import Attachment, AttachmentError
+
+
+def test_as_params_returns_wire_dict(tmp_path: Path) -> None:
+    blob = tmp_path / "photo.jpg"
+    blob.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg-bytes")
+
+    att = Attachment(
+        host_path=str(blob),
+        filename="photo.jpg",
+        content_type="image/jpeg",
+    )
+
+    assert att.as_params() == {
+        "host_path": str(blob),
+        "filename": "photo.jpg",
+        "content_type": "image/jpeg",
+        "size": len(b"\xff\xd8\xff\xe0fake-jpeg-bytes"),
+    }
+
+
+def test_as_params_rejects_missing_path(tmp_path: Path) -> None:
+    att = Attachment(
+        host_path=str(tmp_path / "does-not-exist.jpg"),
+        filename="x.jpg",
+        content_type="image/jpeg",
+    )
+    with pytest.raises(AttachmentError, match="does not exist"):
+        att.as_params()
+
+
+def test_as_params_rejects_directory(tmp_path: Path) -> None:
+    """A directory is not a regular file — same error path as missing.
+
+    Catches the common bug of passing the parent of the temp file by
+    accident.
+    """
+    att = Attachment(
+        host_path=str(tmp_path),
+        filename="x.jpg",
+        content_type="image/jpeg",
+    )
+    with pytest.raises(AttachmentError, match="not a regular file"):
+        att.as_params()
+
+
+def test_as_params_rejects_oversize(tmp_path: Path) -> None:
+    """5 MiB + 1 byte trips the cap — connector decides how to handle.
+
+    The cap lives at the SDK boundary so the connector sees the rejection
+    synchronously rather than discovering it via a supervisor drop.
+    """
+    big = tmp_path / "huge.bin"
+    big.write_bytes(b"\0" * (5 * 1024 * 1024 + 1))
+    att = Attachment(
+        host_path=str(big),
+        filename="huge.bin",
+        content_type="application/octet-stream",
+    )
+    with pytest.raises(AttachmentError, match="5 MiB"):
+        att.as_params()
+
+
+def test_as_params_accepts_exactly_at_cap(tmp_path: Path) -> None:
+    blob = tmp_path / "edge.bin"
+    blob.write_bytes(b"\0" * (5 * 1024 * 1024))
+    att = Attachment(
+        host_path=str(blob),
+        filename="edge.bin",
+        content_type="application/octet-stream",
+    )
+    assert att.as_params()["size"] == 5 * 1024 * 1024
+
+
+def test_attachment_is_frozen() -> None:
+    """frozen=True on the dataclass — connector code can't mutate after build."""
+    att = Attachment(host_path="/x", filename="y", content_type="z")
+    with pytest.raises((AttributeError, TypeError)):
+        att.host_path = "/elsewhere"  # type: ignore[misc]

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -770,6 +770,37 @@ async def list_running_session_ids(conn: asyncpg.Connection[Any]) -> list[str]:
     return [str(r["id"]) for r in rows]
 
 
+async def list_attachment_paths_for_sessions(
+    conn: asyncpg.Connection[Any], session_ids: list[str]
+) -> dict[str, set[str]]:
+    """Return ``in_sandbox_path`` values referenced by each session's events.
+
+    Returns a map keyed by session_id; sessions with no attachment
+    references appear with an empty set so callers can distinguish
+    "no events with attachments" from "session unknown".
+    """
+    result: dict[str, set[str]] = {sid: set() for sid in session_ids}
+    if not session_ids:
+        return result
+    rows = await conn.fetch(
+        """
+        SELECT session_id,
+               jsonb_array_elements(data->'metadata'->'attachments')->>'in_sandbox_path'
+                 AS path
+          FROM events
+         WHERE session_id = ANY($1::text[])
+           AND data->'metadata' ? 'attachments'
+           AND jsonb_typeof(data->'metadata'->'attachments') = 'array'
+        """,
+        session_ids,
+    )
+    for row in rows:
+        path = row["path"]
+        if path is not None:
+            result[row["session_id"]].add(path)
+    return result
+
+
 _UNSET: Any = object()
 
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -778,6 +778,14 @@ async def list_attachment_paths_for_sessions(
     Returns a map keyed by session_id; sessions with no attachment
     references appear with an empty set so callers can distinguish
     "no events with attachments" from "session unknown".
+
+    Note: this query infers reference state purely from event rows, so
+    a ``session_id`` whose row was deleted (or whose events were
+    purged) returns an empty set indistinguishable from "session
+    exists but has no attachments". The orphan GC sweep relies on
+    this and will treat every on-disk file under such a session's
+    ``_attachments/<session_id>/`` dir as orphaned — which is the
+    intended behavior, but worth being explicit about.
     """
     result: dict[str, set[str]] = {sid: set() for sid in session_ids}
     if not session_ids:

--- a/src/aios/harness/attachment_gc.py
+++ b/src/aios/harness/attachment_gc.py
@@ -1,0 +1,78 @@
+"""Worker startup orphan attachment GC.
+
+Walks ``<workspace_root>/_attachments/`` and removes any staged file
+not referenced by an event in the DB. Files become orphans when an
+inbound stages successfully but its dedup transaction rolls back, or
+when staging crashes between rename and append.
+
+Runs once at startup; sessions with no on-disk dir contribute zero
+work. Empty session dirs are left in place so the bind-mount source
+exists for the next provision.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+
+from aios.db import queries
+from aios.logging import get_logger
+from aios.sandbox.volumes import attachments_root
+
+log = get_logger("aios.harness.attachment_gc")
+
+
+async def sweep_orphan_attachments(pool: asyncpg.Pool[Any]) -> int:
+    """Delete files in ``_attachments/`` that no event row references.
+
+    Returns the number of files deleted. Per-file unlink errors are
+    logged and skipped so one bad permission bit doesn't strand the
+    rest of startup.
+    """
+    root = attachments_root()
+    if not root.exists():
+        return 0
+
+    on_disk_by_session: dict[str, dict[str, Path]] = {}
+    for session_dir in root.iterdir():
+        if not session_dir.is_dir():
+            continue
+        session_files: dict[str, Path] = {}
+        for connector_dir in session_dir.iterdir():
+            if not connector_dir.is_dir():
+                continue
+            for file_path in connector_dir.iterdir():
+                if not file_path.is_file():
+                    continue
+                sandbox_path = f"/mnt/attachments/{connector_dir.name}/{file_path.name}"
+                session_files[sandbox_path] = file_path
+        if session_files:
+            on_disk_by_session[session_dir.name] = session_files
+
+    if not on_disk_by_session:
+        return 0
+
+    async with pool.acquire() as conn:
+        referenced_by_session = await queries.list_attachment_paths_for_sessions(
+            conn, list(on_disk_by_session)
+        )
+
+    deleted = 0
+    for session_id, session_files in on_disk_by_session.items():
+        referenced = referenced_by_session.get(session_id, set())
+        for sandbox_path, file_path in session_files.items():
+            if sandbox_path in referenced:
+                continue
+            try:
+                file_path.unlink()
+                deleted += 1
+            except OSError as err:
+                log.warning(
+                    "attachment_gc.unlink_failed",
+                    path=str(file_path),
+                    error=str(err),
+                )
+
+    return deleted

--- a/src/aios/harness/attachment_gc.py
+++ b/src/aios/harness/attachment_gc.py
@@ -18,18 +18,38 @@ from typing import Any
 import asyncpg
 
 from aios.db import queries
-from aios.logging import get_logger
 from aios.sandbox.volumes import attachments_root
 
-log = get_logger("aios.harness.attachment_gc")
+
+class AttachmentGcError(RuntimeError):
+    """Raised when the orphan sweep failed to delete one or more
+    unreferenced files (perm drift, FS gone read-only, etc.).
+
+    Worker startup deliberately surfaces this rather than silently
+    accumulating un-collectable orphans across boots.  The exception
+    message lists every failed path so the operator can act on the
+    real cause.
+    """
 
 
 async def sweep_orphan_attachments(pool: asyncpg.Pool[Any]) -> int:
     """Delete files in ``_attachments/`` that no event row references.
 
-    Returns the number of files deleted. Per-file unlink errors are
-    logged and skipped so one bad permission bit doesn't strand the
-    rest of startup.
+    Returns the number of files deleted. Raises
+    :class:`AttachmentGcError` if any file we identified as orphaned
+    could not be unlinked — those failures (permission drift, FS gone
+    read-only, root squash on the bind) are real signals about
+    worker provisioning and silently swallowing them lets orphans
+    accumulate forever across reboots.
+
+    Note on session dirs without referencing events: if a session row
+    or its events were purged but the on-disk
+    ``_attachments/<session_id>/`` dir survived, this sweep will
+    delete every file in that dir (the events query returns 0 rows
+    → 0 referenced paths → all on-disk files look orphaned). That is
+    the intended behavior given the design splits cleanup of stranded
+    files from cleanup of empty dirs (the latter is a future polish
+    item alongside session deletion).
     """
     root = attachments_root()
     if not root.exists():
@@ -60,6 +80,7 @@ async def sweep_orphan_attachments(pool: asyncpg.Pool[Any]) -> int:
         )
 
     deleted = 0
+    failures: list[tuple[Path, OSError]] = []
     for session_id, session_files in on_disk_by_session.items():
         referenced = referenced_by_session.get(session_id, set())
         for sandbox_path, file_path in session_files.items():
@@ -69,10 +90,12 @@ async def sweep_orphan_attachments(pool: asyncpg.Pool[Any]) -> int:
                 file_path.unlink()
                 deleted += 1
             except OSError as err:
-                log.warning(
-                    "attachment_gc.unlink_failed",
-                    path=str(file_path),
-                    error=str(err),
-                )
+                failures.append((file_path, err))
+
+    if failures:
+        rendered = ", ".join(f"{p}: {e}" for p, e in failures)
+        raise AttachmentGcError(
+            f"failed to unlink {len(failures)} orphan attachment(s): {rendered}"
+        )
 
     return deleted

--- a/src/aios/harness/attachment_staging.py
+++ b/src/aios/harness/attachment_staging.py
@@ -46,6 +46,11 @@ def _safe_filename(name: str) -> str:
     empty or all-dot inputs, and caps length so a pathological
     filename combined with the ULID prefix can't exhaust the host
     FS's per-component limit.
+
+    Unicode-aware: Python's ``\\w`` matches the full Unicode word class
+    by default, so non-ASCII letters are preserved (e.g.
+    ``café.jpg`` → ``café.jpg``). Only structurally unsafe punctuation
+    and whitespace get rewritten.
     """
     base = os.path.basename(name)
     cleaned = _UNSAFE_FILENAME_CHARS.sub("_", base)
@@ -60,10 +65,11 @@ def stage_inbound_attachments(
     connector_name: str,
     event_id: str,
     raw_attachments: Any,
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], list[Path]]:
     """Move connector-owned temp paths into per-session staging and
-    return the structured records that get stamped onto the inbound
-    event's ``metadata.attachments``.
+    return the structured records (for ``metadata.attachments``) plus
+    the host paths newly created by this call (for the caller's
+    compensating action when the dedup transaction fails downstream).
 
     Input record shape (from the SDK over JSON-RPC)::
 
@@ -73,23 +79,41 @@ def stage_inbound_attachments(
 
         {filename, content_type, size, in_sandbox_path}
 
+    Returns ``(records, newly_staged_paths)``. ``records`` always
+    matches ``raw_attachments`` 1:1; ``newly_staged_paths`` lists only
+    the paths this call materialized — replayed entries whose target
+    already existed are not included, so the caller's compensating
+    unlink doesn't delete bytes referenced by a previously committed
+    event.
+
     On any per-attachment failure: any files newly staged for this
     same inbound are removed and :class:`AttachmentStagingError` is
     raised so the caller drops the inbound atomically.
 
     Replay-safe: if the target path already exists (from a prior
-    delivery of the same ``event_id``), the rename is skipped and the
-    record is rebuilt from the input fields.  Orphan GC handles
-    files stranded by events that never made it past dedup.
+    delivery of the same ``event_id``), the rename is skipped, the
+    record is rebuilt from the input fields, and the path is omitted
+    from ``newly_staged_paths``. Orphan GC handles files stranded by
+    events that never made it past dedup.
+
+    Same-inbound collisions fail hard. If two attachments sanitize to
+    the same ``<event_id>-<safe_name>``, we cannot satisfy both records
+    with distinct bytes; silently appending a record pointing at the
+    other attachment's bytes corrupts ``metadata.attachments``. The
+    realistic trigger (e.g. Telegram album with two ``image.jpg``
+    files) is the platform's responsibility to disambiguate via the
+    SDK; the supervisor drops the inbound and the operator sees the
+    canonical ``attachment_staging_failed`` reason.
     """
     if not isinstance(raw_attachments, list) or not raw_attachments:
-        return []
+        return [], []
 
     connector_dir = ensure_session_attachments_dir(session_id) / connector_name
     connector_dir.mkdir(parents=True, exist_ok=True)
 
     staged_records: list[dict[str, Any]] = []
     newly_staged_paths: list[Path] = []
+    target_names_seen: set[str] = set()
 
     try:
         for raw in raw_attachments:
@@ -111,9 +135,24 @@ def stage_inbound_attachments(
                 )
 
             target_name = f"{event_id}-{_safe_filename(filename)}"
+            if target_name in target_names_seen:
+                raise AttachmentStagingError(
+                    f"two attachments in inbound {event_id!r} sanitize to the "
+                    f"same staged name {target_name!r} ({filename!r}); the "
+                    f"connector must disambiguate before delivery"
+                )
+            target_names_seen.add(target_name)
             target = connector_dir / target_name
 
             if not target.exists():
+                # Register the destination path with the cleanup list
+                # *before* we touch the disk so a partial copy (EXDEV
+                # branch can fail mid-write) is still reachable for
+                # the compensating unlink. ``unlink(missing_ok=True)``
+                # makes early registration safe on the rename branch
+                # too, where the target either exists fully or not at
+                # all.
+                newly_staged_paths.append(target)
                 try:
                     os.rename(host_path, target)
                 except FileNotFoundError as err:
@@ -133,7 +172,6 @@ def stage_inbound_attachments(
                         ) from copy_err
                     with contextlib.suppress(FileNotFoundError):
                         os.unlink(host_path)
-                newly_staged_paths.append(target)
 
             staged_records.append(
                 {
@@ -144,7 +182,7 @@ def stage_inbound_attachments(
                 }
             )
 
-        return staged_records
+        return staged_records, newly_staged_paths
     except Exception:
         for path in newly_staged_paths:
             with contextlib.suppress(OSError):

--- a/src/aios/harness/attachment_staging.py
+++ b/src/aios/harness/attachment_staging.py
@@ -1,0 +1,152 @@
+"""Inbound attachment staging.
+
+The connector hands the SDK a host path it owns; bytes never
+traverse stdio. The supervisor renames each attachment into a
+stable per-session location before appending the inbound event::
+
+    <workspace_root>/_attachments/<session_id>/<connector>/<event-ulid>-<filename>
+
+That directory is bind-mounted read-only into the sandbox at
+``/mnt/attachments``. Renames are atomic on same-FS; cross-FS falls
+back to copy + unlink.
+
+Replay-safe: a redelivered ``event_id`` finds the target path
+already populated and skips the rename. Files stranded by a
+rolled-back transaction are reclaimed by
+:mod:`aios.harness.attachment_gc` at worker startup.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+from aios.sandbox.volumes import ensure_session_attachments_dir
+
+
+class AttachmentStagingError(Exception):
+    """Per-attachment staging failure.  Caller drops the inbound with
+    the canonical ``attachment_staging_failed`` reason."""
+
+
+_UNSAFE_FILENAME_CHARS = re.compile(r"[^\w.\-]")
+_MAX_FILENAME_LEN = 200
+
+
+def _safe_filename(name: str) -> str:
+    """Sanitize ``name`` for use as a path leaf.
+
+    Strips directory separators (defeats ``../`` traversal), maps
+    unsupported characters to ``_``, falls back to ``"unnamed"`` for
+    empty or all-dot inputs, and caps length so a pathological
+    filename combined with the ULID prefix can't exhaust the host
+    FS's per-component limit.
+    """
+    base = os.path.basename(name)
+    cleaned = _UNSAFE_FILENAME_CHARS.sub("_", base)
+    if not cleaned or cleaned.replace(".", "") == "":
+        return "unnamed"
+    return cleaned[:_MAX_FILENAME_LEN]
+
+
+def stage_inbound_attachments(
+    *,
+    session_id: str,
+    connector_name: str,
+    event_id: str,
+    raw_attachments: Any,
+) -> list[dict[str, Any]]:
+    """Move connector-owned temp paths into per-session staging and
+    return the structured records that get stamped onto the inbound
+    event's ``metadata.attachments``.
+
+    Input record shape (from the SDK over JSON-RPC)::
+
+        {host_path, filename, content_type, size}
+
+    Output record shape (model-visible via context.py rendering)::
+
+        {filename, content_type, size, in_sandbox_path}
+
+    On any per-attachment failure: any files newly staged for this
+    same inbound are removed and :class:`AttachmentStagingError` is
+    raised so the caller drops the inbound atomically.
+
+    Replay-safe: if the target path already exists (from a prior
+    delivery of the same ``event_id``), the rename is skipped and the
+    record is rebuilt from the input fields.  Orphan GC handles
+    files stranded by events that never made it past dedup.
+    """
+    if not isinstance(raw_attachments, list) or not raw_attachments:
+        return []
+
+    connector_dir = ensure_session_attachments_dir(session_id) / connector_name
+    connector_dir.mkdir(parents=True, exist_ok=True)
+
+    staged_records: list[dict[str, Any]] = []
+    newly_staged_paths: list[Path] = []
+
+    try:
+        for raw in raw_attachments:
+            if not isinstance(raw, dict):
+                raise AttachmentStagingError(f"attachment is not a dict: {raw!r}")
+            host_path = raw.get("host_path")
+            filename = raw.get("filename")
+            content_type = raw.get("content_type")
+            size = raw.get("size")
+            if not (
+                isinstance(host_path, str)
+                and isinstance(filename, str)
+                and isinstance(content_type, str)
+                and isinstance(size, int)
+            ):
+                raise AttachmentStagingError(
+                    f"attachment missing required fields "
+                    f"{{host_path, filename, content_type, size}}: {raw!r}"
+                )
+
+            target_name = f"{event_id}-{_safe_filename(filename)}"
+            target = connector_dir / target_name
+
+            if not target.exists():
+                try:
+                    os.rename(host_path, target)
+                except FileNotFoundError as err:
+                    raise AttachmentStagingError(
+                        f"attachment temp path not found: {host_path!r}"
+                    ) from err
+                except OSError as err:
+                    if err.errno != errno.EXDEV:
+                        raise AttachmentStagingError(
+                            f"failed to stage attachment {filename!r}: {err}"
+                        ) from err
+                    try:
+                        shutil.copy2(host_path, target)
+                    except OSError as copy_err:
+                        raise AttachmentStagingError(
+                            f"failed to copy attachment {filename!r} across filesystems: {copy_err}"
+                        ) from copy_err
+                    with contextlib.suppress(FileNotFoundError):
+                        os.unlink(host_path)
+                newly_staged_paths.append(target)
+
+            staged_records.append(
+                {
+                    "filename": filename,
+                    "content_type": content_type,
+                    "size": size,
+                    "in_sandbox_path": f"/mnt/attachments/{connector_name}/{target_name}",
+                }
+            )
+
+        return staged_records
+    except Exception:
+        for path in newly_staged_paths:
+            with contextlib.suppress(OSError):
+                path.unlink(missing_ok=True)
+        raise

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -84,6 +84,7 @@ to migrate the day the supervisor splits out.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import time
 from collections import Counter, deque
@@ -788,7 +789,7 @@ class ConnectorSubprocessRegistry:
         # acks the spool because the connector's temp file is gone and
         # endless replay would only re-fail.
         try:
-            staged_attachments = stage_inbound_attachments(
+            staged_attachments, newly_staged_paths = stage_inbound_attachments(
                 session_id=target_session_id,
                 connector_name=connector,
                 event_id=event_id,
@@ -822,7 +823,16 @@ class ConnectorSubprocessRegistry:
                 platform_timestamp=platform_timestamp,
             )
         except NotFoundError:
-            # The session vanished between resolution and append.
+            # The session vanished between resolution and append.  Per
+            # design #216 §5, an append failure triggers the synchronous
+            # compensating action (the orphan GC sweep at startup is
+            # the catch-all for crashes, not an excuse to leak files
+            # we already know are unreferenced).  Replay-skipped paths
+            # are excluded by ``stage_inbound_attachments`` so this
+            # only unlinks bytes this call materialized.
+            for path in newly_staged_paths:
+                with contextlib.suppress(OSError):
+                    path.unlink(missing_ok=True)
             self._record_drop(state, "session_missing")
             await self._send_ack(state, event_id)
             return

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -98,6 +98,10 @@ from aios.config import ConnectorInstance, Settings, parse_connector_entry
 from aios.db import queries
 from aios.errors import NotFoundError
 from aios.harness import runtime
+from aios.harness.attachment_staging import (
+    AttachmentStagingError,
+    stage_inbound_attachments,
+)
 from aios.harness.wake import defer_wake
 from aios.logging import get_logger
 from aios.mcp.client import shape_call_result
@@ -145,6 +149,7 @@ DropReason = Literal[
     "malformed",
     "payload_too_large",
     "account_drift",
+    "attachment_staging_failed",
 ]
 
 
@@ -778,7 +783,31 @@ class ConnectorSubprocessRegistry:
             await self._send_ack(state, event_id)
             return
 
-        # 3. Append event + ledger row in the same transaction.
+        # 3. Stage attachments before the dedup transaction.  Renames
+        # are idempotent on the replayed-event_id path; a failure here
+        # acks the spool because the connector's temp file is gone and
+        # endless replay would only re-fail.
+        try:
+            staged_attachments = stage_inbound_attachments(
+                session_id=target_session_id,
+                connector_name=connector,
+                event_id=event_id,
+                raw_attachments=params.get("attachments"),
+            )
+        except AttachmentStagingError as err:
+            log.warning(
+                "connector.attachment_staging_failed",
+                connector=connector,
+                instance=instance,
+                event_id=event_id,
+                session_id=target_session_id,
+                error=str(err),
+            )
+            self._record_drop(state, "attachment_staging_failed")
+            await self._send_ack(state, event_id)
+            return
+
+        # 4. Append event + ledger row in the same transaction.
         try:
             await self._append_with_dedup(
                 connector_name=connector,
@@ -788,7 +817,7 @@ class ConnectorSubprocessRegistry:
                 chat_id=chat_id,
                 sender=sender if isinstance(sender, dict) else {},
                 content=content,
-                attachments=params.get("attachments"),
+                attachments=staged_attachments,
                 connector_metadata=connector_metadata,
                 platform_timestamp=platform_timestamp,
             )
@@ -798,7 +827,7 @@ class ConnectorSubprocessRegistry:
             await self._send_ack(state, event_id)
             return
 
-        # 4. Outside the transaction: defer wake unconditionally.
+        # 5. Outside the transaction: defer wake unconditionally.
         # ``defer_wake`` is idempotent (procrastinate's queueing_lock
         # coalesces duplicates), so we call it on both first-append and
         # dedup paths — the dedup path heals the case where the prior

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -116,6 +116,25 @@ async def worker_main() -> None:
 
         await procrastinate_app.open_async()
         procrastinate_opened = True
+
+        # Sweep orphan attachments BEFORE starting the connector
+        # supervisor.  Once ``connector_registry.start()`` returns, spool
+        # entries can flush and ``_handle_inbound`` may stage new files
+        # at any moment.  Those files are visible to the GC sweep as soon
+        # as they hit disk but are still inside the supervisor's dedup
+        # transaction — uncommitted, so the events query reports them as
+        # unreferenced and the sweep would unlink bytes that are about
+        # to commit.  Deferring the sweep to here means there cannot yet
+        # be any in-flight staging on this worker; cross-worker startup
+        # is fine because a freshly-booted worker only sweeps before its
+        # own supervisor opens, and a sibling worker mid-staging has the
+        # transaction already open by the time it stages, so its
+        # commit-happens-before-sweep ordering is governed by Postgres
+        # snapshot isolation rather than wall-clock.
+        deleted_attachments = await sweep_orphan_attachments(pool)
+        if deleted_attachments:
+            log.info("worker.reaped_orphan_attachments", count=deleted_attachments)
+
         await connector_registry.start()
 
         log.info(
@@ -146,10 +165,6 @@ async def worker_main() -> None:
         reaped = await sandbox_registry.reap_orphans(active_session_ids)
         if reaped:
             log.info("worker.reaped_orphan_containers", count=reaped)
-
-        deleted_attachments = await sweep_orphan_attachments(pool)
-        if deleted_attachments:
-            log.info("worker.reaped_orphan_attachments", count=deleted_attachments)
 
         # Start container idle-TTL reaper.
         sandbox_registry.start_reaper(idle_timeout=settings.container_idle_timeout_seconds)

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -39,6 +39,7 @@ from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.db.pool import create_pool, normalize_dsn
 from aios.harness import runtime
+from aios.harness.attachment_gc import sweep_orphan_attachments
 from aios.harness.connector_supervisor import (
     ConnectorSubprocessRegistry,
     instance_label,
@@ -145,6 +146,10 @@ async def worker_main() -> None:
         reaped = await sandbox_registry.reap_orphans(active_session_ids)
         if reaped:
             log.info("worker.reaped_orphan_containers", count=reaped)
+
+        deleted_attachments = await sweep_orphan_attachments(pool)
+        if deleted_attachments:
+            log.info("worker.reaped_orphan_attachments", count=deleted_attachments)
 
         # Start container idle-TTL reaper.
         sandbox_registry.start_reaper(idle_timeout=settings.container_idle_timeout_seconds)

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -306,7 +306,11 @@ async def _provision_for_session_inner(
 ) -> ContainerHandle:
     """The body of ``provision_for_session``. Split out so the caller's
     try/except cleanly wraps everything that might leak the proxy."""
-    from aios.sandbox.volumes import memory_store_host_dir, session_repo_working_tree_dir
+    from aios.sandbox.volumes import (
+        ensure_session_attachments_dir,
+        memory_store_host_dir,
+        session_repo_working_tree_dir,
+    )
 
     merged_env: dict[str, str] = {
         **(env_config.env if env_config and env_config.env else {}),
@@ -315,6 +319,10 @@ async def _provision_for_session_inner(
 
     networking = env_config.networking if env_config else None
     needs_lockdown = isinstance(networking, LimitedNetworking)
+
+    # Add the bind unconditionally so a fresh inbound landing during a
+    # running step is visible inside the live container without restart.
+    attachments_path = ensure_session_attachments_dir(session_id)
 
     argv = [
         "docker",
@@ -325,6 +333,8 @@ async def _provision_for_session_inner(
         # container. Must be an absolute path on the host.
         "--volume",
         f"{workspace_path}:/workspace",
+        "--volume",
+        f"{attachments_path}:/mnt/attachments:ro",
         "--label",
         f"{MANAGED_LABEL_KEY}={MANAGED_LABEL_VALUE}",
         "--label",

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -320,8 +320,12 @@ async def _provision_for_session_inner(
     networking = env_config.networking if env_config else None
     needs_lockdown = isinstance(networking, LimitedNetworking)
 
-    # Add the bind unconditionally so a fresh inbound landing during a
-    # running step is visible inside the live container without restart.
+    # Bind the per-session attachments dir at every provision so an
+    # inbound landing during a running step is visible to the live
+    # container.  Docker doesn't update binds in place; this works
+    # because the bind exposes the *directory* (not a file snapshot),
+    # and any new file the supervisor stages into it appears through
+    # the existing kernel namespace bind without re-mounting.
     attachments_path = ensure_session_attachments_dir(session_id)
 
     argv = [

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -136,3 +136,60 @@ def session_repo_working_tree_dir(session_id: str, repo_id: str) -> Path:
     ``mount_path``.
     """
     return session_repos_root(session_id) / repo_id
+
+
+_ATTACHMENTS_ROOT = "_attachments"
+
+
+def attachments_root() -> Path:
+    """Return ``<workspace_root>/_attachments`` — the parent of all
+    per-session inbound attachment directories.
+
+    Each session subdir is bind-mounted read-only into its container at
+    ``/mnt/attachments`` (see :mod:`aios.sandbox.provisioner`). Inbound
+    binary blobs (Signal photos, Telegram voice notes, etc.) are staged
+    here by :mod:`aios.harness.connector_supervisor` before the inbound
+    event is appended; the model sees them at stable in-sandbox paths
+    of the form ``/mnt/attachments/<connector>/<event-ulid>-<filename>``.
+    """
+    return (get_settings().workspace_root / _ATTACHMENTS_ROOT).resolve()
+
+
+def session_attachments_dir(session_id: str) -> Path:
+    """Per-session host directory backing ``/mnt/attachments``.
+
+    Pure — does not create the directory. Use
+    :func:`ensure_session_attachments_dir` to create.
+    """
+    return attachments_root() / session_id
+
+
+def ensure_session_attachments_dir(session_id: str) -> Path:
+    """Return the per-session attachments directory, creating it if needed.
+
+    Called eagerly from the provisioner at every container start so the
+    bind-mount source always exists before Docker tries to mount it,
+    even for sessions that have never received an attachment.
+    """
+    path = session_attachments_dir(session_id)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def resolve_to_host_path(session_id: str, sandbox_path: str) -> Path | None:
+    """Map an in-sandbox path to its host-side equivalent for known bind mounts.
+
+    Returns ``None`` when ``sandbox_path`` doesn't resolve into
+    ``/workspace`` or ``/mnt/attachments`` (e.g. ``/etc/hostname``,
+    ``/mnt/memory/...``, ``/tmp/...``). Callers can fall back to
+    docker-exec when the host-side fast path is unavailable.
+    """
+    if sandbox_path == "/workspace":
+        return workspace_dir_for(session_id)
+    if sandbox_path.startswith("/workspace/"):
+        return workspace_dir_for(session_id) / sandbox_path[len("/workspace/") :]
+    if sandbox_path == "/mnt/attachments":
+        return session_attachments_dir(session_id)
+    if sandbox_path.startswith("/mnt/attachments/"):
+        return session_attachments_dir(session_id) / sandbox_path[len("/mnt/attachments/") :]
+    return None

--- a/tests/e2e/_connector_helpers.py
+++ b/tests/e2e/_connector_helpers.py
@@ -1,0 +1,87 @@
+"""Shared helpers for e2e tests that drive ``ConnectorSubprocessRegistry``
+directly without spawning a real connector subprocess.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.config import ConnectorInstance, Settings
+from aios.harness.connector_supervisor import ConnectorSubprocessRegistry
+from aios.ids import make_id
+from aios.mcp.stdio_transport import ConnectorSpec
+from aios.models.agents import ToolSpec
+from aios.services import (
+    agents as agents_service,
+)
+from aios.services import (
+    environments as environments_service,
+)
+from tests.e2e.harness import Harness
+
+
+def make_spec(name: str = "echo") -> ConnectorSpec:
+    """A spec the supervisor can hold without spawning anything.
+
+    Tests never call ``start()`` so command/cwd never run; we only
+    need a name so :class:`ConnectorState` initializes cleanly.
+    """
+    return ConnectorSpec(name=name, command="x", args=[])
+
+
+def make_registry(
+    settings: Settings | None = None, name: str = "echo"
+) -> ConnectorSubprocessRegistry:
+    """Build a registry with one default-instance entry for tests."""
+    settings = settings or Settings()
+    return ConnectorSubprocessRegistry(
+        [(ConnectorInstance(connector=name, instance=name), make_spec(name))],
+        settings=settings,
+    )
+
+
+def unique_account(prefix: str = "acct") -> str:
+    """Per-test account string so testcontainer state stays isolated.
+
+    The active-connection unique index would otherwise reject the
+    second test that re-uses the same account (the testcontainer
+    Postgres persists across tests in a session).
+    """
+    return f"{prefix}-{make_id('evt')[-10:]}"
+
+
+def patch_send_ack(registry: ConnectorSubprocessRegistry) -> list[str]:
+    """Replace ``_send_ack`` with a recorder.
+
+    The real implementation calls ``dispatch_call`` against the
+    (absent) connector subprocess, which would error. Returns the
+    list that records each acked event_id.
+    """
+    recorded: list[str] = []
+
+    async def fake_ack(self: Any, state: Any, event_id: str) -> None:
+        recorded.append(event_id)
+
+    registry._send_ack = fake_ack.__get__(registry, type(registry))  # type: ignore[method-assign]
+    return recorded
+
+
+async def make_agent_and_env(harness: Harness, *, prefix: str = "test") -> tuple[str, str]:
+    """Build a fake agent + environment, returning their ids."""
+    if harness._env_id is None:
+        env = await environments_service.create_environment(
+            harness._pool, name=f"{prefix}-env-{make_id('env')[-8:]}"
+        )
+        harness._env_id = env.id
+    agent = await agents_service.create_agent(
+        harness._pool,
+        name=f"{prefix}-agent-{make_id('agent')[-8:]}",
+        model="fake/test",
+        system="test",
+        tools=[ToolSpec(type="bash")],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    return agent.id, harness._env_id

--- a/tests/e2e/test_connector_inbound_attachments.py
+++ b/tests/e2e/test_connector_inbound_attachments.py
@@ -1,0 +1,316 @@
+"""E2E coverage for inbound attachment staging.
+
+Drives ``ConnectorSubprocessRegistry._handle_inbound`` directly (no
+real subprocess) and verifies:
+
+* a connector temp file is staged into
+  ``<workspace_root>/_attachments/<session>/<connector>/<event-ulid>-<filename>``
+* the appended event carries structured ``metadata.attachments``
+  records with the model-facing ``in_sandbox_path``
+* a redelivered inbound (same ``event_id``) does not double-stage
+* the worker startup orphan GC sweep removes stranded files but
+  leaves referenced ones alone
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from aios.config import get_settings
+from aios.harness.attachment_gc import sweep_orphan_attachments
+from aios.ids import make_id
+from aios.sandbox.volumes import session_attachments_dir
+from aios.services import (
+    connections as connections_service,
+)
+from aios.services import (
+    sessions as sessions_service,
+)
+from tests.conftest import needs_docker
+from tests.e2e._connector_helpers import (
+    make_agent_and_env,
+    make_registry,
+    patch_send_ack,
+    unique_account,
+)
+from tests.e2e.harness import Harness
+
+
+def _make_connector_temp(tmp_path: Path, name: str, payload: bytes) -> dict[str, Any]:
+    """Write a fake connector-side temp file and return the wire-shaped record."""
+    src = tmp_path / name
+    src.write_bytes(payload)
+    return {
+        "host_path": str(src),
+        "filename": name,
+        "content_type": "image/jpeg",
+        "size": len(payload),
+    }
+
+
+@needs_docker
+class TestInboundAttachmentStaging:
+    async def test_attachment_lands_at_staged_path_with_metadata(
+        self, harness: Harness, tmp_path: Path
+    ) -> None:
+        """Happy path: inbound with one attachment.
+
+        Asserts (a) the host file exists at the expected staged path,
+        (b) the event row carries structured metadata.attachments with
+        the in_sandbox_path the renderer will expose to the model.
+        """
+        agent_id, env_id = await make_agent_and_env(harness, prefix="attach")
+        account = unique_account()
+        session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title="attach-1",
+            metadata={},
+        )
+        conn_row = await connections_service.create_connection(
+            harness._pool, connector="echo", account=account, metadata={}
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_row.id, session_id=session.id
+        )
+
+        connector_tmp = tmp_path / "connector-temp"
+        connector_tmp.mkdir()
+        att = _make_connector_temp(connector_tmp, "photo.jpg", b"jpegbytes")
+        event_id = make_id("evt")
+
+        registry = make_registry()
+        patch_send_ack(registry)
+        with mock.patch(
+            "aios.harness.connector_supervisor.defer_wake",
+            new=mock.AsyncMock(return_value=None),
+        ):
+            await registry._handle_inbound(
+                ("echo", "echo"),
+                {
+                    "event_id": event_id,
+                    "account": account,
+                    "chat_id": "chat-x",
+                    "sender": {"display_name": "Alice"},
+                    "content": "look at this",
+                    "attachments": [att],
+                },
+            )
+
+        # File staged with ULID prefix; connector temp consumed.
+        staged = session_attachments_dir(session.id) / "echo" / f"{event_id}-photo.jpg"
+        assert staged.exists()
+        assert staged.read_bytes() == b"jpegbytes"
+        # Connector temp dir is empty: rename consumed the source file.
+        assert list(connector_tmp.iterdir()) == []
+
+        # Event row carries the structured record.
+        events = await harness.events(session.id)
+        user_messages = [e for e in events if e.kind == "message" and e.data.get("role") == "user"]
+        latest = user_messages[-1]
+        attachments = latest.data["metadata"]["attachments"]
+        assert attachments == [
+            {
+                "filename": "photo.jpg",
+                "content_type": "image/jpeg",
+                "size": len(b"jpegbytes"),
+                "in_sandbox_path": f"/mnt/attachments/echo/{event_id}-photo.jpg",
+            }
+        ]
+        # No drop counter bumped.
+        assert dict(registry._states[("echo", "echo")].drops) == {}
+
+    async def test_dedup_replay_does_not_double_stage(
+        self, harness: Harness, tmp_path: Path
+    ) -> None:
+        """Replaying the same event_id twice produces one event row and no
+        duplicate file. The second delivery's staging is a no-op (target
+        already exists from the first attempt) and the dedup ledger
+        rolls the second event back."""
+        agent_id, env_id = await make_agent_and_env(harness, prefix="attach")
+        account = unique_account()
+        session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title="attach-dedup",
+            metadata={},
+        )
+        conn_row = await connections_service.create_connection(
+            harness._pool, connector="echo", account=account, metadata={}
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_row.id, session_id=session.id
+        )
+
+        connector_tmp = tmp_path / "connector-temp"
+        connector_tmp.mkdir()
+        att1 = _make_connector_temp(connector_tmp, "photo.jpg", b"first-bytes")
+        event_id = make_id("evt")
+
+        registry = make_registry()
+        patch_send_ack(registry)
+        with mock.patch(
+            "aios.harness.connector_supervisor.defer_wake",
+            new=mock.AsyncMock(return_value=None),
+        ):
+            params = {
+                "event_id": event_id,
+                "account": account,
+                "chat_id": "chat-dedup",
+                "sender": {"display_name": "Bob"},
+                "content": "hello",
+                "attachments": [att1],
+            }
+            await registry._handle_inbound(("echo", "echo"), params)
+
+            # Second delivery: temp file is gone (consumed by first
+            # rename), but the params still reference it. The replay
+            # path must short-circuit on the existing target file
+            # rather than crashing on a missing temp.
+            params2 = dict(params)
+            params2["attachments"] = [dict(att1)]  # same fields, same host_path
+            await registry._handle_inbound(("echo", "echo"), params2)
+
+        # Exactly one user event with this content.
+        events = await harness.events(session.id)
+        matching = [e for e in events if e.kind == "message" and e.data.get("content") == "hello"]
+        assert len(matching) == 1
+
+        # Exactly one staged file with the expected payload.
+        connector_stage = session_attachments_dir(session.id) / "echo"
+        files = list(connector_stage.iterdir())
+        assert len(files) == 1
+        assert files[0].name == f"{event_id}-photo.jpg"
+        assert files[0].read_bytes() == b"first-bytes"
+
+    async def test_missing_temp_path_drops_inbound(self, harness: Harness, tmp_path: Path) -> None:
+        """A connector that lies about its host path doesn't crash the
+        supervisor — drop with the canonical reason and ack the spool."""
+        agent_id, env_id = await make_agent_and_env(harness, prefix="attach")
+        account = unique_account()
+        session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title="attach-bogus",
+            metadata={},
+        )
+        conn_row = await connections_service.create_connection(
+            harness._pool, connector="echo", account=account, metadata={}
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_row.id, session_id=session.id
+        )
+
+        bogus = {
+            "host_path": str(tmp_path / "definitely-not-here.jpg"),
+            "filename": "ghost.jpg",
+            "content_type": "image/jpeg",
+            "size": 99,
+        }
+
+        registry = make_registry()
+        patch_send_ack(registry)
+        with mock.patch(
+            "aios.harness.connector_supervisor.defer_wake",
+            new=mock.AsyncMock(return_value=None),
+        ):
+            await registry._handle_inbound(
+                ("echo", "echo"),
+                {
+                    "event_id": make_id("evt"),
+                    "account": account,
+                    "chat_id": "chat-bogus",
+                    "sender": {"display_name": "Carol"},
+                    "content": "ghost message",
+                    "attachments": [bogus],
+                },
+            )
+
+        # No event row appended (drop happens before transaction).
+        events = await harness.events(session.id)
+        ghost_messages = [
+            e for e in events if e.kind == "message" and e.data.get("content") == "ghost message"
+        ]
+        assert ghost_messages == []
+        # Drop counter bumped.
+        assert dict(registry._states[("echo", "echo")].drops).get("attachment_staging_failed") == 1
+
+
+@needs_docker
+class TestOrphanAttachmentGc:
+    async def test_sweep_removes_stranded_files_keeps_referenced(
+        self, harness: Harness, tmp_path: Path
+    ) -> None:
+        """An orphan file (no event row referencing its in_sandbox_path)
+        is deleted; a referenced file is left alone."""
+        agent_id, env_id = await make_agent_and_env(harness, prefix="attach")
+        account = unique_account()
+        session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title="attach-gc",
+            metadata={},
+        )
+        conn_row = await connections_service.create_connection(
+            harness._pool, connector="echo", account=account, metadata={}
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_row.id, session_id=session.id
+        )
+
+        # First, drive a real inbound with attachment so we have a
+        # referenced file on disk + matching event row.
+        connector_tmp = tmp_path / "connector-temp"
+        connector_tmp.mkdir()
+        att = _make_connector_temp(connector_tmp, "kept.jpg", b"keep-me")
+        event_id = make_id("evt")
+
+        registry = make_registry()
+        patch_send_ack(registry)
+        with mock.patch(
+            "aios.harness.connector_supervisor.defer_wake",
+            new=mock.AsyncMock(return_value=None),
+        ):
+            await registry._handle_inbound(
+                ("echo", "echo"),
+                {
+                    "event_id": event_id,
+                    "account": account,
+                    "chat_id": "chat-gc",
+                    "sender": {"display_name": "Dave"},
+                    "content": "msg",
+                    "attachments": [att],
+                },
+            )
+
+        # Manually drop an orphan into the same dir, with a fake event-id
+        # prefix that has no corresponding event row.
+        orphan_path = session_attachments_dir(session.id) / "echo" / f"{make_id('evt')}-orphan.jpg"
+        orphan_path.write_bytes(b"orphan-bytes")
+        kept_path = session_attachments_dir(session.id) / "echo" / f"{event_id}-kept.jpg"
+        assert kept_path.exists()
+        assert orphan_path.exists()
+
+        deleted = await sweep_orphan_attachments(harness._pool)
+
+        assert deleted == 1
+        assert not orphan_path.exists()
+        assert kept_path.exists(), "referenced file must survive the sweep"
+
+    async def test_sweep_no_root_dir_returns_zero(
+        self, harness: Harness, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When _attachments/ doesn't exist yet, the sweep is a no-op."""
+        settings = get_settings()
+        # Point at a dir that doesn't exist.
+        monkeypatch.setattr(settings, "workspace_root", tmp_path / "nonexistent")
+        deleted = await sweep_orphan_attachments(harness._pool)
+        assert deleted == 0

--- a/tests/unit/test_attachment_staging.py
+++ b/tests/unit/test_attachment_staging.py
@@ -1,0 +1,265 @@
+"""Unit coverage for :mod:`aios.harness.attachment_staging`.
+
+Exercises the rename/copy/cleanup state machine with a temp
+``workspace_root`` so we never touch the production attachments
+directory. EXDEV is simulated by monkeypatching ``os.rename`` rather
+than spinning up a second filesystem.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aios.config import get_settings
+from aios.harness.attachment_staging import (
+    AttachmentStagingError,
+    _safe_filename,
+    stage_inbound_attachments,
+)
+
+
+@pytest.fixture
+def temp_workspace_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the cached ``Settings`` at a tmpdir for the test.
+
+    Mirrors the pattern in :mod:`tests.unit.test_memory_store_host_dir`:
+    mutate the lru_cached ``Settings`` instance directly so every
+    ``get_settings()`` call site sees the test root.
+    """
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    return tmp_path
+
+
+def _make_temp_attachment(tmp_path: Path, name: str, payload: bytes) -> dict[str, Any]:
+    """Build a wire-shaped attachment record pointing at a real file."""
+    src = tmp_path / name
+    src.write_bytes(payload)
+    return {
+        "host_path": str(src),
+        "filename": name,
+        "content_type": "image/jpeg",
+        "size": len(payload),
+    }
+
+
+class TestSafeFilename:
+    def test_strips_path_separators(self) -> None:
+        # Defeats ``../../etc/passwd`` style traversal attempts.
+        assert _safe_filename("../../etc/passwd") == "passwd"
+
+    def test_replaces_unsafe_chars(self) -> None:
+        assert _safe_filename("hello world!.jpg") == "hello_world_.jpg"
+
+    def test_preserves_dots_and_dashes(self) -> None:
+        assert _safe_filename("photo-2026.05.04.jpg") == "photo-2026.05.04.jpg"
+
+    def test_empty_falls_back_to_unnamed(self) -> None:
+        assert _safe_filename("") == "unnamed"
+
+    def test_all_dots_falls_back_to_unnamed(self) -> None:
+        assert _safe_filename("...") == "unnamed"
+
+    def test_caps_length(self) -> None:
+        result = _safe_filename("a" * 500)
+        assert len(result) <= 200
+
+
+class TestStaging:
+    def test_empty_returns_empty(self, temp_workspace_root: Path) -> None:
+        assert (
+            stage_inbound_attachments(
+                session_id="sess-1",
+                connector_name="echo",
+                event_id="evt-1",
+                raw_attachments=None,
+            )
+            == []
+        )
+        assert (
+            stage_inbound_attachments(
+                session_id="sess-1",
+                connector_name="echo",
+                event_id="evt-1",
+                raw_attachments=[],
+            )
+            == []
+        )
+
+    def test_happy_path_renames_file_and_returns_record(
+        self, tmp_path: Path, temp_workspace_root: Path
+    ) -> None:
+        connector_temp = tmp_path / "connector-temp"
+        connector_temp.mkdir()
+        att = _make_temp_attachment(connector_temp, "photo.jpg", b"jpegbytes")
+
+        records = stage_inbound_attachments(
+            session_id="sess-1",
+            connector_name="echo",
+            event_id="evt-1",
+            raw_attachments=[att],
+        )
+
+        # Wire record carries the in-sandbox path the model will see.
+        assert records == [
+            {
+                "filename": "photo.jpg",
+                "content_type": "image/jpeg",
+                "size": len(b"jpegbytes"),
+                "in_sandbox_path": "/mnt/attachments/echo/evt-1-photo.jpg",
+            }
+        ]
+        # File moved to staged path; original temp gone.
+        staged = temp_workspace_root / "_attachments" / "sess-1" / "echo" / "evt-1-photo.jpg"
+        assert staged.exists()
+        assert staged.read_bytes() == b"jpegbytes"
+        assert not Path(att["host_path"]).exists()
+
+    def test_multiple_attachments_all_staged(
+        self, tmp_path: Path, temp_workspace_root: Path
+    ) -> None:
+        a = _make_temp_attachment(tmp_path, "a.jpg", b"AAA")
+        b = _make_temp_attachment(tmp_path, "b.png", b"BBBB")
+        b["content_type"] = "image/png"
+
+        records = stage_inbound_attachments(
+            session_id="sess-1",
+            connector_name="echo",
+            event_id="evt-1",
+            raw_attachments=[a, b],
+        )
+
+        assert len(records) == 2
+        assert records[0]["filename"] == "a.jpg"
+        assert records[1]["filename"] == "b.png"
+
+    def test_unsafe_filename_sanitized_in_staged_path(
+        self, tmp_path: Path, temp_workspace_root: Path
+    ) -> None:
+        # Connector reports a filename with unsafe chars; original temp
+        # is at a sane path — the unsafe chars only affect the staged name.
+        src = tmp_path / "evil.jpg"
+        src.write_bytes(b"x")
+        att = {
+            "host_path": str(src),
+            "filename": "../escape/bad name.jpg",
+            "content_type": "image/jpeg",
+            "size": 1,
+        }
+        records = stage_inbound_attachments(
+            session_id="sess-1",
+            connector_name="echo",
+            event_id="evt-1",
+            raw_attachments=[att],
+        )
+        # Filename in the *record* is the original (model-facing display),
+        # the sanitized form only shows up in the staged path.
+        assert records[0]["filename"] == "../escape/bad name.jpg"
+        assert records[0]["in_sandbox_path"] == "/mnt/attachments/echo/evt-1-bad_name.jpg"
+
+    def test_replay_with_existing_target_skips_rename(
+        self, tmp_path: Path, temp_workspace_root: Path
+    ) -> None:
+        """Idempotent replay: same event_id delivered twice doesn't double-stage."""
+        a = _make_temp_attachment(tmp_path, "photo.jpg", b"first")
+        first = stage_inbound_attachments(
+            session_id="sess-1",
+            connector_name="echo",
+            event_id="evt-1",
+            raw_attachments=[a],
+        )
+        # First call consumed the temp file; for the replay the connector
+        # would re-supply the spool entry but its temp file is gone. The
+        # function must still succeed (target already at the staged path).
+        a2 = dict(a)  # same params dict the SDK would re-emit from spool
+        second = stage_inbound_attachments(
+            session_id="sess-1",
+            connector_name="echo",
+            event_id="evt-1",
+            raw_attachments=[a2],
+        )
+        assert first == second
+
+    def test_missing_temp_path_raises_and_cleans_up(
+        self, tmp_path: Path, temp_workspace_root: Path
+    ) -> None:
+        good = _make_temp_attachment(tmp_path, "good.jpg", b"good")
+        bogus = {
+            "host_path": str(tmp_path / "does-not-exist.jpg"),
+            "filename": "missing.jpg",
+            "content_type": "image/jpeg",
+            "size": 5,
+        }
+
+        with pytest.raises(AttachmentStagingError, match="temp path not found"):
+            stage_inbound_attachments(
+                session_id="sess-1",
+                connector_name="echo",
+                event_id="evt-1",
+                raw_attachments=[good, bogus],
+            )
+
+        # Compensating action: the first attachment was newly staged,
+        # then the second's failure must roll it back.
+        sess_dir = temp_workspace_root / "_attachments" / "sess-1" / "echo"
+        if sess_dir.exists():
+            assert list(sess_dir.iterdir()) == []
+
+    def test_malformed_dict_raises(self, tmp_path: Path, temp_workspace_root: Path) -> None:
+        with pytest.raises(AttachmentStagingError, match="missing required fields"):
+            stage_inbound_attachments(
+                session_id="sess-1",
+                connector_name="echo",
+                event_id="evt-1",
+                raw_attachments=[{"filename": "x.jpg"}],
+            )
+
+    def test_non_dict_raises(self, temp_workspace_root: Path) -> None:
+        with pytest.raises(AttachmentStagingError, match="not a dict"):
+            stage_inbound_attachments(
+                session_id="sess-1",
+                connector_name="echo",
+                event_id="evt-1",
+                raw_attachments=["not a dict"],
+            )
+
+    def test_exdev_falls_back_to_copy_unlink(
+        self,
+        tmp_path: Path,
+        temp_workspace_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cross-FS rename returns EXDEV; we fall back to copy+unlink.
+
+        Simulated by patching os.rename rather than spinning up a real
+        cross-FS scenario.
+        """
+        a = _make_temp_attachment(tmp_path, "photo.jpg", b"crossfs")
+        original_rename = os.rename
+
+        def fake_rename(src: Any, dst: Any) -> None:
+            err = OSError("simulated cross-fs")
+            err.errno = errno.EXDEV
+            raise err
+
+        monkeypatch.setattr(os, "rename", fake_rename)
+        try:
+            records = stage_inbound_attachments(
+                session_id="sess-1",
+                connector_name="echo",
+                event_id="evt-1",
+                raw_attachments=[a],
+            )
+        finally:
+            monkeypatch.setattr(os, "rename", original_rename)
+
+        staged = temp_workspace_root / "_attachments" / "sess-1" / "echo" / "evt-1-photo.jpg"
+        assert staged.read_bytes() == b"crossfs"
+        # Source temp deleted by the unlink-after-copy step.
+        assert not Path(a["host_path"]).exists()
+        assert records[0]["in_sandbox_path"] == "/mnt/attachments/echo/evt-1-photo.jpg"

--- a/tests/unit/test_attachment_staging.py
+++ b/tests/unit/test_attachment_staging.py
@@ -38,6 +38,7 @@ def temp_workspace_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path
 
 def _make_temp_attachment(tmp_path: Path, name: str, payload: bytes) -> dict[str, Any]:
     """Build a wire-shaped attachment record pointing at a real file."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
     src = tmp_path / name
     src.write_bytes(payload)
     return {
@@ -72,24 +73,18 @@ class TestSafeFilename:
 
 class TestStaging:
     def test_empty_returns_empty(self, temp_workspace_root: Path) -> None:
-        assert (
-            stage_inbound_attachments(
-                session_id="sess-1",
-                connector_name="echo",
-                event_id="evt-1",
-                raw_attachments=None,
-            )
-            == []
-        )
-        assert (
-            stage_inbound_attachments(
-                session_id="sess-1",
-                connector_name="echo",
-                event_id="evt-1",
-                raw_attachments=[],
-            )
-            == []
-        )
+        assert stage_inbound_attachments(
+            session_id="sess-1",
+            connector_name="echo",
+            event_id="evt-1",
+            raw_attachments=None,
+        ) == ([], [])
+        assert stage_inbound_attachments(
+            session_id="sess-1",
+            connector_name="echo",
+            event_id="evt-1",
+            raw_attachments=[],
+        ) == ([], [])
 
     def test_happy_path_renames_file_and_returns_record(
         self, tmp_path: Path, temp_workspace_root: Path
@@ -98,7 +93,7 @@ class TestStaging:
         connector_temp.mkdir()
         att = _make_temp_attachment(connector_temp, "photo.jpg", b"jpegbytes")
 
-        records = stage_inbound_attachments(
+        records, staged_paths = stage_inbound_attachments(
             session_id="sess-1",
             connector_name="echo",
             event_id="evt-1",
@@ -119,6 +114,9 @@ class TestStaging:
         assert staged.exists()
         assert staged.read_bytes() == b"jpegbytes"
         assert not Path(att["host_path"]).exists()
+        # The newly-staged path list lets the supervisor unlink on
+        # post-staging dedup failure.
+        assert staged_paths == [staged]
 
     def test_multiple_attachments_all_staged(
         self, tmp_path: Path, temp_workspace_root: Path
@@ -127,7 +125,7 @@ class TestStaging:
         b = _make_temp_attachment(tmp_path, "b.png", b"BBBB")
         b["content_type"] = "image/png"
 
-        records = stage_inbound_attachments(
+        records, staged_paths = stage_inbound_attachments(
             session_id="sess-1",
             connector_name="echo",
             event_id="evt-1",
@@ -137,6 +135,7 @@ class TestStaging:
         assert len(records) == 2
         assert records[0]["filename"] == "a.jpg"
         assert records[1]["filename"] == "b.png"
+        assert len(staged_paths) == 2
 
     def test_unsafe_filename_sanitized_in_staged_path(
         self, tmp_path: Path, temp_workspace_root: Path
@@ -151,7 +150,7 @@ class TestStaging:
             "content_type": "image/jpeg",
             "size": 1,
         }
-        records = stage_inbound_attachments(
+        records, _ = stage_inbound_attachments(
             session_id="sess-1",
             connector_name="echo",
             event_id="evt-1",
@@ -167,7 +166,7 @@ class TestStaging:
     ) -> None:
         """Idempotent replay: same event_id delivered twice doesn't double-stage."""
         a = _make_temp_attachment(tmp_path, "photo.jpg", b"first")
-        first = stage_inbound_attachments(
+        first_records, first_paths = stage_inbound_attachments(
             session_id="sess-1",
             connector_name="echo",
             event_id="evt-1",
@@ -177,13 +176,20 @@ class TestStaging:
         # would re-supply the spool entry but its temp file is gone. The
         # function must still succeed (target already at the staged path).
         a2 = dict(a)  # same params dict the SDK would re-emit from spool
-        second = stage_inbound_attachments(
+        second_records, second_paths = stage_inbound_attachments(
             session_id="sess-1",
             connector_name="echo",
             event_id="evt-1",
             raw_attachments=[a2],
         )
-        assert first == second
+        # Records match (same event_id → same in_sandbox_path).
+        assert first_records == second_records
+        # First call materialized one path; replay materialized none —
+        # critical so the supervisor's NotFoundError compensating
+        # unlink doesn't blow away bytes already referenced by the
+        # previously committed event.
+        assert len(first_paths) == 1
+        assert second_paths == []
 
     def test_missing_temp_path_raises_and_cleans_up(
         self, tmp_path: Path, temp_workspace_root: Path
@@ -249,7 +255,7 @@ class TestStaging:
 
         monkeypatch.setattr(os, "rename", fake_rename)
         try:
-            records = stage_inbound_attachments(
+            records, _ = stage_inbound_attachments(
                 session_id="sess-1",
                 connector_name="echo",
                 event_id="evt-1",
@@ -263,3 +269,92 @@ class TestStaging:
         # Source temp deleted by the unlink-after-copy step.
         assert not Path(a["host_path"]).exists()
         assert records[0]["in_sandbox_path"] == "/mnt/attachments/echo/evt-1-photo.jpg"
+
+    def test_exdev_partial_copy_is_cleaned_up(
+        self,
+        tmp_path: Path,
+        temp_workspace_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If shutil.copy2 fails mid-write under the EXDEV branch, the
+        partial target file must still be unlinked by the compensating
+        action.  Regression test for the orphan path that survived the
+        original implementation (target appended to the cleanup list
+        only after a successful copy).
+        """
+        a = _make_temp_attachment(tmp_path, "photo.jpg", b"crossfs-partial")
+
+        def fake_rename(src: Any, dst: Any) -> None:
+            err = OSError("simulated cross-fs")
+            err.errno = errno.EXDEV
+            raise err
+
+        def fake_copy2(src: Any, dst: Any) -> None:
+            # Simulate a partial write: drop some bytes at the target
+            # and then fail.  Without the early append-to-cleanup-list,
+            # this file would be orphaned.
+            Path(dst).write_bytes(b"PART")
+            raise OSError("simulated mid-copy failure")
+
+        import shutil as _shutil
+
+        monkeypatch.setattr(os, "rename", fake_rename)
+        monkeypatch.setattr(_shutil, "copy2", fake_copy2)
+
+        with pytest.raises(AttachmentStagingError, match="across filesystems"):
+            stage_inbound_attachments(
+                session_id="sess-1",
+                connector_name="echo",
+                event_id="evt-1",
+                raw_attachments=[a],
+            )
+
+        partial = temp_workspace_root / "_attachments" / "sess-1" / "echo" / "evt-1-photo.jpg"
+        assert not partial.exists(), "EXDEV partial-copy file leaked past cleanup"
+
+    def test_same_inbound_filename_collision_fails_hard(
+        self, tmp_path: Path, temp_workspace_root: Path
+    ) -> None:
+        """Two attachments in the same inbound that sanitize to the
+        same target name must fail loudly — silently appending a
+        second record pointing at the first attachment's bytes would
+        corrupt ``metadata.attachments``.
+
+        Realistic trigger: a Telegram album where two photos arrive
+        as ``image.jpg`` from different devices.
+        """
+        a = _make_temp_attachment(tmp_path / "from-device-1", "image.jpg", b"AAA")
+        b = _make_temp_attachment(tmp_path / "from-device-2", "image.jpg", b"BBB")
+
+        with pytest.raises(AttachmentStagingError, match="sanitize to the same"):
+            stage_inbound_attachments(
+                session_id="sess-1",
+                connector_name="echo",
+                event_id="evt-1",
+                raw_attachments=[a, b],
+            )
+
+        # Compensating action: the first iteration's staged file is
+        # rolled back so the orphan GC has nothing to clean up.
+        sess_dir = temp_workspace_root / "_attachments" / "sess-1" / "echo"
+        if sess_dir.exists():
+            assert list(sess_dir.iterdir()) == []
+
+    def test_collision_via_sanitization_fails_hard(
+        self, tmp_path: Path, temp_workspace_root: Path
+    ) -> None:
+        """Two distinct filenames that sanitize to identical names
+        (``image.jpg`` vs ``image .jpg`` → both end up
+        ``evt-1-image_.jpg`` after the space → ``_`` mapping)
+        also collide.
+        """
+        a = _make_temp_attachment(tmp_path / "a", "image_.jpg", b"AAA")
+        b = _make_temp_attachment(tmp_path / "b", "image .jpg", b"BBB")
+
+        with pytest.raises(AttachmentStagingError, match="sanitize to the same"):
+            stage_inbound_attachments(
+                session_id="sess-1",
+                connector_name="echo",
+                event_id="evt-1",
+                raw_attachments=[a, b],
+            )

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -203,6 +203,10 @@ class TestProvisionerDockerArgs:
             ),
             patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
             patch(
+                "aios.sandbox.volumes.ensure_session_attachments_dir",
+                return_value=Path("/tmp/attachments"),
+            ),
+            patch(
                 "aios.sandbox.provisioner._install_packages",
                 AsyncMock(),
             ) as mock_install,
@@ -253,6 +257,10 @@ class TestProvisionerDockerArgs:
                 AsyncMock(return_value=([], None)),
             ),
             patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
+            patch(
+                "aios.sandbox.volumes.ensure_session_attachments_dir",
+                return_value=Path("/tmp/attachments"),
+            ),
             patch("aios.sandbox.provisioner._install_packages", AsyncMock()),
             patch(
                 "aios.sandbox.provisioner._apply_network_lockdown",
@@ -295,6 +303,10 @@ class TestProvisionerDockerArgs:
                 AsyncMock(return_value=([], None)),
             ),
             patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
+            patch(
+                "aios.sandbox.volumes.ensure_session_attachments_dir",
+                return_value=Path("/tmp/attachments"),
+            ),
             patch("aios.sandbox.provisioner._install_packages", AsyncMock()),
             patch(
                 "aios.sandbox.provisioner._apply_network_lockdown",

--- a/tests/unit/test_volumes_attachments.py
+++ b/tests/unit/test_volumes_attachments.py
@@ -1,0 +1,97 @@
+"""Unit coverage for the attachments helpers in :mod:`aios.sandbox.volumes`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aios.config import get_settings
+from aios.sandbox.volumes import (
+    attachments_root,
+    ensure_session_attachments_dir,
+    resolve_to_host_path,
+    session_attachments_dir,
+)
+
+
+def test_attachments_root_under_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    assert attachments_root() == (tmp_path / "_attachments").resolve()
+
+
+def test_session_attachments_dir_keyed_by_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    a = session_attachments_dir("sess-a")
+    b = session_attachments_dir("sess-b")
+    assert a != b
+    assert a.parent == b.parent == (tmp_path / "_attachments").resolve()
+
+
+def test_session_attachments_dir_pure_function(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    p = session_attachments_dir("sess-new")
+    assert not p.exists()
+
+
+def test_ensure_session_attachments_dir_creates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    p = ensure_session_attachments_dir("sess-1")
+    assert p.exists() and p.is_dir()
+    # Idempotent.
+    p2 = ensure_session_attachments_dir("sess-1")
+    assert p == p2
+
+
+class TestResolveToHostPath:
+    """Mapping must be exact and only fire for known mount roots."""
+
+    def test_workspace_root_maps_to_session_workspace(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        assert resolve_to_host_path("sess-1", "/workspace") == (tmp_path / "sess-1").resolve()
+
+    def test_workspace_subpath(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        result = resolve_to_host_path("sess-1", "/workspace/sub/file.txt")
+        assert result == (tmp_path / "sess-1").resolve() / "sub" / "file.txt"
+
+    def test_attachments_root_maps_to_session_attachments(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        result = resolve_to_host_path("sess-1", "/mnt/attachments")
+        assert result == (tmp_path / "_attachments" / "sess-1").resolve()
+
+    def test_attachments_subpath(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        result = resolve_to_host_path("sess-1", "/mnt/attachments/echo/evt-photo.jpg")
+        assert result == (
+            (tmp_path / "_attachments" / "sess-1").resolve() / "echo" / "evt-photo.jpg"
+        )
+
+    def test_unknown_paths_return_none(self) -> None:
+        # Paths outside the bind-mount roots fall back to docker-exec.
+        assert resolve_to_host_path("sess-1", "/etc/hostname") is None
+        assert resolve_to_host_path("sess-1", "/tmp/x") is None
+        # Memory mounts handled separately — not in scope for this helper.
+        assert resolve_to_host_path("sess-1", "/mnt/memory/foo/bar") is None
+        # No prefix match (relative path).
+        assert resolve_to_host_path("sess-1", "workspace/foo") is None
+        # Not /workspace itself but starts with the literal prefix.
+        assert resolve_to_host_path("sess-1", "/workspaces/foo") is None


### PR DESCRIPTION
## Summary

PR1 of 4 stacked PRs implementing #216 (chat attachment ingestion, vision blocks, outbound MEDIA tag).  This stage adds end-to-end plumbing for inbound binary blobs without yet changing what the model sees — the vision pipeline lands in PR2.

- SDK: `Attachment` frozen dataclass on `aios-connector` with 5 MiB cap and host-path validation at `emit_inbound` time.  Bytes never traverse stdio.
- Storage: per-session host directory at `<workspace_root>/_attachments/<session>/<connector>/<event-ulid>-<filename>` (underscore-sibling convention; no new top-level setting).
- Sandbox: read-only bind mount at `/mnt/attachments` added eagerly on every provision so an inbound landing during a running step is visible without container restart.
- Supervisor: `stage_inbound_attachments` renames each connector temp file into staging before the dedup transaction (idempotent on replay; cross-FS falls back to copy+unlink).  Per-attachment failures drop the inbound with a new `attachment_staging_failed` reason.
- Volumes: `resolve_to_host_path` maps `/workspace/...` and `/mnt/attachments/...` paths to host equivalents — used by PR2's renderer and read tool to skip docker-exec for image bytes.
- Worker startup: `sweep_orphan_attachments` walks `<workspace_root>/_attachments/`, batches one query per worker start (not per-session), removes files unreferenced by any event row.

## Stack

1. **PR1 (this)** — storage + SDK + supervisor staging + sandbox bind + GC
2. PR2 — vision pipeline (`harness/vision.py` + `context.py` `image_url` emission + `tools/read.py` polymorphic image branch)
3. PR3 — outbound MEDIA-tag protocol (SDK helper)
4. PR4 — Signal / Telegram connector porting (lands in connector repos)

Merge back-to-front.

## Test plan
- [x] `uv run mypy src` clean (130 files)
- [x] `uv run ruff check src tests packages` + `ruff format --check` clean
- [x] `uv run pytest tests/unit -q` — 1083 passed
- [x] SDK package tests — 35 passed (includes new `test_attachment.py`)
- [x] e2e: `test_connector_inbound.py` + `test_connector_supervisor.py` + `test_connector_inbound_attachments.py` + `test_context_build_span.py` + `test_context_endpoint.py` — 36 passed
- [x] New e2e test verifies: file lands at expected path, event metadata carries `in_sandbox_path`, dedup-replay doesn't double-stage, missing temp path drops with the right reason, orphan GC removes stranded files but keeps referenced ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)