### PR TITLE
fix(harness): split TTFT and inter-chunk streaming timeouts (#239)

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -33,7 +33,8 @@ litellm.modify_params = True
 # defaults so user values win. The harness's job-level cap in ``run_session_step``
 # is the safety net if both are bypassed somehow.
 _REQUEST_TIMEOUT_S = 300.0
-_STREAM_INACTIVITY_TIMEOUT_S = 60.0
+_STREAM_TTFT_TIMEOUT_S = 300.0
+_STREAM_INTER_CHUNK_TIMEOUT_S = 60.0
 
 if TYPE_CHECKING:
     import asyncpg
@@ -332,7 +333,7 @@ async def stream_litellm(
         "messages": messages,
         "stream": True,
         "timeout": _REQUEST_TIMEOUT_S,
-        "stream_timeout": _STREAM_INACTIVITY_TIMEOUT_S,
+        "stream_timeout": _STREAM_INTER_CHUNK_TIMEOUT_S,
     }
     if tools:
         kwargs["tools"] = tools
@@ -347,16 +348,22 @@ async def stream_litellm(
     # LiteLLM's own per-chunk bound, but its behavior varies by provider
     # adapter. Wrapping each ``__anext__`` with our own ``wait_for`` makes
     # the bound deterministic regardless of provider — a stalled connection
-    # raises ``TimeoutError`` after ``_STREAM_INACTIVITY_TIMEOUT_S`` rather
-    # than hanging the worker. (Required for the harness's zero-hang
-    # guarantee — see also ``run_session_step``'s job-level cap.)
+    # raises ``TimeoutError`` rather than hanging the worker. (Required for
+    # the harness's zero-hang guarantee — see also ``run_session_step``'s
+    # job-level cap.) The first ``__anext__`` waits for TTFT, which on
+    # cold-cache long-prompt requests can legitimately exceed the
+    # inter-chunk bound; the per-iteration timeout select uses the wider
+    # TTFT ceiling until the first chunk arrives.
     chunks: list[Any] = []
     aiter = response.__aiter__()
+    first = True
     while True:
+        timeout = _STREAM_TTFT_TIMEOUT_S if first else _STREAM_INTER_CHUNK_TIMEOUT_S
         try:
-            chunk = await asyncio.wait_for(aiter.__anext__(), timeout=_STREAM_INACTIVITY_TIMEOUT_S)
+            chunk = await asyncio.wait_for(aiter.__anext__(), timeout=timeout)
         except StopAsyncIteration:
             break
+        first = False
         chunks.append(chunk)
         content = chunk.choices[0].delta.content
         if content:

--- a/tests/unit/test_completion_timeouts.py
+++ b/tests/unit/test_completion_timeouts.py
@@ -11,6 +11,7 @@ These tests confirm the wrapper raises ``TimeoutError`` instead.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 
 import pytest
 
@@ -36,6 +37,17 @@ class _StallingResponse:
             return _make_chunk("hello")
         await asyncio.Event().wait()
         raise AssertionError("unreachable")
+
+
+async def _slow_first_chunk_response(ttft_delay_s: float) -> AsyncIterator[object]:
+    """Delay the first chunk by ``ttft_delay_s``, yield it, then exit.
+
+    Mimics cold-cache long-prompt streaming: TTFT exceeds the inter-chunk
+    bound, but once streaming starts there's no abnormal gap — the failure
+    shape issue #239 fixes.
+    """
+    await asyncio.sleep(ttft_delay_s)
+    yield _make_chunk("hello")
 
 
 def _make_chunk(text: str | None) -> object:
@@ -77,7 +89,7 @@ async def test_stream_litellm_raises_timeout_on_stalled_stream(
 ) -> None:
     """A streaming response that hangs after the first chunk must raise
     ``TimeoutError`` once the per-chunk inactivity bound elapses."""
-    monkeypatch.setattr(completion, "_STREAM_INACTIVITY_TIMEOUT_S", 0.1)
+    monkeypatch.setattr(completion, "_STREAM_INTER_CHUNK_TIMEOUT_S", 0.1)
 
     async def fake_acompletion(**kwargs: object) -> _StallingResponse:
         return _StallingResponse()
@@ -91,6 +103,38 @@ async def test_stream_litellm_raises_timeout_on_stalled_stream(
             pool=_StubPool(),  # type: ignore[arg-type]
             session_id="sess_test",
         )
+
+
+@pytest.mark.asyncio
+async def test_stream_litellm_long_ttft_succeeds_when_inter_chunk_is_fast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First-chunk wait may exceed the inter-chunk bound; the TTFT ceiling
+    applies only to the first chunk."""
+    monkeypatch.setattr(completion, "_STREAM_INTER_CHUNK_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(completion, "_STREAM_TTFT_TIMEOUT_S", 2.0)
+
+    async def fake_acompletion(**kwargs: object) -> AsyncIterator[object]:
+        return _slow_first_chunk_response(ttft_delay_s=0.1)
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(
+        completion.litellm,
+        "stream_chunk_builder",
+        lambda chunks: {
+            "usage": {},
+            "choices": [{"message": {"role": "assistant", "content": "hello"}}],
+        },
+    )
+
+    message, _, _ = await completion.stream_litellm(
+        model="anthropic/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "ping"}],
+        pool=_StubPool(),  # type: ignore[arg-type]
+        session_id="sess_test",
+    )
+
+    assert message["content"] == "hello"
 
 
 @pytest.mark.asyncio
@@ -130,7 +174,7 @@ async def test_stream_litellm_passes_timeout_kwargs(
     )
 
     assert captured["timeout"] == completion._REQUEST_TIMEOUT_S
-    assert captured["stream_timeout"] == completion._STREAM_INACTIVITY_TIMEOUT_S
+    assert captured["stream_timeout"] == completion._STREAM_INTER_CHUNK_TIMEOUT_S
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Closes #239. Single 60s `_STREAM_INACTIVITY_TIMEOUT_S` from PR #179 was applied to every `__anext__()` in `stream_litellm` — including the first chunk, where the wait is actually for TTFT, not inter-chunk inactivity. Cold-cache 130K-token Opus through ant-proxy can run TTFT in tens of seconds while inter-chunk gaps stay sub-second once streaming starts; the conflated bound was failing those requests with `TimeoutError` and looping the retry through the same TTFT problem.
- Split the bound: `_STREAM_TTFT_TIMEOUT_S = 300` for the first chunk (matches `_REQUEST_TIMEOUT_S`), `_STREAM_INTER_CHUNK_TIMEOUT_S = 60` (renamed, same value) for subsequent chunks. Track a `first` flag in the stream loop and pick the bound per iteration. Once any chunk arrives, the bound tightens to the original 60s — preserving #179's hang-prevention guarantee.
- TDD: new `test_stream_litellm_long_ttft_succeeds_when_inter_chunk_is_fast` with a fixture that delays the first chunk past the inter-chunk bound then yields and exits. Fails on pre-fix code with `TimeoutError`; passes after the split. Existing `test_stream_litellm_raises_timeout_on_stalled_stream` continues to pass — confirms the inter-chunk bound is still enforced.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1151 passed
- [x] `uv run pytest tests/e2e -q` — 259 passed in 2m33s
- [ ] Restart the dev worker on this HEAD and confirm a cold-cache long-prompt step that previously timed out at 60s now succeeds (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)