### PR TITLE
feat(github): optional git identity fields on github_repository (#207)

### DIFF
--- a/migrations/versions/0028_github_repo_git_identity.py
+++ b/migrations/versions/0028_github_repo_git_identity.py
@@ -1,0 +1,40 @@
+"""Optional git identity (user.name / user.email) on github_repository.
+
+Per #207, an attached repo can carry a deterministic git identity that
+the sandbox stamps via ``git config`` after clone.  Both columns are
+nullable text — absent means "no identity configured" (the v1 default,
+preserved for callers that don't supply them).
+
+Not encrypted: name and email aren't secrets.
+
+Revision ID: 0028
+Revises: 0027
+Create Date: 2026-05-05
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0028"
+down_revision: str = "0027"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE session_github_repositories "
+        "ADD COLUMN git_user_name text, "
+        "ADD COLUMN git_user_email text"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE session_github_repositories "
+        "DROP COLUMN IF EXISTS git_user_email, "
+        "DROP COLUMN IF EXISTS git_user_name"
+    )

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -184,12 +184,22 @@ async def update_resource(
     working tree with the new token.
     """
     _require_github_resource_id(resource_id)
+    # Identity is replaced atomically when the caller mentions either
+    # field in the payload; absent means preserve the stored values
+    # (the common token-only rotation must not silently clear identity).
+    fields_set = body.model_fields_set
+    identity = (
+        (body.git_user_name, body.git_user_email)
+        if "git_user_name" in fields_set or "git_user_email" in fields_set
+        else None
+    )
     return await github_repo_service.rotate_token(
         pool,
         crypto_box,
         session_id=session_id,
         resource_id=resource_id,
         new_token=body.authorization_token.get_secret_value(),
+        identity=identity,
     )
 
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -3575,29 +3575,33 @@ def _row_to_github_repo_echo(row: asyncpg.Record) -> GithubRepositoryResourceEch
         mount_path=row["mount_path"],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
+        git_user_name=row["git_user_name"],
+        git_user_email=row["git_user_email"],
     )
 
 
 async def attach_github_repos_to_session(
     conn: asyncpg.Connection[Any],
     session_id: str,
-    entries: list[tuple[str, str, EncryptedBlob]],
+    entries: list[tuple[str, str, EncryptedBlob, str | None, str | None]],
 ) -> None:
     """Insert pre-encrypted github_repository attachments for a session.
 
-    ``entries`` is ``(repo_url, mount_path, encrypted_token)`` tuples in
-    rank order. Encryption is the caller's responsibility (service layer
-    holds the CryptoBox). Uniqueness on (session_id, mount_path) is
-    enforced by the partial unique index — a duplicate raises asyncpg's
+    ``entries`` is ``(repo_url, mount_path, encrypted_token,
+    git_user_name, git_user_email)`` tuples in rank order. Encryption is
+    the caller's responsibility (service layer holds the CryptoBox).
+    Uniqueness on (session_id, mount_path) is enforced by the partial
+    unique index — a duplicate raises asyncpg's
     ``UniqueViolationError`` which the service layer maps to a 4xx.
     """
-    for rank, (repo_url, mount_path, blob) in enumerate(entries):
+    for rank, (repo_url, mount_path, blob, git_user_name, git_user_email) in enumerate(entries):
         rid = make_id(GITHUB_REPOSITORY)
         await conn.execute(
             """
             INSERT INTO session_github_repositories
-                (id, session_id, rank, repo_url, mount_path, ciphertext, nonce)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+                (id, session_id, rank, repo_url, mount_path, ciphertext, nonce,
+                 git_user_name, git_user_email)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             """,
             rid,
             session_id,
@@ -3606,6 +3610,8 @@ async def attach_github_repos_to_session(
             mount_path,
             blob.ciphertext,
             blob.nonce,
+            git_user_name,
+            git_user_email,
         )
 
 
@@ -3660,26 +3666,50 @@ async def update_session_github_repo_blob(
     session_id: str,
     resource_id: str,
     blob: EncryptedBlob,
+    *,
+    identity: tuple[str | None, str | None] | None = None,
 ) -> GithubRepositoryResourceEcho:
     """Replace the encrypted token blob and bump ``updated_at``.
 
-    Only the secret rotates; ``url`` and ``mount_path`` are immutable to
-    match CMA's behavior (verified by API probe — PUT returns 405,
-    DELETE returns 400, only POST with ``{authorization_token}`` is
-    accepted).
+    ``url`` and ``mount_path`` are immutable to match CMA's behavior
+    (verified by API probe — PUT returns 405, DELETE returns 400, only
+    POST with ``{authorization_token}`` is accepted).  ``identity`` is
+    ``None`` to preserve the existing ``git_user_name`` /
+    ``git_user_email`` (the common token-only rotation), or a
+    ``(name, email)`` tuple to replace both fields atomically — either
+    component may itself be ``None`` to clear that column.
     """
-    row = await conn.fetchrow(
-        """
-        UPDATE session_github_repositories
-        SET ciphertext = $1, nonce = $2, updated_at = now()
-        WHERE session_id = $3 AND id = $4
-        RETURNING *
-        """,
-        blob.ciphertext,
-        blob.nonce,
-        session_id,
-        resource_id,
-    )
+    if identity is None:
+        row = await conn.fetchrow(
+            """
+            UPDATE session_github_repositories
+            SET ciphertext = $1, nonce = $2, updated_at = now()
+            WHERE session_id = $3 AND id = $4
+            RETURNING *
+            """,
+            blob.ciphertext,
+            blob.nonce,
+            session_id,
+            resource_id,
+        )
+    else:
+        git_user_name, git_user_email = identity
+        row = await conn.fetchrow(
+            """
+            UPDATE session_github_repositories
+            SET ciphertext = $1, nonce = $2,
+                git_user_name = $3, git_user_email = $4,
+                updated_at = now()
+            WHERE session_id = $5 AND id = $6
+            RETURNING *
+            """,
+            blob.ciphertext,
+            blob.nonce,
+            git_user_name,
+            git_user_email,
+            session_id,
+            resource_id,
+        )
     if row is None:
         raise NotFoundError(
             f"github_repository resource {resource_id} not found on session {session_id}",

--- a/src/aios/models/github_repositories.py
+++ b/src/aios/models/github_repositories.py
@@ -48,6 +48,12 @@ class GithubRepositoryResource(BaseModel):
     The ``authorization_token`` is a write-only ``SecretStr`` — present on
     request, encrypted on the way to the DB, and never returned in API
     responses (see :class:`GithubRepositoryResourceEcho`).
+
+    ``git_user_name`` / ``git_user_email`` are optional and stamped via
+    ``git config`` after clone so commits made inside the sandbox carry
+    a deterministic identity per resource without the agent needing to
+    self-correct from git's "Please tell me who you are" error.  Absent
+    means "no identity configured" — the v1 default.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -56,6 +62,8 @@ class GithubRepositoryResource(BaseModel):
     url: str = Field(min_length=1)
     mount_path: str = Field(min_length=2, max_length=4096, pattern=_MOUNT_PATH_PATTERN)
     authorization_token: SecretStr
+    git_user_name: str | None = Field(default=None, max_length=256)
+    git_user_email: str | None = Field(default=None, max_length=256)
 
     @model_validator(mode="after")
     def _check(self) -> GithubRepositoryResource:
@@ -70,7 +78,8 @@ class GithubRepositoryResourceEcho(BaseModel):
     ``Session.resources`` and on the per-resource sub-collection endpoints.
 
     Token is intentionally absent; ``id`` is the per-attachment ULID
-    (prefix ``ghrepo``) used by the rotation endpoint.
+    (prefix ``ghrepo``) used by the rotation endpoint.  ``git_user_name``
+    / ``git_user_email`` echo back as plaintext (they aren't secrets).
     """
 
     type: Literal["github_repository"] = "github_repository"
@@ -79,18 +88,25 @@ class GithubRepositoryResourceEcho(BaseModel):
     mount_path: str
     created_at: datetime
     updated_at: datetime
+    git_user_name: str | None = None
+    git_user_email: str | None = None
 
 
 class GithubRepositoryUpdate(BaseModel):
     """Request body for ``POST /v1/sessions/{sid}/resources/{rid}``.
 
-    Only the token rotates. ``url`` and ``mount_path`` are immutable after
-    creation — to change them, detach the resource and attach a new one.
+    Token rotation is the primary action; ``git_user_name`` /
+    ``git_user_email`` may also be supplied alongside, in which case the
+    stored identity is replaced.  ``url`` and ``mount_path`` are
+    immutable after creation — to change them, detach the resource and
+    attach a new one.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     authorization_token: SecretStr
+    git_user_name: str | None = Field(default=None, max_length=256)
+    git_user_email: str | None = Field(default=None, max_length=256)
 
     @model_validator(mode="after")
     def _check(self) -> GithubRepositoryUpdate:

--- a/src/aios/sandbox/github_clone.py
+++ b/src/aios/sandbox/github_clone.py
@@ -206,6 +206,8 @@ async def ensure_session_working_tree(
     token: str,
     cache_dir: Path,
     proxy_url: str,
+    git_user_name: str | None = None,
+    git_user_email: str | None = None,
 ) -> Path:
     """Create a per-session working tree from the cache, then rewrite
     ``origin`` to point at the per-session ``GitProxy`` URL so the
@@ -217,6 +219,13 @@ async def ensure_session_working_tree(
     snapshot) takes effect on the next provision without any "is this
     stale?" detection logic. The ``--reference`` clone is fast because
     object data is reused from the cache.
+
+    When ``git_user_name`` and/or ``git_user_email`` are set, the
+    resulting working tree's ``.git/config`` is stamped via
+    ``git config`` so commits inside the sandbox carry that identity
+    without the agent self-correcting from git's "Please tell me who
+    you are" error (#207).  Both ``None`` means "no identity
+    configured" — pre-#207 v1 behavior, preserved.
     """
     work_dir = session_repo_working_tree_dir(session_id, resource_id)
     session_repos_root(session_id).mkdir(parents=True, exist_ok=True)
@@ -262,6 +271,18 @@ async def ensure_session_working_tree(
             f"failed to scrub origin URL for session {session_id} repo {resource_id}: "
             f"{_redact_token_from_message(stderr.decode('utf-8', errors='replace'), token)}"
         )
+
+    for key, value in (("user.name", git_user_name), ("user.email", git_user_email)):
+        if value is None:
+            continue
+        rc, _stdout, stderr = await _run_git(
+            ["config", key, value], cwd=work_dir, op=f"config {key}"
+        )
+        if rc != 0:
+            raise GithubCloneError(
+                f"failed to set git {key} for session {session_id} repo {resource_id}: "
+                f"{stderr.decode('utf-8', errors='replace')}"
+            )
 
     log.info(
         "github_clone.session_clone_created",

--- a/src/aios/sandbox/provisioner.py
+++ b/src/aios/sandbox/provisioner.py
@@ -230,6 +230,8 @@ async def _materialize_github_clones(
                 token=token,
                 cache_dir=cache_dir,
                 proxy_url=proxy.proxy_url(echo.url, host=_PROXY_HOST_ALIAS),
+                git_user_name=echo.git_user_name,
+                git_user_email=echo.git_user_email,
             )
         except GithubCloneError as err:
             failures.append((echo, err))

--- a/src/aios/services/github_repositories.py
+++ b/src/aios/services/github_repositories.py
@@ -62,10 +62,10 @@ async def attach_to_session(
     """
     if not resources:
         return
-    entries: list[tuple[str, str, Any]] = []
+    entries: list[tuple[str, str, Any, str | None, str | None]] = []
     for res in resources:
         blob = _encrypt_token(crypto_box, res.authorization_token.get_secret_value())
-        entries.append((res.url, res.mount_path, blob))
+        entries.append((res.url, res.mount_path, blob, res.git_user_name, res.git_user_email))
     try:
         await queries.attach_github_repos_to_session(conn, session_id, entries)
     except asyncpg.UniqueViolationError as exc:
@@ -133,16 +133,26 @@ async def rotate_token(
     session_id: str,
     resource_id: str,
     new_token: str,
+    identity: tuple[str | None, str | None] | None = None,
 ) -> GithubRepositoryResourceEcho:
-    """Update only the encrypted token; ``url`` and ``mount_path`` remain.
+    """Update the encrypted token (and optionally the git identity);
+    ``url`` and ``mount_path`` remain.
 
-    Decrypt-merge-encrypt isn't actually needed here (we store only the
-    token, not a payload of multiple fields), so this is a single
-    encrypt-then-update. The transaction guards against torn writes.
+    ``identity`` is ``None`` to preserve the existing identity (the
+    common token-only rotation) or a ``(name, email)`` tuple to replace
+    both fields atomically.  Token-only callers leave ``identity``
+    unset and the stored ``git_user_name`` / ``git_user_email`` survive
+    the rotation.
     """
     blob = _encrypt_token(crypto_box, new_token)
     async with pool.acquire() as conn, conn.transaction():
-        return await queries.update_session_github_repo_blob(conn, session_id, resource_id, blob)
+        return await queries.update_session_github_repo_blob(
+            conn,
+            session_id,
+            resource_id,
+            blob,
+            identity=identity,
+        )
 
 
 async def get_session_token(

--- a/tests/e2e/test_github_repositories.py
+++ b/tests/e2e/test_github_repositories.py
@@ -228,6 +228,116 @@ class TestServiceLayer:
         assert recovered == new_token
         assert recovered != first_token
 
+    async def test_git_identity_round_trip(
+        self, pool: Any, crypto_box: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        """Identity supplied at create-time persists through the DB and
+        echoes back on read.  Rotation overwrites it."""
+        env_id, agent_id = env_and_agent
+        session = await sessions_service.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            resources=[
+                GithubRepositoryResource.model_validate(
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": _pat(),
+                        "git_user_name": "Agent JN",
+                        "git_user_email": "agent+jn@example.com",
+                    }
+                )
+            ],
+            crypto_box=crypto_box,
+        )
+        echo = session.resources[0]
+        assert echo.git_user_name == "Agent JN"
+        assert echo.git_user_email == "agent+jn@example.com"
+
+        rotated = await github_service.rotate_token(
+            pool,
+            crypto_box,
+            session_id=session.id,
+            resource_id=echo.id,
+            new_token=_pat(),
+            identity=("Different Author", "other@example.com"),
+        )
+        assert rotated.git_user_name == "Different Author"
+        assert rotated.git_user_email == "other@example.com"
+
+    async def test_token_only_rotation_preserves_identity(
+        self, pool: Any, crypto_box: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        """Rotating just the PAT (no identity payload) must NOT silently
+        clear a previously configured ``git_user_name`` / ``git_user_email``.
+        The router omits ``identity`` from the service call when the
+        update body has no identity fields set.
+        """
+        env_id, agent_id = env_and_agent
+        session = await sessions_service.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            resources=[
+                GithubRepositoryResource.model_validate(
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": _pat(),
+                        "git_user_name": "Agent JN",
+                        "git_user_email": "agent+jn@example.com",
+                    }
+                )
+            ],
+            crypto_box=crypto_box,
+        )
+        echo = session.resources[0]
+
+        rotated = await github_service.rotate_token(
+            pool,
+            crypto_box,
+            session_id=session.id,
+            resource_id=echo.id,
+            new_token=_pat(),
+        )
+        assert rotated.git_user_name == "Agent JN"
+        assert rotated.git_user_email == "agent+jn@example.com"
+
+    async def test_git_identity_optional_defaults_none(
+        self, pool: Any, crypto_box: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        """Identity unset on create stays NULL through the DB and echoes
+        back as ``None`` — pre-#207 v1 behaviour preserved."""
+        env_id, agent_id = env_and_agent
+        session = await sessions_service.create_session(
+            pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            resources=[
+                GithubRepositoryResource.model_validate(
+                    {
+                        "type": "github_repository",
+                        "url": _OCTOCAT_REPO,
+                        "mount_path": "/workspace/repo",
+                        "authorization_token": _pat(),
+                    }
+                )
+            ],
+            crypto_box=crypto_box,
+        )
+        echo = session.resources[0]
+        assert echo.git_user_name is None
+        assert echo.git_user_email is None
+
     async def test_full_list_replace_detaches_then_reattaches(
         self, pool: Any, crypto_box: Any, env_and_agent: tuple[str, str]
     ) -> None:

--- a/tests/unit/test_github_clone_identity.py
+++ b/tests/unit/test_github_clone_identity.py
@@ -1,0 +1,150 @@
+"""Sandbox clone configures the per-resource git identity (#207).
+
+When a ``github_repository`` attachment carries ``git_user_name`` /
+``git_user_email``, the per-session working tree's ``.git/config`` is
+stamped via ``git config user.name`` / ``git config user.email`` after
+the clone completes.  Subsequent ``git commit`` invocations from inside
+the sandbox attribute commits to that identity without the agent
+seeing or self-correcting from git's "Please tell me who you are"
+error.
+
+These tests pin the sandbox-side wiring (``ensure_session_working_tree``)
+without spinning up a real container — ``_run_git`` is patched so each
+``git`` invocation appears as a captured argv.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aios.sandbox.github_clone import ensure_session_working_tree
+
+
+@pytest.fixture
+def _stub_volumes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect the working-tree dirs into ``tmp_path`` so the test
+    doesn't touch the operator's real workspace."""
+    repos_root = tmp_path / "session-repos"
+
+    def fake_repos_root(_session_id: str) -> Path:
+        repos_root.mkdir(parents=True, exist_ok=True)
+        return repos_root
+
+    def fake_working_tree_dir(_session_id: str, resource_id: str) -> Path:
+        return repos_root / resource_id
+
+    monkeypatch.setattr("aios.sandbox.github_clone.session_repos_root", fake_repos_root)
+    monkeypatch.setattr(
+        "aios.sandbox.github_clone.session_repo_working_tree_dir", fake_working_tree_dir
+    )
+    return repos_root
+
+
+async def _run_with_captured_git(
+    *,
+    git_user_name: str | None,
+    git_user_email: str | None,
+    repos_root: Path,
+) -> list[list[str]]:
+    """Invoke ``ensure_session_working_tree`` with patched ``_run_git``;
+    return the captured argv list (one entry per ``git`` invocation).
+    """
+    captured: list[list[str]] = []
+
+    async def fake_run_git(
+        argv: list[str], *, cwd: Path | None = None, op: str = "git"
+    ) -> tuple[int, bytes, bytes]:
+        full_argv = ["git", *argv] if cwd is None else ["git", "-C", str(cwd), *argv]
+        captured.append(full_argv)
+        return 0, b"", b""
+
+    with patch("aios.sandbox.github_clone._run_git", fake_run_git):
+        await ensure_session_working_tree(
+            session_id="sess_01TEST",
+            resource_id="ghrepo_01ABC",
+            repo_url="https://github.com/octocat/Hello-World",
+            token="ghp_secret",
+            cache_dir=repos_root / "cache",
+            proxy_url="http://host.docker.internal:9090/o/r",
+            git_user_name=git_user_name,
+            git_user_email=git_user_email,
+        )
+    return captured
+
+
+class TestGitIdentityConfig:
+    @pytest.mark.asyncio
+    async def test_both_fields_set_runs_git_config_for_each(self, _stub_volumes: Path) -> None:
+        captured = await _run_with_captured_git(
+            git_user_name="Agent JN",
+            git_user_email="agent+jn@example.com",
+            repos_root=_stub_volumes,
+        )
+
+        config_calls = [c for c in captured if "config" in c]
+        assert any("user.name" in c and "Agent JN" in c for c in config_calls), (
+            f"expected user.name=Agent JN, got {config_calls!r}"
+        )
+        assert any("user.email" in c and "agent+jn@example.com" in c for c in config_calls), (
+            f"expected user.email=agent+jn@example.com, got {config_calls!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_neither_field_set_skips_git_config(self, _stub_volumes: Path) -> None:
+        captured = await _run_with_captured_git(
+            git_user_name=None,
+            git_user_email=None,
+            repos_root=_stub_volumes,
+        )
+
+        # The remote set-url call uses 'remote', not 'config' — only the
+        # identity stamps would emit user.name / user.email tokens.
+        all_args = [arg for c in captured for arg in c]
+        assert "user.name" not in all_args
+        assert "user.email" not in all_args
+
+    @pytest.mark.asyncio
+    async def test_only_name_set_stamps_only_name(self, _stub_volumes: Path) -> None:
+        captured = await _run_with_captured_git(
+            git_user_name="Agent JN",
+            git_user_email=None,
+            repos_root=_stub_volumes,
+        )
+        all_args = [arg for c in captured for arg in c]
+        assert "user.name" in all_args
+        assert "user.email" not in all_args
+
+    @pytest.mark.asyncio
+    async def test_config_runs_after_clone_and_remote_set_url(self, _stub_volumes: Path) -> None:
+        """Identity stamps must come after the clone (so the working tree
+        exists) and after the remote URL scrub (the existing post-clone
+        step).  Order matters because clone + scrub can fail and abort
+        the whole call before any identity is written.
+        """
+        captured = await _run_with_captured_git(
+            git_user_name="Agent JN",
+            git_user_email="agent+jn@example.com",
+            repos_root=_stub_volumes,
+        )
+
+        labels: list[str] = []
+        for c in captured:
+            if "clone" in c:
+                labels.append("clone")
+            elif "remote" in c and "set-url" in c:
+                labels.append("remote-set-url")
+            elif "config" in c and "user.name" in c:
+                labels.append("config-name")
+            elif "config" in c and "user.email" in c:
+                labels.append("config-email")
+
+        clone_idx = labels.index("clone")
+        remote_idx = labels.index("remote-set-url")
+        name_idx = labels.index("config-name")
+        email_idx = labels.index("config-email")
+
+        assert clone_idx < remote_idx < name_idx
+        assert clone_idx < remote_idx < email_idx

--- a/tests/unit/test_github_repositories_models.py
+++ b/tests/unit/test_github_repositories_models.py
@@ -76,6 +76,23 @@ class TestGithubRepositoryResourceCreate:
         with pytest.raises(ValidationError, match="traversal"):
             _resource(mount_path="/workspace/./repo")
 
+    def test_git_identity_fields_optional_default_none(self) -> None:
+        r = _resource()
+        assert r.git_user_name is None
+        assert r.git_user_email is None
+
+    def test_git_identity_fields_accepted(self) -> None:
+        r = GithubRepositoryResource(
+            type="github_repository",
+            url="https://github.com/octocat/Hello-World",
+            mount_path="/workspace/repo",
+            authorization_token=SecretStr("ghp_secret"),
+            git_user_name="Agent JN",
+            git_user_email="agent+jn@example.com",
+        )
+        assert r.git_user_name == "Agent JN"
+        assert r.git_user_email == "agent+jn@example.com"
+
     def test_mount_path_rejects_memory_overlap(self) -> None:
         with pytest.raises(ValidationError, match="/mnt/memory"):
             _resource(mount_path="/mnt/memory/foo")
@@ -129,6 +146,20 @@ class TestGithubRepositoryUpdate:
                 }
             )
 
+    def test_git_identity_fields_optional_default_none(self) -> None:
+        u = GithubRepositoryUpdate(authorization_token=SecretStr("ghp_new"))
+        assert u.git_user_name is None
+        assert u.git_user_email is None
+
+    def test_git_identity_fields_accepted_alongside_token(self) -> None:
+        u = GithubRepositoryUpdate(
+            authorization_token=SecretStr("ghp_new"),
+            git_user_name="Agent JN",
+            git_user_email="agent+jn@example.com",
+        )
+        assert u.git_user_name == "Agent JN"
+        assert u.git_user_email == "agent+jn@example.com"
+
 
 class TestValidateResources:
     def test_empty_list_ok(self) -> None:
@@ -181,3 +212,31 @@ class TestGithubRepositoryResourceEcho:
             updated_at=datetime.now(UTC),
         )
         assert e.type == "github_repository"
+
+    def test_echoes_git_identity_fields(self) -> None:
+        from datetime import UTC, datetime
+
+        e = GithubRepositoryResourceEcho(
+            id="ghrepo_01TEST",
+            url="https://github.com/o/r",
+            mount_path="/workspace/r",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            git_user_name="Agent JN",
+            git_user_email="agent+jn@example.com",
+        )
+        assert e.git_user_name == "Agent JN"
+        assert e.git_user_email == "agent+jn@example.com"
+
+    def test_git_identity_fields_default_none(self) -> None:
+        from datetime import UTC, datetime
+
+        e = GithubRepositoryResourceEcho(
+            id="ghrepo_01TEST",
+            url="https://github.com/o/r",
+            mount_path="/workspace/r",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        assert e.git_user_name is None
+        assert e.git_user_email is None


### PR DESCRIPTION
## Summary

- Closes #207. Adds optional `git_user_name` / `git_user_email` on `github_repository` session resources. After the existing post-clone origin scrub, the per-session working tree's `.git/config` is stamped via `git config user.name` / `git config user.email`. Commits the agent makes inside the sandbox carry the configured identity without burning a round-trip on git's "Please tell me who you are" error.
- Both unset (the v1 default) preserves existing behaviour. Pre-#207 callers and call sites work unchanged.
- Migration 0028 adds 2 nullable text columns (name + email aren't secrets, no encryption).

## Update-path semantic (responding to reviewer sev-88)

The original mechanical implementation had `update_session_github_repo_blob` always overwrite identity, which silently cleared a configured identity on token-only rotation. Reviewer flagged it as a footgun. Fixed: the router uses `body.model_fields_set` to differentiate "identity mentioned in payload" from "identity absent", and passes an explicit `identity=(name, email) | None` tuple to `rotate_token`. None preserves; tuple replaces atomically.

E2e test `test_token_only_rotation_preserves_identity` pins this — token rotation without identity in the body keeps the stored values.

## Test plan

- [x] `tests/unit/test_github_repositories_models.py` — 5 new model tests (Resource accepts identity, Update accepts identity alongside token, Echo round-trips identity, defaults to None on all three)
- [x] `tests/unit/test_github_clone_identity.py` — 4 sandbox-side tests (both fields → both `git config` calls, only one field → only one call, neither field → no calls, post-clone-and-scrub ordering)
- [x] `tests/e2e/test_github_repositories.py` — 3 new e2e tests (identity round-trip, token-only rotate preserves identity, default-None when omitted)
- [x] `uv run pytest tests/unit -q` — 1150 pass
- [x] `uv run mypy src` clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` clean
- [x] `DOCKER_HOST=… uv run pytest tests/integration tests/e2e -q` — 256 pass

## Reviewer notes

Posting per memory's "post all findings":

- **Sev 88** (silent-clear on token-only rotate) — **fixed in this PR**. Router uses `model_fields_set`; `rotate_token` accepts `identity: tuple[str|None, str|None] | None`; SQL has two paths (preserve vs replace).
- **Sev 72** (DB columns are unbounded `text`) — Pydantic enforces `max_length=256`. Direct DB tooling could bypass; acceptable per CLAUDE.md "extreme simplicity".
- **Sev 68** (identity-stamp failure leaves half-configured working tree) — clone + scrub branches `shutil.rmtree(work_dir)` before raising; the new `git config` failure path raises without cleanup. The next provision recreates the working tree from scratch (via `if work_dir.exists(): shutil.rmtree(...)` at the top of `ensure_session_working_tree`), so the inconsistency is self-healing on the next call. Leaving as-is — adding rmtree on every error path expands surface for marginal gain.
- **Sev 55** (test ordering test doesn't pin name-vs-email order) — intentionally lenient; implementation iterates `(("user.name", ...), ("user.email", ...))` so order is deterministic but the test doesn't lock it in. Not a defect.

## Out of scope (per #207 §"Out of scope")

- Anything signing-related (GPG/SSH commit signing, ephemeral signing keys per session)
- Pre-baking a global default identity into the sandbox image
- Changing the v1 token-in-URL design

🤖 Generated with [Claude Code](https://claude.com/claude-code)