### PR TITLE
fix(switch_channel): surface non-focal image attachments in recap (#226)

### DIFF
--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -158,8 +158,9 @@ async def switch_channel_handler(session_id: str, arguments: dict[str, Any]) -> 
 
         await queries.set_session_focal_channel(conn, session_id, target)
         all_events = await queries.read_message_events(conn, session_id)
+        model = await queries.get_session_model(conn, session_id)
 
-    content = render_reorient_block(all_events, target)
+    content = render_reorient_block(all_events, target, model=model, session_id=session_id)
     return ToolResult(
         content=content,
         metadata={
@@ -168,7 +169,13 @@ async def switch_channel_handler(session_id: str, arguments: dict[str, Any]) -> 
     )
 
 
-def render_reorient_block(all_events: list[Event], target: str) -> str:
+def render_reorient_block(
+    all_events: list[Event],
+    target: str,
+    *,
+    model: str | None = None,
+    session_id: str | None = None,
+) -> str | list[dict[str, Any]]:
     """Render the recap block for ``target`` from the event log.
 
     Pure function over the session's message events — no database
@@ -213,6 +220,15 @@ def render_reorient_block(all_events: list[Event], target: str) -> str:
     through the role=tool framing.  Leading ``>`` inside any rendered
     line is escaped to ``\\>`` so peer messages that start with a
     quote character don't collide with the block-quote syntax.
+
+    When ``model`` and ``session_id`` are both supplied and a peer
+    user event on ``target`` carries an inlinable image attachment,
+    the recap return type widens to a content-parts list — the
+    ``image_url`` parts sit between blockquoted text parts so the
+    agent reads "here's the historical text from the channel, and
+    here are the pixels they sent" inside one tool_result.  Without
+    those kwargs (legacy callers), the recap stays a single string
+    and image attachments degrade to text path markers.
     """
     switch_result_tcids = _switch_channel_tool_result_tcids(all_events)
     target_events = [
@@ -236,7 +252,7 @@ def render_reorient_block(all_events: list[Event], target: str) -> str:
     rendered_msgs: list[dict[str, Any]] = []
     token_total = 0
     for e in reversed(target_events):
-        msg = _render_recap_event(e)
+        msg = _render_recap_event(e, model=model, session_id=session_id)
         if msg is None:
             continue
         rendered_msgs.append(msg)
@@ -249,8 +265,7 @@ def render_reorient_block(all_events: list[Event], target: str) -> str:
         return f"Switched to {target}. (no prior messages on this channel)"
 
     rendered_msgs.reverse()
-    quoted_body = _blockquote("\n\n".join(m["content"] for m in rendered_msgs))
-    return f"━━━ Recap: recent messages on {target} ━━━\n{quoted_body}\n━━━ End recap ━━━"
+    return _assemble_recap(rendered_msgs, target)
 
 
 def _switch_channel_tool_result_tcids(all_events: list[Event]) -> set[str]:
@@ -276,7 +291,12 @@ def _switch_channel_tool_result_tcids(all_events: list[Event]) -> set[str]:
     return tcids
 
 
-def _render_recap_event(event: Event) -> dict[str, Any] | None:
+def _render_recap_event(
+    event: Event,
+    *,
+    model: str | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any] | None:
     """Render a single event into a chat-completions message dict for
     the recap body, or ``None`` if the event contributes nothing.
 
@@ -290,7 +310,12 @@ def _render_recap_event(event: Event) -> dict[str, Any] | None:
     User events go through :func:`render_user_event` with
     ``focal_at_arrival=orig_channel`` to force the full-content branch
     (we want headers and full bodies inside the recap, never truncated
-    notification markers).
+    notification markers).  When ``model`` and ``session_id`` are
+    threaded through, the same vision policy that applies at arrival
+    time also applies here: inlinable images on the target channel
+    surface as ``image_url`` content parts inside the user message,
+    and :func:`_assemble_recap` then lifts them out into the recap's
+    top-level content-parts list.
 
     Assistant events drop their text content entirely and render only
     their tool_calls — ``[you called: name(args), ...]`` (second
@@ -311,17 +336,15 @@ def _render_recap_event(event: Event) -> dict[str, Any] | None:
     role = event.data.get("role") if event.kind == "message" else None
 
     if role == "user":
-        # Recap rendering is intentionally text-only: ``model``/``session_id``
-        # are not threaded through, so :func:`render_user_event` short-circuits
-        # any image inlining and emits text markers for every attachment.
-        # The recap body is consumed inside a ``switch_channel`` tool result
-        # (string content), where ``image_url`` parts wouldn't survive the
-        # tool-message envelope; degrading attachments to markers keeps the
-        # recap a single text blob that the agent can read or follow up on
-        # via the in-sandbox path.
-        rendered = render_user_event(event.data, event.orig_channel, event.orig_channel)
+        rendered = render_user_event(
+            event.data,
+            event.orig_channel,
+            event.orig_channel,
+            model=model,
+            session_id=session_id,
+        )
         content = rendered.get("content")
-        if not isinstance(content, str) or not content:
+        if not content or not isinstance(content, (str, list)):
             return None
         return {"role": "user", "content": content}
 
@@ -343,6 +366,51 @@ def _render_recap_event(event: Event) -> dict[str, Any] | None:
         }
 
     return None
+
+
+def _assemble_recap(rendered_msgs: list[dict[str, Any]], target: str) -> str | list[dict[str, Any]]:
+    """Compose rendered recap messages into the final tool-result content.
+
+    All-text rendered_msgs preserve the legacy ``str`` shape bit-for-bit
+    so sessions that never produce inlinable content see no behavior
+    change.  When any user message rendered as a content-parts list,
+    the result widens to a content-parts list with ``image_url`` parts
+    interleaved between the surrounding blockquoted text — the agent
+    reads the historical framing and the pixels in their original
+    conversational order.
+    """
+    if not any(isinstance(m["content"], list) for m in rendered_msgs):
+        quoted_body = _blockquote("\n\n".join(m["content"] for m in rendered_msgs))
+        return f"━━━ Recap: recent messages on {target} ━━━\n{quoted_body}\n━━━ End recap ━━━"
+
+    parts: list[dict[str, Any]] = [
+        {"type": "text", "text": f"━━━ Recap: recent messages on {target} ━━━"}
+    ]
+    text_buf: list[str] = []
+
+    def flush_text() -> None:
+        if not text_buf:
+            return
+        parts.append({"type": "text", "text": _blockquote("\n".join(text_buf))})
+        text_buf.clear()
+
+    for i, msg in enumerate(rendered_msgs):
+        content = msg["content"]
+        if i > 0:
+            text_buf.append("")
+        if isinstance(content, str):
+            text_buf.append(content)
+            continue
+        for sub in content:
+            if sub.get("type") == "image_url":
+                flush_text()
+                parts.append(sub)
+            elif sub.get("type") == "text":
+                text_buf.append(sub.get("text", ""))
+
+    flush_text()
+    parts.append({"type": "text", "text": "━━━ End recap ━━━"})
+    return parts
 
 
 def _render_tool_calls(tool_calls: list[dict[str, Any]]) -> str:

--- a/tests/unit/test_switch_channel_recap_vision.py
+++ b/tests/unit/test_switch_channel_recap_vision.py
@@ -1,0 +1,231 @@
+"""Vision-aware behaviour for :func:`render_reorient_block` (issue #226).
+
+When the model bound to a session is vision-capable and a peer event
+on the target channel carries inlinable image attachments, the recap
+must surface those images as ``image_url`` content parts — not just
+text path markers.  Without this, multi-channel sessions silently lose
+vision on every non-focal image: arrival-time inlining only fires
+while the channel is focal, so the only chance to surface pixels
+across a ``switch_channel`` call is here.
+
+The arrival-time path lives in
+:func:`aios.harness.context.render_user_event` and is exercised by
+``test_context_attachments.py``; this file pins the recap-time path,
+which reuses the same vision policy via ``model``/``session_id``.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aios.config import get_settings
+from aios.harness import vision
+from aios.models.events import Event
+from aios.sandbox.volumes import session_attachments_dir
+from aios.tools.switch_channel import render_reorient_block
+
+CHAN_A = "signal/acct/chat-a"
+CHAN_B = "signal/acct/chat-b"
+SESSION_ID = "sess-test"
+
+
+@pytest.fixture
+def temp_workspace_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _stub_supports_vision(monkeypatch: pytest.MonkeyPatch) -> Any:
+    saved = dict(vision._VISION_OVERRIDES)
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES["model/vision"] = True
+    vision._VISION_OVERRIDES["model/text"] = False
+    yield
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES.update(saved)
+
+
+def _stage_image(workspace_root: Path, connector: str, name: str, payload: bytes) -> str:
+    session_dir = session_attachments_dir(SESSION_ID) / connector
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / name).write_bytes(payload)
+    return f"/mnt/attachments/{connector}/{name}"
+
+
+def _user_with_image(
+    seq: int,
+    *,
+    channel: str,
+    content: str,
+    sandbox_path: str,
+    filename: str = "photo.jpg",
+    content_type: str = "image/jpeg",
+    size: int = 9,
+) -> Event:
+    return Event(
+        id=f"evt_{seq:04d}",
+        session_id=SESSION_ID,
+        seq=seq,
+        kind="message",
+        data={
+            "role": "user",
+            "content": content,
+            "metadata": {
+                "channel": channel,
+                "sender_name": "Peer",
+                "timestamp_ms": 1000 + seq,
+                "attachments": [
+                    {
+                        "filename": filename,
+                        "content_type": content_type,
+                        "size": size,
+                        "in_sandbox_path": sandbox_path,
+                    }
+                ],
+            },
+        },
+        cumulative_tokens=None,
+        created_at=datetime(2026, 4, 20, tzinfo=UTC),
+        orig_channel=channel,
+        focal_channel_at_arrival=channel,
+        channel=channel,
+    )
+
+
+def _user_text_only(seq: int, *, channel: str, content: str) -> Event:
+    return Event(
+        id=f"evt_{seq:04d}",
+        session_id=SESSION_ID,
+        seq=seq,
+        kind="message",
+        data={
+            "role": "user",
+            "content": content,
+            "metadata": {
+                "channel": channel,
+                "sender_name": "Peer",
+                "timestamp_ms": 1000 + seq,
+            },
+        },
+        cumulative_tokens=None,
+        created_at=datetime(2026, 4, 20, tzinfo=UTC),
+        orig_channel=channel,
+        focal_channel_at_arrival=channel,
+        channel=channel,
+    )
+
+
+class TestRecapVision:
+    def test_inlinable_image_emits_image_url_content_part(self, temp_workspace_root: Path) -> None:
+        """A peer image on the target channel must appear as an
+        ``image_url`` content part in the recap when the bound mind
+        supports vision and the image fits the inline cap.  The recap
+        return type widens from ``str`` to a content-parts list to
+        carry the multimodal payload.
+        """
+        payload = b"jpegbytes"
+        sandbox_path = _stage_image(temp_workspace_root, "signal", "evt-1-photo.jpg", payload)
+        events = [
+            _user_with_image(
+                1,
+                channel=CHAN_A,
+                content="check this out",
+                sandbox_path=sandbox_path,
+                size=len(payload),
+            )
+        ]
+        out = render_reorient_block(events, CHAN_A, model="model/vision", session_id=SESSION_ID)
+        assert isinstance(out, list), (
+            f"recap with inlinable image must return content-parts list, got {type(out).__name__}"
+        )
+        image_parts = [p for p in out if p.get("type") == "image_url"]
+        assert len(image_parts) == 1, f"expected one image_url part, got {image_parts!r}"
+        assert image_parts[0]["image_url"]["url"] == (
+            f"data:image/jpeg;base64,{base64.b64encode(payload).decode()}"
+        )
+
+    def test_image_recap_preserves_recap_framing_and_caption(
+        self, temp_workspace_root: Path
+    ) -> None:
+        """The text parts surrounding the image must still carry the
+        ``Recap: recent messages on <target>`` header, the peer
+        message's text caption, and the ``End recap`` footer.  The
+        image content block sits between the framing text parts so
+        the model reads "this is historical content from the channel,
+        and here's the picture they sent".
+        """
+        sandbox_path = _stage_image(temp_workspace_root, "signal", "evt-1-photo.jpg", b"PNGdata")
+        events = [
+            _user_with_image(
+                1,
+                channel=CHAN_A,
+                content="look at this banana",
+                sandbox_path=sandbox_path,
+                size=7,
+            )
+        ]
+        out = render_reorient_block(events, CHAN_A, model="model/vision", session_id=SESSION_ID)
+        assert isinstance(out, list)
+        text_blob = "\n".join(p["text"] for p in out if p.get("type") == "text")
+        assert f"Recap: recent messages on {CHAN_A}" in text_blob
+        assert "End recap" in text_blob
+        assert "look at this banana" in text_blob
+
+    def test_non_vision_model_returns_str_with_text_marker(self, temp_workspace_root: Path) -> None:
+        """Vision-incapable mind: recap stays a single ``str`` and the
+        attachment is rendered as a text path marker, same policy as
+        arrival-time rendering in ``render_user_event``.
+        """
+        sandbox_path = _stage_image(temp_workspace_root, "signal", "evt-1-photo.jpg", b"jpg")
+        events = [
+            _user_with_image(
+                1,
+                channel=CHAN_A,
+                content="picture",
+                sandbox_path=sandbox_path,
+                size=3,
+            )
+        ]
+        out = render_reorient_block(events, CHAN_A, model="model/text", session_id=SESSION_ID)
+        assert isinstance(out, str)
+        assert "[image: photo.jpg" in out
+        assert sandbox_path in out
+
+    def test_text_only_recap_unchanged(self) -> None:
+        """No attachments on any window event: recap returns a ``str``
+        with the same framing as before.  This is the no-images
+        backwards-compat path — vision plumbing must not change the
+        output for sessions that never produce inlinable content.
+        """
+        events = [_user_text_only(1, channel=CHAN_A, content="hello")]
+        out = render_reorient_block(events, CHAN_A, model="model/vision", session_id=SESSION_ID)
+        assert isinstance(out, str)
+        assert "Recap: recent messages on" in out
+        assert "hello" in out
+
+    def test_no_model_kwargs_preserves_legacy_str_behavior(self, temp_workspace_root: Path) -> None:
+        """The pre-#226 callers pass only ``(events, target)``.  Without
+        ``model`` / ``session_id``, the recap stays string-only and any
+        image attachments degrade to text markers — the behavior the
+        code shipped with before this issue.
+        """
+        sandbox_path = _stage_image(temp_workspace_root, "signal", "evt-1-photo.jpg", b"jpg")
+        events = [
+            _user_with_image(
+                1,
+                channel=CHAN_A,
+                content="picture",
+                sandbox_path=sandbox_path,
+                size=3,
+            )
+        ]
+        out = render_reorient_block(events, CHAN_A)
+        assert isinstance(out, str)
+        assert "[image: photo.jpg" in out


### PR DESCRIPTION
## Summary

- Closes #226. Threads `(model, session_id)` through `render_reorient_block` → `_render_recap_event` → `render_user_event` so the existing `harness/vision.py` policy fires at recap-time the same way it does at arrival-time.
- New `_assemble_recap` helper composes the final tool-result content as a `list[dict]` of interleaved text + `image_url` parts when any peer user event on the target channel produces multimodal content. When no images surface (or kwargs are omitted), the recap stays a single `str` — bit-for-bit identical to before.
- `ToolResult.content` and `tool_dispatch.py` already accept `list[dict]` per the #216 stack — no plumbing changes downstream.

## Test plan

- [x] `tests/unit/test_switch_channel_recap_vision.py` — 5 new tests
  - inlinable image → content-parts list with `image_url` data URL
  - recap framing (`Recap:` / `End recap`) preserved around image
  - non-vision mind → `str` with text marker (same as before)
  - all-text recap unchanged
  - legacy no-kwargs caller → `str` (backwards compat)
- [x] Existing 24 tests in `test_switch_channel.py` unchanged + still passing
- [x] `uv run mypy src` clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` clean
- [x] `uv run pytest tests/unit -q` — 1137 pass
- [x] `DOCKER_HOST=… uv run pytest tests/integration tests/e2e -q` — 253 pass

## Reviewer notes (sub-50 observations)

Posting per memory's "post all findings" — none of these block:

- **Sev 35** (`switch_channel.py:399-403`): inter-message separator emits a stray empty `> ` line before image-only messages. Cosmetic; matches what the legacy text path produced for empty-paragraph separators between messages.
- **Sev 30** (`switch_channel.py:344`): `isinstance(content, (str, list))` is looser than the prior `isinstance(content, str)`. Acceptable per fail-hard convention; upstream contract already restricts shape.
- **Sev 25** (`test_switch_channel_recap_vision.py:46`): test mutates private `vision._VISION_OVERRIDES` with save/restore. Pre-existing pattern from `test_context_attachments.py` — a public helper would be cleaner if this duplicates further.

## Coverage gaps not pinned (follow-up candidates, not blocking)

- Multi-event mix: text-only event + image event in same window, asserting ordering.
- Image larger than `INLINE_SIZE_CAP_BYTES` on vision mind → text marker fallback (covered indirectly by the policy's existing `test_context_attachments.py` tests).
- Multiple images in a single peer event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)