### PR TITLE
feat(signal): outbound mentions, quote/edit/delete, group create/rename

### DIFF
--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -113,9 +113,8 @@ forward an inbound file `cp` it into `/workspace/` first).
 ## Out of scope for v1
 
 - Voice / Say / SoundEffect / Listen tools.
-- Group create / rename / add-members.
+- Group add/remove members.
 - Typing indicators.
-- Message editing / deletion.
 - Automated registration.
 
 ## Development

--- a/connectors/signal/src/aios_signal/_utf16.py
+++ b/connectors/signal/src/aios_signal/_utf16.py
@@ -1,0 +1,16 @@
+"""UTF-16 offset helpers shared by markdown and mention encoding.
+
+Signal's textStyles AND mentions both use UTF-16 code-unit offsets — a
+JVM-era choice carried over from signal-cli's Java roots — and Python
+strings index by code points.  These two helpers bridge the gap.
+"""
+
+from __future__ import annotations
+
+
+def utf16_len(text: str) -> int:
+    return len(text.encode("utf-16-le")) // 2
+
+
+def codepoint_to_utf16_offset(text: str, cp_offset: int) -> int:
+    return utf16_len(text[:cp_offset])

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -49,8 +49,9 @@ from aios_connector import (
 
 from .addressing import decode_chat_id, encode_chat_id
 from .config import Settings
-from .daemon import SignalDaemon
+from .daemon import GroupInfo, SignalDaemon
 from .markdown import convert_markdown_to_signal_styles
+from .mentions import encode_mentions
 from .parse import InboundMessage, build_content_text, parse_envelope
 from .prompts import build_instructions
 
@@ -73,6 +74,9 @@ class SignalConnector(Connector):
         # Contacts + group rosters are per-account because each phone has
         # its own contact store and group memberships in signal-cli.
         self._contact_names_by_account: dict[str, dict[str, str]] = {}
+        # Group rosters retained for runtime use (outbound mention
+        # encoding needs the focal group's member UUIDs at send time).
+        self._groups_by_account: dict[str, list[GroupInfo]] = {}
         # Phone → error message for accounts whose boot-time probe
         # (``listContacts`` / ``listGroups``) failed.  signal-cli's
         # daemon stays running and accepts new attachments to other
@@ -129,6 +133,7 @@ class SignalConnector(Connector):
                 self._unavailable_accounts[phone] = str(err)
                 continue
             self._contact_names_by_account[phone] = contact_names
+            self._groups_by_account[phone] = groups
             section = build_instructions(
                 bot_uuid=bot_uuid,
                 phone=phone,
@@ -236,6 +241,9 @@ class SignalConnector(Connector):
         self,
         text: str,
         attachments: list[SandboxPath] | None = None,
+        quote_timestamp_ms: int | None = None,
+        quote_author_uuid: str | None = None,
+        edit_timestamp_ms: int | None = None,
         *,
         account: str,
         chat_id: str,
@@ -249,18 +257,145 @@ class SignalConnector(Connector):
 
         Args:
             text: Message body. Markdown is converted to Signal text styles.
+                In group chats, ``@<uuid_prefix>`` mentions are encoded
+                automatically when the prefix uniquely matches a member.
             attachments: Optional in-sandbox file paths to attach.  The SDK
                 resolves each entry to a host path before this method runs.
+            quote_timestamp_ms: ``timestamp_ms`` of the message you're
+                quoting.  Must be set together with ``quote_author_uuid``;
+                passing only one raises ``ValueError``.
+            quote_author_uuid: ``sender_uuid`` of the message you're quoting.
+            edit_timestamp_ms: ``sent_at_ms`` of a prior message FROM this
+                account to rewrite.  The new ``text`` replaces the old one;
+                Signal clients render an "edited" indicator.
         """
         assert self._daemon is not None
-        phone = self._uuid_to_phone.get(account)
-        if phone is None:
-            raise ValueError(f"signal_send: unknown account {account!r}")
+        phone = self._resolve_phone(account, "signal_send")
         host_paths: list[Path] = list(attachments or [])
-        params = _build_send_params(phone, chat_id, text, attachments=host_paths)
+        member_uuids = self._group_member_uuids(phone, chat_id)
+        params = _build_send_params(
+            phone,
+            chat_id,
+            text,
+            attachments=host_paths,
+            member_uuids=member_uuids,
+            quote_timestamp_ms=quote_timestamp_ms,
+            quote_author_uuid=quote_author_uuid,
+            edit_timestamp_ms=edit_timestamp_ms,
+        )
         result = await self._daemon.rpc.call("send", params)
         ts = _extract_timestamp(result)
         return {"sent_at_ms": ts} if ts is not None else {"status": "ok"}
+
+    @tool()
+    @focal_required
+    async def signal_delete(
+        self,
+        target_timestamp_ms: int,
+        *,
+        account: str,
+        chat_id: str,
+    ) -> dict[str, Any]:
+        """Delete-for-everyone a prior message in your focal Signal chat.
+
+        signal-cli only allows deleting messages this account sent;
+        attempting to delete someone else's message returns an RPC
+        error.  Pass the ``sent_at_ms`` you got back from
+        ``signal_send`` (or ``timestamp_ms`` from an inbound header
+        for self-messages received as sync events).
+
+        Args:
+            target_timestamp_ms: The Signal timestamp of the message to delete.
+        """
+        assert self._daemon is not None
+        phone = self._resolve_phone(account, "signal_delete")
+        chat_type, raw_id = decode_chat_id(chat_id)
+        params: dict[str, Any] = {
+            "account": phone,
+            "targetTimestamp": target_timestamp_ms,
+        }
+        if chat_type == "group":
+            params["groupId"] = raw_id
+        else:
+            params["recipient"] = [raw_id]
+        await self._daemon.rpc.call("remoteDelete", params)
+        return {"status": "ok"}
+
+    @tool()
+    @focal_required
+    async def signal_create_group(
+        self,
+        name: str,
+        member_uuids: list[str],
+        *,
+        account: str,
+        chat_id: str,
+    ) -> dict[str, Any]:
+        """Create a new Signal group on the focal account.
+
+        The new group is owned by the focal account.  ``chat_id`` is
+        passed through by the focal protocol but ignored here — the
+        new group has no chat_id yet.
+
+        Args:
+            name: Group display name.
+            member_uuids: ACI UUIDs of the members to add (excluding this
+                account, which is added implicitly as the creator).
+        """
+        assert self._daemon is not None
+        phone = self._resolve_phone(account, "signal_create_group")
+        result = await self._daemon.rpc.call(
+            "updateGroup",
+            {"account": phone, "name": name, "members": member_uuids},
+        )
+        group_id = result.get("groupId") if result else None
+        return {"group_id": group_id} if group_id else {"status": "ok"}
+
+    @tool()
+    @focal_required
+    async def signal_rename_group(
+        self,
+        name: str,
+        *,
+        account: str,
+        chat_id: str,
+    ) -> dict[str, Any]:
+        """Rename your focal Signal group.
+
+        Only valid when the focal channel is a group; calling this from
+        a DM raises ``ValueError`` with a message the model can recover
+        from on the next turn.
+
+        Args:
+            name: The new group name.
+        """
+        assert self._daemon is not None
+        phone = self._resolve_phone(account, "signal_rename_group")
+        chat_type, raw_id = decode_chat_id(chat_id)
+        if chat_type != "group":
+            raise ValueError("signal_rename_group: focal channel is a DM, not a group")
+        await self._daemon.rpc.call(
+            "updateGroup",
+            {"account": phone, "groupId": raw_id, "name": name},
+        )
+        return {"status": "ok"}
+
+    def _resolve_phone(self, account: str, tool_name: str) -> str:
+        phone = self._uuid_to_phone.get(account)
+        if phone is None:
+            raise ValueError(f"{tool_name}: unknown account {account!r}")
+        return phone
+
+    def _group_member_uuids(self, phone: str, chat_id: str) -> list[str]:
+        """Member UUIDs of the focal group, or ``[]`` if the chat is a DM
+        or the group isn't in the cached roster (mentions become a no-op)."""
+        chat_type, _ = decode_chat_id(chat_id)
+        if chat_type != "group":
+            return []
+        for group in self._groups_by_account.get(phone, []):
+            if group.id == chat_id:
+                return list(group.member_uuids)
+        return []
 
     @tool()
     @focal_required
@@ -294,9 +429,7 @@ class SignalConnector(Connector):
             emoji: The reaction emoji.
         """
         assert self._daemon is not None
-        phone = self._uuid_to_phone.get(account)
-        if phone is None:
-            raise ValueError(f"signal_react: unknown account {account!r}")
+        phone = self._resolve_phone(account, "signal_react")
         params = _build_react_params(phone, chat_id, target_author_uuid, target_timestamp_ms, emoji)
         await self._daemon.rpc.call("sendReaction", params)
         return {"status": "ok"}
@@ -349,19 +482,49 @@ def _build_send_params(
     text: str,
     *,
     attachments: list[Path],
+    member_uuids: list[str] | None = None,
+    quote_timestamp_ms: int | None = None,
+    quote_author_uuid: str | None = None,
+    edit_timestamp_ms: int | None = None,
 ) -> dict[str, Any]:
-    """Translate ``(account_phone, chat_id, text)`` into signal-cli ``send`` params."""
+    """Translate ``(account_phone, chat_id, text)`` into signal-cli ``send`` params.
+
+    ``member_uuids`` enables outbound mention encoding for group sends:
+    any ``@<uuid_prefix>`` in ``text`` that uniquely matches a member's
+    UUID is rewritten as a U+FFFC placeholder + ``mentions`` array
+    entry.  Mention encoding runs BEFORE markdown conversion so the
+    UTF-16 offsets stay correct for both annotation lists.
+
+    Quote: ``quote_timestamp_ms`` and ``quote_author_uuid`` must be
+    set together; one-without-the-other raises ``ValueError`` (signal-cli
+    rejects partial quotes, and silently dropping the model's intent
+    leaves no signal that the thread didn't land).
+
+    Edit: ``edit_timestamp_ms`` rewrites the prior message of this
+    account at that timestamp.  signal-cli routes via the same ``send``
+    RPC; the timestamp identifies which message to replace.
+    """
+    if (quote_timestamp_ms is None) != (quote_author_uuid is None):
+        raise ValueError("quote_timestamp_ms and quote_author_uuid must be set together")
     chat_type, raw_id = decode_chat_id(chat_id)
-    stripped, styles = convert_markdown_to_signal_styles(text)
+    encoded, mentions = encode_mentions(text, member_uuids or [])
+    stripped, styles = convert_markdown_to_signal_styles(encoded)
     params: dict[str, Any] = {"account": account_phone, "message": stripped}
     if styles:
         params["textStyles"] = styles
+    if mentions:
+        params["mentions"] = mentions
     if chat_type == "group":
         params["groupId"] = raw_id
     else:
         params["recipient"] = [raw_id]
     if attachments:
         params["attachments"] = [str(p) for p in attachments]
+    if quote_timestamp_ms is not None and quote_author_uuid is not None:
+        params["quoteTimestamp"] = quote_timestamp_ms
+        params["quoteAuthor"] = quote_author_uuid
+    if edit_timestamp_ms is not None:
+        params["editTimestamp"] = edit_timestamp_ms
     return params
 
 

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -51,7 +51,7 @@ from .addressing import decode_chat_id, encode_chat_id
 from .config import Settings
 from .daemon import GroupInfo, SignalDaemon
 from .markdown import convert_markdown_to_signal_styles
-from .mentions import encode_mentions
+from .mentions import build_mention_strings, encode_mentions
 from .parse import InboundMessage, build_content_text, parse_envelope
 from .prompts import build_instructions
 
@@ -348,8 +348,14 @@ class SignalConnector(Connector):
             "updateGroup",
             {"account": phone, "name": name, "members": member_uuids},
         )
-        group_id = result.get("groupId") if result else None
-        return {"group_id": group_id} if group_id else {"status": "ok"}
+        if not isinstance(result, dict) or not result.get("groupId"):
+            raise RuntimeError(f"signal-cli updateGroup did not return a groupId; got {result!r}")
+        # Refresh the roster cache so an immediate signal_send into this
+        # new group can resolve ``@<uuid_prefix>`` mentions against its
+        # members.  Without the refresh the next send would silently drop
+        # any mentions (group missing from cache → empty member_uuids).
+        self._groups_by_account[phone] = await self._daemon.list_groups(account=phone)
+        return {"group_id": result["groupId"]}
 
     @tool()
     @focal_required
@@ -507,8 +513,13 @@ def _build_send_params(
     if (quote_timestamp_ms is None) != (quote_author_uuid is None):
         raise ValueError("quote_timestamp_ms and quote_author_uuid must be set together")
     chat_type, raw_id = decode_chat_id(chat_id)
-    encoded, mentions = encode_mentions(text, member_uuids or [])
+    # Mention encoding inserts U+FFFC placeholders; markdown stripping
+    # then removes delimiter chars (which can shift placeholder offsets
+    # leftward).  Compute Signal's mention offsets against the *final*
+    # stripped message so they match what the recipient sees.
+    encoded, ordered_uuids = encode_mentions(text, member_uuids or [])
     stripped, styles = convert_markdown_to_signal_styles(encoded)
+    mentions = build_mention_strings(stripped, ordered_uuids)
     params: dict[str, Any] = {"account": account_phone, "message": stripped}
     if styles:
         params["textStyles"] = styles

--- a/connectors/signal/src/aios_signal/markdown.py
+++ b/connectors/signal/src/aios_signal/markdown.py
@@ -19,14 +19,7 @@ from __future__ import annotations
 import re
 from typing import NamedTuple
 
-
-def _utf16_len(text: str) -> int:
-    # Each UTF-16 code unit is 2 bytes; divide by 2 to get code-unit count.
-    return len(text.encode("utf-16-le")) // 2
-
-
-def _codepoint_to_utf16_offset(text: str, cp_offset: int) -> int:
-    return _utf16_len(text[:cp_offset])
+from ._utf16 import codepoint_to_utf16_offset, utf16_len
 
 
 class _StyleSpan(NamedTuple):
@@ -320,8 +313,8 @@ def convert_markdown_to_signal_styles(
         if length_cp <= 0:
             continue
         # Convert to UTF-16 offsets
-        utf16_start = _codepoint_to_utf16_offset(stripped, adj_start)
-        utf16_length = _utf16_len(stripped[adj_start:adj_end])
+        utf16_start = codepoint_to_utf16_offset(stripped, adj_start)
+        utf16_length = utf16_len(stripped[adj_start:adj_end])
         styles.append(f"{utf16_start}:{utf16_length}:{span.style}")
 
     return stripped, styles

--- a/connectors/signal/src/aios_signal/mentions.py
+++ b/connectors/signal/src/aios_signal/mentions.py
@@ -1,0 +1,80 @@
+"""Encode ``@<uuid_prefix>`` mention syntax for outbound Signal messages.
+
+Signal represents mentions in the wire protocol as a U+FFFC placeholder
+in the message body plus a parallel ``mentions`` array of
+``"start:length:uuid"`` entries.  This module turns agent-friendly text
+of the form ``"hey @abcd1234, ping"`` into that wire form.
+
+Group-only by design: the resolver matches each ``@<hex>`` candidate
+against the UUIDs of the current group's members.  In a DM there is
+only one possible counterparty, so callers pass an empty
+``member_uuids`` list and this module is a no-op (the text passes
+through unchanged).
+"""
+
+from __future__ import annotations
+
+import re
+
+from ._utf16 import codepoint_to_utf16_offset
+from .parse import MENTION_PLACEHOLDER
+
+# Min 8 hex chars OR a full dashed UUID.  8 hex is enough to disambiguate
+# within typical group sizes.
+_MENTION_RE = re.compile(
+    r"@([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+    r"|[0-9a-fA-F]{8,})",
+    re.IGNORECASE,
+)
+
+
+def _resolve(candidate: str, member_uuids: list[str]) -> str | None:
+    """Return the unique full UUID matching ``candidate``, or None.
+
+    Strips dashes and lowercases both sides so a prefix like
+    ``"abcd1234"`` matches ``"abcd1234-xxxx-..."``.  Returns None when
+    zero or multiple members match — ambiguity is a no-op rather than
+    a guess.
+    """
+    clean = candidate.lower().replace("-", "")
+    matches = [u for u in member_uuids if u.lower().replace("-", "").startswith(clean)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def encode_mentions(
+    text: str,
+    member_uuids: list[str],
+) -> tuple[str, list[str]]:
+    """Replace resolved ``@<hex>`` syntax with placeholders + mentions metadata.
+
+    Returns ``(encoded_text, mentions)`` where ``mentions`` is a list of
+    ``"<utf16_start>:1:<full_uuid>"`` strings (Signal's textStyles use
+    UTF-16 code-unit offsets, and so do mentions).  Unresolved candidates
+    are left in the text as-is so the agent can see they didn't land
+    when the message arrives.
+    """
+    if not member_uuids or "@" not in text:
+        return text, []
+
+    resolved: list[tuple[int, int, str]] = []  # (start, end, full_uuid) in original text
+    for m in _MENTION_RE.finditer(text):
+        full_uuid = _resolve(m.group(1), member_uuids)
+        if full_uuid is not None:
+            resolved.append((m.start(), m.end(), full_uuid))
+
+    if not resolved:
+        return text, []
+
+    # Splice right-to-left so earlier indices stay valid.
+    encoded = text
+    for start, end, _uuid in reversed(resolved):
+        encoded = encoded[:start] + MENTION_PLACEHOLDER + encoded[end:]
+
+    # Signal mention offsets are UTF-16 code units, not Python code points.
+    mention_uuids = iter(uuid for _, _, uuid in resolved)
+    mentions = [
+        f"{codepoint_to_utf16_offset(encoded, i)}:1:{next(mention_uuids)}"
+        for i, ch in enumerate(encoded)
+        if ch == MENTION_PLACEHOLDER
+    ]
+    return encoded, mentions

--- a/connectors/signal/src/aios_signal/mentions.py
+++ b/connectors/signal/src/aios_signal/mentions.py
@@ -2,14 +2,19 @@
 
 Signal represents mentions in the wire protocol as a U+FFFC placeholder
 in the message body plus a parallel ``mentions`` array of
-``"start:length:uuid"`` entries.  This module turns agent-friendly text
-of the form ``"hey @abcd1234, ping"`` into that wire form.
+``"start:length:uuid"`` entries with UTF-16 code-unit offsets.  The
+flow has two stages because markdown stripping happens between mention
+substitution and the final outbound message:
+
+1. :func:`encode_mentions` — replace ``@<hex>`` syntax with U+FFFC and
+   return the encoded text plus a left-to-right list of resolved UUIDs.
+2. :func:`build_mention_strings` — after any further text mutation
+   (markdown stripping), pair each remaining U+FFFC with its UUID and
+   compute UTF-16 offsets against the *final* message body.
 
 Group-only by design: the resolver matches each ``@<hex>`` candidate
-against the UUIDs of the current group's members.  In a DM there is
-only one possible counterparty, so callers pass an empty
-``member_uuids`` list and this module is a no-op (the text passes
-through unchanged).
+against the UUIDs of the current group's members.  In a DM the caller
+passes an empty ``member_uuids`` list and this module is a no-op.
 """
 
 from __future__ import annotations
@@ -45,18 +50,27 @@ def encode_mentions(
     text: str,
     member_uuids: list[str],
 ) -> tuple[str, list[str]]:
-    """Replace resolved ``@<hex>`` syntax with placeholders + mentions metadata.
+    """Replace resolved ``@<hex>`` syntax with U+FFFC placeholders.
 
-    Returns ``(encoded_text, mentions)`` where ``mentions`` is a list of
-    ``"<utf16_start>:1:<full_uuid>"`` strings (Signal's textStyles use
-    UTF-16 code-unit offsets, and so do mentions).  Unresolved candidates
-    are left in the text as-is so the agent can see they didn't land
-    when the message arrives.
+    Returns ``(encoded_text, ordered_uuids)`` where ``ordered_uuids[i]``
+    is the UUID that the i-th U+FFFC in ``encoded_text`` (left-to-right)
+    represents.  The caller pairs each placeholder with its UUID via
+    :func:`build_mention_strings` *after* any subsequent text mutation
+    (e.g. markdown stripping) — markdown removal preserves placeholder
+    order but shifts character offsets, so offsets must be computed on
+    the final message body.
+
+    Pre-existing U+FFFC characters in ``text`` are stripped before
+    encoding.  Outbound Signal sends use U+FFFC exclusively for
+    mentions; an orphan placeholder would either crash the offset/UUID
+    pairing or be rejected by signal-cli.
     """
+    if MENTION_PLACEHOLDER in text:
+        text = text.replace(MENTION_PLACEHOLDER, "")
     if not member_uuids or "@" not in text:
         return text, []
 
-    resolved: list[tuple[int, int, str]] = []  # (start, end, full_uuid) in original text
+    resolved: list[tuple[int, int, str]] = []  # (start, end, full_uuid)
     for m in _MENTION_RE.finditer(text):
         full_uuid = _resolve(m.group(1), member_uuids)
         if full_uuid is not None:
@@ -70,11 +84,24 @@ def encode_mentions(
     for start, end, _uuid in reversed(resolved):
         encoded = encoded[:start] + MENTION_PLACEHOLDER + encoded[end:]
 
-    # Signal mention offsets are UTF-16 code units, not Python code points.
-    mention_uuids = iter(uuid for _, _, uuid in resolved)
-    mentions = [
-        f"{codepoint_to_utf16_offset(encoded, i)}:1:{next(mention_uuids)}"
-        for i, ch in enumerate(encoded)
+    return encoded, [uuid for _, _, uuid in resolved]
+
+
+def build_mention_strings(message: str, ordered_uuids: list[str]) -> list[str]:
+    """Pair each U+FFFC in ``message`` with the next UUID and emit
+    ``"<utf16_start>:1:<uuid>"`` strings.
+
+    ``message`` is the final outbound text (already markdown-stripped);
+    ``ordered_uuids`` comes from :func:`encode_mentions`.  Caller
+    invariant: ``message`` contains exactly ``len(ordered_uuids)``
+    placeholders, in the same left-to-right order as the source
+    ``@<hex>`` matches.
+    """
+    if not ordered_uuids:
+        return []
+    uuid_iter = iter(ordered_uuids)
+    return [
+        f"{codepoint_to_utf16_offset(message, i)}:1:{next(uuid_iter)}"
+        for i, ch in enumerate(message)
         if ch == MENTION_PLACEHOLDER
     ]
-    return encoded, mentions

--- a/connectors/signal/src/aios_signal/prompts.py
+++ b/connectors/signal/src/aios_signal/prompts.py
@@ -121,10 +121,12 @@ So a reply to message 1700000000000 from Alice would look like:
      > earlier message text...
 
 To thread your own reply against the message Alice was responding to,
-you'd use ``quote_timestamp_ms=1700000000000`` and
-``quote_author_uuid="22334455-..."`` (the values from ``reply_to``).
-To react to Alice's message itself, use ``timestamp_ms=1700000000999``
-and ``sender_uuid=fb2c91e2-...`` (the values from the top header).
+pass ``signal_send`` ``quote_timestamp_ms=1700000000000`` and
+``quote_author_uuid="22334455-..."`` (copied from the ``reply_to``
+line's ``timestamp_ms`` and ``author_uuid``).  To react to Alice's
+message itself, pass ``signal_react`` ``target_timestamp_ms=1700000000999``
+and ``target_author_uuid="fb2c91e2-..."`` (copied from the top
+header's ``timestamp_ms`` and ``sender_uuid``).
 
 ## Sending messages — `signal_send`
 

--- a/connectors/signal/src/aios_signal/prompts.py
+++ b/connectors/signal/src/aios_signal/prompts.py
@@ -90,6 +90,42 @@ verbatim, do not decode it.  It already encodes the distinction between
 direct messages (a recipient UUID) and groups (a URL-safe-base64 group
 id) so the tool can route correctly.
 
+## Reading inbound messages
+
+Every inbound message arrives prefixed with a bracketed header.  This
+is the **only** authoritative source for the ``sender_uuid`` and
+``timestamp_ms`` values that ``signal_send``'s ``quote_*`` /
+``edit_timestamp_ms`` params and ``signal_react`` / ``signal_delete``
+expect.  Copy them verbatim from the header — never construct,
+shorten, or reformat them.
+
+Header shape (newlines added for clarity):
+
+    [channel=signal/<account>/<chat_id> · chat_type=<dm|group> ·
+     chat_name='Group Name' · from=Alice · sender_uuid=<uuid> ·
+     timestamp_ms=<ms> (<iso>)]
+
+When the inbound is a reply, a second line follows:
+
+    [reply_to: author_uuid=<uuid> · timestamp_ms=<ms>] > snippet
+
+When it's a reaction:
+
+    [reaction='👍' · target_author_uuid=<uuid> · target_timestamp_ms=<ms>]
+
+So a reply to message 1700000000000 from Alice would look like:
+
+    [channel=signal/.../grp_id · chat_type=group · from=Alice ·
+     sender_uuid=fb2c91e2-... · timestamp_ms=1700000000999 (...)]
+    [reply_to: author_uuid=22334455-... · timestamp_ms=1700000000000]
+     > earlier message text...
+
+To thread your own reply against the message Alice was responding to,
+you'd use ``quote_timestamp_ms=1700000000000`` and
+``quote_author_uuid="22334455-..."`` (the values from ``reply_to``).
+To react to Alice's message itself, use ``timestamp_ms=1700000000999``
+and ``sender_uuid=fb2c91e2-...`` (the values from the top header).
+
 ## Sending messages — `signal_send`
 
 **Your text responses are NOT sent automatically.** Bare assistant text
@@ -116,8 +152,19 @@ wondering what is happening — if so, send an update.
 
 Pass `quote_timestamp_ms` AND `quote_author_uuid` (both required) to
 thread your reply as a quote of an earlier message.  Copy them from
-the inbound header.  Use this when the conversation has moved on but
-your reply specifically responds to an older message.
+the inbound header (see "Reading inbound messages" above).
+
+**Use quote-reply when:**
+- You're answering a message from earlier in the conversation, not
+  the most recent one — without a quote, the receiver wonders which
+  message you're answering.
+- Multiple people are talking and it might otherwise be unclear who
+  you're responding to.
+
+**Don't quote when:**
+- You're responding to the most recent message — it's already obvious.
+- You're continuing a natural back-and-forth where the context is
+  already clear.  Quoting every turn is noisy.
 
 ### Mentions in groups
 
@@ -126,6 +173,11 @@ must be at least 8 hex chars and uniquely match one member's UUID.
 Full dashed UUIDs work too.  Example: ``@fb2c91e2 can you handle this?``
 Resolved mentions are encoded automatically; an unresolved prefix
 stays as plain text.  Mentions are ignored in DMs.
+
+**Do NOT use display names** like ``@Alice`` or ``@Bob`` — they are
+not resolved.  The recipient sees a literal ``@Alice`` instead of a
+real mention.  The group roster block in your system prompt lists
+each member's UUID; copy 8+ hex characters from there.
 
 ### Editing a prior message — `edit_timestamp_ms`
 
@@ -146,12 +198,28 @@ visible (a tombstone replaces the message).
 
 ## Reacting — `signal_react`
 
-Lighter-weight than a full message.  Call when an emoji says enough:
+Lighter-weight than a full message.  Call when an emoji says enough.
+Use the ``sender_uuid`` and ``timestamp_ms`` from the inbound header
+of the message you're reacting to:
 
     signal_react(
-        target_author_uuid="<uuid from inbound metadata>",
-        target_timestamp_ms=<timestamp from inbound metadata>,
+        target_author_uuid="<sender_uuid from header>",
+        target_timestamp_ms=<timestamp_ms from header>,
         emoji="👍",
+    )
+
+For example, if you see:
+
+    [channel=... · from=Alice · sender_uuid=fb2c91e2-aaaa-... ·
+     timestamp_ms=1700000000000 (...)]
+    Done with the deploy!
+
+react with:
+
+    signal_react(
+        target_author_uuid="fb2c91e2-aaaa-...",
+        target_timestamp_ms=1700000000000,
+        emoji="🎉",
     )
 
 **Common reactions:** 👍 ❤️ 😂 😮 😢 🎉 🔥 ✅

--- a/connectors/signal/src/aios_signal/prompts.py
+++ b/connectors/signal/src/aios_signal/prompts.py
@@ -5,9 +5,8 @@ Returned in the ``InitializeResult.instructions`` field of the MCP
 session's system prompt under a ``## Connector: signal/<account>``
 heading.
 
-Covers only the tools this server actually exposes — ``signal_send``,
-``signal_react``, ``signal_read_receipt``.  Telling the model about
-tools that don't exist would be worse than silence.
+Covers only the tools this server actually exposes.  Telling the
+model about tools that don't exist would be worse than silence.
 
 The instructions are composed per-run: ``build_instructions`` prepends
 an identity block (bot's own ``sender_uuid`` + phone number) and a
@@ -97,7 +96,7 @@ id) so the tool can route correctly.
 is internal monologue; nobody on Signal sees it.  To deliver a message
 you MUST call:
 
-    signal_send(chat_id="<chat_id>", text="your message here")
+    signal_send(text="your message here")
 
 If you don't call this tool, no one will see your response.
 
@@ -113,12 +112,43 @@ work between them (research, file processing, long tasks) and you are
 giving progress updates.  The test is whether the human would be left
 wondering what is happening — if so, send an update.
 
+### Quoting a prior message
+
+Pass `quote_timestamp_ms` AND `quote_author_uuid` (both required) to
+thread your reply as a quote of an earlier message.  Copy them from
+the inbound header.  Use this when the conversation has moved on but
+your reply specifically responds to an older message.
+
+### Mentions in groups
+
+In a group, write `@<uuid_prefix>` to mention a member — the prefix
+must be at least 8 hex chars and uniquely match one member's UUID.
+Full dashed UUIDs work too.  Example: ``@fb2c91e2 can you handle this?``
+Resolved mentions are encoded automatically; an unresolved prefix
+stays as plain text.  Mentions are ignored in DMs.
+
+### Editing a prior message — `edit_timestamp_ms`
+
+Pass `edit_timestamp_ms=<sent_at_ms>` to rewrite a message you sent
+earlier.  The new `text` replaces the old; Signal clients show an
+"edited" indicator.  You can only edit your own messages.  Get the
+timestamp from `sent_at_ms` in a prior `signal_send` result.
+
+## Deleting a message — `signal_delete`
+
+Delete-for-everyone a message you sent earlier.  Pass the
+`sent_at_ms` you got back from `signal_send`:
+
+    signal_delete(target_timestamp_ms=<sent_at_ms>)
+
+Only your own messages can be deleted.  Use sparingly — deletes are
+visible (a tombstone replaces the message).
+
 ## Reacting — `signal_react`
 
 Lighter-weight than a full message.  Call when an emoji says enough:
 
     signal_react(
-        chat_id="<chat_id>",
         target_author_uuid="<uuid from inbound metadata>",
         target_timestamp_ms=<timestamp from inbound metadata>,
         emoji="👍",
@@ -137,19 +167,19 @@ Lighter-weight than a full message.  Call when an emoji says enough:
 Mundane messages do not need reactions; standout moments do.  Think
 about what a human would naturally react to.
 
-## Read receipts — `signal_read_receipt`
+## Group admin — `signal_create_group`, `signal_rename_group`
 
-Mark one or more inbound messages as read so the sender's UI shows the
-double check.  Pass the sender's ACI UUID and the timestamps of the
-messages you are acknowledging:
+Create a new group on the focal account:
 
-    signal_read_receipt(
-        sender_uuid="<uuid>",
-        timestamp_ms_list=[<ts1>, <ts2>],
-    )
+    signal_create_group(name="Project X", member_uuids=["<uuid1>", "<uuid2>"])
 
-Use sparingly — usually only when you have actually consumed the
-messages and the sender benefits from knowing.
+You're added as the creator implicitly; pass the other members'
+UUIDs.  The result includes the new group's id, which you can hand
+to `switch_channel` to focus into it.
+
+Rename your focal group (only valid when focal is a group, not a DM):
+
+    signal_rename_group(name="New name")
 
 ## Markdown subset
 

--- a/connectors/signal/tests/conftest.py
+++ b/connectors/signal/tests/conftest.py
@@ -5,17 +5,61 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
+from aios_connector.base import ToolDescriptor
+
+from aios_signal.config import Settings
+from aios_signal.connector import SignalConnector
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 BOT_UUID = "99999999-8888-7777-6666-555555555555"
 
+# Sample identities used across send/delete/groups tests.
+ALICE_UUID = "11111111-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+BOB_UUID = "22222222-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+GROUP_CHAT_ID = "abcXYZ123_-"  # URL-safe base64; not a UUID
+# decode_chat_id reverses URL-safe → standard base64 before handing the
+# raw form to signal-cli.
+GROUP_RAW_ID = "abcXYZ123/+"
+
 
 def _load(name: str) -> dict[str, Any]:
     data: dict[str, Any] = json.loads((FIXTURES_DIR / name).read_text())
     return data
+
+
+@pytest.fixture
+def connector(tmp_path: Path) -> SignalConnector:
+    """SignalConnector with a stubbed daemon — tests drive RPC via the mock."""
+    cfg = Settings(
+        phones=["+15550001"],
+        config_dir=tmp_path / "cfg",
+        cli_bin="/usr/bin/signal-cli",
+    )
+    c = SignalConnector(cfg)
+    c._uuid_to_phone = {"bot-uuid": "+15550001"}
+    c._daemon = type(
+        "Daemon", (), {"rpc": type("Rpc", (), {"call": AsyncMock(return_value=None)})()}
+    )()
+    return c
+
+
+def descriptor(connector: SignalConnector, name: str) -> ToolDescriptor:
+    """Look up a tool descriptor by name on the connector."""
+    return next(d for d in connector._tools if d.name == name)
+
+
+def stub_focal(connector: SignalConnector, value: str | None) -> None:
+    """Override the connector's focal-channel resolver for a single test."""
+    connector._focal_from_request_meta = lambda: value  # type: ignore[method-assign]
+
+
+def decode_tool_result(content_list: list[Any]) -> dict[str, Any]:
+    """Parse the JSON payload from a tool's MCP-style content list."""
+    return dict(json.loads(content_list[0].text))
 
 
 @pytest.fixture

--- a/connectors/signal/tests/conftest.py
+++ b/connectors/signal/tests/conftest.py
@@ -42,7 +42,14 @@ def connector(tmp_path: Path) -> SignalConnector:
     c = SignalConnector(cfg)
     c._uuid_to_phone = {"bot-uuid": "+15550001"}
     c._daemon = type(
-        "Daemon", (), {"rpc": type("Rpc", (), {"call": AsyncMock(return_value=None)})()}
+        "Daemon",
+        (),
+        {
+            "rpc": type("Rpc", (), {"call": AsyncMock(return_value=None)})(),
+            # signal_create_group refreshes the roster cache via list_groups
+            # post-create; tests that don't care can leave the default ``[]``.
+            "list_groups": AsyncMock(return_value=[]),
+        },
     )()
     return c
 

--- a/connectors/signal/tests/test_mentions.py
+++ b/connectors/signal/tests/test_mentions.py
@@ -1,0 +1,70 @@
+"""Unit coverage for ``aios_signal.mentions.encode_mentions``."""
+
+from __future__ import annotations
+
+from aios_signal.mentions import encode_mentions
+from aios_signal.parse import MENTION_PLACEHOLDER
+
+ALICE = "fb2c91e2-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+BOB = "22334455-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+CAROL = "fb2c91e3-cccc-cccc-cccc-cccccccccccc"  # shares 7-char prefix with ALICE
+
+
+def test_no_members_returns_text_unchanged() -> None:
+    text, mentions = encode_mentions("hi @fb2c91e2 ping", member_uuids=[])
+    assert text == "hi @fb2c91e2 ping"
+    assert mentions == []
+
+
+def test_no_at_sign_short_circuits() -> None:
+    text, mentions = encode_mentions("plain text", member_uuids=[ALICE, BOB])
+    assert text == "plain text"
+    assert mentions == []
+
+
+def test_resolves_unique_8char_prefix() -> None:
+    text, mentions = encode_mentions("hi @fb2c91e2 ping", member_uuids=[ALICE, BOB])
+    assert text == f"hi {MENTION_PLACEHOLDER} ping"
+    assert mentions == [f"3:1:{ALICE}"]
+
+
+def test_resolves_full_uuid() -> None:
+    text, mentions = encode_mentions(f"yo @{ALICE}!", member_uuids=[ALICE, BOB])
+    assert text == f"yo {MENTION_PLACEHOLDER}!"
+    assert mentions == [f"3:1:{ALICE}"]
+
+
+def test_ambiguous_prefix_left_alone() -> None:
+    # 7 chars below the 8-char minimum; even if it WERE matched, ALICE and CAROL
+    # both share the leading "fb2c91e" prefix so the resolver would refuse.
+    text, mentions = encode_mentions("ping @fb2c91e", member_uuids=[ALICE, CAROL])
+    assert text == "ping @fb2c91e"
+    assert mentions == []
+
+
+def test_unresolved_prefix_passes_through() -> None:
+    # 8 hex chars but matches no member — leave as plain text.
+    text, mentions = encode_mentions("hello @deadbeef", member_uuids=[ALICE, BOB])
+    assert text == "hello @deadbeef"
+    assert mentions == []
+
+
+def test_multiple_mentions_get_separate_entries() -> None:
+    text, mentions = encode_mentions("hi @fb2c91e2 and @22334455", member_uuids=[ALICE, BOB])
+    assert text == f"hi {MENTION_PLACEHOLDER} and {MENTION_PLACEHOLDER}"
+    assert mentions == [f"3:1:{ALICE}", f"9:1:{BOB}"]
+
+
+def test_mention_after_emoji_uses_utf16_offset() -> None:
+    # 🎉 is one Python char but two UTF-16 code units — the placeholder
+    # must be reported at offset 2, not 1.
+    text, mentions = encode_mentions("🎉 @fb2c91e2", member_uuids=[ALICE, BOB])
+    assert text == f"🎉 {MENTION_PLACEHOLDER}"
+    assert mentions == [f"3:1:{ALICE}"]
+
+
+def test_mention_resolution_is_dash_insensitive() -> None:
+    # Strip dashes both sides — agent might use "@fb2c91e2aaaa" without dashes.
+    text, mentions = encode_mentions("hi @fb2c91e2aaaa", member_uuids=[ALICE, BOB])
+    assert MENTION_PLACEHOLDER in text
+    assert mentions == [f"3:1:{ALICE}"]

--- a/connectors/signal/tests/test_mentions.py
+++ b/connectors/signal/tests/test_mentions.py
@@ -1,8 +1,8 @@
-"""Unit coverage for ``aios_signal.mentions.encode_mentions``."""
+"""Unit coverage for ``aios_signal.mentions``."""
 
 from __future__ import annotations
 
-from aios_signal.mentions import encode_mentions
+from aios_signal.mentions import build_mention_strings, encode_mentions
 from aios_signal.parse import MENTION_PLACEHOLDER
 
 ALICE = "fb2c91e2-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
@@ -10,61 +10,96 @@ BOB = "22334455-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 CAROL = "fb2c91e3-cccc-cccc-cccc-cccccccccccc"  # shares 7-char prefix with ALICE
 
 
+# ── encode_mentions ──────────────────────────────────────────────────
+
+
 def test_no_members_returns_text_unchanged() -> None:
-    text, mentions = encode_mentions("hi @fb2c91e2 ping", member_uuids=[])
+    text, ordered = encode_mentions("hi @fb2c91e2 ping", member_uuids=[])
     assert text == "hi @fb2c91e2 ping"
-    assert mentions == []
+    assert ordered == []
 
 
 def test_no_at_sign_short_circuits() -> None:
-    text, mentions = encode_mentions("plain text", member_uuids=[ALICE, BOB])
+    text, ordered = encode_mentions("plain text", member_uuids=[ALICE, BOB])
     assert text == "plain text"
-    assert mentions == []
+    assert ordered == []
 
 
 def test_resolves_unique_8char_prefix() -> None:
-    text, mentions = encode_mentions("hi @fb2c91e2 ping", member_uuids=[ALICE, BOB])
+    text, ordered = encode_mentions("hi @fb2c91e2 ping", member_uuids=[ALICE, BOB])
     assert text == f"hi {MENTION_PLACEHOLDER} ping"
-    assert mentions == [f"3:1:{ALICE}"]
+    assert ordered == [ALICE]
 
 
 def test_resolves_full_uuid() -> None:
-    text, mentions = encode_mentions(f"yo @{ALICE}!", member_uuids=[ALICE, BOB])
+    text, ordered = encode_mentions(f"yo @{ALICE}!", member_uuids=[ALICE, BOB])
     assert text == f"yo {MENTION_PLACEHOLDER}!"
-    assert mentions == [f"3:1:{ALICE}"]
+    assert ordered == [ALICE]
 
 
-def test_ambiguous_prefix_left_alone() -> None:
-    # 7 chars below the 8-char minimum; even if it WERE matched, ALICE and CAROL
-    # both share the leading "fb2c91e" prefix so the resolver would refuse.
-    text, mentions = encode_mentions("ping @fb2c91e", member_uuids=[ALICE, CAROL])
+def test_too_short_prefix_left_alone() -> None:
+    # 7 chars below the 8-char minimum — regex doesn't match at all.
+    text, ordered = encode_mentions("ping @fb2c91e", member_uuids=[ALICE, CAROL])
     assert text == "ping @fb2c91e"
-    assert mentions == []
+    assert ordered == []
+
+
+def test_ambiguous_8char_prefix_returns_no_resolution() -> None:
+    # Both DAVE and EVE share the leading "abcd1234" — resolver can't pick
+    # one, so the candidate falls through as plain text.
+    dave = "abcd1234-dddd-dddd-dddd-dddddddddddd"
+    eve = "abcd1234-eeee-eeee-eeee-eeeeeeeeeeee"
+    text, ordered = encode_mentions("yo @abcd1234 ping", member_uuids=[dave, eve])
+    assert text == "yo @abcd1234 ping"
+    assert ordered == []
 
 
 def test_unresolved_prefix_passes_through() -> None:
     # 8 hex chars but matches no member — leave as plain text.
-    text, mentions = encode_mentions("hello @deadbeef", member_uuids=[ALICE, BOB])
+    text, ordered = encode_mentions("hello @deadbeef", member_uuids=[ALICE, BOB])
     assert text == "hello @deadbeef"
-    assert mentions == []
+    assert ordered == []
 
 
-def test_multiple_mentions_get_separate_entries() -> None:
-    text, mentions = encode_mentions("hi @fb2c91e2 and @22334455", member_uuids=[ALICE, BOB])
+def test_multiple_mentions_preserve_left_to_right_order() -> None:
+    text, ordered = encode_mentions("hi @fb2c91e2 and @22334455", member_uuids=[ALICE, BOB])
     assert text == f"hi {MENTION_PLACEHOLDER} and {MENTION_PLACEHOLDER}"
-    assert mentions == [f"3:1:{ALICE}", f"9:1:{BOB}"]
-
-
-def test_mention_after_emoji_uses_utf16_offset() -> None:
-    # 🎉 is one Python char but two UTF-16 code units — the placeholder
-    # must be reported at offset 2, not 1.
-    text, mentions = encode_mentions("🎉 @fb2c91e2", member_uuids=[ALICE, BOB])
-    assert text == f"🎉 {MENTION_PLACEHOLDER}"
-    assert mentions == [f"3:1:{ALICE}"]
+    assert ordered == [ALICE, BOB]
 
 
 def test_mention_resolution_is_dash_insensitive() -> None:
-    # Strip dashes both sides — agent might use "@fb2c91e2aaaa" without dashes.
-    text, mentions = encode_mentions("hi @fb2c91e2aaaa", member_uuids=[ALICE, BOB])
+    text, ordered = encode_mentions("hi @fb2c91e2aaaa", member_uuids=[ALICE, BOB])
     assert MENTION_PLACEHOLDER in text
-    assert mentions == [f"3:1:{ALICE}"]
+    assert ordered == [ALICE]
+
+
+def test_pre_existing_placeholder_stripped_before_encoding() -> None:
+    # Forwarded inbound text could carry a stray U+FFFC; if encode_mentions
+    # let it through, build_mention_strings would crash on the orphan.
+    text, ordered = encode_mentions(
+        f"{MENTION_PLACEHOLDER}stray @fb2c91e2", member_uuids=[ALICE, BOB]
+    )
+    assert text == f"stray {MENTION_PLACEHOLDER}"
+    assert ordered == [ALICE]
+
+
+# ── build_mention_strings ───────────────────────────────────────────
+
+
+def test_build_strings_returns_empty_when_no_uuids() -> None:
+    assert build_mention_strings("plain text", []) == []
+
+
+def test_build_strings_pairs_placeholders_with_uuids_in_order() -> None:
+    msg = f"hi {MENTION_PLACEHOLDER} and {MENTION_PLACEHOLDER}"
+    assert build_mention_strings(msg, [ALICE, BOB]) == [
+        f"3:1:{ALICE}",
+        f"9:1:{BOB}",
+    ]
+
+
+def test_build_strings_uses_utf16_offsets_after_emoji() -> None:
+    # 🎉 is one Python code point but two UTF-16 code units — the
+    # placeholder must report offset 3, not 2.
+    msg = f"🎉 {MENTION_PLACEHOLDER}"
+    assert build_mention_strings(msg, [ALICE]) == [f"3:1:{ALICE}"]

--- a/connectors/signal/tests/test_signal_delete.py
+++ b/connectors/signal/tests/test_signal_delete.py
@@ -1,0 +1,55 @@
+"""Unit coverage for ``signal_delete``."""
+
+from __future__ import annotations
+
+import pytest
+
+from aios_signal.connector import SignalConnector
+from tests.conftest import (
+    ALICE_UUID,
+    GROUP_CHAT_ID,
+    GROUP_RAW_ID,
+    decode_tool_result,
+    descriptor,
+    stub_focal,
+)
+
+
+async def test_signal_delete_dm_uses_recipient(connector: SignalConnector) -> None:
+    stub_focal(connector, f"bot-uuid/{ALICE_UUID}")
+    result = decode_tool_result(
+        await connector._invoke_tool(
+            descriptor(connector, "signal_delete"),
+            {"target_timestamp_ms": 1700000000000},
+        )
+    )
+    assert result == {"status": "ok"}
+    method, params = connector._daemon.rpc.call.call_args.args  # type: ignore[union-attr]
+    assert method == "remoteDelete"
+    assert params == {
+        "account": "+15550001",
+        "targetTimestamp": 1700000000000,
+        "recipient": [ALICE_UUID],
+    }
+
+
+async def test_signal_delete_group_uses_groupid(connector: SignalConnector) -> None:
+    stub_focal(connector, f"bot-uuid/{GROUP_CHAT_ID}")
+    await connector._invoke_tool(
+        descriptor(connector, "signal_delete"), {"target_timestamp_ms": 999}
+    )
+    method, params = connector._daemon.rpc.call.call_args.args  # type: ignore[union-attr]
+    assert method == "remoteDelete"
+    assert params == {
+        "account": "+15550001",
+        "targetTimestamp": 999,
+        "groupId": GROUP_RAW_ID,
+    }
+
+
+async def test_signal_delete_unknown_account_raises(connector: SignalConnector) -> None:
+    stub_focal(connector, f"nope/{ALICE_UUID}")
+    with pytest.raises(ValueError, match="unknown account"):
+        await connector._invoke_tool(
+            descriptor(connector, "signal_delete"), {"target_timestamp_ms": 1}
+        )

--- a/connectors/signal/tests/test_signal_groups.py
+++ b/connectors/signal/tests/test_signal_groups.py
@@ -1,0 +1,84 @@
+"""Unit coverage for ``signal_create_group`` and ``signal_rename_group``."""
+
+from __future__ import annotations
+
+import pytest
+
+from aios_signal.connector import SignalConnector
+from tests.conftest import (
+    ALICE_UUID,
+    BOB_UUID,
+    GROUP_CHAT_ID,
+    GROUP_RAW_ID,
+    decode_tool_result,
+    descriptor,
+    stub_focal,
+)
+
+# ── signal_create_group ──────────────────────────────────────────────
+
+
+async def test_create_group_sends_no_groupid(connector: SignalConnector) -> None:
+    connector._daemon.rpc.call.return_value = {"groupId": "newgroup_id"}  # type: ignore[union-attr]
+    stub_focal(connector, f"bot-uuid/{ALICE_UUID}")  # focal can be a DM
+    result = decode_tool_result(
+        await connector._invoke_tool(
+            descriptor(connector, "signal_create_group"),
+            {"name": "Tea Party", "member_uuids": [ALICE_UUID, BOB_UUID]},
+        )
+    )
+    assert result == {"group_id": "newgroup_id"}
+    method, params = connector._daemon.rpc.call.call_args.args  # type: ignore[union-attr]
+    assert method == "updateGroup"
+    assert params == {
+        "account": "+15550001",
+        "name": "Tea Party",
+        "members": [ALICE_UUID, BOB_UUID],
+    }
+    assert "groupId" not in params
+
+
+async def test_create_group_falls_back_when_no_groupid_in_result(
+    connector: SignalConnector,
+) -> None:
+    # signal-cli sometimes returns null; the tool should still report success.
+    stub_focal(connector, f"bot-uuid/{ALICE_UUID}")
+    result = decode_tool_result(
+        await connector._invoke_tool(
+            descriptor(connector, "signal_create_group"),
+            {"name": "x", "member_uuids": []},
+        )
+    )
+    assert result == {"status": "ok"}
+
+
+# ── signal_rename_group ──────────────────────────────────────────────
+
+
+async def test_rename_group_with_group_focal(connector: SignalConnector) -> None:
+    stub_focal(connector, f"bot-uuid/{GROUP_CHAT_ID}")
+    result = decode_tool_result(
+        await connector._invoke_tool(
+            descriptor(connector, "signal_rename_group"), {"name": "Renamed"}
+        )
+    )
+    assert result == {"status": "ok"}
+    method, params = connector._daemon.rpc.call.call_args.args  # type: ignore[union-attr]
+    assert method == "updateGroup"
+    assert params == {
+        "account": "+15550001",
+        "groupId": GROUP_RAW_ID,
+        "name": "Renamed",
+    }
+
+
+async def test_rename_group_from_dm_focal_raises(connector: SignalConnector) -> None:
+    stub_focal(connector, f"bot-uuid/{ALICE_UUID}")
+    with pytest.raises(ValueError, match="DM, not a group"):
+        await connector._invoke_tool(descriptor(connector, "signal_rename_group"), {"name": "X"})
+
+
+async def test_rename_group_unknown_account_raises(connector: SignalConnector) -> None:
+    stub_focal(connector, f"nope/{GROUP_CHAT_ID}")
+    with pytest.raises(ValueError, match="unknown account"):
+        await connector._invoke_tool(descriptor(connector, "signal_rename_group"), {"name": "X"})

--- a/connectors/signal/tests/test_signal_groups.py
+++ b/connectors/signal/tests/test_signal_groups.py
@@ -38,18 +38,18 @@ async def test_create_group_sends_no_groupid(connector: SignalConnector) -> None
     assert "groupId" not in params
 
 
-async def test_create_group_falls_back_when_no_groupid_in_result(
+async def test_create_group_raises_when_no_groupid_in_result(
     connector: SignalConnector,
 ) -> None:
-    # signal-cli sometimes returns null; the tool should still report success.
+    # signal-cli's contract is to return {"groupId": ...} on a successful
+    # create.  Anything else is a contract break — fail loud rather than
+    # silently swallowing.
     stub_focal(connector, f"bot-uuid/{ALICE_UUID}")
-    result = decode_tool_result(
+    with pytest.raises(RuntimeError, match="did not return a groupId"):
         await connector._invoke_tool(
             descriptor(connector, "signal_create_group"),
             {"name": "x", "member_uuids": []},
         )
-    )
-    assert result == {"status": "ok"}
 
 
 # ── signal_rename_group ──────────────────────────────────────────────

--- a/connectors/signal/tests/test_signal_send.py
+++ b/connectors/signal/tests/test_signal_send.py
@@ -19,6 +19,14 @@ from aios_connector.base import ToolDescriptor
 
 from aios_signal.config import Settings
 from aios_signal.connector import SignalConnector, _build_send_params
+from aios_signal.daemon import GroupInfo
+from aios_signal.parse import MENTION_PLACEHOLDER
+
+ALICE_UUID = "11111111-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+BOB_UUID = "22222222-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+GROUP_CHAT_ID = "abcXYZ123_-"  # URL-safe base64; not a UUID
+# decode_chat_id maps URL-safe back to signal-cli's standard base64 form.
+GROUP_RAW_ID = "abcXYZ123/+"
 
 
 def test_build_params_no_attachments() -> None:
@@ -210,3 +218,91 @@ async def test_signal_send_unknown_account_raises(
     descriptor = _signal_send_descriptor(connector)
     with pytest.raises(ValueError, match="unknown account"):
         await connector._invoke_tool(descriptor, {"text": "hi"})
+
+
+# ── quote / reply ─────────────────────────────────────────────────────
+
+
+def test_build_params_quote_both_set_passes_through() -> None:
+    params = _build_send_params(
+        "+15550001",
+        ALICE_UUID,
+        "replying",
+        attachments=[],
+        quote_timestamp_ms=1700000000000,
+        quote_author_uuid=ALICE_UUID,
+    )
+    assert params["quoteTimestamp"] == 1700000000000
+    assert params["quoteAuthor"] == ALICE_UUID
+
+
+def test_build_params_quote_partial_raises() -> None:
+    with pytest.raises(ValueError, match="must be set together"):
+        _build_send_params("+15550001", ALICE_UUID, "x", attachments=[], quote_timestamp_ms=123)
+    with pytest.raises(ValueError, match="must be set together"):
+        _build_send_params(
+            "+15550001", ALICE_UUID, "x", attachments=[], quote_author_uuid=ALICE_UUID
+        )
+
+
+# ── edit ──────────────────────────────────────────────────────────────
+
+
+def test_build_params_edit_timestamp_threaded() -> None:
+    params = _build_send_params(
+        "+15550001",
+        ALICE_UUID,
+        "edited",
+        attachments=[],
+        edit_timestamp_ms=1700000005000,
+    )
+    assert params["editTimestamp"] == 1700000005000
+
+
+# ── outbound mentions ─────────────────────────────────────────────────
+
+
+def test_build_params_mentions_resolved_in_group() -> None:
+    params = _build_send_params(
+        "+15550001",
+        GROUP_CHAT_ID,
+        f"hi @{ALICE_UUID[:8]}",
+        attachments=[],
+        member_uuids=[ALICE_UUID, BOB_UUID],
+    )
+    assert params["message"] == f"hi {MENTION_PLACEHOLDER}"
+    assert params["mentions"] == [f"3:1:{ALICE_UUID}"]
+    assert params["groupId"] == GROUP_RAW_ID
+
+
+def test_build_params_no_member_uuids_no_mentions_added() -> None:
+    # DMs (and groups before the roster cache populates) get empty
+    # member_uuids; ``@<hex>`` syntax should pass through verbatim.
+    params = _build_send_params(
+        "+15550001",
+        ALICE_UUID,
+        f"hi @{ALICE_UUID[:8]}",
+        attachments=[],
+    )
+    assert params["message"] == f"hi @{ALICE_UUID[:8]}"
+    assert "mentions" not in params
+
+
+# ── group focal: signal_send picks up member_uuids from connector state ─
+
+
+async def test_signal_send_in_group_encodes_mentions(
+    connector: SignalConnector,
+) -> None:
+    # Seed the connector's group cache so signal_send knows the focal
+    # group's members at send time.
+    connector._groups_by_account["+15550001"] = [
+        GroupInfo(id=GROUP_CHAT_ID, name="Tea Party", member_uuids=[ALICE_UUID, BOB_UUID])
+    ]
+    _stub_focal(connector, f"bot-uuid/{GROUP_CHAT_ID}")
+    descriptor = _signal_send_descriptor(connector)
+    await connector._invoke_tool(descriptor, {"text": f"hey @{ALICE_UUID[:8]}, ready?"})
+    sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
+    assert sent_params["message"] == f"hey {MENTION_PLACEHOLDER}, ready?"
+    assert sent_params["mentions"] == [f"4:1:{ALICE_UUID}"]
+    assert sent_params["groupId"] == GROUP_RAW_ID

--- a/connectors/signal/tests/test_signal_send.py
+++ b/connectors/signal/tests/test_signal_send.py
@@ -1,32 +1,37 @@
-"""Unit coverage for ``signal_send``'s ``attachments`` parameter
-and ``_build_send_params``'s ``attachments`` field.
+"""Unit coverage for ``signal_send``.
 
-Drives the build helper directly (no signal-cli) plus exercises the
-high-level ``signal_send`` method via the SDK's ``_invoke_tool``
-dispatch wrapper — that's the layer where ``SandboxPath`` resolution
-happens, so connector-side tests must go through it.
+Drives the ``_build_send_params`` helper directly (no signal-cli) plus
+exercises the high-level ``signal_send`` method via the SDK's
+``_invoke_tool`` dispatch wrapper — that's the layer where
+``SandboxPath`` resolution happens, so connector-side tests must go
+through it.
 """
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from typing import Any
-from unittest.mock import AsyncMock
 
 import pytest
-from aios_connector.base import ToolDescriptor
 
-from aios_signal.config import Settings
 from aios_signal.connector import SignalConnector, _build_send_params
 from aios_signal.daemon import GroupInfo
 from aios_signal.parse import MENTION_PLACEHOLDER
+from tests.conftest import (
+    ALICE_UUID,
+    BOB_UUID,
+    GROUP_CHAT_ID,
+    GROUP_RAW_ID,
+    decode_tool_result,
+    descriptor,
+    stub_focal,
+)
 
-ALICE_UUID = "11111111-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-BOB_UUID = "22222222-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
-GROUP_CHAT_ID = "abcXYZ123_-"  # URL-safe base64; not a UUID
-# decode_chat_id maps URL-safe back to signal-cli's standard base64 form.
-GROUP_RAW_ID = "abcXYZ123/+"
+
+def _stub_session_id(connector: SignalConnector, value: str | None) -> None:
+    connector.current_session_id = lambda: value  # type: ignore[method-assign]
+
+
+# ── _build_send_params: attachments ─────────────────────────────────
 
 
 def test_build_params_no_attachments() -> None:
@@ -45,78 +50,37 @@ def test_build_params_with_attachments() -> None:
     assert params["attachments"] == ["/host/a.jpg", "/host/b.jpg"]
 
 
-@pytest.fixture
-def connector(tmp_path: Path) -> SignalConnector:
-    cfg = Settings(
-        phones=["+15550001"],
-        config_dir=tmp_path / "cfg",
-        cli_bin="/usr/bin/signal-cli",
-    )
-    c = SignalConnector(cfg)
-    c._uuid_to_phone = {"bot-uuid": "+15550001"}
-    c._daemon = type(  # type: ignore[assignment]
-        "Daemon", (), {"rpc": type("Rpc", (), {"call": AsyncMock(return_value=None)})()}
-    )()
-    return c
-
-
-def _descriptor_for(connector: SignalConnector, name: str) -> ToolDescriptor:
-    descriptor = next(d for d in connector._tools if d.name == name)
-    assert isinstance(descriptor, ToolDescriptor)
-    return descriptor
-
-
-def _signal_send_descriptor(connector: SignalConnector) -> ToolDescriptor:
-    return _descriptor_for(connector, "signal_send")
-
-
-def _stub_focal(connector: SignalConnector, value: str | None) -> None:
-    connector._focal_from_request_meta = lambda: value  # type: ignore[method-assign]
-
-
-def _stub_session_id(connector: SignalConnector, value: str | None) -> None:
-    connector.current_session_id = lambda: value  # type: ignore[method-assign]
-
-
-def _decode(content_list: list[Any]) -> dict[str, Any]:
-    assert len(content_list) == 1
-    payload = json.loads(content_list[0].text)
-    assert isinstance(payload, dict)
-    return payload
-
-
-# Methods bypass focal/sandbox dispatch entirely — verify the descriptor
-# carries the right metadata so a regression in ``@tool`` would surface.
+# ── descriptor metadata ─────────────────────────────────────────────
 
 
 def test_signal_send_descriptor_records_sandbox_param(
     connector: SignalConnector,
 ) -> None:
-    descriptor = _signal_send_descriptor(connector)
-    assert descriptor.sandbox_params == {"attachments": "list"}
+    d = descriptor(connector, "signal_send")
+    assert d.sandbox_params == {"attachments": "list"}
 
 
 def test_signal_send_schema_publishes_string_array_with_description(
     connector: SignalConnector,
 ) -> None:
-    descriptor = _signal_send_descriptor(connector)
-    attachments_schema = descriptor.input_schema["properties"]["attachments"]
+    d = descriptor(connector, "signal_send")
+    attachments_schema = d.input_schema["properties"]["attachments"]
     assert attachments_schema["type"] == "array"
     assert attachments_schema["items"]["type"] == "string"
     assert "/workspace/" in attachments_schema["items"]["description"]
 
 
-# End-to-end via _invoke_tool exercises the dispatch wrapper that
-# auto-resolves SandboxPath args before the tool body runs.
+# ── signal_send via _invoke_tool (exercises SandboxPath resolution) ─
 
 
 async def test_signal_send_text_only_no_session_id_required(
     connector: SignalConnector,
 ) -> None:
-    _stub_focal(connector, "bot-uuid/alice")
+    stub_focal(connector, "bot-uuid/alice")
     _stub_session_id(connector, None)
-    descriptor = _signal_send_descriptor(connector)
-    result = _decode(await connector._invoke_tool(descriptor, {"text": "hello there"}))
+    result = decode_tool_result(
+        await connector._invoke_tool(descriptor(connector, "signal_send"), {"text": "hello there"})
+    )
     assert result == {"status": "ok"}
     sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
     assert sent_params["message"] == "hello there"
@@ -128,16 +92,15 @@ async def test_signal_send_with_attachments_resolves_to_host_paths(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _stub_focal(connector, "bot-uuid/alice")
+    stub_focal(connector, "bot-uuid/alice")
     _stub_session_id(connector, "sess-1")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
     ws = (tmp_path / "sess-1").resolve()
     ws.mkdir(parents=True)
     (ws / "cat.jpg").write_bytes(b"x")
 
-    descriptor = _signal_send_descriptor(connector)
     await connector._invoke_tool(
-        descriptor,
+        descriptor(connector, "signal_send"),
         {"text": "look", "attachments": ["/workspace/cat.jpg"]},
     )
 
@@ -151,13 +114,12 @@ async def test_signal_send_attachments_without_session_id_raises(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _stub_focal(connector, "bot-uuid/alice")
+    stub_focal(connector, "bot-uuid/alice")
     _stub_session_id(connector, None)
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
-    descriptor = _signal_send_descriptor(connector)
     with pytest.raises(RuntimeError, match=r"aios\.session_id"):
         await connector._invoke_tool(
-            descriptor,
+            descriptor(connector, "signal_send"),
             {"text": "look", "attachments": ["/workspace/cat.jpg"]},
         )
 
@@ -167,15 +129,14 @@ async def test_signal_send_attachment_traversal_rejected(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _stub_focal(connector, "bot-uuid/alice")
+    stub_focal(connector, "bot-uuid/alice")
     _stub_session_id(connector, "sess-1")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
     (tmp_path / "sess-1").mkdir(parents=True)
 
-    descriptor = _signal_send_descriptor(connector)
     with pytest.raises(ValueError, match="could not be resolved"):
         await connector._invoke_tool(
-            descriptor,
+            descriptor(connector, "signal_send"),
             {"text": "look", "attachments": ["/workspace/../escape.jpg"]},
         )
 
@@ -183,12 +144,11 @@ async def test_signal_send_attachment_traversal_rejected(
 async def test_signal_send_attachment_disallowed_root_rejected(
     connector: SignalConnector,
 ) -> None:
-    _stub_focal(connector, "bot-uuid/alice")
+    stub_focal(connector, "bot-uuid/alice")
     _stub_session_id(connector, "sess-1")
-    descriptor = _signal_send_descriptor(connector)
     with pytest.raises(ValueError, match="could not be resolved"):
         await connector._invoke_tool(
-            descriptor,
+            descriptor(connector, "signal_send"),
             {"text": "boom", "attachments": ["/etc/passwd"]},
         )
 
@@ -198,15 +158,14 @@ async def test_signal_send_attachment_missing_file_raises_clear_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _stub_focal(connector, "bot-uuid/alice")
+    stub_focal(connector, "bot-uuid/alice")
     _stub_session_id(connector, "sess-1")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
     (tmp_path / "sess-1").mkdir(parents=True)
 
-    descriptor = _signal_send_descriptor(connector)
     with pytest.raises(ValueError, match="does not exist"):
         await connector._invoke_tool(
-            descriptor,
+            descriptor(connector, "signal_send"),
             {"text": "look", "attachments": ["/workspace/typo.jpg"]},
         )
 
@@ -214,10 +173,9 @@ async def test_signal_send_attachment_missing_file_raises_clear_error(
 async def test_signal_send_unknown_account_raises(
     connector: SignalConnector,
 ) -> None:
-    _stub_focal(connector, "nope/alice")
-    descriptor = _signal_send_descriptor(connector)
+    stub_focal(connector, "nope/alice")
     with pytest.raises(ValueError, match="unknown account"):
-        await connector._invoke_tool(descriptor, {"text": "hi"})
+        await connector._invoke_tool(descriptor(connector, "signal_send"), {"text": "hi"})
 
 
 # ── quote / reply ─────────────────────────────────────────────────────
@@ -288,6 +246,38 @@ def test_build_params_no_member_uuids_no_mentions_added() -> None:
     assert "mentions" not in params
 
 
+def test_build_params_mention_after_markdown_uses_stripped_offset() -> None:
+    # Markdown delimiters before a mention shift the placeholder leftward
+    # in ``stripped`` text; the mention offset must reflect ``stripped``,
+    # not the pre-strip ``encoded`` form.  Without offset rebasing, Signal
+    # would highlight the wrong character.
+    params = _build_send_params(
+        "+15550001",
+        GROUP_CHAT_ID,
+        f"**bold** @{ALICE_UUID[:8]} check",
+        attachments=[],
+        member_uuids=[ALICE_UUID, BOB_UUID],
+    )
+    assert params["message"] == f"bold {MENTION_PLACEHOLDER} check"
+    # Placeholder is at UTF-16 offset 5 in stripped text, not 9 in encoded.
+    assert params["mentions"] == [f"5:1:{ALICE_UUID}"]
+
+
+def test_build_params_pre_existing_placeholder_does_not_crash() -> None:
+    # Forwarded inbound text could carry a stray U+FFFC (e.g. attachment-
+    # inline marker).  encode_mentions strips it so build_mention_strings
+    # doesn't see an orphan placeholder it can't pair with a UUID.
+    params = _build_send_params(
+        "+15550001",
+        GROUP_CHAT_ID,
+        f"{MENTION_PLACEHOLDER}stray @{ALICE_UUID[:8]}",
+        attachments=[],
+        member_uuids=[ALICE_UUID, BOB_UUID],
+    )
+    assert params["message"] == f"stray {MENTION_PLACEHOLDER}"
+    assert params["mentions"] == [f"6:1:{ALICE_UUID}"]
+
+
 # ── group focal: signal_send picks up member_uuids from connector state ─
 
 
@@ -299,9 +289,10 @@ async def test_signal_send_in_group_encodes_mentions(
     connector._groups_by_account["+15550001"] = [
         GroupInfo(id=GROUP_CHAT_ID, name="Tea Party", member_uuids=[ALICE_UUID, BOB_UUID])
     ]
-    _stub_focal(connector, f"bot-uuid/{GROUP_CHAT_ID}")
-    descriptor = _signal_send_descriptor(connector)
-    await connector._invoke_tool(descriptor, {"text": f"hey @{ALICE_UUID[:8]}, ready?"})
+    stub_focal(connector, f"bot-uuid/{GROUP_CHAT_ID}")
+    await connector._invoke_tool(
+        descriptor(connector, "signal_send"), {"text": f"hey @{ALICE_UUID[:8]}, ready?"}
+    )
     sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
     assert sent_params["message"] == f"hey {MENTION_PLACEHOLDER}, ready?"
     assert sent_params["mentions"] == [f"4:1:{ALICE_UUID}"]


### PR DESCRIPTION
## Summary

Closes the parity gap between the aios Signal connector and `~/code/jarvis` on messaging-protocol features (mentions, quotes, edits, deletes) and group-admin operations (create, rename). signal-cli's JSON-RPC surface already supported all of these — the connector just hadn't surfaced them yet. Audio (Say/Listen/SoundEffect) and typing indicators were intentionally left out of scope.

- `signal_send` gains `quote_timestamp_ms` + `quote_author_uuid` (must be set together; partial raises `ValueError` rather than silently dropping the model's intent) and `edit_timestamp_ms` (rewrites a prior message of this account).
- In group sends, `@<uuid_prefix>` syntax (min 8 hex) is encoded as Signal's U+FFFC placeholder + `mentions` metadata when the prefix uniquely matches a member. DM sends ignore the syntax. Unresolved prefixes pass through as plain text.
- New `signal_delete` calls `remoteDelete`; new `signal_create_group` / `signal_rename_group` call `updateGroup` (with/without `groupId`). `signal_rename_group` requires a group focal — DM focal raises with a self-describing message the model can recover from.
- UTF-16 offset helpers extracted to `_utf16.py` so `markdown.py` and the new `mentions.py` share one implementation.
- `_resolve_phone` extracted from the now-five tools that look up `phone` from focal `account`.
- Test fixtures (`connector`, `descriptor`, `stub_focal`, `decode_tool_result`, sample UUIDs) hoisted into `conftest.py`.
- README "Out of scope for v1" loses the four items now in scope.

## Test plan

- [x] `connectors/signal/`: 114 unit tests (29 new) — `pytest -q` clean
- [x] `connectors/signal/`: `mypy src` strict + `ruff check` + `ruff format --check`
- [x] Repo root: 1135 unit tests pass (via pre-commit hook)
- [x] Repo root: 252 e2e tests pass with Docker
- [ ] Manual smoke (post-merge): focal a group, agent uses `@<uuid_prefix>` mention; agent replies via `quote_timestamp_ms`; agent edits with `edit_timestamp_ms`; agent deletes via `signal_delete`; agent creates+renames a group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)