### PR TITLE
feat(connectors): outbound MEDIA-tag wiring for signal_send + telegram_send (#216, PR5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ venv/
 # aios runtime state
 /var/lib/aios/
 workspaces/
+
+# smoke-test runtime artifacts
+.logs/
+spool.sqlite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,6 @@ They don't share connections; they share Postgres state.
 - **Raw SQL + asyncpg**, no ORM. Every query lives in `db/queries.py`.
 - **`pg_notify($1, $2)` function form**, never literal `NOTIFY`. Postgres case-folds unquoted identifiers; our ULIDs have uppercase.
 - **structlog** with `structlog.stdlib.LoggerFactory()`. NOT `PrintLoggerFactory`.
-- **"Mind" not "brain"** — load-bearing terminology for the model/inference concept.
 - **Extreme simplicity.** No defensive guards for model mistakes, no fuzzy matching, no model-specific shims. The model sees raw errors and retries through the session log. Ask: "can the model handle this failure itself?" If yes, don't add complexity.
 - **Events are OpenAI chat-completions format**, not Anthropic Messages format. LiteLLM translates at the provider boundary.
 - **Conventional commits**: `feat:`, `fix:`, `refactor:`, etc. Substantial commit bodies.

--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -97,9 +97,21 @@ That env var is removed cleanly — set `AIOS_SIGNAL_PHONES=+1...` (a
 one-element CSV) for an equivalent single-phone deployment.  Multi-
 phone setups become `AIOS_SIGNAL_PHONES=+1...,+2...`.
 
+## Attachments
+
+Inbound photos, voice notes, and documents surface to the model as
+`image_url` content parts (vision-capable minds) or text markers,
+via the harness's vision pipeline.  Each file is staged under
+`<workspace_root>/_attachments/<session>/signal/...` and made
+readable inside the sandbox at `/mnt/attachments/signal/...`.
+
+Outbound: pass an `attachments: list[str]` parameter to
+`signal_send` alongside `text`.  Each path must be under
+`/workspace/` or `/mnt/attachments/` (the latter is read-only, so to
+forward an inbound file `cp` it into `/workspace/` first).
+
 ## Out of scope for v1
 
-- Attachments (inbound messages with attachments are posted text-only with `[attachment: <name> (<mime>)]` markers; `signal_send` has no attachment parameter).
 - Voice / Say / SoundEffect / Listen tools.
 - Group create / rename / add-members.
 - Typing indicators.

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -230,8 +230,15 @@ class SignalConnector(Connector):
 
     @tool()
     @focal_required
-    async def signal_send(self, text: str, *, account: str, chat_id: str) -> dict[str, Any]:
-        """Send a text message to your focal Signal chat.
+    async def signal_send(
+        self,
+        text: str,
+        attachments: list[str] | None = None,
+        *,
+        account: str,
+        chat_id: str,
+    ) -> dict[str, Any]:
+        """Send a Signal message to your focal chat, optionally with attachments.
 
         The account (your bot UUID) and chat id are taken implicitly
         from your focal channel — aios injects them via the JSON-RPC
@@ -240,12 +247,18 @@ class SignalConnector(Connector):
 
         Args:
             text: Message body. Markdown is converted to Signal text styles.
+            attachments: Optional list of in-sandbox file paths to attach.
+                Each path must be under ``/workspace/`` or
+                ``/mnt/attachments/``.  ``/mnt/attachments/`` is read-only,
+                so to forward an inbound photo ``cp`` it into ``/workspace/``
+                first.
         """
         assert self._daemon is not None
         phone = self._uuid_to_phone.get(account)
         if phone is None:
             raise ValueError(f"signal_send: unknown account {account!r}")
-        params = _build_send_params(phone, chat_id, text)
+        host_paths = self.resolve_media_paths(attachments or [], tool_name="signal_send")
+        params = _build_send_params(phone, chat_id, text, attachments=host_paths)
         result = await self._daemon.rpc.call("send", params)
         ts = _extract_timestamp(result)
         return {"sent_at_ms": ts} if ts is not None else {"status": "ok"}
@@ -331,7 +344,13 @@ class SignalConnector(Connector):
         return out
 
 
-def _build_send_params(account_phone: str, chat_id: str, text: str) -> dict[str, Any]:
+def _build_send_params(
+    account_phone: str,
+    chat_id: str,
+    text: str,
+    *,
+    attachments: list[str],
+) -> dict[str, Any]:
     """Translate ``(account_phone, chat_id, text)`` into signal-cli ``send`` params."""
     chat_type, raw_id = decode_chat_id(chat_id)
     stripped, styles = convert_markdown_to_signal_styles(text)
@@ -342,6 +361,8 @@ def _build_send_params(account_phone: str, chat_id: str, text: str) -> dict[str,
         params["groupId"] = raw_id
     else:
         params["recipient"] = [raw_id]
+    if attachments:
+        params["attachments"] = attachments
     return params
 
 

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 import structlog
@@ -40,6 +41,7 @@ from aios_connector import (
 from aios_connector import (
     AttachmentError,
     Connector,
+    SandboxPath,
     focal_required,
     make_account,
     tool,
@@ -233,7 +235,7 @@ class SignalConnector(Connector):
     async def signal_send(
         self,
         text: str,
-        attachments: list[str] | None = None,
+        attachments: list[SandboxPath] | None = None,
         *,
         account: str,
         chat_id: str,
@@ -247,17 +249,14 @@ class SignalConnector(Connector):
 
         Args:
             text: Message body. Markdown is converted to Signal text styles.
-            attachments: Optional list of in-sandbox file paths to attach.
-                Each path must be under ``/workspace/`` or
-                ``/mnt/attachments/``.  ``/mnt/attachments/`` is read-only,
-                so to forward an inbound photo ``cp`` it into ``/workspace/``
-                first.
+            attachments: Optional in-sandbox file paths to attach.  The SDK
+                resolves each entry to a host path before this method runs.
         """
         assert self._daemon is not None
         phone = self._uuid_to_phone.get(account)
         if phone is None:
             raise ValueError(f"signal_send: unknown account {account!r}")
-        host_paths = self.resolve_media_paths(attachments or [], tool_name="signal_send")
+        host_paths: list[Path] = list(attachments or [])
         params = _build_send_params(phone, chat_id, text, attachments=host_paths)
         result = await self._daemon.rpc.call("send", params)
         ts = _extract_timestamp(result)
@@ -349,7 +348,7 @@ def _build_send_params(
     chat_id: str,
     text: str,
     *,
-    attachments: list[str],
+    attachments: list[Path],
 ) -> dict[str, Any]:
     """Translate ``(account_phone, chat_id, text)`` into signal-cli ``send`` params."""
     chat_type, raw_id = decode_chat_id(chat_id)
@@ -362,7 +361,7 @@ def _build_send_params(
     else:
         params["recipient"] = [raw_id]
     if attachments:
-        params["attachments"] = attachments
+        params["attachments"] = [str(p) for p in attachments]
     return params
 
 

--- a/connectors/signal/tests/test_signal_send.py
+++ b/connectors/signal/tests/test_signal_send.py
@@ -2,16 +2,20 @@
 and ``_build_send_params``'s ``attachments`` field.
 
 Drives the build helper directly (no signal-cli) plus exercises the
-high-level ``signal_send`` method with a stubbed daemon to verify
-that attachment paths reach the RPC params resolved to host paths.
+high-level ``signal_send`` method via the SDK's ``_invoke_tool``
+dispatch wrapper — that's the layer where ``SandboxPath`` resolution
+happens, so connector-side tests must go through it.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+from aios_connector.base import ToolDescriptor
 
 from aios_signal.config import Settings
 from aios_signal.connector import SignalConnector, _build_send_params
@@ -28,7 +32,7 @@ def test_build_params_with_attachments() -> None:
         "+15550001",
         "alice",
         "look",
-        attachments=["/host/a.jpg", "/host/b.jpg"],
+        attachments=[Path("/host/a.jpg"), Path("/host/b.jpg")],
     )
     assert params["attachments"] == ["/host/a.jpg", "/host/b.jpg"]
 
@@ -48,15 +52,63 @@ def connector(tmp_path: Path) -> SignalConnector:
     return c
 
 
-def _patch_session_id(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
-    monkeypatch.setattr(SignalConnector, "current_session_id", lambda self: value)
+def _descriptor_for(connector: SignalConnector, name: str) -> ToolDescriptor:
+    descriptor = next(d for d in connector._tools if d.name == name)
+    assert isinstance(descriptor, ToolDescriptor)
+    return descriptor
+
+
+def _signal_send_descriptor(connector: SignalConnector) -> ToolDescriptor:
+    return _descriptor_for(connector, "signal_send")
+
+
+def _stub_focal(connector: SignalConnector, value: str | None) -> None:
+    connector._focal_from_request_meta = lambda: value  # type: ignore[method-assign]
+
+
+def _stub_session_id(connector: SignalConnector, value: str | None) -> None:
+    connector.current_session_id = lambda: value  # type: ignore[method-assign]
+
+
+def _decode(content_list: list[Any]) -> dict[str, Any]:
+    assert len(content_list) == 1
+    payload = json.loads(content_list[0].text)
+    assert isinstance(payload, dict)
+    return payload
+
+
+# Methods bypass focal/sandbox dispatch entirely — verify the descriptor
+# carries the right metadata so a regression in ``@tool`` would surface.
+
+
+def test_signal_send_descriptor_records_sandbox_param(
+    connector: SignalConnector,
+) -> None:
+    descriptor = _signal_send_descriptor(connector)
+    assert descriptor.sandbox_params == {"attachments": "list"}
+
+
+def test_signal_send_schema_publishes_string_array_with_description(
+    connector: SignalConnector,
+) -> None:
+    descriptor = _signal_send_descriptor(connector)
+    attachments_schema = descriptor.input_schema["properties"]["attachments"]
+    assert attachments_schema["type"] == "array"
+    assert attachments_schema["items"]["type"] == "string"
+    assert "/workspace/" in attachments_schema["items"]["description"]
+
+
+# End-to-end via _invoke_tool exercises the dispatch wrapper that
+# auto-resolves SandboxPath args before the tool body runs.
 
 
 async def test_signal_send_text_only_no_session_id_required(
-    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+    connector: SignalConnector,
 ) -> None:
-    _patch_session_id(monkeypatch, None)
-    result = await connector.signal_send("hello there", account="bot-uuid", chat_id="alice")
+    _stub_focal(connector, "bot-uuid/alice")
+    _stub_session_id(connector, None)
+    descriptor = _signal_send_descriptor(connector)
+    result = _decode(await connector._invoke_tool(descriptor, {"text": "hello there"}))
     assert result == {"status": "ok"}
     sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
     assert sent_params["message"] == "hello there"
@@ -68,17 +120,17 @@ async def test_signal_send_with_attachments_resolves_to_host_paths(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_id(monkeypatch, "sess-1")
+    _stub_focal(connector, "bot-uuid/alice")
+    _stub_session_id(connector, "sess-1")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
     ws = (tmp_path / "sess-1").resolve()
     ws.mkdir(parents=True)
     (ws / "cat.jpg").write_bytes(b"x")
 
-    await connector.signal_send(
-        "look",
-        attachments=["/workspace/cat.jpg"],
-        account="bot-uuid",
-        chat_id="alice",
+    descriptor = _signal_send_descriptor(connector)
+    await connector._invoke_tool(
+        descriptor,
+        {"text": "look", "attachments": ["/workspace/cat.jpg"]},
     )
 
     sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
@@ -91,14 +143,14 @@ async def test_signal_send_attachments_without_session_id_raises(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_id(monkeypatch, None)
+    _stub_focal(connector, "bot-uuid/alice")
+    _stub_session_id(connector, None)
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    descriptor = _signal_send_descriptor(connector)
     with pytest.raises(RuntimeError, match=r"aios\.session_id"):
-        await connector.signal_send(
-            "look",
-            attachments=["/workspace/cat.jpg"],
-            account="bot-uuid",
-            chat_id="alice",
+        await connector._invoke_tool(
+            descriptor,
+            {"text": "look", "attachments": ["/workspace/cat.jpg"]},
         )
 
 
@@ -107,30 +159,29 @@ async def test_signal_send_attachment_traversal_rejected(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_id(monkeypatch, "sess-1")
+    _stub_focal(connector, "bot-uuid/alice")
+    _stub_session_id(connector, "sess-1")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
     (tmp_path / "sess-1").mkdir(parents=True)
 
+    descriptor = _signal_send_descriptor(connector)
     with pytest.raises(ValueError, match="could not be resolved"):
-        await connector.signal_send(
-            "look",
-            attachments=["/workspace/../escape.jpg"],
-            account="bot-uuid",
-            chat_id="alice",
+        await connector._invoke_tool(
+            descriptor,
+            {"text": "look", "attachments": ["/workspace/../escape.jpg"]},
         )
 
 
 async def test_signal_send_attachment_disallowed_root_rejected(
     connector: SignalConnector,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_id(monkeypatch, "sess-1")
+    _stub_focal(connector, "bot-uuid/alice")
+    _stub_session_id(connector, "sess-1")
+    descriptor = _signal_send_descriptor(connector)
     with pytest.raises(ValueError, match="could not be resolved"):
-        await connector.signal_send(
-            "boom",
-            attachments=["/etc/passwd"],
-            account="bot-uuid",
-            chat_id="alice",
+        await connector._invoke_tool(
+            descriptor,
+            {"text": "boom", "attachments": ["/etc/passwd"]},
         )
 
 
@@ -139,21 +190,23 @@ async def test_signal_send_attachment_missing_file_raises_clear_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_id(monkeypatch, "sess-1")
+    _stub_focal(connector, "bot-uuid/alice")
+    _stub_session_id(connector, "sess-1")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
     (tmp_path / "sess-1").mkdir(parents=True)
 
+    descriptor = _signal_send_descriptor(connector)
     with pytest.raises(ValueError, match="does not exist"):
-        await connector.signal_send(
-            "look",
-            attachments=["/workspace/typo.jpg"],
-            account="bot-uuid",
-            chat_id="alice",
+        await connector._invoke_tool(
+            descriptor,
+            {"text": "look", "attachments": ["/workspace/typo.jpg"]},
         )
 
 
 async def test_signal_send_unknown_account_raises(
     connector: SignalConnector,
 ) -> None:
+    _stub_focal(connector, "nope/alice")
+    descriptor = _signal_send_descriptor(connector)
     with pytest.raises(ValueError, match="unknown account"):
-        await connector.signal_send("hi", account="nope", chat_id="alice")
+        await connector._invoke_tool(descriptor, {"text": "hi"})

--- a/connectors/signal/tests/test_signal_send.py
+++ b/connectors/signal/tests/test_signal_send.py
@@ -1,0 +1,159 @@
+"""Unit coverage for ``signal_send``'s ``attachments`` parameter
+and ``_build_send_params``'s ``attachments`` field.
+
+Drives the build helper directly (no signal-cli) plus exercises the
+high-level ``signal_send`` method with a stubbed daemon to verify
+that attachment paths reach the RPC params resolved to host paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios_signal.config import Settings
+from aios_signal.connector import SignalConnector, _build_send_params
+
+
+def test_build_params_no_attachments() -> None:
+    params = _build_send_params("+15550001", "alice", "hello", attachments=[])
+    assert "attachments" not in params
+    assert params["message"] == "hello"
+
+
+def test_build_params_with_attachments() -> None:
+    params = _build_send_params(
+        "+15550001",
+        "alice",
+        "look",
+        attachments=["/host/a.jpg", "/host/b.jpg"],
+    )
+    assert params["attachments"] == ["/host/a.jpg", "/host/b.jpg"]
+
+
+@pytest.fixture
+def connector(tmp_path: Path) -> SignalConnector:
+    cfg = Settings(
+        phones=["+15550001"],
+        config_dir=tmp_path / "cfg",
+        cli_bin="/usr/bin/signal-cli",
+    )
+    c = SignalConnector(cfg)
+    c._uuid_to_phone = {"bot-uuid": "+15550001"}
+    c._daemon = type(  # type: ignore[assignment]
+        "Daemon", (), {"rpc": type("Rpc", (), {"call": AsyncMock(return_value=None)})()}
+    )()
+    return c
+
+
+def _patch_session_id(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    monkeypatch.setattr(SignalConnector, "current_session_id", lambda self: value)
+
+
+async def test_signal_send_text_only_no_session_id_required(
+    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_session_id(monkeypatch, None)
+    result = await connector.signal_send("hello there", account="bot-uuid", chat_id="alice")
+    assert result == {"status": "ok"}
+    sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
+    assert sent_params["message"] == "hello there"
+    assert "attachments" not in sent_params
+
+
+async def test_signal_send_with_attachments_resolves_to_host_paths(
+    connector: SignalConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    (ws / "cat.jpg").write_bytes(b"x")
+
+    await connector.signal_send(
+        "look",
+        attachments=["/workspace/cat.jpg"],
+        account="bot-uuid",
+        chat_id="alice",
+    )
+
+    sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
+    assert sent_params["message"] == "look"
+    assert sent_params["attachments"] == [str(ws / "cat.jpg")]
+
+
+async def test_signal_send_attachments_without_session_id_raises(
+    connector: SignalConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, None)
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    with pytest.raises(RuntimeError, match=r"aios\.session_id"):
+        await connector.signal_send(
+            "look",
+            attachments=["/workspace/cat.jpg"],
+            account="bot-uuid",
+            chat_id="alice",
+        )
+
+
+async def test_signal_send_attachment_traversal_rejected(
+    connector: SignalConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-1").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await connector.signal_send(
+            "look",
+            attachments=["/workspace/../escape.jpg"],
+            account="bot-uuid",
+            chat_id="alice",
+        )
+
+
+async def test_signal_send_attachment_disallowed_root_rejected(
+    connector: SignalConnector,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await connector.signal_send(
+            "boom",
+            attachments=["/etc/passwd"],
+            account="bot-uuid",
+            chat_id="alice",
+        )
+
+
+async def test_signal_send_attachment_missing_file_raises_clear_error(
+    connector: SignalConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-1").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="does not exist"):
+        await connector.signal_send(
+            "look",
+            attachments=["/workspace/typo.jpg"],
+            account="bot-uuid",
+            chat_id="alice",
+        )
+
+
+async def test_signal_send_unknown_account_raises(
+    connector: SignalConnector,
+) -> None:
+    with pytest.raises(ValueError, match="unknown account"):
+        await connector.signal_send("hi", account="nope", chat_id="alice")

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -76,10 +76,26 @@ When deploying multiple instances, set
 `AIOS_TELEGRAM_SUPPORT_BOT_TOKEN`).  Instance names match
 `^[a-z][a-z0-9_]*$`.
 
+## Attachments
+
+Inbound photos, voice notes, documents, video, and audio are
+downloaded via `bot.get_file()` and surfaced as `image_url` content
+parts (vision-capable minds) or text markers, via the harness's
+vision pipeline.  Stickers and animations are dropped; captions
+become the message text.
+
+Outbound: pass an `attachments: list[str]` parameter to
+`telegram_send` alongside `text`.  Type is inferred from extension
+— `.jpg`/`.png` photo, `.mp4` video, `.ogg` voice, `.mp3` audio,
+anything else document.  Single attachment uses
+`send_photo`/`send_voice`/etc with caption; multiple attachments
+use `send_media_group` (caption rides on the first item only, per
+Telegram's API).  Paths must be under `/workspace/` or
+`/mnt/attachments/`.
+
 ## Out of scope for v1
 
-- Inbound media (photos, voice, documents, stickers) — dropped silently.
-- Outbound media — no `telegram_send_photo` / `_document`.
+- Stickers and animations (dropped on inbound).
 - Reactions — punt.
 - Message editing / deletion.
 - Typing indicators / chat actions.

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -44,6 +44,7 @@ from aios_connector import (
 from aios_connector import (
     AttachmentError,
     Connector,
+    SandboxPath,
     focal_required,
     make_account,
     tool,
@@ -275,7 +276,7 @@ class TelegramConnector(Connector):
     async def telegram_send(
         self,
         text: str,
-        attachments: list[str] | None = None,
+        attachments: list[SandboxPath] | None = None,
         *,
         chat_id: str,
     ) -> dict[str, Any]:
@@ -288,15 +289,15 @@ class TelegramConnector(Connector):
         Args:
             text: Message body. Plain text only — markdown is not rendered.
                 Becomes the caption when attachments are present.
-            attachments: Optional list of in-sandbox file paths.  Type is
-                inferred from extension (``.jpg``/``.png``/``.gif``/``.webp``
-                → photo, ``.mp4``/``.mov`` → video, ``.ogg`` → voice,
+            attachments: Optional in-sandbox file paths.  Type is inferred
+                from extension (``.jpg``/``.png``/``.gif``/``.webp`` →
+                photo, ``.mp4``/``.mov`` → video, ``.ogg`` → voice,
                 ``.mp3``/``.m4a``/``.wav`` → audio, anything else →
                 document).  Single attachment uses ``send_photo`` /
                 ``send_voice`` / etc.; multiple attachments use
                 ``send_media_group`` with caption attached to the first
-                item only (per Telegram API).  Paths must be under
-                ``/workspace/`` or ``/mnt/attachments/``.
+                item only (per Telegram API).  The SDK resolves each
+                entry to a host path before this method runs.
         """
         assert self._application is not None
         try:
@@ -304,7 +305,7 @@ class TelegramConnector(Connector):
         except ValueError as e:
             raise ValueError(f"telegram chat_id must be an integer; got {chat_id!r}") from e
 
-        host_paths = self.resolve_media_paths(attachments or [], tool_name="telegram_send")
+        host_paths: list[Path] = list(attachments or [])
         bot = self._application.bot
 
         if not host_paths:
@@ -333,8 +334,8 @@ _VOICE_EXTS = frozenset({".ogg", ".oga"})
 _AUDIO_EXTS = frozenset({".mp3", ".m4a", ".wav", ".flac"})
 
 
-def _classify(host_path: str) -> str:
-    ext = Path(host_path).suffix.lower()
+def _classify(host_path: Path) -> str:
+    ext = host_path.suffix.lower()
     if ext in _PHOTO_EXTS:
         return "photo"
     if ext in _VIDEO_EXTS:
@@ -350,7 +351,7 @@ async def _send_single_media(
     bot: Any,
     *,
     chat_id: int,
-    host_path: str,
+    host_path: Path,
     caption: str | None,
 ) -> Any:
     kind = _classify(host_path)
@@ -367,7 +368,7 @@ async def _send_single_media(
     return await sender(**kwargs)
 
 
-def _build_media_group(host_paths: list[str], *, caption: str | None) -> list[Any]:
+def _build_media_group(host_paths: list[Path], *, caption: str | None) -> list[Any]:
     # Caption rides on the FIRST item only — Telegram's API ignores
     # captions on items 2..N of a media group.
     items: list[Any] = []

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -48,6 +48,12 @@ from aios_connector import (
     make_account,
     tool,
 )
+from telegram import (
+    InputMediaAudio,
+    InputMediaDocument,
+    InputMediaPhoto,
+    InputMediaVideo,
+)
 from telegram.error import TelegramError
 from telegram.ext import Application, ContextTypes, MessageHandler, filters
 
@@ -266,8 +272,14 @@ class TelegramConnector(Connector):
 
     @tool()
     @focal_required
-    async def telegram_send(self, text: str, *, chat_id: str) -> dict[str, Any]:
-        """Send a text message to your focal Telegram chat.
+    async def telegram_send(
+        self,
+        text: str,
+        attachments: list[str] | None = None,
+        *,
+        chat_id: str,
+    ) -> dict[str, Any]:
+        """Send a Telegram message to your focal chat, optionally with attachments.
 
         The chat id is taken implicitly from your focal channel — aios
         injects it via the JSON-RPC ``_meta`` field on each call.  Set
@@ -275,14 +287,105 @@ class TelegramConnector(Connector):
 
         Args:
             text: Message body. Plain text only — markdown is not rendered.
+                Becomes the caption when attachments are present.
+            attachments: Optional list of in-sandbox file paths.  Type is
+                inferred from extension (``.jpg``/``.png``/``.gif``/``.webp``
+                → photo, ``.mp4``/``.mov`` → video, ``.ogg`` → voice,
+                ``.mp3``/``.m4a``/``.wav`` → audio, anything else →
+                document).  Single attachment uses ``send_photo`` /
+                ``send_voice`` / etc.; multiple attachments use
+                ``send_media_group`` with caption attached to the first
+                item only (per Telegram API).  Paths must be under
+                ``/workspace/`` or ``/mnt/attachments/``.
         """
         assert self._application is not None
         try:
             chat_id_int = int(chat_id)
         except ValueError as e:
             raise ValueError(f"telegram chat_id must be an integer; got {chat_id!r}") from e
-        sent = await self._application.bot.send_message(chat_id=chat_id_int, text=text)
-        return {"message_id": sent.message_id}
+
+        host_paths = self.resolve_media_paths(attachments or [], tool_name="telegram_send")
+        bot = self._application.bot
+
+        if not host_paths:
+            sent = await bot.send_message(chat_id=chat_id_int, text=text)
+            return {"message_id": sent.message_id}
+
+        if len(host_paths) == 1:
+            single = await _send_single_media(
+                bot,
+                chat_id=chat_id_int,
+                host_path=host_paths[0],
+                caption=text or None,
+            )
+            return {"message_id": single.message_id}
+
+        sent_group = await bot.send_media_group(
+            chat_id=chat_id_int,
+            media=_build_media_group(host_paths, caption=text or None),
+        )
+        return {"message_ids": [m.message_id for m in sent_group]}
+
+
+_PHOTO_EXTS = frozenset({".jpg", ".jpeg", ".png", ".gif", ".webp"})
+_VIDEO_EXTS = frozenset({".mp4", ".mov", ".webm"})
+_VOICE_EXTS = frozenset({".ogg", ".oga"})
+_AUDIO_EXTS = frozenset({".mp3", ".m4a", ".wav", ".flac"})
+
+
+def _classify(host_path: str) -> str:
+    ext = Path(host_path).suffix.lower()
+    if ext in _PHOTO_EXTS:
+        return "photo"
+    if ext in _VIDEO_EXTS:
+        return "video"
+    if ext in _VOICE_EXTS:
+        return "voice"
+    if ext in _AUDIO_EXTS:
+        return "audio"
+    return "document"
+
+
+async def _send_single_media(
+    bot: Any,
+    *,
+    chat_id: int,
+    host_path: str,
+    caption: str | None,
+) -> Any:
+    kind = _classify(host_path)
+    sender = {
+        "photo": bot.send_photo,
+        "video": bot.send_video,
+        "voice": bot.send_voice,
+        "audio": bot.send_audio,
+        "document": bot.send_document,
+    }[kind]
+    kwargs: dict[str, Any] = {"chat_id": chat_id, kind: host_path}
+    if caption is not None:
+        kwargs["caption"] = caption
+    return await sender(**kwargs)
+
+
+def _build_media_group(host_paths: list[str], *, caption: str | None) -> list[Any]:
+    # Caption rides on the FIRST item only — Telegram's API ignores
+    # captions on items 2..N of a media group.
+    items: list[Any] = []
+    for idx, path in enumerate(host_paths):
+        kind = _classify(path)
+        kwargs: dict[str, Any] = {"media": path}
+        if idx == 0 and caption is not None:
+            kwargs["caption"] = caption
+        if kind == "photo":
+            items.append(InputMediaPhoto(**kwargs))
+        elif kind == "video":
+            items.append(InputMediaVideo(**kwargs))
+        elif kind == "audio":
+            items.append(InputMediaAudio(**kwargs))
+        else:
+            # Voice can't go in a media group; fall back to document.
+            items.append(InputMediaDocument(**kwargs))
+    return items
 
 
 def build_metadata(msg: InboundMessage, bot_id: int) -> dict[str, Any]:

--- a/connectors/telegram/tests/test_telegram_send.py
+++ b/connectors/telegram/tests/test_telegram_send.py
@@ -1,0 +1,216 @@
+"""Unit coverage for ``telegram_send``'s ``attachments`` parameter,
+type-by-extension routing, and the caption-on-first quirk in
+``send_media_group``.
+
+The PTB ``Bot`` is mocked end-to-end; tests assert that the right
+``send_*`` method was called with the right ``chat_id`` /
+``caption`` / ``media`` arguments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios_telegram.config import Settings
+from aios_telegram.connector import (
+    TelegramConnector,
+    _build_media_group,
+    _classify,
+)
+
+
+def test_classify_extensions() -> None:
+    assert _classify("/x/cat.jpg") == "photo"
+    assert _classify("/x/CAT.JPEG") == "photo"
+    assert _classify("/x/clip.mp4") == "video"
+    assert _classify("/x/voice.ogg") == "voice"
+    assert _classify("/x/song.mp3") == "audio"
+    assert _classify("/x/report.pdf") == "document"
+    assert _classify("/x/no-ext") == "document"
+
+
+def test_build_media_group_caption_on_first_only() -> None:
+    items = _build_media_group(
+        ["/host/a.jpg", "/host/b.jpg", "/host/c.jpg"],
+        caption="three pics",
+    )
+    assert items[0].caption == "three pics"
+    assert items[1].caption is None
+    assert items[2].caption is None
+
+
+def test_build_media_group_no_caption() -> None:
+    items = _build_media_group(["/host/a.jpg", "/host/b.jpg"], caption=None)
+    assert all(item.caption is None for item in items)
+
+
+def test_build_media_group_voice_demoted_to_document() -> None:
+    """Voice can't ride in a media group; falls back to document."""
+    from telegram import InputMediaDocument
+
+    items = _build_media_group(["/host/v.ogg"], caption=None)
+    assert isinstance(items[0], InputMediaDocument)
+
+
+@pytest.fixture
+def connector() -> TelegramConnector:
+    cfg = Settings(bot_token="0:test")
+    c = TelegramConnector(cfg)
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=42))
+    bot.send_photo = AsyncMock(return_value=MagicMock(message_id=43))
+    bot.send_voice = AsyncMock(return_value=MagicMock(message_id=44))
+    bot.send_video = AsyncMock(return_value=MagicMock(message_id=45))
+    bot.send_audio = AsyncMock(return_value=MagicMock(message_id=46))
+    bot.send_document = AsyncMock(return_value=MagicMock(message_id=47))
+    bot.send_media_group = AsyncMock(
+        return_value=[
+            MagicMock(message_id=100),
+            MagicMock(message_id=101),
+        ]
+    )
+    c._application = MagicMock()
+    c._application.bot = bot
+    return c
+
+
+def _patch_session_id(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    monkeypatch.setattr(TelegramConnector, "current_session_id", lambda self: value)
+
+
+async def test_telegram_send_text_only(
+    connector: TelegramConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_session_id(monkeypatch, None)
+    result = await connector.telegram_send("hello", chat_id="123")
+    assert result == {"message_id": 42}
+    connector._application.bot.send_message.assert_awaited_once_with(  # type: ignore[union-attr]
+        chat_id=123, text="hello"
+    )
+
+
+async def test_telegram_send_single_photo_routes_to_send_photo(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    (ws / "cat.jpg").write_bytes(b"x")
+
+    result = await connector.telegram_send(
+        "look", attachments=["/workspace/cat.jpg"], chat_id="123"
+    )
+
+    assert result == {"message_id": 43}
+    bot = connector._application.bot  # type: ignore[union-attr]
+    bot.send_photo.assert_awaited_once()
+    kwargs = bot.send_photo.call_args.kwargs
+    assert kwargs["chat_id"] == 123
+    assert kwargs["photo"] == str(ws / "cat.jpg")
+    assert kwargs["caption"] == "look"
+
+
+async def test_telegram_send_single_voice_routes_to_send_voice(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    (ws / "v.ogg").write_bytes(b"x")
+
+    await connector.telegram_send("", attachments=["/workspace/v.ogg"], chat_id="123")
+
+    connector._application.bot.send_voice.assert_awaited_once()  # type: ignore[union-attr]
+
+
+async def test_telegram_send_single_document_routes_to_send_document(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    (ws / "report.pdf").write_bytes(b"x")
+
+    await connector.telegram_send("", attachments=["/workspace/report.pdf"], chat_id="123")
+
+    connector._application.bot.send_document.assert_awaited_once()  # type: ignore[union-attr]
+
+
+async def test_telegram_send_multi_media_uses_send_media_group(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    for name in ("a.jpg", "b.jpg"):
+        (ws / name).write_bytes(b"x")
+
+    result = await connector.telegram_send(
+        "two pics",
+        attachments=["/workspace/a.jpg", "/workspace/b.jpg"],
+        chat_id="123",
+    )
+
+    assert result == {"message_ids": [100, 101]}
+    bot = connector._application.bot  # type: ignore[union-attr]
+    bot.send_media_group.assert_awaited_once()
+    bot.send_photo.assert_not_awaited()
+    media = bot.send_media_group.call_args.kwargs["media"]
+    assert len(media) == 2
+    assert media[0].caption == "two pics"
+    assert media[1].caption is None
+
+
+async def test_telegram_send_attachment_traversal_rejected(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-1").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await connector.telegram_send("", attachments=["/workspace/../escape.jpg"], chat_id="123")
+
+
+async def test_telegram_send_attachment_disallowed_root_raises(
+    connector: TelegramConnector,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await connector.telegram_send("", attachments=["/etc/passwd"], chat_id="123")
+
+
+async def test_telegram_send_attachment_without_session_id_raises(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, None)
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    with pytest.raises(RuntimeError, match=r"aios\.session_id"):
+        await connector.telegram_send("", attachments=["/workspace/x.jpg"], chat_id="123")
+
+
+async def test_telegram_send_non_int_chat_id_raises(
+    connector: TelegramConnector,
+) -> None:
+    with pytest.raises(ValueError, match="must be an integer"):
+        await connector.telegram_send("hi", chat_id="not-a-number")

--- a/connectors/telegram/tests/test_telegram_send.py
+++ b/connectors/telegram/tests/test_telegram_send.py
@@ -5,14 +5,21 @@ type-by-extension routing, and the caption-on-first quirk in
 The PTB ``Bot`` is mocked end-to-end; tests assert that the right
 ``send_*`` method was called with the right ``chat_id`` /
 ``caption`` / ``media`` arguments.
+
+End-to-end tests go through the SDK's ``_invoke_tool`` dispatch
+wrapper — that's the layer where ``SandboxPath`` resolution happens,
+so connector-side tests must exercise it.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aios_connector.base import ToolDescriptor
 
 from aios_telegram.config import Settings
 from aios_telegram.connector import (
@@ -23,18 +30,18 @@ from aios_telegram.connector import (
 
 
 def test_classify_extensions() -> None:
-    assert _classify("/x/cat.jpg") == "photo"
-    assert _classify("/x/CAT.JPEG") == "photo"
-    assert _classify("/x/clip.mp4") == "video"
-    assert _classify("/x/voice.ogg") == "voice"
-    assert _classify("/x/song.mp3") == "audio"
-    assert _classify("/x/report.pdf") == "document"
-    assert _classify("/x/no-ext") == "document"
+    assert _classify(Path("/x/cat.jpg")) == "photo"
+    assert _classify(Path("/x/CAT.JPEG")) == "photo"
+    assert _classify(Path("/x/clip.mp4")) == "video"
+    assert _classify(Path("/x/voice.ogg")) == "voice"
+    assert _classify(Path("/x/song.mp3")) == "audio"
+    assert _classify(Path("/x/report.pdf")) == "document"
+    assert _classify(Path("/x/no-ext")) == "document"
 
 
 def test_build_media_group_caption_on_first_only() -> None:
     items = _build_media_group(
-        ["/host/a.jpg", "/host/b.jpg", "/host/c.jpg"],
+        [Path("/host/a.jpg"), Path("/host/b.jpg"), Path("/host/c.jpg")],
         caption="three pics",
     )
     assert items[0].caption == "three pics"
@@ -43,7 +50,7 @@ def test_build_media_group_caption_on_first_only() -> None:
 
 
 def test_build_media_group_no_caption() -> None:
-    items = _build_media_group(["/host/a.jpg", "/host/b.jpg"], caption=None)
+    items = _build_media_group([Path("/host/a.jpg"), Path("/host/b.jpg")], caption=None)
     assert all(item.caption is None for item in items)
 
 
@@ -51,7 +58,7 @@ def test_build_media_group_voice_demoted_to_document() -> None:
     """Voice can't ride in a media group; falls back to document."""
     from telegram import InputMediaDocument
 
-    items = _build_media_group(["/host/v.ogg"], caption=None)
+    items = _build_media_group([Path("/host/v.ogg")], caption=None)
     assert isinstance(items[0], InputMediaDocument)
 
 
@@ -77,15 +84,57 @@ def connector() -> TelegramConnector:
     return c
 
 
-def _patch_session_id(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
-    monkeypatch.setattr(TelegramConnector, "current_session_id", lambda self: value)
+def _telegram_send_descriptor(connector: TelegramConnector) -> ToolDescriptor:
+    descriptor = next(d for d in connector._tools if d.name == "telegram_send")
+    assert isinstance(descriptor, ToolDescriptor)
+    return descriptor
 
 
-async def test_telegram_send_text_only(
-    connector: TelegramConnector, monkeypatch: pytest.MonkeyPatch
+def _stub_focal(connector: TelegramConnector, value: str | None) -> None:
+    connector._focal_from_request_meta = lambda: value  # type: ignore[method-assign]
+
+
+def _stub_session_id(connector: TelegramConnector, value: str | None) -> None:
+    connector.current_session_id = lambda: value  # type: ignore[method-assign]
+
+
+def _decode(content_list: list[Any]) -> dict[str, Any]:
+    assert len(content_list) == 1
+    payload = json.loads(content_list[0].text)
+    assert isinstance(payload, dict)
+    return payload
+
+
+# Descriptor-level checks: the schema reaches the model with the right
+# shape and the dispatch wrapper knows which arg to resolve.
+
+
+def test_telegram_send_descriptor_records_sandbox_param(
+    connector: TelegramConnector,
 ) -> None:
-    _patch_session_id(monkeypatch, None)
-    result = await connector.telegram_send("hello", chat_id="123")
+    descriptor = _telegram_send_descriptor(connector)
+    assert descriptor.sandbox_params == {"attachments": "list"}
+
+
+def test_telegram_send_schema_publishes_string_array_with_description(
+    connector: TelegramConnector,
+) -> None:
+    descriptor = _telegram_send_descriptor(connector)
+    attachments_schema = descriptor.input_schema["properties"]["attachments"]
+    assert attachments_schema["type"] == "array"
+    assert attachments_schema["items"]["type"] == "string"
+    assert "/workspace/" in attachments_schema["items"]["description"]
+
+
+# End-to-end tests via _invoke_tool (the dispatch wrapper resolves
+# SandboxPath args before the tool body runs).
+
+
+async def test_telegram_send_text_only(connector: TelegramConnector) -> None:
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, None)
+    descriptor = _telegram_send_descriptor(connector)
+    result = _decode(await connector._invoke_tool(descriptor, {"text": "hello"}))
     assert result == {"message_id": 42}
     connector._application.bot.send_message.assert_awaited_once_with(  # type: ignore[union-attr]
         chat_id=123, text="hello"
@@ -97,14 +146,19 @@ async def test_telegram_send_single_photo_routes_to_send_photo(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_id(monkeypatch, "sess-1")
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, "sess-1")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
     ws = (tmp_path / "sess-1").resolve()
     ws.mkdir(parents=True)
     (ws / "cat.jpg").write_bytes(b"x")
 
-    result = await connector.telegram_send(
-        "look", attachments=["/workspace/cat.jpg"], chat_id="123"
+    descriptor = _telegram_send_descriptor(connector)
+    result = _decode(
+        await connector._invoke_tool(
+            descriptor,
+            {"text": "look", "attachments": ["/workspace/cat.jpg"]},
+        )
     )
 
     assert result == {"message_id": 43}
@@ -112,7 +166,7 @@ async def test_telegram_send_single_photo_routes_to_send_photo(
     bot.send_photo.assert_awaited_once()
     kwargs = bot.send_photo.call_args.kwargs
     assert kwargs["chat_id"] == 123
-    assert kwargs["photo"] == str(ws / "cat.jpg")
+    assert kwargs["photo"] == ws / "cat.jpg"
     assert kwargs["caption"] == "look"
 
 
@@ -121,13 +175,17 @@ async def test_telegram_send_single_voice_routes_to_send_voice(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_id(monkeypatch, "sess-1")
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, "sess-1")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
     ws = (tmp_path / "sess-1").resolve()
     ws.mkdir(parents=True)
     (ws / "v.ogg").write_bytes(b"x")
 
-    await connector.telegram_send("", attachments=["/workspace/v.ogg"], chat_id="123")
+    descriptor = _telegram_send_descriptor(connector)
+    await connector._invoke_tool(
+        descriptor, {"text": "", "attachments": ["/workspace/v.ogg"]}
+    )
 
     connector._application.bot.send_voice.assert_awaited_once()  # type: ignore[union-attr]
 
@@ -137,13 +195,17 @@ async def test_telegram_send_single_document_routes_to_send_document(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_id(monkeypatch, "sess-1")
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, "sess-1")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
     ws = (tmp_path / "sess-1").resolve()
     ws.mkdir(parents=True)
     (ws / "report.pdf").write_bytes(b"x")
 
-    await connector.telegram_send("", attachments=["/workspace/report.pdf"], chat_id="123")
+    descriptor = _telegram_send_descriptor(connector)
+    await connector._invoke_tool(
+        descriptor, {"text": "", "attachments": ["/workspace/report.pdf"]}
+    )
 
     connector._application.bot.send_document.assert_awaited_once()  # type: ignore[union-attr]
 
@@ -153,17 +215,23 @@ async def test_telegram_send_multi_media_uses_send_media_group(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_id(monkeypatch, "sess-1")
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, "sess-1")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
     ws = (tmp_path / "sess-1").resolve()
     ws.mkdir(parents=True)
     for name in ("a.jpg", "b.jpg"):
         (ws / name).write_bytes(b"x")
 
-    result = await connector.telegram_send(
-        "two pics",
-        attachments=["/workspace/a.jpg", "/workspace/b.jpg"],
-        chat_id="123",
+    descriptor = _telegram_send_descriptor(connector)
+    result = _decode(
+        await connector._invoke_tool(
+            descriptor,
+            {
+                "text": "two pics",
+                "attachments": ["/workspace/a.jpg", "/workspace/b.jpg"],
+            },
+        )
     )
 
     assert result == {"message_ids": [100, 101]}
@@ -181,21 +249,29 @@ async def test_telegram_send_attachment_traversal_rejected(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_id(monkeypatch, "sess-1")
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, "sess-1")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
     (tmp_path / "sess-1").mkdir(parents=True)
 
+    descriptor = _telegram_send_descriptor(connector)
     with pytest.raises(ValueError, match="could not be resolved"):
-        await connector.telegram_send("", attachments=["/workspace/../escape.jpg"], chat_id="123")
+        await connector._invoke_tool(
+            descriptor,
+            {"text": "", "attachments": ["/workspace/../escape.jpg"]},
+        )
 
 
 async def test_telegram_send_attachment_disallowed_root_raises(
     connector: TelegramConnector,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_id(monkeypatch, "sess-1")
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, "sess-1")
+    descriptor = _telegram_send_descriptor(connector)
     with pytest.raises(ValueError, match="could not be resolved"):
-        await connector.telegram_send("", attachments=["/etc/passwd"], chat_id="123")
+        await connector._invoke_tool(
+            descriptor, {"text": "", "attachments": ["/etc/passwd"]}
+        )
 
 
 async def test_telegram_send_attachment_without_session_id_raises(
@@ -203,14 +279,20 @@ async def test_telegram_send_attachment_without_session_id_raises(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_session_id(monkeypatch, None)
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, None)
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    descriptor = _telegram_send_descriptor(connector)
     with pytest.raises(RuntimeError, match=r"aios\.session_id"):
-        await connector.telegram_send("", attachments=["/workspace/x.jpg"], chat_id="123")
+        await connector._invoke_tool(
+            descriptor, {"text": "", "attachments": ["/workspace/x.jpg"]}
+        )
 
 
 async def test_telegram_send_non_int_chat_id_raises(
     connector: TelegramConnector,
 ) -> None:
+    _stub_focal(connector, "0/not-a-number")
+    descriptor = _telegram_send_descriptor(connector)
     with pytest.raises(ValueError, match="must be an integer"):
-        await connector.telegram_send("hi", chat_id="not-a-number")
+        await connector._invoke_tool(descriptor, {"text": "hi"})

--- a/packages/aios-connector/aios_connector/__init__.py
+++ b/packages/aios-connector/aios_connector/__init__.py
@@ -26,9 +26,9 @@ Public API:
 * :class:`Attachment` / :class:`AttachmentError` — inbound binary blobs
   (photos, voice notes, documents) and the SDK-boundary validation
   failure connectors catch.
-* :func:`resolve_sandbox_path` — host-path resolver for outbound
-  attachments; connector send tools call this for each entry in
-  their ``attachments`` parameter.
+* :data:`SandboxPath` — type marker for outbound-attachment parameters;
+  the SDK auto-resolves model-supplied in-sandbox path strings to host
+  :class:`pathlib.Path` objects before the tool body runs.
 """
 
 from __future__ import annotations
@@ -41,14 +41,14 @@ from aios_connector.base import (
     make_account,
     tool,
 )
-from aios_connector.media import resolve_sandbox_path
+from aios_connector.media import SandboxPath
 
 __all__ = [
     "Attachment",
     "AttachmentError",
     "Connector",
+    "SandboxPath",
     "focal_required",
     "make_account",
-    "resolve_sandbox_path",
     "tool",
 ]

--- a/packages/aios-connector/aios_connector/base.py
+++ b/packages/aios-connector/aios_connector/base.py
@@ -68,6 +68,16 @@ _INBOUND_METHOD = f"{_AIOS_NOTIFICATION_PREFIX}inbound"
 # focal-required tool methods.
 _FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
+# MCP ``_meta`` key carrying the calling session's id.  Mirrors
+# ``aios.harness.channels.SESSION_ID_META_KEY`` server-side.
+_SESSION_ID_META_KEY = "aios.session_id"
+
+# Default sandbox bind-mount root.  Connector subprocesses inherit
+# ``AIOS_WORKSPACE_ROOT`` from the worker; this constant is only the
+# fallback for tests + dev environments without it set.  Must match
+# :attr:`aios.config.Settings.workspace_root`'s default.
+_DEFAULT_WORKSPACE_ROOT = "/var/lib/aios/workspaces"
+
 ToolFn = Callable[..., Awaitable[Any]]
 
 
@@ -683,13 +693,55 @@ class Connector:
         return [TextContent(type="text", text=json.dumps(result, ensure_ascii=False))]
 
     def _focal_from_request_meta(self) -> str | None:
-        """Read ``_meta.aios.focal_channel_path`` from the active request.
+        """Read the focal-channel suffix from the active request, or ``None``."""
+        return self._read_meta_str(_FOCAL_CHANNEL_META_KEY)
 
-        The lowlevel server stashes the raw request on a context var
-        the call_tool handler can reach via :attr:`Server.request_context`.
-        Missing or malformed meta returns ``None`` so the caller raises
-        a tool-level error.
+    def current_session_id(self) -> str | None:
+        """Read ``_meta.aios.session_id`` from the active request, or ``None``."""
+        return self._read_meta_str(_SESSION_ID_META_KEY)
+
+    def resolve_media_paths(self, paths: list[str], *, tool_name: str) -> list[str]:
+        """Map sandbox-visible attachment paths to host paths.
+
+        Empty input short-circuits without requiring ``_meta.aios.session_id``,
+        so text-only send tools work in test harnesses that don't stamp it.
+        Non-empty input raises ``RuntimeError`` if session_id is missing,
+        ``ValueError`` if any path fails containment or doesn't exist.
         """
+        if not paths:
+            return []
+        session_id = self.current_session_id()
+        if session_id is None:
+            raise RuntimeError(
+                f"{tool_name} with attachments requires _meta.aios.session_id; "
+                "the harness should always inject this for tool dispatches"
+            )
+        from aios_connector.media import resolve_sandbox_path
+
+        workspace_root = Path(os.environ.get("AIOS_WORKSPACE_ROOT", _DEFAULT_WORKSPACE_ROOT))
+        resolved: list[str] = []
+        for sandbox_path in paths:
+            host = resolve_sandbox_path(
+                session_id=session_id,
+                sandbox_path=sandbox_path,
+                workspace_root=workspace_root,
+            )
+            if host is None:
+                raise ValueError(
+                    f"attachment path {sandbox_path!r} could not be resolved "
+                    f"to a host path (must be under /workspace/ or "
+                    f"/mnt/attachments/, no .. escapes)"
+                )
+            if not host.is_file():
+                raise ValueError(
+                    f"attachment path {sandbox_path!r} does not exist (resolved to {host})"
+                )
+            resolved.append(str(host))
+        return resolved
+
+    def _read_meta_str(self, key: str) -> str | None:
+        """Fetch a string-typed key from ``_meta`` of the active tool-call
+        request, or ``None`` when absent / empty / wrong type."""
         from mcp.server.lowlevel.server import request_ctx
 
         try:
@@ -700,10 +752,10 @@ class Connector:
         if meta is None:
             return None
         extra = getattr(meta, "model_extra", None) or {}
-        path: Any = extra.get(_FOCAL_CHANNEL_META_KEY)
-        if not isinstance(path, str) or not path:
+        value: Any = extra.get(key)
+        if not isinstance(value, str) or not value:
             return None
-        return path
+        return value
 
     # ── Internal: aios_inbound_ack tool ───────────────────────────────
 

--- a/packages/aios-connector/aios_connector/base.py
+++ b/packages/aios-connector/aios_connector/base.py
@@ -30,10 +30,12 @@ import json
 import os
 import stat
 import time
+import types
+import typing
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, ClassVar, get_type_hints
+from typing import Any, ClassVar, Literal, get_type_hints
 
 import anyio
 import anyio.abc
@@ -47,8 +49,10 @@ from mcp.types import (
     TextContent,
     Tool,
 )
+from pydantic import TypeAdapter
 from ulid import ULID
 
+from aios_connector.media import _resolve_sandbox_path, _SandboxPathMarker
 from aios_connector.spool import SOFT_WARN_BYTES, Spool
 
 # Method names the connector emits over stdio.  Mirrors the constant in
@@ -96,8 +100,12 @@ class ToolDescriptor:
     splits the focal-channel path on the first ``/`` and injects only
     those kwargs the method asked for — connectors that serve a single
     account omit ``account`` from their signature and pay no
-    multi-account routing cost.  The frozenset is computed once at
-    registration so dispatch doesn't re-introspect on every call.
+    multi-account routing cost.
+
+    ``sandbox_params`` maps each parameter annotated with
+    :data:`SandboxPath` (or ``list[SandboxPath]``) to its kind so the
+    dispatch wrapper resolves model-supplied path strings to host
+    :class:`Path` objects before the tool body runs.
     """
 
     name: str
@@ -106,6 +114,7 @@ class ToolDescriptor:
     fn: ToolFn
     focal_required: bool = False
     focal_kwargs: frozenset[str] = frozenset()
+    sandbox_params: dict[str, Literal["scalar", "list"]] = field(default_factory=dict)
 
 
 _TOOL_ATTR = "__aios_connector_tool__"
@@ -160,7 +169,13 @@ def tool(
                 "present in the signature, and a tool that wants neither "
                 "shouldn't be focal-required"
             )
-        schema = _build_input_schema(fn, focal_required=is_focal)
+        hints = get_type_hints(fn, include_extras=True)
+        schema = _build_input_schema(fn, hints=hints, focal_required=is_focal)
+        sandbox_params: dict[str, Literal["scalar", "list"]] = {}
+        for param_name, hint in hints.items():
+            found = _extract_sandbox_kind(hint)
+            if found is not None:
+                sandbox_params[param_name] = found[1]
         descriptor = ToolDescriptor(
             name=tool_name,
             description=description or doc,
@@ -168,6 +183,7 @@ def tool(
             fn=fn,
             focal_required=is_focal,
             focal_kwargs=focal_kwargs,
+            sandbox_params=sandbox_params,
         )
         setattr(fn, _TOOL_ATTR, descriptor)
         return fn
@@ -202,26 +218,22 @@ def _detect_focal_kwargs(fn: ToolFn) -> frozenset[str]:
     return frozenset(inspect.signature(fn).parameters) & _FOCAL_INJECTED_KWARGS
 
 
-def _build_input_schema(fn: ToolFn, *, focal_required: bool) -> dict[str, Any]:
+def _build_input_schema(
+    fn: ToolFn, *, hints: dict[str, Any] | None = None, focal_required: bool
+) -> dict[str, Any]:
     """Generate a JSON Schema for ``fn``'s non-self parameters.
 
-    Walks the resolved type hints (so ``from __future__ import
-    annotations`` callers still get usable schemas) and maps Python
-    primitives to the JSON Schema equivalents.  Optional parameters
-    (defaulting to anything) are non-required; the rest are required.
-
     When ``focal_required=True``, ``account`` and ``chat_id`` are
-    SDK-injected from the focal-channel meta and are excluded from the
-    model-facing schema.  Non-focal tools that take ``account`` (e.g.
-    ``list_chats(account: str)`` per design §3.4) keep it as a
-    model-visible argument.
+    SDK-injected and excluded from the model-facing schema.
+
+    ``hints`` may be passed by callers that already resolved them with
+    ``get_type_hints(fn, include_extras=True)``; otherwise we resolve
+    here.  ``include_extras`` is required so ``Annotated`` metadata
+    (e.g. the :data:`SandboxPath` marker) survives.
     """
     sig = inspect.signature(fn)
-    # Fail loudly here: an unresolvable hint at decoration time means
-    # the connector author has a forward-reference / circular-import
-    # bug.  Silently emitting an "any" schema would publish the wrong
-    # tool contract to the model.
-    hints = get_type_hints(fn)
+    if hints is None:
+        hints = get_type_hints(fn, include_extras=True)
 
     properties: dict[str, dict[str, Any]] = {}
     required: list[str] = []
@@ -247,31 +259,102 @@ def _build_input_schema(fn: ToolFn, *, focal_required: bool) -> dict[str, Any]:
 
 
 def _hint_to_schema(hint: Any) -> dict[str, Any]:
-    """Map a Python type hint to a JSON Schema fragment."""
-    if hint is None or hint is type(None):
-        return {"type": "null"}
-    if hint is str:
-        return {"type": "string"}
-    if hint is int:
-        return {"type": "integer"}
-    if hint is float:
-        return {"type": "number"}
-    if hint is bool:
-        return {"type": "boolean"}
-    if hint is list:
-        return {"type": "array"}
-    if hint is dict:
-        return {"type": "object"}
-    # Best effort for parameterized generics: ``list[str]`` etc.  The
-    # SDK keeps this minimal; connector authors who need richer schemas
-    # should pass description= on @tool or supply schemas via a
-    # follow-up enhancement.
-    origin = getattr(hint, "__origin__", None)
-    if origin is list:
-        return {"type": "array"}
-    if origin is dict:
-        return {"type": "object"}
-    return {}
+    """Map a Python type hint to a JSON Schema fragment via pydantic, with
+    ``T | None`` flattened to ``T`` and :data:`SandboxPath` rendered as a
+    string (the model passes in-sandbox path strings; the SDK auto-resolves)."""
+    if hint is None or hint is inspect.Parameter.empty:
+        return {}
+    sandbox_schema = _sandbox_path_schema(hint)
+    if sandbox_schema is not None:
+        return sandbox_schema
+    schema: dict[str, Any] = TypeAdapter(hint).json_schema()
+    any_of = schema.get("anyOf")
+    if isinstance(any_of, list):
+        non_null: list[dict[str, Any]] = [s for s in any_of if s != {"type": "null"}]
+        if len(non_null) == 1:
+            return non_null[0]
+    return schema
+
+
+def _sandbox_path_schema(hint: Any) -> dict[str, Any] | None:
+    """JSON Schema for a hint involving :data:`SandboxPath`, or ``None``."""
+    found = _extract_sandbox_kind(hint)
+    if found is None:
+        return None
+    marker, kind = found
+    if kind == "list":
+        return {
+            "type": "array",
+            "items": {"type": "string", "description": marker.description},
+        }
+    return {"type": "string", "description": marker.description}
+
+
+def _strip_optional(hint: Any) -> Any:
+    """Strip a ``| None`` arm; return ``hint`` unchanged for any other union."""
+    origin = typing.get_origin(hint)
+    if origin is None:
+        return hint
+    if origin is typing.Union or origin is types.UnionType:
+        args = [a for a in typing.get_args(hint) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return hint
+
+
+def _extract_sandbox_kind(
+    hint: Any,
+) -> tuple[_SandboxPathMarker, Literal["scalar", "list"]] | None:
+    """Return ``(marker, kind)`` if ``hint`` is :data:`SandboxPath` or
+    ``list[SandboxPath]`` (with an optional ``| None``), else ``None``."""
+    bare = _strip_optional(hint)
+    marker = _marker_in_metadata(bare)
+    if marker is not None:
+        return (marker, "scalar")
+    if typing.get_origin(bare) is list:
+        args = typing.get_args(bare)
+        if len(args) == 1:
+            inner = _marker_in_metadata(_strip_optional(args[0]))
+            if inner is not None:
+                return (inner, "list")
+    return None
+
+
+def _marker_in_metadata(hint: Any) -> _SandboxPathMarker | None:
+    metadata = getattr(hint, "__metadata__", None)
+    if not metadata:
+        return None
+    for meta in metadata:
+        if isinstance(meta, _SandboxPathMarker):
+            return meta
+    return None
+
+
+def _resolve_one_sandbox_path(
+    *,
+    sandbox_path: str,
+    session_id: str,
+    workspace_root: Path,
+    tool_name: str,
+) -> Path:
+    """Resolve one in-sandbox path string to its host :class:`Path`, with
+    uniform error wording across connectors."""
+    host = _resolve_sandbox_path(
+        session_id=session_id,
+        sandbox_path=sandbox_path,
+        workspace_root=workspace_root,
+    )
+    if host is None:
+        raise ValueError(
+            f"{tool_name}: sandbox path {sandbox_path!r} could not be resolved "
+            f"to a host path (must be under /workspace/ or "
+            f"/mnt/attachments/, no .. escapes)"
+        )
+    if not host.is_file():
+        raise ValueError(
+            f"{tool_name}: sandbox path {sandbox_path!r} does not exist (resolved to {host})"
+        )
+    return host
 
 
 @dataclass
@@ -660,17 +743,7 @@ class Connector:
     async def _invoke_tool(
         self, descriptor: ToolDescriptor, arguments: dict[str, Any]
     ) -> list[TextContent]:
-        """Dispatch a tool, parsing focal meta if the descriptor opted in.
-
-        For ``@focal_required`` tools: split the focal path on the first
-        ``/`` (yielding ``account`` and the chat-id portion, which may
-        itself contain further ``/``-separated thread/sub-chat segments)
-        and inject only the kwargs the tool method's signature declared
-        (per ``descriptor.focal_kwargs``).  Tools fail loudly when the
-        meta key is missing — the agent shouldn't reach a focal-required
-        tool without focal set, so any absence is a bug to surface, not
-        a condition to fall back on.
-        """
+        """Dispatch a tool: inject focal kwargs, resolve sandbox paths, call."""
         kwargs = dict(arguments)
         if descriptor.focal_required:
             focal = self._focal_from_request_meta()
@@ -685,12 +758,70 @@ class Connector:
             if "chat_id" in descriptor.focal_kwargs:
                 kwargs["chat_id"] = chat_id
 
+        if descriptor.sandbox_params:
+            self._resolve_sandbox_kwargs(descriptor, kwargs)
+
         result = await descriptor.fn(self, **kwargs)
         if isinstance(result, list) and all(isinstance(x, TextContent) for x in result):
             return result
         if isinstance(result, str):
             return [TextContent(type="text", text=result)]
         return [TextContent(type="text", text=json.dumps(result, ensure_ascii=False))]
+
+    def _resolve_sandbox_kwargs(self, descriptor: ToolDescriptor, kwargs: dict[str, Any]) -> None:
+        """Replace each :data:`SandboxPath` / ``list[SandboxPath]`` argument
+        with a resolved host :class:`Path`, mutating ``kwargs`` in place.
+
+        Empty/absent values pass through; ``session_id`` is fetched lazily
+        so text-only calls don't require ``_meta.aios.session_id``.
+        """
+        workspace_root = Path(os.environ.get("AIOS_WORKSPACE_ROOT", _DEFAULT_WORKSPACE_ROOT))
+        session_id: str | None = None
+
+        for param_name, kind in descriptor.sandbox_params.items():
+            if param_name not in kwargs:
+                continue
+            value = kwargs[param_name]
+            if value is None:
+                continue
+            if kind == "list":
+                if not isinstance(value, list):
+                    raise TypeError(
+                        f"tool {descriptor.name!r} parameter {param_name!r} expects a "
+                        f"list of in-sandbox path strings; got {type(value).__name__}"
+                    )
+                if not value:
+                    continue
+                if session_id is None:
+                    session_id = self._require_session_id(descriptor.name)
+                kwargs[param_name] = [
+                    _resolve_one_sandbox_path(
+                        sandbox_path=str(item),
+                        session_id=session_id,
+                        workspace_root=workspace_root,
+                        tool_name=descriptor.name,
+                    )
+                    for item in value
+                ]
+            else:  # "scalar"
+                if session_id is None:
+                    session_id = self._require_session_id(descriptor.name)
+                kwargs[param_name] = _resolve_one_sandbox_path(
+                    sandbox_path=str(value),
+                    session_id=session_id,
+                    workspace_root=workspace_root,
+                    tool_name=descriptor.name,
+                )
+
+    def _require_session_id(self, tool_name: str) -> str:
+        session_id = self.current_session_id()
+        if session_id is None:
+            raise RuntimeError(
+                f"{tool_name} with sandbox-path arguments requires "
+                "_meta.aios.session_id; the harness should always inject "
+                "this for tool dispatches"
+            )
+        return session_id
 
     def _focal_from_request_meta(self) -> str | None:
         """Read the focal-channel suffix from the active request, or ``None``."""
@@ -699,45 +830,6 @@ class Connector:
     def current_session_id(self) -> str | None:
         """Read ``_meta.aios.session_id`` from the active request, or ``None``."""
         return self._read_meta_str(_SESSION_ID_META_KEY)
-
-    def resolve_media_paths(self, paths: list[str], *, tool_name: str) -> list[str]:
-        """Map sandbox-visible attachment paths to host paths.
-
-        Empty input short-circuits without requiring ``_meta.aios.session_id``,
-        so text-only send tools work in test harnesses that don't stamp it.
-        Non-empty input raises ``RuntimeError`` if session_id is missing,
-        ``ValueError`` if any path fails containment or doesn't exist.
-        """
-        if not paths:
-            return []
-        session_id = self.current_session_id()
-        if session_id is None:
-            raise RuntimeError(
-                f"{tool_name} with attachments requires _meta.aios.session_id; "
-                "the harness should always inject this for tool dispatches"
-            )
-        from aios_connector.media import resolve_sandbox_path
-
-        workspace_root = Path(os.environ.get("AIOS_WORKSPACE_ROOT", _DEFAULT_WORKSPACE_ROOT))
-        resolved: list[str] = []
-        for sandbox_path in paths:
-            host = resolve_sandbox_path(
-                session_id=session_id,
-                sandbox_path=sandbox_path,
-                workspace_root=workspace_root,
-            )
-            if host is None:
-                raise ValueError(
-                    f"attachment path {sandbox_path!r} could not be resolved "
-                    f"to a host path (must be under /workspace/ or "
-                    f"/mnt/attachments/, no .. escapes)"
-                )
-            if not host.is_file():
-                raise ValueError(
-                    f"attachment path {sandbox_path!r} does not exist (resolved to {host})"
-                )
-            resolved.append(str(host))
-        return resolved
 
     def _read_meta_str(self, key: str) -> str | None:
         """Fetch a string-typed key from ``_meta`` of the active tool-call

--- a/packages/aios-connector/aios_connector/media.py
+++ b/packages/aios-connector/aios_connector/media.py
@@ -1,39 +1,52 @@
 """Sandbox path resolution for connector send tools.
 
-Connectors take a structured ``attachments: list[str]`` parameter on
-their send tools (the model passes in-sandbox paths like
-``/workspace/cat.jpg``).  This module's :func:`resolve_sandbox_path`
-maps each one to its host-side equivalent so the connector can
-``open()`` the file before uploading to the platform.
+Connector tool methods annotate path parameters with :data:`SandboxPath`;
+the SDK's dispatch wrapper resolves each value to its host-side
+:class:`pathlib.Path` before the tool body runs.  Connector authors never
+call the resolver directly.
+
+Duplicated from :func:`aios.sandbox.volumes.resolve_to_host_path` rather
+than imported so the reference SDK has zero aios-server dependency
+(mirrors the ``_AIOS_NOTIFICATION_PREFIX`` precedent in base.py).
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Annotated
 
-# Trailing slash is load-bearing — prevents ``/workspaces/foo`` matching
-# ``/workspace``.  Duplicated from :mod:`aios.sandbox.volumes` rather
-# than imported so the reference SDK has zero dependency on aios server
-# code (mirrors the ``_AIOS_NOTIFICATION_PREFIX`` precedent in base.py).
+# Trailing slash on _WORKSPACE_PREFIX is load-bearing — prevents
+# ``/workspaces/foo`` matching ``/workspace``.
 _WORKSPACE_PREFIX = "/workspace/"
 _ATTACHMENTS_PREFIX = "/mnt/attachments/"
 _ATTACHMENTS_HOST_SUBDIR = "_attachments"
 
+_SANDBOX_PATH_DESCRIPTION = (
+    "In-sandbox file path under /workspace/ or /mnt/attachments/ "
+    "(/mnt/attachments/ is read-only — cp into /workspace/ first to "
+    "forward an inbound photo)."
+)
 
-def resolve_sandbox_path(
+
+@dataclass(frozen=True, slots=True)
+class _SandboxPathMarker:
+    description: str = _SANDBOX_PATH_DESCRIPTION
+
+
+SANDBOX_PATH_MARKER = _SandboxPathMarker()
+SandboxPath = Annotated[Path, SANDBOX_PATH_MARKER]
+
+
+def _resolve_sandbox_path(
     *,
     session_id: str,
     sandbox_path: str,
     workspace_root: Path,
 ) -> Path | None:
-    """Map an in-sandbox path to its host-side equivalent, or ``None`` when
-    it doesn't fall under ``/workspace/`` or ``/mnt/attachments/`` or escapes
-    the bind-mount root after ``..`` / symlink resolution.
-
-    Duplicated from :func:`aios.sandbox.volumes.resolve_to_host_path`
-    rather than imported so the reference SDK has zero aios server
-    dependency (mirrors the ``_AIOS_NOTIFICATION_PREFIX`` precedent).
-    """
+    """Map an in-sandbox path to its host equivalent, or ``None`` when it
+    falls outside ``/workspace/`` and ``/mnt/attachments/`` or escapes the
+    bind-mount root after ``..`` / symlink resolution."""
     if sandbox_path.startswith(_WORKSPACE_PREFIX):
         base = workspace_root / session_id
         suffix = sandbox_path[len(_WORKSPACE_PREFIX) :]

--- a/packages/aios-connector/tests/test_invoke_tool.py
+++ b/packages/aios-connector/tests/test_invoke_tool.py
@@ -1,9 +1,14 @@
-"""Dispatch-side tests for ``Connector._invoke_tool`` focal injection.
+"""Dispatch-side tests for ``Connector._invoke_tool``.
 
-Exercises the signature-inspection branch end-to-end without a live MCP
-server: stub out ``_focal_from_request_meta`` to return a known path,
-invoke ``_invoke_tool`` directly, and assert the right kwargs reach the
-tool method.
+Exercises both the focal-injection branch (signature inspection picks
+which kwargs to inject from ``_meta.aios.focal_channel_path``) and the
+:data:`SandboxPath` auto-resolution branch (each tool param annotated
+with ``SandboxPath`` / ``list[SandboxPath]`` is resolved to a host
+:class:`Path` before the tool body runs).
+
+Stub out ``_focal_from_request_meta`` and ``current_session_id`` to
+return known values, invoke ``_invoke_tool`` directly, and assert the
+right kwargs reach the tool method.
 """
 
 from __future__ import annotations
@@ -13,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from aios_connector import Connector, focal_required, tool
+from aios_connector import Connector, SandboxPath, focal_required, tool
 from aios_connector.base import _TOOL_ATTR, ToolDescriptor
 
 
@@ -112,3 +117,178 @@ async def test_non_focal_tool_ignores_meta(fixture: _DispatchFixture) -> None:
     descriptor = _descriptor_for(_DispatchFixture.non_focal)
     result = _decode(await fixture._invoke_tool(descriptor, {"text": "hi"}))
     assert result == {"text": "hi"}
+
+
+# ── SandboxPath dispatch: model strings → host Path objects ─────────
+
+
+class _SandboxDispatchFixture(Connector):
+    name = "_sandbox_dispatch_fixture"
+
+    @tool()
+    async def take_list(
+        self,
+        attachments: list[SandboxPath] | None = None,
+    ) -> dict[str, Any]:
+        """Body sees a list[Path] — the SDK pre-resolved each entry."""
+        if attachments is None:
+            return {"attachments": None}
+        return {
+            "attachments": [str(p) for p in attachments],
+            "kinds": [type(p).__name__ for p in attachments],
+        }
+
+    @tool()
+    async def take_scalar(
+        self,
+        path: SandboxPath,
+    ) -> dict[str, Any]:
+        """Body sees a Path — the SDK pre-resolved the string."""
+        return {"path": str(path), "kind": type(path).__name__}
+
+
+@pytest.fixture
+def sandbox_fixture(tmp_path: Path) -> _SandboxDispatchFixture:
+    return _SandboxDispatchFixture(spool_dir=tmp_path)
+
+
+def _stub_session_id(connector: Connector, value: str | None) -> None:
+    connector.current_session_id = lambda: value  # type: ignore[method-assign]
+
+
+async def test_list_sandbox_path_resolved_to_paths(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dispatch wrapper resolves each model-supplied string to a host
+    :class:`Path` BEFORE the tool body runs."""
+    _stub_session_id(sandbox_fixture, "sess-x")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-x").resolve()
+    ws.mkdir(parents=True)
+    (ws / "cat.jpg").write_bytes(b"x")
+    (ws / "dog.jpg").write_bytes(b"y")
+
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    result = _decode(
+        await sandbox_fixture._invoke_tool(
+            descriptor,
+            {"attachments": ["/workspace/cat.jpg", "/workspace/dog.jpg"]},
+        )
+    )
+    assert result["attachments"] == [str(ws / "cat.jpg"), str(ws / "dog.jpg")]
+    assert all(k in {"PosixPath", "WindowsPath"} for k in result["kinds"])
+
+
+async def test_scalar_sandbox_path_resolved_to_path(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_session_id(sandbox_fixture, "sess-x")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-x").resolve()
+    ws.mkdir(parents=True)
+    (ws / "cat.jpg").write_bytes(b"x")
+
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_scalar)
+    result = _decode(
+        await sandbox_fixture._invoke_tool(
+            descriptor,
+            {"path": "/workspace/cat.jpg"},
+        )
+    )
+    assert result["path"] == str(ws / "cat.jpg")
+    assert result["kind"] in {"PosixPath", "WindowsPath"}
+
+
+async def test_omitted_optional_list_sandbox_path_passes_through_as_none(
+    sandbox_fixture: _SandboxDispatchFixture,
+) -> None:
+    """The optional ``attachments`` parameter omitted by the model — no
+    session_id, no resolution work, body sees the default ``None``."""
+    _stub_session_id(sandbox_fixture, None)
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    result = _decode(await sandbox_fixture._invoke_tool(descriptor, {}))
+    assert result == {"attachments": None}
+
+
+async def test_empty_list_sandbox_path_passes_through_without_session_id(
+    sandbox_fixture: _SandboxDispatchFixture,
+) -> None:
+    """Empty list short-circuits — no path strings means no session_id
+    is needed, so text-only call sites work in tests that don't stamp it."""
+    _stub_session_id(sandbox_fixture, None)
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    result = _decode(await sandbox_fixture._invoke_tool(descriptor, {"attachments": []}))
+    assert result == {"attachments": [], "kinds": []}
+
+
+async def test_list_sandbox_path_missing_session_id_raises(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_session_id(sandbox_fixture, None)
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    with pytest.raises(RuntimeError, match=r"aios\.session_id"):
+        await sandbox_fixture._invoke_tool(descriptor, {"attachments": ["/workspace/x.jpg"]})
+
+
+async def test_list_sandbox_path_containment_violation_uniformly_raises(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Uniform error wording across connectors is the whole point — any
+    sandbox-path arg that fails containment raises the same ValueError."""
+    _stub_session_id(sandbox_fixture, "sess-x")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await sandbox_fixture._invoke_tool(descriptor, {"attachments": ["/etc/passwd"]})
+
+
+async def test_list_sandbox_path_traversal_rejected(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_session_id(sandbox_fixture, "sess-x")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-x").mkdir(parents=True)
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await sandbox_fixture._invoke_tool(
+            descriptor, {"attachments": ["/workspace/../escape.jpg"]}
+        )
+
+
+async def test_list_sandbox_path_missing_file_raises(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_session_id(sandbox_fixture, "sess-x")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-x").mkdir(parents=True)
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    with pytest.raises(ValueError, match="does not exist"):
+        await sandbox_fixture._invoke_tool(descriptor, {"attachments": ["/workspace/typo.jpg"]})
+
+
+async def test_list_sandbox_path_wrong_arg_type_raises_typeerror(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The model passing a string instead of a list is a contract bug,
+    not silent recovery — surface the error so the model retries with
+    the right shape."""
+    _stub_session_id(sandbox_fixture, "sess-x")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    with pytest.raises(TypeError, match="expects a list"):
+        await sandbox_fixture._invoke_tool(descriptor, {"attachments": "/workspace/x.jpg"})

--- a/packages/aios-connector/tests/test_media.py
+++ b/packages/aios-connector/tests/test_media.py
@@ -1,4 +1,4 @@
-"""Unit coverage for ``resolve_sandbox_path``.
+"""Unit coverage for ``_resolve_sandbox_path``.
 
 Mirrors the server-side ``resolve_to_host_path`` containment tests.
 Both helpers must reject the same attacks; duplicating coverage
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from aios_connector import resolve_sandbox_path
+from aios_connector.media import _resolve_sandbox_path
 
 
 class TestResolveSandboxPath:
     def test_workspace_subpath(self, tmp_path: Path) -> None:
-        result = resolve_sandbox_path(
+        result = _resolve_sandbox_path(
             session_id="sess-1",
             sandbox_path="/workspace/foo.jpg",
             workspace_root=tmp_path,
@@ -23,7 +23,7 @@ class TestResolveSandboxPath:
         assert result == (tmp_path / "sess-1" / "foo.jpg").resolve()
 
     def test_attachments_subpath(self, tmp_path: Path) -> None:
-        result = resolve_sandbox_path(
+        result = _resolve_sandbox_path(
             session_id="sess-1",
             sandbox_path="/mnt/attachments/echo/evt-photo.jpg",
             workspace_root=tmp_path,
@@ -31,7 +31,7 @@ class TestResolveSandboxPath:
         assert result == (tmp_path / "_attachments" / "sess-1" / "echo" / "evt-photo.jpg").resolve()
 
     def test_workspace_root(self, tmp_path: Path) -> None:
-        result = resolve_sandbox_path(
+        result = _resolve_sandbox_path(
             session_id="sess-1",
             sandbox_path="/workspace",
             workspace_root=tmp_path,
@@ -47,7 +47,7 @@ class TestResolveSandboxPath:
             "/workspaces/foo",
         ):
             assert (
-                resolve_sandbox_path(
+                _resolve_sandbox_path(
                     session_id="sess-1",
                     sandbox_path=bad,
                     workspace_root=tmp_path,
@@ -57,7 +57,7 @@ class TestResolveSandboxPath:
 
     def test_dotdot_escape_from_workspace_rejected(self, tmp_path: Path) -> None:
         assert (
-            resolve_sandbox_path(
+            _resolve_sandbox_path(
                 session_id="sess-1",
                 sandbox_path="/workspace/../../etc/hostname",
                 workspace_root=tmp_path,
@@ -67,7 +67,7 @@ class TestResolveSandboxPath:
 
     def test_dotdot_escape_from_attachments_rejected(self, tmp_path: Path) -> None:
         assert (
-            resolve_sandbox_path(
+            _resolve_sandbox_path(
                 session_id="sess-1",
                 sandbox_path="/mnt/attachments/../foo",
                 workspace_root=tmp_path,
@@ -76,7 +76,7 @@ class TestResolveSandboxPath:
         )
 
     def test_innocuous_dotdot_inside_workspace_allowed(self, tmp_path: Path) -> None:
-        result = resolve_sandbox_path(
+        result = _resolve_sandbox_path(
             session_id="sess-1",
             sandbox_path="/workspace/sub/../foo.jpg",
             workspace_root=tmp_path,
@@ -91,7 +91,7 @@ class TestResolveSandboxPath:
         (ws / "sneaky.jpg").symlink_to(outside)
 
         assert (
-            resolve_sandbox_path(
+            _resolve_sandbox_path(
                 session_id="sess-1",
                 sandbox_path="/workspace/sneaky.jpg",
                 workspace_root=tmp_path,
@@ -106,7 +106,7 @@ class TestResolveSandboxPath:
         target.write_bytes(b"x")
         (ws / "alias.jpg").symlink_to(target)
 
-        result = resolve_sandbox_path(
+        result = _resolve_sandbox_path(
             session_id="sess-1",
             sandbox_path="/workspace/alias.jpg",
             workspace_root=tmp_path,

--- a/packages/aios-connector/tests/test_tool_schema.py
+++ b/packages/aios-connector/tests/test_tool_schema.py
@@ -1,0 +1,252 @@
+"""JSON Schema generation from Python type hints.
+
+Covers the ``_hint_to_schema`` helper end-to-end: primitive types,
+parameterized generics, ``T | None`` unions (the headline case — a
+connector parameter typed ``list[str] | None`` must surface the
+array-of-strings shape, not an empty schema), plus an integration
+test that runs the full ``@tool()`` decorator path so a regression
+in the helper would also surface here.
+
+Also covers :data:`aios_connector.SandboxPath`, the marker connector
+authors annotate outbound-attachment parameters with: the schema must
+publish ``string`` (not ``Path``) so the model passes path strings,
+and the SDK's dispatch wrapper resolves them to host ``Path`` objects
+before the tool body runs.
+
+Wire evidence motivating this:  ``mcp__telegram__telegram_send``'s
+``attachments: list[str] | None = None`` parameter previously
+published an empty ``{}`` schema, leaving the model to guess the
+shape and learn from a tool error.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Annotated
+
+from aios_connector import Connector, SandboxPath, tool
+from aios_connector.base import _TOOL_ATTR, ToolDescriptor, _hint_to_schema
+
+# ── primitive shapes survive the swap ───────────────────────────────
+
+
+def test_str_hint() -> None:
+    assert _hint_to_schema(str) == {"type": "string"}
+
+
+def test_int_hint() -> None:
+    assert _hint_to_schema(int) == {"type": "integer"}
+
+
+def test_float_hint() -> None:
+    assert _hint_to_schema(float) == {"type": "number"}
+
+
+def test_bool_hint() -> None:
+    assert _hint_to_schema(bool) == {"type": "boolean"}
+
+
+# ── parameterized generics now carry their item / value type ────────
+
+
+def test_list_of_str_includes_items() -> None:
+    """``list[str]`` must publish ``items`` so the model knows it's a
+    list of strings, not an array of anything."""
+    assert _hint_to_schema(list[str]) == {"type": "array", "items": {"type": "string"}}
+
+
+def test_list_of_int_includes_items() -> None:
+    assert _hint_to_schema(list[int]) == {"type": "array", "items": {"type": "integer"}}
+
+
+def test_dict_str_int_includes_additional_properties() -> None:
+    """``dict[str, int]`` must publish ``additionalProperties`` so the
+    model knows values are integers, not arbitrary."""
+    assert _hint_to_schema(dict[str, int]) == {
+        "type": "object",
+        "additionalProperties": {"type": "integer"},
+    }
+
+
+# ── T | None flattens to T (optional handled by required[] absence) ─
+
+
+def test_optional_list_of_str_flattens_to_array() -> None:
+    """The headline failing case.  ``list[str] | None`` previously
+    produced ``{}``; pydantic emits an ``anyOf`` with a ``null`` arm
+    that we strip — the parameter being optional is encoded by its
+    absence from the parent object's ``required[]``, not by JSON
+    ``null`` shape (per MCP / OpenAI / Anthropic tool-args convention).
+    """
+    assert _hint_to_schema(list[str] | None) == {
+        "type": "array",
+        "items": {"type": "string"},
+    }
+
+
+def test_optional_str_flattens_to_string() -> None:
+    assert _hint_to_schema(str | None) == {"type": "string"}
+
+
+def test_optional_int_flattens_to_integer() -> None:
+    assert _hint_to_schema(int | None) == {"type": "integer"}
+
+
+# ── empty / unannotated parameters keep the SDK's best-effort floor ─
+
+
+def test_empty_hint_returns_empty_dict() -> None:
+    """A parameter without an annotation — ``def f(self, x)`` — must
+    not crash; the helper returns ``{}`` so schema generation stays
+    best-effort."""
+    assert _hint_to_schema(inspect.Parameter.empty) == {}
+
+
+def test_none_hint_returns_empty_dict() -> None:
+    assert _hint_to_schema(None) == {}
+
+
+# ── Annotated[X, ...] passes through to the inner type ──────────────
+
+
+def test_annotated_passes_through() -> None:
+    """``Annotated[str, "description"]`` should still produce a string
+    schema (pydantic treats Annotated metadata as descriptive, not
+    type-changing)."""
+    schema = _hint_to_schema(Annotated[str, "some metadata"])
+    assert schema["type"] == "string"
+
+
+# ── full @tool() integration: list[str] | None on a fixture method ──
+
+
+class _SchemaFixtureConnector(Connector):
+    name = "_schema_fixture"
+
+    @tool()
+    async def with_optional_list(
+        self,
+        text: str,
+        attachments: list[str] | None = None,
+    ) -> dict[str, object]:
+        """Mirror of telegram_send's signature for end-to-end verification."""
+        return {"text": text, "attachments": attachments}
+
+
+def _descriptor(fn: object) -> ToolDescriptor:
+    descriptor = getattr(fn, _TOOL_ATTR, None)
+    assert isinstance(descriptor, ToolDescriptor)
+    return descriptor
+
+
+def test_decorator_publishes_full_array_schema_for_optional_list() -> None:
+    """The @tool() decorator must publish the array-of-strings shape
+    for ``attachments: list[str] | None``.  This is the exact wire
+    failure the pydantic swap fixes — previously
+    ``input_schema["properties"]["attachments"]`` was ``{}``.
+    """
+    descriptor = _descriptor(_SchemaFixtureConnector.with_optional_list)
+    properties = descriptor.input_schema["properties"]
+    assert properties["text"] == {"type": "string"}
+    assert properties["attachments"] == {
+        "type": "array",
+        "items": {"type": "string"},
+    }
+    # `attachments` has a default → optional → not in required[].
+    assert descriptor.input_schema["required"] == ["text"]
+
+
+# ── SandboxPath: model-facing schema is `string`, body sees `Path` ───
+
+
+def test_sandbox_path_schema_is_string() -> None:
+    """A bare :data:`SandboxPath` parameter must publish a string schema —
+    the model passes in-sandbox path strings, the SDK auto-resolves to
+    a host :class:`Path` before the tool body runs.
+    """
+    schema = _hint_to_schema(SandboxPath)
+    assert schema["type"] == "string"
+    assert "/workspace/" in schema["description"]
+
+
+def test_list_sandbox_path_schema_is_array_of_strings() -> None:
+    schema = _hint_to_schema(list[SandboxPath])
+    assert schema == {
+        "type": "array",
+        "items": {
+            "type": "string",
+            "description": schema["items"]["description"],
+        },
+    }
+    assert "/workspace/" in schema["items"]["description"]
+
+
+def test_optional_sandbox_path_schema_is_string() -> None:
+    schema = _hint_to_schema(SandboxPath | None)
+    assert schema["type"] == "string"
+    assert "/workspace/" in schema["description"]
+
+
+def test_optional_list_sandbox_path_schema_is_array_of_strings() -> None:
+    """The headline shape signal/telegram tools use:
+    ``list[SandboxPath] | None = None``.
+    """
+    schema = _hint_to_schema(list[SandboxPath] | None)
+    assert schema["type"] == "array"
+    assert schema["items"]["type"] == "string"
+    assert "/workspace/" in schema["items"]["description"]
+
+
+class _SandboxFixtureConnector(Connector):
+    name = "_sandbox_fixture"
+
+    @tool()
+    async def with_attachments(
+        self,
+        text: str,
+        attachments: list[SandboxPath] | None = None,
+    ) -> dict[str, object]:
+        """End-to-end: list[SandboxPath] arrives resolved as list[Path]."""
+        if attachments is None:
+            return {"text": text}
+        return {"text": text, "first_path": str(attachments[0])}
+
+    @tool()
+    async def with_one_attachment(
+        self,
+        path: SandboxPath,
+    ) -> dict[str, object]:
+        """End-to-end: scalar SandboxPath arrives resolved as Path."""
+        return {"path": str(path)}
+
+
+def test_sandbox_path_descriptor_records_list_kind() -> None:
+    """The dispatch wrapper needs to know which params to resolve and how —
+    ``sandbox_params`` is the structured record built at decoration time.
+    """
+    descriptor = _descriptor(_SandboxFixtureConnector.with_attachments)
+    assert descriptor.sandbox_params == {"attachments": "list"}
+
+
+def test_sandbox_path_descriptor_records_scalar_kind() -> None:
+    descriptor = _descriptor(_SandboxFixtureConnector.with_one_attachment)
+    assert descriptor.sandbox_params == {"path": "scalar"}
+
+
+def test_sandbox_path_published_schema_is_string_array() -> None:
+    """Integration: the @tool() decorator publishes the array-of-strings
+    shape for ``attachments: list[SandboxPath] | None``."""
+    descriptor = _descriptor(_SandboxFixtureConnector.with_attachments)
+    properties = descriptor.input_schema["properties"]
+    assert properties["attachments"]["type"] == "array"
+    assert properties["attachments"]["items"]["type"] == "string"
+    assert "/workspace/" in properties["attachments"]["items"]["description"]
+    # `attachments` has a default → optional → not in required[].
+    assert descriptor.input_schema["required"] == ["text"]
+
+
+def test_scalar_sandbox_path_published_schema_is_string() -> None:
+    descriptor = _descriptor(_SandboxFixtureConnector.with_one_attachment)
+    properties = descriptor.input_schema["properties"]
+    assert properties["path"]["type"] == "string"
+    assert "/workspace/" in properties["path"]["description"]

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -771,7 +771,7 @@ async def list_running_session_ids(conn: asyncpg.Connection[Any]) -> list[str]:
 
 
 async def get_session_model(conn: asyncpg.Connection[Any], session_id: str) -> str:
-    """Return the bound mind URL for ``session_id`` in one round trip.
+    """Return the bound model for ``session_id`` in one round trip.
 
     Pinned ``agent_version`` wins when set; otherwise the live agent's
     current ``model`` is returned.
@@ -988,13 +988,13 @@ async def model_token_ratio(
     Below-threshold results are not cached, so newly accumulating models
     can activate as soon as the minimum sample count is reached.
 
-    ``model`` is the raw mind string (``agent.model``) — NO NORMALIZATION.
+    ``model`` is the raw model string (``agent.model``) — NO NORMALIZATION.
     Different LiteLLM routes (``anthropic/...`` vs
     ``openrouter/anthropic/...``) hit different provider tokenizers and
     must partition separately.  The same string must appear at stamp time
     and at query time for the same step — always plumb ``agent.model`` on
     both sides.  aios sessions do not carry a model override; the session's
-    active mind is always its agent's configured model.
+    active model is always its agent's configured model.
 
     Scope: the aggregate pools samples across every session in this
     database.  Token counts are scalar only — no content crosses between
@@ -1442,7 +1442,7 @@ async def read_windowed_events(
     ``window_max`` by the overhead amount.  Callers that don't have any
     such overhead (preview tooling, test scaffolds) pass ``0``.
 
-    ``model`` must be the session's currently-active mind string —
+    ``model`` must be the session's currently-active model string —
     ``agent.model`` on the session's pinned agent/version.  The same
     string is what :func:`~aios.harness.loop.run_session_step` stamps on
     ``model_request_end`` spans, so stamp-side and query-side stay

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -34,6 +34,15 @@ SWITCH_CHANNEL_METADATA_KEY = "switch_channel"
 # keys per the MCP spec.
 FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
+# Carries the calling session's id so MCP servers can resolve
+# model-visible in-sandbox paths to host equivalents.  Stamped on
+# every outbound MCP request alongside the focal-channel suffix —
+# including agent-declared HTTP MCP servers, which see the ULID and
+# ignore unknown ``_meta`` keys per the MCP spec.  ULIDs are not
+# secrets, but the leak is a real cross-boundary signal worth
+# knowing about.
+SESSION_ID_META_KEY = "aios.session_id"
+
 
 def focal_channel_path(focal: str | None) -> str | None:
     """Return the connector-relative suffix of a focal address.

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -104,7 +104,7 @@ from aios.harness.attachment_staging import (
 )
 from aios.harness.wake import defer_wake
 from aios.logging import get_logger
-from aios.mcp.client import shape_call_result
+from aios.mcp.client import MAX_TOOLS_PER_SERVER, shape_call_result
 from aios.mcp.stdio_transport import ConnectorSpec, open_connector_session
 from aios.models.sessions import MAX_USER_MESSAGE_CHARS
 from aios.services import sessions as sessions_service
@@ -288,8 +288,10 @@ def _apply_instance_overlay(
     on a fresh install.
 
     env: always pass the worker's ``os.environ`` to the subprocess so
-    pydantic-settings reads the same vars the operator set.  For
-    non-default instances, also re-export
+    pydantic-settings reads the same vars the operator set, with
+    path-shaped settings (``AIOS_WORKSPACE_ROOT``) absolutized so the
+    subprocess's different cwd doesn't shift the resolved location.
+    For non-default instances, also re-export
     ``AIOS_<CONN_UPPER>_<INST_UPPER>_*`` as ``AIOS_<CONN_UPPER>_*`` so
     connector subprocess code stays instance-naive — it just reads
     config under the standard prefix.  Single-instance deployments use
@@ -301,16 +303,20 @@ def _apply_instance_overlay(
         if ci.instance != ci.connector:
             cwd = cwd / ci.instance
     cwd.mkdir(parents=True, exist_ok=True)
-    env = _build_instance_env(ci, base=spec.env)
+    env = _build_instance_env(ci, settings=settings, base=spec.env)
     return replace(spec, cwd=cwd, env=env)
 
 
-def _build_instance_env(ci: ConnectorInstance, *, base: dict[str, str] | None) -> dict[str, str]:
+def _build_instance_env(
+    ci: ConnectorInstance, *, settings: Settings, base: dict[str, str] | None
+) -> dict[str, str]:
     """Construct the env dict for a connector subprocess.
 
     Starts from ``os.environ`` (so the subprocess inherits operator-set
     config), layers the factory-supplied ``base`` on top (factory wins
-    over inherited if both set the same key), and finally — for
+    over inherited if both set the same key), then absolutizes the
+    path-shaped settings the SDK and connector code rely on
+    (``AIOS_WORKSPACE_ROOT`` today — see below), and finally — for
     non-default instances — re-exports
     ``AIOS_<CONN_UPPER>_<INST_UPPER>_<FIELD>`` as
     ``AIOS_<CONN_UPPER>_<FIELD>`` so the connector reads its config
@@ -318,6 +324,18 @@ def _build_instance_env(ci: ConnectorInstance, *, base: dict[str, str] | None) -
     from the resulting env so each subprocess sees only its own
     credentials (a wedged or chatty connector that iterates
     ``os.environ`` won't surface sibling tokens).
+
+    Path absolutization: the worker resolves ``settings.workspace_root``
+    against its own cwd, but spawns connector subprocesses under
+    ``<connectors_dir>/<connector>/[<instance>/]``.  Inheriting the
+    operator's relative ``AIOS_WORKSPACE_ROOT`` (e.g. ``./workspaces``
+    in ``.env``) would let the SDK's ``SandboxPath`` resolution resolve
+    ``/workspace/foo.png`` against the wrong directory.  We stamp the
+    worker-resolved absolute path so harness and SDK agree on the
+    bind-mount root regardless of subprocess cwd.  Factory-supplied
+    overrides lose to this absolutized value: a connector that sets
+    ``AIOS_WORKSPACE_ROOT`` in ``spec.env`` would silently desynchronize
+    from the harness's bind-mount, which is almost certainly a bug.
 
     The re-export overrides any unscoped value: an operator running
     ``connectors_enabled=telegram:bot1,telegram:bot2`` with both
@@ -329,6 +347,11 @@ def _build_instance_env(ci: ConnectorInstance, *, base: dict[str, str] | None) -
     env: dict[str, str] = dict(os.environ)
     if base:
         env.update(base)
+    # Absolutize path-shaped settings the SDK/harness share via env so
+    # subprocesses don't resolve them against their own cwd.  Add new
+    # path-shaped settings here when they're introduced rather than
+    # relying on per-setting fixes scattered across call sites.
+    env["AIOS_WORKSPACE_ROOT"] = str(settings.workspace_root.resolve())
     if ci.instance == ci.connector:
         return env
     scope_prefix = f"AIOS_{ci.connector.upper()}_{ci.instance.upper()}_"
@@ -445,6 +468,54 @@ class ConnectorSubprocessRegistry:
     def lookup_instance_for_account(self, connector: str, account: str) -> str | None:
         """Return which instance serves ``(connector, account)`` per the routing map."""
         return self._account_to_instance.get((connector, account))
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """Enumerate connector-subprocess tools as OpenAI-format tool dicts.
+
+        Each ``mcp__<connector>__<tool>`` namespace matches the HTTP-MCP
+        path in :func:`aios.mcp.client.discover_mcp_tools` so the
+        dispatcher resolves either kind without a branch.  Multi-instance
+        connectors collapse duplicates by name with first-wins ordering.
+        Instances not in ``running`` are skipped; truncation cap mirrors
+        the HTTP-MCP path.  ``aios_inbound_ack`` is internal harness
+        machinery and never reaches the model.
+        """
+        running = [
+            (connector, state.session)
+            for (connector, _instance), state in self._states.items()
+            if state.status == "running" and state.session is not None
+        ]
+        if not running:
+            return []
+        results = await asyncio.gather(*(session.list_tools() for _, session in running))
+        seen: set[str] = set()
+        tools: list[dict[str, Any]] = []
+        for (connector, _session), result in zip(running, results, strict=True):
+            if len(result.tools) > MAX_TOOLS_PER_SERVER:
+                log.warning(
+                    "connector.tools_truncated",
+                    connector=connector,
+                    total=len(result.tools),
+                    limit=MAX_TOOLS_PER_SERVER,
+                )
+            for tool in result.tools[:MAX_TOOLS_PER_SERVER]:
+                if tool.name == "aios_inbound_ack":
+                    continue
+                qualified = f"mcp__{connector}__{tool.name}"
+                if qualified in seen:
+                    continue
+                seen.add(qualified)
+                tools.append(
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": qualified,
+                            "description": tool.description or "",
+                            "parameters": tool.inputSchema,
+                        },
+                    }
+                )
+        return tools
 
     async def get_session(self, connector: str, instance: str) -> ClientSession:
         """Return the live session for ``(connector, instance)``.

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -12,7 +12,7 @@ Two public functions:
 
 Both are pure functions of the event log + caller-supplied vision
 policy inputs (``model``, ``session_id``).  They DO read host bytes
-when an image attachment can be inlined for the bound mind — that I/O
+when an image attachment can be inlined for the bound model — that I/O
 is the cost of producing an ``image_url`` content part.  No DB access,
 no async.
 
@@ -201,7 +201,7 @@ def render_user_event(
       ``POST /sessions/{id}/messages`` traffic and pre-migration rows.
     * ``orig == focal_at_arrival`` (non-NULL) → full content with a
       metadata header inlined.  When the focal event's metadata
-      carries ``attachments`` and the bound mind supports vision,
+      carries ``attachments`` and the bound model supports vision,
       inlinable images are emitted as ``image_url`` content parts;
       everything else gets a text marker referencing the in-sandbox
       path.
@@ -299,7 +299,7 @@ def _apply_attachments(
         # non-empty`) so omit the leading text part when there is no caption,
         # no channel header, and no markers — the image_url parts stand on
         # their own.  OpenAI tolerates the empty part, but emitting it would
-        # break any vision-capable Anthropic-routed mind on a caption-less
+        # break any vision-capable Anthropic-routed model on a caption-less
         # image-only inbound.
         if text:
             msg["content"] = [{"type": "text", "text": text}, *image_parts]

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -95,6 +95,7 @@ async def compute_step_prelude(
     :func:`compose_step_context` unchanged, so the composed prompt stays
     byte-identical to what it was before the split.
     """
+    from aios.harness import runtime
     from aios.harness.channels import (
         augment_with_focal_paradigm,
         max_tail_block_local,
@@ -118,6 +119,12 @@ async def compute_step_prelude(
         mcp_tools, mcp_instructions = await discover_session_mcp_tools(pool, session_id, agent)
         tools.extend(mcp_tools)
         instructions_block = _build_instructions_block(agent.mcp_servers, mcp_instructions)
+
+    # Connector-subprocess (stdio MCP) tools come from the worker-scoped
+    # registry, separate from agent.mcp_servers (HTTP MCP).
+    connector_registry = runtime.connector_subprocess_registry
+    if connector_registry is not None:
+        tools.extend(await connector_registry.list_tools())
 
     skill_versions = (
         await skills_service.resolve_skill_refs(pool, agent.skills) if agent.skills else []

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -392,12 +392,16 @@ async def _execute_mcp_tool_async(
 
         server_name, tool_name = _parse_mcp_tool_name(name)
 
-        from aios.harness.channels import FOCAL_CHANNEL_META_KEY, focal_channel_path
+        from aios.harness.channels import (
+            FOCAL_CHANNEL_META_KEY,
+            SESSION_ID_META_KEY,
+            focal_channel_path,
+        )
 
-        meta: dict[str, Any] | None = None
+        meta: dict[str, Any] = {SESSION_ID_META_KEY: session_id}
         suffix = focal_channel_path(focal_channel)
         if suffix is not None:
-            meta = {FOCAL_CHANNEL_META_KEY: suffix}
+            meta[FOCAL_CHANNEL_META_KEY] = suffix
 
         # Connector subprocesses (stdio MCP children of the worker) take
         # precedence over agent-declared HTTP MCP servers: the model

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -49,7 +49,7 @@ def can_inline_image(*, model: str, content_type: str, size_bytes: int) -> bool:
     """True when ``model`` can see image bytes inlined as ``image_url``.
 
     Returns ``False`` for non-image content_types, oversize files
-    (over :data:`INLINE_SIZE_CAP_BYTES`), and minds without vision
+    (over :data:`INLINE_SIZE_CAP_BYTES`), and models without vision
     support.  Callers fall back to a text marker referencing the
     in-sandbox path so the model can still ``read`` the file later.
     """
@@ -71,7 +71,7 @@ def make_image_url_part(*, content_type: str, data_b64: str) -> dict[str, Any]:
 def text_marker(record: dict[str, Any]) -> str:
     """Inert text marker for an attachment that won't be inlined.
 
-    Used when the model can't see the pixels (non-vision mind, oversize
+    Used when the model can't see the pixels (non-vision model, oversize
     image, non-image attachment, legacy stub without ``in_sandbox_path``).
     The marker carries enough info for the model to ``read`` the path
     if the file is in fact reachable.

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -115,7 +115,7 @@ async def get_session(pool: asyncpg.Pool[Any], session_id: str) -> Session:
 
 
 async def get_session_model(pool: asyncpg.Pool[Any], session_id: str) -> str:
-    """Bound mind URL for ``session_id`` (pinned agent version wins)."""
+    """Bound model for ``session_id`` (pinned agent version wins)."""
     async with pool.acquire() as conn:
         return await queries.get_session_model(conn, session_id)
 

--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -3,7 +3,7 @@
 Text files return ``LINE_NUM<TAB>CONTENT`` windowed by ``offset`` /
 ``limit`` via ``cat -n | sed``.  Image files (extensions in
 :data:`_EXT_TO_MIME`) return a content-parts list with an
-``image_url`` block when the bound mind supports vision and the file
+``image_url`` block when the bound model supports vision and the file
 fits the inline cap; otherwise an explanatory ``ToolResult``.
 """
 

--- a/tests/unit/test_connector_subprocess_tools.py
+++ b/tests/unit/test_connector_subprocess_tools.py
@@ -1,0 +1,218 @@
+"""Unit tests for connector-subprocess tool enumeration.
+
+The ``ConnectorSubprocessRegistry`` owns long-lived stdio MCP sessions
+for every connector instance.  For the model to actually call those
+tools — instead of pattern-matching tool *names* from prior history —
+the harness has to enumerate them at step-prelude time and merge them
+into the ``tools[]`` payload sent to LiteLLM.
+
+These tests pin two pieces of that contract:
+
+* ``ConnectorSubprocessRegistry.list_tools()`` walks the running
+  instances, calls each session's ``list_tools()``, and returns
+  OpenAI-format tool dicts namespaced ``mcp__<connector>__<tool>``.
+
+* ``compute_step_prelude`` calls into that registry and the resulting
+  ``StepPrelude.tools`` includes the connector tools alongside builtin
+  + HTTP MCP tools.
+
+Both the SDK and the registry's per-instance state are mocked; we're
+only exercising orchestration.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.config import Settings
+from aios.harness.connector_supervisor import (
+    ConnectorState,
+    ConnectorSubprocessRegistry,
+)
+from aios.mcp.stdio_transport import ConnectorSpec
+
+
+def _fake_tool(name: str, description: str = "", schema: dict[str, Any] | None = None) -> Any:
+    """Minimal ``mcp.types.Tool`` stand-in: only the attributes the
+    enumeration code reads (``name``, ``description``, ``inputSchema``).
+    Using ``SimpleNamespace`` keeps us off the real pydantic model so
+    schema-evolution upstream doesn't break these tests.
+    """
+    return SimpleNamespace(
+        name=name,
+        description=description,
+        inputSchema=schema or {"type": "object", "properties": {}},
+    )
+
+
+def _registry_with_running_instance(
+    *,
+    connector: str,
+    instance: str,
+    tools: list[Any],
+) -> ConnectorSubprocessRegistry:
+    """Build a registry whose ``(connector, instance)`` state has a
+    fake live session whose ``list_tools()`` returns ``tools``.
+    """
+    spec = ConnectorSpec(name=connector, command="/bin/true", args=[])
+    state = ConnectorState(connector=connector, instance=instance, spec=spec)
+    state.status = "running"
+    fake_session = MagicMock()
+    fake_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=tools))
+    state.session = fake_session
+    state.ready.set()
+
+    registry = ConnectorSubprocessRegistry([], settings=Settings())
+    # Inject the prepared state directly; we're skipping the supervisor
+    # loop entirely (that's covered by other tests).
+    registry._states[(connector, instance)] = state
+    return registry
+
+
+class TestRegistryListTools:
+    async def test_returns_namespaced_openai_tools_for_running_instance(self) -> None:
+        registry = _registry_with_running_instance(
+            connector="telegram",
+            instance="telegram",
+            tools=[
+                _fake_tool(
+                    "telegram_send",
+                    description="Send a message",
+                    schema={
+                        "type": "object",
+                        "properties": {
+                            "account": {"type": "string"},
+                            "chat_id": {"type": "string"},
+                            "text": {"type": "string"},
+                        },
+                        "required": ["account", "chat_id", "text"],
+                    },
+                )
+            ],
+        )
+
+        tools = await registry.list_tools()
+
+        assert len(tools) == 1
+        tool = tools[0]
+        assert tool["type"] == "function"
+        fn = tool["function"]
+        assert fn["name"] == "mcp__telegram__telegram_send"
+        assert fn["description"] == "Send a message"
+        # Schema flows through unchanged so the model sees parameter shapes.
+        assert "account" in fn["parameters"]["properties"]
+        assert "text" in fn["parameters"]["properties"]
+
+    async def test_skips_instances_that_arent_running(self) -> None:
+        spec = ConnectorSpec(name="signal", command="/bin/true", args=[])
+        state = ConnectorState(connector="signal", instance="signal", spec=spec)
+        # status defaults to "starting"; ready is not set; session is None.
+        registry = ConnectorSubprocessRegistry([], settings=Settings())
+        registry._states[("signal", "signal")] = state
+
+        tools = await registry.list_tools()
+
+        assert tools == []
+
+    async def test_dedupes_tools_across_instances_of_same_connector(self) -> None:
+        """Multi-instance connectors (telegram:bot1, telegram:bot2)
+        publish the same toolset.  The model sees one ``mcp__telegram__*``
+        namespace, so duplicates from sibling instances must be collapsed.
+        """
+        registry = _registry_with_running_instance(
+            connector="telegram",
+            instance="bot1",
+            tools=[_fake_tool("telegram_send")],
+        )
+        # Add a second instance with the same tool.
+        spec = ConnectorSpec(name="telegram", command="/bin/true", args=[])
+        bot2_state = ConnectorState(connector="telegram", instance="bot2", spec=spec)
+        bot2_state.status = "running"
+        fake_session = MagicMock()
+        fake_session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[_fake_tool("telegram_send")])
+        )
+        bot2_state.session = fake_session
+        bot2_state.ready.set()
+        registry._states[("telegram", "bot2")] = bot2_state
+
+        tools = await registry.list_tools()
+
+        names = [t["function"]["name"] for t in tools]
+        assert names == ["mcp__telegram__telegram_send"]
+
+
+class TestStepPreludeIncludesConnectorTools:
+    """Integration over ``compute_step_prelude``: with a connector
+    registry on ``runtime``, the connector tools must appear in
+    ``StepPrelude.tools``.  This is the bug the parent investigation
+    surfaced: a live worker request had 51 tools, none of which were
+    connector tools, because tool assembly never consulted the registry.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_registry(self) -> Any:
+        """Clear ``runtime.connector_subprocess_registry`` after each test
+        so a fixture isn't visible to unrelated tests in the same run.
+        """
+        from aios.harness import runtime
+
+        before = runtime.connector_subprocess_registry
+        try:
+            yield
+        finally:
+            runtime.connector_subprocess_registry = before
+
+    async def test_connector_tools_appear_in_prelude(self) -> None:
+        from aios.harness import runtime
+        from aios.harness.step_context import compute_step_prelude
+
+        runtime.connector_subprocess_registry = _registry_with_running_instance(
+            connector="signal",
+            instance="signal",
+            tools=[
+                _fake_tool(
+                    "signal_send",
+                    description="Send a Signal message",
+                    schema={
+                        "type": "object",
+                        "properties": {
+                            "account": {"type": "string"},
+                            "recipient": {"type": "string"},
+                            "text": {"type": "string"},
+                        },
+                        "required": ["account", "recipient", "text"],
+                    },
+                )
+            ],
+        )
+
+        agent = SimpleNamespace(
+            tools=[],
+            mcp_servers=[],
+            skills=[],
+            system="you are an agent",
+        )
+        session = SimpleNamespace(id="sess_x", focal_channel=None)
+
+        with patch(
+            "aios.harness.skills.augment_system_prompt",
+            side_effect=lambda system, _versions: system,
+        ):
+            prelude = await compute_step_prelude(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                session=session,
+                agent=agent,
+                channels=[],
+                memory_store_echoes=[],
+            )
+
+        names = [t["function"]["name"] for t in prelude.tools]
+        assert "mcp__signal__signal_send" in names, (
+            f"connector tool absent from prelude — model will never see schema. tools={names}"
+        )

--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -85,12 +85,19 @@ class TestResolveConnectorSpecs:
     plan-decision #11.
     """
 
-    def _settings(self, *, enabled: list[str], connectors_dir: Any = None) -> Any:
+    def _settings(
+        self,
+        *,
+        enabled: list[str],
+        connectors_dir: Any = None,
+        workspace_root: Any = None,
+    ) -> Any:
         from pathlib import Path
 
         s = MagicMock()
         s.connectors_enabled = enabled
         s.connectors_dir = connectors_dir or Path("/tmp/aios-connectors-test")
+        s.workspace_root = workspace_root or Path("/tmp/aios-workspaces-test")
         return s
 
     def test_unknown_name_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -208,6 +215,79 @@ class TestResolveConnectorSpecs:
         # Default-instance just inherits parent env unmodified.
         assert spec.env is not None
         assert spec.env["AIOS_TELEGRAM_BOT_TOKEN"] == "the-only-token"
+
+    def test_workspace_root_absolutized_for_subprocess(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """Operator's relative ``AIOS_WORKSPACE_ROOT`` (or relative
+        ``workspace_root`` setting) must be absolutized before reaching the
+        connector subprocess.
+
+        The subprocess runs under ``<connectors_dir>/<connector>/`` as cwd,
+        so a relative env value would resolve against the wrong directory
+        inside the SDK's ``SandboxPath`` resolution.  Wire-level
+        symptom: outbound attachments fail with ``sandbox path
+        '/workspace/foo.png' does not exist (resolved to
+        <connectors_dir>/<connector>/workspaces/<session>/foo.png)``.
+        """
+        from pathlib import Path
+
+        ep = MagicMock()
+        ep.name = "telegram"
+        ep.load.return_value = lambda name, settings: ConnectorSpec(name=name, command="/bin/echo")
+        monkeypatch.setattr(
+            "aios.harness.connector_supervisor.entry_points",
+            lambda group: [ep],
+        )
+        # Operator's parent env carries a relative path (real .env scenario).
+        monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "./workspaces")
+        monkeypatch.chdir(tmp_path)
+        specs = resolve_connector_specs(
+            self._settings(
+                enabled=["telegram"],
+                workspace_root=Path("./workspaces"),
+            )
+        )
+        _, spec = specs[0]
+        assert spec.env is not None
+        resolved = spec.env["AIOS_WORKSPACE_ROOT"]
+        assert os.path.isabs(resolved), (
+            f"AIOS_WORKSPACE_ROOT should be absolute in subprocess env, got {resolved!r}"
+        )
+        # And it should resolve against the worker's CWD (tmp_path), not
+        # the connector subprocess's cwd.
+        assert Path(resolved) == (tmp_path / "workspaces").resolve()
+
+    def test_factory_supplied_workspace_root_is_overridden(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """Factory specs that set ``AIOS_WORKSPACE_ROOT`` lose to the
+        worker-resolved absolute path.
+
+        The harness uses ``settings.workspace_root`` to find session
+        workspaces on the host; a connector author overriding it via
+        ``spec.env`` would silently desynchronize the SDK's
+        ``SandboxPath`` resolution from the harness's bind-mount, so the
+        absolutized worker value wins.
+        """
+        from pathlib import Path
+
+        ep = MagicMock()
+        ep.name = "telegram"
+        ep.load.return_value = lambda name, settings: ConnectorSpec(
+            name=name,
+            command="/bin/echo",
+            env={"AIOS_WORKSPACE_ROOT": "/nope/factory/wins"},
+        )
+        monkeypatch.setattr(
+            "aios.harness.connector_supervisor.entry_points",
+            lambda group: [ep],
+        )
+        ws = tmp_path / "workspaces"
+        specs = resolve_connector_specs(self._settings(enabled=["telegram"], workspace_root=ws))
+        _, spec = specs[0]
+        assert spec.env is not None
+        assert Path(spec.env["AIOS_WORKSPACE_ROOT"]) == ws.resolve()
 
 
 class TestPumpStderrLineExtraction:

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -3,7 +3,7 @@
 The renderer's vision policy is delegated to
 :mod:`aios.harness.vision`; here we exercise the wiring around it —
 host-bytes-read for inlinable images, text-marker fallback for
-non-vision minds and oversize images, and the legacy-stub path.
+non-vision models and oversize images, and the legacy-stub path.
 """
 
 from __future__ import annotations
@@ -35,8 +35,8 @@ def _stub_supports_vision(monkeypatch: pytest.MonkeyPatch) -> Any:
     """
     saved = dict(vision._VISION_OVERRIDES)
     vision._VISION_OVERRIDES.clear()
-    vision._VISION_OVERRIDES["mind/vision"] = True
-    vision._VISION_OVERRIDES["mind/text"] = False
+    vision._VISION_OVERRIDES["model/vision"] = True
+    vision._VISION_OVERRIDES["model/text"] = False
     yield
     vision._VISION_OVERRIDES.clear()
     vision._VISION_OVERRIDES.update(saved)
@@ -85,7 +85,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/vision",
+            model="model/vision",
             session_id="sess-1",
         )
         content = msg["content"]
@@ -118,7 +118,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/vision",
+            model="model/vision",
             session_id="sess-1",
         )
         assert isinstance(msg["content"], str)
@@ -142,7 +142,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/text",
+            model="model/text",
             session_id="sess-1",
         )
         assert isinstance(msg["content"], str)
@@ -167,7 +167,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/vision",
+            model="model/vision",
             session_id="sess-1",
         )
         assert isinstance(msg["content"], str)
@@ -188,7 +188,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/vision",
+            model="model/vision",
             session_id="sess-1",
         )
         assert isinstance(msg["content"], str)
@@ -224,7 +224,7 @@ class TestVisionAwareRendering:
         text blocks (``text content blocks must be non-empty``).  The
         common path is fine because the channel header populates the
         leading text, but legacy events with metadata-stripped headers
-        would 400 against Anthropic-routed minds.  Regression test for
+        would 400 against Anthropic-routed models.  Regression test for
         PR #218.
         """
         sandbox_path = _stage_image(
@@ -260,7 +260,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/vision",
+            model="model/vision",
             session_id="sess-1",
         )
         content = msg["content"]
@@ -298,7 +298,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/vision",
+            model="model/vision",
             session_id="sess-1",
         )
         content = msg["content"]

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -72,8 +72,8 @@ def stub_runtime(stub_handle: ContainerHandle) -> Any:
 def _vision_overrides(monkeypatch: pytest.MonkeyPatch) -> Any:
     saved = dict(vision._VISION_OVERRIDES)
     vision._VISION_OVERRIDES.clear()
-    vision._VISION_OVERRIDES["mind/vision"] = True
-    vision._VISION_OVERRIDES["mind/text"] = False
+    vision._VISION_OVERRIDES["model/vision"] = True
+    vision._VISION_OVERRIDES["model/text"] = False
     yield
     vision._VISION_OVERRIDES.clear()
     vision._VISION_OVERRIDES.update(saved)
@@ -84,7 +84,7 @@ def stub_get_session_model(monkeypatch: pytest.MonkeyPatch) -> Any:
     """Replace the DB lookup with a callable returning whatever the test sets."""
 
     class _Model:
-        value: str = "mind/vision"
+        value: str = "model/vision"
 
     state = _Model()
 
@@ -118,7 +118,7 @@ class TestImageBranch:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         _stage_workspace_image("sess_01TEST", "screenshot.png", b"PNGbytes")
 
         result = await read_handler("sess_01TEST", {"path": "/workspace/screenshot.png"})
@@ -139,7 +139,7 @@ class TestImageBranch:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         _stage_attachment("sess_01TEST", "echo", "evt-1-photo.jpg", b"JPGbytes")
 
         result = await read_handler(
@@ -156,7 +156,7 @@ class TestImageBranch:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/text"
+        stub_get_session_model.value = "model/text"
         _stage_workspace_image("sess_01TEST", "screenshot.png", b"PNG")
 
         result = await read_handler("sess_01TEST", {"path": "/workspace/screenshot.png"})
@@ -172,7 +172,7 @@ class TestImageBranch:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         _stage_workspace_image("sess_01TEST", "huge.png", b"\0" * (3 * 1024 * 1024))
 
         result = await read_handler("sess_01TEST", {"path": "/workspace/huge.png"})
@@ -188,7 +188,7 @@ class TestImageBranch:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         workspace_dir_for("sess_01TEST").mkdir(parents=True, exist_ok=True)
 
         result = await read_handler("sess_01TEST", {"path": "/workspace/nope.png"})
@@ -207,7 +207,7 @@ class TestImageBranch:
     ) -> None:
         """Reading ``/etc/foo.png`` (not a bind mount) hits docker-exec
         with one combined stat+base64 invocation."""
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         b64_payload = base64.b64encode(b"otherbytes").decode()
         stub_handle.run_command = AsyncMock(  # type: ignore[method-assign]
             return_value=CommandResult(
@@ -248,7 +248,7 @@ class TestImagePathTraversalAttack:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         host_secret = b"HOST-SECRET-BYTES-DO-NOT-LEAK"
         (temp_workspace_root / "host_secret.png").write_bytes(host_secret)
         workspace_dir_for("sess_01TEST").mkdir(parents=True, exist_ok=True)
@@ -282,7 +282,7 @@ class TestImagePathTraversalAttack:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         host_secret = b"ATTACHMENTS-LEAK-PROBE"
         (temp_workspace_root / "leak.png").write_bytes(host_secret)
         session_attachments_dir("sess_01TEST").mkdir(parents=True, exist_ok=True)
@@ -317,7 +317,7 @@ class TestImagePathTraversalAttack:
         lives outside the bind-mount root (e.g. via ``ln -s`` from inside
         the sandbox), then ``read``s through it. Containment must follow
         the symlink and reject."""
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         host_secret = b"SYMLINK-ESCAPE-PROBE-BYTES"
         outside = temp_workspace_root / "outside.png"
         outside.write_bytes(host_secret)


### PR DESCRIPTION
## Summary

Closes the outbound half of #216.  The model writes ``MEDIA:<absolute_path>`` tokens in a send-tool's text argument; the connector resolves each path to a host equivalent and uploads the file as platform media.  Remaining text becomes caption.

**Stacked on:** [#220 (PR4/4)](https://github.com/eumemic/aios/pull/220) — base ``wt/recursive-weaving-sundae-pr4``.

### Server side
- New ``SESSION_ID_META_KEY = \"aios.session_id\"`` in ``harness/channels.py``; ``tool_dispatch.py`` stamps it alongside ``FOCAL_CHANNEL_META_KEY`` on every outbound MCP request.

### SDK
- ``Connector.current_session_id()`` accessor reads ``_meta.aios.session_id``.
- ``Connector.resolve_media_paths(paths, *, tool_name)`` consolidates the per-connector resolution loop into the base class.
- ``aios_connector.media.resolve_sandbox_path`` mirrors server-side ``resolve_to_host_path`` with the same containment check (intentional duplication; SDK has zero aios-server dependency).

### Connectors
- **Signal:** ``signal_send`` passes ``attachments=[...]`` to signal-cli's ``send`` RPC.  Multi-attachment sends ride on the same RPC call.
- **Telegram:** ``telegram_send`` classifies by extension and routes single-media to ``send_photo``/``send_voice``/``send_document``/``send_video``/``send_audio``; multi-media to ``send_media_group`` with caption on the first item only (Telegram API quirk).  Voice in a media group is demoted to document.

### Documentation
- Send-tool docstrings teach the MEDIA convention to the model with examples + path allowlist.
- Connector READMEs gain Attachments sections covering inbound staging + outbound MEDIA.

## Tests

- **SDK** (62 total): 9 new ``TestResolveSandboxPath`` tests mirror the server-side traversal + symlink-escape coverage from PR2's containment fix.
- **Signal** (81 total): 8 new ``test_signal_send_*`` tests covering text-only, single/multi MEDIA, traversal rejection, disallowed-root rejection, missing session_id.
- **Telegram** (33 total): 13 new ``test_telegram_send_*`` tests covering type-by-extension routing, media-group caption-on-first, traversal/disallowed-root/missing-session_id failures, voice-demoted-to-document.

## Test plan
- [x] ``uv run mypy src`` — 131 files
- [x] All connector packages mypy-clean (signal: 13 src files, telegram: 9, SDK: 4)
- [x] ``uv run ruff check`` + ``ruff format --check`` clean
- [x] Unit suite — 1123 passed
- [x] SDK package — 62 passed
- [x] Signal connector — 81 passed
- [x] Telegram connector — 33 passed

## Stack

1. PR1 ([#217](https://github.com/eumemic/aios/pull/217))
2. PR2 ([#218](https://github.com/eumemic/aios/pull/218))
3. PR3 ([#219](https://github.com/eumemic/aios/pull/219))
4. PR4 ([#220](https://github.com/eumemic/aios/pull/220))
5. **PR5 (this)** — outbound MEDIA wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)