### PR TITLE
fix(test): redact leaked Telegram bot token from supervisor test (#223 §4)

### DIFF
--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -282,7 +282,10 @@ class TestPumpStderrLineExtraction:
         """
         captured: list[str] = []
         read_fd, write_fd = os.pipe()
-        token = "8116307959:AAFv1He6CZ-tpGun19CTp1tjbBoWtJrGrL8"
+        # Synthetic token matching the bot<digits>:<base64-ish> shape
+        # the redaction regex expects.  Replaces a real token that
+        # leaked through PR #214 / #205 (rotated upstream; #223 §4).
+        token = "1234567890:AAExample-Fake-Token-for-Tests-Only0"
         try:
             pump = asyncio.create_task(_pump_stderr("test_conn", read_fd))
             with mock_log_capture(captured):


### PR DESCRIPTION
## Summary
- ``tests/unit/test_connector_supervisor.py:285`` had a real Telegram bot token (``8116307959:AAFv1He6CZ-tpGun19CTp1tjbBoWtJrGrL8``) that leaked through PR #214 / #205.
- Token is already rotated upstream — replaced with a synthetic ``<digits>:<base64-ish>`` shape so the redaction-regex test still exercises the matcher.

## Context
Split out from #224 so the #216 stack stays linear. The other two findings in #223 (§3 boot health, §8 inbound fallback) are folded into PR #220 (PR4 of the #216 stack).

## Test plan
- [x] ``uv run pytest tests/unit/test_connector_supervisor.py::TestPumpStderrLineExtraction``

🤖 Generated with [Claude Code](https://claude.com/claude-code)