### PR TITLE
feat(harness): vision pipeline — image_url parts at render + image-aware read tool (#216, PR2/4)

### DIFF
--- a/packages/aios-connector/README.md
+++ b/packages/aios-connector/README.md
@@ -191,3 +191,85 @@ notification.  On reconnect the SDK replays unacked entries; the
 worker-side dedup ledger (`connector_inbound_acks`) guarantees
 at-most-once event append even across worker SIGKILL between commit
 and ack.
+
+## Attachments (inbound)
+
+Pass a list of `Attachment` instances to `emit_inbound(attachments=...)`
+when the platform delivers a photo, voice note, or document.  The
+connector hands aios a *host path* it owns (e.g. signal-cli's
+download dir, Telegram's `getFile()` result) — bytes never traverse
+stdio.
+
+```python
+from aios_connector import Attachment
+
+await self.emit_inbound(
+    account=...,
+    chat_id=...,
+    sender=...,
+    content="check this out",
+    attachments=[
+        Attachment(
+            host_path="/tmp/signal-cli-downloads/abc.jpg",
+            filename="photo.jpg",
+            content_type="image/jpeg",
+        ),
+    ],
+)
+```
+
+The SDK validates each attachment at `emit_inbound` time:
+
+- `host_path` must be a regular file the SDK can stat.
+- size must be ≤ 5 MiB.
+
+Failures raise `AttachmentError` synchronously; the connector decides
+whether to skip the attachment, send a placeholder text message, or
+refuse the inbound.
+
+The supervisor stages each attachment into a stable per-session
+location and bind-mounts it read-only into the sandbox at
+`/mnt/attachments/<connector>/<event-ulid>-<filename>`.
+
+## Outbound attachments
+
+Send tools take a structured `attachments: list[str] | None`
+parameter alongside `text`.  The model passes in-sandbox paths;
+the connector resolves each to a host path via
+`resolve_sandbox_path`, validates it's under `/workspace/` or
+`/mnt/attachments/`, then opens the file and uploads it as platform
+media with `text` as caption.
+
+```python
+from pathlib import Path
+import os
+from aios_connector import resolve_sandbox_path
+
+@tool()
+@focal_required
+async def signal_send(
+    self,
+    text: str,
+    attachments: list[str] | None = None,
+    *,
+    chat_id: str,
+) -> dict[str, Any]:
+    """Send a Signal message with optional attachments."""
+    workspace_root = Path(os.environ["AIOS_WORKSPACE_ROOT"])
+    session_id = self.current_session_id()
+    host_paths: list[str] = []
+    for sandbox_path in attachments or []:
+        host = resolve_sandbox_path(
+            session_id=session_id,
+            sandbox_path=sandbox_path,
+            workspace_root=workspace_root,
+        )
+        if host is None:
+            raise ValueError(f"path {sandbox_path!r} outside the sandbox bind mount")
+        host_paths.append(str(host))
+    # ... call platform send API with text + host_paths
+```
+
+Path allowlist: `/workspace/...` and `/mnt/attachments/...` only.
+`/mnt/attachments/` is read-only inside the sandbox, so the model
+must `cp` an inbound file into `/workspace/` before forwarding it.

--- a/packages/aios-connector/aios_connector/__init__.py
+++ b/packages/aios-connector/aios_connector/__init__.py
@@ -26,6 +26,9 @@ Public API:
 * :class:`Attachment` / :class:`AttachmentError` — inbound binary blobs
   (photos, voice notes, documents) and the SDK-boundary validation
   failure connectors catch.
+* :func:`resolve_sandbox_path` — host-path resolver for outbound
+  attachments; connector send tools call this for each entry in
+  their ``attachments`` parameter.
 """
 
 from __future__ import annotations
@@ -38,6 +41,7 @@ from aios_connector.base import (
     make_account,
     tool,
 )
+from aios_connector.media import resolve_sandbox_path
 
 __all__ = [
     "Attachment",
@@ -45,5 +49,6 @@ __all__ = [
     "Connector",
     "focal_required",
     "make_account",
+    "resolve_sandbox_path",
     "tool",
 ]

--- a/packages/aios-connector/aios_connector/media.py
+++ b/packages/aios-connector/aios_connector/media.py
@@ -1,0 +1,60 @@
+"""Sandbox path resolution for connector send tools.
+
+Connectors take a structured ``attachments: list[str]`` parameter on
+their send tools (the model passes in-sandbox paths like
+``/workspace/cat.jpg``).  This module's :func:`resolve_sandbox_path`
+maps each one to its host-side equivalent so the connector can
+``open()`` the file before uploading to the platform.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Trailing slash is load-bearing — prevents ``/workspaces/foo`` matching
+# ``/workspace``.  Duplicated from :mod:`aios.sandbox.volumes` rather
+# than imported so the reference SDK has zero dependency on aios server
+# code (mirrors the ``_AIOS_NOTIFICATION_PREFIX`` precedent in base.py).
+_WORKSPACE_PREFIX = "/workspace/"
+_ATTACHMENTS_PREFIX = "/mnt/attachments/"
+_ATTACHMENTS_HOST_SUBDIR = "_attachments"
+
+
+def resolve_sandbox_path(
+    *,
+    session_id: str,
+    sandbox_path: str,
+    workspace_root: Path,
+) -> Path | None:
+    """Map an in-sandbox path to its host-side equivalent, or ``None`` when
+    it doesn't fall under ``/workspace/`` or ``/mnt/attachments/`` or escapes
+    the bind-mount root after ``..`` / symlink resolution.
+
+    Duplicated from :func:`aios.sandbox.volumes.resolve_to_host_path`
+    rather than imported so the reference SDK has zero aios server
+    dependency (mirrors the ``_AIOS_NOTIFICATION_PREFIX`` precedent).
+    """
+    if sandbox_path.startswith(_WORKSPACE_PREFIX):
+        base = workspace_root / session_id
+        suffix = sandbox_path[len(_WORKSPACE_PREFIX) :]
+    elif sandbox_path == "/workspace":
+        base = workspace_root / session_id
+        suffix = ""
+    elif sandbox_path.startswith(_ATTACHMENTS_PREFIX):
+        base = workspace_root / _ATTACHMENTS_HOST_SUBDIR / session_id
+        suffix = sandbox_path[len(_ATTACHMENTS_PREFIX) :]
+    elif sandbox_path == "/mnt/attachments":
+        base = workspace_root / _ATTACHMENTS_HOST_SUBDIR / session_id
+        suffix = ""
+    else:
+        return None
+
+    candidate = base if not suffix else base / suffix
+    try:
+        resolved = candidate.resolve(strict=False)
+        resolved_base = base.resolve(strict=False)
+    except OSError:
+        return None
+    if resolved != resolved_base and not resolved.is_relative_to(resolved_base):
+        return None
+    return resolved

--- a/packages/aios-connector/tests/test_media.py
+++ b/packages/aios-connector/tests/test_media.py
@@ -1,0 +1,114 @@
+"""Unit coverage for ``resolve_sandbox_path``.
+
+Mirrors the server-side ``resolve_to_host_path`` containment tests.
+Both helpers must reject the same attacks; duplicating coverage
+(rather than sharing an import) keeps the SDK independently
+verifiable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aios_connector import resolve_sandbox_path
+
+
+class TestResolveSandboxPath:
+    def test_workspace_subpath(self, tmp_path: Path) -> None:
+        result = resolve_sandbox_path(
+            session_id="sess-1",
+            sandbox_path="/workspace/foo.jpg",
+            workspace_root=tmp_path,
+        )
+        assert result == (tmp_path / "sess-1" / "foo.jpg").resolve()
+
+    def test_attachments_subpath(self, tmp_path: Path) -> None:
+        result = resolve_sandbox_path(
+            session_id="sess-1",
+            sandbox_path="/mnt/attachments/echo/evt-photo.jpg",
+            workspace_root=tmp_path,
+        )
+        assert result == (tmp_path / "_attachments" / "sess-1" / "echo" / "evt-photo.jpg").resolve()
+
+    def test_workspace_root(self, tmp_path: Path) -> None:
+        result = resolve_sandbox_path(
+            session_id="sess-1",
+            sandbox_path="/workspace",
+            workspace_root=tmp_path,
+        )
+        assert result == (tmp_path / "sess-1").resolve()
+
+    def test_unknown_paths_return_none(self, tmp_path: Path) -> None:
+        for bad in (
+            "/etc/passwd",
+            "/tmp/x",
+            "/mnt/memory/foo",
+            "workspace/foo",
+            "/workspaces/foo",
+        ):
+            assert (
+                resolve_sandbox_path(
+                    session_id="sess-1",
+                    sandbox_path=bad,
+                    workspace_root=tmp_path,
+                )
+                is None
+            )
+
+    def test_dotdot_escape_from_workspace_rejected(self, tmp_path: Path) -> None:
+        assert (
+            resolve_sandbox_path(
+                session_id="sess-1",
+                sandbox_path="/workspace/../../etc/hostname",
+                workspace_root=tmp_path,
+            )
+            is None
+        )
+
+    def test_dotdot_escape_from_attachments_rejected(self, tmp_path: Path) -> None:
+        assert (
+            resolve_sandbox_path(
+                session_id="sess-1",
+                sandbox_path="/mnt/attachments/../foo",
+                workspace_root=tmp_path,
+            )
+            is None
+        )
+
+    def test_innocuous_dotdot_inside_workspace_allowed(self, tmp_path: Path) -> None:
+        result = resolve_sandbox_path(
+            session_id="sess-1",
+            sandbox_path="/workspace/sub/../foo.jpg",
+            workspace_root=tmp_path,
+        )
+        assert result == (tmp_path / "sess-1" / "foo.jpg").resolve()
+
+    def test_symlink_escape_via_workspace_rejected(self, tmp_path: Path) -> None:
+        ws = (tmp_path / "sess-1").resolve()
+        ws.mkdir(parents=True)
+        outside = tmp_path / "outside.txt"
+        outside.write_text("host-secret")
+        (ws / "sneaky.jpg").symlink_to(outside)
+
+        assert (
+            resolve_sandbox_path(
+                session_id="sess-1",
+                sandbox_path="/workspace/sneaky.jpg",
+                workspace_root=tmp_path,
+            )
+            is None
+        )
+
+    def test_symlink_target_inside_workspace_allowed(self, tmp_path: Path) -> None:
+        ws = (tmp_path / "sess-1").resolve()
+        ws.mkdir(parents=True)
+        target = ws / "real.jpg"
+        target.write_bytes(b"x")
+        (ws / "alias.jpg").symlink_to(target)
+
+        result = resolve_sandbox_path(
+            session_id="sess-1",
+            sandbox_path="/workspace/alias.jpg",
+            workspace_root=tmp_path,
+        )
+        assert result == target.resolve()

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -770,6 +770,28 @@ async def list_running_session_ids(conn: asyncpg.Connection[Any]) -> list[str]:
     return [str(r["id"]) for r in rows]
 
 
+async def get_session_model(conn: asyncpg.Connection[Any], session_id: str) -> str:
+    """Return the bound mind URL for ``session_id`` in one round trip.
+
+    Pinned ``agent_version`` wins when set; otherwise the live agent's
+    current ``model`` is returned.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT COALESCE(av.model, a.model) AS model
+          FROM sessions s
+          JOIN agents a ON a.id = s.agent_id
+     LEFT JOIN agent_versions av
+            ON av.agent_id = s.agent_id AND av.version = s.agent_version
+         WHERE s.id = $1
+        """,
+        session_id,
+    )
+    if row is None:
+        raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
+    return str(row["model"])
+
+
 async def list_attachment_paths_for_sessions(
     conn: asyncpg.Connection[Any], session_ids: list[str]
 ) -> dict[str, set[str]]:

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1280,6 +1280,16 @@ async def append_event(
         if kind == "message":
             prev = await _latest_cumulative_tokens(conn, session_id)
             if data.get("role") == "user" and orig_channel is not None:
+                # TODO(vision): plumb ``agent.model`` through here so
+                # :func:`render_user_event` matches build-time output for
+                # image-bearing events.  Today this call site renders without
+                # ``model``/``session_id``, so attachments degrade to text
+                # markers and the per-event ``cumulative_tokens`` undercounts
+                # inlined images by ~55 LiteLLM tokens each (text marker ~30
+                # vs. ``image_url`` part ~85).  The undercount is bounded by
+                # ``model_token_ratio`` calibration in
+                # :func:`read_windowed_events`; see PR #218 for the
+                # follow-up plan to make append-time vision-aware.
                 rendered = render_user_event(data, orig_channel, focal_at_arrival)
                 cum_tokens = (prev or 0) + approx_tokens([rendered])
             else:

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -262,6 +262,12 @@ def _apply_attachments(
             and can_inline_image(model=model, content_type=content_type, size_bytes=size)
         )
         if inline:
+            # v1 deliberately re-reads + re-base64-encodes per render: the
+            # staged bytes are typically immutable (`/mnt/attachments/` is
+            # read-only) so an LRU cache on (host_path, mtime, size) would
+            # be a clean follow-up if profiling shows pressure.  See
+            # PR #216 §14 for the discussion of cache vs. encode-at-staging
+            # alternatives we deferred for v1.
             try:
                 payload = host_path.read_bytes()
             except OSError as err:
@@ -289,7 +295,16 @@ def _apply_attachments(
         text = f"{text}\n{chr(10).join(marker_lines)}" if text else "\n".join(marker_lines)
 
     if image_parts:
-        msg["content"] = [{"type": "text", "text": text}, *image_parts]
+        # Anthropic rejects empty text blocks (`text content blocks must be
+        # non-empty`) so omit the leading text part when there is no caption,
+        # no channel header, and no markers — the image_url parts stand on
+        # their own.  OpenAI tolerates the empty part, but emitting it would
+        # break any vision-capable Anthropic-routed mind on a caption-less
+        # image-only inbound.
+        if text:
+            msg["content"] = [{"type": "text", "text": text}, *image_parts]
+        else:
+            msg["content"] = list(image_parts)
     else:
         msg["content"] = text
 

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -10,7 +10,11 @@ Two public functions:
   tool calls and reordering tool results so they appear immediately
   after their requesting assistant message.
 
-Both are pure functions: no DB access, no side effects, easy to test.
+Both are pure functions of the event log + caller-supplied vision
+policy inputs (``model``, ``session_id``).  They DO read host bytes
+when an image attachment can be inlined for the bound mind — that I/O
+is the cost of producing an ``image_url`` content part.  No DB access,
+no async.
 
 The ``reacting_to`` field on assistant messages is the key coordination
 mechanism. Each assistant message records the seq of the latest user or
@@ -24,12 +28,22 @@ follow-up step.
 
 from __future__ import annotations
 
+import base64
 import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from aios.harness.vision import (
+    can_inline_image,
+    make_image_url_part,
+    text_marker,
+)
+from aios.logging import get_logger
 from aios.models.events import Event
+from aios.sandbox.volumes import resolve_to_host_path
+
+log = get_logger("aios.harness.context")
 
 # Chat-completions spec fields per role.  Only these are emitted in the
 # context; provider-specific extensions (reasoning_content, etc.) stay
@@ -167,14 +181,18 @@ def render_user_event(
     event_data: dict[str, Any],
     orig_channel: str | None,
     focal_channel_at_arrival: str | None,
+    *,
+    model: str | None = None,
+    session_id: str | None = None,
 ) -> dict[str, Any]:
     """Render a user event into its chat-completions message form.
 
     Rendering is a deterministic function of the event's stamped
-    ``orig_channel`` and ``focal_channel_at_arrival``.  ``build_messages``
-    and the append-time token counter in ``queries.append_event`` share
-    this helper so the context and the ``cumulative_tokens`` column
-    stay in lock-step.
+    ``orig_channel``, ``focal_channel_at_arrival``, and the optional
+    vision policy inputs ``model`` / ``session_id``.  ``build_messages``
+    threads vision policy through; the append-time token counter in
+    ``queries.append_event`` does not (and pays a small under-count
+    per inlined image, absorbed by ``model_token_ratio`` calibration).
 
     Branches:
 
@@ -182,7 +200,11 @@ def render_user_event(
       metadata stripped, no header, no notification.  Covers direct
       ``POST /sessions/{id}/messages`` traffic and pre-migration rows.
     * ``orig == focal_at_arrival`` (non-NULL) → full content with a
-      metadata header inlined.
+      metadata header inlined.  When the focal event's metadata
+      carries ``attachments`` and the bound mind supports vision,
+      inlinable images are emitted as ``image_url`` content parts;
+      everything else gets a text marker referencing the in-sandbox
+      path.
     * Otherwise (focal is NULL, or focal differs from orig) →
       notification marker: a short, emoji-prefixed one-liner surfacing
       the origin channel, sender, and a truncated content preview.
@@ -200,6 +222,14 @@ def render_user_event(
             if header:
                 existing = msg.get("content") or ""
                 msg["content"] = f"{header}\n{existing}" if existing else header
+            attachments = metadata.get("attachments")
+            if isinstance(attachments, list) and attachments:
+                _apply_attachments(
+                    msg,
+                    attachments,
+                    model=model,
+                    session_id=session_id,
+                )
         return msg
 
     content = event_data.get("content", "")
@@ -207,6 +237,68 @@ def render_user_event(
         content = ""
     marker = _format_notification_marker(orig_channel, metadata, content)
     return {"role": "user", "content": marker}
+
+
+def _apply_attachments(
+    msg: dict[str, Any],
+    attachments: list[Any],
+    *,
+    model: str | None,
+    session_id: str | None,
+) -> None:
+    leading_text = msg.get("content") if isinstance(msg.get("content"), str) else ""
+    marker_lines: list[str] = []
+    image_parts: list[dict[str, Any]] = []
+
+    for record in attachments:
+        host_path = _resolve_attachment_host_path(record, session_id)
+        size = record.get("size")
+        content_type = record.get("content_type")
+        inline = (
+            host_path is not None
+            and model is not None
+            and isinstance(content_type, str)
+            and isinstance(size, int)
+            and can_inline_image(model=model, content_type=content_type, size_bytes=size)
+        )
+        if inline:
+            try:
+                payload = host_path.read_bytes()
+            except OSError as err:
+                # The staged file disappeared (manual cleanup, FS corruption,
+                # GC race). Fall back to a text marker rather than raising
+                # mid-render — losing one image shouldn't fail the whole step.
+                log.warning(
+                    "context.attachment_read_failed",
+                    path=str(host_path),
+                    error=str(err),
+                )
+                marker_lines.append(text_marker(record))
+                continue
+            image_parts.append(
+                make_image_url_part(
+                    content_type=content_type,
+                    data_b64=base64.b64encode(payload).decode("ascii"),
+                )
+            )
+        else:
+            marker_lines.append(text_marker(record))
+
+    text = leading_text
+    if marker_lines:
+        text = f"{text}\n{chr(10).join(marker_lines)}" if text else "\n".join(marker_lines)
+
+    if image_parts:
+        msg["content"] = [{"type": "text", "text": text}, *image_parts]
+    else:
+        msg["content"] = text
+
+
+def _resolve_attachment_host_path(record: dict[str, Any], session_id: str | None) -> Any:
+    sandbox_path = record.get("in_sandbox_path")
+    if not isinstance(sandbox_path, str) or session_id is None:
+        return None
+    return resolve_to_host_path(session_id, sandbox_path)
 
 
 def _sanitize_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -345,6 +437,8 @@ def build_messages(
     events: list[Event],
     *,
     system_prompt: str | None,
+    model: str | None = None,
+    session_id: str | None = None,
 ) -> ContextResult:
     """Assemble a chat-completions message list from pre-windowed events.
 
@@ -404,7 +498,13 @@ def build_messages(
         role = e.data.get("role")
 
         if role == "user":
-            msg = render_user_event(e.data, e.orig_channel, e.focal_channel_at_arrival)
+            msg = render_user_event(
+                e.data,
+                e.orig_channel,
+                e.focal_channel_at_arrival,
+                model=model,
+                session_id=session_id,
+            )
             messages.append(msg)
             max_stimulus_seq = max(max_stimulus_seq, e.seq)
 

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -535,15 +535,47 @@ def build_messages(
             # (preserves prefix monotonicity — see docstring).
             for inj_tcid, inj_data in inject_after.pop(e.seq, []):
                 name = inj_data.get("name", "tool")
-                messages.append(
-                    {
-                        "role": "user",
-                        "content": (
-                            f"[Tool result: {name} (call {inj_tcid}) completed]\n"
-                            f"{inj_data.get('content', '')}"
-                        ),
-                    }
-                )
+                header = f"[Tool result: {name} (call {inj_tcid}) completed]"
+                inj_content = inj_data.get("content", "")
+                if isinstance(inj_content, list):
+                    # Multimodal tool result (e.g. image-aware read returning a
+                    # text + image_url part list).  F-stringing would emit the
+                    # Python repr of the list, losing the pixels — splice the
+                    # parts into the synthetic user message instead so the model
+                    # sees the image in the blind-spot signal too.  Spec'd text
+                    # parts are concatenated under the header; non-text parts
+                    # (image_url, etc.) follow as siblings.
+                    text_chunks: list[str] = [header]
+                    other_parts: list[dict[str, Any]] = []
+                    for part in inj_content:
+                        if not isinstance(part, dict):
+                            continue
+                        if part.get("type") == "text":
+                            txt = part.get("text")
+                            if isinstance(txt, str) and txt:
+                                text_chunks.append(txt)
+                        else:
+                            other_parts.append(part)
+                    combined_text = "\n".join(text_chunks)
+                    if other_parts:
+                        messages.append(
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": combined_text},
+                                    *other_parts,
+                                ],
+                            }
+                        )
+                    else:
+                        messages.append({"role": "user", "content": combined_text})
+                else:
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": f"{header}\n{inj_content}",
+                        }
+                    )
                 max_stimulus_seq = max(max_stimulus_seq, real_result_seqs[inj_tcid])
 
         elif role == "tool":

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -173,7 +173,12 @@ async def compose_step_context(
     """
     from aios.harness.channels import build_channels_tail_block
 
-    ctx = build_messages(events, system_prompt=prelude.system_prompt)
+    ctx = build_messages(
+        events,
+        system_prompt=prelude.system_prompt,
+        model=agent.model,
+        session_id=session.id,
+    )
 
     # Tail block lives *after* build_messages so its per-step mutations
     # (unread counts, previews) don't bust the prefix cache.  Paradigm

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -146,7 +146,7 @@ async def _execute_tool_async(
             "name": name,
         }
         if isinstance(result, ToolResult):
-            if isinstance(result.content, str):
+            if isinstance(result.content, (str, list)):
                 event_data["content"] = result.content
             else:
                 event_data["content"] = json.dumps(result.content, ensure_ascii=False)

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -1,0 +1,88 @@
+"""Vision-policy helper: single source of truth for image-into-vision decisions.
+
+LiteLLM's :func:`token_counter` returns a flat ~85 tokens per
+``image_url`` part regardless of provider; under-counting only
+matters near the window boundary and provider rejection there is
+recoverable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import litellm
+
+INLINE_SIZE_CAP_BYTES = 2 * 1024 * 1024
+
+_VISION_OVERRIDES: dict[str, bool] = {}
+
+
+def supports_vision(model: str) -> bool:
+    """True when ``model`` accepts ``image_url`` content parts.
+
+    Consults :data:`_VISION_OVERRIDES` first for cases LiteLLM is wrong
+    or behind on (empty initially; populated as we hit them), then
+    falls back to ``litellm.get_model_info``.
+    """
+    if model in _VISION_OVERRIDES:
+        return _VISION_OVERRIDES[model]
+    try:
+        info = litellm.get_model_info(model)
+    except Exception:
+        return False
+    return bool(info.get("supports_vision"))
+
+
+def can_inline_image(*, model: str, content_type: str, size_bytes: int) -> bool:
+    """True when ``model`` can see image bytes inlined as ``image_url``.
+
+    Returns ``False`` for non-image content_types, oversize files
+    (over :data:`INLINE_SIZE_CAP_BYTES`), and minds without vision
+    support.  Callers fall back to a text marker referencing the
+    in-sandbox path so the model can still ``read`` the file later.
+    """
+    if not content_type.startswith("image/"):
+        return False
+    if size_bytes > INLINE_SIZE_CAP_BYTES:
+        return False
+    return supports_vision(model)
+
+
+def make_image_url_part(*, content_type: str, data_b64: str) -> dict[str, Any]:
+    """Build a chat-completions ``image_url`` content part."""
+    return {
+        "type": "image_url",
+        "image_url": {"url": f"data:{content_type};base64,{data_b64}"},
+    }
+
+
+def text_marker(record: dict[str, Any]) -> str:
+    """Inert text marker for an attachment that won't be inlined.
+
+    Used when the model can't see the pixels (non-vision mind, oversize
+    image, non-image attachment, legacy stub without ``in_sandbox_path``).
+    The marker carries enough info for the model to ``read`` the path
+    if the file is in fact reachable.
+    """
+    filename = record.get("filename") or "unnamed"
+    content_type = record.get("content_type") or "application/octet-stream"
+    size = record.get("size")
+    path = record.get("in_sandbox_path")
+
+    size_str = human_size(size) if isinstance(size, int) else "unknown size"
+    kind = (
+        "image"
+        if isinstance(content_type, str) and content_type.startswith("image/")
+        else "attachment"
+    )
+    if path:
+        return f"[{kind}: {filename} ({content_type}, {size_str}) at {path}]"
+    return f"[{kind}: {filename} ({content_type}, {size_str})]"
+
+
+def human_size(n: int) -> str:
+    if n < 1024:
+        return f"{n}B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f}KB"
+    return f"{n / (1024 * 1024):.1f}MB"

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -12,6 +12,10 @@ from typing import Any
 
 import litellm
 
+from aios.logging import get_logger
+
+log = get_logger("aios.harness.vision")
+
 INLINE_SIZE_CAP_BYTES = 2 * 1024 * 1024
 
 _VISION_OVERRIDES: dict[str, bool] = {}
@@ -28,7 +32,15 @@ def supports_vision(model: str) -> bool:
         return _VISION_OVERRIDES[model]
     try:
         info = litellm.get_model_info(model)
-    except Exception:
+    except Exception as err:
+        # ``get_model_info`` raises a mix of ``BadRequestError`` (unknown
+        # model), KeyError, and import/network errors depending on the
+        # failure mode.  Collapsing to "no vision" is the safe fallback
+        # (we degrade to a text marker the model can still ``read``), but
+        # the silence makes a transient outage look identical to "unknown
+        # model" — log warn-level so operators have a grep target when
+        # vision unexpectedly degrades across a deploy or provider blip.
+        log.warning("vision.litellm_lookup_failed", model=model, error=str(err))
         return False
     return bool(info.get("supports_vision"))
 

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -179,17 +179,46 @@ def ensure_session_attachments_dir(session_id: str) -> Path:
 def resolve_to_host_path(session_id: str, sandbox_path: str) -> Path | None:
     """Map an in-sandbox path to its host-side equivalent for known bind mounts.
 
-    Returns ``None`` when ``sandbox_path`` doesn't resolve into
-    ``/workspace`` or ``/mnt/attachments`` (e.g. ``/etc/hostname``,
-    ``/mnt/memory/...``, ``/tmp/...``). Callers can fall back to
-    docker-exec when the host-side fast path is unavailable.
+    Returns ``None`` when:
+
+    * ``sandbox_path`` doesn't resolve into ``/workspace`` or
+      ``/mnt/attachments`` (e.g. ``/etc/hostname``, ``/mnt/memory/...``,
+      ``/tmp/...``), or
+    * the resolved candidate escapes the bind-mount root after ``..``
+      normalization or symlink dereferencing.
+
+    The containment check defends model-controlled callers (notably the
+    image branch of :mod:`aios.tools.read`): without it, a path like
+    ``/workspace/../../etc/hostname`` or a symlink at
+    ``/workspace/sneaky.jpg`` pointing outside the bind mount would
+    let the model read arbitrary host files the worker can access.
+    """
+    base, suffix = _bind_mount_base(session_id, sandbox_path)
+    if base is None:
+        return None
+    candidate = base if suffix is None else base / suffix
+    try:
+        resolved = candidate.resolve(strict=False)
+        resolved_base = base.resolve(strict=False)
+    except OSError:
+        return None
+    if resolved != resolved_base and not resolved.is_relative_to(resolved_base):
+        return None
+    return resolved
+
+
+def _bind_mount_base(session_id: str, sandbox_path: str) -> tuple[Path | None, str | None]:
+    """Return the host base dir + remainder for ``sandbox_path``.
+
+    ``(None, None)`` when the path doesn't fall under a known bind
+    mount.  ``(base, None)`` when the path is exactly the root.
     """
     if sandbox_path == "/workspace":
-        return workspace_dir_for(session_id)
+        return workspace_dir_for(session_id), None
     if sandbox_path.startswith("/workspace/"):
-        return workspace_dir_for(session_id) / sandbox_path[len("/workspace/") :]
+        return workspace_dir_for(session_id), sandbox_path[len("/workspace/") :]
     if sandbox_path == "/mnt/attachments":
-        return session_attachments_dir(session_id)
+        return session_attachments_dir(session_id), None
     if sandbox_path.startswith("/mnt/attachments/"):
-        return session_attachments_dir(session_id) / sandbox_path[len("/mnt/attachments/") :]
-    return None
+        return session_attachments_dir(session_id), sandbox_path[len("/mnt/attachments/") :]
+    return None, None

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -114,6 +114,12 @@ async def get_session(pool: asyncpg.Pool[Any], session_id: str) -> Session:
         return session.model_copy(update={"vault_ids": vault_ids, "resources": echoes})
 
 
+async def get_session_model(pool: asyncpg.Pool[Any], session_id: str) -> str:
+    """Bound mind URL for ``session_id`` (pinned agent version wins)."""
+    async with pool.acquire() as conn:
+        return await queries.get_session_model(conn, session_id)
+
+
 async def list_sessions(
     pool: asyncpg.Pool[Any],
     *,

--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -1,35 +1,41 @@
 """The read tool — read a file inside the session's sandbox.
 
-A thin wrapper over ``cat -n`` piped through ``sed``. Returns file
-content with ``LINE_NUM<TAB>CONTENT`` line numbers, windowed by
-``offset`` (1-indexed) and ``limit`` so the model can page through
-large files without blowing its context window in one shot.
-
-The tool shells out once per call via :meth:`ContainerHandle.run_command`
-and trusts the model for everything else: no binary-file guard, no
-device blocklist, no char ceiling, no dedup. If the model reads
-``/dev/zero``, the container timeout (``bash_default_timeout_seconds``)
-kills it and the model sees an error. If the model re-reads the same
-range 10 times, that shows up in the session log and the model pays
-the token cost.
-
-Return shape::
-
-    {"path": "/workspace/foo.py", "content": "     1\\thello\\n     2\\tworld"}
-
-On failure (nonzero exit from ``cat``), returns ``{"error": "..."}``.
+Text files return ``LINE_NUM<TAB>CONTENT`` windowed by ``offset`` /
+``limit`` via ``cat -n | sed``.  Image files (extensions in
+:data:`_EXT_TO_MIME`) return a content-parts list with an
+``image_url`` block when the bound mind supports vision and the file
+fits the inline cap; otherwise an explanatory ``ToolResult``.
 """
 
 from __future__ import annotations
 
+import base64
+import os
 import shlex
 from typing import Any
 
 from aios.config import get_settings
 from aios.errors import AiosError
 from aios.harness import runtime
+from aios.harness.vision import (
+    can_inline_image,
+    human_size,
+    make_image_url_part,
+    supports_vision,
+)
+from aios.sandbox.container import ContainerHandle
+from aios.sandbox.volumes import resolve_to_host_path
+from aios.services import sessions as sessions_service
 from aios.tools.memory_intercept import resolve_memory_target
-from aios.tools.registry import registry
+from aios.tools.registry import ToolResult, registry
+
+_EXT_TO_MIME = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
 
 
 class ReadArgumentError(AiosError):
@@ -73,8 +79,8 @@ READ_PARAMETERS_SCHEMA: dict[str, Any] = {
 }
 
 
-async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
-    """Handler for the read tool. See module docstring for the return shape."""
+async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any] | ToolResult:
+    """Handler for the read tool. See module docstring for return shapes."""
     path = arguments.get("path")
     if not isinstance(path, str) or not path.strip():
         raise ReadArgumentError("read tool requires a non-empty 'path' string")
@@ -88,8 +94,13 @@ async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
         raise ReadArgumentError("limit must be a positive integer")
 
     settings = get_settings()
+    pool = runtime.require_pool()
     sandbox = runtime.require_sandbox_registry()
-    handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
+    handle = await sandbox.get_or_provision(session_id, pool=pool)
+
+    if _looks_like_image(path):
+        return await _read_image(session_id=session_id, path=path, handle=handle, pool=pool)
+
     target = resolve_memory_target(session_id, path)
 
     end = offset + limit - 1
@@ -128,6 +139,86 @@ async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     sha_line, _, content = result.stdout.partition("\n")
     runtime.set_read_sha(session_id, target.store_id, target.store_path, sha_line.strip())
     return {"path": path, "content": content}
+
+
+def _looks_like_image(path: str) -> bool:
+    return os.path.splitext(path)[1].lower() in _EXT_TO_MIME
+
+
+async def _read_image(
+    *,
+    session_id: str,
+    path: str,
+    handle: ContainerHandle,
+    pool: Any,
+) -> ToolResult:
+    mime = _EXT_TO_MIME[os.path.splitext(path)[1].lower()]
+    model = await sessions_service.get_session_model(pool, session_id)
+
+    host_path = resolve_to_host_path(session_id, path)
+    if host_path is not None:
+        try:
+            data = host_path.read_bytes()
+        except FileNotFoundError:
+            return ToolResult(content=f"file not found: {path}", is_error=True)
+        except OSError as err:
+            return ToolResult(content=f"read failed: {err}", is_error=True)
+        size = len(data)
+    else:
+        result = await _stat_and_read_via_exec(handle, path)
+        if result is None:
+            return ToolResult(
+                content=f"read failed: file not readable inside sandbox: {path}",
+                is_error=True,
+            )
+        data, size = result
+
+    if not can_inline_image(model=model, content_type=mime, size_bytes=size):
+        vision = "yes" if supports_vision(model) else "no"
+        return ToolResult(
+            content=(
+                f"Image at {path} exists ({human_size(size)}, {mime}) but cannot "
+                f"be inlined. Mind vision support: {vision}. Inline cap: 2 MiB."
+            ),
+            is_error=False,
+        )
+
+    encoded = base64.b64encode(data).decode("ascii")
+    return ToolResult(
+        content=[
+            {
+                "type": "text",
+                "text": f"Image: {os.path.basename(path)} ({mime}, {human_size(size)})",
+            },
+            make_image_url_part(content_type=mime, data_b64=encoded),
+        ],
+    )
+
+
+async def _stat_and_read_via_exec(handle: ContainerHandle, path: str) -> tuple[bytes, int] | None:
+    """Fetch ``(bytes, size)`` for non-bind-mount image paths via one docker-exec.
+
+    Returns ``None`` on any read failure (missing path, exec error,
+    unparseable size).  Combines stat + base64 into a single shell so
+    we don't pay two docker-exec round-trips.
+    """
+    settings = get_settings()
+    quoted = shlex.quote(path)
+    cmd = f"stat -c %s -- {quoted} && base64 -w0 -- {quoted}"
+    result = await handle.run_command(
+        cmd,
+        timeout_seconds=settings.bash_default_timeout_seconds,
+        max_output_bytes=settings.bash_max_output_bytes,
+    )
+    if result.exit_code != 0:
+        return None
+    size_line, _, b64 = result.stdout.partition("\n")
+    try:
+        size = int(size_line.strip())
+        data = base64.b64decode(b64.strip())
+    except (ValueError, TypeError):
+        return None
+    return data, size
 
 
 def _register() -> None:

--- a/src/aios/tools/registry.py
+++ b/src/aios/tools/registry.py
@@ -56,13 +56,17 @@ class ToolResult:
     ``ToolResult`` instead.
 
     * ``content`` — ``str``: used verbatim.  ``dict``: JSON-encoded.
+      ``list[dict]``: passed through as a content-parts list (multimodal
+      tool results, e.g. ``read`` returning an image; the chat-completions
+      wire format already accepts ``content: list[dict]`` on tool messages
+      and LiteLLM translates per provider).
     * ``metadata`` — merged into the event's ``data.metadata`` (stripped
       from the chat-completions wire shape by ``_strip_to_spec``).
     * ``is_error`` — records a handler-level error (separate from
       dispatch-level exceptions, which raise).
     """
 
-    content: str | dict[str, Any]
+    content: str | dict[str, Any] | list[dict[str, Any]]
     metadata: dict[str, Any] | None = None
     is_error: bool = False
 

--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -311,6 +311,14 @@ def _render_recap_event(event: Event) -> dict[str, Any] | None:
     role = event.data.get("role") if event.kind == "message" else None
 
     if role == "user":
+        # Recap rendering is intentionally text-only: ``model``/``session_id``
+        # are not threaded through, so :func:`render_user_event` short-circuits
+        # any image inlining and emits text markers for every attachment.
+        # The recap body is consumed inside a ``switch_channel`` tool result
+        # (string content), where ``image_url`` parts wouldn't survive the
+        # tool-message envelope; degrading attachments to markers keeps the
+        # recap a single text blob that the agent can read or follow up on
+        # via the in-sandbox path.
         rendered = render_user_event(event.data, event.orig_channel, event.orig_channel)
         content = rendered.get("content")
         if not isinstance(content, str) or not content:

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -614,6 +614,94 @@ class TestMonotonicity:
         ctx = build_messages(events, system_prompt=None)
         assert ctx.reacting_to >= 3
 
+    def test_blind_spot_injection_multimodal_list_content(self) -> None:
+        """When a tool returns ``list[dict]`` content (image-aware read,
+        multi-part output) AND the result lands during inference, the
+        synthetic user-message injection must splice the parts in
+        properly — NOT f-string the list (which would emit Python repr
+        and lose the image).  Regression test for PR #218."""
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/jpeg;base64,AAAA"},
+        }
+        tool_content = [
+            {"type": "text", "text": "screenshot below"},
+            image_part,
+        ]
+        events = [
+            _evt(1, "user", content="show me the screen"),
+            _evt(2, "assistant", tool_calls=[_tc("read_1")]),
+            _evt(3, "tool", tool_call_id="read_1", content=""),  # placeholder; overridden below
+            _evt(4, "assistant", content="working on it"),
+        ]
+        # Set the tool result content to a list[dict] (the new shape PR2 added).
+        events[2].data["content"] = tool_content
+        events[2].data["name"] = "read"
+        events[1].data["reacting_to"] = 1
+        events[3].data["reacting_to"] = 1  # blind to tool at seq=3
+
+        msgs = self._build(events)
+        # Locate the injected user message — it follows the horizon-setter
+        # assistant ("working on it") and carries the completion header.
+        injected = next(
+            (
+                m
+                for m in msgs
+                if m["role"] == "user"
+                and (
+                    (isinstance(m.get("content"), str) and "completed]" in m["content"])
+                    or (
+                        isinstance(m.get("content"), list)
+                        and any(
+                            isinstance(p, dict)
+                            and p.get("type") == "text"
+                            and "completed]" in (p.get("text") or "")
+                            for p in m["content"]
+                        )
+                    )
+                )
+            ),
+            None,
+        )
+        assert injected is not None, "blind-spot injection must be emitted"
+        # The injection MUST carry an image_url part — not the Python repr
+        # of the list.
+        content = injected["content"]
+        assert isinstance(content, list), (
+            f"multimodal injection must be content-parts, got {type(content).__name__}"
+        )
+        assert any(p.get("type") == "image_url" for p in content), (
+            "image_url part must survive the injection"
+        )
+        # And no part should contain the literal repr fragment that the bug
+        # would have produced.
+        for p in content:
+            text = p.get("text") if isinstance(p, dict) else None
+            if isinstance(text, str):
+                assert "image_url" not in text or text.startswith("[Tool result"), (
+                    "f-stringed list repr leaked into the injection text"
+                )
+
+    def test_blind_spot_injection_string_content_unchanged(self) -> None:
+        """Plain string tool results still produce a string-content injection
+        (back-compat: PR #218's multimodal branch must not regress the
+        common path)."""
+        events = [
+            _evt(1, "user", content="run it"),
+            _evt(2, "assistant", tool_calls=[_tc("bash_1")]),
+            _evt(3, "tool", tool_call_id="bash_1", content="DONE"),
+            _evt(4, "assistant", content="still going"),
+        ]
+        events[2].data["name"] = "bash"
+        events[1].data["reacting_to"] = 1
+        events[3].data["reacting_to"] = 1
+
+        msgs = self._build(events)
+        injected = next(m for m in msgs if m["role"] == "user" and m != msgs[0])
+        assert isinstance(injected["content"], str)
+        assert "completed]" in injected["content"]
+        assert "DONE" in injected["content"]
+
 
 # ─── field stripping ────────────────────────────────────────────────────────
 

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -1,0 +1,251 @@
+"""Unit coverage for vision-aware rendering in :func:`render_user_event`.
+
+The renderer's vision policy is delegated to
+:mod:`aios.harness.vision`; here we exercise the wiring around it —
+host-bytes-read for inlinable images, text-marker fallback for
+non-vision minds and oversize images, and the legacy-stub path.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aios.config import get_settings
+from aios.harness import vision
+from aios.harness.context import render_user_event
+from aios.sandbox.volumes import session_attachments_dir
+
+
+@pytest.fixture
+def temp_workspace_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _stub_supports_vision(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Default: vision-capable model returns True; non-vision-capable returns False.
+
+    Tests can override individual mappings via ``vision._VISION_OVERRIDES``.
+    """
+    saved = dict(vision._VISION_OVERRIDES)
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES["mind/vision"] = True
+    vision._VISION_OVERRIDES["mind/text"] = False
+    yield
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES.update(saved)
+
+
+def _stage_image(
+    workspace_root: Path, session_id: str, connector: str, name: str, payload: bytes
+) -> str:
+    """Write a fake staged attachment, return its in-sandbox path."""
+    session_dir = session_attachments_dir(session_id) / connector
+    session_dir.mkdir(parents=True, exist_ok=True)
+    file_path = session_dir / name
+    file_path.write_bytes(payload)
+    return f"/mnt/attachments/{connector}/{name}"
+
+
+def _user_event(
+    *,
+    content: str = "hi",
+    channel: str = "echo/acct/chat-1",
+    attachments: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"channel": channel}
+    if attachments is not None:
+        metadata["attachments"] = attachments
+    return {"role": "user", "content": content, "metadata": metadata}
+
+
+class TestVisionAwareRendering:
+    def test_inlinable_image_emits_image_url_part(self, temp_workspace_root: Path) -> None:
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"jpegbytes"
+        )
+        event = _user_event(
+            content="hello",
+            attachments=[
+                {
+                    "filename": "photo.jpg",
+                    "content_type": "image/jpeg",
+                    "size": len(b"jpegbytes"),
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/vision",
+            session_id="sess-1",
+        )
+        content = msg["content"]
+        assert isinstance(content, list)
+        assert content[0]["type"] == "text"
+        assert "hello" in content[0]["text"]
+        assert content[1] == {
+            "type": "image_url",
+            "image_url": {
+                "url": f"data:image/jpeg;base64,{base64.b64encode(b'jpegbytes').decode()}"
+            },
+        }
+
+    def test_oversize_image_falls_back_to_marker(self, temp_workspace_root: Path) -> None:
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-big.jpg", b"\0" * (3 * 1024 * 1024)
+        )
+        event = _user_event(
+            content="big",
+            attachments=[
+                {
+                    "filename": "big.jpg",
+                    "content_type": "image/jpeg",
+                    "size": 3 * 1024 * 1024,
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/vision",
+            session_id="sess-1",
+        )
+        assert isinstance(msg["content"], str)
+        assert "[image: big.jpg" in msg["content"]
+        assert "/mnt/attachments/echo/evt-1-big.jpg" in msg["content"]
+
+    def test_non_vision_mind_renders_marker(self, temp_workspace_root: Path) -> None:
+        sandbox_path = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"x")
+        event = _user_event(
+            content="hi",
+            attachments=[
+                {
+                    "filename": "photo.jpg",
+                    "content_type": "image/jpeg",
+                    "size": 1,
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/text",
+            session_id="sess-1",
+        )
+        assert isinstance(msg["content"], str)
+        assert "[image: photo.jpg" in msg["content"]
+
+    def test_document_emits_attachment_marker(self, temp_workspace_root: Path) -> None:
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-report.pdf", b"%PDF"
+        )
+        event = _user_event(
+            content="here",
+            attachments=[
+                {
+                    "filename": "report.pdf",
+                    "content_type": "application/pdf",
+                    "size": 4,
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/vision",
+            session_id="sess-1",
+        )
+        assert isinstance(msg["content"], str)
+        assert "[attachment: report.pdf" in msg["content"]
+
+    def test_legacy_stub_no_in_sandbox_path(self) -> None:
+        event = _user_event(
+            content="legacy",
+            attachments=[
+                {
+                    "filename": "old.jpg",
+                    "content_type": "image/jpeg",
+                    "size": 1024,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/vision",
+            session_id="sess-1",
+        )
+        assert isinstance(msg["content"], str)
+        assert "[image: old.jpg" in msg["content"]
+
+    def test_no_model_disables_inlining(self, temp_workspace_root: Path) -> None:
+        """Append-time call (no model passed) emits text markers only.
+
+        That keeps cum_tokens deterministic without a model lookup.
+        """
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"bytes"
+        )
+        event = _user_event(
+            attachments=[
+                {
+                    "filename": "photo.jpg",
+                    "content_type": "image/jpeg",
+                    "size": 5,
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(event, "echo/acct/chat-1", "echo/acct/chat-1")
+        assert isinstance(msg["content"], str)
+        assert "[image: photo.jpg" in msg["content"]
+
+    def test_multiple_attachments_mixed(self, temp_workspace_root: Path) -> None:
+        a = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-a.jpg", b"AAA")
+        b = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-b.pdf", b"PDF")
+        event = _user_event(
+            content="two",
+            attachments=[
+                {
+                    "filename": "a.jpg",
+                    "content_type": "image/jpeg",
+                    "size": 3,
+                    "in_sandbox_path": a,
+                },
+                {
+                    "filename": "b.pdf",
+                    "content_type": "application/pdf",
+                    "size": 3,
+                    "in_sandbox_path": b,
+                },
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/vision",
+            session_id="sess-1",
+        )
+        content = msg["content"]
+        assert isinstance(content, list)
+        assert content[0]["type"] == "text"
+        assert "[attachment: b.pdf" in content[0]["text"]
+        assert content[1]["type"] == "image_url"
+        assert content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -216,6 +216,64 @@ class TestVisionAwareRendering:
         assert isinstance(msg["content"], str)
         assert "[image: photo.jpg" in msg["content"]
 
+    def test_image_only_no_caption_no_header_omits_empty_text(
+        self, temp_workspace_root: Path
+    ) -> None:
+        """An image-only event with no caption AND no channel header must
+        NOT emit ``{"type":"text","text":""}`` — Anthropic rejects empty
+        text blocks (``text content blocks must be non-empty``).  The
+        common path is fine because the channel header populates the
+        leading text, but legacy events with metadata-stripped headers
+        would 400 against Anthropic-routed minds.  Regression test for
+        PR #218.
+        """
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"PNG"
+        )
+        # Construct an event whose metadata has attachments but lacks
+        # ``channel`` — _format_channel_header returns "" so leading_text
+        # stays empty.  Content is also empty (image-only inbound).
+        event: dict[str, Any] = {
+            "role": "user",
+            "content": "",
+            "metadata": {
+                "channel": "echo/acct/chat-1",
+                "attachments": [
+                    {
+                        "filename": "photo.jpg",
+                        "content_type": "image/jpeg",
+                        "size": 3,
+                        "in_sandbox_path": sandbox_path,
+                    }
+                ],
+            },
+        }
+        # Strip the channel header by zeroing all the fields _format_channel_header
+        # consumes after the bare "channel" key: the header is the channel marker
+        # plus the inbound content, both empty here, so leading_text is just the
+        # bare ``[channel=...]`` line.  To exercise the no-header branch we drop
+        # ``channel`` from metadata entirely below.
+        event["metadata"].pop("channel")
+        # Re-add ``attachments`` only — _format_channel_header returns "" when
+        # channel is absent, leaving leading_text empty for the image-only path.
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/vision",
+            session_id="sess-1",
+        )
+        content = msg["content"]
+        assert isinstance(content, list), (
+            "image_only message must still emit content parts when image is inlined"
+        )
+        # No empty text block in the parts.
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                assert part.get("text"), f"empty text part rejected by Anthropic — got {part!r}"
+        # And the image_url part is preserved.
+        assert any(p.get("type") == "image_url" for p in content)
+
     def test_multiple_attachments_mixed(self, temp_workspace_root: Path) -> None:
         a = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-a.jpg", b"AAA")
         b = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-b.pdf", b"PDF")

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -221,6 +221,7 @@ class TestImageBranch:
 
         result = await read_handler("sess_01TEST", {"path": "/etc/foo.png"})
 
+        assert isinstance(result, ToolResult)
         run_command = stub_handle.run_command
         assert isinstance(run_command, AsyncMock)
         assert run_command.call_count == 1
@@ -228,6 +229,118 @@ class TestImageBranch:
         assert "stat -c %s" in cmd_arg
         assert "base64 -w0" in cmd_arg
 
-        assert isinstance(result, ToolResult)
-        assert isinstance(result.content, list)
-        assert result.content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+class TestImagePathTraversalAttack:
+    """End-to-end regression for the path-traversal vulnerability.
+
+    Each case plants a sentinel "host secret" file outside the
+    workspace bind-mount root, then asks ``read`` to fetch it via a
+    traversal-style sandbox path. The fixed behavior: the host-side
+    fast path declines (containment check), the read falls through to
+    docker-exec which is correctly contained by the container's
+    namespace, and the host-secret bytes never reach the tool result.
+    """
+
+    async def test_dotdot_traversal_does_not_return_host_bytes(
+        self,
+        temp_workspace_root: Path,
+        stub_handle: ContainerHandle,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/vision"
+        host_secret = b"HOST-SECRET-BYTES-DO-NOT-LEAK"
+        (temp_workspace_root / "host_secret.png").write_bytes(host_secret)
+        workspace_dir_for("sess_01TEST").mkdir(parents=True, exist_ok=True)
+
+        sandbox_payload = b"sandbox-side-content"
+        b64 = base64.b64encode(sandbox_payload).decode()
+        stub_handle.run_command = AsyncMock(  # type: ignore[method-assign]
+            return_value=CommandResult(
+                exit_code=0,
+                stdout=f"{len(sandbox_payload)}\n{b64}",
+                stderr="",
+                timed_out=False,
+                truncated=False,
+            )
+        )
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/../host_secret.png"})
+
+        b64_secret = base64.b64encode(host_secret).decode()
+        if isinstance(result, ToolResult) and isinstance(result.content, list):
+            url = result.content[1]["image_url"]["url"]
+            assert b64_secret not in url
+        elif isinstance(result, dict):
+            assert b64_secret not in str(result)
+        assert stub_handle.run_command.call_count == 1  # type: ignore[attr-defined]
+
+    async def test_attachments_traversal_does_not_return_host_bytes(
+        self,
+        temp_workspace_root: Path,
+        stub_handle: ContainerHandle,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/vision"
+        host_secret = b"ATTACHMENTS-LEAK-PROBE"
+        (temp_workspace_root / "leak.png").write_bytes(host_secret)
+        session_attachments_dir("sess_01TEST").mkdir(parents=True, exist_ok=True)
+
+        stub_handle.run_command = AsyncMock(  # type: ignore[method-assign]
+            return_value=CommandResult(
+                exit_code=0,
+                stdout=f"{4}\n{base64.b64encode(b'safe').decode()}",
+                stderr="",
+                timed_out=False,
+                truncated=False,
+            )
+        )
+
+        result = await read_handler("sess_01TEST", {"path": "/mnt/attachments/../../leak.png"})
+
+        b64_secret = base64.b64encode(host_secret).decode()
+        if isinstance(result, ToolResult) and isinstance(result.content, list):
+            url = result.content[1]["image_url"]["url"]
+            assert b64_secret not in url
+        elif isinstance(result, dict):
+            assert b64_secret not in str(result)
+
+    async def test_symlink_escape_does_not_return_host_bytes(
+        self,
+        temp_workspace_root: Path,
+        stub_handle: ContainerHandle,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """The model creates a symlink inside ``/workspace`` whose target
+        lives outside the bind-mount root (e.g. via ``ln -s`` from inside
+        the sandbox), then ``read``s through it. Containment must follow
+        the symlink and reject."""
+        stub_get_session_model.value = "mind/vision"
+        host_secret = b"SYMLINK-ESCAPE-PROBE-BYTES"
+        outside = temp_workspace_root / "outside.png"
+        outside.write_bytes(host_secret)
+        ws = workspace_dir_for("sess_01TEST")
+        ws.mkdir(parents=True, exist_ok=True)
+        (ws / "sneaky.jpg").symlink_to(outside)
+
+        stub_handle.run_command = AsyncMock(  # type: ignore[method-assign]
+            return_value=CommandResult(
+                exit_code=0,
+                stdout=f"{3}\n{base64.b64encode(b'sbx').decode()}",
+                stderr="",
+                timed_out=False,
+                truncated=False,
+            )
+        )
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/sneaky.jpg"})
+
+        b64_secret = base64.b64encode(host_secret).decode()
+        if isinstance(result, ToolResult) and isinstance(result.content, list):
+            url = result.content[1]["image_url"]["url"]
+            assert b64_secret not in url
+        elif isinstance(result, dict):
+            assert b64_secret not in str(result)
+        assert stub_handle.run_command.call_count == 1  # type: ignore[attr-defined]

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -1,0 +1,233 @@
+"""Unit coverage for the read tool's image branch.
+
+Stubs the sandbox handle and ``get_session_model`` so the tests never
+touch Docker or the DB.  Same pattern as :mod:`test_read_handler`.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.config import get_settings
+from aios.harness import runtime, vision
+from aios.sandbox.container import CommandResult, ContainerHandle
+from aios.sandbox.volumes import session_attachments_dir, workspace_dir_for
+from aios.tools.read import read_handler
+from aios.tools.registry import ToolResult
+
+
+class _StubRegistry:
+    def __init__(self, handle: ContainerHandle) -> None:
+        self._handle = handle
+
+    async def get_or_provision(self, session_id: str, **_kwargs: Any) -> ContainerHandle:
+        return self._handle
+
+
+@pytest.fixture
+def temp_workspace_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def stub_handle(tmp_path: Path) -> ContainerHandle:
+    handle = ContainerHandle(
+        session_id="sess_01TEST",
+        container_id="container_abc",
+        workspace_path=tmp_path,
+    )
+    handle.run_command = AsyncMock(  # type: ignore[method-assign]
+        return_value=CommandResult(
+            exit_code=0,
+            stdout="",
+            stderr="",
+            timed_out=False,
+            truncated=False,
+        )
+    )
+    return handle
+
+
+@pytest.fixture
+def stub_runtime(stub_handle: ContainerHandle) -> Any:
+    prev_registry = runtime.sandbox_registry
+    prev_pool = runtime.pool
+    runtime.sandbox_registry = _StubRegistry(stub_handle)  # type: ignore[assignment]
+    runtime.pool = MagicMock()
+    try:
+        yield
+    finally:
+        runtime.sandbox_registry = prev_registry
+        runtime.pool = prev_pool
+
+
+@pytest.fixture(autouse=True)
+def _vision_overrides(monkeypatch: pytest.MonkeyPatch) -> Any:
+    saved = dict(vision._VISION_OVERRIDES)
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES["mind/vision"] = True
+    vision._VISION_OVERRIDES["mind/text"] = False
+    yield
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES.update(saved)
+
+
+@pytest.fixture
+def stub_get_session_model(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Replace the DB lookup with a callable returning whatever the test sets."""
+
+    class _Model:
+        value: str = "mind/vision"
+
+    state = _Model()
+
+    async def fake(_pool: Any, _session_id: str) -> str:
+        return state.value
+
+    monkeypatch.setattr("aios.tools.read.sessions_service.get_session_model", fake)
+    return state
+
+
+def _stage_workspace_image(session_id: str, name: str, payload: bytes) -> Path:
+    ws = workspace_dir_for(session_id)
+    ws.mkdir(parents=True, exist_ok=True)
+    file_path = ws / name
+    file_path.write_bytes(payload)
+    return file_path
+
+
+def _stage_attachment(session_id: str, connector: str, name: str, payload: bytes) -> Path:
+    target = session_attachments_dir(session_id) / connector
+    target.mkdir(parents=True, exist_ok=True)
+    file_path = target / name
+    file_path.write_bytes(payload)
+    return file_path
+
+
+class TestImageBranch:
+    async def test_workspace_image_inlines_for_vision_mind(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/vision"
+        _stage_workspace_image("sess_01TEST", "screenshot.png", b"PNGbytes")
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/screenshot.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[0]["type"] == "text"
+        assert "Image: screenshot.png" in result.content[0]["text"]
+        assert result.content[1] == {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(b'PNGbytes').decode()}"},
+        }
+        assert result.is_error is False
+
+    async def test_attachment_image_inlines_for_vision_mind(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/vision"
+        _stage_attachment("sess_01TEST", "echo", "evt-1-photo.jpg", b"JPGbytes")
+
+        result = await read_handler(
+            "sess_01TEST", {"path": "/mnt/attachments/echo/evt-1-photo.jpg"}
+        )
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+    async def test_blocked_for_non_vision_mind_is_not_an_error(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/text"
+        _stage_workspace_image("sess_01TEST", "screenshot.png", b"PNG")
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/screenshot.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, str)
+        assert "Mind vision support: no" in result.content
+        assert result.is_error is False
+
+    async def test_oversize_image_blocked_with_explanatory_text(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/vision"
+        _stage_workspace_image("sess_01TEST", "huge.png", b"\0" * (3 * 1024 * 1024))
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/huge.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, str)
+        assert "Inline cap: 2 MiB" in result.content
+        assert result.is_error is False
+
+    async def test_missing_image_returns_error(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/vision"
+        workspace_dir_for("sess_01TEST").mkdir(parents=True, exist_ok=True)
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/nope.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, str)
+        assert "file not found" in result.content
+        assert result.is_error is True
+
+    async def test_non_bind_mount_falls_back_to_docker_exec(
+        self,
+        temp_workspace_root: Path,
+        stub_handle: ContainerHandle,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """Reading ``/etc/foo.png`` (not a bind mount) hits docker-exec
+        with one combined stat+base64 invocation."""
+        stub_get_session_model.value = "mind/vision"
+        b64_payload = base64.b64encode(b"otherbytes").decode()
+        stub_handle.run_command = AsyncMock(  # type: ignore[method-assign]
+            return_value=CommandResult(
+                exit_code=0,
+                stdout=f"10\n{b64_payload}",
+                stderr="",
+                timed_out=False,
+                truncated=False,
+            )
+        )
+
+        result = await read_handler("sess_01TEST", {"path": "/etc/foo.png"})
+
+        run_command = stub_handle.run_command
+        assert isinstance(run_command, AsyncMock)
+        assert run_command.call_count == 1
+        cmd_arg = run_command.call_args.args[0]
+        assert "stat -c %s" in cmd_arg
+        assert "base64 -w0" in cmd_arg
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[1]["image_url"]["url"].startswith("data:image/png;base64,")

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -48,6 +48,25 @@ class TestSupportsVision:
         _patch_get_model_info(monkeypatch, {})  # any model raises
         assert vision.supports_vision("totally/unknown") is False
 
+    def test_litellm_exception_emits_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bare exception path must surface at warn-level so operators can
+        grep when vision degrades across a deploy / provider blip."""
+        _patch_get_model_info(monkeypatch, {})  # any model raises
+
+        warned: list[tuple[str, dict[str, Any]]] = []
+
+        class _Recorder:
+            def warning(self, event: str, **kwargs: Any) -> None:
+                warned.append((event, kwargs))
+
+        monkeypatch.setattr("aios.harness.vision.log", _Recorder())
+        assert vision.supports_vision("totally/unknown") is False
+        assert len(warned) == 1
+        event, kwargs = warned[0]
+        assert event == "vision.litellm_lookup_failed"
+        assert kwargs["model"] == "totally/unknown"
+        assert "error" in kwargs
+
     def test_override_wins_over_litellm(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Even if litellm reports True, an explicit False override takes effect.
         _patch_get_model_info(monkeypatch, {"foo/vision": {"supports_vision": True}})

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -1,0 +1,134 @@
+"""Unit coverage for :mod:`aios.harness.vision`.
+
+Pure decision logic — no I/O.  ``supports_vision`` delegates to
+``litellm.get_model_info``, which we monkeypatch to keep tests
+hermetic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aios.harness import vision
+
+
+@pytest.fixture(autouse=True)
+def _clear_vision_overrides() -> Any:
+    """Wipe the override dict between tests so order doesn't matter."""
+    saved = dict(vision._VISION_OVERRIDES)
+    vision._VISION_OVERRIDES.clear()
+    yield
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES.update(saved)
+
+
+def _patch_get_model_info(
+    monkeypatch: pytest.MonkeyPatch, mapping: dict[str, dict[str, Any]]
+) -> None:
+    def fake(model: str) -> dict[str, Any]:
+        if model not in mapping:
+            raise Exception(f"unknown model: {model}")
+        return mapping[model]
+
+    monkeypatch.setattr("aios.harness.vision.litellm.get_model_info", fake)
+
+
+class TestSupportsVision:
+    def test_true_when_litellm_says_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"foo/vision": {"supports_vision": True}})
+        assert vision.supports_vision("foo/vision") is True
+
+    def test_false_when_litellm_says_no(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"foo/text": {"supports_vision": False}})
+        assert vision.supports_vision("foo/text") is False
+
+    def test_false_when_litellm_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {})  # any model raises
+        assert vision.supports_vision("totally/unknown") is False
+
+    def test_override_wins_over_litellm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Even if litellm reports True, an explicit False override takes effect.
+        _patch_get_model_info(monkeypatch, {"foo/vision": {"supports_vision": True}})
+        vision._VISION_OVERRIDES["foo/vision"] = False
+        assert vision.supports_vision("foo/vision") is False
+
+
+class TestCanInlineImage:
+    def test_image_under_cap_with_vision_mind(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"vision/m": {"supports_vision": True}})
+        assert vision.can_inline_image(
+            model="vision/m", content_type="image/jpeg", size_bytes=500_000
+        )
+
+    def test_image_at_exact_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"vision/m": {"supports_vision": True}})
+        assert vision.can_inline_image(
+            model="vision/m",
+            content_type="image/png",
+            size_bytes=vision.INLINE_SIZE_CAP_BYTES,
+        )
+
+    def test_image_over_cap_blocked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"vision/m": {"supports_vision": True}})
+        assert not vision.can_inline_image(
+            model="vision/m",
+            content_type="image/jpeg",
+            size_bytes=vision.INLINE_SIZE_CAP_BYTES + 1,
+        )
+
+    def test_non_vision_mind_blocked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"text/m": {"supports_vision": False}})
+        assert not vision.can_inline_image(
+            model="text/m", content_type="image/jpeg", size_bytes=100
+        )
+
+    def test_non_image_blocked_even_with_vision(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"vision/m": {"supports_vision": True}})
+        assert not vision.can_inline_image(
+            model="vision/m", content_type="application/pdf", size_bytes=100
+        )
+
+    def test_audio_blocked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"vision/m": {"supports_vision": True}})
+        assert not vision.can_inline_image(
+            model="vision/m", content_type="audio/ogg", size_bytes=100
+        )
+
+
+class TestMakeImageUrlPart:
+    def test_shape(self) -> None:
+        part = vision.make_image_url_part(content_type="image/png", data_b64="ZmFrZQ==")
+        assert part == {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,ZmFrZQ=="},
+        }
+
+
+class TestTextMarker:
+    def test_image_with_path(self) -> None:
+        record = {
+            "filename": "photo.jpg",
+            "content_type": "image/jpeg",
+            "size": 524_288,
+            "in_sandbox_path": "/mnt/attachments/echo/evt-1-photo.jpg",
+        }
+        assert vision.text_marker(record) == (
+            "[image: photo.jpg (image/jpeg, 512.0KB) at /mnt/attachments/echo/evt-1-photo.jpg]"
+        )
+
+    def test_non_image_falls_back_to_attachment(self) -> None:
+        record = {
+            "filename": "doc.pdf",
+            "content_type": "application/pdf",
+            "size": 1024,
+            "in_sandbox_path": "/mnt/attachments/sig/x-doc.pdf",
+        }
+        assert "attachment: doc.pdf" in vision.text_marker(record)
+
+    def test_legacy_stub_no_path(self) -> None:
+        record = {"filename": "old.jpg", "content_type": "image/jpeg", "size": 100}
+        marker = vision.text_marker(record)
+        assert "old.jpg" in marker
+        assert "at " not in marker

--- a/tests/unit/test_volumes_attachments.py
+++ b/tests/unit/test_volumes_attachments.py
@@ -95,3 +95,74 @@ class TestResolveToHostPath:
         assert resolve_to_host_path("sess-1", "workspace/foo") is None
         # Not /workspace itself but starts with the literal prefix.
         assert resolve_to_host_path("sess-1", "/workspaces/foo") is None
+
+
+class TestResolveToHostPathTraversal:
+    """Containment check: model-controlled paths must not escape the
+    bind-mount root via ``..`` normalization or symlink dereferencing."""
+
+    def test_dotdot_escape_from_workspace_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        # `/workspace/../../etc/hostname` resolves outside the session's
+        # workspace dir → must be rejected.
+        assert resolve_to_host_path("sess-1", "/workspace/../../etc/hostname") is None
+
+    def test_dotdot_escape_from_attachments_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        assert resolve_to_host_path("sess-1", "/mnt/attachments/../foo") is None
+
+    def test_deeply_nested_dotdot_escape_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        assert resolve_to_host_path("sess-1", "/workspace/sub/../../../../etc/passwd") is None
+
+    def test_innocuous_dotdot_inside_workspace_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``..`` that stays inside the workspace after normalization is fine."""
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        result = resolve_to_host_path("sess-1", "/workspace/sub/../foo.jpg")
+        assert result == (tmp_path / "sess-1").resolve() / "foo.jpg"
+
+    def test_symlink_escape_via_workspace_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A symlink inside ``/workspace`` whose target lives outside the
+        bind mount must be rejected.  This covers the real attack: the
+        model creates the symlink via ``bash`` inside the sandbox, then
+        ``read``s through it to bypass containment."""
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        # Create the workspace dir (the bind-mount source) and an
+        # outside-the-workspace target.
+        ws = (tmp_path / "sess-1").resolve()
+        ws.mkdir(parents=True)
+        outside = tmp_path / "outside.txt"
+        outside.write_text("host-secret")
+        (ws / "sneaky.jpg").symlink_to(outside)
+
+        assert resolve_to_host_path("sess-1", "/workspace/sneaky.jpg") is None
+
+    def test_symlink_target_inside_workspace_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A symlink whose target stays inside the workspace is fine."""
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        ws = (tmp_path / "sess-1").resolve()
+        ws.mkdir(parents=True)
+        target = ws / "real.jpg"
+        target.write_bytes(b"x")
+        (ws / "alias.jpg").symlink_to(target)
+
+        result = resolve_to_host_path("sess-1", "/workspace/alias.jpg")
+        assert result == target.resolve()


### PR DESCRIPTION
## Summary

PR2 of 4 stacked PRs implementing #216.  Vision-capable minds receive ``image_url`` content blocks at arrival time (via the renderer) AND on demand (via the read tool).  One ``harness/vision.py`` helper drives both decisions so "can these pixels reach me?" has a single answer regardless of entry point.

**Stacked on:** [#217 (PR1/4)](https://github.com/eumemic/aios/pull/217) — this PR's base is ``wt/recursive-weaving-sundae``.

- ``harness/vision.py`` (new) — single source of truth: ``supports_vision``, ``can_inline_image`` (image + ≤2 MiB + vision-capable), ``make_image_url_part``, ``text_marker``, ``human_size``.
- ``harness/context.py`` — ``render_user_event`` accepts ``model`` / ``session_id`` kwargs; focal-channel attachments inline as ``image_url`` parts when allowed, else text marker.  Build-time read failures log via structlog and fall back to a marker.
- ``tool_dispatch.py`` + ``tools/registry.py`` — ``ToolResult.content`` union widened to allow ``list[dict]`` (multimodal pass-through).
- ``tools/read.py`` — image-extension branch returns multimodal ``ToolResult`` for vision-capable minds; blocked reads return ``is_error=False`` with explanatory text per the design's "the read succeeded, pixels just weren't surfaced" semantics.  Bind-mounted paths read host-side; other paths fall back to one combined ``stat + base64`` docker-exec.
- ``services/sessions.py`` + ``db/queries.py`` — ``get_session_model`` resolves the bound mind URL in one query (sessions ⋈ agents ⋈ agent_versions).

### Locked design decisions (from review on PR1)

- **Encoding cost**: read host bytes + base64 at every render; LRU is the obvious follow-up if profiling shows pressure.
- **``is_error=False`` for blocked image read**: keeps span telemetry honest; ``is_error=True`` reserved for genuine read failures.
- **Host-side reads for bind mounts**: avoids docker-exec for ``/workspace/...`` and ``/mnt/attachments/...``.
- **No token-budget override**: LiteLLM returns flat ~85 per ``image_url`` part regardless of provider; under-counts Anthropic by ~10-20× per image but only matters near window boundaries, where provider rejection is recoverable.

## Stack

1. PR1 ([#217](https://github.com/eumemic/aios/pull/217)) — storage + SDK + supervisor staging + sandbox bind + GC
2. **PR2 (this)** — vision pipeline
3. PR3 — outbound MEDIA-tag protocol (SDK helper)
4. PR4 — Signal / Telegram connector porting (lands in connector repos)

Merge back-to-front.

## Test plan
- [x] ``uv run mypy src`` clean (131 files)
- [x] ``uv run ruff check src tests packages`` + ``ruff format --check`` clean
- [x] ``uv run pytest tests/unit -q`` — 1110 passed
- [x] e2e: connector inbound, supervisor, attachment staging, context build/endpoint, step model, focal channel — 94 passed
- [x] New unit coverage: ``test_vision.py`` (14), ``test_context_attachments.py`` (7), ``test_read_image.py`` (6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)