### PR TITLE
fix: signal smoke-test findings — inbound attachments + boot health + token fixture (#223)

### DIFF
--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -97,9 +97,21 @@ That env var is removed cleanly — set `AIOS_SIGNAL_PHONES=+1...` (a
 one-element CSV) for an equivalent single-phone deployment.  Multi-
 phone setups become `AIOS_SIGNAL_PHONES=+1...,+2...`.
 
+## Attachments
+
+Inbound photos, voice notes, and documents surface to the model as
+`image_url` content parts (vision-capable minds) or text markers,
+via the harness's vision pipeline.  Each file is staged under
+`<workspace_root>/_attachments/<session>/signal/...` and made
+readable inside the sandbox at `/mnt/attachments/signal/...`.
+
+Outbound: pass an `attachments: list[str]` parameter to
+`signal_send` alongside `text`.  Each path must be under
+`/workspace/` or `/mnt/attachments/` (the latter is read-only, so to
+forward an inbound file `cp` it into `/workspace/` first).
+
 ## Out of scope for v1
 
-- Attachments (inbound messages with attachments are posted text-only with `[attachment: <name> (<mime>)]` markers; `signal_send` has no attachment parameter).
 - Voice / Say / SoundEffect / Listen tools.
 - Group create / rename / add-members.
 - Typing indicators.

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -197,8 +197,15 @@ class SignalConnector(Connector):
 
     @tool()
     @focal_required
-    async def signal_send(self, text: str, *, account: str, chat_id: str) -> dict[str, Any]:
-        """Send a text message to your focal Signal chat.
+    async def signal_send(
+        self,
+        text: str,
+        attachments: list[str] | None = None,
+        *,
+        account: str,
+        chat_id: str,
+    ) -> dict[str, Any]:
+        """Send a Signal message to your focal chat, optionally with attachments.
 
         The account (your bot UUID) and chat id are taken implicitly
         from your focal channel — aios injects them via the JSON-RPC
@@ -207,12 +214,18 @@ class SignalConnector(Connector):
 
         Args:
             text: Message body. Markdown is converted to Signal text styles.
+            attachments: Optional list of in-sandbox file paths to attach.
+                Each path must be under ``/workspace/`` or
+                ``/mnt/attachments/``.  ``/mnt/attachments/`` is read-only,
+                so to forward an inbound photo ``cp`` it into ``/workspace/``
+                first.
         """
         assert self._daemon is not None
         phone = self._uuid_to_phone.get(account)
         if phone is None:
             raise ValueError(f"signal_send: unknown account {account!r}")
-        params = _build_send_params(phone, chat_id, text)
+        host_paths = self.resolve_media_paths(attachments or [], tool_name="signal_send")
+        params = _build_send_params(phone, chat_id, text, attachments=host_paths)
         result = await self._daemon.rpc.call("send", params)
         ts = _extract_timestamp(result)
         return {"sent_at_ms": ts} if ts is not None else {"status": "ok"}
@@ -287,7 +300,13 @@ def _build_sdk_attachments(msg: InboundMessage) -> list[SDKAttachment]:
     return out
 
 
-def _build_send_params(account_phone: str, chat_id: str, text: str) -> dict[str, Any]:
+def _build_send_params(
+    account_phone: str,
+    chat_id: str,
+    text: str,
+    *,
+    attachments: list[str],
+) -> dict[str, Any]:
     """Translate ``(account_phone, chat_id, text)`` into signal-cli ``send`` params."""
     chat_type, raw_id = decode_chat_id(chat_id)
     stripped, styles = convert_markdown_to_signal_styles(text)
@@ -298,6 +317,8 @@ def _build_send_params(account_phone: str, chat_id: str, text: str) -> dict[str,
         params["groupId"] = raw_id
     else:
         params["recipient"] = [raw_id]
+    if attachments:
+        params["attachments"] = attachments
     return params
 
 

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -34,7 +34,16 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
-from aios_connector import Connector, focal_required, make_account, tool
+from aios_connector import (
+    Attachment as SDKAttachment,
+)
+from aios_connector import (
+    AttachmentError,
+    Connector,
+    focal_required,
+    make_account,
+    tool,
+)
 
 from .addressing import decode_chat_id, encode_chat_id
 from .config import Settings
@@ -164,6 +173,7 @@ class SignalConnector(Connector):
                 "uuid": msg.sender_uuid,
                 "display_name": msg.sender_name or msg.sender_uuid,
             }
+            sdk_attachments = _build_sdk_attachments(msg)
             # Signal envelope timestamps are millis since epoch.  Render
             # them as ISO-8601 UTC so the supervisor stamps a string that
             # operators (and any future cross-platform tooling) can read
@@ -178,6 +188,7 @@ class SignalConnector(Connector):
                 chat_id=chat_id,
                 sender=sender_payload,
                 content=content,
+                attachments=sdk_attachments or None,
                 metadata=metadata,
                 timestamp=timestamp_iso,
             )
@@ -244,6 +255,36 @@ class SignalConnector(Connector):
         params = _build_react_params(phone, chat_id, target_author_uuid, target_timestamp_ms, emoji)
         await self._daemon.rpc.call("sendReaction", params)
         return {"status": "ok"}
+
+
+def _build_sdk_attachments(msg: InboundMessage) -> list[SDKAttachment]:
+    """Build SDK Attachment records, logging+skipping any rejected by ``as_params``."""
+    out: list[SDKAttachment] = []
+    for att in msg.attachments:
+        if att.host_path is None:
+            log.warning(
+                "signal.inbound.attachment_no_host_path",
+                content_type=att.content_type,
+                filename=att.filename,
+            )
+            continue
+        candidate = SDKAttachment(
+            host_path=att.host_path,
+            filename=att.filename or "unnamed",
+            content_type=att.content_type,
+        )
+        try:
+            candidate.as_params()
+        except AttachmentError as err:
+            log.warning(
+                "signal.inbound.attachment_rejected",
+                host_path=att.host_path,
+                filename=att.filename,
+                error=str(err),
+            )
+            continue
+        out.append(candidate)
+    return out
 
 
 def _build_send_params(account_phone: str, chat_id: str, text: str) -> dict[str, Any]:

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -71,6 +71,15 @@ class SignalConnector(Connector):
         # Contacts + group rosters are per-account because each phone has
         # its own contact store and group memberships in signal-cli.
         self._contact_names_by_account: dict[str, dict[str, str]] = {}
+        # Phone → error message for accounts whose boot-time probe
+        # (``listContacts`` / ``listGroups``) failed.  signal-cli's
+        # daemon stays running and accepts new attachments to other
+        # accounts, so we don't refuse the connector outright; but
+        # unhealthy accounts are dropped from ``discover_accounts``
+        # so the operator's ``aios connectors accounts`` listing
+        # surfaces only the working ones.  The connector refuses
+        # to start if NO accounts are healthy (in :meth:`setup`).
+        self._unavailable_accounts: dict[str, str] = {}
 
     # ── lifecycle ─────────────────────────────────────────────────────
 
@@ -97,10 +106,27 @@ class SignalConnector(Connector):
         # race for the daemon's contact-store lock without measurable
         # speedup at this scale.
         instructions_sections: list[str] = []
+        healthy_count = 0
         for phone, bot_uuid in self._bot_uuids.items():
-            contact_names = await self._daemon.list_contacts(account=phone)
+            try:
+                contact_names = await self._daemon.list_contacts(account=phone)
+                groups = await self._daemon.list_groups(account=phone)
+            except Exception as err:
+                # signal-cli rejected the boot probe — typically because
+                # the account isn't registered with Signal's servers
+                # (operator hasn't run ``signal-cli register``, or the
+                # registration expired).  Don't mark this account ready;
+                # log loudly so the operator sees red on
+                # ``aios connectors list`` instead of silent inbound-drops.
+                log.error(
+                    "signal.account.unavailable",
+                    bot_uuid=bot_uuid,
+                    phone=phone,
+                    error=str(err),
+                )
+                self._unavailable_accounts[phone] = str(err)
+                continue
             self._contact_names_by_account[phone] = contact_names
-            groups = await self._daemon.list_groups(account=phone)
             section = build_instructions(
                 bot_uuid=bot_uuid,
                 phone=phone,
@@ -109,12 +135,18 @@ class SignalConnector(Connector):
                 contact_names=contact_names,
             )
             instructions_sections.append(section)
+            healthy_count += 1
             log.info(
                 "signal.account.ready",
                 bot_uuid=bot_uuid,
                 phone=phone,
                 contacts=len(contact_names),
                 groups=len(groups),
+            )
+        if healthy_count == 0 and self._bot_uuids:
+            errs = ", ".join(f"{phone}: {err}" for phone, err in self._unavailable_accounts.items())
+            raise RuntimeError(
+                f"signal connector cannot start: no configured account is healthy ({errs})"
             )
         # Concatenate per-account sections.  build_instructions already
         # produces a self-contained block per account; joining with a
@@ -130,6 +162,7 @@ class SignalConnector(Connector):
                 metadata={"phone": phone},
             )
             for phone, bot_uuid in self._bot_uuids.items()
+            if phone not in self._unavailable_accounts
         ]
 
     async def teardown(self) -> None:
@@ -173,7 +206,7 @@ class SignalConnector(Connector):
                 "uuid": msg.sender_uuid,
                 "display_name": msg.sender_name or msg.sender_uuid,
             }
-            sdk_attachments = _build_sdk_attachments(msg)
+            sdk_attachments = self._build_sdk_attachments(msg)
             # Signal envelope timestamps are millis since epoch.  Render
             # them as ISO-8601 UTC so the supervisor stamps a string that
             # operators (and any future cross-platform tooling) can read
@@ -269,35 +302,46 @@ class SignalConnector(Connector):
         await self._daemon.rpc.call("sendReaction", params)
         return {"status": "ok"}
 
+    def _build_sdk_attachments(self, msg: InboundMessage) -> list[SDKAttachment]:
+        """Build SDK Attachment records, logging+skipping any rejected.
 
-def _build_sdk_attachments(msg: InboundMessage) -> list[SDKAttachment]:
-    """Build SDK Attachment records, logging+skipping any rejected by ``as_params``."""
-    out: list[SDKAttachment] = []
-    for att in msg.attachments:
-        if att.host_path is None:
-            log.warning(
-                "signal.inbound.attachment_no_host_path",
+        signal-cli's JSON-RPC daemon mode (0.14.x) auto-downloads
+        attachment bytes but omits the ``file`` field from the
+        envelope — it was only emitted by the legacy CLI command
+        output.  We fall back to the storage-layout convention
+        ``<config_dir>/attachments/<id>`` for envelopes without a
+        host_path; SDK ``as_params`` validates the file actually
+        exists.
+        """
+        out: list[SDKAttachment] = []
+        for att in msg.attachments:
+            host_path = att.host_path
+            if host_path is None and att.id is not None:
+                host_path = str(self._cfg.config_dir / "attachments" / att.id)
+            if host_path is None:
+                log.warning(
+                    "signal.inbound.attachment_no_host_path",
+                    content_type=att.content_type,
+                    filename=att.filename,
+                )
+                continue
+            candidate = SDKAttachment(
+                host_path=host_path,
+                filename=att.filename or "unnamed",
                 content_type=att.content_type,
-                filename=att.filename,
             )
-            continue
-        candidate = SDKAttachment(
-            host_path=att.host_path,
-            filename=att.filename or "unnamed",
-            content_type=att.content_type,
-        )
-        try:
-            candidate.as_params()
-        except AttachmentError as err:
-            log.warning(
-                "signal.inbound.attachment_rejected",
-                host_path=att.host_path,
-                filename=att.filename,
-                error=str(err),
-            )
-            continue
-        out.append(candidate)
-    return out
+            try:
+                candidate.as_params()
+            except AttachmentError as err:
+                log.warning(
+                    "signal.inbound.attachment_rejected",
+                    host_path=host_path,
+                    filename=att.filename,
+                    error=str(err),
+                )
+                continue
+            out.append(candidate)
+        return out
 
 
 def _build_send_params(

--- a/connectors/signal/src/aios_signal/daemon.py
+++ b/connectors/signal/src/aios_signal/daemon.py
@@ -235,19 +235,22 @@ class SignalDaemon:
     async def list_groups(self, *, account: str) -> list[GroupInfo]:
         """Return the bot's group memberships via signal-cli ``listGroups``.
 
-        Best-effort: returns an empty list on RPC failure or malformed
-        responses.  Group IDs are re-encoded into URL-safe base64 so the
-        caller can use them directly as channel-path suffixes
+        Raises ``RpcError`` / ``RpcTimeoutError`` on RPC failure — the
+        boot-time caller in :meth:`SignalConnector.setup` uses the raise
+        to refuse marking the account ready when signal-cli reports
+        e.g. ``Specified account does not exist`` (the operator
+        forgot to register it, or the registration expired).  The
+        supervisor surfaces the resulting setup failure to ``aios
+        connectors list`` so the operator sees red instead of green.
+
+        Group IDs are re-encoded into URL-safe base64 so the caller
+        can use them directly as channel-path suffixes
         (``signal/<bot>/<id>``) — matching :func:`encode_chat_id`'s
-        ``group`` branch.  Groups missing either an ``id`` or ``members``
-        are dropped; the agent-facing roster is supposed to be a
-        complete picture of "who is in this room with me."
+        ``group`` branch.  Groups missing either an ``id`` or
+        ``members`` are dropped; the agent-facing roster is supposed
+        to be a complete picture of "who is in this room with me."
         """
-        try:
-            result = await self.rpc.call("listGroups", {"account": account})
-        except Exception:
-            log.warning("signal.list_groups.failed", account=account, exc_info=True)
-            return []
+        result = await self.rpc.call("listGroups", {"account": account})
         if not isinstance(result, list):
             return []
         out: list[GroupInfo] = []

--- a/connectors/signal/src/aios_signal/parse.py
+++ b/connectors/signal/src/aios_signal/parse.py
@@ -24,6 +24,12 @@ class Attachment:
     content_type: str
     filename: str | None
     host_path: str | None
+    # signal-cli's storage id, used to compute the on-disk path when
+    # the daemon's JSON-RPC envelope omits the ``file`` field (which it
+    # does in JSON-RPC daemon mode 0.14.x — only the legacy CLI output
+    # included it).  By signal-cli convention the file lives at
+    # ``<config_dir>/attachments/<id>``.
+    id: str | None
 
 
 @dataclass(slots=True, frozen=True)
@@ -151,6 +157,7 @@ def parse_envelope(
             content_type=a.get("contentType", "application/octet-stream"),
             filename=a.get("filename") if isinstance(a.get("filename"), str) else None,
             host_path=a.get("file") if isinstance(a.get("file"), str) else None,
+            id=a.get("id") if isinstance(a.get("id"), str) else None,
         )
         for a in attachments_raw
         if isinstance(a, dict)

--- a/connectors/signal/src/aios_signal/parse.py
+++ b/connectors/signal/src/aios_signal/parse.py
@@ -23,6 +23,7 @@ MENTION_PLACEHOLDER = "\ufffc"
 class Attachment:
     content_type: str
     filename: str | None
+    host_path: str | None
 
 
 @dataclass(slots=True, frozen=True)
@@ -149,6 +150,7 @@ def parse_envelope(
         Attachment(
             content_type=a.get("contentType", "application/octet-stream"),
             filename=a.get("filename") if isinstance(a.get("filename"), str) else None,
+            host_path=a.get("file") if isinstance(a.get("file"), str) else None,
         )
         for a in attachments_raw
         if isinstance(a, dict)
@@ -179,9 +181,4 @@ def parse_envelope(
 
 
 def build_content_text(msg: InboundMessage) -> str:
-    parts: list[str] = []
-    if msg.text:
-        parts.append(msg.text)
-    for a in msg.attachments:
-        parts.append(f"[attachment: {a.filename or '(unnamed)'} ({a.content_type})]")
-    return "\n".join(parts)
+    return msg.text

--- a/connectors/signal/tests/conftest.py
+++ b/connectors/signal/tests/conftest.py
@@ -49,6 +49,11 @@ def envelope_attachment_only() -> dict[str, Any]:
 
 
 @pytest.fixture
+def envelope_attachment_no_file_field() -> dict[str, Any]:
+    return _load("attachment_no_file_field.json")
+
+
+@pytest.fixture
 def envelope_receipt() -> dict[str, Any]:
     return _load("receipt.json")
 

--- a/connectors/signal/tests/fixtures/attachment_no_file_field.json
+++ b/connectors/signal/tests/fixtures/attachment_no_file_field.json
@@ -1,0 +1,18 @@
+{
+  "source": "+15551234567",
+  "sourceUuid": "11111111-2222-3333-4444-555555555555",
+  "sourceName": "Alice",
+  "sourceDevice": 1,
+  "timestamp": 1700000005000,
+  "dataMessage": {
+    "timestamp": 1700000005000,
+    "attachments": [
+      {
+        "contentType": "image/png",
+        "filename": "photo.png",
+        "id": "xyz-789",
+        "size": 27794
+      }
+    ]
+  }
+}

--- a/connectors/signal/tests/test_inbound_attachment_fallback.py
+++ b/connectors/signal/tests/test_inbound_attachment_fallback.py
@@ -1,0 +1,132 @@
+"""Regression for #223 §8: signal-cli's JSON-RPC daemon mode omits the
+``file`` field from attachment envelopes.  The connector falls back to
+the ``<config_dir>/attachments/<id>`` storage convention so inbound
+photos still reach the model as ``image_url`` parts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aios_signal.config import Settings
+from aios_signal.connector import SignalConnector
+from aios_signal.parse import Attachment, InboundMessage
+
+
+def _make_connector(config_dir: Path) -> SignalConnector:
+    cfg = Settings(
+        phones=["+15550001"],
+        config_dir=config_dir,
+        cli_bin="/usr/bin/signal-cli",
+    )
+    return SignalConnector(cfg)
+
+
+def _make_msg(attachments: tuple[Attachment, ...]) -> InboundMessage:
+    return InboundMessage(
+        chat_type="dm",
+        raw_chat_id="11111111-2222-3333-4444-555555555555",
+        sender_uuid="11111111-2222-3333-4444-555555555555",
+        sender_name="Alice",
+        chat_name=None,
+        timestamp_ms=1700000000000,
+        text="",
+        attachments=attachments,
+        reply=None,
+        reaction=None,
+    )
+
+
+def test_fallback_to_config_dir_when_file_field_omitted(tmp_path: Path) -> None:
+    """The daemon's JSON-RPC envelope omits ``file`` but ``id``
+    points at ``<config_dir>/attachments/<id>``.  Plant the file
+    there and assert the SDK Attachment surfaces with that path."""
+    config_dir = tmp_path / "signal-cfg"
+    (config_dir / "attachments").mkdir(parents=True)
+    expected_path = config_dir / "attachments" / "xyz-789"
+    expected_path.write_bytes(b"fake-png-bytes")
+
+    connector = _make_connector(config_dir)
+    msg = _make_msg(
+        (
+            Attachment(
+                content_type="image/png",
+                filename="photo.png",
+                host_path=None,
+                id="xyz-789",
+            ),
+        )
+    )
+
+    sdk_atts = connector._build_sdk_attachments(msg)
+
+    assert len(sdk_atts) == 1
+    assert sdk_atts[0].host_path == str(expected_path)
+    assert sdk_atts[0].content_type == "image/png"
+
+
+def test_fallback_skips_when_file_missing_on_disk(tmp_path: Path) -> None:
+    """If the file isn't where we'd expect (signal-cli didn't auto-download
+    or the daemon's storage layout differs), as_params rejects and the
+    attachment is logged + skipped."""
+    config_dir = tmp_path / "signal-cfg"
+    (config_dir / "attachments").mkdir(parents=True)
+
+    connector = _make_connector(config_dir)
+    msg = _make_msg(
+        (
+            Attachment(
+                content_type="image/png",
+                filename="photo.png",
+                host_path=None,
+                id="never-downloaded",
+            ),
+        )
+    )
+
+    sdk_atts = connector._build_sdk_attachments(msg)
+    assert sdk_atts == []
+
+
+def test_no_id_no_host_path_skips_with_warning(tmp_path: Path) -> None:
+    """Records that have neither host_path nor id (shouldn't happen, but
+    a malformed daemon could produce it) get logged + skipped, not
+    crashed on."""
+    connector = _make_connector(tmp_path / "cfg")
+    msg = _make_msg(
+        (
+            Attachment(
+                content_type="image/png",
+                filename="photo.png",
+                host_path=None,
+                id=None,
+            ),
+        )
+    )
+
+    assert connector._build_sdk_attachments(msg) == []
+
+
+def test_explicit_host_path_wins_over_id_fallback(tmp_path: Path) -> None:
+    """When the envelope DOES include ``file`` (legacy CLI shape), the
+    explicit host_path is used and the id-based fallback isn't consulted."""
+    config_dir = tmp_path / "signal-cfg"
+    config_dir.mkdir()
+    explicit = tmp_path / "explicit-path.png"
+    explicit.write_bytes(b"x")
+
+    connector = _make_connector(config_dir)
+    msg = _make_msg(
+        (
+            Attachment(
+                content_type="image/png",
+                filename="photo.png",
+                host_path=str(explicit),
+                id="ignored",
+            ),
+        )
+    )
+
+    sdk_atts = connector._build_sdk_attachments(msg)
+    assert len(sdk_atts) == 1
+    assert sdk_atts[0].host_path == str(explicit)

--- a/connectors/signal/tests/test_list_groups.py
+++ b/connectors/signal/tests/test_list_groups.py
@@ -62,10 +62,13 @@ class TestListGroups:
             member_uuids=["33333333-0003-0000-0000-000000000000"],
         )
 
-    async def test_empty_list_when_rpc_fails(self) -> None:
+    async def test_rpc_failure_propagates(self) -> None:
+        """Boot-time callers depend on the raise to mark accounts unhealthy
+        rather than silently treating "not registered" as "no groups"."""
         daemon = _make_daemon()
         daemon.rpc.call = AsyncMock(side_effect=RuntimeError("rpc broken"))  # type: ignore[method-assign]
-        assert await daemon.list_groups(account="+15550001111") == []
+        with pytest.raises(RuntimeError, match="rpc broken"):
+            await daemon.list_groups(account="+15550001111")
 
     async def test_empty_list_when_rpc_returns_non_list(self) -> None:
         daemon = _make_daemon()

--- a/connectors/signal/tests/test_parse.py
+++ b/connectors/signal/tests/test_parse.py
@@ -82,13 +82,12 @@ def test_missing_source_uuid_returns_none(bot_uuid: str) -> None:
     assert parse_envelope(envelope, bot_account_uuid=bot_uuid) is None
 
 
-def test_build_content_text_with_attachments(
+def test_build_content_text_attachment_only_is_empty(
     envelope_attachment_only: dict[str, Any], bot_uuid: str
 ) -> None:
     msg = parse_envelope(envelope_attachment_only, bot_account_uuid=bot_uuid)
     assert msg is not None
-    rendered = build_content_text(msg)
-    assert rendered == "[attachment: photo.jpg (image/jpeg)]"
+    assert build_content_text(msg) == ""
 
 
 def test_build_content_text_with_text_and_attachment(bot_uuid: str) -> None:
@@ -102,9 +101,16 @@ def test_build_content_text_with_text_and_attachment(bot_uuid: str) -> None:
         chat_name=None,
         timestamp_ms=1,
         text="Check this out",
-        attachments=(Attachment(content_type="image/png", filename="x.png"),),
+        attachments=(Attachment(content_type="image/png", filename="x.png", host_path="/tmp/x"),),
         reply=None,
         reaction=None,
     )
-    rendered = build_content_text(msg)
-    assert rendered == "Check this out\n[attachment: x.png (image/png)]"
+    assert build_content_text(msg) == "Check this out"
+
+
+def test_attachment_captures_host_path(
+    envelope_attachment_only: dict[str, Any], bot_uuid: str
+) -> None:
+    msg = parse_envelope(envelope_attachment_only, bot_account_uuid=bot_uuid)
+    assert msg is not None
+    assert msg.attachments[0].host_path == "/tmp/signal-cli/attachments/abc-def-123"

--- a/connectors/signal/tests/test_parse.py
+++ b/connectors/signal/tests/test_parse.py
@@ -101,7 +101,14 @@ def test_build_content_text_with_text_and_attachment(bot_uuid: str) -> None:
         chat_name=None,
         timestamp_ms=1,
         text="Check this out",
-        attachments=(Attachment(content_type="image/png", filename="x.png", host_path="/tmp/x"),),
+        attachments=(
+            Attachment(
+                content_type="image/png",
+                filename="x.png",
+                host_path="/tmp/x",
+                id="abc",
+            ),
+        ),
         reply=None,
         reaction=None,
     )
@@ -114,3 +121,15 @@ def test_attachment_captures_host_path(
     msg = parse_envelope(envelope_attachment_only, bot_account_uuid=bot_uuid)
     assert msg is not None
     assert msg.attachments[0].host_path == "/tmp/signal-cli/attachments/abc-def-123"
+    assert msg.attachments[0].id == "abc-def-123"
+
+
+def test_attachment_no_file_field_carries_id(
+    envelope_attachment_no_file_field: dict[str, Any], bot_uuid: str
+) -> None:
+    """JSON-RPC daemon mode envelopes omit ``file`` but keep ``id``;
+    connector-side fallback uses ``id`` to reconstruct the on-disk path."""
+    msg = parse_envelope(envelope_attachment_no_file_field, bot_account_uuid=bot_uuid)
+    assert msg is not None
+    assert msg.attachments[0].host_path is None
+    assert msg.attachments[0].id == "xyz-789"

--- a/connectors/signal/tests/test_setup_health.py
+++ b/connectors/signal/tests/test_setup_health.py
@@ -1,0 +1,95 @@
+"""Regression for #223 §3: signal connector startup must surface
+listGroups failure (typically "account not registered") rather than
+marking the account ready with empty contacts/groups.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios_signal.config import Settings
+from aios_signal.connector import SignalConnector
+
+
+def _stub_daemon() -> MagicMock:
+    daemon = MagicMock()
+    daemon.discover_bot_uuids = AsyncMock()
+    daemon.list_contacts = AsyncMock()
+    daemon.list_groups = AsyncMock()
+    daemon.__aenter__ = AsyncMock(return_value=daemon)
+    daemon.__aexit__ = AsyncMock(return_value=None)
+    return daemon
+
+
+@pytest.fixture
+def connector(tmp_path: Path) -> SignalConnector:
+    cfg = Settings(
+        phones=["+15551111111"],
+        config_dir=tmp_path / "cfg",
+        cli_bin="/usr/bin/signal-cli",
+    )
+    return SignalConnector(cfg)
+
+
+async def test_setup_refuses_when_only_account_unavailable(
+    connector: SignalConnector,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One configured phone whose listGroups raises → setup must raise.
+    Operator sees the connector fail to start instead of green-but-dead."""
+    daemon = _stub_daemon()
+    daemon.discover_bot_uuids.return_value = {"+15551111111": "bot-uuid"}
+    daemon.list_contacts.return_value = {}
+    daemon.list_groups.side_effect = RuntimeError("Specified account does not exist")
+    monkeypatch.setattr(
+        "aios_signal.connector.SignalDaemon",
+        MagicMock(return_value=daemon),
+    )
+
+    with pytest.raises(RuntimeError, match="no configured account is healthy"):
+        await connector.setup()
+
+
+async def test_setup_drops_unavailable_account_when_others_healthy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multi-account setup: one bad account, one good → connector starts,
+    bad account dropped from discover_accounts."""
+    cfg = Settings(
+        phones=["+15551111111", "+15552222222"],
+        config_dir=tmp_path / "cfg",
+        cli_bin="/usr/bin/signal-cli",
+    )
+    connector = SignalConnector(cfg)
+
+    daemon = _stub_daemon()
+    daemon.discover_bot_uuids.return_value = {
+        "+15551111111": "bot-bad",
+        "+15552222222": "bot-good",
+    }
+    daemon.list_contacts.side_effect = lambda account: (
+        {"bot-good": "Good Bot"} if account == "+15552222222" else {}
+    )
+
+    async def _list_groups(account: str) -> list[Any]:
+        if account == "+15551111111":
+            raise RuntimeError("not registered")
+        return []
+
+    daemon.list_groups.side_effect = _list_groups
+    monkeypatch.setattr(
+        "aios_signal.connector.SignalDaemon",
+        MagicMock(return_value=daemon),
+    )
+
+    await connector.setup()
+
+    accounts = await connector.discover_accounts()
+    assert len(accounts) == 1
+    assert accounts[0]["id"] == "bot-good"
+    assert "+15551111111" in connector._unavailable_accounts

--- a/connectors/signal/tests/test_signal_send.py
+++ b/connectors/signal/tests/test_signal_send.py
@@ -1,0 +1,159 @@
+"""Unit coverage for ``signal_send``'s ``attachments`` parameter
+and ``_build_send_params``'s ``attachments`` field.
+
+Drives the build helper directly (no signal-cli) plus exercises the
+high-level ``signal_send`` method with a stubbed daemon to verify
+that attachment paths reach the RPC params resolved to host paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios_signal.config import Settings
+from aios_signal.connector import SignalConnector, _build_send_params
+
+
+def test_build_params_no_attachments() -> None:
+    params = _build_send_params("+15550001", "alice", "hello", attachments=[])
+    assert "attachments" not in params
+    assert params["message"] == "hello"
+
+
+def test_build_params_with_attachments() -> None:
+    params = _build_send_params(
+        "+15550001",
+        "alice",
+        "look",
+        attachments=["/host/a.jpg", "/host/b.jpg"],
+    )
+    assert params["attachments"] == ["/host/a.jpg", "/host/b.jpg"]
+
+
+@pytest.fixture
+def connector(tmp_path: Path) -> SignalConnector:
+    cfg = Settings(
+        phones=["+15550001"],
+        config_dir=tmp_path / "cfg",
+        cli_bin="/usr/bin/signal-cli",
+    )
+    c = SignalConnector(cfg)
+    c._uuid_to_phone = {"bot-uuid": "+15550001"}
+    c._daemon = type(  # type: ignore[assignment]
+        "Daemon", (), {"rpc": type("Rpc", (), {"call": AsyncMock(return_value=None)})()}
+    )()
+    return c
+
+
+def _patch_session_id(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    monkeypatch.setattr(SignalConnector, "current_session_id", lambda self: value)
+
+
+async def test_signal_send_text_only_no_session_id_required(
+    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_session_id(monkeypatch, None)
+    result = await connector.signal_send("hello there", account="bot-uuid", chat_id="alice")
+    assert result == {"status": "ok"}
+    sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
+    assert sent_params["message"] == "hello there"
+    assert "attachments" not in sent_params
+
+
+async def test_signal_send_with_attachments_resolves_to_host_paths(
+    connector: SignalConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    (ws / "cat.jpg").write_bytes(b"x")
+
+    await connector.signal_send(
+        "look",
+        attachments=["/workspace/cat.jpg"],
+        account="bot-uuid",
+        chat_id="alice",
+    )
+
+    sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
+    assert sent_params["message"] == "look"
+    assert sent_params["attachments"] == [str(ws / "cat.jpg")]
+
+
+async def test_signal_send_attachments_without_session_id_raises(
+    connector: SignalConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, None)
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    with pytest.raises(RuntimeError, match=r"aios\.session_id"):
+        await connector.signal_send(
+            "look",
+            attachments=["/workspace/cat.jpg"],
+            account="bot-uuid",
+            chat_id="alice",
+        )
+
+
+async def test_signal_send_attachment_traversal_rejected(
+    connector: SignalConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-1").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await connector.signal_send(
+            "look",
+            attachments=["/workspace/../escape.jpg"],
+            account="bot-uuid",
+            chat_id="alice",
+        )
+
+
+async def test_signal_send_attachment_disallowed_root_rejected(
+    connector: SignalConnector,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await connector.signal_send(
+            "boom",
+            attachments=["/etc/passwd"],
+            account="bot-uuid",
+            chat_id="alice",
+        )
+
+
+async def test_signal_send_attachment_missing_file_raises_clear_error(
+    connector: SignalConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-1").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="does not exist"):
+        await connector.signal_send(
+            "look",
+            attachments=["/workspace/typo.jpg"],
+            account="bot-uuid",
+            chat_id="alice",
+        )
+
+
+async def test_signal_send_unknown_account_raises(
+    connector: SignalConnector,
+) -> None:
+    with pytest.raises(ValueError, match="unknown account"):
+        await connector.signal_send("hi", account="nope", chat_id="alice")

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -76,10 +76,26 @@ When deploying multiple instances, set
 `AIOS_TELEGRAM_SUPPORT_BOT_TOKEN`).  Instance names match
 `^[a-z][a-z0-9_]*$`.
 
+## Attachments
+
+Inbound photos, voice notes, documents, video, and audio are
+downloaded via `bot.get_file()` and surfaced as `image_url` content
+parts (vision-capable minds) or text markers, via the harness's
+vision pipeline.  Stickers and animations are dropped; captions
+become the message text.
+
+Outbound: pass an `attachments: list[str]` parameter to
+`telegram_send` alongside `text`.  Type is inferred from extension
+— `.jpg`/`.png` photo, `.mp4` video, `.ogg` voice, `.mp3` audio,
+anything else document.  Single attachment uses
+`send_photo`/`send_voice`/etc with caption; multiple attachments
+use `send_media_group` (caption rides on the first item only, per
+Telegram's API).  Paths must be under `/workspace/` or
+`/mnt/attachments/`.
+
 ## Out of scope for v1
 
-- Inbound media (photos, voice, documents, stickers) — dropped silently.
-- Outbound media — no `telegram_send_photo` / `_document`.
+- Stickers and animations (dropped on inbound).
 - Reactions — punt.
 - Message editing / deletion.
 - Typing indicators / chat actions.

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -32,15 +32,27 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import tempfile
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 import structlog
-from aios_connector import Connector, focal_required, make_account, tool
+from aios_connector import (
+    Attachment as SDKAttachment,
+)
+from aios_connector import (
+    AttachmentError,
+    Connector,
+    focal_required,
+    make_account,
+    tool,
+)
+from telegram.error import TelegramError
 from telegram.ext import Application, ContextTypes, MessageHandler, filters
 
 from .config import Settings
-from .parse import InboundMessage, parse_message
+from .parse import Attachment, InboundMessage, parse_message
 from .prompts import build_instructions
 
 log = structlog.get_logger(__name__)
@@ -104,7 +116,8 @@ class TelegramConnector(Connector):
         async def on_error(_update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
             log.error("telegram.handler.error", error=str(context.error))
 
-        application.add_handler(MessageHandler(filters.TEXT, on_message))
+        # parse_message handles channel/bot filtering with full message context.
+        application.add_handler(MessageHandler(filters.ALL, on_message))
         application.add_error_handler(on_error)
         log.info(
             "telegram.bot.identified",
@@ -165,6 +178,7 @@ class TelegramConnector(Connector):
     async def _drain_queue(self) -> None:
         assert self._inbound_queue is not None
         assert self._bot_id is not None
+        assert self._application is not None
         while True:
             msg = await self._inbound_queue.get()
             sender_payload: dict[str, Any] = {
@@ -181,14 +195,72 @@ class TelegramConnector(Connector):
                 if msg.timestamp_ms
                 else None
             )
+            sdk_attachments = await self._download_attachments(msg.attachments)
             await self.emit_inbound(
                 account=str(self._bot_id),
                 chat_id=str(msg.chat_id),
                 sender=sender_payload,
                 content=msg.text,
+                attachments=sdk_attachments or None,
                 metadata=metadata,
                 timestamp=timestamp_iso,
             )
+
+    async def _download_attachments(
+        self, attachments: tuple[Attachment, ...]
+    ) -> list[SDKAttachment]:
+        """Download each attachment in parallel, log+skip the rejects."""
+        host_paths = await asyncio.gather(*(self._download_one(a) for a in attachments))
+        out: list[SDKAttachment] = []
+        for att, host_path in zip(attachments, host_paths, strict=True):
+            if host_path is None:
+                continue
+            candidate = SDKAttachment(
+                host_path=str(host_path),
+                filename=att.filename,
+                content_type=att.content_type,
+            )
+            try:
+                candidate.as_params()
+            except AttachmentError as err:
+                log.warning(
+                    "telegram.inbound.attachment_rejected",
+                    file_id=att.file_id,
+                    filename=att.filename,
+                    error=str(err),
+                )
+                continue
+            out.append(candidate)
+        return out
+
+    async def _download_one(self, att: Attachment) -> Path | None:
+        assert self._application is not None
+        try:
+            file = await self._application.bot.get_file(att.file_id)
+        except TelegramError as err:
+            log.warning(
+                "telegram.inbound.get_file_failed",
+                file_id=att.file_id,
+                error=str(err),
+            )
+            return None
+        # Close the handle immediately so PTB owns the write side.
+        with tempfile.NamedTemporaryFile(
+            prefix="aios-telegram-", suffix=Path(att.filename).suffix, delete=False
+        ) as tmp:
+            target = Path(tmp.name)
+        try:
+            await file.download_to_drive(custom_path=target)
+        except (TelegramError, OSError) as err:
+            log.warning(
+                "telegram.inbound.download_failed",
+                file_id=att.file_id,
+                target=str(target),
+                error=str(err),
+            )
+            await asyncio.to_thread(target.unlink, missing_ok=True)
+            return None
+        return target
 
     # ── model-facing tools ────────────────────────────────────────────
 

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -48,6 +48,12 @@ from aios_connector import (
     make_account,
     tool,
 )
+from telegram import (
+    InputMediaAudio,
+    InputMediaDocument,
+    InputMediaPhoto,
+    InputMediaVideo,
+)
 from telegram.error import TelegramError
 from telegram.ext import Application, ContextTypes, MessageHandler, filters
 
@@ -266,8 +272,14 @@ class TelegramConnector(Connector):
 
     @tool()
     @focal_required
-    async def telegram_send(self, text: str, *, chat_id: str) -> dict[str, Any]:
-        """Send a text message to your focal Telegram chat.
+    async def telegram_send(
+        self,
+        text: str,
+        attachments: list[str] | None = None,
+        *,
+        chat_id: str,
+    ) -> dict[str, Any]:
+        """Send a Telegram message to your focal chat, optionally with attachments.
 
         The chat id is taken implicitly from your focal channel — aios
         injects it via the JSON-RPC ``_meta`` field on each call.  Set
@@ -275,14 +287,105 @@ class TelegramConnector(Connector):
 
         Args:
             text: Message body. Plain text only — markdown is not rendered.
+                Becomes the caption when attachments are present.
+            attachments: Optional list of in-sandbox file paths.  Type is
+                inferred from extension (``.jpg``/``.png``/``.gif``/``.webp``
+                → photo, ``.mp4``/``.mov`` → video, ``.ogg`` → voice,
+                ``.mp3``/``.m4a``/``.wav`` → audio, anything else →
+                document).  Single attachment uses ``send_photo`` /
+                ``send_voice`` / etc.; multiple attachments use
+                ``send_media_group`` with caption attached to the first
+                item only (per Telegram API).  Paths must be under
+                ``/workspace/`` or ``/mnt/attachments/``.
         """
         assert self._application is not None
         try:
             chat_id_int = int(chat_id)
         except ValueError as e:
             raise ValueError(f"telegram chat_id must be an integer; got {chat_id!r}") from e
-        sent = await self._application.bot.send_message(chat_id=chat_id_int, text=text)
-        return {"message_id": sent.message_id}
+
+        host_paths = self.resolve_media_paths(attachments or [], tool_name="telegram_send")
+        bot = self._application.bot
+
+        if not host_paths:
+            sent = await bot.send_message(chat_id=chat_id_int, text=text)
+            return {"message_id": sent.message_id}
+
+        if len(host_paths) == 1:
+            single = await _send_single_media(
+                bot,
+                chat_id=chat_id_int,
+                host_path=host_paths[0],
+                caption=text or None,
+            )
+            return {"message_id": single.message_id}
+
+        sent_group = await bot.send_media_group(
+            chat_id=chat_id_int,
+            media=_build_media_group(host_paths, caption=text or None),
+        )
+        return {"message_ids": [m.message_id for m in sent_group]}
+
+
+_PHOTO_EXTS = frozenset({".jpg", ".jpeg", ".png", ".gif", ".webp"})
+_VIDEO_EXTS = frozenset({".mp4", ".mov", ".webm"})
+_VOICE_EXTS = frozenset({".ogg", ".oga"})
+_AUDIO_EXTS = frozenset({".mp3", ".m4a", ".wav", ".flac"})
+
+
+def _classify(host_path: str) -> str:
+    ext = Path(host_path).suffix.lower()
+    if ext in _PHOTO_EXTS:
+        return "photo"
+    if ext in _VIDEO_EXTS:
+        return "video"
+    if ext in _VOICE_EXTS:
+        return "voice"
+    if ext in _AUDIO_EXTS:
+        return "audio"
+    return "document"
+
+
+async def _send_single_media(
+    bot: Any,
+    *,
+    chat_id: int,
+    host_path: str,
+    caption: str | None,
+) -> Any:
+    kind = _classify(host_path)
+    sender = {
+        "photo": bot.send_photo,
+        "video": bot.send_video,
+        "voice": bot.send_voice,
+        "audio": bot.send_audio,
+        "document": bot.send_document,
+    }[kind]
+    kwargs: dict[str, Any] = {"chat_id": chat_id, kind: host_path}
+    if caption is not None:
+        kwargs["caption"] = caption
+    return await sender(**kwargs)
+
+
+def _build_media_group(host_paths: list[str], *, caption: str | None) -> list[Any]:
+    # Caption rides on the FIRST item only — Telegram's API ignores
+    # captions on items 2..N of a media group.
+    items: list[Any] = []
+    for idx, path in enumerate(host_paths):
+        kind = _classify(path)
+        kwargs: dict[str, Any] = {"media": path}
+        if idx == 0 and caption is not None:
+            kwargs["caption"] = caption
+        if kind == "photo":
+            items.append(InputMediaPhoto(**kwargs))
+        elif kind == "video":
+            items.append(InputMediaVideo(**kwargs))
+        elif kind == "audio":
+            items.append(InputMediaAudio(**kwargs))
+        else:
+            # Voice can't go in a media group; fall back to document.
+            items.append(InputMediaDocument(**kwargs))
+    return items
 
 
 def build_metadata(msg: InboundMessage, bot_id: int) -> dict[str, Any]:

--- a/connectors/telegram/src/aios_telegram/parse.py
+++ b/connectors/telegram/src/aios_telegram/parse.py
@@ -1,13 +1,8 @@
 """Parse python-telegram-bot ``Message`` objects into :class:`InboundMessage`.
 
-v1 scope is text only. We return ``None`` for anything we don't forward to
-aios — messages from the bot itself, bot-to-bot traffic, non-text payloads
-(photos, stickers, voice, documents), and messages without a sender.
-
-Edits (``update.edited_message``) and channel posts never reach this
-function because the handler in :mod:`aios_telegram.bot` registers on
-``update.message`` with a ``filters.TEXT`` gate — this module is only
-responsible for the parse, not for the filter-at-dispatch.
+Returns ``None`` for messages from the bot itself, bot-to-bot
+traffic, channel posts (no ``from_user``), and otherwise-empty
+messages.
 """
 
 from __future__ import annotations
@@ -19,6 +14,13 @@ from telegram import Message
 from telegram.constants import ChatType
 
 ChatKind = Literal["dm", "group", "supergroup", "channel"]
+
+
+@dataclass(slots=True, frozen=True)
+class Attachment:
+    file_id: str
+    content_type: str
+    filename: str
 
 
 @dataclass(slots=True, frozen=True)
@@ -37,6 +39,7 @@ class InboundMessage:
     message_id: int
     timestamp_ms: int
     text: str
+    attachments: tuple[Attachment, ...]
     reply: Reply | None
 
 
@@ -50,20 +53,71 @@ def _chat_kind(chat_type: str) -> ChatKind:
     return "channel"
 
 
+def _extract_attachments(message: Message) -> tuple[Attachment, ...]:
+    """Pick out media we forward: photo / voice / document / video / audio."""
+    out: list[Attachment] = []
+    if message.photo:
+        # ``photo`` is a tuple of progressively larger PhotoSizes; the
+        # last one is the largest the bot has access to.
+        largest = message.photo[-1]
+        out.append(
+            Attachment(
+                file_id=largest.file_id,
+                content_type="image/jpeg",
+                filename=f"photo-{message.message_id}.jpg",
+            )
+        )
+    if message.voice:
+        out.append(
+            Attachment(
+                file_id=message.voice.file_id,
+                content_type=message.voice.mime_type or "audio/ogg",
+                filename=f"voice-{message.message_id}.ogg",
+            )
+        )
+    if message.document:
+        doc = message.document
+        out.append(
+            Attachment(
+                file_id=doc.file_id,
+                content_type=doc.mime_type or "application/octet-stream",
+                filename=doc.file_name or f"document-{message.message_id}",
+            )
+        )
+    if message.video:
+        vid = message.video
+        out.append(
+            Attachment(
+                file_id=vid.file_id,
+                content_type=vid.mime_type or "video/mp4",
+                filename=vid.file_name or f"video-{message.message_id}.mp4",
+            )
+        )
+    if message.audio:
+        aud = message.audio
+        out.append(
+            Attachment(
+                file_id=aud.file_id,
+                content_type=aud.mime_type or "audio/mpeg",
+                filename=aud.file_name or f"audio-{message.message_id}.mp3",
+            )
+        )
+    return tuple(out)
+
+
 def parse_message(message: Message, *, bot_id: int) -> InboundMessage | None:
     sender = message.from_user
     if sender is None:
-        # Channel posts and anonymous admins have no ``from_user``. Out of
-        # scope for v1.
+        # Channel posts and anonymous admins have no ``from_user``.
         return None
     if sender.id == bot_id:
         return None
     if sender.is_bot:
         return None
 
-    text = message.text
-    if not text:
-        # v1 is text-only. Media, stickers, voice, etc. are dropped.
+    text = message.text or message.caption or ""
+    attachments = _extract_attachments(message)
+    if not text and not attachments:
         return None
 
     chat = message.chat
@@ -86,5 +140,6 @@ def parse_message(message: Message, *, bot_id: int) -> InboundMessage | None:
         message_id=message.message_id,
         timestamp_ms=int(message.date.timestamp() * 1000),
         text=text,
+        attachments=attachments,
         reply=reply,
     )

--- a/connectors/telegram/tests/conftest.py
+++ b/connectors/telegram/tests/conftest.py
@@ -149,6 +149,62 @@ def message_photo_no_text(ptb_bot: Bot) -> Message:
 
 
 @pytest.fixture
+def message_photo_with_caption(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 709,
+            "date": 1700000010,
+            "chat": {"id": 123456789, "type": "private"},
+            "from": {"id": 123456789, "is_bot": False, "first_name": "Alice"},
+            "caption": "look at this cat",
+            "photo": [
+                {"file_id": "S1", "file_unique_id": "s1", "width": 90, "height": 90},
+                {"file_id": "L1", "file_unique_id": "l1", "width": 1280, "height": 1280},
+            ],
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
+def message_voice(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 710,
+            "date": 1700000011,
+            "chat": {"id": 123456789, "type": "private"},
+            "from": {"id": 123456789, "is_bot": False, "first_name": "Alice"},
+            "voice": {
+                "file_id": "VOICE-A",
+                "file_unique_id": "voice-a",
+                "duration": 4,
+                "mime_type": "audio/ogg",
+            },
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
+def message_document(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 711,
+            "date": 1700000012,
+            "chat": {"id": 123456789, "type": "private"},
+            "from": {"id": 123456789, "is_bot": False, "first_name": "Alice"},
+            "document": {
+                "file_id": "DOC-A",
+                "file_unique_id": "doc-a",
+                "file_name": "report.pdf",
+                "mime_type": "application/pdf",
+            },
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
 def message_channel_post_no_sender(ptb_bot: Bot) -> Message:
     return _make_message(
         {

--- a/connectors/telegram/tests/test_parse.py
+++ b/connectors/telegram/tests/test_parse.py
@@ -55,8 +55,47 @@ def test_other_bot_returns_none(message_from_other_bot: Message, bot_id: int) ->
     assert parse_message(message_from_other_bot, bot_id=bot_id) is None
 
 
-def test_photo_without_text_returns_none(message_photo_no_text: Message, bot_id: int) -> None:
-    assert parse_message(message_photo_no_text, bot_id=bot_id) is None
+def test_photo_without_text_surfaces_attachment(
+    message_photo_no_text: Message, bot_id: int
+) -> None:
+    msg = parse_message(message_photo_no_text, bot_id=bot_id)
+    assert msg is not None
+    assert msg.text == ""
+    assert len(msg.attachments) == 1
+    att = msg.attachments[0]
+    assert att.content_type == "image/jpeg"
+    assert att.filename.endswith(".jpg")
+
+
+def test_photo_with_caption_surfaces_both(message_photo_with_caption: Message, bot_id: int) -> None:
+    msg = parse_message(message_photo_with_caption, bot_id=bot_id)
+    assert msg is not None
+    assert msg.text == "look at this cat"
+    assert len(msg.attachments) == 1
+    # Largest PhotoSize wins.
+    assert msg.attachments[0].file_id == "L1"
+
+
+def test_voice_surfaces_attachment(message_voice: Message, bot_id: int) -> None:
+    msg = parse_message(message_voice, bot_id=bot_id)
+    assert msg is not None
+    assert msg.text == ""
+    assert len(msg.attachments) == 1
+    att = msg.attachments[0]
+    assert att.file_id == "VOICE-A"
+    assert att.content_type == "audio/ogg"
+    assert att.filename.endswith(".ogg")
+
+
+def test_document_surfaces_attachment(message_document: Message, bot_id: int) -> None:
+    msg = parse_message(message_document, bot_id=bot_id)
+    assert msg is not None
+    assert msg.text == ""
+    assert len(msg.attachments) == 1
+    att = msg.attachments[0]
+    assert att.file_id == "DOC-A"
+    assert att.content_type == "application/pdf"
+    assert att.filename == "report.pdf"
 
 
 def test_channel_post_without_sender_returns_none(

--- a/connectors/telegram/tests/test_telegram_send.py
+++ b/connectors/telegram/tests/test_telegram_send.py
@@ -1,0 +1,216 @@
+"""Unit coverage for ``telegram_send``'s ``attachments`` parameter,
+type-by-extension routing, and the caption-on-first quirk in
+``send_media_group``.
+
+The PTB ``Bot`` is mocked end-to-end; tests assert that the right
+``send_*`` method was called with the right ``chat_id`` /
+``caption`` / ``media`` arguments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios_telegram.config import Settings
+from aios_telegram.connector import (
+    TelegramConnector,
+    _build_media_group,
+    _classify,
+)
+
+
+def test_classify_extensions() -> None:
+    assert _classify("/x/cat.jpg") == "photo"
+    assert _classify("/x/CAT.JPEG") == "photo"
+    assert _classify("/x/clip.mp4") == "video"
+    assert _classify("/x/voice.ogg") == "voice"
+    assert _classify("/x/song.mp3") == "audio"
+    assert _classify("/x/report.pdf") == "document"
+    assert _classify("/x/no-ext") == "document"
+
+
+def test_build_media_group_caption_on_first_only() -> None:
+    items = _build_media_group(
+        ["/host/a.jpg", "/host/b.jpg", "/host/c.jpg"],
+        caption="three pics",
+    )
+    assert items[0].caption == "three pics"
+    assert items[1].caption is None
+    assert items[2].caption is None
+
+
+def test_build_media_group_no_caption() -> None:
+    items = _build_media_group(["/host/a.jpg", "/host/b.jpg"], caption=None)
+    assert all(item.caption is None for item in items)
+
+
+def test_build_media_group_voice_demoted_to_document() -> None:
+    """Voice can't ride in a media group; falls back to document."""
+    from telegram import InputMediaDocument
+
+    items = _build_media_group(["/host/v.ogg"], caption=None)
+    assert isinstance(items[0], InputMediaDocument)
+
+
+@pytest.fixture
+def connector() -> TelegramConnector:
+    cfg = Settings(bot_token="0:test")
+    c = TelegramConnector(cfg)
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=42))
+    bot.send_photo = AsyncMock(return_value=MagicMock(message_id=43))
+    bot.send_voice = AsyncMock(return_value=MagicMock(message_id=44))
+    bot.send_video = AsyncMock(return_value=MagicMock(message_id=45))
+    bot.send_audio = AsyncMock(return_value=MagicMock(message_id=46))
+    bot.send_document = AsyncMock(return_value=MagicMock(message_id=47))
+    bot.send_media_group = AsyncMock(
+        return_value=[
+            MagicMock(message_id=100),
+            MagicMock(message_id=101),
+        ]
+    )
+    c._application = MagicMock()
+    c._application.bot = bot
+    return c
+
+
+def _patch_session_id(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    monkeypatch.setattr(TelegramConnector, "current_session_id", lambda self: value)
+
+
+async def test_telegram_send_text_only(
+    connector: TelegramConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_session_id(monkeypatch, None)
+    result = await connector.telegram_send("hello", chat_id="123")
+    assert result == {"message_id": 42}
+    connector._application.bot.send_message.assert_awaited_once_with(  # type: ignore[union-attr]
+        chat_id=123, text="hello"
+    )
+
+
+async def test_telegram_send_single_photo_routes_to_send_photo(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    (ws / "cat.jpg").write_bytes(b"x")
+
+    result = await connector.telegram_send(
+        "look", attachments=["/workspace/cat.jpg"], chat_id="123"
+    )
+
+    assert result == {"message_id": 43}
+    bot = connector._application.bot  # type: ignore[union-attr]
+    bot.send_photo.assert_awaited_once()
+    kwargs = bot.send_photo.call_args.kwargs
+    assert kwargs["chat_id"] == 123
+    assert kwargs["photo"] == str(ws / "cat.jpg")
+    assert kwargs["caption"] == "look"
+
+
+async def test_telegram_send_single_voice_routes_to_send_voice(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    (ws / "v.ogg").write_bytes(b"x")
+
+    await connector.telegram_send("", attachments=["/workspace/v.ogg"], chat_id="123")
+
+    connector._application.bot.send_voice.assert_awaited_once()  # type: ignore[union-attr]
+
+
+async def test_telegram_send_single_document_routes_to_send_document(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    (ws / "report.pdf").write_bytes(b"x")
+
+    await connector.telegram_send("", attachments=["/workspace/report.pdf"], chat_id="123")
+
+    connector._application.bot.send_document.assert_awaited_once()  # type: ignore[union-attr]
+
+
+async def test_telegram_send_multi_media_uses_send_media_group(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    for name in ("a.jpg", "b.jpg"):
+        (ws / name).write_bytes(b"x")
+
+    result = await connector.telegram_send(
+        "two pics",
+        attachments=["/workspace/a.jpg", "/workspace/b.jpg"],
+        chat_id="123",
+    )
+
+    assert result == {"message_ids": [100, 101]}
+    bot = connector._application.bot  # type: ignore[union-attr]
+    bot.send_media_group.assert_awaited_once()
+    bot.send_photo.assert_not_awaited()
+    media = bot.send_media_group.call_args.kwargs["media"]
+    assert len(media) == 2
+    assert media[0].caption == "two pics"
+    assert media[1].caption is None
+
+
+async def test_telegram_send_attachment_traversal_rejected(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-1").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await connector.telegram_send("", attachments=["/workspace/../escape.jpg"], chat_id="123")
+
+
+async def test_telegram_send_attachment_disallowed_root_raises(
+    connector: TelegramConnector,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, "sess-1")
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await connector.telegram_send("", attachments=["/etc/passwd"], chat_id="123")
+
+
+async def test_telegram_send_attachment_without_session_id_raises(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_session_id(monkeypatch, None)
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    with pytest.raises(RuntimeError, match=r"aios\.session_id"):
+        await connector.telegram_send("", attachments=["/workspace/x.jpg"], chat_id="123")
+
+
+async def test_telegram_send_non_int_chat_id_raises(
+    connector: TelegramConnector,
+) -> None:
+    with pytest.raises(ValueError, match="must be an integer"):
+        await connector.telegram_send("hi", chat_id="not-a-number")

--- a/packages/aios-connector/aios_connector/base.py
+++ b/packages/aios-connector/aios_connector/base.py
@@ -68,6 +68,16 @@ _INBOUND_METHOD = f"{_AIOS_NOTIFICATION_PREFIX}inbound"
 # focal-required tool methods.
 _FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
+# MCP ``_meta`` key carrying the calling session's id.  Mirrors
+# ``aios.harness.channels.SESSION_ID_META_KEY`` server-side.
+_SESSION_ID_META_KEY = "aios.session_id"
+
+# Default sandbox bind-mount root.  Connector subprocesses inherit
+# ``AIOS_WORKSPACE_ROOT`` from the worker; this constant is only the
+# fallback for tests + dev environments without it set.  Must match
+# :attr:`aios.config.Settings.workspace_root`'s default.
+_DEFAULT_WORKSPACE_ROOT = "/var/lib/aios/workspaces"
+
 ToolFn = Callable[..., Awaitable[Any]]
 
 
@@ -683,13 +693,55 @@ class Connector:
         return [TextContent(type="text", text=json.dumps(result, ensure_ascii=False))]
 
     def _focal_from_request_meta(self) -> str | None:
-        """Read ``_meta.aios.focal_channel_path`` from the active request.
+        """Read the focal-channel suffix from the active request, or ``None``."""
+        return self._read_meta_str(_FOCAL_CHANNEL_META_KEY)
 
-        The lowlevel server stashes the raw request on a context var
-        the call_tool handler can reach via :attr:`Server.request_context`.
-        Missing or malformed meta returns ``None`` so the caller raises
-        a tool-level error.
+    def current_session_id(self) -> str | None:
+        """Read ``_meta.aios.session_id`` from the active request, or ``None``."""
+        return self._read_meta_str(_SESSION_ID_META_KEY)
+
+    def resolve_media_paths(self, paths: list[str], *, tool_name: str) -> list[str]:
+        """Map sandbox-visible attachment paths to host paths.
+
+        Empty input short-circuits without requiring ``_meta.aios.session_id``,
+        so text-only send tools work in test harnesses that don't stamp it.
+        Non-empty input raises ``RuntimeError`` if session_id is missing,
+        ``ValueError`` if any path fails containment or doesn't exist.
         """
+        if not paths:
+            return []
+        session_id = self.current_session_id()
+        if session_id is None:
+            raise RuntimeError(
+                f"{tool_name} with attachments requires _meta.aios.session_id; "
+                "the harness should always inject this for tool dispatches"
+            )
+        from aios_connector.media import resolve_sandbox_path
+
+        workspace_root = Path(os.environ.get("AIOS_WORKSPACE_ROOT", _DEFAULT_WORKSPACE_ROOT))
+        resolved: list[str] = []
+        for sandbox_path in paths:
+            host = resolve_sandbox_path(
+                session_id=session_id,
+                sandbox_path=sandbox_path,
+                workspace_root=workspace_root,
+            )
+            if host is None:
+                raise ValueError(
+                    f"attachment path {sandbox_path!r} could not be resolved "
+                    f"to a host path (must be under /workspace/ or "
+                    f"/mnt/attachments/, no .. escapes)"
+                )
+            if not host.is_file():
+                raise ValueError(
+                    f"attachment path {sandbox_path!r} does not exist (resolved to {host})"
+                )
+            resolved.append(str(host))
+        return resolved
+
+    def _read_meta_str(self, key: str) -> str | None:
+        """Fetch a string-typed key from ``_meta`` of the active tool-call
+        request, or ``None`` when absent / empty / wrong type."""
         from mcp.server.lowlevel.server import request_ctx
 
         try:
@@ -700,10 +752,10 @@ class Connector:
         if meta is None:
             return None
         extra = getattr(meta, "model_extra", None) or {}
-        path: Any = extra.get(_FOCAL_CHANNEL_META_KEY)
-        if not isinstance(path, str) or not path:
+        value: Any = extra.get(key)
+        if not isinstance(value, str) or not value:
             return None
-        return path
+        return value
 
     # ── Internal: aios_inbound_ack tool ───────────────────────────────
 

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -34,6 +34,15 @@ SWITCH_CHANNEL_METADATA_KEY = "switch_channel"
 # keys per the MCP spec.
 FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
+# Carries the calling session's id so MCP servers can resolve
+# model-visible in-sandbox paths to host equivalents.  Stamped on
+# every outbound MCP request alongside the focal-channel suffix —
+# including agent-declared HTTP MCP servers, which see the ULID and
+# ignore unknown ``_meta`` keys per the MCP spec.  ULIDs are not
+# secrets, but the leak is a real cross-boundary signal worth
+# knowing about.
+SESSION_ID_META_KEY = "aios.session_id"
+
 
 def focal_channel_path(focal: str | None) -> str | None:
     """Return the connector-relative suffix of a focal address.

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -392,12 +392,16 @@ async def _execute_mcp_tool_async(
 
         server_name, tool_name = _parse_mcp_tool_name(name)
 
-        from aios.harness.channels import FOCAL_CHANNEL_META_KEY, focal_channel_path
+        from aios.harness.channels import (
+            FOCAL_CHANNEL_META_KEY,
+            SESSION_ID_META_KEY,
+            focal_channel_path,
+        )
 
-        meta: dict[str, Any] | None = None
+        meta: dict[str, Any] = {SESSION_ID_META_KEY: session_id}
         suffix = focal_channel_path(focal_channel)
         if suffix is not None:
-            meta = {FOCAL_CHANNEL_META_KEY: suffix}
+            meta[FOCAL_CHANNEL_META_KEY] = suffix
 
         # Connector subprocesses (stdio MCP children of the worker) take
         # precedence over agent-declared HTTP MCP servers: the model

--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -282,7 +282,10 @@ class TestPumpStderrLineExtraction:
         """
         captured: list[str] = []
         read_fd, write_fd = os.pipe()
-        token = "8116307959:AAFv1He6CZ-tpGun19CTp1tjbBoWtJrGrL8"
+        # Synthetic token matching the bot<digits>:<base64-ish> shape
+        # the redaction regex expects.  Replaces a real token that
+        # leaked through PR #214 / #205 (rotated upstream; #223 §4).
+        token = "1234567890:AAExample-Fake-Token-for-Tests-Only0"
         try:
             pump = asyncio.create_task(_pump_stderr("test_conn", read_fd))
             with mock_log_capture(captured):


### PR DESCRIPTION
## Summary

Three fixes flagged by the live smoke test (#223) on the unmerged #216 stack.  Stacks as a sibling of [PR #221](https://github.com/eumemic/aios/pull/221) (attachment shape rework); none of these belong upstream in the architectural rework PRs.

**Stacked on:** ``wt/recursive-weaving-sundae-pr5``.

### #223 §8 — Signal inbound attachments stuck at parse boundary

signal-cli's JSON-RPC daemon mode (0.14.x) auto-downloads attachment bytes but omits the ``file`` field from the envelope — that field was only emitted by the legacy CLI command output.  The connector's ``parse.py`` was treating ``file=None`` as "no host path" and ``_build_sdk_attachments`` was log+skipping every attachment, so photos sent to Signal never reached the model as ``image_url`` parts even though the bytes were on disk.

- ``parse.Attachment`` carries the new ``id`` field signal-cli always emits — that's the on-disk filename under ``<config_dir>/attachments/``.
- ``_build_sdk_attachments`` becomes a method on ``SignalConnector`` so it can read ``self._cfg.config_dir``; falls back to ``<config_dir>/attachments/<id>`` when ``host_path`` is ``None``.  SDK ``as_params`` validates the resulting path exists.
- New regression suite ``test_inbound_attachment_fallback.py`` covers the fallback, the still-skipped no-id-no-host_path edge case, and the explicit-host_path-wins precedence.

### #223 §3 — Connector logs ``signal.account.ready`` when the account is unregistered

When ``listGroups`` failed at boot (e.g. ``Specified account does not exist``), the connector swallowed the error and marked the account ready with empty contacts/groups.  Operator had no signal something was wrong until inbounds never arrived.

- ``daemon.list_groups`` no longer swallows; raises ``RpcError`` through.
- ``connector.setup`` wraps the per-account boot probe in try/except.  Failed accounts go in ``self._unavailable_accounts`` (logged as ``signal.account.unavailable`` at error level) and are dropped from ``discover_accounts``.
- If ALL accounts fail, setup raises and the connector refuses to reach ``running``.
- New ``test_setup_health.py`` covers single-account refusal + multi-account-with-one-bad partial degradation.

### #223 §4 — Test fixture leaked the real Telegram bot token

``tests/unit/test_connector_supervisor.py:285`` had a real MetalsAndAIBot token (rotated upstream).  Replaced with a synthetic token of the same shape.

## Test plan
- [x] ``uv run mypy src`` — 131 files
- [x] ``uv run ruff check`` + ``ruff format --check`` clean
- [x] Unit suite — 1123 passed
- [x] SDK package — 44 passed
- [x] Signal connector — 89 passed (8 new across the two new test files + 1 modified ``test_list_groups`` case)
- [x] Telegram connector — 33 passed (untouched here)

## Stack

This branch is a smoke-fix sibling of PR5; merges back-to-front alongside the rework stack:

1. PR1 ([#217](https://github.com/eumemic/aios/pull/217))
2. PR2 ([#218](https://github.com/eumemic/aios/pull/218))
3. PR3 ([#219](https://github.com/eumemic/aios/pull/219))
4. PR4 ([#220](https://github.com/eumemic/aios/pull/220))
5. PR5 ([#221](https://github.com/eumemic/aios/pull/221))
6. **Smoke fixes (this)** — siblings on PR5

🤖 Generated with [Claude Code](https://claude.com/claude-code)