### PR TITLE
feat(connector): per-chat operator bindings for connection routing (#215)

### DIFF
--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -73,6 +73,25 @@ aios connections attach <conn_id> --session=<session_id>
 Or configure per-chat session spawning via a session template
 (`aios connections configure-per-chat <conn_id> --template=<tpl_id>`).
 
+#### Operator-curated per-chat bindings
+
+To route a specific chat on a connection's account to a specific
+existing session — the middle case between attach (whole account →
+one session) and configure-per-chat (each chat → fresh template-spawn) —
+pre-populate a binding:
+
+```
+aios connections recent-chats <conn_id>           # find the chat_id
+aios connections bind-chat <conn_id> --chat-id=<id> --session-id=<sess_id>
+aios connections bound-chats <conn_id>            # inspect operator + supervisor rows
+aios connections unbind-chat <conn_id> --chat-id=<id>
+```
+
+The binding is consulted before the connection's mode-default fallback,
+so it works on top of any mode (single_session, per_chat, or even
+detached). Inbound on bound chats routes to the bound session;
+unbound chats fall back to the connection's default behaviour.
+
 ### 5. DM the bot — the agent replies
 
 Inbound messages on each phone route to its connection's session.

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -58,6 +58,25 @@ aios connections list --connector=telegram
 aios connections attach <conn_id> --session=<session_id>
 ```
 
+#### Operator-curated per-chat bindings
+
+To route a specific chat on a bot's account to a specific existing
+session — the middle case between attach (whole bot → one session)
+and configure-per-chat (each chat → fresh template-spawn) — pre-populate
+a binding:
+
+```
+aios connections recent-chats <conn_id>           # find the chat_id
+aios connections bind-chat <conn_id> --chat-id=<id> --session-id=<sess_id>
+aios connections bound-chats <conn_id>            # inspect operator + supervisor rows
+aios connections unbind-chat <conn_id> --chat-id=<id>
+```
+
+The binding is consulted before the connection's mode-default fallback,
+so it works on top of any mode (single_session, per_chat, or even
+detached). Inbound on bound chats routes to the bound session;
+unbound chats fall back to the connection's default behaviour.
+
 ### 5. DM the bot — the agent replies
 
 Inbound messages on each bot route to its connection's session.  The

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -30,11 +30,14 @@ from aios.errors import AccountDriftError
 from aios.harness.connector_tasks import defer_connector_status
 from aios.models.common import ListResponse
 from aios.models.connections import (
+    BindChatRequest,
+    BoundChat,
     Connection,
     ConnectionAttach,
     ConnectionConfigurePerChat,
     ConnectionCreate,
     ConnectionMode,
+    RecentChat,
 )
 from aios.services import connections as service
 
@@ -194,3 +197,48 @@ async def configure_per_chat(
 @router.post("/{connection_id}/unconfigure")
 async def unconfigure(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Connection:
     return await service.unconfigure_connection(pool, connection_id)
+
+
+@router.post("/{connection_id}/bind-chat", status_code=status.HTTP_201_CREATED)
+async def bind_chat(
+    connection_id: str, body: BindChatRequest, pool: PoolDep, _auth: AuthDep
+) -> BoundChat:
+    """Operator-curate a chat → session mapping (#215).
+
+    A row in ``connection_chat_sessions`` overrides the connection's
+    mode-default fallback for that ``chat_id``.  Operators use this to
+    point different chats on a single account at different existing
+    sessions — the middle case the unified ``connections`` shape didn't
+    cover after #205.
+
+    Idempotent on ``(connection_id, chat_id)``: a second call with the
+    same chat returns the existing row (its ``session_id`` may differ
+    from the requested one if a concurrent writer landed first or the
+    supervisor pre-populated it via per_chat spawn).
+    """
+    return await service.bind_chat_to_session(
+        pool, connection_id, chat_id=body.chat_id, session_id=body.session_id
+    )
+
+
+@router.delete("/{connection_id}/bind-chat/{chat_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def unbind_chat(connection_id: str, chat_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+    """Drop the operator-curated row.  Idempotent — repeat calls 204."""
+    await service.unbind_chat(pool, connection_id, chat_id)
+
+
+@router.get("/{connection_id}/bound-chats")
+async def bound_chats(connection_id: str, pool: PoolDep, _auth: AuthDep) -> ListResponse[BoundChat]:
+    items = await service.list_bound_chats(pool, connection_id)
+    return ListResponse[BoundChat](data=items, has_more=False, next_after=None)
+
+
+@router.get("/{connection_id}/recent-chats")
+async def recent_chats(
+    connection_id: str,
+    pool: PoolDep,
+    _auth: AuthDep,
+    limit: int = 50,
+) -> ListResponse[RecentChat]:
+    items = await service.list_recent_chats(pool, connection_id, limit=limit)
+    return ListResponse[RecentChat](data=items, has_more=False, next_after=None)

--- a/src/aios/cli/commands/connections.py
+++ b/src/aios/cli/commands/connections.py
@@ -182,6 +182,93 @@ def unconfigure(ctx: typer.Context, connection_id: str) -> None:
     run_or_die(_run)
 
 
+@app.command(
+    "bind-chat",
+    help="Pre-bind a chat_id on a connection's account to an existing session.",
+)
+def bind_chat(
+    ctx: typer.Context,
+    connection_id: str,
+    chat_id: Annotated[str, typer.Option("--chat-id", help="Platform-native chat id.")],
+    session_id: Annotated[str, typer.Option("--session-id", help="Target session id.")],
+) -> None:
+    def _run() -> None:
+        client = just_client(ctx)
+        with client:
+            obj = client.request(
+                "POST",
+                f"/v1/connections/{connection_id}/bind-chat",
+                json_body={"chat_id": chat_id, "session_id": session_id},
+            )
+        render_single(obj)
+
+    run_or_die(_run)
+
+
+@app.command(
+    "unbind-chat",
+    help="Drop a chat → session binding, returning the chat to the connection's mode default.",
+)
+def unbind_chat(
+    ctx: typer.Context,
+    connection_id: str,
+    chat_id: Annotated[str, typer.Option("--chat-id")],
+) -> None:
+    def _run() -> None:
+        client = just_client(ctx)
+        with client:
+            client.request("DELETE", f"/v1/connections/{connection_id}/bind-chat/{chat_id}")
+        print_success("unbound", f"{connection_id}:{chat_id}")
+
+    run_or_die(_run)
+
+
+@app.command(
+    "bound-chats",
+    help="List all chat → session bindings (operator-curated + supervisor-spawned).",
+)
+def bound_chats(ctx: typer.Context, connection_id: str) -> None:
+    def _run() -> None:
+        state, client = with_client(ctx)
+        with client:
+            envelope = client.request("GET", f"/v1/connections/{connection_id}/bound-chats")
+        render_list(
+            state.output_format,
+            envelope,
+            columns=("chat_id", "session_id", "created_at"),
+            max_widths={"chat_id": 40, "session_id": 24},
+        )
+
+    run_or_die(_run)
+
+
+@app.command(
+    "recent-chats",
+    help="List distinct chat_ids on this connection's account that have produced inbound.",
+)
+def recent_chats(
+    ctx: typer.Context,
+    connection_id: str,
+    limit: Annotated[int, typer.Option("--limit", min=1, max=200)] = 50,
+) -> None:
+    def _run() -> None:
+        state, client = with_client(ctx)
+        with client:
+            envelope = client.request(
+                "GET",
+                f"/v1/connections/{connection_id}/recent-chats",
+                params={"limit": limit},
+            )
+        render_list(
+            state.output_format,
+            envelope,
+            columns=("chat_id", "last_seen_at"),
+            max_widths={"chat_id": 40},
+        )
+
+    run_or_die(_run)
+
+
 @app.command("archive", help="Archive a detached connection (soft-delete, retained for audit).")
 def archive(ctx: typer.Context, connection_id: str) -> None:
     def _run() -> None:

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import math
 import time
+from datetime import datetime
 from types import EllipsisType
 from typing import Any, NoReturn
 
@@ -2315,12 +2316,18 @@ async def session_authorizes_connector_account(
     """Permission check for outbound connector tool calls.
 
     True iff there's an active connection whose ``(connector, account)``
-    matches AND whose ``session_id`` is this session OR whose ``id`` is
-    the session's ``spawned_from_connection_id``.  Used by the
-    outbound MCP dispatch to gate tool calls that take an explicit
-    ``account`` argument — the supervisor will happily forward to the
-    connector regardless, but the model shouldn't be able to reach
-    accounts the operator hasn't bound to this session.
+    matches AND any of:
+
+    * ``c.session_id`` is this session (single_session attach), OR
+    * ``c.id`` is this session's ``spawned_from_connection_id``
+      (per_chat origin grant), OR
+    * a row in ``connection_chat_sessions`` ties this connection to
+      this session (operator-curated chat binding, #215).
+
+    Used by the outbound MCP dispatch to gate tool calls that take an
+    explicit ``account`` argument — the supervisor will happily forward
+    to the connector regardless, but the model shouldn't be able to
+    reach accounts the operator hasn't bound to this session.
     """
     row = await conn.fetchrow(
         """
@@ -2330,7 +2337,11 @@ async def session_authorizes_connector_account(
          WHERE c.connector = $2
            AND c.account = $3
            AND c.archived_at IS NULL
-           AND (c.session_id = $1 OR c.id = s.spawned_from_connection_id)
+           AND (c.session_id = $1
+                OR c.id = s.spawned_from_connection_id
+                OR EXISTS (SELECT 1 FROM connection_chat_sessions ccs
+                            WHERE ccs.connection_id = c.id
+                              AND ccs.session_id = $1))
          LIMIT 1
         """,
         session_id,
@@ -2639,6 +2650,107 @@ async def insert_chat_session(
             detail={"connection_id": connection_id, "chat_id": chat_id},
         )
     return existing
+
+
+async def delete_chat_session(
+    conn: asyncpg.Connection[Any], connection_id: str, chat_id: str
+) -> bool:
+    """Remove a ``connection_chat_sessions`` row.  Returns ``True`` iff
+    a row was actually deleted.
+
+    Used by the operator-bound chat unbind endpoint.  Hard delete (no
+    soft-archive): the row is just an operator-curated route, deleting
+    it returns the chat to the connection's mode-default fallback.
+    """
+    result = await conn.execute(
+        "DELETE FROM connection_chat_sessions WHERE connection_id = $1 AND chat_id = $2",
+        connection_id,
+        chat_id,
+    )
+    return bool(result.endswith(" 1"))
+
+
+async def get_chat_session_row(
+    conn: asyncpg.Connection[Any], connection_id: str, chat_id: str
+) -> tuple[str, str, datetime] | None:
+    """Return ``(chat_id, session_id, created_at)`` for one row, or ``None``.
+
+    Used after :func:`insert_chat_session` to materialise the just-bound
+    row's ``created_at`` for the API response without re-listing the
+    full per-connection set.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT chat_id, session_id, created_at
+          FROM connection_chat_sessions
+         WHERE connection_id = $1 AND chat_id = $2
+        """,
+        connection_id,
+        chat_id,
+    )
+    if row is None:
+        return None
+    return row["chat_id"], row["session_id"], row["created_at"]
+
+
+async def list_chat_sessions_for_connection(
+    conn: asyncpg.Connection[Any], connection_id: str
+) -> list[tuple[str, str, datetime]]:
+    """List ``(chat_id, session_id, created_at)`` rows in chat_id order.
+
+    Operator-bound and supervisor-spawned rows are returned together —
+    the table doesn't tag the writer, and the union is what an operator
+    wants to see when answering "where does each chat on this account
+    route?".
+    """
+    rows = await conn.fetch(
+        """
+        SELECT chat_id, session_id, created_at
+          FROM connection_chat_sessions
+         WHERE connection_id = $1
+         ORDER BY chat_id
+        """,
+        connection_id,
+    )
+    return [(r["chat_id"], r["session_id"], r["created_at"]) for r in rows]
+
+
+async def list_recent_chat_ids(
+    conn: asyncpg.Connection[Any], connector: str, account: str, *, limit: int
+) -> list[tuple[str, datetime]]:
+    """Distinct ``(chat_id, last_seen_at)`` for inbound user events
+    matching the ``<connector>/<account>/<chat_id>`` channel prefix.
+
+    Used by the operator's "what chats has this account produced
+    inbound on?" helper — the input to ``aios connections bind-chat``
+    when the operator doesn't know the chat_id off the top of their
+    head.
+
+    The chat_id is the third path segment of the derived
+    ``events.channel`` column; events arriving on a different
+    ``focal_channel_at_arrival`` still have ``orig_channel`` set to
+    their inbound channel, but ``channel`` (derived) collapses them
+    correctly.  We filter on user role to skip assistant / tool rows
+    that share the channel.
+    """
+    prefix = f"{connector}/{account}/"
+    rows = await conn.fetch(
+        """
+        SELECT
+          split_part(channel, '/', 3) AS chat_id,
+          MAX(created_at) AS last_seen_at
+        FROM events
+        WHERE channel LIKE $1
+          AND kind = 'message'
+          AND data->>'role' = 'user'
+        GROUP BY chat_id
+        ORDER BY last_seen_at DESC
+        LIMIT $2
+        """,
+        prefix + "%",
+        limit,
+    )
+    return [(r["chat_id"], r["last_seen_at"]) for r in rows if r["chat_id"]]
 
 
 # ─── connector_inbound_acks (dedup ledger) ──────────────────────────────────

--- a/src/aios/harness/connector_supervisor.py
+++ b/src/aios/harness/connector_supervisor.py
@@ -774,10 +774,17 @@ class ConnectorSubprocessRegistry:
             return
 
         # 1. Look up connection (fresh read — no caching, since the
-        #    operator may have just attached/configured the connection).
+        #    operator may have just attached/configured the connection)
+        #    plus an operator-curated chat binding if any: a row in
+        #    ``connection_chat_sessions`` wins regardless of mode (#215).
         async with pool.acquire() as conn:
             connection = await queries.get_connection_for_account(
                 conn, connector=connector, account=account
+            )
+            target_session_id: str | None = (
+                await queries.lookup_chat_session(conn, connection.id, chat_id)
+                if connection is not None
+                else None
             )
         if connection is None:
             await self._auto_create_or_drop(state, account=account)
@@ -787,23 +794,25 @@ class ConnectorSubprocessRegistry:
             await self._send_ack(state, event_id)
             return
 
-        # 2. Branch on routing mode.
-        target_session_id: str | None = None
-        if connection.session_id is not None:
-            target_session_id = connection.session_id
-        elif connection.session_template_id is not None:
-            target_session_id = await self._resolve_per_chat_session(
-                state,
-                connection_id=connection.id,
-                template_id=connection.session_template_id,
-                connector_name=connector,
-                account=account,
-                chat_id=chat_id,
-            )
-        else:
-            self._record_drop(state, "detached")
-            await self._send_ack(state, event_id)
-            return
+        # 2. Resolve target session: bound row first (already fetched),
+        # else fall back to the connection's mode-default (single_session
+        # session_id, per_chat spawn-from-template, or detached drop).
+        if target_session_id is None:
+            if connection.session_id is not None:
+                target_session_id = connection.session_id
+            elif connection.session_template_id is not None:
+                target_session_id = await self._resolve_per_chat_session(
+                    state,
+                    connection_id=connection.id,
+                    template_id=connection.session_template_id,
+                    connector_name=connector,
+                    account=account,
+                    chat_id=chat_id,
+                )
+            else:
+                self._record_drop(state, "detached")
+                await self._send_ack(state, event_id)
+                return
 
         if target_session_id is None:
             # Per-chat resolution already recorded the drop reason.

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -89,3 +89,45 @@ class Connection(BaseModel):
     attached_at: datetime | None = None
     updated_at: datetime
     archived_at: datetime | None = None
+
+
+class BindChatRequest(BaseModel):
+    """Request body for ``POST /v1/connections/{id}/bind-chat``.
+
+    Pre-populates a ``connection_chat_sessions`` row so inbound on
+    ``chat_id`` routes to ``session_id`` regardless of the connection's
+    mode-default fallback (#215).  Operators use this to point
+    different chats on a single account at different operator-curated
+    existing sessions.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    chat_id: str = Field(min_length=1, max_length=512)
+    session_id: str
+
+
+class BoundChat(BaseModel):
+    """Read view of one ``connection_chat_sessions`` row.
+
+    Returned by ``GET /v1/connections/{id}/bound-chats``.  Operator-bound
+    rows and supervisor-spawned rows are returned together — the table
+    doesn't tag the writer.
+    """
+
+    chat_id: str
+    session_id: str
+    created_at: datetime
+
+
+class RecentChat(BaseModel):
+    """Distinct chat_id observed on a connection's account, with the
+    most-recent inbound timestamp.
+
+    Returned by ``GET /v1/connections/{id}/recent-chats`` so operators
+    can find the chat_id for a specific peer without digging through
+    event logs before calling ``bind-chat``.
+    """
+
+    chat_id: str
+    last_seen_at: datetime

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -16,8 +16,13 @@ from typing import Any
 import asyncpg
 
 from aios.db import queries
-from aios.errors import ConflictError
-from aios.models.connections import Connection, ConnectionMode
+from aios.errors import ConflictError, NotFoundError
+from aios.models.connections import (
+    BoundChat,
+    Connection,
+    ConnectionMode,
+    RecentChat,
+)
 
 
 async def create_connection(
@@ -98,14 +103,95 @@ async def validate_account_for_session(
 
     Authorization model: a session may invoke connector tools targeted
     at accounts that are either bound to it via ``connections.session_id``
-    (single_session attach) or that spawned it via
-    ``sessions.spawned_from_connection_id`` (per_chat).  Used by the
-    outbound MCP dispatch — see :mod:`aios.harness.tool_dispatch`.
+    (single_session attach), spawned it via
+    ``sessions.spawned_from_connection_id`` (per_chat origin), or
+    operator-curated to it via a row in ``connection_chat_sessions``
+    (#215).  Used by the outbound MCP dispatch — see
+    :mod:`aios.harness.tool_dispatch`.
     """
     async with pool.acquire() as conn:
         return await queries.session_authorizes_connector_account(
             conn, session_id, connector, account
         )
+
+
+async def bind_chat_to_session(
+    pool: asyncpg.Pool[Any],
+    connection_id: str,
+    *,
+    chat_id: str,
+    session_id: str,
+) -> BoundChat:
+    """Insert an operator-curated ``connection_chat_sessions`` row.
+
+    On conflict (a row already exists for this ``(connection_id, chat_id)``,
+    either operator-bound earlier or supervisor-spawned via per_chat) the
+    existing row is preserved — the call is idempotent.  The returned
+    ``BoundChat`` reflects whichever ``session_id`` is now stored, which
+    may differ from the requested one if the conflict path triggered.
+    """
+    async with pool.acquire() as conn, conn.transaction():
+        # Validate both FKs at the service boundary — without this,
+        # asyncpg surfaces FK violations as 500s instead of clean 4xxs.
+        await queries.get_connection(conn, connection_id)
+        await queries.get_session(conn, session_id)
+        await queries.insert_chat_session(
+            conn,
+            connection_id=connection_id,
+            chat_id=chat_id,
+            session_id=session_id,
+        )
+        row = await queries.get_chat_session_row(conn, connection_id, chat_id)
+    if row is None:
+        raise NotFoundError(
+            f"bound chat ({connection_id}, {chat_id}) not found after insert",
+            detail={"connection_id": connection_id, "chat_id": chat_id},
+        )
+    row_chat_id, row_session_id, row_created_at = row
+    return BoundChat(
+        chat_id=row_chat_id,
+        session_id=row_session_id,
+        created_at=row_created_at,
+    )
+
+
+async def unbind_chat(pool: asyncpg.Pool[Any], connection_id: str, chat_id: str) -> bool:
+    """Delete a ``connection_chat_sessions`` row.  Returns whether one
+    was actually present (idempotent — repeat calls are no-ops)."""
+    async with pool.acquire() as conn:
+        return await queries.delete_chat_session(conn, connection_id, chat_id)
+
+
+async def list_bound_chats(pool: asyncpg.Pool[Any], connection_id: str) -> list[BoundChat]:
+    """All ``connection_chat_sessions`` rows for ``connection_id``,
+    operator-bound and supervisor-spawned together.  An unknown
+    ``connection_id`` 404s rather than returning ``[]`` so the operator
+    surface is symmetric with the sibling endpoints."""
+    async with pool.acquire() as conn:
+        await queries.get_connection(conn, connection_id)
+        rows = await queries.list_chat_sessions_for_connection(conn, connection_id)
+    return [
+        BoundChat(chat_id=chat_id, session_id=session_id, created_at=created_at)
+        for chat_id, session_id, created_at in rows
+    ]
+
+
+async def list_recent_chats(
+    pool: asyncpg.Pool[Any], connection_id: str, *, limit: int = 50
+) -> list[RecentChat]:
+    """Distinct chat_ids that have produced inbound on this connection's
+    account, ordered most-recent first.  Used as the input to
+    ``bind-chat`` when an operator needs to find a specific chat's
+    ``chat_id`` without digging through event logs.
+    """
+    async with pool.acquire() as conn:
+        connection = await queries.get_connection(conn, connection_id)
+        rows = await queries.list_recent_chat_ids(
+            conn, connection.connector, connection.account, limit=limit
+        )
+    return [
+        RecentChat(chat_id=chat_id, last_seen_at=last_seen_at) for chat_id, last_seen_at in rows
+    ]
 
 
 async def archive_connection(pool: asyncpg.Pool[Any], connection_id: str) -> Connection:

--- a/tests/e2e/test_connector_inbound.py
+++ b/tests/e2e/test_connector_inbound.py
@@ -301,6 +301,275 @@ class TestPerChatInbound:
 
 
 @needs_docker
+class TestOperatorBoundChat:
+    """Operator-curated bindings on top of single_session / per_chat (#215).
+
+    The connection_chat_sessions ledger is consulted before the
+    connection's mode-default fallback, so an operator-inserted row
+    overrides where a chat would otherwise route — that gives the
+    middle case (different chats on one account → different existing
+    sessions) without reintroducing the channel_bindings table.
+    """
+
+    async def test_bound_chat_overrides_single_session_default(self, harness: Harness) -> None:
+        """A single_session connection with an operator-bound chat:
+        bound chat routes to the bound session, other chats fall back
+        to ``connection.session_id``.
+        """
+        agent_id, env_id = await _make_agent_and_env(harness)
+        default_session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title="default",
+            metadata={},
+        )
+        bound_session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title="bound",
+            metadata={},
+        )
+        account = _unique_account()
+        conn_row = await connections_service.create_connection(
+            harness._pool, connector="echo", account=account, metadata={}
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_row.id, session_id=default_session.id
+        )
+        async with harness._pool.acquire() as conn:
+            await queries.insert_chat_session(
+                conn,
+                connection_id=conn_row.id,
+                chat_id="chat-bound",
+                session_id=bound_session.id,
+            )
+
+        registry = _registry()
+        _patch_send_ack(registry)
+        with mock.patch(
+            "aios.harness.connector_supervisor.defer_wake",
+            new=mock.AsyncMock(return_value=None),
+        ):
+            await registry._handle_inbound(
+                ("echo", "echo"),
+                {
+                    "event_id": make_id("evt"),
+                    "account": account,
+                    "chat_id": "chat-bound",
+                    "sender": {"display_name": "Bound peer"},
+                    "content": "from bound chat",
+                },
+            )
+            await registry._handle_inbound(
+                ("echo", "echo"),
+                {
+                    "event_id": make_id("evt"),
+                    "account": account,
+                    "chat_id": "chat-fallback",
+                    "sender": {"display_name": "Other peer"},
+                    "content": "from fallback chat",
+                },
+            )
+
+        bound_events = await harness.events(bound_session.id)
+        bound_contents = [
+            e.data.get("content") for e in bound_events if e.data.get("role") == "user"
+        ]
+        assert "from bound chat" in bound_contents
+        assert "from fallback chat" not in bound_contents
+
+        default_events = await harness.events(default_session.id)
+        default_contents = [
+            e.data.get("content") for e in default_events if e.data.get("role") == "user"
+        ]
+        assert "from fallback chat" in default_contents
+        assert "from bound chat" not in default_contents
+
+    async def test_bound_chat_overrides_per_chat_spawn(self, harness: Harness) -> None:
+        """A per_chat connection with an operator-bound chat: bound chat
+        routes to the bound session (NOT a freshly-spawned one); other
+        chats spawn from the template as usual.
+        """
+        agent_id, env_id = await _make_agent_and_env(harness)
+        bound_session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title="bound-existing",
+            metadata={},
+        )
+        account = _unique_account()
+        template = await session_templates_service.create_session_template(
+            harness._pool,
+            name=f"tpl-{make_id('stpl')[-8:]}",
+            agent_id=agent_id,
+            environment_id=env_id,
+            agent_version=None,
+            vault_ids=[],
+            memory_store_ids=[],
+            metadata={},
+        )
+        conn_row = await connections_service.create_connection(
+            harness._pool, connector="echo", account=account, metadata={}
+        )
+        await connections_service.configure_per_chat(
+            harness._pool, conn_row.id, session_template_id=template.id
+        )
+        async with harness._pool.acquire() as conn:
+            await queries.insert_chat_session(
+                conn,
+                connection_id=conn_row.id,
+                chat_id="chat-bound",
+                session_id=bound_session.id,
+            )
+
+        registry = _registry()
+        _patch_send_ack(registry)
+        with mock.patch(
+            "aios.harness.connector_supervisor.defer_wake",
+            new=mock.AsyncMock(return_value=None),
+        ):
+            await registry._handle_inbound(
+                ("echo", "echo"),
+                {
+                    "event_id": make_id("evt"),
+                    "account": account,
+                    "chat_id": "chat-bound",
+                    "sender": {"display_name": "Bound peer"},
+                    "content": "lands on bound",
+                },
+            )
+            await registry._handle_inbound(
+                ("echo", "echo"),
+                {
+                    "event_id": make_id("evt"),
+                    "account": account,
+                    "chat_id": "chat-spawn",
+                    "sender": {"display_name": "Spawn peer"},
+                    "content": "spawns new",
+                },
+            )
+
+        # Bound chat lands on the pre-existing session — NOT spawned from template.
+        bound_events = await harness.events(bound_session.id)
+        bound_contents = [
+            e.data.get("content") for e in bound_events if e.data.get("role") == "user"
+        ]
+        assert "lands on bound" in bound_contents
+        async with harness._pool.acquire() as conn:
+            spawned_origin = await queries.get_session_spawn_origin(conn, bound_session.id)
+        assert spawned_origin is None  # bound session was never per_chat-spawned
+
+        # Other chat spawns a fresh session via the template path.
+        async with harness._pool.acquire() as conn:
+            spawned_session_id = await queries.lookup_chat_session(conn, conn_row.id, "chat-spawn")
+        assert spawned_session_id is not None
+        assert spawned_session_id != bound_session.id
+
+    async def test_bind_chat_is_idempotent_and_404s_on_unknowns(self, harness: Harness) -> None:
+        """``bind_chat_to_session`` is idempotent on ``(connection_id,
+        chat_id)``: a second call returns the existing row rather than
+        ON CONFLICT-ing into a 500.  Unknown connection_id / session_id
+        each surface as 4xx (NotFoundError).
+        """
+        from aios.errors import NotFoundError
+
+        agent_id, env_id = await _make_agent_and_env(harness)
+        first_session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title="first",
+            metadata={},
+        )
+        second_session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title="second",
+            metadata={},
+        )
+        account = _unique_account()
+        conn_row = await connections_service.create_connection(
+            harness._pool, connector="echo", account=account, metadata={}
+        )
+
+        first = await connections_service.bind_chat_to_session(
+            harness._pool,
+            conn_row.id,
+            chat_id="chat-x",
+            session_id=first_session.id,
+        )
+        assert first.session_id == first_session.id
+
+        # Repeat: the existing row wins; second_session is intentionally
+        # ignored.  Operator who really wants to re-route must unbind
+        # first.
+        second = await connections_service.bind_chat_to_session(
+            harness._pool,
+            conn_row.id,
+            chat_id="chat-x",
+            session_id=second_session.id,
+        )
+        assert second.session_id == first_session.id
+
+        # Unknown connection_id → NotFoundError (FK guard, prevents 500).
+        with pytest.raises(NotFoundError):
+            await connections_service.bind_chat_to_session(
+                harness._pool,
+                "conn_missing",
+                chat_id="chat-x",
+                session_id=first_session.id,
+            )
+
+        # Unknown session_id → NotFoundError (FK guard, prevents 500).
+        with pytest.raises(NotFoundError):
+            await connections_service.bind_chat_to_session(
+                harness._pool,
+                conn_row.id,
+                chat_id="chat-y",
+                session_id="sess_missing",
+            )
+
+    async def test_validate_account_for_session_recognizes_ledger_binding(
+        self, harness: Harness
+    ) -> None:
+        """A session reachable only via an operator-bound row in
+        ``connection_chat_sessions`` (no direct attach, no spawn-from
+        pointer) must still pass outbound auth — the third OR clause
+        in ``session_authorizes_connector_account``.
+        """
+        agent_id, env_id = await _make_agent_and_env(harness)
+        bound_session = await sessions_service.create_session(
+            harness._pool,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title="bound-only",
+            metadata={},
+        )
+        account = _unique_account()
+        conn_row = await connections_service.create_connection(
+            harness._pool, connector="echo", account=account, metadata={}
+        )
+        # Connection is in detached mode — no attach, no per_chat config.
+        # bound_session is reachable only via the ledger row.
+        async with harness._pool.acquire() as conn:
+            await queries.insert_chat_session(
+                conn,
+                connection_id=conn_row.id,
+                chat_id="chat-bound",
+                session_id=bound_session.id,
+            )
+
+        authorized = await connections_service.validate_account_for_session(
+            harness._pool, bound_session.id, connector="echo", account=account
+        )
+        assert authorized is True
+
+
+@needs_docker
 class TestDetachedConnection:
     async def test_detached_drops_with_counter_and_ack(self, harness: Harness) -> None:
         account = _unique_account()


### PR DESCRIPTION
## Summary

- Closes #215. Treats `connection_chat_sessions` as the canonical first-look table for inbound routing — an operator-inserted row wins regardless of the connection's mode-default. Restores the middle case between attach (whole account → one session) and configure-per-chat (each chat → fresh template-spawn) that PR #205 unintentionally dropped.
- Outbound auth (`session_authorizes_connector_account`) gains a third OR clause via `EXISTS(connection_chat_sessions)` — ledger-bound sessions can call connector tools with the connection's `(connector, account)` the same way `single_session` and `per_chat` sessions can.
- 4 new API endpoints + 4 matching CLI subcommands. Doc note in both connector READMEs.
- No schema change — the table existed already; only the use-cases expand.

## Test plan

- [x] `tests/e2e/test_connector_inbound.py::TestOperatorBoundChat` — 4 new e2e tests:
  - bound chat overrides single_session default
  - bound chat overrides per_chat spawn
  - `validate_account_for_session` recognises ledger-bound sessions
  - `bind_chat_to_session` is idempotent + 404s on unknown connection/session FKs
- [x] `uv run pytest tests/unit -q` — 1150 pass
- [x] `uv run mypy src` clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` clean
- [x] `DOCKER_HOST=… uv run pytest tests/integration tests/e2e -q` — 260 pass

## Reviewer notes (sub-90 findings)

Posting per memory's "post all findings":

- **Sev 82** (`bind_chat_to_session` would 500 on unknown connection_id) — **fixed in this PR**. Service guards both FKs explicitly via `get_connection` + `get_session` so bad path-params surface as 4xx not asyncpg FK-violation 500s. `list_bound_chats` aligned for consistency. Idempotency contract test added.
- **Sev 80** (stale docstring on `validate_account_for_session`) — **fixed in this PR**. Service-level docstring now matches the query-level one (three-clause auth model).
- **Sev 80** (no e2e for the 4 new API endpoints) — partially addressed. Added a service-level idempotency + 404 test in `TestOperatorBoundChat`. Full http_client-based router test would require new fixture infrastructure for `tests/e2e/test_connections_api.py`-style tests; deferring as a follow-up since the endpoints are thin pass-throughs to the (now-tested) service layer.

## Notes

- **CLI naming** is `bind-chat` / `unbind-chat` / `bound-chats` / `recent-chats` — verb-noun rather than the existing `attach` / `detach` / `configure-per-chat` / `unconfigure` pattern. Defended on the grounds that "bind a chat" reads more discoverably than a hypothetical `bind`/`unbind` with a `--chat-id` option as the only argument.
- **Forum-thread channels** (`telegram/<bot>/<chat>/<thread>`) are NOT collapsed by the `recent-chats` query — verified that `split_part(channel, '/', 3)` correctly extracts the chat_id even for 4-segment channels (Telegram forum threads aren't yet encoded into the channel scheme).

## Out of scope (per #215 §"Out of scope")

- Pattern-based routing (regex/glob over chat names) — `connection_routing_rules` is gone for a reason; explicit per-chat-id bindings handle the surfaced use case.
- Routing by sender (DMs from specific users → specific sessions) — different problem, punt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)