### PR TITLE
feat(sandbox): pin pip/npm installs into /workspace (#227)

### DIFF
--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -93,6 +93,25 @@ PACKAGE_REGISTRY_HOSTS: frozenset[str] = frozenset(
 # the worker step path (per issue #179 / commit e675ed2).
 _DOCKER_CLI_TIMEOUT_S = 30.0
 
+# Bind-mounted ``/workspace`` is the only path that survives idle release;
+# pinning pip/npm installs into these subdirs lets long-lived sessions
+# stop re-installing pdfminer / jq-cli-wrapper / etc. on every cold
+# sandbox.  See issue #227 for the trade-offs vs PIP_TARGET / project-
+# local node_modules / derived images.
+_WORKSPACE_VENV = "/workspace/.venv"
+_WORKSPACE_NPM = "/workspace/.npm"
+_WORKSPACE_RUNTIME_ENV: dict[str, str] = {
+    "VIRTUAL_ENV": _WORKSPACE_VENV,
+    "NPM_CONFIG_PREFIX": _WORKSPACE_NPM,
+    "NODE_PATH": f"{_WORKSPACE_NPM}/lib/node_modules",
+    # Hardcoded system PATH because docker --env doesn't expand $PATH;
+    # the suffix matches the python:3.13-slim-bookworm image's default.
+    "PATH": (
+        f"{_WORKSPACE_VENV}/bin:{_WORKSPACE_NPM}/bin:"
+        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    ),
+}
+
 
 async def _run_docker(
     argv: list[str], *, timeout_s: float = _DOCKER_CLI_TIMEOUT_S
@@ -313,6 +332,7 @@ async def _provision_for_session_inner(
     )
 
     merged_env: dict[str, str] = {
+        **_WORKSPACE_RUNTIME_ENV,
         **(env_config.env if env_config and env_config.env else {}),
         **session_env,
     }
@@ -400,6 +420,7 @@ async def _provision_for_session_inner(
     )
 
     try:
+        await _ensure_workspace_runtime_dirs(handle, session_id)
         await _install_packages(handle, env_config, session_id)
         if needs_lockdown and isinstance(networking, LimitedNetworking):
             extra_host_ports: list[tuple[str, int]] = (
@@ -423,6 +444,37 @@ async def _provision_for_session_inner(
     )
 
     return handle
+
+
+async def _ensure_workspace_runtime_dirs(handle: ContainerHandle, session_id: str) -> None:
+    """Idempotently create ``/workspace/.venv`` and ``/workspace/.npm``.
+
+    Both live under the workspace bind mount so they survive idle
+    release; the venv pins ``pip install`` into a persistent
+    ``site-packages``, and the npm prefix pins ``npm install -g``.  The
+    ``[ -e .venv/bin/python ]`` guard makes venv creation a no-op on
+    every cold provision after the first.
+
+    Failures are logged but don't fail the provision — the model can
+    still operate without the persistence layer (it just falls back to
+    re-installing tools after each idle release, which is the pre-#227
+    behaviour).
+    """
+    settings = get_settings()
+    cmd = (
+        f"mkdir -p {_WORKSPACE_NPM}/lib {_WORKSPACE_NPM}/bin && "
+        f"([ -e {_WORKSPACE_VENV}/bin/python ] || python3 -m venv {_WORKSPACE_VENV})"
+    )
+    result = await handle.run_command(
+        cmd, timeout_seconds=60, max_output_bytes=settings.bash_max_output_bytes
+    )
+    if result.exit_code != 0:
+        log.warning(
+            "sandbox.workspace_runtime_dirs_setup_failed",
+            session_id=session_id,
+            exit_code=result.exit_code,
+            stderr=result.stderr[:500],
+        )
 
 
 async def _install_packages(

--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -158,8 +158,9 @@ async def switch_channel_handler(session_id: str, arguments: dict[str, Any]) -> 
 
         await queries.set_session_focal_channel(conn, session_id, target)
         all_events = await queries.read_message_events(conn, session_id)
+        model = await queries.get_session_model(conn, session_id)
 
-    content = render_reorient_block(all_events, target)
+    content = render_reorient_block(all_events, target, model=model, session_id=session_id)
     return ToolResult(
         content=content,
         metadata={
@@ -168,7 +169,13 @@ async def switch_channel_handler(session_id: str, arguments: dict[str, Any]) -> 
     )
 
 
-def render_reorient_block(all_events: list[Event], target: str) -> str:
+def render_reorient_block(
+    all_events: list[Event],
+    target: str,
+    *,
+    model: str | None = None,
+    session_id: str | None = None,
+) -> str | list[dict[str, Any]]:
     """Render the recap block for ``target`` from the event log.
 
     Pure function over the session's message events — no database
@@ -213,6 +220,15 @@ def render_reorient_block(all_events: list[Event], target: str) -> str:
     through the role=tool framing.  Leading ``>`` inside any rendered
     line is escaped to ``\\>`` so peer messages that start with a
     quote character don't collide with the block-quote syntax.
+
+    When ``model`` and ``session_id`` are both supplied and a peer
+    user event on ``target`` carries an inlinable image attachment,
+    the recap return type widens to a content-parts list — the
+    ``image_url`` parts sit between blockquoted text parts so the
+    agent reads "here's the historical text from the channel, and
+    here are the pixels they sent" inside one tool_result.  Without
+    those kwargs (legacy callers), the recap stays a single string
+    and image attachments degrade to text path markers.
     """
     switch_result_tcids = _switch_channel_tool_result_tcids(all_events)
     target_events = [
@@ -236,7 +252,7 @@ def render_reorient_block(all_events: list[Event], target: str) -> str:
     rendered_msgs: list[dict[str, Any]] = []
     token_total = 0
     for e in reversed(target_events):
-        msg = _render_recap_event(e)
+        msg = _render_recap_event(e, model=model, session_id=session_id)
         if msg is None:
             continue
         rendered_msgs.append(msg)
@@ -249,8 +265,7 @@ def render_reorient_block(all_events: list[Event], target: str) -> str:
         return f"Switched to {target}. (no prior messages on this channel)"
 
     rendered_msgs.reverse()
-    quoted_body = _blockquote("\n\n".join(m["content"] for m in rendered_msgs))
-    return f"━━━ Recap: recent messages on {target} ━━━\n{quoted_body}\n━━━ End recap ━━━"
+    return _assemble_recap(rendered_msgs, target)
 
 
 def _switch_channel_tool_result_tcids(all_events: list[Event]) -> set[str]:
@@ -276,7 +291,12 @@ def _switch_channel_tool_result_tcids(all_events: list[Event]) -> set[str]:
     return tcids
 
 
-def _render_recap_event(event: Event) -> dict[str, Any] | None:
+def _render_recap_event(
+    event: Event,
+    *,
+    model: str | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any] | None:
     """Render a single event into a chat-completions message dict for
     the recap body, or ``None`` if the event contributes nothing.
 
@@ -290,7 +310,12 @@ def _render_recap_event(event: Event) -> dict[str, Any] | None:
     User events go through :func:`render_user_event` with
     ``focal_at_arrival=orig_channel`` to force the full-content branch
     (we want headers and full bodies inside the recap, never truncated
-    notification markers).
+    notification markers).  When ``model`` and ``session_id`` are
+    threaded through, the same vision policy that applies at arrival
+    time also applies here: inlinable images on the target channel
+    surface as ``image_url`` content parts inside the user message,
+    and :func:`_assemble_recap` then lifts them out into the recap's
+    top-level content-parts list.
 
     Assistant events drop their text content entirely and render only
     their tool_calls — ``[you called: name(args), ...]`` (second
@@ -311,17 +336,15 @@ def _render_recap_event(event: Event) -> dict[str, Any] | None:
     role = event.data.get("role") if event.kind == "message" else None
 
     if role == "user":
-        # Recap rendering is intentionally text-only: ``model``/``session_id``
-        # are not threaded through, so :func:`render_user_event` short-circuits
-        # any image inlining and emits text markers for every attachment.
-        # The recap body is consumed inside a ``switch_channel`` tool result
-        # (string content), where ``image_url`` parts wouldn't survive the
-        # tool-message envelope; degrading attachments to markers keeps the
-        # recap a single text blob that the agent can read or follow up on
-        # via the in-sandbox path.
-        rendered = render_user_event(event.data, event.orig_channel, event.orig_channel)
+        rendered = render_user_event(
+            event.data,
+            event.orig_channel,
+            event.orig_channel,
+            model=model,
+            session_id=session_id,
+        )
         content = rendered.get("content")
-        if not isinstance(content, str) or not content:
+        if not content or not isinstance(content, (str, list)):
             return None
         return {"role": "user", "content": content}
 
@@ -343,6 +366,51 @@ def _render_recap_event(event: Event) -> dict[str, Any] | None:
         }
 
     return None
+
+
+def _assemble_recap(rendered_msgs: list[dict[str, Any]], target: str) -> str | list[dict[str, Any]]:
+    """Compose rendered recap messages into the final tool-result content.
+
+    All-text rendered_msgs preserve the legacy ``str`` shape bit-for-bit
+    so sessions that never produce inlinable content see no behavior
+    change.  When any user message rendered as a content-parts list,
+    the result widens to a content-parts list with ``image_url`` parts
+    interleaved between the surrounding blockquoted text — the agent
+    reads the historical framing and the pixels in their original
+    conversational order.
+    """
+    if not any(isinstance(m["content"], list) for m in rendered_msgs):
+        quoted_body = _blockquote("\n\n".join(m["content"] for m in rendered_msgs))
+        return f"━━━ Recap: recent messages on {target} ━━━\n{quoted_body}\n━━━ End recap ━━━"
+
+    parts: list[dict[str, Any]] = [
+        {"type": "text", "text": f"━━━ Recap: recent messages on {target} ━━━"}
+    ]
+    text_buf: list[str] = []
+
+    def flush_text() -> None:
+        if not text_buf:
+            return
+        parts.append({"type": "text", "text": _blockquote("\n".join(text_buf))})
+        text_buf.clear()
+
+    for i, msg in enumerate(rendered_msgs):
+        content = msg["content"]
+        if i > 0:
+            text_buf.append("")
+        if isinstance(content, str):
+            text_buf.append(content)
+            continue
+        for sub in content:
+            if sub.get("type") == "image_url":
+                flush_text()
+                parts.append(sub)
+            elif sub.get("type") == "text":
+                text_buf.append(sub.get("text", ""))
+
+    flush_text()
+    parts.append({"type": "text", "text": "━━━ End recap ━━━"})
+    return parts
 
 
 def _render_tool_calls(tool_calls: list[dict[str, Any]]) -> str:

--- a/tests/unit/test_switch_channel_recap_vision.py
+++ b/tests/unit/test_switch_channel_recap_vision.py
@@ -1,0 +1,231 @@
+"""Vision-aware behaviour for :func:`render_reorient_block` (issue #226).
+
+When the model bound to a session is vision-capable and a peer event
+on the target channel carries inlinable image attachments, the recap
+must surface those images as ``image_url`` content parts — not just
+text path markers.  Without this, multi-channel sessions silently lose
+vision on every non-focal image: arrival-time inlining only fires
+while the channel is focal, so the only chance to surface pixels
+across a ``switch_channel`` call is here.
+
+The arrival-time path lives in
+:func:`aios.harness.context.render_user_event` and is exercised by
+``test_context_attachments.py``; this file pins the recap-time path,
+which reuses the same vision policy via ``model``/``session_id``.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aios.config import get_settings
+from aios.harness import vision
+from aios.models.events import Event
+from aios.sandbox.volumes import session_attachments_dir
+from aios.tools.switch_channel import render_reorient_block
+
+CHAN_A = "signal/acct/chat-a"
+CHAN_B = "signal/acct/chat-b"
+SESSION_ID = "sess-test"
+
+
+@pytest.fixture
+def temp_workspace_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _stub_supports_vision(monkeypatch: pytest.MonkeyPatch) -> Any:
+    saved = dict(vision._VISION_OVERRIDES)
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES["model/vision"] = True
+    vision._VISION_OVERRIDES["model/text"] = False
+    yield
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES.update(saved)
+
+
+def _stage_image(workspace_root: Path, connector: str, name: str, payload: bytes) -> str:
+    session_dir = session_attachments_dir(SESSION_ID) / connector
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / name).write_bytes(payload)
+    return f"/mnt/attachments/{connector}/{name}"
+
+
+def _user_with_image(
+    seq: int,
+    *,
+    channel: str,
+    content: str,
+    sandbox_path: str,
+    filename: str = "photo.jpg",
+    content_type: str = "image/jpeg",
+    size: int = 9,
+) -> Event:
+    return Event(
+        id=f"evt_{seq:04d}",
+        session_id=SESSION_ID,
+        seq=seq,
+        kind="message",
+        data={
+            "role": "user",
+            "content": content,
+            "metadata": {
+                "channel": channel,
+                "sender_name": "Peer",
+                "timestamp_ms": 1000 + seq,
+                "attachments": [
+                    {
+                        "filename": filename,
+                        "content_type": content_type,
+                        "size": size,
+                        "in_sandbox_path": sandbox_path,
+                    }
+                ],
+            },
+        },
+        cumulative_tokens=None,
+        created_at=datetime(2026, 4, 20, tzinfo=UTC),
+        orig_channel=channel,
+        focal_channel_at_arrival=channel,
+        channel=channel,
+    )
+
+
+def _user_text_only(seq: int, *, channel: str, content: str) -> Event:
+    return Event(
+        id=f"evt_{seq:04d}",
+        session_id=SESSION_ID,
+        seq=seq,
+        kind="message",
+        data={
+            "role": "user",
+            "content": content,
+            "metadata": {
+                "channel": channel,
+                "sender_name": "Peer",
+                "timestamp_ms": 1000 + seq,
+            },
+        },
+        cumulative_tokens=None,
+        created_at=datetime(2026, 4, 20, tzinfo=UTC),
+        orig_channel=channel,
+        focal_channel_at_arrival=channel,
+        channel=channel,
+    )
+
+
+class TestRecapVision:
+    def test_inlinable_image_emits_image_url_content_part(self, temp_workspace_root: Path) -> None:
+        """A peer image on the target channel must appear as an
+        ``image_url`` content part in the recap when the bound mind
+        supports vision and the image fits the inline cap.  The recap
+        return type widens from ``str`` to a content-parts list to
+        carry the multimodal payload.
+        """
+        payload = b"jpegbytes"
+        sandbox_path = _stage_image(temp_workspace_root, "signal", "evt-1-photo.jpg", payload)
+        events = [
+            _user_with_image(
+                1,
+                channel=CHAN_A,
+                content="check this out",
+                sandbox_path=sandbox_path,
+                size=len(payload),
+            )
+        ]
+        out = render_reorient_block(events, CHAN_A, model="model/vision", session_id=SESSION_ID)
+        assert isinstance(out, list), (
+            f"recap with inlinable image must return content-parts list, got {type(out).__name__}"
+        )
+        image_parts = [p for p in out if p.get("type") == "image_url"]
+        assert len(image_parts) == 1, f"expected one image_url part, got {image_parts!r}"
+        assert image_parts[0]["image_url"]["url"] == (
+            f"data:image/jpeg;base64,{base64.b64encode(payload).decode()}"
+        )
+
+    def test_image_recap_preserves_recap_framing_and_caption(
+        self, temp_workspace_root: Path
+    ) -> None:
+        """The text parts surrounding the image must still carry the
+        ``Recap: recent messages on <target>`` header, the peer
+        message's text caption, and the ``End recap`` footer.  The
+        image content block sits between the framing text parts so
+        the model reads "this is historical content from the channel,
+        and here's the picture they sent".
+        """
+        sandbox_path = _stage_image(temp_workspace_root, "signal", "evt-1-photo.jpg", b"PNGdata")
+        events = [
+            _user_with_image(
+                1,
+                channel=CHAN_A,
+                content="look at this banana",
+                sandbox_path=sandbox_path,
+                size=7,
+            )
+        ]
+        out = render_reorient_block(events, CHAN_A, model="model/vision", session_id=SESSION_ID)
+        assert isinstance(out, list)
+        text_blob = "\n".join(p["text"] for p in out if p.get("type") == "text")
+        assert f"Recap: recent messages on {CHAN_A}" in text_blob
+        assert "End recap" in text_blob
+        assert "look at this banana" in text_blob
+
+    def test_non_vision_model_returns_str_with_text_marker(self, temp_workspace_root: Path) -> None:
+        """Vision-incapable mind: recap stays a single ``str`` and the
+        attachment is rendered as a text path marker, same policy as
+        arrival-time rendering in ``render_user_event``.
+        """
+        sandbox_path = _stage_image(temp_workspace_root, "signal", "evt-1-photo.jpg", b"jpg")
+        events = [
+            _user_with_image(
+                1,
+                channel=CHAN_A,
+                content="picture",
+                sandbox_path=sandbox_path,
+                size=3,
+            )
+        ]
+        out = render_reorient_block(events, CHAN_A, model="model/text", session_id=SESSION_ID)
+        assert isinstance(out, str)
+        assert "[image: photo.jpg" in out
+        assert sandbox_path in out
+
+    def test_text_only_recap_unchanged(self) -> None:
+        """No attachments on any window event: recap returns a ``str``
+        with the same framing as before.  This is the no-images
+        backwards-compat path — vision plumbing must not change the
+        output for sessions that never produce inlinable content.
+        """
+        events = [_user_text_only(1, channel=CHAN_A, content="hello")]
+        out = render_reorient_block(events, CHAN_A, model="model/vision", session_id=SESSION_ID)
+        assert isinstance(out, str)
+        assert "Recap: recent messages on" in out
+        assert "hello" in out
+
+    def test_no_model_kwargs_preserves_legacy_str_behavior(self, temp_workspace_root: Path) -> None:
+        """The pre-#226 callers pass only ``(events, target)``.  Without
+        ``model`` / ``session_id``, the recap stays string-only and any
+        image attachments degrade to text markers — the behavior the
+        code shipped with before this issue.
+        """
+        sandbox_path = _stage_image(temp_workspace_root, "signal", "evt-1-photo.jpg", b"jpg")
+        events = [
+            _user_with_image(
+                1,
+                channel=CHAN_A,
+                content="picture",
+                sandbox_path=sandbox_path,
+                size=3,
+            )
+        ]
+        out = render_reorient_block(events, CHAN_A)
+        assert isinstance(out, str)
+        assert "[image: photo.jpg" in out

--- a/tests/unit/test_workspace_runtime_dirs.py
+++ b/tests/unit/test_workspace_runtime_dirs.py
@@ -1,0 +1,168 @@
+"""Sandbox provisioner pins language-package installs into /workspace (#227).
+
+Tools the model installs at runtime (``pip install``, ``npm install -g``)
+land in the container's writable layer by default, which gets reclaimed
+on ``sandbox.idle_release``.  By pre-creating ``/workspace/.venv`` and
+``/workspace/.npm`` at every provision and setting the matching env
+vars (``VIRTUAL_ENV``, ``NPM_CONFIG_PREFIX``, ``NODE_PATH``, ``PATH``),
+those installs land inside the bind mount and survive idle release.
+
+These tests exercise the provisioner's docker-run argv composition and
+the post-start setup that creates the runtime dirs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aios.models.environments import EnvironmentConfig
+from aios.sandbox.container import CommandResult
+
+
+def _env_dict_from_argv(argv: list[str]) -> dict[str, str]:
+    """Extract --env KEY=VALUE pairs from a docker run argv into a dict.
+
+    Later occurrences win, matching docker's last-flag-wins semantics.
+    """
+    out: dict[str, str] = {}
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--env" and i + 1 < len(argv):
+            key, _, value = argv[i + 1].partition("=")
+            out[key] = value
+            i += 2
+        else:
+            i += 1
+    return out
+
+
+async def _capture_provision_argv(
+    *,
+    env_config: EnvironmentConfig | None = None,
+    session_env: dict[str, str] | None = None,
+) -> tuple[list[str], list[tuple[tuple[Any, ...], dict[str, Any]]]]:
+    """Run provision_for_session under heavy mock; return docker run argv
+    and the run_command call list (for inspecting the post-start setup).
+    """
+    from aios.sandbox.container import ContainerHandle
+
+    captured_argv: list[list[str]] = []
+    captured_run_commands: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def fake_run_docker(argv: list[str]) -> tuple[int, bytes, bytes]:
+        captured_argv.append(argv)
+        return 0, b"container_abc123\n", b""
+
+    async def fake_run_command(self: ContainerHandle, command: str, **kwargs: Any) -> CommandResult:
+        captured_run_commands.append(((command,), kwargs))
+        return CommandResult(exit_code=0, stdout="", stderr="", timed_out=False, truncated=False)
+
+    with (
+        patch.object(ContainerHandle, "run_command", fake_run_command),
+        patch(
+            "aios.sandbox.provisioner._load_environment_config",
+            AsyncMock(return_value=env_config),
+        ),
+        patch("aios.sandbox.provisioner._run_docker", fake_run_docker),
+        patch(
+            "aios.sandbox.provisioner._load_session_provisioning",
+            AsyncMock(return_value=("/tmp/ws", session_env or {})),
+        ),
+        patch(
+            "aios.sandbox.provisioner._materialize_memory_mounts",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "aios.sandbox.provisioner._materialize_github_clones",
+            AsyncMock(return_value=([], None)),
+        ),
+        patch("aios.sandbox.volumes.ensure_workspace_path", return_value=Path("/tmp/ws")),
+        patch(
+            "aios.sandbox.volumes.ensure_session_attachments_dir",
+            return_value=Path("/tmp/attachments"),
+        ),
+    ):
+        from aios.sandbox.provisioner import provision_for_session
+
+        await provision_for_session("sess_01TEST")
+
+    return captured_argv[0], captured_run_commands
+
+
+class TestWorkspaceRuntimeEnv:
+    @pytest.mark.asyncio
+    async def test_default_env_includes_venv_and_npm_pins(self) -> None:
+        """Default provision (no env_config) sets VIRTUAL_ENV / NPM_CONFIG_PREFIX
+        / NODE_PATH / PATH so language-package installs land inside the bind
+        mount.
+        """
+        argv, _ = await _capture_provision_argv()
+        env = _env_dict_from_argv(argv)
+
+        assert env["VIRTUAL_ENV"] == "/workspace/.venv"
+        assert env["NPM_CONFIG_PREFIX"] == "/workspace/.npm"
+        assert env["NODE_PATH"] == "/workspace/.npm/lib/node_modules"
+
+    @pytest.mark.asyncio
+    async def test_path_prepends_venv_and_npm_bin(self) -> None:
+        """PATH must put /workspace/.venv/bin and /workspace/.npm/bin BEFORE
+        system bin dirs so the venv's python and npm-installed tools resolve
+        ahead of the image's defaults.
+        """
+        argv, _ = await _capture_provision_argv()
+        env = _env_dict_from_argv(argv)
+
+        path_segments = env["PATH"].split(":")
+        assert path_segments[0] == "/workspace/.venv/bin"
+        assert path_segments[1] == "/workspace/.npm/bin"
+        assert "/usr/local/bin" in path_segments
+        assert "/usr/bin" in path_segments
+
+    @pytest.mark.asyncio
+    async def test_user_env_overrides_runtime_pins(self) -> None:
+        """env_config.env wins over the runtime-pin defaults so operators
+        can opt out (e.g. a session that needs a different VIRTUAL_ENV).
+        """
+        argv, _ = await _capture_provision_argv(
+            env_config=EnvironmentConfig(env={"VIRTUAL_ENV": "/custom/venv"})
+        )
+        env = _env_dict_from_argv(argv)
+
+        assert env["VIRTUAL_ENV"] == "/custom/venv"
+        assert env["NPM_CONFIG_PREFIX"] == "/workspace/.npm"
+
+
+class TestWorkspaceRuntimeDirsSetup:
+    @pytest.mark.asyncio
+    async def test_post_start_creates_venv_and_npm_dirs(self) -> None:
+        """After docker run, the provisioner runs a setup command that
+        creates ``/workspace/.venv`` (via python3 -m venv) and the
+        ``/workspace/.npm/{lib,bin}`` dirs.
+        """
+        _, run_commands = await _capture_provision_argv()
+
+        cmds = [pargs[0] for pargs, _pkwargs in run_commands]
+        joined = "\n".join(cmds)
+
+        assert "python3 -m venv /workspace/.venv" in joined
+        assert "/workspace/.npm/lib" in joined
+        assert "/workspace/.npm/bin" in joined
+
+    @pytest.mark.asyncio
+    async def test_venv_creation_is_idempotent(self) -> None:
+        """The setup command must not re-run python3 -m venv when the venv
+        already exists (would error out / waste cycles on every cold
+        provision).  A ``[ -e .venv/bin/python ] || python3 -m venv``
+        guard handles this in one shell call.
+        """
+        _, run_commands = await _capture_provision_argv()
+
+        cmds = [pargs[0] for pargs, _pkwargs in run_commands]
+        joined = "\n".join(cmds)
+
+        assert "[ -e /workspace/.venv/bin/python ]" in joined
+        assert "||" in joined


### PR DESCRIPTION
## Summary

- Closes #227. Pre-creates `/workspace/.venv` and `/workspace/.npm/{lib,bin}` at every sandbox provision so language-package installs land in the workspace bind mount and survive `sandbox.idle_release`. Setting `VIRTUAL_ENV` / `NPM_CONFIG_PREFIX` / `NODE_PATH` / `PATH` on the docker run argv makes `pip install foo` and `npm install -g foo` route through the persistent paths automatically.
- Uses `[ -e /workspace/.venv/bin/python ]` guard so `python3 -m venv` is a no-op on every cold provision after the first (and self-repairs partial-init failures).
- `env_config.env` still wins over the defaults so operators can opt out.

## Test plan

- [x] `tests/unit/test_workspace_runtime_dirs.py` — 5 new tests
  - default env includes `VIRTUAL_ENV`, `NPM_CONFIG_PREFIX`, `NODE_PATH` pins
  - `PATH` prepends venv bin and npm bin before system bin dirs
  - user env overrides the runtime pins
  - post-start runs `python3 -m venv` and creates `/workspace/.npm/{lib,bin}`
  - venv creation guarded by `[ -e .venv/bin/python ]` for idempotency
- [x] `uv run pytest tests/unit -q` — 1142 pass
- [x] `uv run mypy src` clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` clean
- [x] `DOCKER_HOST=… uv run pytest tests/integration tests/e2e -q` — 253 pass

## Reviewer notes (sub-50 observations)

Posting per memory's "post all findings":

- **Sev 35** (test scaffolding): the heavy-mock ladder for `provision_for_session` is duplicated between `test_networking.py` and the new `test_workspace_runtime_dirs.py`. Two callsites is the threshold where extracting a `_provision_under_mocks` fixture into `tests/unit/conftest.py` starts paying. Follow-up, not blocking.
- **Sev 30** (PATH drift): the hardcoded `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` matches `python:3.13-slim-bookworm`'s default. If the base image changes (e.g. to `slim-trixie` adding `/opt/foo/bin`), it disappears for sessions silently. An e2e smoke that asserts system bins are reachable inside a fresh sandbox would catch drift; not in scope here.
- **Sev 20** (idempotency anchor): `[ -e .venv/bin/python ]` checks the binary not the dir. Issue body says "if they don't exist," but binary-level guard is stricter and self-repairs partial-init failures (interrupted `python3 -m venv` leaves the dir without a working `python`). Defensible.

## Out of scope (per #227 §"Out of scope")

- apt / system-package persistence — `/var/lib/dpkg`, `/usr/bin` can't be redirected into `/workspace`; needs derived images.
- Cross-session sharing of installs — each session keeps its own `.venv`, intentional.
- Auto-`requirements.txt` discovery — separate follow-up.
- Pre-baking common packages into a derived image — separate optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)