### PR TITLE
feat(config): cloister per-instance runtime state under ~/.aios/instances/<id>/ (#238)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ workspaces/
 
 # smoke-test runtime artifacts
 .logs/
-spool.sqlite
+spool.sqlite*

--- a/connectors/MIGRATION.md
+++ b/connectors/MIGRATION.md
@@ -1,0 +1,21 @@
+# Connector storage migration notes
+
+## Per-instance cloister (#238)
+
+Pre-#238 deployments stored connector state at `~/.aios/connectors/<name>/`
+(spool databases, signal-cli config, etc.). That path is now per-instance:
+`~/.aios/instances/<instance_id>/connectors/<name>/`. Concurrent dev worktrees
+no longer clobber each other's spools.
+
+For an existing `instance_id="default"` deployment (the production
+single-instance case), one-time move:
+
+```
+mkdir -p ~/.aios/instances/default
+mv ~/.aios/connectors ~/.aios/instances/default/connectors
+```
+
+`aios dev bootstrap` writes `AIOS_CONNECTORS_DIR=~/.aios/instances/<id>/connectors`
+into the per-worktree `.env` automatically — dev instances cloister without
+operator action. Operators that explicitly set `AIOS_CONNECTORS_DIR` keep their
+override (escape hatch for ops that pre-bake connector state elsewhere).

--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -109,6 +109,11 @@ when the session has a focal channel set via `switch_channel`.
 | `AIOS_SIGNAL_DAEMON_HOST` | `127.0.0.1` | Internal TCP host for signal-cli daemon |
 | `AIOS_SIGNAL_DAEMON_PORT` | `7583` | Internal TCP port for signal-cli daemon |
 
+## Migration from pre-cloister `~/.aios/connectors`
+
+See [`../MIGRATION.md`](../MIGRATION.md#per-instance-cloister-238) — connector
+state moved to `~/.aios/instances/<instance_id>/connectors/<name>/` in #238.
+
 ## Migration from single-phone PR3
 
 Pre-this-PR signal connectors used `AIOS_SIGNAL_PHONE` (singular).

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -95,6 +95,11 @@ When deploying multiple instances, set
 `AIOS_TELEGRAM_SUPPORT_BOT_TOKEN`).  Instance names match
 `^[a-z][a-z0-9_]*$`.
 
+## Migration from pre-cloister `~/.aios/connectors`
+
+See [`../MIGRATION.md`](../MIGRATION.md#per-instance-cloister-238) — connector
+state moved to `~/.aios/instances/<instance_id>/connectors/<name>/` in #238.
+
 ## Attachments
 
 Inbound photos, voice notes, documents, video, and audio are

--- a/packages/aios-connector/aios_connector/spool.py
+++ b/packages/aios-connector/aios_connector/spool.py
@@ -15,9 +15,10 @@ Deliberate non-features:
 * No per-row TTL.  Spool entries clear on ack; that's the only
   pruning path.
 
-Schema lives at ``~/.aios/connectors/<name>/spool.sqlite`` (the cwd
-the supervisor stamps on every connector subprocess).  Single
-``inbound`` table:
+Schema lives at ``~/.aios/instances/<instance_id>/connectors/<name>/spool.sqlite``
+— the cwd the supervisor stamps on every connector subprocess (#238).
+Per-instance cloistering keeps concurrent dev instances from clobbering
+each other's spools.  Single ``inbound`` table:
 
     event_id    TEXT PRIMARY KEY  — ULID, also the dedup-ledger key
     payload     BLOB NOT NULL     — raw JSON-RPC params bytes

--- a/src/aios/cli/commands/dev.py
+++ b/src/aios/cli/commands/dev.py
@@ -162,7 +162,13 @@ def load_instance_env(repo_root: Path) -> dict[str, str]:
     """
     env_path = repo_root / ".env"
     env = parse_env_file(env_path)
-    required = ("AIOS_INSTANCE_ID", "AIOS_DB_URL", "AIOS_API_PORT", "AIOS_WORKSPACE_ROOT")
+    required = (
+        "AIOS_INSTANCE_ID",
+        "AIOS_DB_URL",
+        "AIOS_API_PORT",
+        "AIOS_WORKSPACE_ROOT",
+        "AIOS_CONNECTORS_DIR",
+    )
     missing = [k for k in required if k not in env]
     if missing:
         print_error(
@@ -435,8 +441,11 @@ def bootstrap() -> None:
     else:
         port = pick_free_port()
 
-    workspace_root = (Path.home() / ".aios" / "workspaces" / instance_id).resolve()
+    instance_root = (Path.home() / ".aios" / "instances" / instance_id).resolve()
+    workspace_root = instance_root / "workspaces"
+    connectors_dir = instance_root / "connectors"
     workspace_root.mkdir(parents=True, exist_ok=True)
+    connectors_dir.mkdir(parents=True, exist_ok=True)
 
     runtime_db_url = derive_runtime_db_url(admin_url, instance_id)
 
@@ -447,6 +456,7 @@ def bootstrap() -> None:
             "AIOS_DB_URL": runtime_db_url,
             "AIOS_API_PORT": str(port),
             "AIOS_WORKSPACE_ROOT": str(workspace_root),
+            "AIOS_CONNECTORS_DIR": str(connectors_dir),
         },
     )
 
@@ -459,6 +469,7 @@ def bootstrap() -> None:
         "AIOS_DB_URL": runtime_db_url,
         "AIOS_API_PORT": str(port),
         "AIOS_WORKSPACE_ROOT": str(workspace_root),
+        "AIOS_CONNECTORS_DIR": str(connectors_dir),
         "AIOS_API_KEY": secrets["AIOS_API_KEY"],
         "AIOS_VAULT_KEY": secrets["AIOS_VAULT_KEY"],
     }
@@ -563,11 +574,13 @@ def status() -> None:
     db_name = DB_PREFIX + instance_id
     port = int(env["AIOS_API_PORT"])
     workspace_root = Path(env["AIOS_WORKSPACE_ROOT"])
+    connectors_dir = Path(env["AIOS_CONNECTORS_DIR"])
 
     print(f"instance_id:     {instance_id}")
     print(f"database:        {db_name}")
     print(f"api_port:        {port}")
     print(f"workspace_root:  {workspace_root}")
+    print(f"connectors_dir:  {connectors_dir}")
 
     container_ids = _list_instance_containers(instance_id)
     print(f"containers:      {len(container_ids)}")

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -12,7 +12,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Annotated, Literal, NamedTuple
 
-from pydantic import Field, SecretStr, field_validator
+from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 # Instance names: stricter than ``Settings.instance_id`` (which allows a
@@ -21,6 +21,13 @@ from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 # re-export would produce double-underscore POSIX env names like
 # ``AIOS_SIGNAL__BOT_TOKEN`` if leading underscores were allowed.
 _INSTANCE_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+# Sentinel that ``connectors_dir`` defaults to when neither env nor kwarg
+# explicitly sets it.  ``Settings._cloister_connectors_dir`` swaps this
+# for ``~/.aios/instances/<instance_id>/connectors`` post-init (#238).
+# A clearly-marked absolute path no operator would set is safer than an
+# Optional + None handshake that would force every consumer to narrow.
+_CONNECTORS_DIR_SENTINEL = Path("/__aios_connectors_dir_unset__")
 
 # Sentinel ``instance`` value the CLI / API passes when the operator
 # omits the instance segment.  The worker resolves it to the sole
@@ -207,13 +214,34 @@ class Settings(BaseSettings):
         "Empty (the default) means the worker boots no connector children.",
     )
     connectors_dir: Path = Field(
-        default=Path.home() / ".aios" / "connectors",
-        description="Per-connector working-directory root. The supervisor cd's "
-        "into ``<connectors_dir>/<connector>/`` for default-instance setups "
-        "(``instance == connector``) and ``<connectors_dir>/<connector>/<instance>/`` "
-        "for non-default instances, so spool databases and other state files "
-        "live next to each connector subprocess.",
+        default_factory=lambda: _CONNECTORS_DIR_SENTINEL,
+        description="Defaults to ``~/.aios/instances/<instance_id>/connectors`` "
+        "(the sentinel default is rewritten by the model validator). The "
+        "supervisor cd's into ``<connectors_dir>/<connector>/`` for default-"
+        "instance setups (``instance == connector``) and "
+        "``<connectors_dir>/<connector>/<instance>/`` for non-default instances, "
+        "so spool databases and other state files live next to each connector "
+        "subprocess.  The cloister default (#238) keeps concurrent dev instances "
+        "from clobbering each other's spools at the legacy shared "
+        "``~/.aios/connectors`` path.  An explicit value (env or kwarg) "
+        "bypasses the cloister default — the escape hatch for ops that pre-bake "
+        "connector state elsewhere.",
+        json_schema_extra={"default": "~/.aios/instances/<instance_id>/connectors"},
     )
+
+    @model_validator(mode="after")
+    def _cloister_connectors_dir(self) -> Settings:
+        """Cloister ``connectors_dir`` under ``instance_id`` when not set.
+
+        Pydantic v2's ``default_factory`` can't see ``instance_id``, so we
+        emit a sentinel default and patch it here once the model is
+        otherwise built.  Explicit values pass through.
+        """
+        if self.connectors_dir == _CONNECTORS_DIR_SENTINEL:
+            self.connectors_dir = (
+                Path.home() / ".aios" / "instances" / self.instance_id / "connectors"
+            )
+        return self
 
     @field_validator("connectors_enabled", mode="before")
     @classmethod

--- a/tests/unit/test_config_connectors.py
+++ b/tests/unit/test_config_connectors.py
@@ -7,6 +7,8 @@ backs ``AIOS_CONNECTORS_ENABLED`` env parsing.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
@@ -137,3 +139,61 @@ class TestConnectorsEnabledValidator:
         monkeypatch.setenv("AIOS_CONNECTORS_ENABLED", " signal , telegram:bot1 , ")
         s = Settings()
         assert s.connectors_enabled == ["signal", "telegram:bot1"]
+
+
+class TestConnectorsDirCloister:
+    """``connectors_dir`` defaults to a per-instance cloister under
+    ``~/.aios/instances/<instance_id>/connectors`` (#238).
+
+    The cloister keeps two worktree dev instances running connectors
+    concurrently from clobbering each other's spool databases at the
+    legacy shared ``~/.aios/connectors`` path.  Operators that override
+    ``AIOS_CONNECTORS_DIR`` explicitly keep their override.
+    """
+
+    def test_default_instance_resolves_to_default_cloister(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("AIOS_CONNECTORS_DIR", raising=False)
+        monkeypatch.delenv("AIOS_INSTANCE_ID", raising=False)
+        s = Settings(_env_file=None, **_BASE_KWARGS)
+        assert s.instance_id == "default"
+        assert s.connectors_dir == Path.home() / ".aios" / "instances" / "default" / "connectors"
+
+    def test_custom_instance_id_resolves_per_instance_cloister(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("AIOS_CONNECTORS_DIR", raising=False)
+        s = Settings(_env_file=None, instance_id="aios_dev_abc12345", **_BASE_KWARGS)
+        assert (
+            s.connectors_dir
+            == Path.home() / ".aios" / "instances" / "aios_dev_abc12345" / "connectors"
+        )
+
+    def test_explicit_connectors_dir_override_wins(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An explicit ``AIOS_CONNECTORS_DIR`` (env or kwarg) preserves the
+        operator's override even with a non-default instance_id.  This
+        is the escape hatch for ops that pre-bake connectors elsewhere.
+        """
+        monkeypatch.delenv("AIOS_CONNECTORS_DIR", raising=False)
+        custom = tmp_path / "operator-chosen-dir"
+        s = Settings(
+            _env_file=None,
+            instance_id="aios_dev_abc12345",
+            connectors_dir=custom,
+            **_BASE_KWARGS,
+        )
+        assert s.connectors_dir == custom
+
+    def test_env_var_override_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """``AIOS_CONNECTORS_DIR`` env var wins over the cloister default."""
+        custom = tmp_path / "via-env"
+        monkeypatch.setenv("AIOS_CONNECTORS_DIR", str(custom))
+        monkeypatch.setenv("AIOS_API_KEY", _BASE_KWARGS["api_key"])
+        monkeypatch.setenv("AIOS_VAULT_KEY", _BASE_KWARGS["vault_key"])
+        monkeypatch.setenv("AIOS_DB_URL", _BASE_KWARGS["db_url"])
+        monkeypatch.setenv("AIOS_INSTANCE_ID", "aios_dev_abc12345")
+        s = Settings()
+        assert s.connectors_dir == custom


### PR DESCRIPTION
## Summary

- Closes #238. `Settings.connectors_dir` defaults to `~/.aios/instances/<instance_id>/connectors` so concurrent dev worktrees no longer clobber each other's spool databases at the legacy shared `~/.aios/connectors` path.
- `aios dev bootstrap` writes both `AIOS_CONNECTORS_DIR` and `AIOS_WORKSPACE_ROOT` into the per-worktree `.env`, pointing at `~/.aios/instances/<id>/{connectors,workspaces}`. Dev instances isolate without operator action.
- Migration recipe documented in connector READMEs: `mv ~/.aios/connectors ~/.aios/instances/default/connectors` for existing single-instance deployments.

## Design

The cloister default is derived from `instance_id` via a sentinel + `model_validator(mode="after")` (Pydantic v2's `default_factory` can't see other fields). The field annotation stays `Path` so no consumer sites need to narrow. Explicit `AIOS_CONNECTORS_DIR` (env or kwarg) bypasses the cloister — escape hatch for ops that pre-bake connector state elsewhere.

## Test plan

- [x] `tests/unit/test_config_connectors.py::TestConnectorsDirCloister` — 4 new tests:
  - default `instance_id` resolves to `~/.aios/instances/default/connectors`
  - custom `instance_id` resolves to `~/.aios/instances/<id>/connectors`
  - explicit `connectors_dir` kwarg overrides
  - explicit `AIOS_CONNECTORS_DIR` env overrides
- [x] `uv run pytest tests/unit -q` — 1154 pass
- [x] `uv run mypy src` clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` clean
- [x] `DOCKER_HOST=… uv run pytest tests/integration tests/e2e -q` — 260 pass

## Reviewer notes

Posting per memory's "post all findings":

- **Sev 85** (status display had inconsistent defensive guard) — **fixed in this PR**. `load_instance_env` now requires `AIOS_CONNECTORS_DIR`, so pre-#238 worktrees fail loudly with a re-bootstrap hint rather than silently incomplete status display. Aligns with the project's "fail hard, no fallbacks" stance.
- **Sev 82** (sentinel makes `Field.default` misleading in introspection) — **fixed in this PR**. Added `json_schema_extra={"default": "~/.aios/instances/<instance_id>/connectors"}` plus a leading-line note in the description so OpenAPI / `--help` consumers see the documented default, not the literal sentinel string.
- **Sev 80** (no test for adversarial sentinel-equality override) — skipped per reviewer's "skip if you consider the sentinel name sufficient defense". `_CONNECTORS_DIR_SENTINEL = Path("/__aios_connectors_dir_unset__")` is unambiguous enough.

## Out of scope (per #238)

- Automated migration tool (`aios migrate-paths` command). Manual `mv` is short and one-time.
- signal-cli daemon socket collision (operator-discipline issue, not code).
- Logs cloister move — `.logs/` stays per-worktree so they live next to the code that produced them.
- Renaming or hard-deprecating `~/.aios/connectors`. Path no longer holds runtime state after upgrade; docs point at the new location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)