### PR TITLE
feat(connector): chat attachments + vision pipeline + outbound + smoke fixes (#216, PR2-5 + capstone)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ venv/
 # aios runtime state
 /var/lib/aios/
 workspaces/
+
+# smoke-test runtime artifacts
+.logs/
+spool.sqlite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,6 @@ They don't share connections; they share Postgres state.
 - **Raw SQL + asyncpg**, no ORM. Every query lives in `db/queries.py`.
 - **`pg_notify($1, $2)` function form**, never literal `NOTIFY`. Postgres case-folds unquoted identifiers; our ULIDs have uppercase.
 - **structlog** with `structlog.stdlib.LoggerFactory()`. NOT `PrintLoggerFactory`.
-- **"Mind" not "brain"** — load-bearing terminology for the model/inference concept.
 - **Extreme simplicity.** No defensive guards for model mistakes, no fuzzy matching, no model-specific shims. The model sees raw errors and retries through the session log. Ask: "can the model handle this failure itself?" If yes, don't add complexity.
 - **Events are OpenAI chat-completions format**, not Anthropic Messages format. LiteLLM translates at the provider boundary.
 - **Conventional commits**: `feat:`, `fix:`, `refactor:`, etc. Substantial commit bodies.

--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -97,9 +97,21 @@ That env var is removed cleanly — set `AIOS_SIGNAL_PHONES=+1...` (a
 one-element CSV) for an equivalent single-phone deployment.  Multi-
 phone setups become `AIOS_SIGNAL_PHONES=+1...,+2...`.
 
+## Attachments
+
+Inbound photos, voice notes, and documents surface to the model as
+`image_url` content parts (vision-capable minds) or text markers,
+via the harness's vision pipeline.  Each file is staged under
+`<workspace_root>/_attachments/<session>/signal/...` and made
+readable inside the sandbox at `/mnt/attachments/signal/...`.
+
+Outbound: pass an `attachments: list[str]` parameter to
+`signal_send` alongside `text`.  Each path must be under
+`/workspace/` or `/mnt/attachments/` (the latter is read-only, so to
+forward an inbound file `cp` it into `/workspace/` first).
+
 ## Out of scope for v1
 
-- Attachments (inbound messages with attachments are posted text-only with `[attachment: <name> (<mime>)]` markers; `signal_send` has no attachment parameter).
 - Voice / Say / SoundEffect / Listen tools.
 - Group create / rename / add-members.
 - Typing indicators.

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -34,7 +34,16 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
-from aios_connector import Connector, focal_required, make_account, tool
+from aios_connector import (
+    Attachment as SDKAttachment,
+)
+from aios_connector import (
+    AttachmentError,
+    Connector,
+    focal_required,
+    make_account,
+    tool,
+)
 
 from .addressing import decode_chat_id, encode_chat_id
 from .config import Settings
@@ -62,6 +71,15 @@ class SignalConnector(Connector):
         # Contacts + group rosters are per-account because each phone has
         # its own contact store and group memberships in signal-cli.
         self._contact_names_by_account: dict[str, dict[str, str]] = {}
+        # Phone → error message for accounts whose boot-time probe
+        # (``listContacts`` / ``listGroups``) failed.  signal-cli's
+        # daemon stays running and accepts new attachments to other
+        # accounts, so we don't refuse the connector outright; but
+        # unhealthy accounts are dropped from ``discover_accounts``
+        # so the operator's ``aios connectors accounts`` listing
+        # surfaces only the working ones.  The connector refuses
+        # to start if NO accounts are healthy (in :meth:`setup`).
+        self._unavailable_accounts: dict[str, str] = {}
 
     # ── lifecycle ─────────────────────────────────────────────────────
 
@@ -88,10 +106,27 @@ class SignalConnector(Connector):
         # race for the daemon's contact-store lock without measurable
         # speedup at this scale.
         instructions_sections: list[str] = []
+        healthy_count = 0
         for phone, bot_uuid in self._bot_uuids.items():
-            contact_names = await self._daemon.list_contacts(account=phone)
+            try:
+                contact_names = await self._daemon.list_contacts(account=phone)
+                groups = await self._daemon.list_groups(account=phone)
+            except Exception as err:
+                # signal-cli rejected the boot probe — typically because
+                # the account isn't registered with Signal's servers
+                # (operator hasn't run ``signal-cli register``, or the
+                # registration expired).  Don't mark this account ready;
+                # log loudly so the operator sees red on
+                # ``aios connectors list`` instead of silent inbound-drops.
+                log.error(
+                    "signal.account.unavailable",
+                    bot_uuid=bot_uuid,
+                    phone=phone,
+                    error=str(err),
+                )
+                self._unavailable_accounts[phone] = str(err)
+                continue
             self._contact_names_by_account[phone] = contact_names
-            groups = await self._daemon.list_groups(account=phone)
             section = build_instructions(
                 bot_uuid=bot_uuid,
                 phone=phone,
@@ -100,12 +135,18 @@ class SignalConnector(Connector):
                 contact_names=contact_names,
             )
             instructions_sections.append(section)
+            healthy_count += 1
             log.info(
                 "signal.account.ready",
                 bot_uuid=bot_uuid,
                 phone=phone,
                 contacts=len(contact_names),
                 groups=len(groups),
+            )
+        if healthy_count == 0 and self._bot_uuids:
+            errs = ", ".join(f"{phone}: {err}" for phone, err in self._unavailable_accounts.items())
+            raise RuntimeError(
+                f"signal connector cannot start: no configured account is healthy ({errs})"
             )
         # Concatenate per-account sections.  build_instructions already
         # produces a self-contained block per account; joining with a
@@ -121,6 +162,7 @@ class SignalConnector(Connector):
                 metadata={"phone": phone},
             )
             for phone, bot_uuid in self._bot_uuids.items()
+            if phone not in self._unavailable_accounts
         ]
 
     async def teardown(self) -> None:
@@ -164,6 +206,7 @@ class SignalConnector(Connector):
                 "uuid": msg.sender_uuid,
                 "display_name": msg.sender_name or msg.sender_uuid,
             }
+            sdk_attachments = self._build_sdk_attachments(msg)
             # Signal envelope timestamps are millis since epoch.  Render
             # them as ISO-8601 UTC so the supervisor stamps a string that
             # operators (and any future cross-platform tooling) can read
@@ -178,6 +221,7 @@ class SignalConnector(Connector):
                 chat_id=chat_id,
                 sender=sender_payload,
                 content=content,
+                attachments=sdk_attachments or None,
                 metadata=metadata,
                 timestamp=timestamp_iso,
             )
@@ -244,6 +288,47 @@ class SignalConnector(Connector):
         params = _build_react_params(phone, chat_id, target_author_uuid, target_timestamp_ms, emoji)
         await self._daemon.rpc.call("sendReaction", params)
         return {"status": "ok"}
+
+    def _build_sdk_attachments(self, msg: InboundMessage) -> list[SDKAttachment]:
+        """Build SDK Attachment records, logging+skipping any rejected.
+
+        signal-cli's JSON-RPC daemon mode (0.14.x) auto-downloads
+        attachment bytes but omits the ``file`` field from the
+        envelope — it was only emitted by the legacy CLI command
+        output.  We fall back to the storage-layout convention
+        ``<config_dir>/attachments/<id>`` for envelopes without a
+        host_path; SDK ``as_params`` validates the file actually
+        exists.
+        """
+        out: list[SDKAttachment] = []
+        for att in msg.attachments:
+            host_path = att.host_path
+            if host_path is None and att.id is not None:
+                host_path = str(self._cfg.config_dir / "attachments" / att.id)
+            if host_path is None:
+                log.warning(
+                    "signal.inbound.attachment_no_host_path",
+                    content_type=att.content_type,
+                    filename=att.filename,
+                )
+                continue
+            candidate = SDKAttachment(
+                host_path=host_path,
+                filename=att.filename or "unnamed",
+                content_type=att.content_type,
+            )
+            try:
+                candidate.as_params()
+            except AttachmentError as err:
+                log.warning(
+                    "signal.inbound.attachment_rejected",
+                    host_path=host_path,
+                    filename=att.filename,
+                    error=str(err),
+                )
+                continue
+            out.append(candidate)
+        return out
 
 
 def _build_send_params(account_phone: str, chat_id: str, text: str) -> dict[str, Any]:

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 import structlog
@@ -40,6 +41,7 @@ from aios_connector import (
 from aios_connector import (
     AttachmentError,
     Connector,
+    SandboxPath,
     focal_required,
     make_account,
     tool,
@@ -230,8 +232,15 @@ class SignalConnector(Connector):
 
     @tool()
     @focal_required
-    async def signal_send(self, text: str, *, account: str, chat_id: str) -> dict[str, Any]:
-        """Send a text message to your focal Signal chat.
+    async def signal_send(
+        self,
+        text: str,
+        attachments: list[SandboxPath] | None = None,
+        *,
+        account: str,
+        chat_id: str,
+    ) -> dict[str, Any]:
+        """Send a Signal message to your focal chat, optionally with attachments.
 
         The account (your bot UUID) and chat id are taken implicitly
         from your focal channel — aios injects them via the JSON-RPC
@@ -240,12 +249,15 @@ class SignalConnector(Connector):
 
         Args:
             text: Message body. Markdown is converted to Signal text styles.
+            attachments: Optional in-sandbox file paths to attach.  The SDK
+                resolves each entry to a host path before this method runs.
         """
         assert self._daemon is not None
         phone = self._uuid_to_phone.get(account)
         if phone is None:
             raise ValueError(f"signal_send: unknown account {account!r}")
-        params = _build_send_params(phone, chat_id, text)
+        host_paths: list[Path] = list(attachments or [])
+        params = _build_send_params(phone, chat_id, text, attachments=host_paths)
         result = await self._daemon.rpc.call("send", params)
         ts = _extract_timestamp(result)
         return {"sent_at_ms": ts} if ts is not None else {"status": "ok"}
@@ -331,7 +343,13 @@ class SignalConnector(Connector):
         return out
 
 
-def _build_send_params(account_phone: str, chat_id: str, text: str) -> dict[str, Any]:
+def _build_send_params(
+    account_phone: str,
+    chat_id: str,
+    text: str,
+    *,
+    attachments: list[Path],
+) -> dict[str, Any]:
     """Translate ``(account_phone, chat_id, text)`` into signal-cli ``send`` params."""
     chat_type, raw_id = decode_chat_id(chat_id)
     stripped, styles = convert_markdown_to_signal_styles(text)
@@ -342,6 +360,8 @@ def _build_send_params(account_phone: str, chat_id: str, text: str) -> dict[str,
         params["groupId"] = raw_id
     else:
         params["recipient"] = [raw_id]
+    if attachments:
+        params["attachments"] = [str(p) for p in attachments]
     return params
 
 

--- a/connectors/signal/src/aios_signal/daemon.py
+++ b/connectors/signal/src/aios_signal/daemon.py
@@ -235,19 +235,22 @@ class SignalDaemon:
     async def list_groups(self, *, account: str) -> list[GroupInfo]:
         """Return the bot's group memberships via signal-cli ``listGroups``.
 
-        Best-effort: returns an empty list on RPC failure or malformed
-        responses.  Group IDs are re-encoded into URL-safe base64 so the
-        caller can use them directly as channel-path suffixes
+        Raises ``RpcError`` / ``RpcTimeoutError`` on RPC failure — the
+        boot-time caller in :meth:`SignalConnector.setup` uses the raise
+        to refuse marking the account ready when signal-cli reports
+        e.g. ``Specified account does not exist`` (the operator
+        forgot to register it, or the registration expired).  The
+        supervisor surfaces the resulting setup failure to ``aios
+        connectors list`` so the operator sees red instead of green.
+
+        Group IDs are re-encoded into URL-safe base64 so the caller
+        can use them directly as channel-path suffixes
         (``signal/<bot>/<id>``) — matching :func:`encode_chat_id`'s
-        ``group`` branch.  Groups missing either an ``id`` or ``members``
-        are dropped; the agent-facing roster is supposed to be a
-        complete picture of "who is in this room with me."
+        ``group`` branch.  Groups missing either an ``id`` or
+        ``members`` are dropped; the agent-facing roster is supposed
+        to be a complete picture of "who is in this room with me."
         """
-        try:
-            result = await self.rpc.call("listGroups", {"account": account})
-        except Exception:
-            log.warning("signal.list_groups.failed", account=account, exc_info=True)
-            return []
+        result = await self.rpc.call("listGroups", {"account": account})
         if not isinstance(result, list):
             return []
         out: list[GroupInfo] = []

--- a/connectors/signal/src/aios_signal/parse.py
+++ b/connectors/signal/src/aios_signal/parse.py
@@ -23,6 +23,13 @@ MENTION_PLACEHOLDER = "\ufffc"
 class Attachment:
     content_type: str
     filename: str | None
+    host_path: str | None
+    # signal-cli's storage id, used to compute the on-disk path when
+    # the daemon's JSON-RPC envelope omits the ``file`` field (which it
+    # does in JSON-RPC daemon mode 0.14.x — only the legacy CLI output
+    # included it).  By signal-cli convention the file lives at
+    # ``<config_dir>/attachments/<id>``.
+    id: str | None
 
 
 @dataclass(slots=True, frozen=True)
@@ -149,6 +156,8 @@ def parse_envelope(
         Attachment(
             content_type=a.get("contentType", "application/octet-stream"),
             filename=a.get("filename") if isinstance(a.get("filename"), str) else None,
+            host_path=a.get("file") if isinstance(a.get("file"), str) else None,
+            id=a.get("id") if isinstance(a.get("id"), str) else None,
         )
         for a in attachments_raw
         if isinstance(a, dict)
@@ -179,9 +188,4 @@ def parse_envelope(
 
 
 def build_content_text(msg: InboundMessage) -> str:
-    parts: list[str] = []
-    if msg.text:
-        parts.append(msg.text)
-    for a in msg.attachments:
-        parts.append(f"[attachment: {a.filename or '(unnamed)'} ({a.content_type})]")
-    return "\n".join(parts)
+    return msg.text

--- a/connectors/signal/tests/conftest.py
+++ b/connectors/signal/tests/conftest.py
@@ -49,6 +49,11 @@ def envelope_attachment_only() -> dict[str, Any]:
 
 
 @pytest.fixture
+def envelope_attachment_no_file_field() -> dict[str, Any]:
+    return _load("attachment_no_file_field.json")
+
+
+@pytest.fixture
 def envelope_receipt() -> dict[str, Any]:
     return _load("receipt.json")
 

--- a/connectors/signal/tests/fixtures/attachment_no_file_field.json
+++ b/connectors/signal/tests/fixtures/attachment_no_file_field.json
@@ -1,0 +1,18 @@
+{
+  "source": "+15551234567",
+  "sourceUuid": "11111111-2222-3333-4444-555555555555",
+  "sourceName": "Alice",
+  "sourceDevice": 1,
+  "timestamp": 1700000005000,
+  "dataMessage": {
+    "timestamp": 1700000005000,
+    "attachments": [
+      {
+        "contentType": "image/png",
+        "filename": "photo.png",
+        "id": "xyz-789",
+        "size": 27794
+      }
+    ]
+  }
+}

--- a/connectors/signal/tests/test_inbound_attachment_fallback.py
+++ b/connectors/signal/tests/test_inbound_attachment_fallback.py
@@ -1,0 +1,132 @@
+"""Regression for #223 §8: signal-cli's JSON-RPC daemon mode omits the
+``file`` field from attachment envelopes.  The connector falls back to
+the ``<config_dir>/attachments/<id>`` storage convention so inbound
+photos still reach the model as ``image_url`` parts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aios_signal.config import Settings
+from aios_signal.connector import SignalConnector
+from aios_signal.parse import Attachment, InboundMessage
+
+
+def _make_connector(config_dir: Path) -> SignalConnector:
+    cfg = Settings(
+        phones=["+15550001"],
+        config_dir=config_dir,
+        cli_bin="/usr/bin/signal-cli",
+    )
+    return SignalConnector(cfg)
+
+
+def _make_msg(attachments: tuple[Attachment, ...]) -> InboundMessage:
+    return InboundMessage(
+        chat_type="dm",
+        raw_chat_id="11111111-2222-3333-4444-555555555555",
+        sender_uuid="11111111-2222-3333-4444-555555555555",
+        sender_name="Alice",
+        chat_name=None,
+        timestamp_ms=1700000000000,
+        text="",
+        attachments=attachments,
+        reply=None,
+        reaction=None,
+    )
+
+
+def test_fallback_to_config_dir_when_file_field_omitted(tmp_path: Path) -> None:
+    """The daemon's JSON-RPC envelope omits ``file`` but ``id``
+    points at ``<config_dir>/attachments/<id>``.  Plant the file
+    there and assert the SDK Attachment surfaces with that path."""
+    config_dir = tmp_path / "signal-cfg"
+    (config_dir / "attachments").mkdir(parents=True)
+    expected_path = config_dir / "attachments" / "xyz-789"
+    expected_path.write_bytes(b"fake-png-bytes")
+
+    connector = _make_connector(config_dir)
+    msg = _make_msg(
+        (
+            Attachment(
+                content_type="image/png",
+                filename="photo.png",
+                host_path=None,
+                id="xyz-789",
+            ),
+        )
+    )
+
+    sdk_atts = connector._build_sdk_attachments(msg)
+
+    assert len(sdk_atts) == 1
+    assert sdk_atts[0].host_path == str(expected_path)
+    assert sdk_atts[0].content_type == "image/png"
+
+
+def test_fallback_skips_when_file_missing_on_disk(tmp_path: Path) -> None:
+    """If the file isn't where we'd expect (signal-cli didn't auto-download
+    or the daemon's storage layout differs), as_params rejects and the
+    attachment is logged + skipped."""
+    config_dir = tmp_path / "signal-cfg"
+    (config_dir / "attachments").mkdir(parents=True)
+
+    connector = _make_connector(config_dir)
+    msg = _make_msg(
+        (
+            Attachment(
+                content_type="image/png",
+                filename="photo.png",
+                host_path=None,
+                id="never-downloaded",
+            ),
+        )
+    )
+
+    sdk_atts = connector._build_sdk_attachments(msg)
+    assert sdk_atts == []
+
+
+def test_no_id_no_host_path_skips_with_warning(tmp_path: Path) -> None:
+    """Records that have neither host_path nor id (shouldn't happen, but
+    a malformed daemon could produce it) get logged + skipped, not
+    crashed on."""
+    connector = _make_connector(tmp_path / "cfg")
+    msg = _make_msg(
+        (
+            Attachment(
+                content_type="image/png",
+                filename="photo.png",
+                host_path=None,
+                id=None,
+            ),
+        )
+    )
+
+    assert connector._build_sdk_attachments(msg) == []
+
+
+def test_explicit_host_path_wins_over_id_fallback(tmp_path: Path) -> None:
+    """When the envelope DOES include ``file`` (legacy CLI shape), the
+    explicit host_path is used and the id-based fallback isn't consulted."""
+    config_dir = tmp_path / "signal-cfg"
+    config_dir.mkdir()
+    explicit = tmp_path / "explicit-path.png"
+    explicit.write_bytes(b"x")
+
+    connector = _make_connector(config_dir)
+    msg = _make_msg(
+        (
+            Attachment(
+                content_type="image/png",
+                filename="photo.png",
+                host_path=str(explicit),
+                id="ignored",
+            ),
+        )
+    )
+
+    sdk_atts = connector._build_sdk_attachments(msg)
+    assert len(sdk_atts) == 1
+    assert sdk_atts[0].host_path == str(explicit)

--- a/connectors/signal/tests/test_list_groups.py
+++ b/connectors/signal/tests/test_list_groups.py
@@ -62,10 +62,13 @@ class TestListGroups:
             member_uuids=["33333333-0003-0000-0000-000000000000"],
         )
 
-    async def test_empty_list_when_rpc_fails(self) -> None:
+    async def test_rpc_failure_propagates(self) -> None:
+        """Boot-time callers depend on the raise to mark accounts unhealthy
+        rather than silently treating "not registered" as "no groups"."""
         daemon = _make_daemon()
         daemon.rpc.call = AsyncMock(side_effect=RuntimeError("rpc broken"))  # type: ignore[method-assign]
-        assert await daemon.list_groups(account="+15550001111") == []
+        with pytest.raises(RuntimeError, match="rpc broken"):
+            await daemon.list_groups(account="+15550001111")
 
     async def test_empty_list_when_rpc_returns_non_list(self) -> None:
         daemon = _make_daemon()

--- a/connectors/signal/tests/test_parse.py
+++ b/connectors/signal/tests/test_parse.py
@@ -82,13 +82,12 @@ def test_missing_source_uuid_returns_none(bot_uuid: str) -> None:
     assert parse_envelope(envelope, bot_account_uuid=bot_uuid) is None
 
 
-def test_build_content_text_with_attachments(
+def test_build_content_text_attachment_only_is_empty(
     envelope_attachment_only: dict[str, Any], bot_uuid: str
 ) -> None:
     msg = parse_envelope(envelope_attachment_only, bot_account_uuid=bot_uuid)
     assert msg is not None
-    rendered = build_content_text(msg)
-    assert rendered == "[attachment: photo.jpg (image/jpeg)]"
+    assert build_content_text(msg) == ""
 
 
 def test_build_content_text_with_text_and_attachment(bot_uuid: str) -> None:
@@ -102,9 +101,35 @@ def test_build_content_text_with_text_and_attachment(bot_uuid: str) -> None:
         chat_name=None,
         timestamp_ms=1,
         text="Check this out",
-        attachments=(Attachment(content_type="image/png", filename="x.png"),),
+        attachments=(
+            Attachment(
+                content_type="image/png",
+                filename="x.png",
+                host_path="/tmp/x",
+                id="abc",
+            ),
+        ),
         reply=None,
         reaction=None,
     )
-    rendered = build_content_text(msg)
-    assert rendered == "Check this out\n[attachment: x.png (image/png)]"
+    assert build_content_text(msg) == "Check this out"
+
+
+def test_attachment_captures_host_path(
+    envelope_attachment_only: dict[str, Any], bot_uuid: str
+) -> None:
+    msg = parse_envelope(envelope_attachment_only, bot_account_uuid=bot_uuid)
+    assert msg is not None
+    assert msg.attachments[0].host_path == "/tmp/signal-cli/attachments/abc-def-123"
+    assert msg.attachments[0].id == "abc-def-123"
+
+
+def test_attachment_no_file_field_carries_id(
+    envelope_attachment_no_file_field: dict[str, Any], bot_uuid: str
+) -> None:
+    """JSON-RPC daemon mode envelopes omit ``file`` but keep ``id``;
+    connector-side fallback uses ``id`` to reconstruct the on-disk path."""
+    msg = parse_envelope(envelope_attachment_no_file_field, bot_account_uuid=bot_uuid)
+    assert msg is not None
+    assert msg.attachments[0].host_path is None
+    assert msg.attachments[0].id == "xyz-789"

--- a/connectors/signal/tests/test_setup_health.py
+++ b/connectors/signal/tests/test_setup_health.py
@@ -1,0 +1,95 @@
+"""Regression for #223 §3: signal connector startup must surface
+listGroups failure (typically "account not registered") rather than
+marking the account ready with empty contacts/groups.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios_signal.config import Settings
+from aios_signal.connector import SignalConnector
+
+
+def _stub_daemon() -> MagicMock:
+    daemon = MagicMock()
+    daemon.discover_bot_uuids = AsyncMock()
+    daemon.list_contacts = AsyncMock()
+    daemon.list_groups = AsyncMock()
+    daemon.__aenter__ = AsyncMock(return_value=daemon)
+    daemon.__aexit__ = AsyncMock(return_value=None)
+    return daemon
+
+
+@pytest.fixture
+def connector(tmp_path: Path) -> SignalConnector:
+    cfg = Settings(
+        phones=["+15551111111"],
+        config_dir=tmp_path / "cfg",
+        cli_bin="/usr/bin/signal-cli",
+    )
+    return SignalConnector(cfg)
+
+
+async def test_setup_refuses_when_only_account_unavailable(
+    connector: SignalConnector,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One configured phone whose listGroups raises → setup must raise.
+    Operator sees the connector fail to start instead of green-but-dead."""
+    daemon = _stub_daemon()
+    daemon.discover_bot_uuids.return_value = {"+15551111111": "bot-uuid"}
+    daemon.list_contacts.return_value = {}
+    daemon.list_groups.side_effect = RuntimeError("Specified account does not exist")
+    monkeypatch.setattr(
+        "aios_signal.connector.SignalDaemon",
+        MagicMock(return_value=daemon),
+    )
+
+    with pytest.raises(RuntimeError, match="no configured account is healthy"):
+        await connector.setup()
+
+
+async def test_setup_drops_unavailable_account_when_others_healthy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multi-account setup: one bad account, one good → connector starts,
+    bad account dropped from discover_accounts."""
+    cfg = Settings(
+        phones=["+15551111111", "+15552222222"],
+        config_dir=tmp_path / "cfg",
+        cli_bin="/usr/bin/signal-cli",
+    )
+    connector = SignalConnector(cfg)
+
+    daemon = _stub_daemon()
+    daemon.discover_bot_uuids.return_value = {
+        "+15551111111": "bot-bad",
+        "+15552222222": "bot-good",
+    }
+    daemon.list_contacts.side_effect = lambda account: (
+        {"bot-good": "Good Bot"} if account == "+15552222222" else {}
+    )
+
+    async def _list_groups(account: str) -> list[Any]:
+        if account == "+15551111111":
+            raise RuntimeError("not registered")
+        return []
+
+    daemon.list_groups.side_effect = _list_groups
+    monkeypatch.setattr(
+        "aios_signal.connector.SignalDaemon",
+        MagicMock(return_value=daemon),
+    )
+
+    await connector.setup()
+
+    accounts = await connector.discover_accounts()
+    assert len(accounts) == 1
+    assert accounts[0]["id"] == "bot-good"
+    assert "+15551111111" in connector._unavailable_accounts

--- a/connectors/signal/tests/test_signal_send.py
+++ b/connectors/signal/tests/test_signal_send.py
@@ -1,0 +1,212 @@
+"""Unit coverage for ``signal_send``'s ``attachments`` parameter
+and ``_build_send_params``'s ``attachments`` field.
+
+Drives the build helper directly (no signal-cli) plus exercises the
+high-level ``signal_send`` method via the SDK's ``_invoke_tool``
+dispatch wrapper — that's the layer where ``SandboxPath`` resolution
+happens, so connector-side tests must go through it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from aios_connector.base import ToolDescriptor
+
+from aios_signal.config import Settings
+from aios_signal.connector import SignalConnector, _build_send_params
+
+
+def test_build_params_no_attachments() -> None:
+    params = _build_send_params("+15550001", "alice", "hello", attachments=[])
+    assert "attachments" not in params
+    assert params["message"] == "hello"
+
+
+def test_build_params_with_attachments() -> None:
+    params = _build_send_params(
+        "+15550001",
+        "alice",
+        "look",
+        attachments=[Path("/host/a.jpg"), Path("/host/b.jpg")],
+    )
+    assert params["attachments"] == ["/host/a.jpg", "/host/b.jpg"]
+
+
+@pytest.fixture
+def connector(tmp_path: Path) -> SignalConnector:
+    cfg = Settings(
+        phones=["+15550001"],
+        config_dir=tmp_path / "cfg",
+        cli_bin="/usr/bin/signal-cli",
+    )
+    c = SignalConnector(cfg)
+    c._uuid_to_phone = {"bot-uuid": "+15550001"}
+    c._daemon = type(  # type: ignore[assignment]
+        "Daemon", (), {"rpc": type("Rpc", (), {"call": AsyncMock(return_value=None)})()}
+    )()
+    return c
+
+
+def _descriptor_for(connector: SignalConnector, name: str) -> ToolDescriptor:
+    descriptor = next(d for d in connector._tools if d.name == name)
+    assert isinstance(descriptor, ToolDescriptor)
+    return descriptor
+
+
+def _signal_send_descriptor(connector: SignalConnector) -> ToolDescriptor:
+    return _descriptor_for(connector, "signal_send")
+
+
+def _stub_focal(connector: SignalConnector, value: str | None) -> None:
+    connector._focal_from_request_meta = lambda: value  # type: ignore[method-assign]
+
+
+def _stub_session_id(connector: SignalConnector, value: str | None) -> None:
+    connector.current_session_id = lambda: value  # type: ignore[method-assign]
+
+
+def _decode(content_list: list[Any]) -> dict[str, Any]:
+    assert len(content_list) == 1
+    payload = json.loads(content_list[0].text)
+    assert isinstance(payload, dict)
+    return payload
+
+
+# Methods bypass focal/sandbox dispatch entirely — verify the descriptor
+# carries the right metadata so a regression in ``@tool`` would surface.
+
+
+def test_signal_send_descriptor_records_sandbox_param(
+    connector: SignalConnector,
+) -> None:
+    descriptor = _signal_send_descriptor(connector)
+    assert descriptor.sandbox_params == {"attachments": "list"}
+
+
+def test_signal_send_schema_publishes_string_array_with_description(
+    connector: SignalConnector,
+) -> None:
+    descriptor = _signal_send_descriptor(connector)
+    attachments_schema = descriptor.input_schema["properties"]["attachments"]
+    assert attachments_schema["type"] == "array"
+    assert attachments_schema["items"]["type"] == "string"
+    assert "/workspace/" in attachments_schema["items"]["description"]
+
+
+# End-to-end via _invoke_tool exercises the dispatch wrapper that
+# auto-resolves SandboxPath args before the tool body runs.
+
+
+async def test_signal_send_text_only_no_session_id_required(
+    connector: SignalConnector,
+) -> None:
+    _stub_focal(connector, "bot-uuid/alice")
+    _stub_session_id(connector, None)
+    descriptor = _signal_send_descriptor(connector)
+    result = _decode(await connector._invoke_tool(descriptor, {"text": "hello there"}))
+    assert result == {"status": "ok"}
+    sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
+    assert sent_params["message"] == "hello there"
+    assert "attachments" not in sent_params
+
+
+async def test_signal_send_with_attachments_resolves_to_host_paths(
+    connector: SignalConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_focal(connector, "bot-uuid/alice")
+    _stub_session_id(connector, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    (ws / "cat.jpg").write_bytes(b"x")
+
+    descriptor = _signal_send_descriptor(connector)
+    await connector._invoke_tool(
+        descriptor,
+        {"text": "look", "attachments": ["/workspace/cat.jpg"]},
+    )
+
+    sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
+    assert sent_params["message"] == "look"
+    assert sent_params["attachments"] == [str(ws / "cat.jpg")]
+
+
+async def test_signal_send_attachments_without_session_id_raises(
+    connector: SignalConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_focal(connector, "bot-uuid/alice")
+    _stub_session_id(connector, None)
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    descriptor = _signal_send_descriptor(connector)
+    with pytest.raises(RuntimeError, match=r"aios\.session_id"):
+        await connector._invoke_tool(
+            descriptor,
+            {"text": "look", "attachments": ["/workspace/cat.jpg"]},
+        )
+
+
+async def test_signal_send_attachment_traversal_rejected(
+    connector: SignalConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_focal(connector, "bot-uuid/alice")
+    _stub_session_id(connector, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-1").mkdir(parents=True)
+
+    descriptor = _signal_send_descriptor(connector)
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await connector._invoke_tool(
+            descriptor,
+            {"text": "look", "attachments": ["/workspace/../escape.jpg"]},
+        )
+
+
+async def test_signal_send_attachment_disallowed_root_rejected(
+    connector: SignalConnector,
+) -> None:
+    _stub_focal(connector, "bot-uuid/alice")
+    _stub_session_id(connector, "sess-1")
+    descriptor = _signal_send_descriptor(connector)
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await connector._invoke_tool(
+            descriptor,
+            {"text": "boom", "attachments": ["/etc/passwd"]},
+        )
+
+
+async def test_signal_send_attachment_missing_file_raises_clear_error(
+    connector: SignalConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_focal(connector, "bot-uuid/alice")
+    _stub_session_id(connector, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-1").mkdir(parents=True)
+
+    descriptor = _signal_send_descriptor(connector)
+    with pytest.raises(ValueError, match="does not exist"):
+        await connector._invoke_tool(
+            descriptor,
+            {"text": "look", "attachments": ["/workspace/typo.jpg"]},
+        )
+
+
+async def test_signal_send_unknown_account_raises(
+    connector: SignalConnector,
+) -> None:
+    _stub_focal(connector, "nope/alice")
+    descriptor = _signal_send_descriptor(connector)
+    with pytest.raises(ValueError, match="unknown account"):
+        await connector._invoke_tool(descriptor, {"text": "hi"})

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -76,10 +76,26 @@ When deploying multiple instances, set
 `AIOS_TELEGRAM_SUPPORT_BOT_TOKEN`).  Instance names match
 `^[a-z][a-z0-9_]*$`.
 
+## Attachments
+
+Inbound photos, voice notes, documents, video, and audio are
+downloaded via `bot.get_file()` and surfaced as `image_url` content
+parts (vision-capable minds) or text markers, via the harness's
+vision pipeline.  Stickers and animations are dropped; captions
+become the message text.
+
+Outbound: pass an `attachments: list[str]` parameter to
+`telegram_send` alongside `text`.  Type is inferred from extension
+— `.jpg`/`.png` photo, `.mp4` video, `.ogg` voice, `.mp3` audio,
+anything else document.  Single attachment uses
+`send_photo`/`send_voice`/etc with caption; multiple attachments
+use `send_media_group` (caption rides on the first item only, per
+Telegram's API).  Paths must be under `/workspace/` or
+`/mnt/attachments/`.
+
 ## Out of scope for v1
 
-- Inbound media (photos, voice, documents, stickers) — dropped silently.
-- Outbound media — no `telegram_send_photo` / `_document`.
+- Stickers and animations (dropped on inbound).
 - Reactions — punt.
 - Message editing / deletion.
 - Typing indicators / chat actions.

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -44,9 +44,16 @@ from aios_connector import (
 from aios_connector import (
     AttachmentError,
     Connector,
+    SandboxPath,
     focal_required,
     make_account,
     tool,
+)
+from telegram import (
+    InputMediaAudio,
+    InputMediaDocument,
+    InputMediaPhoto,
+    InputMediaVideo,
 )
 from telegram.error import TelegramError
 from telegram.ext import Application, ContextTypes, MessageHandler, filters
@@ -266,8 +273,14 @@ class TelegramConnector(Connector):
 
     @tool()
     @focal_required
-    async def telegram_send(self, text: str, *, chat_id: str) -> dict[str, Any]:
-        """Send a text message to your focal Telegram chat.
+    async def telegram_send(
+        self,
+        text: str,
+        attachments: list[SandboxPath] | None = None,
+        *,
+        chat_id: str,
+    ) -> dict[str, Any]:
+        """Send a Telegram message to your focal chat, optionally with attachments.
 
         The chat id is taken implicitly from your focal channel — aios
         injects it via the JSON-RPC ``_meta`` field on each call.  Set
@@ -275,14 +288,105 @@ class TelegramConnector(Connector):
 
         Args:
             text: Message body. Plain text only — markdown is not rendered.
+                Becomes the caption when attachments are present.
+            attachments: Optional in-sandbox file paths.  Type is inferred
+                from extension (``.jpg``/``.png``/``.gif``/``.webp`` →
+                photo, ``.mp4``/``.mov`` → video, ``.ogg`` → voice,
+                ``.mp3``/``.m4a``/``.wav`` → audio, anything else →
+                document).  Single attachment uses ``send_photo`` /
+                ``send_voice`` / etc.; multiple attachments use
+                ``send_media_group`` with caption attached to the first
+                item only (per Telegram API).  The SDK resolves each
+                entry to a host path before this method runs.
         """
         assert self._application is not None
         try:
             chat_id_int = int(chat_id)
         except ValueError as e:
             raise ValueError(f"telegram chat_id must be an integer; got {chat_id!r}") from e
-        sent = await self._application.bot.send_message(chat_id=chat_id_int, text=text)
-        return {"message_id": sent.message_id}
+
+        host_paths: list[Path] = list(attachments or [])
+        bot = self._application.bot
+
+        if not host_paths:
+            sent = await bot.send_message(chat_id=chat_id_int, text=text)
+            return {"message_id": sent.message_id}
+
+        if len(host_paths) == 1:
+            single = await _send_single_media(
+                bot,
+                chat_id=chat_id_int,
+                host_path=host_paths[0],
+                caption=text or None,
+            )
+            return {"message_id": single.message_id}
+
+        sent_group = await bot.send_media_group(
+            chat_id=chat_id_int,
+            media=_build_media_group(host_paths, caption=text or None),
+        )
+        return {"message_ids": [m.message_id for m in sent_group]}
+
+
+_PHOTO_EXTS = frozenset({".jpg", ".jpeg", ".png", ".gif", ".webp"})
+_VIDEO_EXTS = frozenset({".mp4", ".mov", ".webm"})
+_VOICE_EXTS = frozenset({".ogg", ".oga"})
+_AUDIO_EXTS = frozenset({".mp3", ".m4a", ".wav", ".flac"})
+
+
+def _classify(host_path: Path) -> str:
+    ext = host_path.suffix.lower()
+    if ext in _PHOTO_EXTS:
+        return "photo"
+    if ext in _VIDEO_EXTS:
+        return "video"
+    if ext in _VOICE_EXTS:
+        return "voice"
+    if ext in _AUDIO_EXTS:
+        return "audio"
+    return "document"
+
+
+async def _send_single_media(
+    bot: Any,
+    *,
+    chat_id: int,
+    host_path: Path,
+    caption: str | None,
+) -> Any:
+    kind = _classify(host_path)
+    sender = {
+        "photo": bot.send_photo,
+        "video": bot.send_video,
+        "voice": bot.send_voice,
+        "audio": bot.send_audio,
+        "document": bot.send_document,
+    }[kind]
+    kwargs: dict[str, Any] = {"chat_id": chat_id, kind: host_path}
+    if caption is not None:
+        kwargs["caption"] = caption
+    return await sender(**kwargs)
+
+
+def _build_media_group(host_paths: list[Path], *, caption: str | None) -> list[Any]:
+    # Caption rides on the FIRST item only — Telegram's API ignores
+    # captions on items 2..N of a media group.
+    items: list[Any] = []
+    for idx, path in enumerate(host_paths):
+        kind = _classify(path)
+        kwargs: dict[str, Any] = {"media": path}
+        if idx == 0 and caption is not None:
+            kwargs["caption"] = caption
+        if kind == "photo":
+            items.append(InputMediaPhoto(**kwargs))
+        elif kind == "video":
+            items.append(InputMediaVideo(**kwargs))
+        elif kind == "audio":
+            items.append(InputMediaAudio(**kwargs))
+        else:
+            # Voice can't go in a media group; fall back to document.
+            items.append(InputMediaDocument(**kwargs))
+    return items
 
 
 def build_metadata(msg: InboundMessage, bot_id: int) -> dict[str, Any]:

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -32,15 +32,27 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import tempfile
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 import structlog
-from aios_connector import Connector, focal_required, make_account, tool
+from aios_connector import (
+    Attachment as SDKAttachment,
+)
+from aios_connector import (
+    AttachmentError,
+    Connector,
+    focal_required,
+    make_account,
+    tool,
+)
+from telegram.error import TelegramError
 from telegram.ext import Application, ContextTypes, MessageHandler, filters
 
 from .config import Settings
-from .parse import InboundMessage, parse_message
+from .parse import Attachment, InboundMessage, parse_message
 from .prompts import build_instructions
 
 log = structlog.get_logger(__name__)
@@ -104,7 +116,8 @@ class TelegramConnector(Connector):
         async def on_error(_update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
             log.error("telegram.handler.error", error=str(context.error))
 
-        application.add_handler(MessageHandler(filters.TEXT, on_message))
+        # parse_message handles channel/bot filtering with full message context.
+        application.add_handler(MessageHandler(filters.ALL, on_message))
         application.add_error_handler(on_error)
         log.info(
             "telegram.bot.identified",
@@ -165,6 +178,7 @@ class TelegramConnector(Connector):
     async def _drain_queue(self) -> None:
         assert self._inbound_queue is not None
         assert self._bot_id is not None
+        assert self._application is not None
         while True:
             msg = await self._inbound_queue.get()
             sender_payload: dict[str, Any] = {
@@ -181,14 +195,72 @@ class TelegramConnector(Connector):
                 if msg.timestamp_ms
                 else None
             )
+            sdk_attachments = await self._download_attachments(msg.attachments)
             await self.emit_inbound(
                 account=str(self._bot_id),
                 chat_id=str(msg.chat_id),
                 sender=sender_payload,
                 content=msg.text,
+                attachments=sdk_attachments or None,
                 metadata=metadata,
                 timestamp=timestamp_iso,
             )
+
+    async def _download_attachments(
+        self, attachments: tuple[Attachment, ...]
+    ) -> list[SDKAttachment]:
+        """Download each attachment in parallel, log+skip the rejects."""
+        host_paths = await asyncio.gather(*(self._download_one(a) for a in attachments))
+        out: list[SDKAttachment] = []
+        for att, host_path in zip(attachments, host_paths, strict=True):
+            if host_path is None:
+                continue
+            candidate = SDKAttachment(
+                host_path=str(host_path),
+                filename=att.filename,
+                content_type=att.content_type,
+            )
+            try:
+                candidate.as_params()
+            except AttachmentError as err:
+                log.warning(
+                    "telegram.inbound.attachment_rejected",
+                    file_id=att.file_id,
+                    filename=att.filename,
+                    error=str(err),
+                )
+                continue
+            out.append(candidate)
+        return out
+
+    async def _download_one(self, att: Attachment) -> Path | None:
+        assert self._application is not None
+        try:
+            file = await self._application.bot.get_file(att.file_id)
+        except TelegramError as err:
+            log.warning(
+                "telegram.inbound.get_file_failed",
+                file_id=att.file_id,
+                error=str(err),
+            )
+            return None
+        # Close the handle immediately so PTB owns the write side.
+        with tempfile.NamedTemporaryFile(
+            prefix="aios-telegram-", suffix=Path(att.filename).suffix, delete=False
+        ) as tmp:
+            target = Path(tmp.name)
+        try:
+            await file.download_to_drive(custom_path=target)
+        except (TelegramError, OSError) as err:
+            log.warning(
+                "telegram.inbound.download_failed",
+                file_id=att.file_id,
+                target=str(target),
+                error=str(err),
+            )
+            await asyncio.to_thread(target.unlink, missing_ok=True)
+            return None
+        return target
 
     # ── model-facing tools ────────────────────────────────────────────
 

--- a/connectors/telegram/src/aios_telegram/parse.py
+++ b/connectors/telegram/src/aios_telegram/parse.py
@@ -1,13 +1,8 @@
 """Parse python-telegram-bot ``Message`` objects into :class:`InboundMessage`.
 
-v1 scope is text only. We return ``None`` for anything we don't forward to
-aios — messages from the bot itself, bot-to-bot traffic, non-text payloads
-(photos, stickers, voice, documents), and messages without a sender.
-
-Edits (``update.edited_message``) and channel posts never reach this
-function because the handler in :mod:`aios_telegram.bot` registers on
-``update.message`` with a ``filters.TEXT`` gate — this module is only
-responsible for the parse, not for the filter-at-dispatch.
+Returns ``None`` for messages from the bot itself, bot-to-bot
+traffic, channel posts (no ``from_user``), and otherwise-empty
+messages.
 """
 
 from __future__ import annotations
@@ -19,6 +14,13 @@ from telegram import Message
 from telegram.constants import ChatType
 
 ChatKind = Literal["dm", "group", "supergroup", "channel"]
+
+
+@dataclass(slots=True, frozen=True)
+class Attachment:
+    file_id: str
+    content_type: str
+    filename: str
 
 
 @dataclass(slots=True, frozen=True)
@@ -37,6 +39,7 @@ class InboundMessage:
     message_id: int
     timestamp_ms: int
     text: str
+    attachments: tuple[Attachment, ...]
     reply: Reply | None
 
 
@@ -50,20 +53,71 @@ def _chat_kind(chat_type: str) -> ChatKind:
     return "channel"
 
 
+def _extract_attachments(message: Message) -> tuple[Attachment, ...]:
+    """Pick out media we forward: photo / voice / document / video / audio."""
+    out: list[Attachment] = []
+    if message.photo:
+        # ``photo`` is a tuple of progressively larger PhotoSizes; the
+        # last one is the largest the bot has access to.
+        largest = message.photo[-1]
+        out.append(
+            Attachment(
+                file_id=largest.file_id,
+                content_type="image/jpeg",
+                filename=f"photo-{message.message_id}.jpg",
+            )
+        )
+    if message.voice:
+        out.append(
+            Attachment(
+                file_id=message.voice.file_id,
+                content_type=message.voice.mime_type or "audio/ogg",
+                filename=f"voice-{message.message_id}.ogg",
+            )
+        )
+    if message.document:
+        doc = message.document
+        out.append(
+            Attachment(
+                file_id=doc.file_id,
+                content_type=doc.mime_type or "application/octet-stream",
+                filename=doc.file_name or f"document-{message.message_id}",
+            )
+        )
+    if message.video:
+        vid = message.video
+        out.append(
+            Attachment(
+                file_id=vid.file_id,
+                content_type=vid.mime_type or "video/mp4",
+                filename=vid.file_name or f"video-{message.message_id}.mp4",
+            )
+        )
+    if message.audio:
+        aud = message.audio
+        out.append(
+            Attachment(
+                file_id=aud.file_id,
+                content_type=aud.mime_type or "audio/mpeg",
+                filename=aud.file_name or f"audio-{message.message_id}.mp3",
+            )
+        )
+    return tuple(out)
+
+
 def parse_message(message: Message, *, bot_id: int) -> InboundMessage | None:
     sender = message.from_user
     if sender is None:
-        # Channel posts and anonymous admins have no ``from_user``. Out of
-        # scope for v1.
+        # Channel posts and anonymous admins have no ``from_user``.
         return None
     if sender.id == bot_id:
         return None
     if sender.is_bot:
         return None
 
-    text = message.text
-    if not text:
-        # v1 is text-only. Media, stickers, voice, etc. are dropped.
+    text = message.text or message.caption or ""
+    attachments = _extract_attachments(message)
+    if not text and not attachments:
         return None
 
     chat = message.chat
@@ -86,5 +140,6 @@ def parse_message(message: Message, *, bot_id: int) -> InboundMessage | None:
         message_id=message.message_id,
         timestamp_ms=int(message.date.timestamp() * 1000),
         text=text,
+        attachments=attachments,
         reply=reply,
     )

--- a/connectors/telegram/tests/conftest.py
+++ b/connectors/telegram/tests/conftest.py
@@ -149,6 +149,62 @@ def message_photo_no_text(ptb_bot: Bot) -> Message:
 
 
 @pytest.fixture
+def message_photo_with_caption(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 709,
+            "date": 1700000010,
+            "chat": {"id": 123456789, "type": "private"},
+            "from": {"id": 123456789, "is_bot": False, "first_name": "Alice"},
+            "caption": "look at this cat",
+            "photo": [
+                {"file_id": "S1", "file_unique_id": "s1", "width": 90, "height": 90},
+                {"file_id": "L1", "file_unique_id": "l1", "width": 1280, "height": 1280},
+            ],
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
+def message_voice(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 710,
+            "date": 1700000011,
+            "chat": {"id": 123456789, "type": "private"},
+            "from": {"id": 123456789, "is_bot": False, "first_name": "Alice"},
+            "voice": {
+                "file_id": "VOICE-A",
+                "file_unique_id": "voice-a",
+                "duration": 4,
+                "mime_type": "audio/ogg",
+            },
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
+def message_document(ptb_bot: Bot) -> Message:
+    return _make_message(
+        {
+            "message_id": 711,
+            "date": 1700000012,
+            "chat": {"id": 123456789, "type": "private"},
+            "from": {"id": 123456789, "is_bot": False, "first_name": "Alice"},
+            "document": {
+                "file_id": "DOC-A",
+                "file_unique_id": "doc-a",
+                "file_name": "report.pdf",
+                "mime_type": "application/pdf",
+            },
+        },
+        ptb_bot,
+    )
+
+
+@pytest.fixture
 def message_channel_post_no_sender(ptb_bot: Bot) -> Message:
     return _make_message(
         {

--- a/connectors/telegram/tests/test_parse.py
+++ b/connectors/telegram/tests/test_parse.py
@@ -55,8 +55,47 @@ def test_other_bot_returns_none(message_from_other_bot: Message, bot_id: int) ->
     assert parse_message(message_from_other_bot, bot_id=bot_id) is None
 
 
-def test_photo_without_text_returns_none(message_photo_no_text: Message, bot_id: int) -> None:
-    assert parse_message(message_photo_no_text, bot_id=bot_id) is None
+def test_photo_without_text_surfaces_attachment(
+    message_photo_no_text: Message, bot_id: int
+) -> None:
+    msg = parse_message(message_photo_no_text, bot_id=bot_id)
+    assert msg is not None
+    assert msg.text == ""
+    assert len(msg.attachments) == 1
+    att = msg.attachments[0]
+    assert att.content_type == "image/jpeg"
+    assert att.filename.endswith(".jpg")
+
+
+def test_photo_with_caption_surfaces_both(message_photo_with_caption: Message, bot_id: int) -> None:
+    msg = parse_message(message_photo_with_caption, bot_id=bot_id)
+    assert msg is not None
+    assert msg.text == "look at this cat"
+    assert len(msg.attachments) == 1
+    # Largest PhotoSize wins.
+    assert msg.attachments[0].file_id == "L1"
+
+
+def test_voice_surfaces_attachment(message_voice: Message, bot_id: int) -> None:
+    msg = parse_message(message_voice, bot_id=bot_id)
+    assert msg is not None
+    assert msg.text == ""
+    assert len(msg.attachments) == 1
+    att = msg.attachments[0]
+    assert att.file_id == "VOICE-A"
+    assert att.content_type == "audio/ogg"
+    assert att.filename.endswith(".ogg")
+
+
+def test_document_surfaces_attachment(message_document: Message, bot_id: int) -> None:
+    msg = parse_message(message_document, bot_id=bot_id)
+    assert msg is not None
+    assert msg.text == ""
+    assert len(msg.attachments) == 1
+    att = msg.attachments[0]
+    assert att.file_id == "DOC-A"
+    assert att.content_type == "application/pdf"
+    assert att.filename == "report.pdf"
 
 
 def test_channel_post_without_sender_returns_none(

--- a/connectors/telegram/tests/test_telegram_send.py
+++ b/connectors/telegram/tests/test_telegram_send.py
@@ -1,0 +1,298 @@
+"""Unit coverage for ``telegram_send``'s ``attachments`` parameter,
+type-by-extension routing, and the caption-on-first quirk in
+``send_media_group``.
+
+The PTB ``Bot`` is mocked end-to-end; tests assert that the right
+``send_*`` method was called with the right ``chat_id`` /
+``caption`` / ``media`` arguments.
+
+End-to-end tests go through the SDK's ``_invoke_tool`` dispatch
+wrapper — that's the layer where ``SandboxPath`` resolution happens,
+so connector-side tests must exercise it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aios_connector.base import ToolDescriptor
+
+from aios_telegram.config import Settings
+from aios_telegram.connector import (
+    TelegramConnector,
+    _build_media_group,
+    _classify,
+)
+
+
+def test_classify_extensions() -> None:
+    assert _classify(Path("/x/cat.jpg")) == "photo"
+    assert _classify(Path("/x/CAT.JPEG")) == "photo"
+    assert _classify(Path("/x/clip.mp4")) == "video"
+    assert _classify(Path("/x/voice.ogg")) == "voice"
+    assert _classify(Path("/x/song.mp3")) == "audio"
+    assert _classify(Path("/x/report.pdf")) == "document"
+    assert _classify(Path("/x/no-ext")) == "document"
+
+
+def test_build_media_group_caption_on_first_only() -> None:
+    items = _build_media_group(
+        [Path("/host/a.jpg"), Path("/host/b.jpg"), Path("/host/c.jpg")],
+        caption="three pics",
+    )
+    assert items[0].caption == "three pics"
+    assert items[1].caption is None
+    assert items[2].caption is None
+
+
+def test_build_media_group_no_caption() -> None:
+    items = _build_media_group([Path("/host/a.jpg"), Path("/host/b.jpg")], caption=None)
+    assert all(item.caption is None for item in items)
+
+
+def test_build_media_group_voice_demoted_to_document() -> None:
+    """Voice can't ride in a media group; falls back to document."""
+    from telegram import InputMediaDocument
+
+    items = _build_media_group([Path("/host/v.ogg")], caption=None)
+    assert isinstance(items[0], InputMediaDocument)
+
+
+@pytest.fixture
+def connector() -> TelegramConnector:
+    cfg = Settings(bot_token="0:test")
+    c = TelegramConnector(cfg)
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=42))
+    bot.send_photo = AsyncMock(return_value=MagicMock(message_id=43))
+    bot.send_voice = AsyncMock(return_value=MagicMock(message_id=44))
+    bot.send_video = AsyncMock(return_value=MagicMock(message_id=45))
+    bot.send_audio = AsyncMock(return_value=MagicMock(message_id=46))
+    bot.send_document = AsyncMock(return_value=MagicMock(message_id=47))
+    bot.send_media_group = AsyncMock(
+        return_value=[
+            MagicMock(message_id=100),
+            MagicMock(message_id=101),
+        ]
+    )
+    c._application = MagicMock()
+    c._application.bot = bot
+    return c
+
+
+def _telegram_send_descriptor(connector: TelegramConnector) -> ToolDescriptor:
+    descriptor = next(d for d in connector._tools if d.name == "telegram_send")
+    assert isinstance(descriptor, ToolDescriptor)
+    return descriptor
+
+
+def _stub_focal(connector: TelegramConnector, value: str | None) -> None:
+    connector._focal_from_request_meta = lambda: value  # type: ignore[method-assign]
+
+
+def _stub_session_id(connector: TelegramConnector, value: str | None) -> None:
+    connector.current_session_id = lambda: value  # type: ignore[method-assign]
+
+
+def _decode(content_list: list[Any]) -> dict[str, Any]:
+    assert len(content_list) == 1
+    payload = json.loads(content_list[0].text)
+    assert isinstance(payload, dict)
+    return payload
+
+
+# Descriptor-level checks: the schema reaches the model with the right
+# shape and the dispatch wrapper knows which arg to resolve.
+
+
+def test_telegram_send_descriptor_records_sandbox_param(
+    connector: TelegramConnector,
+) -> None:
+    descriptor = _telegram_send_descriptor(connector)
+    assert descriptor.sandbox_params == {"attachments": "list"}
+
+
+def test_telegram_send_schema_publishes_string_array_with_description(
+    connector: TelegramConnector,
+) -> None:
+    descriptor = _telegram_send_descriptor(connector)
+    attachments_schema = descriptor.input_schema["properties"]["attachments"]
+    assert attachments_schema["type"] == "array"
+    assert attachments_schema["items"]["type"] == "string"
+    assert "/workspace/" in attachments_schema["items"]["description"]
+
+
+# End-to-end tests via _invoke_tool (the dispatch wrapper resolves
+# SandboxPath args before the tool body runs).
+
+
+async def test_telegram_send_text_only(connector: TelegramConnector) -> None:
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, None)
+    descriptor = _telegram_send_descriptor(connector)
+    result = _decode(await connector._invoke_tool(descriptor, {"text": "hello"}))
+    assert result == {"message_id": 42}
+    connector._application.bot.send_message.assert_awaited_once_with(  # type: ignore[union-attr]
+        chat_id=123, text="hello"
+    )
+
+
+async def test_telegram_send_single_photo_routes_to_send_photo(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    (ws / "cat.jpg").write_bytes(b"x")
+
+    descriptor = _telegram_send_descriptor(connector)
+    result = _decode(
+        await connector._invoke_tool(
+            descriptor,
+            {"text": "look", "attachments": ["/workspace/cat.jpg"]},
+        )
+    )
+
+    assert result == {"message_id": 43}
+    bot = connector._application.bot  # type: ignore[union-attr]
+    bot.send_photo.assert_awaited_once()
+    kwargs = bot.send_photo.call_args.kwargs
+    assert kwargs["chat_id"] == 123
+    assert kwargs["photo"] == ws / "cat.jpg"
+    assert kwargs["caption"] == "look"
+
+
+async def test_telegram_send_single_voice_routes_to_send_voice(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    (ws / "v.ogg").write_bytes(b"x")
+
+    descriptor = _telegram_send_descriptor(connector)
+    await connector._invoke_tool(
+        descriptor, {"text": "", "attachments": ["/workspace/v.ogg"]}
+    )
+
+    connector._application.bot.send_voice.assert_awaited_once()  # type: ignore[union-attr]
+
+
+async def test_telegram_send_single_document_routes_to_send_document(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    (ws / "report.pdf").write_bytes(b"x")
+
+    descriptor = _telegram_send_descriptor(connector)
+    await connector._invoke_tool(
+        descriptor, {"text": "", "attachments": ["/workspace/report.pdf"]}
+    )
+
+    connector._application.bot.send_document.assert_awaited_once()  # type: ignore[union-attr]
+
+
+async def test_telegram_send_multi_media_uses_send_media_group(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-1").resolve()
+    ws.mkdir(parents=True)
+    for name in ("a.jpg", "b.jpg"):
+        (ws / name).write_bytes(b"x")
+
+    descriptor = _telegram_send_descriptor(connector)
+    result = _decode(
+        await connector._invoke_tool(
+            descriptor,
+            {
+                "text": "two pics",
+                "attachments": ["/workspace/a.jpg", "/workspace/b.jpg"],
+            },
+        )
+    )
+
+    assert result == {"message_ids": [100, 101]}
+    bot = connector._application.bot  # type: ignore[union-attr]
+    bot.send_media_group.assert_awaited_once()
+    bot.send_photo.assert_not_awaited()
+    media = bot.send_media_group.call_args.kwargs["media"]
+    assert len(media) == 2
+    assert media[0].caption == "two pics"
+    assert media[1].caption is None
+
+
+async def test_telegram_send_attachment_traversal_rejected(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, "sess-1")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-1").mkdir(parents=True)
+
+    descriptor = _telegram_send_descriptor(connector)
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await connector._invoke_tool(
+            descriptor,
+            {"text": "", "attachments": ["/workspace/../escape.jpg"]},
+        )
+
+
+async def test_telegram_send_attachment_disallowed_root_raises(
+    connector: TelegramConnector,
+) -> None:
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, "sess-1")
+    descriptor = _telegram_send_descriptor(connector)
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await connector._invoke_tool(
+            descriptor, {"text": "", "attachments": ["/etc/passwd"]}
+        )
+
+
+async def test_telegram_send_attachment_without_session_id_raises(
+    connector: TelegramConnector,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_focal(connector, "0/123")
+    _stub_session_id(connector, None)
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    descriptor = _telegram_send_descriptor(connector)
+    with pytest.raises(RuntimeError, match=r"aios\.session_id"):
+        await connector._invoke_tool(
+            descriptor, {"text": "", "attachments": ["/workspace/x.jpg"]}
+        )
+
+
+async def test_telegram_send_non_int_chat_id_raises(
+    connector: TelegramConnector,
+) -> None:
+    _stub_focal(connector, "0/not-a-number")
+    descriptor = _telegram_send_descriptor(connector)
+    with pytest.raises(ValueError, match="must be an integer"):
+        await connector._invoke_tool(descriptor, {"text": "hi"})

--- a/packages/aios-connector/README.md
+++ b/packages/aios-connector/README.md
@@ -191,3 +191,85 @@ notification.  On reconnect the SDK replays unacked entries; the
 worker-side dedup ledger (`connector_inbound_acks`) guarantees
 at-most-once event append even across worker SIGKILL between commit
 and ack.
+
+## Attachments (inbound)
+
+Pass a list of `Attachment` instances to `emit_inbound(attachments=...)`
+when the platform delivers a photo, voice note, or document.  The
+connector hands aios a *host path* it owns (e.g. signal-cli's
+download dir, Telegram's `getFile()` result) — bytes never traverse
+stdio.
+
+```python
+from aios_connector import Attachment
+
+await self.emit_inbound(
+    account=...,
+    chat_id=...,
+    sender=...,
+    content="check this out",
+    attachments=[
+        Attachment(
+            host_path="/tmp/signal-cli-downloads/abc.jpg",
+            filename="photo.jpg",
+            content_type="image/jpeg",
+        ),
+    ],
+)
+```
+
+The SDK validates each attachment at `emit_inbound` time:
+
+- `host_path` must be a regular file the SDK can stat.
+- size must be ≤ 5 MiB.
+
+Failures raise `AttachmentError` synchronously; the connector decides
+whether to skip the attachment, send a placeholder text message, or
+refuse the inbound.
+
+The supervisor stages each attachment into a stable per-session
+location and bind-mounts it read-only into the sandbox at
+`/mnt/attachments/<connector>/<event-ulid>-<filename>`.
+
+## Outbound attachments
+
+Send tools take a structured `attachments: list[str] | None`
+parameter alongside `text`.  The model passes in-sandbox paths;
+the connector resolves each to a host path via
+`resolve_sandbox_path`, validates it's under `/workspace/` or
+`/mnt/attachments/`, then opens the file and uploads it as platform
+media with `text` as caption.
+
+```python
+from pathlib import Path
+import os
+from aios_connector import resolve_sandbox_path
+
+@tool()
+@focal_required
+async def signal_send(
+    self,
+    text: str,
+    attachments: list[str] | None = None,
+    *,
+    chat_id: str,
+) -> dict[str, Any]:
+    """Send a Signal message with optional attachments."""
+    workspace_root = Path(os.environ["AIOS_WORKSPACE_ROOT"])
+    session_id = self.current_session_id()
+    host_paths: list[str] = []
+    for sandbox_path in attachments or []:
+        host = resolve_sandbox_path(
+            session_id=session_id,
+            sandbox_path=sandbox_path,
+            workspace_root=workspace_root,
+        )
+        if host is None:
+            raise ValueError(f"path {sandbox_path!r} outside the sandbox bind mount")
+        host_paths.append(str(host))
+    # ... call platform send API with text + host_paths
+```
+
+Path allowlist: `/workspace/...` and `/mnt/attachments/...` only.
+`/mnt/attachments/` is read-only inside the sandbox, so the model
+must `cp` an inbound file into `/workspace/` before forwarding it.

--- a/packages/aios-connector/aios_connector/__init__.py
+++ b/packages/aios-connector/aios_connector/__init__.py
@@ -26,6 +26,9 @@ Public API:
 * :class:`Attachment` / :class:`AttachmentError` — inbound binary blobs
   (photos, voice notes, documents) and the SDK-boundary validation
   failure connectors catch.
+* :func:`resolve_sandbox_path` — host-path resolver for outbound
+  attachments; connector send tools call this for each entry in
+  their ``attachments`` parameter.
 """
 
 from __future__ import annotations
@@ -38,6 +41,7 @@ from aios_connector.base import (
     make_account,
     tool,
 )
+from aios_connector.media import resolve_sandbox_path
 
 __all__ = [
     "Attachment",
@@ -45,5 +49,6 @@ __all__ = [
     "Connector",
     "focal_required",
     "make_account",
+    "resolve_sandbox_path",
     "tool",
 ]

--- a/packages/aios-connector/aios_connector/__init__.py
+++ b/packages/aios-connector/aios_connector/__init__.py
@@ -26,9 +26,9 @@ Public API:
 * :class:`Attachment` / :class:`AttachmentError` — inbound binary blobs
   (photos, voice notes, documents) and the SDK-boundary validation
   failure connectors catch.
-* :func:`resolve_sandbox_path` — host-path resolver for outbound
-  attachments; connector send tools call this for each entry in
-  their ``attachments`` parameter.
+* :data:`SandboxPath` — type marker for outbound-attachment parameters;
+  the SDK auto-resolves model-supplied in-sandbox path strings to host
+  :class:`pathlib.Path` objects before the tool body runs.
 """
 
 from __future__ import annotations
@@ -41,14 +41,14 @@ from aios_connector.base import (
     make_account,
     tool,
 )
-from aios_connector.media import resolve_sandbox_path
+from aios_connector.media import SandboxPath
 
 __all__ = [
     "Attachment",
     "AttachmentError",
     "Connector",
+    "SandboxPath",
     "focal_required",
     "make_account",
-    "resolve_sandbox_path",
     "tool",
 ]

--- a/packages/aios-connector/aios_connector/base.py
+++ b/packages/aios-connector/aios_connector/base.py
@@ -30,10 +30,12 @@ import json
 import os
 import stat
 import time
+import types
+import typing
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, ClassVar, get_type_hints
+from typing import Any, ClassVar, Literal, get_type_hints
 
 import anyio
 import anyio.abc
@@ -47,8 +49,10 @@ from mcp.types import (
     TextContent,
     Tool,
 )
+from pydantic import TypeAdapter
 from ulid import ULID
 
+from aios_connector.media import _resolve_sandbox_path, _SandboxPathMarker
 from aios_connector.spool import SOFT_WARN_BYTES, Spool
 
 # Method names the connector emits over stdio.  Mirrors the constant in
@@ -68,6 +72,16 @@ _INBOUND_METHOD = f"{_AIOS_NOTIFICATION_PREFIX}inbound"
 # focal-required tool methods.
 _FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
+# MCP ``_meta`` key carrying the calling session's id.  Mirrors
+# ``aios.harness.channels.SESSION_ID_META_KEY`` server-side.
+_SESSION_ID_META_KEY = "aios.session_id"
+
+# Default sandbox bind-mount root.  Connector subprocesses inherit
+# ``AIOS_WORKSPACE_ROOT`` from the worker; this constant is only the
+# fallback for tests + dev environments without it set.  Must match
+# :attr:`aios.config.Settings.workspace_root`'s default.
+_DEFAULT_WORKSPACE_ROOT = "/var/lib/aios/workspaces"
+
 ToolFn = Callable[..., Awaitable[Any]]
 
 
@@ -86,8 +100,12 @@ class ToolDescriptor:
     splits the focal-channel path on the first ``/`` and injects only
     those kwargs the method asked for — connectors that serve a single
     account omit ``account`` from their signature and pay no
-    multi-account routing cost.  The frozenset is computed once at
-    registration so dispatch doesn't re-introspect on every call.
+    multi-account routing cost.
+
+    ``sandbox_params`` maps each parameter annotated with
+    :data:`SandboxPath` (or ``list[SandboxPath]``) to its kind so the
+    dispatch wrapper resolves model-supplied path strings to host
+    :class:`Path` objects before the tool body runs.
     """
 
     name: str
@@ -96,6 +114,7 @@ class ToolDescriptor:
     fn: ToolFn
     focal_required: bool = False
     focal_kwargs: frozenset[str] = frozenset()
+    sandbox_params: dict[str, Literal["scalar", "list"]] = field(default_factory=dict)
 
 
 _TOOL_ATTR = "__aios_connector_tool__"
@@ -150,7 +169,13 @@ def tool(
                 "present in the signature, and a tool that wants neither "
                 "shouldn't be focal-required"
             )
-        schema = _build_input_schema(fn, focal_required=is_focal)
+        hints = get_type_hints(fn, include_extras=True)
+        schema = _build_input_schema(fn, hints=hints, focal_required=is_focal)
+        sandbox_params: dict[str, Literal["scalar", "list"]] = {}
+        for param_name, hint in hints.items():
+            found = _extract_sandbox_kind(hint)
+            if found is not None:
+                sandbox_params[param_name] = found[1]
         descriptor = ToolDescriptor(
             name=tool_name,
             description=description or doc,
@@ -158,6 +183,7 @@ def tool(
             fn=fn,
             focal_required=is_focal,
             focal_kwargs=focal_kwargs,
+            sandbox_params=sandbox_params,
         )
         setattr(fn, _TOOL_ATTR, descriptor)
         return fn
@@ -192,26 +218,22 @@ def _detect_focal_kwargs(fn: ToolFn) -> frozenset[str]:
     return frozenset(inspect.signature(fn).parameters) & _FOCAL_INJECTED_KWARGS
 
 
-def _build_input_schema(fn: ToolFn, *, focal_required: bool) -> dict[str, Any]:
+def _build_input_schema(
+    fn: ToolFn, *, hints: dict[str, Any] | None = None, focal_required: bool
+) -> dict[str, Any]:
     """Generate a JSON Schema for ``fn``'s non-self parameters.
 
-    Walks the resolved type hints (so ``from __future__ import
-    annotations`` callers still get usable schemas) and maps Python
-    primitives to the JSON Schema equivalents.  Optional parameters
-    (defaulting to anything) are non-required; the rest are required.
-
     When ``focal_required=True``, ``account`` and ``chat_id`` are
-    SDK-injected from the focal-channel meta and are excluded from the
-    model-facing schema.  Non-focal tools that take ``account`` (e.g.
-    ``list_chats(account: str)`` per design §3.4) keep it as a
-    model-visible argument.
+    SDK-injected and excluded from the model-facing schema.
+
+    ``hints`` may be passed by callers that already resolved them with
+    ``get_type_hints(fn, include_extras=True)``; otherwise we resolve
+    here.  ``include_extras`` is required so ``Annotated`` metadata
+    (e.g. the :data:`SandboxPath` marker) survives.
     """
     sig = inspect.signature(fn)
-    # Fail loudly here: an unresolvable hint at decoration time means
-    # the connector author has a forward-reference / circular-import
-    # bug.  Silently emitting an "any" schema would publish the wrong
-    # tool contract to the model.
-    hints = get_type_hints(fn)
+    if hints is None:
+        hints = get_type_hints(fn, include_extras=True)
 
     properties: dict[str, dict[str, Any]] = {}
     required: list[str] = []
@@ -237,31 +259,102 @@ def _build_input_schema(fn: ToolFn, *, focal_required: bool) -> dict[str, Any]:
 
 
 def _hint_to_schema(hint: Any) -> dict[str, Any]:
-    """Map a Python type hint to a JSON Schema fragment."""
-    if hint is None or hint is type(None):
-        return {"type": "null"}
-    if hint is str:
-        return {"type": "string"}
-    if hint is int:
-        return {"type": "integer"}
-    if hint is float:
-        return {"type": "number"}
-    if hint is bool:
-        return {"type": "boolean"}
-    if hint is list:
-        return {"type": "array"}
-    if hint is dict:
-        return {"type": "object"}
-    # Best effort for parameterized generics: ``list[str]`` etc.  The
-    # SDK keeps this minimal; connector authors who need richer schemas
-    # should pass description= on @tool or supply schemas via a
-    # follow-up enhancement.
-    origin = getattr(hint, "__origin__", None)
-    if origin is list:
-        return {"type": "array"}
-    if origin is dict:
-        return {"type": "object"}
-    return {}
+    """Map a Python type hint to a JSON Schema fragment via pydantic, with
+    ``T | None`` flattened to ``T`` and :data:`SandboxPath` rendered as a
+    string (the model passes in-sandbox path strings; the SDK auto-resolves)."""
+    if hint is None or hint is inspect.Parameter.empty:
+        return {}
+    sandbox_schema = _sandbox_path_schema(hint)
+    if sandbox_schema is not None:
+        return sandbox_schema
+    schema: dict[str, Any] = TypeAdapter(hint).json_schema()
+    any_of = schema.get("anyOf")
+    if isinstance(any_of, list):
+        non_null: list[dict[str, Any]] = [s for s in any_of if s != {"type": "null"}]
+        if len(non_null) == 1:
+            return non_null[0]
+    return schema
+
+
+def _sandbox_path_schema(hint: Any) -> dict[str, Any] | None:
+    """JSON Schema for a hint involving :data:`SandboxPath`, or ``None``."""
+    found = _extract_sandbox_kind(hint)
+    if found is None:
+        return None
+    marker, kind = found
+    if kind == "list":
+        return {
+            "type": "array",
+            "items": {"type": "string", "description": marker.description},
+        }
+    return {"type": "string", "description": marker.description}
+
+
+def _strip_optional(hint: Any) -> Any:
+    """Strip a ``| None`` arm; return ``hint`` unchanged for any other union."""
+    origin = typing.get_origin(hint)
+    if origin is None:
+        return hint
+    if origin is typing.Union or origin is types.UnionType:
+        args = [a for a in typing.get_args(hint) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return hint
+
+
+def _extract_sandbox_kind(
+    hint: Any,
+) -> tuple[_SandboxPathMarker, Literal["scalar", "list"]] | None:
+    """Return ``(marker, kind)`` if ``hint`` is :data:`SandboxPath` or
+    ``list[SandboxPath]`` (with an optional ``| None``), else ``None``."""
+    bare = _strip_optional(hint)
+    marker = _marker_in_metadata(bare)
+    if marker is not None:
+        return (marker, "scalar")
+    if typing.get_origin(bare) is list:
+        args = typing.get_args(bare)
+        if len(args) == 1:
+            inner = _marker_in_metadata(_strip_optional(args[0]))
+            if inner is not None:
+                return (inner, "list")
+    return None
+
+
+def _marker_in_metadata(hint: Any) -> _SandboxPathMarker | None:
+    metadata = getattr(hint, "__metadata__", None)
+    if not metadata:
+        return None
+    for meta in metadata:
+        if isinstance(meta, _SandboxPathMarker):
+            return meta
+    return None
+
+
+def _resolve_one_sandbox_path(
+    *,
+    sandbox_path: str,
+    session_id: str,
+    workspace_root: Path,
+    tool_name: str,
+) -> Path:
+    """Resolve one in-sandbox path string to its host :class:`Path`, with
+    uniform error wording across connectors."""
+    host = _resolve_sandbox_path(
+        session_id=session_id,
+        sandbox_path=sandbox_path,
+        workspace_root=workspace_root,
+    )
+    if host is None:
+        raise ValueError(
+            f"{tool_name}: sandbox path {sandbox_path!r} could not be resolved "
+            f"to a host path (must be under /workspace/ or "
+            f"/mnt/attachments/, no .. escapes)"
+        )
+    if not host.is_file():
+        raise ValueError(
+            f"{tool_name}: sandbox path {sandbox_path!r} does not exist (resolved to {host})"
+        )
+    return host
 
 
 @dataclass
@@ -650,17 +743,7 @@ class Connector:
     async def _invoke_tool(
         self, descriptor: ToolDescriptor, arguments: dict[str, Any]
     ) -> list[TextContent]:
-        """Dispatch a tool, parsing focal meta if the descriptor opted in.
-
-        For ``@focal_required`` tools: split the focal path on the first
-        ``/`` (yielding ``account`` and the chat-id portion, which may
-        itself contain further ``/``-separated thread/sub-chat segments)
-        and inject only the kwargs the tool method's signature declared
-        (per ``descriptor.focal_kwargs``).  Tools fail loudly when the
-        meta key is missing — the agent shouldn't reach a focal-required
-        tool without focal set, so any absence is a bug to surface, not
-        a condition to fall back on.
-        """
+        """Dispatch a tool: inject focal kwargs, resolve sandbox paths, call."""
         kwargs = dict(arguments)
         if descriptor.focal_required:
             focal = self._focal_from_request_meta()
@@ -675,6 +758,9 @@ class Connector:
             if "chat_id" in descriptor.focal_kwargs:
                 kwargs["chat_id"] = chat_id
 
+        if descriptor.sandbox_params:
+            self._resolve_sandbox_kwargs(descriptor, kwargs)
+
         result = await descriptor.fn(self, **kwargs)
         if isinstance(result, list) and all(isinstance(x, TextContent) for x in result):
             return result
@@ -682,14 +768,72 @@ class Connector:
             return [TextContent(type="text", text=result)]
         return [TextContent(type="text", text=json.dumps(result, ensure_ascii=False))]
 
-    def _focal_from_request_meta(self) -> str | None:
-        """Read ``_meta.aios.focal_channel_path`` from the active request.
+    def _resolve_sandbox_kwargs(self, descriptor: ToolDescriptor, kwargs: dict[str, Any]) -> None:
+        """Replace each :data:`SandboxPath` / ``list[SandboxPath]`` argument
+        with a resolved host :class:`Path`, mutating ``kwargs`` in place.
 
-        The lowlevel server stashes the raw request on a context var
-        the call_tool handler can reach via :attr:`Server.request_context`.
-        Missing or malformed meta returns ``None`` so the caller raises
-        a tool-level error.
+        Empty/absent values pass through; ``session_id`` is fetched lazily
+        so text-only calls don't require ``_meta.aios.session_id``.
         """
+        workspace_root = Path(os.environ.get("AIOS_WORKSPACE_ROOT", _DEFAULT_WORKSPACE_ROOT))
+        session_id: str | None = None
+
+        for param_name, kind in descriptor.sandbox_params.items():
+            if param_name not in kwargs:
+                continue
+            value = kwargs[param_name]
+            if value is None:
+                continue
+            if kind == "list":
+                if not isinstance(value, list):
+                    raise TypeError(
+                        f"tool {descriptor.name!r} parameter {param_name!r} expects a "
+                        f"list of in-sandbox path strings; got {type(value).__name__}"
+                    )
+                if not value:
+                    continue
+                if session_id is None:
+                    session_id = self._require_session_id(descriptor.name)
+                kwargs[param_name] = [
+                    _resolve_one_sandbox_path(
+                        sandbox_path=str(item),
+                        session_id=session_id,
+                        workspace_root=workspace_root,
+                        tool_name=descriptor.name,
+                    )
+                    for item in value
+                ]
+            else:  # "scalar"
+                if session_id is None:
+                    session_id = self._require_session_id(descriptor.name)
+                kwargs[param_name] = _resolve_one_sandbox_path(
+                    sandbox_path=str(value),
+                    session_id=session_id,
+                    workspace_root=workspace_root,
+                    tool_name=descriptor.name,
+                )
+
+    def _require_session_id(self, tool_name: str) -> str:
+        session_id = self.current_session_id()
+        if session_id is None:
+            raise RuntimeError(
+                f"{tool_name} with sandbox-path arguments requires "
+                "_meta.aios.session_id; the harness should always inject "
+                "this for tool dispatches"
+            )
+        return session_id
+
+    def _focal_from_request_meta(self) -> str | None:
+        """Read the focal-channel suffix from the active request, or ``None``."""
+        return self._read_meta_str(_FOCAL_CHANNEL_META_KEY)
+
+    def current_session_id(self) -> str | None:
+        """Read ``_meta.aios.session_id`` from the active request, or ``None``."""
+        return self._read_meta_str(_SESSION_ID_META_KEY)
+
+    def _read_meta_str(self, key: str) -> str | None:
+        """Fetch a string-typed key from ``_meta`` of the active tool-call
+        request, or ``None`` when absent / empty / wrong type."""
         from mcp.server.lowlevel.server import request_ctx
 
         try:
@@ -700,10 +844,10 @@ class Connector:
         if meta is None:
             return None
         extra = getattr(meta, "model_extra", None) or {}
-        path: Any = extra.get(_FOCAL_CHANNEL_META_KEY)
-        if not isinstance(path, str) or not path:
+        value: Any = extra.get(key)
+        if not isinstance(value, str) or not value:
             return None
-        return path
+        return value
 
     # ── Internal: aios_inbound_ack tool ───────────────────────────────
 

--- a/packages/aios-connector/aios_connector/media.py
+++ b/packages/aios-connector/aios_connector/media.py
@@ -1,39 +1,52 @@
 """Sandbox path resolution for connector send tools.
 
-Connectors take a structured ``attachments: list[str]`` parameter on
-their send tools (the model passes in-sandbox paths like
-``/workspace/cat.jpg``).  This module's :func:`resolve_sandbox_path`
-maps each one to its host-side equivalent so the connector can
-``open()`` the file before uploading to the platform.
+Connector tool methods annotate path parameters with :data:`SandboxPath`;
+the SDK's dispatch wrapper resolves each value to its host-side
+:class:`pathlib.Path` before the tool body runs.  Connector authors never
+call the resolver directly.
+
+Duplicated from :func:`aios.sandbox.volumes.resolve_to_host_path` rather
+than imported so the reference SDK has zero aios-server dependency
+(mirrors the ``_AIOS_NOTIFICATION_PREFIX`` precedent in base.py).
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Annotated
 
-# Trailing slash is load-bearing — prevents ``/workspaces/foo`` matching
-# ``/workspace``.  Duplicated from :mod:`aios.sandbox.volumes` rather
-# than imported so the reference SDK has zero dependency on aios server
-# code (mirrors the ``_AIOS_NOTIFICATION_PREFIX`` precedent in base.py).
+# Trailing slash on _WORKSPACE_PREFIX is load-bearing — prevents
+# ``/workspaces/foo`` matching ``/workspace``.
 _WORKSPACE_PREFIX = "/workspace/"
 _ATTACHMENTS_PREFIX = "/mnt/attachments/"
 _ATTACHMENTS_HOST_SUBDIR = "_attachments"
 
+_SANDBOX_PATH_DESCRIPTION = (
+    "In-sandbox file path under /workspace/ or /mnt/attachments/ "
+    "(/mnt/attachments/ is read-only — cp into /workspace/ first to "
+    "forward an inbound photo)."
+)
 
-def resolve_sandbox_path(
+
+@dataclass(frozen=True, slots=True)
+class _SandboxPathMarker:
+    description: str = _SANDBOX_PATH_DESCRIPTION
+
+
+SANDBOX_PATH_MARKER = _SandboxPathMarker()
+SandboxPath = Annotated[Path, SANDBOX_PATH_MARKER]
+
+
+def _resolve_sandbox_path(
     *,
     session_id: str,
     sandbox_path: str,
     workspace_root: Path,
 ) -> Path | None:
-    """Map an in-sandbox path to its host-side equivalent, or ``None`` when
-    it doesn't fall under ``/workspace/`` or ``/mnt/attachments/`` or escapes
-    the bind-mount root after ``..`` / symlink resolution.
-
-    Duplicated from :func:`aios.sandbox.volumes.resolve_to_host_path`
-    rather than imported so the reference SDK has zero aios server
-    dependency (mirrors the ``_AIOS_NOTIFICATION_PREFIX`` precedent).
-    """
+    """Map an in-sandbox path to its host equivalent, or ``None`` when it
+    falls outside ``/workspace/`` and ``/mnt/attachments/`` or escapes the
+    bind-mount root after ``..`` / symlink resolution."""
     if sandbox_path.startswith(_WORKSPACE_PREFIX):
         base = workspace_root / session_id
         suffix = sandbox_path[len(_WORKSPACE_PREFIX) :]

--- a/packages/aios-connector/aios_connector/media.py
+++ b/packages/aios-connector/aios_connector/media.py
@@ -1,0 +1,60 @@
+"""Sandbox path resolution for connector send tools.
+
+Connectors take a structured ``attachments: list[str]`` parameter on
+their send tools (the model passes in-sandbox paths like
+``/workspace/cat.jpg``).  This module's :func:`resolve_sandbox_path`
+maps each one to its host-side equivalent so the connector can
+``open()`` the file before uploading to the platform.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Trailing slash is load-bearing — prevents ``/workspaces/foo`` matching
+# ``/workspace``.  Duplicated from :mod:`aios.sandbox.volumes` rather
+# than imported so the reference SDK has zero dependency on aios server
+# code (mirrors the ``_AIOS_NOTIFICATION_PREFIX`` precedent in base.py).
+_WORKSPACE_PREFIX = "/workspace/"
+_ATTACHMENTS_PREFIX = "/mnt/attachments/"
+_ATTACHMENTS_HOST_SUBDIR = "_attachments"
+
+
+def resolve_sandbox_path(
+    *,
+    session_id: str,
+    sandbox_path: str,
+    workspace_root: Path,
+) -> Path | None:
+    """Map an in-sandbox path to its host-side equivalent, or ``None`` when
+    it doesn't fall under ``/workspace/`` or ``/mnt/attachments/`` or escapes
+    the bind-mount root after ``..`` / symlink resolution.
+
+    Duplicated from :func:`aios.sandbox.volumes.resolve_to_host_path`
+    rather than imported so the reference SDK has zero aios server
+    dependency (mirrors the ``_AIOS_NOTIFICATION_PREFIX`` precedent).
+    """
+    if sandbox_path.startswith(_WORKSPACE_PREFIX):
+        base = workspace_root / session_id
+        suffix = sandbox_path[len(_WORKSPACE_PREFIX) :]
+    elif sandbox_path == "/workspace":
+        base = workspace_root / session_id
+        suffix = ""
+    elif sandbox_path.startswith(_ATTACHMENTS_PREFIX):
+        base = workspace_root / _ATTACHMENTS_HOST_SUBDIR / session_id
+        suffix = sandbox_path[len(_ATTACHMENTS_PREFIX) :]
+    elif sandbox_path == "/mnt/attachments":
+        base = workspace_root / _ATTACHMENTS_HOST_SUBDIR / session_id
+        suffix = ""
+    else:
+        return None
+
+    candidate = base if not suffix else base / suffix
+    try:
+        resolved = candidate.resolve(strict=False)
+        resolved_base = base.resolve(strict=False)
+    except OSError:
+        return None
+    if resolved != resolved_base and not resolved.is_relative_to(resolved_base):
+        return None
+    return resolved

--- a/packages/aios-connector/tests/test_invoke_tool.py
+++ b/packages/aios-connector/tests/test_invoke_tool.py
@@ -1,9 +1,14 @@
-"""Dispatch-side tests for ``Connector._invoke_tool`` focal injection.
+"""Dispatch-side tests for ``Connector._invoke_tool``.
 
-Exercises the signature-inspection branch end-to-end without a live MCP
-server: stub out ``_focal_from_request_meta`` to return a known path,
-invoke ``_invoke_tool`` directly, and assert the right kwargs reach the
-tool method.
+Exercises both the focal-injection branch (signature inspection picks
+which kwargs to inject from ``_meta.aios.focal_channel_path``) and the
+:data:`SandboxPath` auto-resolution branch (each tool param annotated
+with ``SandboxPath`` / ``list[SandboxPath]`` is resolved to a host
+:class:`Path` before the tool body runs).
+
+Stub out ``_focal_from_request_meta`` and ``current_session_id`` to
+return known values, invoke ``_invoke_tool`` directly, and assert the
+right kwargs reach the tool method.
 """
 
 from __future__ import annotations
@@ -13,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from aios_connector import Connector, focal_required, tool
+from aios_connector import Connector, SandboxPath, focal_required, tool
 from aios_connector.base import _TOOL_ATTR, ToolDescriptor
 
 
@@ -112,3 +117,178 @@ async def test_non_focal_tool_ignores_meta(fixture: _DispatchFixture) -> None:
     descriptor = _descriptor_for(_DispatchFixture.non_focal)
     result = _decode(await fixture._invoke_tool(descriptor, {"text": "hi"}))
     assert result == {"text": "hi"}
+
+
+# ── SandboxPath dispatch: model strings → host Path objects ─────────
+
+
+class _SandboxDispatchFixture(Connector):
+    name = "_sandbox_dispatch_fixture"
+
+    @tool()
+    async def take_list(
+        self,
+        attachments: list[SandboxPath] | None = None,
+    ) -> dict[str, Any]:
+        """Body sees a list[Path] — the SDK pre-resolved each entry."""
+        if attachments is None:
+            return {"attachments": None}
+        return {
+            "attachments": [str(p) for p in attachments],
+            "kinds": [type(p).__name__ for p in attachments],
+        }
+
+    @tool()
+    async def take_scalar(
+        self,
+        path: SandboxPath,
+    ) -> dict[str, Any]:
+        """Body sees a Path — the SDK pre-resolved the string."""
+        return {"path": str(path), "kind": type(path).__name__}
+
+
+@pytest.fixture
+def sandbox_fixture(tmp_path: Path) -> _SandboxDispatchFixture:
+    return _SandboxDispatchFixture(spool_dir=tmp_path)
+
+
+def _stub_session_id(connector: Connector, value: str | None) -> None:
+    connector.current_session_id = lambda: value  # type: ignore[method-assign]
+
+
+async def test_list_sandbox_path_resolved_to_paths(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dispatch wrapper resolves each model-supplied string to a host
+    :class:`Path` BEFORE the tool body runs."""
+    _stub_session_id(sandbox_fixture, "sess-x")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-x").resolve()
+    ws.mkdir(parents=True)
+    (ws / "cat.jpg").write_bytes(b"x")
+    (ws / "dog.jpg").write_bytes(b"y")
+
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    result = _decode(
+        await sandbox_fixture._invoke_tool(
+            descriptor,
+            {"attachments": ["/workspace/cat.jpg", "/workspace/dog.jpg"]},
+        )
+    )
+    assert result["attachments"] == [str(ws / "cat.jpg"), str(ws / "dog.jpg")]
+    assert all(k in {"PosixPath", "WindowsPath"} for k in result["kinds"])
+
+
+async def test_scalar_sandbox_path_resolved_to_path(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_session_id(sandbox_fixture, "sess-x")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    ws = (tmp_path / "sess-x").resolve()
+    ws.mkdir(parents=True)
+    (ws / "cat.jpg").write_bytes(b"x")
+
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_scalar)
+    result = _decode(
+        await sandbox_fixture._invoke_tool(
+            descriptor,
+            {"path": "/workspace/cat.jpg"},
+        )
+    )
+    assert result["path"] == str(ws / "cat.jpg")
+    assert result["kind"] in {"PosixPath", "WindowsPath"}
+
+
+async def test_omitted_optional_list_sandbox_path_passes_through_as_none(
+    sandbox_fixture: _SandboxDispatchFixture,
+) -> None:
+    """The optional ``attachments`` parameter omitted by the model — no
+    session_id, no resolution work, body sees the default ``None``."""
+    _stub_session_id(sandbox_fixture, None)
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    result = _decode(await sandbox_fixture._invoke_tool(descriptor, {}))
+    assert result == {"attachments": None}
+
+
+async def test_empty_list_sandbox_path_passes_through_without_session_id(
+    sandbox_fixture: _SandboxDispatchFixture,
+) -> None:
+    """Empty list short-circuits — no path strings means no session_id
+    is needed, so text-only call sites work in tests that don't stamp it."""
+    _stub_session_id(sandbox_fixture, None)
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    result = _decode(await sandbox_fixture._invoke_tool(descriptor, {"attachments": []}))
+    assert result == {"attachments": [], "kinds": []}
+
+
+async def test_list_sandbox_path_missing_session_id_raises(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_session_id(sandbox_fixture, None)
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    with pytest.raises(RuntimeError, match=r"aios\.session_id"):
+        await sandbox_fixture._invoke_tool(descriptor, {"attachments": ["/workspace/x.jpg"]})
+
+
+async def test_list_sandbox_path_containment_violation_uniformly_raises(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Uniform error wording across connectors is the whole point — any
+    sandbox-path arg that fails containment raises the same ValueError."""
+    _stub_session_id(sandbox_fixture, "sess-x")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await sandbox_fixture._invoke_tool(descriptor, {"attachments": ["/etc/passwd"]})
+
+
+async def test_list_sandbox_path_traversal_rejected(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_session_id(sandbox_fixture, "sess-x")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-x").mkdir(parents=True)
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    with pytest.raises(ValueError, match="could not be resolved"):
+        await sandbox_fixture._invoke_tool(
+            descriptor, {"attachments": ["/workspace/../escape.jpg"]}
+        )
+
+
+async def test_list_sandbox_path_missing_file_raises(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_session_id(sandbox_fixture, "sess-x")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    (tmp_path / "sess-x").mkdir(parents=True)
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    with pytest.raises(ValueError, match="does not exist"):
+        await sandbox_fixture._invoke_tool(descriptor, {"attachments": ["/workspace/typo.jpg"]})
+
+
+async def test_list_sandbox_path_wrong_arg_type_raises_typeerror(
+    sandbox_fixture: _SandboxDispatchFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The model passing a string instead of a list is a contract bug,
+    not silent recovery — surface the error so the model retries with
+    the right shape."""
+    _stub_session_id(sandbox_fixture, "sess-x")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    descriptor = _descriptor_for(_SandboxDispatchFixture.take_list)
+    with pytest.raises(TypeError, match="expects a list"):
+        await sandbox_fixture._invoke_tool(descriptor, {"attachments": "/workspace/x.jpg"})

--- a/packages/aios-connector/tests/test_media.py
+++ b/packages/aios-connector/tests/test_media.py
@@ -1,4 +1,4 @@
-"""Unit coverage for ``resolve_sandbox_path``.
+"""Unit coverage for ``_resolve_sandbox_path``.
 
 Mirrors the server-side ``resolve_to_host_path`` containment tests.
 Both helpers must reject the same attacks; duplicating coverage
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from aios_connector import resolve_sandbox_path
+from aios_connector.media import _resolve_sandbox_path
 
 
 class TestResolveSandboxPath:
     def test_workspace_subpath(self, tmp_path: Path) -> None:
-        result = resolve_sandbox_path(
+        result = _resolve_sandbox_path(
             session_id="sess-1",
             sandbox_path="/workspace/foo.jpg",
             workspace_root=tmp_path,
@@ -23,7 +23,7 @@ class TestResolveSandboxPath:
         assert result == (tmp_path / "sess-1" / "foo.jpg").resolve()
 
     def test_attachments_subpath(self, tmp_path: Path) -> None:
-        result = resolve_sandbox_path(
+        result = _resolve_sandbox_path(
             session_id="sess-1",
             sandbox_path="/mnt/attachments/echo/evt-photo.jpg",
             workspace_root=tmp_path,
@@ -31,7 +31,7 @@ class TestResolveSandboxPath:
         assert result == (tmp_path / "_attachments" / "sess-1" / "echo" / "evt-photo.jpg").resolve()
 
     def test_workspace_root(self, tmp_path: Path) -> None:
-        result = resolve_sandbox_path(
+        result = _resolve_sandbox_path(
             session_id="sess-1",
             sandbox_path="/workspace",
             workspace_root=tmp_path,
@@ -47,7 +47,7 @@ class TestResolveSandboxPath:
             "/workspaces/foo",
         ):
             assert (
-                resolve_sandbox_path(
+                _resolve_sandbox_path(
                     session_id="sess-1",
                     sandbox_path=bad,
                     workspace_root=tmp_path,
@@ -57,7 +57,7 @@ class TestResolveSandboxPath:
 
     def test_dotdot_escape_from_workspace_rejected(self, tmp_path: Path) -> None:
         assert (
-            resolve_sandbox_path(
+            _resolve_sandbox_path(
                 session_id="sess-1",
                 sandbox_path="/workspace/../../etc/hostname",
                 workspace_root=tmp_path,
@@ -67,7 +67,7 @@ class TestResolveSandboxPath:
 
     def test_dotdot_escape_from_attachments_rejected(self, tmp_path: Path) -> None:
         assert (
-            resolve_sandbox_path(
+            _resolve_sandbox_path(
                 session_id="sess-1",
                 sandbox_path="/mnt/attachments/../foo",
                 workspace_root=tmp_path,
@@ -76,7 +76,7 @@ class TestResolveSandboxPath:
         )
 
     def test_innocuous_dotdot_inside_workspace_allowed(self, tmp_path: Path) -> None:
-        result = resolve_sandbox_path(
+        result = _resolve_sandbox_path(
             session_id="sess-1",
             sandbox_path="/workspace/sub/../foo.jpg",
             workspace_root=tmp_path,
@@ -91,7 +91,7 @@ class TestResolveSandboxPath:
         (ws / "sneaky.jpg").symlink_to(outside)
 
         assert (
-            resolve_sandbox_path(
+            _resolve_sandbox_path(
                 session_id="sess-1",
                 sandbox_path="/workspace/sneaky.jpg",
                 workspace_root=tmp_path,
@@ -106,7 +106,7 @@ class TestResolveSandboxPath:
         target.write_bytes(b"x")
         (ws / "alias.jpg").symlink_to(target)
 
-        result = resolve_sandbox_path(
+        result = _resolve_sandbox_path(
             session_id="sess-1",
             sandbox_path="/workspace/alias.jpg",
             workspace_root=tmp_path,

--- a/packages/aios-connector/tests/test_media.py
+++ b/packages/aios-connector/tests/test_media.py
@@ -1,0 +1,114 @@
+"""Unit coverage for ``resolve_sandbox_path``.
+
+Mirrors the server-side ``resolve_to_host_path`` containment tests.
+Both helpers must reject the same attacks; duplicating coverage
+(rather than sharing an import) keeps the SDK independently
+verifiable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aios_connector import resolve_sandbox_path
+
+
+class TestResolveSandboxPath:
+    def test_workspace_subpath(self, tmp_path: Path) -> None:
+        result = resolve_sandbox_path(
+            session_id="sess-1",
+            sandbox_path="/workspace/foo.jpg",
+            workspace_root=tmp_path,
+        )
+        assert result == (tmp_path / "sess-1" / "foo.jpg").resolve()
+
+    def test_attachments_subpath(self, tmp_path: Path) -> None:
+        result = resolve_sandbox_path(
+            session_id="sess-1",
+            sandbox_path="/mnt/attachments/echo/evt-photo.jpg",
+            workspace_root=tmp_path,
+        )
+        assert result == (tmp_path / "_attachments" / "sess-1" / "echo" / "evt-photo.jpg").resolve()
+
+    def test_workspace_root(self, tmp_path: Path) -> None:
+        result = resolve_sandbox_path(
+            session_id="sess-1",
+            sandbox_path="/workspace",
+            workspace_root=tmp_path,
+        )
+        assert result == (tmp_path / "sess-1").resolve()
+
+    def test_unknown_paths_return_none(self, tmp_path: Path) -> None:
+        for bad in (
+            "/etc/passwd",
+            "/tmp/x",
+            "/mnt/memory/foo",
+            "workspace/foo",
+            "/workspaces/foo",
+        ):
+            assert (
+                resolve_sandbox_path(
+                    session_id="sess-1",
+                    sandbox_path=bad,
+                    workspace_root=tmp_path,
+                )
+                is None
+            )
+
+    def test_dotdot_escape_from_workspace_rejected(self, tmp_path: Path) -> None:
+        assert (
+            resolve_sandbox_path(
+                session_id="sess-1",
+                sandbox_path="/workspace/../../etc/hostname",
+                workspace_root=tmp_path,
+            )
+            is None
+        )
+
+    def test_dotdot_escape_from_attachments_rejected(self, tmp_path: Path) -> None:
+        assert (
+            resolve_sandbox_path(
+                session_id="sess-1",
+                sandbox_path="/mnt/attachments/../foo",
+                workspace_root=tmp_path,
+            )
+            is None
+        )
+
+    def test_innocuous_dotdot_inside_workspace_allowed(self, tmp_path: Path) -> None:
+        result = resolve_sandbox_path(
+            session_id="sess-1",
+            sandbox_path="/workspace/sub/../foo.jpg",
+            workspace_root=tmp_path,
+        )
+        assert result == (tmp_path / "sess-1" / "foo.jpg").resolve()
+
+    def test_symlink_escape_via_workspace_rejected(self, tmp_path: Path) -> None:
+        ws = (tmp_path / "sess-1").resolve()
+        ws.mkdir(parents=True)
+        outside = tmp_path / "outside.txt"
+        outside.write_text("host-secret")
+        (ws / "sneaky.jpg").symlink_to(outside)
+
+        assert (
+            resolve_sandbox_path(
+                session_id="sess-1",
+                sandbox_path="/workspace/sneaky.jpg",
+                workspace_root=tmp_path,
+            )
+            is None
+        )
+
+    def test_symlink_target_inside_workspace_allowed(self, tmp_path: Path) -> None:
+        ws = (tmp_path / "sess-1").resolve()
+        ws.mkdir(parents=True)
+        target = ws / "real.jpg"
+        target.write_bytes(b"x")
+        (ws / "alias.jpg").symlink_to(target)
+
+        result = resolve_sandbox_path(
+            session_id="sess-1",
+            sandbox_path="/workspace/alias.jpg",
+            workspace_root=tmp_path,
+        )
+        assert result == target.resolve()

--- a/packages/aios-connector/tests/test_tool_schema.py
+++ b/packages/aios-connector/tests/test_tool_schema.py
@@ -1,0 +1,252 @@
+"""JSON Schema generation from Python type hints.
+
+Covers the ``_hint_to_schema`` helper end-to-end: primitive types,
+parameterized generics, ``T | None`` unions (the headline case — a
+connector parameter typed ``list[str] | None`` must surface the
+array-of-strings shape, not an empty schema), plus an integration
+test that runs the full ``@tool()`` decorator path so a regression
+in the helper would also surface here.
+
+Also covers :data:`aios_connector.SandboxPath`, the marker connector
+authors annotate outbound-attachment parameters with: the schema must
+publish ``string`` (not ``Path``) so the model passes path strings,
+and the SDK's dispatch wrapper resolves them to host ``Path`` objects
+before the tool body runs.
+
+Wire evidence motivating this:  ``mcp__telegram__telegram_send``'s
+``attachments: list[str] | None = None`` parameter previously
+published an empty ``{}`` schema, leaving the model to guess the
+shape and learn from a tool error.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Annotated
+
+from aios_connector import Connector, SandboxPath, tool
+from aios_connector.base import _TOOL_ATTR, ToolDescriptor, _hint_to_schema
+
+# ── primitive shapes survive the swap ───────────────────────────────
+
+
+def test_str_hint() -> None:
+    assert _hint_to_schema(str) == {"type": "string"}
+
+
+def test_int_hint() -> None:
+    assert _hint_to_schema(int) == {"type": "integer"}
+
+
+def test_float_hint() -> None:
+    assert _hint_to_schema(float) == {"type": "number"}
+
+
+def test_bool_hint() -> None:
+    assert _hint_to_schema(bool) == {"type": "boolean"}
+
+
+# ── parameterized generics now carry their item / value type ────────
+
+
+def test_list_of_str_includes_items() -> None:
+    """``list[str]`` must publish ``items`` so the model knows it's a
+    list of strings, not an array of anything."""
+    assert _hint_to_schema(list[str]) == {"type": "array", "items": {"type": "string"}}
+
+
+def test_list_of_int_includes_items() -> None:
+    assert _hint_to_schema(list[int]) == {"type": "array", "items": {"type": "integer"}}
+
+
+def test_dict_str_int_includes_additional_properties() -> None:
+    """``dict[str, int]`` must publish ``additionalProperties`` so the
+    model knows values are integers, not arbitrary."""
+    assert _hint_to_schema(dict[str, int]) == {
+        "type": "object",
+        "additionalProperties": {"type": "integer"},
+    }
+
+
+# ── T | None flattens to T (optional handled by required[] absence) ─
+
+
+def test_optional_list_of_str_flattens_to_array() -> None:
+    """The headline failing case.  ``list[str] | None`` previously
+    produced ``{}``; pydantic emits an ``anyOf`` with a ``null`` arm
+    that we strip — the parameter being optional is encoded by its
+    absence from the parent object's ``required[]``, not by JSON
+    ``null`` shape (per MCP / OpenAI / Anthropic tool-args convention).
+    """
+    assert _hint_to_schema(list[str] | None) == {
+        "type": "array",
+        "items": {"type": "string"},
+    }
+
+
+def test_optional_str_flattens_to_string() -> None:
+    assert _hint_to_schema(str | None) == {"type": "string"}
+
+
+def test_optional_int_flattens_to_integer() -> None:
+    assert _hint_to_schema(int | None) == {"type": "integer"}
+
+
+# ── empty / unannotated parameters keep the SDK's best-effort floor ─
+
+
+def test_empty_hint_returns_empty_dict() -> None:
+    """A parameter without an annotation — ``def f(self, x)`` — must
+    not crash; the helper returns ``{}`` so schema generation stays
+    best-effort."""
+    assert _hint_to_schema(inspect.Parameter.empty) == {}
+
+
+def test_none_hint_returns_empty_dict() -> None:
+    assert _hint_to_schema(None) == {}
+
+
+# ── Annotated[X, ...] passes through to the inner type ──────────────
+
+
+def test_annotated_passes_through() -> None:
+    """``Annotated[str, "description"]`` should still produce a string
+    schema (pydantic treats Annotated metadata as descriptive, not
+    type-changing)."""
+    schema = _hint_to_schema(Annotated[str, "some metadata"])
+    assert schema["type"] == "string"
+
+
+# ── full @tool() integration: list[str] | None on a fixture method ──
+
+
+class _SchemaFixtureConnector(Connector):
+    name = "_schema_fixture"
+
+    @tool()
+    async def with_optional_list(
+        self,
+        text: str,
+        attachments: list[str] | None = None,
+    ) -> dict[str, object]:
+        """Mirror of telegram_send's signature for end-to-end verification."""
+        return {"text": text, "attachments": attachments}
+
+
+def _descriptor(fn: object) -> ToolDescriptor:
+    descriptor = getattr(fn, _TOOL_ATTR, None)
+    assert isinstance(descriptor, ToolDescriptor)
+    return descriptor
+
+
+def test_decorator_publishes_full_array_schema_for_optional_list() -> None:
+    """The @tool() decorator must publish the array-of-strings shape
+    for ``attachments: list[str] | None``.  This is the exact wire
+    failure the pydantic swap fixes — previously
+    ``input_schema["properties"]["attachments"]`` was ``{}``.
+    """
+    descriptor = _descriptor(_SchemaFixtureConnector.with_optional_list)
+    properties = descriptor.input_schema["properties"]
+    assert properties["text"] == {"type": "string"}
+    assert properties["attachments"] == {
+        "type": "array",
+        "items": {"type": "string"},
+    }
+    # `attachments` has a default → optional → not in required[].
+    assert descriptor.input_schema["required"] == ["text"]
+
+
+# ── SandboxPath: model-facing schema is `string`, body sees `Path` ───
+
+
+def test_sandbox_path_schema_is_string() -> None:
+    """A bare :data:`SandboxPath` parameter must publish a string schema —
+    the model passes in-sandbox path strings, the SDK auto-resolves to
+    a host :class:`Path` before the tool body runs.
+    """
+    schema = _hint_to_schema(SandboxPath)
+    assert schema["type"] == "string"
+    assert "/workspace/" in schema["description"]
+
+
+def test_list_sandbox_path_schema_is_array_of_strings() -> None:
+    schema = _hint_to_schema(list[SandboxPath])
+    assert schema == {
+        "type": "array",
+        "items": {
+            "type": "string",
+            "description": schema["items"]["description"],
+        },
+    }
+    assert "/workspace/" in schema["items"]["description"]
+
+
+def test_optional_sandbox_path_schema_is_string() -> None:
+    schema = _hint_to_schema(SandboxPath | None)
+    assert schema["type"] == "string"
+    assert "/workspace/" in schema["description"]
+
+
+def test_optional_list_sandbox_path_schema_is_array_of_strings() -> None:
+    """The headline shape signal/telegram tools use:
+    ``list[SandboxPath] | None = None``.
+    """
+    schema = _hint_to_schema(list[SandboxPath] | None)
+    assert schema["type"] == "array"
+    assert schema["items"]["type"] == "string"
+    assert "/workspace/" in schema["items"]["description"]
+
+
+class _SandboxFixtureConnector(Connector):
+    name = "_sandbox_fixture"
+
+    @tool()
+    async def with_attachments(
+        self,
+        text: str,
+        attachments: list[SandboxPath] | None = None,
+    ) -> dict[str, object]:
+        """End-to-end: list[SandboxPath] arrives resolved as list[Path]."""
+        if attachments is None:
+            return {"text": text}
+        return {"text": text, "first_path": str(attachments[0])}
+
+    @tool()
+    async def with_one_attachment(
+        self,
+        path: SandboxPath,
+    ) -> dict[str, object]:
+        """End-to-end: scalar SandboxPath arrives resolved as Path."""
+        return {"path": str(path)}
+
+
+def test_sandbox_path_descriptor_records_list_kind() -> None:
+    """The dispatch wrapper needs to know which params to resolve and how —
+    ``sandbox_params`` is the structured record built at decoration time.
+    """
+    descriptor = _descriptor(_SandboxFixtureConnector.with_attachments)
+    assert descriptor.sandbox_params == {"attachments": "list"}
+
+
+def test_sandbox_path_descriptor_records_scalar_kind() -> None:
+    descriptor = _descriptor(_SandboxFixtureConnector.with_one_attachment)
+    assert descriptor.sandbox_params == {"path": "scalar"}
+
+
+def test_sandbox_path_published_schema_is_string_array() -> None:
+    """Integration: the @tool() decorator publishes the array-of-strings
+    shape for ``attachments: list[SandboxPath] | None``."""
+    descriptor = _descriptor(_SandboxFixtureConnector.with_attachments)
+    properties = descriptor.input_schema["properties"]
+    assert properties["attachments"]["type"] == "array"
+    assert properties["attachments"]["items"]["type"] == "string"
+    assert "/workspace/" in properties["attachments"]["items"]["description"]
+    # `attachments` has a default → optional → not in required[].
+    assert descriptor.input_schema["required"] == ["text"]
+
+
+def test_scalar_sandbox_path_published_schema_is_string() -> None:
+    descriptor = _descriptor(_SandboxFixtureConnector.with_one_attachment)
+    properties = descriptor.input_schema["properties"]
+    assert properties["path"]["type"] == "string"
+    assert "/workspace/" in properties["path"]["description"]

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -771,7 +771,7 @@ async def list_running_session_ids(conn: asyncpg.Connection[Any]) -> list[str]:
 
 
 async def get_session_model(conn: asyncpg.Connection[Any], session_id: str) -> str:
-    """Return the bound mind URL for ``session_id`` in one round trip.
+    """Return the bound model for ``session_id`` in one round trip.
 
     Pinned ``agent_version`` wins when set; otherwise the live agent's
     current ``model`` is returned.
@@ -996,13 +996,13 @@ async def model_token_ratio(
     Below-threshold results are not cached, so newly accumulating models
     can activate as soon as the minimum sample count is reached.
 
-    ``model`` is the raw mind string (``agent.model``) — NO NORMALIZATION.
+    ``model`` is the raw model string (``agent.model``) — NO NORMALIZATION.
     Different LiteLLM routes (``anthropic/...`` vs
     ``openrouter/anthropic/...``) hit different provider tokenizers and
     must partition separately.  The same string must appear at stamp time
     and at query time for the same step — always plumb ``agent.model`` on
     both sides.  aios sessions do not carry a model override; the session's
-    active mind is always its agent's configured model.
+    active model is always its agent's configured model.
 
     Scope: the aggregate pools samples across every session in this
     database.  Token counts are scalar only — no content crosses between
@@ -1450,7 +1450,7 @@ async def read_windowed_events(
     ``window_max`` by the overhead amount.  Callers that don't have any
     such overhead (preview tooling, test scaffolds) pass ``0``.
 
-    ``model`` must be the session's currently-active mind string —
+    ``model`` must be the session's currently-active model string —
     ``agent.model`` on the session's pinned agent/version.  The same
     string is what :func:`~aios.harness.loop.run_session_step` stamps on
     ``model_request_end`` spans, so stamp-side and query-side stay

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1288,6 +1288,16 @@ async def append_event(
         if kind == "message":
             prev = await _latest_cumulative_tokens(conn, session_id)
             if data.get("role") == "user" and orig_channel is not None:
+                # TODO(vision): plumb ``agent.model`` through here so
+                # :func:`render_user_event` matches build-time output for
+                # image-bearing events.  Today this call site renders without
+                # ``model``/``session_id``, so attachments degrade to text
+                # markers and the per-event ``cumulative_tokens`` undercounts
+                # inlined images by ~55 LiteLLM tokens each (text marker ~30
+                # vs. ``image_url`` part ~85).  The undercount is bounded by
+                # ``model_token_ratio`` calibration in
+                # :func:`read_windowed_events`; see PR #218 for the
+                # follow-up plan to make append-time vision-aware.
                 rendered = render_user_event(data, orig_channel, focal_at_arrival)
                 cum_tokens = (prev or 0) + approx_tokens([rendered])
             else:

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -770,6 +770,28 @@ async def list_running_session_ids(conn: asyncpg.Connection[Any]) -> list[str]:
     return [str(r["id"]) for r in rows]
 
 
+async def get_session_model(conn: asyncpg.Connection[Any], session_id: str) -> str:
+    """Return the bound mind URL for ``session_id`` in one round trip.
+
+    Pinned ``agent_version`` wins when set; otherwise the live agent's
+    current ``model`` is returned.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT COALESCE(av.model, a.model) AS model
+          FROM sessions s
+          JOIN agents a ON a.id = s.agent_id
+     LEFT JOIN agent_versions av
+            ON av.agent_id = s.agent_id AND av.version = s.agent_version
+         WHERE s.id = $1
+        """,
+        session_id,
+    )
+    if row is None:
+        raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
+    return str(row["model"])
+
+
 async def list_attachment_paths_for_sessions(
     conn: asyncpg.Connection[Any], session_ids: list[str]
 ) -> dict[str, set[str]]:

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -34,6 +34,15 @@ SWITCH_CHANNEL_METADATA_KEY = "switch_channel"
 # keys per the MCP spec.
 FOCAL_CHANNEL_META_KEY = "aios.focal_channel_path"
 
+# Carries the calling session's id so MCP servers can resolve
+# model-visible in-sandbox paths to host equivalents.  Stamped on
+# every outbound MCP request alongside the focal-channel suffix —
+# including agent-declared HTTP MCP servers, which see the ULID and
+# ignore unknown ``_meta`` keys per the MCP spec.  ULIDs are not
+# secrets, but the leak is a real cross-boundary signal worth
+# knowing about.
+SESSION_ID_META_KEY = "aios.session_id"
+
 
 def focal_channel_path(focal: str | None) -> str | None:
     """Return the connector-relative suffix of a focal address.

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -105,7 +105,7 @@ from aios.harness.attachment_staging import (
 )
 from aios.harness.wake import defer_wake
 from aios.logging import get_logger
-from aios.mcp.client import shape_call_result
+from aios.mcp.client import MAX_TOOLS_PER_SERVER, shape_call_result
 from aios.mcp.stdio_transport import ConnectorSpec, open_connector_session
 from aios.models.sessions import MAX_USER_MESSAGE_CHARS
 from aios.services import sessions as sessions_service
@@ -289,8 +289,10 @@ def _apply_instance_overlay(
     on a fresh install.
 
     env: always pass the worker's ``os.environ`` to the subprocess so
-    pydantic-settings reads the same vars the operator set.  For
-    non-default instances, also re-export
+    pydantic-settings reads the same vars the operator set, with
+    path-shaped settings (``AIOS_WORKSPACE_ROOT``) absolutized so the
+    subprocess's different cwd doesn't shift the resolved location.
+    For non-default instances, also re-export
     ``AIOS_<CONN_UPPER>_<INST_UPPER>_*`` as ``AIOS_<CONN_UPPER>_*`` so
     connector subprocess code stays instance-naive — it just reads
     config under the standard prefix.  Single-instance deployments use
@@ -302,16 +304,20 @@ def _apply_instance_overlay(
         if ci.instance != ci.connector:
             cwd = cwd / ci.instance
     cwd.mkdir(parents=True, exist_ok=True)
-    env = _build_instance_env(ci, base=spec.env)
+    env = _build_instance_env(ci, settings=settings, base=spec.env)
     return replace(spec, cwd=cwd, env=env)
 
 
-def _build_instance_env(ci: ConnectorInstance, *, base: dict[str, str] | None) -> dict[str, str]:
+def _build_instance_env(
+    ci: ConnectorInstance, *, settings: Settings, base: dict[str, str] | None
+) -> dict[str, str]:
     """Construct the env dict for a connector subprocess.
 
     Starts from ``os.environ`` (so the subprocess inherits operator-set
     config), layers the factory-supplied ``base`` on top (factory wins
-    over inherited if both set the same key), and finally — for
+    over inherited if both set the same key), then absolutizes the
+    path-shaped settings the SDK and connector code rely on
+    (``AIOS_WORKSPACE_ROOT`` today — see below), and finally — for
     non-default instances — re-exports
     ``AIOS_<CONN_UPPER>_<INST_UPPER>_<FIELD>`` as
     ``AIOS_<CONN_UPPER>_<FIELD>`` so the connector reads its config
@@ -319,6 +325,18 @@ def _build_instance_env(ci: ConnectorInstance, *, base: dict[str, str] | None) -
     from the resulting env so each subprocess sees only its own
     credentials (a wedged or chatty connector that iterates
     ``os.environ`` won't surface sibling tokens).
+
+    Path absolutization: the worker resolves ``settings.workspace_root``
+    against its own cwd, but spawns connector subprocesses under
+    ``<connectors_dir>/<connector>/[<instance>/]``.  Inheriting the
+    operator's relative ``AIOS_WORKSPACE_ROOT`` (e.g. ``./workspaces``
+    in ``.env``) would let the SDK's ``SandboxPath`` resolution resolve
+    ``/workspace/foo.png`` against the wrong directory.  We stamp the
+    worker-resolved absolute path so harness and SDK agree on the
+    bind-mount root regardless of subprocess cwd.  Factory-supplied
+    overrides lose to this absolutized value: a connector that sets
+    ``AIOS_WORKSPACE_ROOT`` in ``spec.env`` would silently desynchronize
+    from the harness's bind-mount, which is almost certainly a bug.
 
     The re-export overrides any unscoped value: an operator running
     ``connectors_enabled=telegram:bot1,telegram:bot2`` with both
@@ -330,6 +348,11 @@ def _build_instance_env(ci: ConnectorInstance, *, base: dict[str, str] | None) -
     env: dict[str, str] = dict(os.environ)
     if base:
         env.update(base)
+    # Absolutize path-shaped settings the SDK/harness share via env so
+    # subprocesses don't resolve them against their own cwd.  Add new
+    # path-shaped settings here when they're introduced rather than
+    # relying on per-setting fixes scattered across call sites.
+    env["AIOS_WORKSPACE_ROOT"] = str(settings.workspace_root.resolve())
     if ci.instance == ci.connector:
         return env
     scope_prefix = f"AIOS_{ci.connector.upper()}_{ci.instance.upper()}_"
@@ -446,6 +469,54 @@ class ConnectorSubprocessRegistry:
     def lookup_instance_for_account(self, connector: str, account: str) -> str | None:
         """Return which instance serves ``(connector, account)`` per the routing map."""
         return self._account_to_instance.get((connector, account))
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """Enumerate connector-subprocess tools as OpenAI-format tool dicts.
+
+        Each ``mcp__<connector>__<tool>`` namespace matches the HTTP-MCP
+        path in :func:`aios.mcp.client.discover_mcp_tools` so the
+        dispatcher resolves either kind without a branch.  Multi-instance
+        connectors collapse duplicates by name with first-wins ordering.
+        Instances not in ``running`` are skipped; truncation cap mirrors
+        the HTTP-MCP path.  ``aios_inbound_ack`` is internal harness
+        machinery and never reaches the model.
+        """
+        running = [
+            (connector, state.session)
+            for (connector, _instance), state in self._states.items()
+            if state.status == "running" and state.session is not None
+        ]
+        if not running:
+            return []
+        results = await asyncio.gather(*(session.list_tools() for _, session in running))
+        seen: set[str] = set()
+        tools: list[dict[str, Any]] = []
+        for (connector, _session), result in zip(running, results, strict=True):
+            if len(result.tools) > MAX_TOOLS_PER_SERVER:
+                log.warning(
+                    "connector.tools_truncated",
+                    connector=connector,
+                    total=len(result.tools),
+                    limit=MAX_TOOLS_PER_SERVER,
+                )
+            for tool in result.tools[:MAX_TOOLS_PER_SERVER]:
+                if tool.name == "aios_inbound_ack":
+                    continue
+                qualified = f"mcp__{connector}__{tool.name}"
+                if qualified in seen:
+                    continue
+                seen.add(qualified)
+                tools.append(
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": qualified,
+                            "description": tool.description or "",
+                            "parameters": tool.inputSchema,
+                        },
+                    }
+                )
+        return tools
 
     async def get_session(self, connector: str, instance: str) -> ClientSession:
         """Return the live session for ``(connector, instance)``.

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -262,6 +262,12 @@ def _apply_attachments(
             and can_inline_image(model=model, content_type=content_type, size_bytes=size)
         )
         if inline:
+            # v1 deliberately re-reads + re-base64-encodes per render: the
+            # staged bytes are typically immutable (`/mnt/attachments/` is
+            # read-only) so an LRU cache on (host_path, mtime, size) would
+            # be a clean follow-up if profiling shows pressure.  See
+            # PR #216 §14 for the discussion of cache vs. encode-at-staging
+            # alternatives we deferred for v1.
             try:
                 payload = host_path.read_bytes()
             except OSError as err:
@@ -289,7 +295,16 @@ def _apply_attachments(
         text = f"{text}\n{chr(10).join(marker_lines)}" if text else "\n".join(marker_lines)
 
     if image_parts:
-        msg["content"] = [{"type": "text", "text": text}, *image_parts]
+        # Anthropic rejects empty text blocks (`text content blocks must be
+        # non-empty`) so omit the leading text part when there is no caption,
+        # no channel header, and no markers — the image_url parts stand on
+        # their own.  OpenAI tolerates the empty part, but emitting it would
+        # break any vision-capable Anthropic-routed mind on a caption-less
+        # image-only inbound.
+        if text:
+            msg["content"] = [{"type": "text", "text": text}, *image_parts]
+        else:
+            msg["content"] = list(image_parts)
     else:
         msg["content"] = text
 

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -12,7 +12,7 @@ Two public functions:
 
 Both are pure functions of the event log + caller-supplied vision
 policy inputs (``model``, ``session_id``).  They DO read host bytes
-when an image attachment can be inlined for the bound mind — that I/O
+when an image attachment can be inlined for the bound model — that I/O
 is the cost of producing an ``image_url`` content part.  No DB access,
 no async.
 
@@ -201,7 +201,7 @@ def render_user_event(
       ``POST /sessions/{id}/messages`` traffic and pre-migration rows.
     * ``orig == focal_at_arrival`` (non-NULL) → full content with a
       metadata header inlined.  When the focal event's metadata
-      carries ``attachments`` and the bound mind supports vision,
+      carries ``attachments`` and the bound model supports vision,
       inlinable images are emitted as ``image_url`` content parts;
       everything else gets a text marker referencing the in-sandbox
       path.
@@ -299,7 +299,7 @@ def _apply_attachments(
         # non-empty`) so omit the leading text part when there is no caption,
         # no channel header, and no markers — the image_url parts stand on
         # their own.  OpenAI tolerates the empty part, but emitting it would
-        # break any vision-capable Anthropic-routed mind on a caption-less
+        # break any vision-capable Anthropic-routed model on a caption-less
         # image-only inbound.
         if text:
             msg["content"] = [{"type": "text", "text": text}, *image_parts]

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -10,7 +10,11 @@ Two public functions:
   tool calls and reordering tool results so they appear immediately
   after their requesting assistant message.
 
-Both are pure functions: no DB access, no side effects, easy to test.
+Both are pure functions of the event log + caller-supplied vision
+policy inputs (``model``, ``session_id``).  They DO read host bytes
+when an image attachment can be inlined for the bound mind — that I/O
+is the cost of producing an ``image_url`` content part.  No DB access,
+no async.
 
 The ``reacting_to`` field on assistant messages is the key coordination
 mechanism. Each assistant message records the seq of the latest user or
@@ -24,12 +28,22 @@ follow-up step.
 
 from __future__ import annotations
 
+import base64
 import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from aios.harness.vision import (
+    can_inline_image,
+    make_image_url_part,
+    text_marker,
+)
+from aios.logging import get_logger
 from aios.models.events import Event
+from aios.sandbox.volumes import resolve_to_host_path
+
+log = get_logger("aios.harness.context")
 
 # Chat-completions spec fields per role.  Only these are emitted in the
 # context; provider-specific extensions (reasoning_content, etc.) stay
@@ -167,14 +181,18 @@ def render_user_event(
     event_data: dict[str, Any],
     orig_channel: str | None,
     focal_channel_at_arrival: str | None,
+    *,
+    model: str | None = None,
+    session_id: str | None = None,
 ) -> dict[str, Any]:
     """Render a user event into its chat-completions message form.
 
     Rendering is a deterministic function of the event's stamped
-    ``orig_channel`` and ``focal_channel_at_arrival``.  ``build_messages``
-    and the append-time token counter in ``queries.append_event`` share
-    this helper so the context and the ``cumulative_tokens`` column
-    stay in lock-step.
+    ``orig_channel``, ``focal_channel_at_arrival``, and the optional
+    vision policy inputs ``model`` / ``session_id``.  ``build_messages``
+    threads vision policy through; the append-time token counter in
+    ``queries.append_event`` does not (and pays a small under-count
+    per inlined image, absorbed by ``model_token_ratio`` calibration).
 
     Branches:
 
@@ -182,7 +200,11 @@ def render_user_event(
       metadata stripped, no header, no notification.  Covers direct
       ``POST /sessions/{id}/messages`` traffic and pre-migration rows.
     * ``orig == focal_at_arrival`` (non-NULL) → full content with a
-      metadata header inlined.
+      metadata header inlined.  When the focal event's metadata
+      carries ``attachments`` and the bound mind supports vision,
+      inlinable images are emitted as ``image_url`` content parts;
+      everything else gets a text marker referencing the in-sandbox
+      path.
     * Otherwise (focal is NULL, or focal differs from orig) →
       notification marker: a short, emoji-prefixed one-liner surfacing
       the origin channel, sender, and a truncated content preview.
@@ -200,6 +222,14 @@ def render_user_event(
             if header:
                 existing = msg.get("content") or ""
                 msg["content"] = f"{header}\n{existing}" if existing else header
+            attachments = metadata.get("attachments")
+            if isinstance(attachments, list) and attachments:
+                _apply_attachments(
+                    msg,
+                    attachments,
+                    model=model,
+                    session_id=session_id,
+                )
         return msg
 
     content = event_data.get("content", "")
@@ -207,6 +237,68 @@ def render_user_event(
         content = ""
     marker = _format_notification_marker(orig_channel, metadata, content)
     return {"role": "user", "content": marker}
+
+
+def _apply_attachments(
+    msg: dict[str, Any],
+    attachments: list[Any],
+    *,
+    model: str | None,
+    session_id: str | None,
+) -> None:
+    leading_text = msg.get("content") if isinstance(msg.get("content"), str) else ""
+    marker_lines: list[str] = []
+    image_parts: list[dict[str, Any]] = []
+
+    for record in attachments:
+        host_path = _resolve_attachment_host_path(record, session_id)
+        size = record.get("size")
+        content_type = record.get("content_type")
+        inline = (
+            host_path is not None
+            and model is not None
+            and isinstance(content_type, str)
+            and isinstance(size, int)
+            and can_inline_image(model=model, content_type=content_type, size_bytes=size)
+        )
+        if inline:
+            try:
+                payload = host_path.read_bytes()
+            except OSError as err:
+                # The staged file disappeared (manual cleanup, FS corruption,
+                # GC race). Fall back to a text marker rather than raising
+                # mid-render — losing one image shouldn't fail the whole step.
+                log.warning(
+                    "context.attachment_read_failed",
+                    path=str(host_path),
+                    error=str(err),
+                )
+                marker_lines.append(text_marker(record))
+                continue
+            image_parts.append(
+                make_image_url_part(
+                    content_type=content_type,
+                    data_b64=base64.b64encode(payload).decode("ascii"),
+                )
+            )
+        else:
+            marker_lines.append(text_marker(record))
+
+    text = leading_text
+    if marker_lines:
+        text = f"{text}\n{chr(10).join(marker_lines)}" if text else "\n".join(marker_lines)
+
+    if image_parts:
+        msg["content"] = [{"type": "text", "text": text}, *image_parts]
+    else:
+        msg["content"] = text
+
+
+def _resolve_attachment_host_path(record: dict[str, Any], session_id: str | None) -> Any:
+    sandbox_path = record.get("in_sandbox_path")
+    if not isinstance(sandbox_path, str) or session_id is None:
+        return None
+    return resolve_to_host_path(session_id, sandbox_path)
 
 
 def _sanitize_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -345,6 +437,8 @@ def build_messages(
     events: list[Event],
     *,
     system_prompt: str | None,
+    model: str | None = None,
+    session_id: str | None = None,
 ) -> ContextResult:
     """Assemble a chat-completions message list from pre-windowed events.
 
@@ -404,7 +498,13 @@ def build_messages(
         role = e.data.get("role")
 
         if role == "user":
-            msg = render_user_event(e.data, e.orig_channel, e.focal_channel_at_arrival)
+            msg = render_user_event(
+                e.data,
+                e.orig_channel,
+                e.focal_channel_at_arrival,
+                model=model,
+                session_id=session_id,
+            )
             messages.append(msg)
             max_stimulus_seq = max(max_stimulus_seq, e.seq)
 

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -535,15 +535,47 @@ def build_messages(
             # (preserves prefix monotonicity — see docstring).
             for inj_tcid, inj_data in inject_after.pop(e.seq, []):
                 name = inj_data.get("name", "tool")
-                messages.append(
-                    {
-                        "role": "user",
-                        "content": (
-                            f"[Tool result: {name} (call {inj_tcid}) completed]\n"
-                            f"{inj_data.get('content', '')}"
-                        ),
-                    }
-                )
+                header = f"[Tool result: {name} (call {inj_tcid}) completed]"
+                inj_content = inj_data.get("content", "")
+                if isinstance(inj_content, list):
+                    # Multimodal tool result (e.g. image-aware read returning a
+                    # text + image_url part list).  F-stringing would emit the
+                    # Python repr of the list, losing the pixels — splice the
+                    # parts into the synthetic user message instead so the model
+                    # sees the image in the blind-spot signal too.  Spec'd text
+                    # parts are concatenated under the header; non-text parts
+                    # (image_url, etc.) follow as siblings.
+                    text_chunks: list[str] = [header]
+                    other_parts: list[dict[str, Any]] = []
+                    for part in inj_content:
+                        if not isinstance(part, dict):
+                            continue
+                        if part.get("type") == "text":
+                            txt = part.get("text")
+                            if isinstance(txt, str) and txt:
+                                text_chunks.append(txt)
+                        else:
+                            other_parts.append(part)
+                    combined_text = "\n".join(text_chunks)
+                    if other_parts:
+                        messages.append(
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": combined_text},
+                                    *other_parts,
+                                ],
+                            }
+                        )
+                    else:
+                        messages.append({"role": "user", "content": combined_text})
+                else:
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": f"{header}\n{inj_content}",
+                        }
+                    )
                 max_stimulus_seq = max(max_stimulus_seq, real_result_seqs[inj_tcid])
 
         elif role == "tool":

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -173,7 +173,12 @@ async def compose_step_context(
     """
     from aios.harness.channels import build_channels_tail_block
 
-    ctx = build_messages(events, system_prompt=prelude.system_prompt)
+    ctx = build_messages(
+        events,
+        system_prompt=prelude.system_prompt,
+        model=agent.model,
+        session_id=session.id,
+    )
 
     # Tail block lives *after* build_messages so its per-step mutations
     # (unread counts, previews) don't bust the prefix cache.  Paradigm

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -95,6 +95,7 @@ async def compute_step_prelude(
     :func:`compose_step_context` unchanged, so the composed prompt stays
     byte-identical to what it was before the split.
     """
+    from aios.harness import runtime
     from aios.harness.channels import (
         augment_with_focal_paradigm,
         max_tail_block_local,
@@ -118,6 +119,12 @@ async def compute_step_prelude(
         mcp_tools, mcp_instructions = await discover_session_mcp_tools(pool, session_id, agent)
         tools.extend(mcp_tools)
         instructions_block = _build_instructions_block(agent.mcp_servers, mcp_instructions)
+
+    # Connector-subprocess (stdio MCP) tools come from the worker-scoped
+    # registry, separate from agent.mcp_servers (HTTP MCP).
+    connector_registry = runtime.connector_subprocess_registry
+    if connector_registry is not None:
+        tools.extend(await connector_registry.list_tools())
 
     skill_versions = (
         await skills_service.resolve_skill_refs(pool, agent.skills) if agent.skills else []

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -392,12 +392,16 @@ async def _execute_mcp_tool_async(
 
         server_name, tool_name = _parse_mcp_tool_name(name)
 
-        from aios.harness.channels import FOCAL_CHANNEL_META_KEY, focal_channel_path
+        from aios.harness.channels import (
+            FOCAL_CHANNEL_META_KEY,
+            SESSION_ID_META_KEY,
+            focal_channel_path,
+        )
 
-        meta: dict[str, Any] | None = None
+        meta: dict[str, Any] = {SESSION_ID_META_KEY: session_id}
         suffix = focal_channel_path(focal_channel)
         if suffix is not None:
-            meta = {FOCAL_CHANNEL_META_KEY: suffix}
+            meta[FOCAL_CHANNEL_META_KEY] = suffix
 
         # Connector subprocesses (stdio MCP children of the worker) take
         # precedence over agent-declared HTTP MCP servers: the model

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -146,7 +146,7 @@ async def _execute_tool_async(
             "name": name,
         }
         if isinstance(result, ToolResult):
-            if isinstance(result.content, str):
+            if isinstance(result.content, (str, list)):
                 event_data["content"] = result.content
             else:
                 event_data["content"] = json.dumps(result.content, ensure_ascii=False)

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -1,0 +1,88 @@
+"""Vision-policy helper: single source of truth for image-into-vision decisions.
+
+LiteLLM's :func:`token_counter` returns a flat ~85 tokens per
+``image_url`` part regardless of provider; under-counting only
+matters near the window boundary and provider rejection there is
+recoverable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import litellm
+
+INLINE_SIZE_CAP_BYTES = 2 * 1024 * 1024
+
+_VISION_OVERRIDES: dict[str, bool] = {}
+
+
+def supports_vision(model: str) -> bool:
+    """True when ``model`` accepts ``image_url`` content parts.
+
+    Consults :data:`_VISION_OVERRIDES` first for cases LiteLLM is wrong
+    or behind on (empty initially; populated as we hit them), then
+    falls back to ``litellm.get_model_info``.
+    """
+    if model in _VISION_OVERRIDES:
+        return _VISION_OVERRIDES[model]
+    try:
+        info = litellm.get_model_info(model)
+    except Exception:
+        return False
+    return bool(info.get("supports_vision"))
+
+
+def can_inline_image(*, model: str, content_type: str, size_bytes: int) -> bool:
+    """True when ``model`` can see image bytes inlined as ``image_url``.
+
+    Returns ``False`` for non-image content_types, oversize files
+    (over :data:`INLINE_SIZE_CAP_BYTES`), and minds without vision
+    support.  Callers fall back to a text marker referencing the
+    in-sandbox path so the model can still ``read`` the file later.
+    """
+    if not content_type.startswith("image/"):
+        return False
+    if size_bytes > INLINE_SIZE_CAP_BYTES:
+        return False
+    return supports_vision(model)
+
+
+def make_image_url_part(*, content_type: str, data_b64: str) -> dict[str, Any]:
+    """Build a chat-completions ``image_url`` content part."""
+    return {
+        "type": "image_url",
+        "image_url": {"url": f"data:{content_type};base64,{data_b64}"},
+    }
+
+
+def text_marker(record: dict[str, Any]) -> str:
+    """Inert text marker for an attachment that won't be inlined.
+
+    Used when the model can't see the pixels (non-vision mind, oversize
+    image, non-image attachment, legacy stub without ``in_sandbox_path``).
+    The marker carries enough info for the model to ``read`` the path
+    if the file is in fact reachable.
+    """
+    filename = record.get("filename") or "unnamed"
+    content_type = record.get("content_type") or "application/octet-stream"
+    size = record.get("size")
+    path = record.get("in_sandbox_path")
+
+    size_str = human_size(size) if isinstance(size, int) else "unknown size"
+    kind = (
+        "image"
+        if isinstance(content_type, str) and content_type.startswith("image/")
+        else "attachment"
+    )
+    if path:
+        return f"[{kind}: {filename} ({content_type}, {size_str}) at {path}]"
+    return f"[{kind}: {filename} ({content_type}, {size_str})]"
+
+
+def human_size(n: int) -> str:
+    if n < 1024:
+        return f"{n}B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f}KB"
+    return f"{n / (1024 * 1024):.1f}MB"

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -49,7 +49,7 @@ def can_inline_image(*, model: str, content_type: str, size_bytes: int) -> bool:
     """True when ``model`` can see image bytes inlined as ``image_url``.
 
     Returns ``False`` for non-image content_types, oversize files
-    (over :data:`INLINE_SIZE_CAP_BYTES`), and minds without vision
+    (over :data:`INLINE_SIZE_CAP_BYTES`), and models without vision
     support.  Callers fall back to a text marker referencing the
     in-sandbox path so the model can still ``read`` the file later.
     """
@@ -71,7 +71,7 @@ def make_image_url_part(*, content_type: str, data_b64: str) -> dict[str, Any]:
 def text_marker(record: dict[str, Any]) -> str:
     """Inert text marker for an attachment that won't be inlined.
 
-    Used when the model can't see the pixels (non-vision mind, oversize
+    Used when the model can't see the pixels (non-vision model, oversize
     image, non-image attachment, legacy stub without ``in_sandbox_path``).
     The marker carries enough info for the model to ``read`` the path
     if the file is in fact reachable.

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -12,6 +12,10 @@ from typing import Any
 
 import litellm
 
+from aios.logging import get_logger
+
+log = get_logger("aios.harness.vision")
+
 INLINE_SIZE_CAP_BYTES = 2 * 1024 * 1024
 
 _VISION_OVERRIDES: dict[str, bool] = {}
@@ -28,7 +32,15 @@ def supports_vision(model: str) -> bool:
         return _VISION_OVERRIDES[model]
     try:
         info = litellm.get_model_info(model)
-    except Exception:
+    except Exception as err:
+        # ``get_model_info`` raises a mix of ``BadRequestError`` (unknown
+        # model), KeyError, and import/network errors depending on the
+        # failure mode.  Collapsing to "no vision" is the safe fallback
+        # (we degrade to a text marker the model can still ``read``), but
+        # the silence makes a transient outage look identical to "unknown
+        # model" — log warn-level so operators have a grep target when
+        # vision unexpectedly degrades across a deploy or provider blip.
+        log.warning("vision.litellm_lookup_failed", model=model, error=str(err))
         return False
     return bool(info.get("supports_vision"))
 

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -179,17 +179,46 @@ def ensure_session_attachments_dir(session_id: str) -> Path:
 def resolve_to_host_path(session_id: str, sandbox_path: str) -> Path | None:
     """Map an in-sandbox path to its host-side equivalent for known bind mounts.
 
-    Returns ``None`` when ``sandbox_path`` doesn't resolve into
-    ``/workspace`` or ``/mnt/attachments`` (e.g. ``/etc/hostname``,
-    ``/mnt/memory/...``, ``/tmp/...``). Callers can fall back to
-    docker-exec when the host-side fast path is unavailable.
+    Returns ``None`` when:
+
+    * ``sandbox_path`` doesn't resolve into ``/workspace`` or
+      ``/mnt/attachments`` (e.g. ``/etc/hostname``, ``/mnt/memory/...``,
+      ``/tmp/...``), or
+    * the resolved candidate escapes the bind-mount root after ``..``
+      normalization or symlink dereferencing.
+
+    The containment check defends model-controlled callers (notably the
+    image branch of :mod:`aios.tools.read`): without it, a path like
+    ``/workspace/../../etc/hostname`` or a symlink at
+    ``/workspace/sneaky.jpg`` pointing outside the bind mount would
+    let the model read arbitrary host files the worker can access.
+    """
+    base, suffix = _bind_mount_base(session_id, sandbox_path)
+    if base is None:
+        return None
+    candidate = base if suffix is None else base / suffix
+    try:
+        resolved = candidate.resolve(strict=False)
+        resolved_base = base.resolve(strict=False)
+    except OSError:
+        return None
+    if resolved != resolved_base and not resolved.is_relative_to(resolved_base):
+        return None
+    return resolved
+
+
+def _bind_mount_base(session_id: str, sandbox_path: str) -> tuple[Path | None, str | None]:
+    """Return the host base dir + remainder for ``sandbox_path``.
+
+    ``(None, None)`` when the path doesn't fall under a known bind
+    mount.  ``(base, None)`` when the path is exactly the root.
     """
     if sandbox_path == "/workspace":
-        return workspace_dir_for(session_id)
+        return workspace_dir_for(session_id), None
     if sandbox_path.startswith("/workspace/"):
-        return workspace_dir_for(session_id) / sandbox_path[len("/workspace/") :]
+        return workspace_dir_for(session_id), sandbox_path[len("/workspace/") :]
     if sandbox_path == "/mnt/attachments":
-        return session_attachments_dir(session_id)
+        return session_attachments_dir(session_id), None
     if sandbox_path.startswith("/mnt/attachments/"):
-        return session_attachments_dir(session_id) / sandbox_path[len("/mnt/attachments/") :]
-    return None
+        return session_attachments_dir(session_id), sandbox_path[len("/mnt/attachments/") :]
+    return None, None

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -115,7 +115,7 @@ async def get_session(pool: asyncpg.Pool[Any], session_id: str) -> Session:
 
 
 async def get_session_model(pool: asyncpg.Pool[Any], session_id: str) -> str:
-    """Bound mind URL for ``session_id`` (pinned agent version wins)."""
+    """Bound model for ``session_id`` (pinned agent version wins)."""
     async with pool.acquire() as conn:
         return await queries.get_session_model(conn, session_id)
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -114,6 +114,12 @@ async def get_session(pool: asyncpg.Pool[Any], session_id: str) -> Session:
         return session.model_copy(update={"vault_ids": vault_ids, "resources": echoes})
 
 
+async def get_session_model(pool: asyncpg.Pool[Any], session_id: str) -> str:
+    """Bound mind URL for ``session_id`` (pinned agent version wins)."""
+    async with pool.acquire() as conn:
+        return await queries.get_session_model(conn, session_id)
+
+
 async def list_sessions(
     pool: asyncpg.Pool[Any],
     *,

--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -1,35 +1,41 @@
 """The read tool — read a file inside the session's sandbox.
 
-A thin wrapper over ``cat -n`` piped through ``sed``. Returns file
-content with ``LINE_NUM<TAB>CONTENT`` line numbers, windowed by
-``offset`` (1-indexed) and ``limit`` so the model can page through
-large files without blowing its context window in one shot.
-
-The tool shells out once per call via :meth:`ContainerHandle.run_command`
-and trusts the model for everything else: no binary-file guard, no
-device blocklist, no char ceiling, no dedup. If the model reads
-``/dev/zero``, the container timeout (``bash_default_timeout_seconds``)
-kills it and the model sees an error. If the model re-reads the same
-range 10 times, that shows up in the session log and the model pays
-the token cost.
-
-Return shape::
-
-    {"path": "/workspace/foo.py", "content": "     1\\thello\\n     2\\tworld"}
-
-On failure (nonzero exit from ``cat``), returns ``{"error": "..."}``.
+Text files return ``LINE_NUM<TAB>CONTENT`` windowed by ``offset`` /
+``limit`` via ``cat -n | sed``.  Image files (extensions in
+:data:`_EXT_TO_MIME`) return a content-parts list with an
+``image_url`` block when the bound mind supports vision and the file
+fits the inline cap; otherwise an explanatory ``ToolResult``.
 """
 
 from __future__ import annotations
 
+import base64
+import os
 import shlex
 from typing import Any
 
 from aios.config import get_settings
 from aios.errors import AiosError
 from aios.harness import runtime
+from aios.harness.vision import (
+    can_inline_image,
+    human_size,
+    make_image_url_part,
+    supports_vision,
+)
+from aios.sandbox.container import ContainerHandle
+from aios.sandbox.volumes import resolve_to_host_path
+from aios.services import sessions as sessions_service
 from aios.tools.memory_intercept import resolve_memory_target
-from aios.tools.registry import registry
+from aios.tools.registry import ToolResult, registry
+
+_EXT_TO_MIME = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
 
 
 class ReadArgumentError(AiosError):
@@ -73,8 +79,8 @@ READ_PARAMETERS_SCHEMA: dict[str, Any] = {
 }
 
 
-async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
-    """Handler for the read tool. See module docstring for the return shape."""
+async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any] | ToolResult:
+    """Handler for the read tool. See module docstring for return shapes."""
     path = arguments.get("path")
     if not isinstance(path, str) or not path.strip():
         raise ReadArgumentError("read tool requires a non-empty 'path' string")
@@ -88,8 +94,13 @@ async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
         raise ReadArgumentError("limit must be a positive integer")
 
     settings = get_settings()
+    pool = runtime.require_pool()
     sandbox = runtime.require_sandbox_registry()
-    handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
+    handle = await sandbox.get_or_provision(session_id, pool=pool)
+
+    if _looks_like_image(path):
+        return await _read_image(session_id=session_id, path=path, handle=handle, pool=pool)
+
     target = resolve_memory_target(session_id, path)
 
     end = offset + limit - 1
@@ -128,6 +139,86 @@ async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     sha_line, _, content = result.stdout.partition("\n")
     runtime.set_read_sha(session_id, target.store_id, target.store_path, sha_line.strip())
     return {"path": path, "content": content}
+
+
+def _looks_like_image(path: str) -> bool:
+    return os.path.splitext(path)[1].lower() in _EXT_TO_MIME
+
+
+async def _read_image(
+    *,
+    session_id: str,
+    path: str,
+    handle: ContainerHandle,
+    pool: Any,
+) -> ToolResult:
+    mime = _EXT_TO_MIME[os.path.splitext(path)[1].lower()]
+    model = await sessions_service.get_session_model(pool, session_id)
+
+    host_path = resolve_to_host_path(session_id, path)
+    if host_path is not None:
+        try:
+            data = host_path.read_bytes()
+        except FileNotFoundError:
+            return ToolResult(content=f"file not found: {path}", is_error=True)
+        except OSError as err:
+            return ToolResult(content=f"read failed: {err}", is_error=True)
+        size = len(data)
+    else:
+        result = await _stat_and_read_via_exec(handle, path)
+        if result is None:
+            return ToolResult(
+                content=f"read failed: file not readable inside sandbox: {path}",
+                is_error=True,
+            )
+        data, size = result
+
+    if not can_inline_image(model=model, content_type=mime, size_bytes=size):
+        vision = "yes" if supports_vision(model) else "no"
+        return ToolResult(
+            content=(
+                f"Image at {path} exists ({human_size(size)}, {mime}) but cannot "
+                f"be inlined. Mind vision support: {vision}. Inline cap: 2 MiB."
+            ),
+            is_error=False,
+        )
+
+    encoded = base64.b64encode(data).decode("ascii")
+    return ToolResult(
+        content=[
+            {
+                "type": "text",
+                "text": f"Image: {os.path.basename(path)} ({mime}, {human_size(size)})",
+            },
+            make_image_url_part(content_type=mime, data_b64=encoded),
+        ],
+    )
+
+
+async def _stat_and_read_via_exec(handle: ContainerHandle, path: str) -> tuple[bytes, int] | None:
+    """Fetch ``(bytes, size)`` for non-bind-mount image paths via one docker-exec.
+
+    Returns ``None`` on any read failure (missing path, exec error,
+    unparseable size).  Combines stat + base64 into a single shell so
+    we don't pay two docker-exec round-trips.
+    """
+    settings = get_settings()
+    quoted = shlex.quote(path)
+    cmd = f"stat -c %s -- {quoted} && base64 -w0 -- {quoted}"
+    result = await handle.run_command(
+        cmd,
+        timeout_seconds=settings.bash_default_timeout_seconds,
+        max_output_bytes=settings.bash_max_output_bytes,
+    )
+    if result.exit_code != 0:
+        return None
+    size_line, _, b64 = result.stdout.partition("\n")
+    try:
+        size = int(size_line.strip())
+        data = base64.b64decode(b64.strip())
+    except (ValueError, TypeError):
+        return None
+    return data, size
 
 
 def _register() -> None:

--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -3,7 +3,7 @@
 Text files return ``LINE_NUM<TAB>CONTENT`` windowed by ``offset`` /
 ``limit`` via ``cat -n | sed``.  Image files (extensions in
 :data:`_EXT_TO_MIME`) return a content-parts list with an
-``image_url`` block when the bound mind supports vision and the file
+``image_url`` block when the bound model supports vision and the file
 fits the inline cap; otherwise an explanatory ``ToolResult``.
 """
 

--- a/src/aios/tools/registry.py
+++ b/src/aios/tools/registry.py
@@ -56,13 +56,17 @@ class ToolResult:
     ``ToolResult`` instead.
 
     * ``content`` — ``str``: used verbatim.  ``dict``: JSON-encoded.
+      ``list[dict]``: passed through as a content-parts list (multimodal
+      tool results, e.g. ``read`` returning an image; the chat-completions
+      wire format already accepts ``content: list[dict]`` on tool messages
+      and LiteLLM translates per provider).
     * ``metadata`` — merged into the event's ``data.metadata`` (stripped
       from the chat-completions wire shape by ``_strip_to_spec``).
     * ``is_error`` — records a handler-level error (separate from
       dispatch-level exceptions, which raise).
     """
 
-    content: str | dict[str, Any]
+    content: str | dict[str, Any] | list[dict[str, Any]]
     metadata: dict[str, Any] | None = None
     is_error: bool = False
 

--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -311,6 +311,14 @@ def _render_recap_event(event: Event) -> dict[str, Any] | None:
     role = event.data.get("role") if event.kind == "message" else None
 
     if role == "user":
+        # Recap rendering is intentionally text-only: ``model``/``session_id``
+        # are not threaded through, so :func:`render_user_event` short-circuits
+        # any image inlining and emits text markers for every attachment.
+        # The recap body is consumed inside a ``switch_channel`` tool result
+        # (string content), where ``image_url`` parts wouldn't survive the
+        # tool-message envelope; degrading attachments to markers keeps the
+        # recap a single text blob that the agent can read or follow up on
+        # via the in-sandbox path.
         rendered = render_user_event(event.data, event.orig_channel, event.orig_channel)
         content = rendered.get("content")
         if not isinstance(content, str) or not content:

--- a/tests/unit/test_connector_subprocess_tools.py
+++ b/tests/unit/test_connector_subprocess_tools.py
@@ -1,0 +1,218 @@
+"""Unit tests for connector-subprocess tool enumeration.
+
+The ``ConnectorSubprocessRegistry`` owns long-lived stdio MCP sessions
+for every connector instance.  For the model to actually call those
+tools — instead of pattern-matching tool *names* from prior history —
+the harness has to enumerate them at step-prelude time and merge them
+into the ``tools[]`` payload sent to LiteLLM.
+
+These tests pin two pieces of that contract:
+
+* ``ConnectorSubprocessRegistry.list_tools()`` walks the running
+  instances, calls each session's ``list_tools()``, and returns
+  OpenAI-format tool dicts namespaced ``mcp__<connector>__<tool>``.
+
+* ``compute_step_prelude`` calls into that registry and the resulting
+  ``StepPrelude.tools`` includes the connector tools alongside builtin
+  + HTTP MCP tools.
+
+Both the SDK and the registry's per-instance state are mocked; we're
+only exercising orchestration.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.config import Settings
+from aios.harness.connector_supervisor import (
+    ConnectorState,
+    ConnectorSubprocessRegistry,
+)
+from aios.mcp.stdio_transport import ConnectorSpec
+
+
+def _fake_tool(name: str, description: str = "", schema: dict[str, Any] | None = None) -> Any:
+    """Minimal ``mcp.types.Tool`` stand-in: only the attributes the
+    enumeration code reads (``name``, ``description``, ``inputSchema``).
+    Using ``SimpleNamespace`` keeps us off the real pydantic model so
+    schema-evolution upstream doesn't break these tests.
+    """
+    return SimpleNamespace(
+        name=name,
+        description=description,
+        inputSchema=schema or {"type": "object", "properties": {}},
+    )
+
+
+def _registry_with_running_instance(
+    *,
+    connector: str,
+    instance: str,
+    tools: list[Any],
+) -> ConnectorSubprocessRegistry:
+    """Build a registry whose ``(connector, instance)`` state has a
+    fake live session whose ``list_tools()`` returns ``tools``.
+    """
+    spec = ConnectorSpec(name=connector, command="/bin/true", args=[])
+    state = ConnectorState(connector=connector, instance=instance, spec=spec)
+    state.status = "running"
+    fake_session = MagicMock()
+    fake_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=tools))
+    state.session = fake_session
+    state.ready.set()
+
+    registry = ConnectorSubprocessRegistry([], settings=Settings())
+    # Inject the prepared state directly; we're skipping the supervisor
+    # loop entirely (that's covered by other tests).
+    registry._states[(connector, instance)] = state
+    return registry
+
+
+class TestRegistryListTools:
+    async def test_returns_namespaced_openai_tools_for_running_instance(self) -> None:
+        registry = _registry_with_running_instance(
+            connector="telegram",
+            instance="telegram",
+            tools=[
+                _fake_tool(
+                    "telegram_send",
+                    description="Send a message",
+                    schema={
+                        "type": "object",
+                        "properties": {
+                            "account": {"type": "string"},
+                            "chat_id": {"type": "string"},
+                            "text": {"type": "string"},
+                        },
+                        "required": ["account", "chat_id", "text"],
+                    },
+                )
+            ],
+        )
+
+        tools = await registry.list_tools()
+
+        assert len(tools) == 1
+        tool = tools[0]
+        assert tool["type"] == "function"
+        fn = tool["function"]
+        assert fn["name"] == "mcp__telegram__telegram_send"
+        assert fn["description"] == "Send a message"
+        # Schema flows through unchanged so the model sees parameter shapes.
+        assert "account" in fn["parameters"]["properties"]
+        assert "text" in fn["parameters"]["properties"]
+
+    async def test_skips_instances_that_arent_running(self) -> None:
+        spec = ConnectorSpec(name="signal", command="/bin/true", args=[])
+        state = ConnectorState(connector="signal", instance="signal", spec=spec)
+        # status defaults to "starting"; ready is not set; session is None.
+        registry = ConnectorSubprocessRegistry([], settings=Settings())
+        registry._states[("signal", "signal")] = state
+
+        tools = await registry.list_tools()
+
+        assert tools == []
+
+    async def test_dedupes_tools_across_instances_of_same_connector(self) -> None:
+        """Multi-instance connectors (telegram:bot1, telegram:bot2)
+        publish the same toolset.  The model sees one ``mcp__telegram__*``
+        namespace, so duplicates from sibling instances must be collapsed.
+        """
+        registry = _registry_with_running_instance(
+            connector="telegram",
+            instance="bot1",
+            tools=[_fake_tool("telegram_send")],
+        )
+        # Add a second instance with the same tool.
+        spec = ConnectorSpec(name="telegram", command="/bin/true", args=[])
+        bot2_state = ConnectorState(connector="telegram", instance="bot2", spec=spec)
+        bot2_state.status = "running"
+        fake_session = MagicMock()
+        fake_session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[_fake_tool("telegram_send")])
+        )
+        bot2_state.session = fake_session
+        bot2_state.ready.set()
+        registry._states[("telegram", "bot2")] = bot2_state
+
+        tools = await registry.list_tools()
+
+        names = [t["function"]["name"] for t in tools]
+        assert names == ["mcp__telegram__telegram_send"]
+
+
+class TestStepPreludeIncludesConnectorTools:
+    """Integration over ``compute_step_prelude``: with a connector
+    registry on ``runtime``, the connector tools must appear in
+    ``StepPrelude.tools``.  This is the bug the parent investigation
+    surfaced: a live worker request had 51 tools, none of which were
+    connector tools, because tool assembly never consulted the registry.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_registry(self) -> Any:
+        """Clear ``runtime.connector_subprocess_registry`` after each test
+        so a fixture isn't visible to unrelated tests in the same run.
+        """
+        from aios.harness import runtime
+
+        before = runtime.connector_subprocess_registry
+        try:
+            yield
+        finally:
+            runtime.connector_subprocess_registry = before
+
+    async def test_connector_tools_appear_in_prelude(self) -> None:
+        from aios.harness import runtime
+        from aios.harness.step_context import compute_step_prelude
+
+        runtime.connector_subprocess_registry = _registry_with_running_instance(
+            connector="signal",
+            instance="signal",
+            tools=[
+                _fake_tool(
+                    "signal_send",
+                    description="Send a Signal message",
+                    schema={
+                        "type": "object",
+                        "properties": {
+                            "account": {"type": "string"},
+                            "recipient": {"type": "string"},
+                            "text": {"type": "string"},
+                        },
+                        "required": ["account", "recipient", "text"],
+                    },
+                )
+            ],
+        )
+
+        agent = SimpleNamespace(
+            tools=[],
+            mcp_servers=[],
+            skills=[],
+            system="you are an agent",
+        )
+        session = SimpleNamespace(id="sess_x", focal_channel=None)
+
+        with patch(
+            "aios.harness.skills.augment_system_prompt",
+            side_effect=lambda system, _versions: system,
+        ):
+            prelude = await compute_step_prelude(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                session=session,
+                agent=agent,
+                channels=[],
+                memory_store_echoes=[],
+            )
+
+        names = [t["function"]["name"] for t in prelude.tools]
+        assert "mcp__signal__signal_send" in names, (
+            f"connector tool absent from prelude — model will never see schema. tools={names}"
+        )

--- a/tests/unit/test_connector_supervisor.py
+++ b/tests/unit/test_connector_supervisor.py
@@ -85,12 +85,19 @@ class TestResolveConnectorSpecs:
     plan-decision #11.
     """
 
-    def _settings(self, *, enabled: list[str], connectors_dir: Any = None) -> Any:
+    def _settings(
+        self,
+        *,
+        enabled: list[str],
+        connectors_dir: Any = None,
+        workspace_root: Any = None,
+    ) -> Any:
         from pathlib import Path
 
         s = MagicMock()
         s.connectors_enabled = enabled
         s.connectors_dir = connectors_dir or Path("/tmp/aios-connectors-test")
+        s.workspace_root = workspace_root or Path("/tmp/aios-workspaces-test")
         return s
 
     def test_unknown_name_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -208,6 +215,79 @@ class TestResolveConnectorSpecs:
         # Default-instance just inherits parent env unmodified.
         assert spec.env is not None
         assert spec.env["AIOS_TELEGRAM_BOT_TOKEN"] == "the-only-token"
+
+    def test_workspace_root_absolutized_for_subprocess(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """Operator's relative ``AIOS_WORKSPACE_ROOT`` (or relative
+        ``workspace_root`` setting) must be absolutized before reaching the
+        connector subprocess.
+
+        The subprocess runs under ``<connectors_dir>/<connector>/`` as cwd,
+        so a relative env value would resolve against the wrong directory
+        inside the SDK's ``SandboxPath`` resolution.  Wire-level
+        symptom: outbound attachments fail with ``sandbox path
+        '/workspace/foo.png' does not exist (resolved to
+        <connectors_dir>/<connector>/workspaces/<session>/foo.png)``.
+        """
+        from pathlib import Path
+
+        ep = MagicMock()
+        ep.name = "telegram"
+        ep.load.return_value = lambda name, settings: ConnectorSpec(name=name, command="/bin/echo")
+        monkeypatch.setattr(
+            "aios.harness.connector_supervisor.entry_points",
+            lambda group: [ep],
+        )
+        # Operator's parent env carries a relative path (real .env scenario).
+        monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "./workspaces")
+        monkeypatch.chdir(tmp_path)
+        specs = resolve_connector_specs(
+            self._settings(
+                enabled=["telegram"],
+                workspace_root=Path("./workspaces"),
+            )
+        )
+        _, spec = specs[0]
+        assert spec.env is not None
+        resolved = spec.env["AIOS_WORKSPACE_ROOT"]
+        assert os.path.isabs(resolved), (
+            f"AIOS_WORKSPACE_ROOT should be absolute in subprocess env, got {resolved!r}"
+        )
+        # And it should resolve against the worker's CWD (tmp_path), not
+        # the connector subprocess's cwd.
+        assert Path(resolved) == (tmp_path / "workspaces").resolve()
+
+    def test_factory_supplied_workspace_root_is_overridden(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """Factory specs that set ``AIOS_WORKSPACE_ROOT`` lose to the
+        worker-resolved absolute path.
+
+        The harness uses ``settings.workspace_root`` to find session
+        workspaces on the host; a connector author overriding it via
+        ``spec.env`` would silently desynchronize the SDK's
+        ``SandboxPath`` resolution from the harness's bind-mount, so the
+        absolutized worker value wins.
+        """
+        from pathlib import Path
+
+        ep = MagicMock()
+        ep.name = "telegram"
+        ep.load.return_value = lambda name, settings: ConnectorSpec(
+            name=name,
+            command="/bin/echo",
+            env={"AIOS_WORKSPACE_ROOT": "/nope/factory/wins"},
+        )
+        monkeypatch.setattr(
+            "aios.harness.connector_supervisor.entry_points",
+            lambda group: [ep],
+        )
+        ws = tmp_path / "workspaces"
+        specs = resolve_connector_specs(self._settings(enabled=["telegram"], workspace_root=ws))
+        _, spec = specs[0]
+        assert spec.env is not None
+        assert Path(spec.env["AIOS_WORKSPACE_ROOT"]) == ws.resolve()
 
 
 class TestPumpStderrLineExtraction:

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -614,6 +614,94 @@ class TestMonotonicity:
         ctx = build_messages(events, system_prompt=None)
         assert ctx.reacting_to >= 3
 
+    def test_blind_spot_injection_multimodal_list_content(self) -> None:
+        """When a tool returns ``list[dict]`` content (image-aware read,
+        multi-part output) AND the result lands during inference, the
+        synthetic user-message injection must splice the parts in
+        properly — NOT f-string the list (which would emit Python repr
+        and lose the image).  Regression test for PR #218."""
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/jpeg;base64,AAAA"},
+        }
+        tool_content = [
+            {"type": "text", "text": "screenshot below"},
+            image_part,
+        ]
+        events = [
+            _evt(1, "user", content="show me the screen"),
+            _evt(2, "assistant", tool_calls=[_tc("read_1")]),
+            _evt(3, "tool", tool_call_id="read_1", content=""),  # placeholder; overridden below
+            _evt(4, "assistant", content="working on it"),
+        ]
+        # Set the tool result content to a list[dict] (the new shape PR2 added).
+        events[2].data["content"] = tool_content
+        events[2].data["name"] = "read"
+        events[1].data["reacting_to"] = 1
+        events[3].data["reacting_to"] = 1  # blind to tool at seq=3
+
+        msgs = self._build(events)
+        # Locate the injected user message — it follows the horizon-setter
+        # assistant ("working on it") and carries the completion header.
+        injected = next(
+            (
+                m
+                for m in msgs
+                if m["role"] == "user"
+                and (
+                    (isinstance(m.get("content"), str) and "completed]" in m["content"])
+                    or (
+                        isinstance(m.get("content"), list)
+                        and any(
+                            isinstance(p, dict)
+                            and p.get("type") == "text"
+                            and "completed]" in (p.get("text") or "")
+                            for p in m["content"]
+                        )
+                    )
+                )
+            ),
+            None,
+        )
+        assert injected is not None, "blind-spot injection must be emitted"
+        # The injection MUST carry an image_url part — not the Python repr
+        # of the list.
+        content = injected["content"]
+        assert isinstance(content, list), (
+            f"multimodal injection must be content-parts, got {type(content).__name__}"
+        )
+        assert any(p.get("type") == "image_url" for p in content), (
+            "image_url part must survive the injection"
+        )
+        # And no part should contain the literal repr fragment that the bug
+        # would have produced.
+        for p in content:
+            text = p.get("text") if isinstance(p, dict) else None
+            if isinstance(text, str):
+                assert "image_url" not in text or text.startswith("[Tool result"), (
+                    "f-stringed list repr leaked into the injection text"
+                )
+
+    def test_blind_spot_injection_string_content_unchanged(self) -> None:
+        """Plain string tool results still produce a string-content injection
+        (back-compat: PR #218's multimodal branch must not regress the
+        common path)."""
+        events = [
+            _evt(1, "user", content="run it"),
+            _evt(2, "assistant", tool_calls=[_tc("bash_1")]),
+            _evt(3, "tool", tool_call_id="bash_1", content="DONE"),
+            _evt(4, "assistant", content="still going"),
+        ]
+        events[2].data["name"] = "bash"
+        events[1].data["reacting_to"] = 1
+        events[3].data["reacting_to"] = 1
+
+        msgs = self._build(events)
+        injected = next(m for m in msgs if m["role"] == "user" and m != msgs[0])
+        assert isinstance(injected["content"], str)
+        assert "completed]" in injected["content"]
+        assert "DONE" in injected["content"]
+
 
 # ─── field stripping ────────────────────────────────────────────────────────
 

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -1,0 +1,251 @@
+"""Unit coverage for vision-aware rendering in :func:`render_user_event`.
+
+The renderer's vision policy is delegated to
+:mod:`aios.harness.vision`; here we exercise the wiring around it —
+host-bytes-read for inlinable images, text-marker fallback for
+non-vision minds and oversize images, and the legacy-stub path.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aios.config import get_settings
+from aios.harness import vision
+from aios.harness.context import render_user_event
+from aios.sandbox.volumes import session_attachments_dir
+
+
+@pytest.fixture
+def temp_workspace_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _stub_supports_vision(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Default: vision-capable model returns True; non-vision-capable returns False.
+
+    Tests can override individual mappings via ``vision._VISION_OVERRIDES``.
+    """
+    saved = dict(vision._VISION_OVERRIDES)
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES["mind/vision"] = True
+    vision._VISION_OVERRIDES["mind/text"] = False
+    yield
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES.update(saved)
+
+
+def _stage_image(
+    workspace_root: Path, session_id: str, connector: str, name: str, payload: bytes
+) -> str:
+    """Write a fake staged attachment, return its in-sandbox path."""
+    session_dir = session_attachments_dir(session_id) / connector
+    session_dir.mkdir(parents=True, exist_ok=True)
+    file_path = session_dir / name
+    file_path.write_bytes(payload)
+    return f"/mnt/attachments/{connector}/{name}"
+
+
+def _user_event(
+    *,
+    content: str = "hi",
+    channel: str = "echo/acct/chat-1",
+    attachments: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"channel": channel}
+    if attachments is not None:
+        metadata["attachments"] = attachments
+    return {"role": "user", "content": content, "metadata": metadata}
+
+
+class TestVisionAwareRendering:
+    def test_inlinable_image_emits_image_url_part(self, temp_workspace_root: Path) -> None:
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"jpegbytes"
+        )
+        event = _user_event(
+            content="hello",
+            attachments=[
+                {
+                    "filename": "photo.jpg",
+                    "content_type": "image/jpeg",
+                    "size": len(b"jpegbytes"),
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/vision",
+            session_id="sess-1",
+        )
+        content = msg["content"]
+        assert isinstance(content, list)
+        assert content[0]["type"] == "text"
+        assert "hello" in content[0]["text"]
+        assert content[1] == {
+            "type": "image_url",
+            "image_url": {
+                "url": f"data:image/jpeg;base64,{base64.b64encode(b'jpegbytes').decode()}"
+            },
+        }
+
+    def test_oversize_image_falls_back_to_marker(self, temp_workspace_root: Path) -> None:
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-big.jpg", b"\0" * (3 * 1024 * 1024)
+        )
+        event = _user_event(
+            content="big",
+            attachments=[
+                {
+                    "filename": "big.jpg",
+                    "content_type": "image/jpeg",
+                    "size": 3 * 1024 * 1024,
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/vision",
+            session_id="sess-1",
+        )
+        assert isinstance(msg["content"], str)
+        assert "[image: big.jpg" in msg["content"]
+        assert "/mnt/attachments/echo/evt-1-big.jpg" in msg["content"]
+
+    def test_non_vision_mind_renders_marker(self, temp_workspace_root: Path) -> None:
+        sandbox_path = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"x")
+        event = _user_event(
+            content="hi",
+            attachments=[
+                {
+                    "filename": "photo.jpg",
+                    "content_type": "image/jpeg",
+                    "size": 1,
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/text",
+            session_id="sess-1",
+        )
+        assert isinstance(msg["content"], str)
+        assert "[image: photo.jpg" in msg["content"]
+
+    def test_document_emits_attachment_marker(self, temp_workspace_root: Path) -> None:
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-report.pdf", b"%PDF"
+        )
+        event = _user_event(
+            content="here",
+            attachments=[
+                {
+                    "filename": "report.pdf",
+                    "content_type": "application/pdf",
+                    "size": 4,
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/vision",
+            session_id="sess-1",
+        )
+        assert isinstance(msg["content"], str)
+        assert "[attachment: report.pdf" in msg["content"]
+
+    def test_legacy_stub_no_in_sandbox_path(self) -> None:
+        event = _user_event(
+            content="legacy",
+            attachments=[
+                {
+                    "filename": "old.jpg",
+                    "content_type": "image/jpeg",
+                    "size": 1024,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/vision",
+            session_id="sess-1",
+        )
+        assert isinstance(msg["content"], str)
+        assert "[image: old.jpg" in msg["content"]
+
+    def test_no_model_disables_inlining(self, temp_workspace_root: Path) -> None:
+        """Append-time call (no model passed) emits text markers only.
+
+        That keeps cum_tokens deterministic without a model lookup.
+        """
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"bytes"
+        )
+        event = _user_event(
+            attachments=[
+                {
+                    "filename": "photo.jpg",
+                    "content_type": "image/jpeg",
+                    "size": 5,
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(event, "echo/acct/chat-1", "echo/acct/chat-1")
+        assert isinstance(msg["content"], str)
+        assert "[image: photo.jpg" in msg["content"]
+
+    def test_multiple_attachments_mixed(self, temp_workspace_root: Path) -> None:
+        a = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-a.jpg", b"AAA")
+        b = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-b.pdf", b"PDF")
+        event = _user_event(
+            content="two",
+            attachments=[
+                {
+                    "filename": "a.jpg",
+                    "content_type": "image/jpeg",
+                    "size": 3,
+                    "in_sandbox_path": a,
+                },
+                {
+                    "filename": "b.pdf",
+                    "content_type": "application/pdf",
+                    "size": 3,
+                    "in_sandbox_path": b,
+                },
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/vision",
+            session_id="sess-1",
+        )
+        content = msg["content"]
+        assert isinstance(content, list)
+        assert content[0]["type"] == "text"
+        assert "[attachment: b.pdf" in content[0]["text"]
+        assert content[1]["type"] == "image_url"
+        assert content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -216,6 +216,64 @@ class TestVisionAwareRendering:
         assert isinstance(msg["content"], str)
         assert "[image: photo.jpg" in msg["content"]
 
+    def test_image_only_no_caption_no_header_omits_empty_text(
+        self, temp_workspace_root: Path
+    ) -> None:
+        """An image-only event with no caption AND no channel header must
+        NOT emit ``{"type":"text","text":""}`` — Anthropic rejects empty
+        text blocks (``text content blocks must be non-empty``).  The
+        common path is fine because the channel header populates the
+        leading text, but legacy events with metadata-stripped headers
+        would 400 against Anthropic-routed minds.  Regression test for
+        PR #218.
+        """
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"PNG"
+        )
+        # Construct an event whose metadata has attachments but lacks
+        # ``channel`` — _format_channel_header returns "" so leading_text
+        # stays empty.  Content is also empty (image-only inbound).
+        event: dict[str, Any] = {
+            "role": "user",
+            "content": "",
+            "metadata": {
+                "channel": "echo/acct/chat-1",
+                "attachments": [
+                    {
+                        "filename": "photo.jpg",
+                        "content_type": "image/jpeg",
+                        "size": 3,
+                        "in_sandbox_path": sandbox_path,
+                    }
+                ],
+            },
+        }
+        # Strip the channel header by zeroing all the fields _format_channel_header
+        # consumes after the bare "channel" key: the header is the channel marker
+        # plus the inbound content, both empty here, so leading_text is just the
+        # bare ``[channel=...]`` line.  To exercise the no-header branch we drop
+        # ``channel`` from metadata entirely below.
+        event["metadata"].pop("channel")
+        # Re-add ``attachments`` only — _format_channel_header returns "" when
+        # channel is absent, leaving leading_text empty for the image-only path.
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="mind/vision",
+            session_id="sess-1",
+        )
+        content = msg["content"]
+        assert isinstance(content, list), (
+            "image_only message must still emit content parts when image is inlined"
+        )
+        # No empty text block in the parts.
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                assert part.get("text"), f"empty text part rejected by Anthropic — got {part!r}"
+        # And the image_url part is preserved.
+        assert any(p.get("type") == "image_url" for p in content)
+
     def test_multiple_attachments_mixed(self, temp_workspace_root: Path) -> None:
         a = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-a.jpg", b"AAA")
         b = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-b.pdf", b"PDF")

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -3,7 +3,7 @@
 The renderer's vision policy is delegated to
 :mod:`aios.harness.vision`; here we exercise the wiring around it —
 host-bytes-read for inlinable images, text-marker fallback for
-non-vision minds and oversize images, and the legacy-stub path.
+non-vision models and oversize images, and the legacy-stub path.
 """
 
 from __future__ import annotations
@@ -35,8 +35,8 @@ def _stub_supports_vision(monkeypatch: pytest.MonkeyPatch) -> Any:
     """
     saved = dict(vision._VISION_OVERRIDES)
     vision._VISION_OVERRIDES.clear()
-    vision._VISION_OVERRIDES["mind/vision"] = True
-    vision._VISION_OVERRIDES["mind/text"] = False
+    vision._VISION_OVERRIDES["model/vision"] = True
+    vision._VISION_OVERRIDES["model/text"] = False
     yield
     vision._VISION_OVERRIDES.clear()
     vision._VISION_OVERRIDES.update(saved)
@@ -85,7 +85,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/vision",
+            model="model/vision",
             session_id="sess-1",
         )
         content = msg["content"]
@@ -118,7 +118,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/vision",
+            model="model/vision",
             session_id="sess-1",
         )
         assert isinstance(msg["content"], str)
@@ -142,7 +142,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/text",
+            model="model/text",
             session_id="sess-1",
         )
         assert isinstance(msg["content"], str)
@@ -167,7 +167,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/vision",
+            model="model/vision",
             session_id="sess-1",
         )
         assert isinstance(msg["content"], str)
@@ -188,7 +188,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/vision",
+            model="model/vision",
             session_id="sess-1",
         )
         assert isinstance(msg["content"], str)
@@ -224,7 +224,7 @@ class TestVisionAwareRendering:
         text blocks (``text content blocks must be non-empty``).  The
         common path is fine because the channel header populates the
         leading text, but legacy events with metadata-stripped headers
-        would 400 against Anthropic-routed minds.  Regression test for
+        would 400 against Anthropic-routed models.  Regression test for
         PR #218.
         """
         sandbox_path = _stage_image(
@@ -260,7 +260,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/vision",
+            model="model/vision",
             session_id="sess-1",
         )
         content = msg["content"]
@@ -298,7 +298,7 @@ class TestVisionAwareRendering:
             event,
             "echo/acct/chat-1",
             "echo/acct/chat-1",
-            model="mind/vision",
+            model="model/vision",
             session_id="sess-1",
         )
         content = msg["content"]

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -72,8 +72,8 @@ def stub_runtime(stub_handle: ContainerHandle) -> Any:
 def _vision_overrides(monkeypatch: pytest.MonkeyPatch) -> Any:
     saved = dict(vision._VISION_OVERRIDES)
     vision._VISION_OVERRIDES.clear()
-    vision._VISION_OVERRIDES["mind/vision"] = True
-    vision._VISION_OVERRIDES["mind/text"] = False
+    vision._VISION_OVERRIDES["model/vision"] = True
+    vision._VISION_OVERRIDES["model/text"] = False
     yield
     vision._VISION_OVERRIDES.clear()
     vision._VISION_OVERRIDES.update(saved)
@@ -84,7 +84,7 @@ def stub_get_session_model(monkeypatch: pytest.MonkeyPatch) -> Any:
     """Replace the DB lookup with a callable returning whatever the test sets."""
 
     class _Model:
-        value: str = "mind/vision"
+        value: str = "model/vision"
 
     state = _Model()
 
@@ -118,7 +118,7 @@ class TestImageBranch:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         _stage_workspace_image("sess_01TEST", "screenshot.png", b"PNGbytes")
 
         result = await read_handler("sess_01TEST", {"path": "/workspace/screenshot.png"})
@@ -139,7 +139,7 @@ class TestImageBranch:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         _stage_attachment("sess_01TEST", "echo", "evt-1-photo.jpg", b"JPGbytes")
 
         result = await read_handler(
@@ -156,7 +156,7 @@ class TestImageBranch:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/text"
+        stub_get_session_model.value = "model/text"
         _stage_workspace_image("sess_01TEST", "screenshot.png", b"PNG")
 
         result = await read_handler("sess_01TEST", {"path": "/workspace/screenshot.png"})
@@ -172,7 +172,7 @@ class TestImageBranch:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         _stage_workspace_image("sess_01TEST", "huge.png", b"\0" * (3 * 1024 * 1024))
 
         result = await read_handler("sess_01TEST", {"path": "/workspace/huge.png"})
@@ -188,7 +188,7 @@ class TestImageBranch:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         workspace_dir_for("sess_01TEST").mkdir(parents=True, exist_ok=True)
 
         result = await read_handler("sess_01TEST", {"path": "/workspace/nope.png"})
@@ -207,7 +207,7 @@ class TestImageBranch:
     ) -> None:
         """Reading ``/etc/foo.png`` (not a bind mount) hits docker-exec
         with one combined stat+base64 invocation."""
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         b64_payload = base64.b64encode(b"otherbytes").decode()
         stub_handle.run_command = AsyncMock(  # type: ignore[method-assign]
             return_value=CommandResult(
@@ -248,7 +248,7 @@ class TestImagePathTraversalAttack:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         host_secret = b"HOST-SECRET-BYTES-DO-NOT-LEAK"
         (temp_workspace_root / "host_secret.png").write_bytes(host_secret)
         workspace_dir_for("sess_01TEST").mkdir(parents=True, exist_ok=True)
@@ -282,7 +282,7 @@ class TestImagePathTraversalAttack:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         host_secret = b"ATTACHMENTS-LEAK-PROBE"
         (temp_workspace_root / "leak.png").write_bytes(host_secret)
         session_attachments_dir("sess_01TEST").mkdir(parents=True, exist_ok=True)
@@ -317,7 +317,7 @@ class TestImagePathTraversalAttack:
         lives outside the bind-mount root (e.g. via ``ln -s`` from inside
         the sandbox), then ``read``s through it. Containment must follow
         the symlink and reject."""
-        stub_get_session_model.value = "mind/vision"
+        stub_get_session_model.value = "model/vision"
         host_secret = b"SYMLINK-ESCAPE-PROBE-BYTES"
         outside = temp_workspace_root / "outside.png"
         outside.write_bytes(host_secret)

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -221,6 +221,7 @@ class TestImageBranch:
 
         result = await read_handler("sess_01TEST", {"path": "/etc/foo.png"})
 
+        assert isinstance(result, ToolResult)
         run_command = stub_handle.run_command
         assert isinstance(run_command, AsyncMock)
         assert run_command.call_count == 1
@@ -228,6 +229,118 @@ class TestImageBranch:
         assert "stat -c %s" in cmd_arg
         assert "base64 -w0" in cmd_arg
 
-        assert isinstance(result, ToolResult)
-        assert isinstance(result.content, list)
-        assert result.content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+class TestImagePathTraversalAttack:
+    """End-to-end regression for the path-traversal vulnerability.
+
+    Each case plants a sentinel "host secret" file outside the
+    workspace bind-mount root, then asks ``read`` to fetch it via a
+    traversal-style sandbox path. The fixed behavior: the host-side
+    fast path declines (containment check), the read falls through to
+    docker-exec which is correctly contained by the container's
+    namespace, and the host-secret bytes never reach the tool result.
+    """
+
+    async def test_dotdot_traversal_does_not_return_host_bytes(
+        self,
+        temp_workspace_root: Path,
+        stub_handle: ContainerHandle,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/vision"
+        host_secret = b"HOST-SECRET-BYTES-DO-NOT-LEAK"
+        (temp_workspace_root / "host_secret.png").write_bytes(host_secret)
+        workspace_dir_for("sess_01TEST").mkdir(parents=True, exist_ok=True)
+
+        sandbox_payload = b"sandbox-side-content"
+        b64 = base64.b64encode(sandbox_payload).decode()
+        stub_handle.run_command = AsyncMock(  # type: ignore[method-assign]
+            return_value=CommandResult(
+                exit_code=0,
+                stdout=f"{len(sandbox_payload)}\n{b64}",
+                stderr="",
+                timed_out=False,
+                truncated=False,
+            )
+        )
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/../host_secret.png"})
+
+        b64_secret = base64.b64encode(host_secret).decode()
+        if isinstance(result, ToolResult) and isinstance(result.content, list):
+            url = result.content[1]["image_url"]["url"]
+            assert b64_secret not in url
+        elif isinstance(result, dict):
+            assert b64_secret not in str(result)
+        assert stub_handle.run_command.call_count == 1  # type: ignore[attr-defined]
+
+    async def test_attachments_traversal_does_not_return_host_bytes(
+        self,
+        temp_workspace_root: Path,
+        stub_handle: ContainerHandle,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/vision"
+        host_secret = b"ATTACHMENTS-LEAK-PROBE"
+        (temp_workspace_root / "leak.png").write_bytes(host_secret)
+        session_attachments_dir("sess_01TEST").mkdir(parents=True, exist_ok=True)
+
+        stub_handle.run_command = AsyncMock(  # type: ignore[method-assign]
+            return_value=CommandResult(
+                exit_code=0,
+                stdout=f"{4}\n{base64.b64encode(b'safe').decode()}",
+                stderr="",
+                timed_out=False,
+                truncated=False,
+            )
+        )
+
+        result = await read_handler("sess_01TEST", {"path": "/mnt/attachments/../../leak.png"})
+
+        b64_secret = base64.b64encode(host_secret).decode()
+        if isinstance(result, ToolResult) and isinstance(result.content, list):
+            url = result.content[1]["image_url"]["url"]
+            assert b64_secret not in url
+        elif isinstance(result, dict):
+            assert b64_secret not in str(result)
+
+    async def test_symlink_escape_does_not_return_host_bytes(
+        self,
+        temp_workspace_root: Path,
+        stub_handle: ContainerHandle,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """The model creates a symlink inside ``/workspace`` whose target
+        lives outside the bind-mount root (e.g. via ``ln -s`` from inside
+        the sandbox), then ``read``s through it. Containment must follow
+        the symlink and reject."""
+        stub_get_session_model.value = "mind/vision"
+        host_secret = b"SYMLINK-ESCAPE-PROBE-BYTES"
+        outside = temp_workspace_root / "outside.png"
+        outside.write_bytes(host_secret)
+        ws = workspace_dir_for("sess_01TEST")
+        ws.mkdir(parents=True, exist_ok=True)
+        (ws / "sneaky.jpg").symlink_to(outside)
+
+        stub_handle.run_command = AsyncMock(  # type: ignore[method-assign]
+            return_value=CommandResult(
+                exit_code=0,
+                stdout=f"{3}\n{base64.b64encode(b'sbx').decode()}",
+                stderr="",
+                timed_out=False,
+                truncated=False,
+            )
+        )
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/sneaky.jpg"})
+
+        b64_secret = base64.b64encode(host_secret).decode()
+        if isinstance(result, ToolResult) and isinstance(result.content, list):
+            url = result.content[1]["image_url"]["url"]
+            assert b64_secret not in url
+        elif isinstance(result, dict):
+            assert b64_secret not in str(result)
+        assert stub_handle.run_command.call_count == 1  # type: ignore[attr-defined]

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -1,0 +1,233 @@
+"""Unit coverage for the read tool's image branch.
+
+Stubs the sandbox handle and ``get_session_model`` so the tests never
+touch Docker or the DB.  Same pattern as :mod:`test_read_handler`.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.config import get_settings
+from aios.harness import runtime, vision
+from aios.sandbox.container import CommandResult, ContainerHandle
+from aios.sandbox.volumes import session_attachments_dir, workspace_dir_for
+from aios.tools.read import read_handler
+from aios.tools.registry import ToolResult
+
+
+class _StubRegistry:
+    def __init__(self, handle: ContainerHandle) -> None:
+        self._handle = handle
+
+    async def get_or_provision(self, session_id: str, **_kwargs: Any) -> ContainerHandle:
+        return self._handle
+
+
+@pytest.fixture
+def temp_workspace_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def stub_handle(tmp_path: Path) -> ContainerHandle:
+    handle = ContainerHandle(
+        session_id="sess_01TEST",
+        container_id="container_abc",
+        workspace_path=tmp_path,
+    )
+    handle.run_command = AsyncMock(  # type: ignore[method-assign]
+        return_value=CommandResult(
+            exit_code=0,
+            stdout="",
+            stderr="",
+            timed_out=False,
+            truncated=False,
+        )
+    )
+    return handle
+
+
+@pytest.fixture
+def stub_runtime(stub_handle: ContainerHandle) -> Any:
+    prev_registry = runtime.sandbox_registry
+    prev_pool = runtime.pool
+    runtime.sandbox_registry = _StubRegistry(stub_handle)  # type: ignore[assignment]
+    runtime.pool = MagicMock()
+    try:
+        yield
+    finally:
+        runtime.sandbox_registry = prev_registry
+        runtime.pool = prev_pool
+
+
+@pytest.fixture(autouse=True)
+def _vision_overrides(monkeypatch: pytest.MonkeyPatch) -> Any:
+    saved = dict(vision._VISION_OVERRIDES)
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES["mind/vision"] = True
+    vision._VISION_OVERRIDES["mind/text"] = False
+    yield
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES.update(saved)
+
+
+@pytest.fixture
+def stub_get_session_model(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Replace the DB lookup with a callable returning whatever the test sets."""
+
+    class _Model:
+        value: str = "mind/vision"
+
+    state = _Model()
+
+    async def fake(_pool: Any, _session_id: str) -> str:
+        return state.value
+
+    monkeypatch.setattr("aios.tools.read.sessions_service.get_session_model", fake)
+    return state
+
+
+def _stage_workspace_image(session_id: str, name: str, payload: bytes) -> Path:
+    ws = workspace_dir_for(session_id)
+    ws.mkdir(parents=True, exist_ok=True)
+    file_path = ws / name
+    file_path.write_bytes(payload)
+    return file_path
+
+
+def _stage_attachment(session_id: str, connector: str, name: str, payload: bytes) -> Path:
+    target = session_attachments_dir(session_id) / connector
+    target.mkdir(parents=True, exist_ok=True)
+    file_path = target / name
+    file_path.write_bytes(payload)
+    return file_path
+
+
+class TestImageBranch:
+    async def test_workspace_image_inlines_for_vision_mind(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/vision"
+        _stage_workspace_image("sess_01TEST", "screenshot.png", b"PNGbytes")
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/screenshot.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[0]["type"] == "text"
+        assert "Image: screenshot.png" in result.content[0]["text"]
+        assert result.content[1] == {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(b'PNGbytes').decode()}"},
+        }
+        assert result.is_error is False
+
+    async def test_attachment_image_inlines_for_vision_mind(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/vision"
+        _stage_attachment("sess_01TEST", "echo", "evt-1-photo.jpg", b"JPGbytes")
+
+        result = await read_handler(
+            "sess_01TEST", {"path": "/mnt/attachments/echo/evt-1-photo.jpg"}
+        )
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+    async def test_blocked_for_non_vision_mind_is_not_an_error(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/text"
+        _stage_workspace_image("sess_01TEST", "screenshot.png", b"PNG")
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/screenshot.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, str)
+        assert "Mind vision support: no" in result.content
+        assert result.is_error is False
+
+    async def test_oversize_image_blocked_with_explanatory_text(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/vision"
+        _stage_workspace_image("sess_01TEST", "huge.png", b"\0" * (3 * 1024 * 1024))
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/huge.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, str)
+        assert "Inline cap: 2 MiB" in result.content
+        assert result.is_error is False
+
+    async def test_missing_image_returns_error(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "mind/vision"
+        workspace_dir_for("sess_01TEST").mkdir(parents=True, exist_ok=True)
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/nope.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, str)
+        assert "file not found" in result.content
+        assert result.is_error is True
+
+    async def test_non_bind_mount_falls_back_to_docker_exec(
+        self,
+        temp_workspace_root: Path,
+        stub_handle: ContainerHandle,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """Reading ``/etc/foo.png`` (not a bind mount) hits docker-exec
+        with one combined stat+base64 invocation."""
+        stub_get_session_model.value = "mind/vision"
+        b64_payload = base64.b64encode(b"otherbytes").decode()
+        stub_handle.run_command = AsyncMock(  # type: ignore[method-assign]
+            return_value=CommandResult(
+                exit_code=0,
+                stdout=f"10\n{b64_payload}",
+                stderr="",
+                timed_out=False,
+                truncated=False,
+            )
+        )
+
+        result = await read_handler("sess_01TEST", {"path": "/etc/foo.png"})
+
+        run_command = stub_handle.run_command
+        assert isinstance(run_command, AsyncMock)
+        assert run_command.call_count == 1
+        cmd_arg = run_command.call_args.args[0]
+        assert "stat -c %s" in cmd_arg
+        assert "base64 -w0" in cmd_arg
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[1]["image_url"]["url"].startswith("data:image/png;base64,")

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -48,6 +48,25 @@ class TestSupportsVision:
         _patch_get_model_info(monkeypatch, {})  # any model raises
         assert vision.supports_vision("totally/unknown") is False
 
+    def test_litellm_exception_emits_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bare exception path must surface at warn-level so operators can
+        grep when vision degrades across a deploy / provider blip."""
+        _patch_get_model_info(monkeypatch, {})  # any model raises
+
+        warned: list[tuple[str, dict[str, Any]]] = []
+
+        class _Recorder:
+            def warning(self, event: str, **kwargs: Any) -> None:
+                warned.append((event, kwargs))
+
+        monkeypatch.setattr("aios.harness.vision.log", _Recorder())
+        assert vision.supports_vision("totally/unknown") is False
+        assert len(warned) == 1
+        event, kwargs = warned[0]
+        assert event == "vision.litellm_lookup_failed"
+        assert kwargs["model"] == "totally/unknown"
+        assert "error" in kwargs
+
     def test_override_wins_over_litellm(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Even if litellm reports True, an explicit False override takes effect.
         _patch_get_model_info(monkeypatch, {"foo/vision": {"supports_vision": True}})

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -1,0 +1,134 @@
+"""Unit coverage for :mod:`aios.harness.vision`.
+
+Pure decision logic — no I/O.  ``supports_vision`` delegates to
+``litellm.get_model_info``, which we monkeypatch to keep tests
+hermetic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aios.harness import vision
+
+
+@pytest.fixture(autouse=True)
+def _clear_vision_overrides() -> Any:
+    """Wipe the override dict between tests so order doesn't matter."""
+    saved = dict(vision._VISION_OVERRIDES)
+    vision._VISION_OVERRIDES.clear()
+    yield
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES.update(saved)
+
+
+def _patch_get_model_info(
+    monkeypatch: pytest.MonkeyPatch, mapping: dict[str, dict[str, Any]]
+) -> None:
+    def fake(model: str) -> dict[str, Any]:
+        if model not in mapping:
+            raise Exception(f"unknown model: {model}")
+        return mapping[model]
+
+    monkeypatch.setattr("aios.harness.vision.litellm.get_model_info", fake)
+
+
+class TestSupportsVision:
+    def test_true_when_litellm_says_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"foo/vision": {"supports_vision": True}})
+        assert vision.supports_vision("foo/vision") is True
+
+    def test_false_when_litellm_says_no(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"foo/text": {"supports_vision": False}})
+        assert vision.supports_vision("foo/text") is False
+
+    def test_false_when_litellm_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {})  # any model raises
+        assert vision.supports_vision("totally/unknown") is False
+
+    def test_override_wins_over_litellm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Even if litellm reports True, an explicit False override takes effect.
+        _patch_get_model_info(monkeypatch, {"foo/vision": {"supports_vision": True}})
+        vision._VISION_OVERRIDES["foo/vision"] = False
+        assert vision.supports_vision("foo/vision") is False
+
+
+class TestCanInlineImage:
+    def test_image_under_cap_with_vision_mind(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"vision/m": {"supports_vision": True}})
+        assert vision.can_inline_image(
+            model="vision/m", content_type="image/jpeg", size_bytes=500_000
+        )
+
+    def test_image_at_exact_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"vision/m": {"supports_vision": True}})
+        assert vision.can_inline_image(
+            model="vision/m",
+            content_type="image/png",
+            size_bytes=vision.INLINE_SIZE_CAP_BYTES,
+        )
+
+    def test_image_over_cap_blocked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"vision/m": {"supports_vision": True}})
+        assert not vision.can_inline_image(
+            model="vision/m",
+            content_type="image/jpeg",
+            size_bytes=vision.INLINE_SIZE_CAP_BYTES + 1,
+        )
+
+    def test_non_vision_mind_blocked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"text/m": {"supports_vision": False}})
+        assert not vision.can_inline_image(
+            model="text/m", content_type="image/jpeg", size_bytes=100
+        )
+
+    def test_non_image_blocked_even_with_vision(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"vision/m": {"supports_vision": True}})
+        assert not vision.can_inline_image(
+            model="vision/m", content_type="application/pdf", size_bytes=100
+        )
+
+    def test_audio_blocked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_get_model_info(monkeypatch, {"vision/m": {"supports_vision": True}})
+        assert not vision.can_inline_image(
+            model="vision/m", content_type="audio/ogg", size_bytes=100
+        )
+
+
+class TestMakeImageUrlPart:
+    def test_shape(self) -> None:
+        part = vision.make_image_url_part(content_type="image/png", data_b64="ZmFrZQ==")
+        assert part == {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,ZmFrZQ=="},
+        }
+
+
+class TestTextMarker:
+    def test_image_with_path(self) -> None:
+        record = {
+            "filename": "photo.jpg",
+            "content_type": "image/jpeg",
+            "size": 524_288,
+            "in_sandbox_path": "/mnt/attachments/echo/evt-1-photo.jpg",
+        }
+        assert vision.text_marker(record) == (
+            "[image: photo.jpg (image/jpeg, 512.0KB) at /mnt/attachments/echo/evt-1-photo.jpg]"
+        )
+
+    def test_non_image_falls_back_to_attachment(self) -> None:
+        record = {
+            "filename": "doc.pdf",
+            "content_type": "application/pdf",
+            "size": 1024,
+            "in_sandbox_path": "/mnt/attachments/sig/x-doc.pdf",
+        }
+        assert "attachment: doc.pdf" in vision.text_marker(record)
+
+    def test_legacy_stub_no_path(self) -> None:
+        record = {"filename": "old.jpg", "content_type": "image/jpeg", "size": 100}
+        marker = vision.text_marker(record)
+        assert "old.jpg" in marker
+        assert "at " not in marker

--- a/tests/unit/test_volumes_attachments.py
+++ b/tests/unit/test_volumes_attachments.py
@@ -95,3 +95,74 @@ class TestResolveToHostPath:
         assert resolve_to_host_path("sess-1", "workspace/foo") is None
         # Not /workspace itself but starts with the literal prefix.
         assert resolve_to_host_path("sess-1", "/workspaces/foo") is None
+
+
+class TestResolveToHostPathTraversal:
+    """Containment check: model-controlled paths must not escape the
+    bind-mount root via ``..`` normalization or symlink dereferencing."""
+
+    def test_dotdot_escape_from_workspace_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        # `/workspace/../../etc/hostname` resolves outside the session's
+        # workspace dir → must be rejected.
+        assert resolve_to_host_path("sess-1", "/workspace/../../etc/hostname") is None
+
+    def test_dotdot_escape_from_attachments_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        assert resolve_to_host_path("sess-1", "/mnt/attachments/../foo") is None
+
+    def test_deeply_nested_dotdot_escape_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        assert resolve_to_host_path("sess-1", "/workspace/sub/../../../../etc/passwd") is None
+
+    def test_innocuous_dotdot_inside_workspace_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``..`` that stays inside the workspace after normalization is fine."""
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        result = resolve_to_host_path("sess-1", "/workspace/sub/../foo.jpg")
+        assert result == (tmp_path / "sess-1").resolve() / "foo.jpg"
+
+    def test_symlink_escape_via_workspace_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A symlink inside ``/workspace`` whose target lives outside the
+        bind mount must be rejected.  This covers the real attack: the
+        model creates the symlink via ``bash`` inside the sandbox, then
+        ``read``s through it to bypass containment."""
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        # Create the workspace dir (the bind-mount source) and an
+        # outside-the-workspace target.
+        ws = (tmp_path / "sess-1").resolve()
+        ws.mkdir(parents=True)
+        outside = tmp_path / "outside.txt"
+        outside.write_text("host-secret")
+        (ws / "sneaky.jpg").symlink_to(outside)
+
+        assert resolve_to_host_path("sess-1", "/workspace/sneaky.jpg") is None
+
+    def test_symlink_target_inside_workspace_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A symlink whose target stays inside the workspace is fine."""
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        ws = (tmp_path / "sess-1").resolve()
+        ws.mkdir(parents=True)
+        target = ws / "real.jpg"
+        target.write_bytes(b"x")
+        (ws / "alias.jpg").symlink_to(target)
+
+        result = resolve_to_host_path("sess-1", "/workspace/alias.jpg")
+        assert result == target.resolve()


### PR DESCRIPTION
## Summary

Recovers PRs #218–#221 + #228 into a single squashable merge. The original cascade tried to squash bottom-up but the auto-merge fired on PRs that were already CLEAN, so they merged out of order — #220 ended up CLOSED with its base branch deleted, even though all the content is still here on ``wt/recursive-weaving-sundae-pr4``.

The branch ``wt/recursive-weaving-sundae-pr4`` carries the entire remaining stack on top of master (which already has PR1 from #217):

* PR2: vision pipeline — ``image_url`` parts at render + image-aware ``read`` tool (was [#218](https://github.com/eumemic/aios/pull/218))
* PR3: SDK ``resolve_sandbox_path`` helper for outbound attachments (was [#219](https://github.com/eumemic/aios/pull/219), merged into now-deleted pr2 chain)
* PR4: Signal+Telegram inbound attachment ports + signal connector boot health + ``host_path`` fallback (was [#220](https://github.com/eumemic/aios/pull/220), closed by GitHub when its base was deleted)
* PR5: outbound ``attachments`` parameter on ``signal_send`` / ``telegram_send`` (squashed, was [#221](https://github.com/eumemic/aios/pull/221))
* Capstone: stdio-MCP tool enumeration, pydantic schemas, ``AIOS_WORKSPACE_ROOT`` absolutize, ``SandboxPath`` auto-resolve, ``mind`` terminology drop, /simplify pass — fail-loud, gather, comment trim (squashed, was [#228](https://github.com/eumemic/aios/pull/228))

Squash-merging this PR lands all of the above as one commit on master, completing the #216 chat-attachments stack.

## Test plan

All checks ran green on each predecessor PR before the cascade. To re-verify:

- [ ] ``uv run mypy src``
- [ ] ``uv run ruff check src tests packages && uv run ruff format --check src tests packages``
- [ ] ``uv run pytest tests/unit -q``
- [ ] ``uv run --package aios-connector pytest packages/aios-connector``
- [ ] ``uv run pytest connectors/signal connectors/telegram``

Live verification (already exercised end-to-end during the smoke test):
- [x] Inbound photo on Telegram → vision pipeline, model identified content
- [x] Inbound photo on Signal → vision pipeline, model identified content
- [x] Outbound photo via ``attachments=[…]`` on Telegram → ``message_id`` returned
- [x] Outbound photo via ``attachments=[…]`` on Signal → ``sent_at_ms`` returned
- [x] Inbound document on both connectors → text marker, model ``pdftotext``-extracted

🤖 Generated with [Claude Code](https://claude.com/claude-code)