### PR TITLE
feat(harness): notify worker on session-lock release (#237)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ They don't share connections; they share Postgres state.
 - **Push back on bad requests** — if a request conflicts with existing architecture, or has an obvious root-cause fix the user missed, flag it before implementing. You have context the user may not in the moment.
 - **Don't deprecate, delete** — remove old code paths rather than leaving shims. Git history preserves them.
 - **After refactors, grep exhaustively** — for any rename or move, search the whole tree (including tests) for the old name before declaring done.
+- **Broken windows policy** — when a review (or your own pass) flags a clear quality issue, fix it now even if it's pre-existing. Don't pile new code on top of broken patterns or label them "out of scope." This complements rather than contradicts "don't add features beyond the task": the rule is reactive, not proactive — you don't go hunting for cleanup, but you don't ignore what you've already seen. Premature abstractions are still bad; three similar lines is still better than one over-engineered helper. The policy targets *flagged* issues, not aesthetic preferences.
 
 ## Key invariants
 

--- a/src/aios/cli/commands/ops.py
+++ b/src/aios/cli/commands/ops.py
@@ -39,15 +39,15 @@ def _run_worker() -> int:
 
 
 async def _apply_procrastinate_schema_if_missing() -> None:
-    """Apply procrastinate's schema if it isn't already present.
+    """Apply procrastinate's schema if missing, then idempotently install
+    aios's lock-release trigger.
 
-    ``apply_schema_async`` isn't idempotent, so we guard with
-    ``to_regclass('procrastinate_jobs')``.
+    ``apply_schema_async`` isn't idempotent, hence the ``to_regclass``
+    guard; the trigger DDL is.
     """
-    import asyncpg
-
     from aios.config import get_settings
     from aios.db.pool import create_pool
+    from aios.db.procrastinate_extensions import apply_lock_release_trigger
     from aios.harness.procrastinate_app import app as procrastinate_app
 
     settings = get_settings()
@@ -55,20 +55,20 @@ async def _apply_procrastinate_schema_if_missing() -> None:
     try:
         async with pool.acquire() as conn:
             present = await conn.fetchval("SELECT to_regclass('procrastinate_jobs')")
-            if present is not None:
+            if present is None:
+                print("applying procrastinate schema...", file=sys.stderr)
+                await procrastinate_app.open_async()
+                try:
+                    await procrastinate_app.schema_manager.apply_schema_async()
+                finally:
+                    await procrastinate_app.close_async()
+                print("procrastinate schema applied", file=sys.stderr)
+            else:
                 print("procrastinate schema already present, skipping", file=sys.stderr)
-                return
+            await apply_lock_release_trigger(conn)
+            print("aios lock-release trigger ensured", file=sys.stderr)
     finally:
         await pool.close()
-
-    print("applying procrastinate schema...", file=sys.stderr)
-    await procrastinate_app.open_async()
-    try:
-        await procrastinate_app.schema_manager.apply_schema_async()
-    finally:
-        await procrastinate_app.close_async()
-    print("procrastinate schema applied", file=sys.stderr)
-    _ = asyncpg  # validate asyncpg is on the path (create_pool uses it transitively)
 
 
 def _run_migrate() -> int:

--- a/src/aios/cli/commands/ops.py
+++ b/src/aios/cli/commands/ops.py
@@ -47,7 +47,7 @@ async def _apply_procrastinate_schema_if_missing() -> None:
     """
     from aios.config import get_settings
     from aios.db.pool import create_pool
-    from aios.db.procrastinate_extensions import apply_lock_release_trigger
+    from aios.db.procrastinate_extensions import LOCK_RELEASE_TRIGGER_DDL
     from aios.harness.procrastinate_app import app as procrastinate_app
 
     settings = get_settings()
@@ -65,7 +65,7 @@ async def _apply_procrastinate_schema_if_missing() -> None:
                 print("procrastinate schema applied", file=sys.stderr)
             else:
                 print("procrastinate schema already present, skipping", file=sys.stderr)
-            await apply_lock_release_trigger(conn)
+            await conn.execute(LOCK_RELEASE_TRIGGER_DDL)
             print("aios lock-release trigger ensured", file=sys.stderr)
     finally:
         await pool.close()

--- a/src/aios/db/procrastinate_extensions.py
+++ b/src/aios/db/procrastinate_extensions.py
@@ -1,0 +1,45 @@
+"""Aios-side extensions to procrastinate's schema.
+
+Procrastinate emits ``job_inserted`` NOTIFY only on INSERT, so a queued
+same-session wake's lock-release transition is invisible to the worker
+and pickup waits up to ``fetch_job_polling_interval`` (5s default).
+This trigger fires the same NOTIFY on ``doing → !doing`` transitions
+(issue #237). The 5s polling remains as a correctness backstop.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import asyncpg
+
+
+LOCK_RELEASE_TRIGGER_DDL = """
+CREATE OR REPLACE FUNCTION aios_notify_job_lock_released_v1()
+    RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    payload TEXT;
+BEGIN
+    SELECT json_build_object('type', 'job_inserted', 'job_id', NEW.id)::text INTO payload;
+    PERFORM pg_notify('procrastinate_queue_v1#' || NEW.queue_name, payload);
+    PERFORM pg_notify('procrastinate_any_queue_v1', payload);
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS aios_jobs_notify_lock_released_v1 ON procrastinate_jobs;
+
+CREATE TRIGGER aios_jobs_notify_lock_released_v1
+    AFTER UPDATE OF status ON procrastinate_jobs
+    FOR EACH ROW
+    WHEN (OLD.status = 'doing' AND NEW.status != 'doing')
+    EXECUTE FUNCTION aios_notify_job_lock_released_v1();
+"""
+
+
+async def apply_lock_release_trigger(conn: asyncpg.Connection[object]) -> None:
+    """Idempotently install the lock-release NOTIFY trigger on ``procrastinate_jobs``."""
+    await conn.execute(LOCK_RELEASE_TRIGGER_DDL)

--- a/src/aios/db/procrastinate_extensions.py
+++ b/src/aios/db/procrastinate_extensions.py
@@ -9,12 +9,6 @@ This trigger fires the same NOTIFY on ``doing → !doing`` transitions
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    import asyncpg
-
-
 LOCK_RELEASE_TRIGGER_DDL = """
 CREATE OR REPLACE FUNCTION aios_notify_job_lock_released_v1()
     RETURNS trigger
@@ -38,8 +32,3 @@ CREATE TRIGGER aios_jobs_notify_lock_released_v1
     WHEN (OLD.status = 'doing' AND NEW.status != 'doing')
     EXECUTE FUNCTION aios_notify_job_lock_released_v1();
 """
-
-
-async def apply_lock_release_trigger(conn: asyncpg.Connection[object]) -> None:
-    """Idempotently install the lock-release NOTIFY trigger on ``procrastinate_jobs``."""
-    await conn.execute(LOCK_RELEASE_TRIGGER_DDL)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -67,7 +67,7 @@ async def ensure_procrastinate_schema(aios_db_url: str) -> None:
     from procrastinate import App, PsycopgConnector
 
     from aios.config import get_settings
-    from aios.db.procrastinate_extensions import apply_lock_release_trigger
+    from aios.db.procrastinate_extensions import LOCK_RELEASE_TRIGGER_DDL
 
     settings = get_settings()
     conn = await asyncpg.connect(settings.db_url)
@@ -81,7 +81,7 @@ async def ensure_procrastinate_schema(aios_db_url: str) -> None:
                 await tmp_app.schema_manager.apply_schema_async()
             finally:
                 await tmp_app.close_async()
-        await apply_lock_release_trigger(conn)
+        await conn.execute(LOCK_RELEASE_TRIGGER_DDL)
     finally:
         await conn.close()
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -14,13 +14,35 @@ Docker containers.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+import asyncio
+import inspect
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 from unittest import mock
 
 import pytest
 
 from tests.e2e.harness import Harness
+
+
+async def wait_for_predicate(
+    predicate: Callable[[], bool | Awaitable[bool]],
+    *,
+    max_wait_s: float = 10.0,
+    interval_s: float = 0.05,
+) -> None:
+    """Poll ``predicate()`` until truthy or ``max_wait_s`` elapses.
+    Predicate may be sync or async."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max_wait_s
+    while loop.time() < deadline:
+        result: bool | Awaitable[bool] = predicate()
+        if inspect.isawaitable(result):
+            result = await result
+        if result:
+            return
+        await asyncio.sleep(interval_s)
+    raise AssertionError(f"predicate {predicate!r} did not become true within {max_wait_s}s")
 
 
 async def _noop_defer_wake(
@@ -39,37 +61,48 @@ async def _noop_defer_retry_wake(pool: Any, session_id: str, *, delay_seconds: f
 
 
 async def ensure_procrastinate_schema(aios_db_url: str) -> None:
-    """Apply procrastinate's schema to the testcontainer DB if missing.
-
-    The shared ``migrated_db_url`` only runs aios's alembic migrations;
-    tests that touch ``procrastinate_jobs`` directly (or run a worker
-    against the testcontainer) need procrastinate's tables too. The
-    module-level :mod:`aios.harness.procrastinate_app` singleton's
-    connector is fixed at import time against whatever settings were
-    active then (usually wrong in tests), so we build a temporary
-    ``App`` here.
-    """
+    """Apply procrastinate's schema if missing, then install the aios
+    lock-release trigger. Mirrors ``aios migrate`` for tests."""
     import asyncpg
     from procrastinate import App, PsycopgConnector
 
     from aios.config import get_settings
+    from aios.db.procrastinate_extensions import apply_lock_release_trigger
 
     settings = get_settings()
     conn = await asyncpg.connect(settings.db_url)
     try:
         present = await conn.fetchval("SELECT to_regclass('procrastinate_jobs')")
+        if present is None:
+            conninfo = aios_db_url.replace("postgresql+psycopg://", "postgresql://")
+            tmp_app = App(connector=PsycopgConnector(conninfo=conninfo))
+            await tmp_app.open_async()
+            try:
+                await tmp_app.schema_manager.apply_schema_async()
+            finally:
+                await tmp_app.close_async()
+        await apply_lock_release_trigger(conn)
     finally:
         await conn.close()
-    if present is not None:
-        return
 
-    conninfo = aios_db_url.replace("postgresql+psycopg://", "postgresql://")
-    tmp_app = App(connector=PsycopgConnector(conninfo=conninfo))
-    await tmp_app.open_async()
+
+@pytest.fixture
+async def real_wake_setup(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    """Real pool + procrastinate schema (with the aios lock-release trigger).
+
+    Used by tests that exercise the real ``defer_wake`` and a real
+    procrastinate worker — the ``harness`` fixture's ``defer_wake`` is
+    a no-op and so unsuitable here.
+    """
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    await ensure_procrastinate_schema(aios_env["AIOS_DB_URL"])
+    pool = await create_pool(get_settings().db_url, min_size=1, max_size=8)
     try:
-        await tmp_app.schema_manager.apply_schema_async()
+        yield pool
     finally:
-        await tmp_app.close_async()
+        await pool.close()
 
 
 @pytest.fixture

--- a/tests/e2e/test_connector_supervisor.py
+++ b/tests/e2e/test_connector_supervisor.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from typing import Any
 
 import pytest
 from aios_connector import ConnectorSpec
@@ -26,6 +25,7 @@ from aios_connector import ConnectorSpec
 from aios.config import ConnectorInstance, Settings
 from aios.harness import connector_supervisor as supervisor_mod
 from aios.harness.connector_supervisor import ConnectorSubprocessRegistry
+from tests.e2e.conftest import wait_for_predicate as _wait_for
 
 
 def _echo_specs() -> list[tuple[ConnectorInstance, ConnectorSpec]]:
@@ -64,21 +64,6 @@ def _multi_instance_echo_specs() -> list[tuple[ConnectorInstance, ConnectorSpec]
             ConnectorSpec(name="echo", command=sys.executable, args=base_args),
         ),
     ]
-
-
-async def _wait_for(predicate: Any, *, max_wait_s: float = 10.0) -> None:
-    """Poll ``predicate()`` every 50 ms until it returns truthy or we time out.
-
-    Used in place of bespoke event/Condition wiring — the supervisor
-    surfaces state changes as ``ConnectorState`` field updates, and
-    polling is fine for a small handful of test asserts.
-    """
-    deadline = asyncio.get_event_loop().time() + max_wait_s
-    while asyncio.get_event_loop().time() < deadline:
-        if predicate():
-            return
-        await asyncio.sleep(0.05)
-    raise AssertionError(f"predicate {predicate!r} did not become true within {max_wait_s}s")
 
 
 class TestConnectorSupervisor:

--- a/tests/e2e/test_focal_required_dispatch.py
+++ b/tests/e2e/test_focal_required_dispatch.py
@@ -27,12 +27,12 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from typing import Any
 
 from aios_connector import ConnectorSpec
 
 from aios.config import ConnectorInstance, Settings
 from aios.harness.connector_supervisor import ConnectorSubprocessRegistry
+from tests.e2e.conftest import wait_for_predicate as _wait_for
 
 
 def _aios_echo_specs() -> list[tuple[ConnectorInstance, ConnectorSpec]]:
@@ -54,15 +54,6 @@ def _aios_echo_specs() -> list[tuple[ConnectorInstance, ConnectorSpec]]:
             ),
         )
     ]
-
-
-async def _wait_for(predicate: Any, *, max_wait_s: float = 10.0) -> None:
-    deadline = asyncio.get_event_loop().time() + max_wait_s
-    while asyncio.get_event_loop().time() < deadline:
-        if predicate():
-            return
-        await asyncio.sleep(0.05)
-    raise AssertionError(f"predicate {predicate!r} did not become true within {max_wait_s}s")
 
 
 class TestFocalRequiredDispatch:

--- a/tests/e2e/test_orphan_stuck.py
+++ b/tests/e2e/test_orphan_stuck.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-import pytest
-
 from tests.conftest import needs_docker
+from tests.e2e.conftest import wait_for_predicate
 from tests.e2e.harness import Harness, assistant, tool_call
 
 
@@ -60,20 +59,16 @@ class TestOrphanRecovery:
         await asyncio.wait_for(tool_a_started.wait(), timeout=5.0)
         await asyncio.wait_for(tool_b_started.wait(), timeout=5.0)
 
-        # Wait for tool A's result to appear in the event log.
-        for _ in range(50):
+        async def _tool_a_logged() -> bool:
             events = await harness.events(session.id)
-            tool_a_done = any(
+            return any(
                 e.kind == "message"
                 and e.data.get("role") == "tool"
                 and e.data.get("tool_call_id") == "call_a"
                 for e in events
             )
-            if tool_a_done:
-                break
-            await asyncio.sleep(0.05)
-        else:
-            pytest.fail("tool A result never appeared in event log")
+
+        await wait_for_predicate(_tool_a_logged, max_wait_s=2.5, interval_s=0.05)
 
         # Verify precondition: tool B has no result in the log.
         events = await harness.events(session.id)

--- a/tests/e2e/test_sse_lock.py
+++ b/tests/e2e/test_sse_lock.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import AsyncIterator
 from typing import Any
 
 import asyncpg
 import pytest
+
+from tests.e2e.conftest import wait_for_predicate
 
 
 @pytest.fixture
@@ -44,10 +45,10 @@ class TestSubscriberLockRoundTrip:
 
         # Give pg a moment to release — auto-release on close is
         # synchronous in Postgres, but asyncpg's close is async.
-        for _ in range(10):
-            if not await has_subscriber(pool, session_id):
-                break
-            await asyncio.sleep(0.05)
+        async def _released() -> bool:
+            return not await has_subscriber(pool, session_id)
+
+        await wait_for_predicate(_released, max_wait_s=0.5, interval_s=0.05)
         assert await has_subscriber(pool, session_id) is False
 
     async def test_multiple_subscribers_coexist(self, pool: Any, aios_env: dict[str, str]) -> None:
@@ -72,10 +73,10 @@ class TestSubscriberLockRoundTrip:
         finally:
             await conn_b.close()
 
-        for _ in range(10):
-            if not await has_subscriber(pool, session_id):
-                break
-            await asyncio.sleep(0.05)
+        async def _released() -> bool:
+            return not await has_subscriber(pool, session_id)
+
+        await wait_for_predicate(_released, max_wait_s=0.5, interval_s=0.05)
         assert await has_subscriber(pool, session_id) is False
 
     async def test_different_sessions_are_isolated(

--- a/tests/e2e/test_sweep.py
+++ b/tests/e2e/test_sweep.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from aios.services import sessions as sessions_service
 from tests.conftest import needs_docker
+from tests.e2e.conftest import wait_for_predicate
 from tests.e2e.harness import Harness, assistant, tool_call
 
 # ─── ghost recovery ──────────────────────────────────────────────────────────
@@ -190,16 +191,15 @@ class TestGhostRecovery:
         await harness.run_step(session.id)
         await asyncio.wait_for(tool_a_started.wait(), timeout=5.0)
 
-        # Wait for fast_tool to complete.
-        for _ in range(50):
+        async def _call_fast_logged() -> bool:
             events = await harness.events(session.id)
-            if any(
+            return any(
                 e.data.get("tool_call_id") == "call_fast"
                 for e in events
                 if e.kind == "message" and e.data.get("role") == "tool"
-            ):
-                break
-            await asyncio.sleep(0.05)
+            )
+
+        await wait_for_predicate(_call_fast_logged, max_wait_s=2.5, interval_s=0.05)
 
         # Simulate SIGKILL of slow_tool.
         await harness.simulate_sigkill(session.id)
@@ -426,16 +426,15 @@ class TestSweepWaking:
         await asyncio.wait_for(tool_a_started.wait(), timeout=5.0)
         await asyncio.wait_for(tool_b_started.wait(), timeout=5.0)
 
-        # Wait for tool A result to appear in the log.
-        for _ in range(50):
+        async def _call_a_logged() -> bool:
             events = await harness.events(session.id)
-            if any(
+            return any(
                 e.data.get("tool_call_id") == "call_a"
                 for e in events
                 if e.kind == "message" and e.data.get("role") == "tool"
-            ):
-                break
-            await asyncio.sleep(0.05)
+            )
+
+        await wait_for_predicate(_call_a_logged, max_wait_s=2.5, interval_s=0.05)
 
         # Tool B is still in-flight. Sweep should say "not ready."
         needs = await harness.sessions_needing_inference(session.id)

--- a/tests/e2e/test_wake_lock_release_latency.py
+++ b/tests/e2e/test_wake_lock_release_latency.py
@@ -1,0 +1,152 @@
+"""Lock-release wake-pickup latency must be sub-second (issue #237)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest import mock
+
+import asyncpg
+import pytest
+from procrastinate import PsycopgConnector
+
+from aios.models.agents import ToolSpec
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+from tests.conftest import needs_docker
+from tests.e2e.conftest import wait_for_predicate
+
+_TERMINAL_STATUSES = ("succeeded", "failed", "aborted", "cancelled")
+_TERMINAL_EVENT_TYPES = ("succeeded", "failed", "aborted")
+
+
+async def _has_doing_wake(pool: asyncpg.Pool[Any], session_id: str) -> bool:
+    async with pool.acquire() as conn:
+        n = await conn.fetchval(
+            "SELECT count(*) FROM procrastinate_jobs "
+            "WHERE task_name = 'harness.wake_session' "
+            "AND args->>'session_id' = $1 AND status = 'doing'",
+            session_id,
+        )
+    return bool(n)
+
+
+async def _both_wakes_terminal(pool: asyncpg.Pool[Any], session_id: str) -> bool:
+    async with pool.acquire() as conn:
+        n = await conn.fetchval(
+            "SELECT count(*) FROM procrastinate_jobs "
+            "WHERE task_name = 'harness.wake_session' "
+            "AND args->>'session_id' = $1 AND status = ANY($2)",
+            session_id,
+            list(_TERMINAL_STATUSES),
+        )
+    return int(n or 0) >= 2
+
+
+@needs_docker
+class TestWakeLockReleaseLatencyE2E:
+    @pytest.mark.asyncio
+    async def test_pickup_gap_after_lock_release_is_sub_second(
+        self, real_wake_setup: asyncpg.Pool[Any], aios_env: dict[str, str]
+    ) -> None:
+        """When a lock-blocked wake becomes eligible, the worker must pick
+        it up within a single LISTEN/NOTIFY round-trip (<200ms)."""
+        from aios.harness.procrastinate_app import app as procrastinate_app
+        from aios.harness.wake import defer_wake
+
+        pool = real_wake_setup
+
+        agent = await agents_service.create_agent(
+            pool,
+            name="lock-release-test-agent",
+            model="fake/test",
+            system="t",
+            tools=[ToolSpec(type="bash")],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(pool, name="lock-release-test-env")
+        session = await sessions_service.create_session(
+            pool, agent_id=agent.id, environment_id=env.id, title="lock-release-test", metadata={}
+        )
+        session_id = session.id
+
+        first_call_done = asyncio.Event()
+
+        async def fake_step(session_id: str, **kwargs: Any) -> None:
+            # First call holds the lock for 1s — comfortably longer than
+            # the 200ms assertion window. Subsequent calls return fast.
+            if not first_call_done.is_set():
+                first_call_done.set()
+                await asyncio.sleep(1.0)
+
+        conninfo = aios_env["AIOS_DB_URL"].replace("postgresql+psycopg://", "postgresql://")
+        new_connector = PsycopgConnector(conninfo=conninfo)
+        await new_connector.open_async()
+
+        try:
+            with (
+                procrastinate_app.replace_connector(new_connector),
+                mock.patch("aios.harness.loop.run_session_step", fake_step),
+            ):
+                procrastinate_app.perform_import_paths()
+                # Construct the Worker directly so we can stop() it
+                # explicitly. wait=True keeps it alive past the
+                # initial-fetch drain so B (deferred mid-A) gets picked
+                # up after A's lock releases.
+                worker = procrastinate_app._worker(
+                    queues=["sessions"],
+                    concurrency=4,
+                    wait=True,
+                    install_signal_handlers=False,
+                )
+
+                await defer_wake(pool, session_id, cause="message")
+                worker_task = asyncio.create_task(worker.run())
+
+                await wait_for_predicate(
+                    lambda: _has_doing_wake(pool, session_id),
+                    max_wait_s=5.0,
+                    interval_s=0.02,
+                )
+                await defer_wake(pool, session_id, cause="message")
+
+                await wait_for_predicate(
+                    lambda: _both_wakes_terminal(pool, session_id),
+                    max_wait_s=15.0,
+                    interval_s=0.02,
+                )
+                worker.stop()
+                await asyncio.wait_for(worker_task, timeout=5.0)
+        finally:
+            await new_connector.close_async()
+
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT j.id AS job_id, "
+                "       (SELECT at FROM procrastinate_events e "
+                "         WHERE e.job_id = j.id AND e.type = 'started') AS started_at, "
+                "       (SELECT at FROM procrastinate_events e "
+                "         WHERE e.job_id = j.id "
+                "         AND e.type = ANY($2)) AS ended_at "
+                "FROM procrastinate_jobs j "
+                "WHERE j.task_name = 'harness.wake_session' "
+                "AND j.args->>'session_id' = $1 "
+                "ORDER BY j.id ASC",
+                session_id,
+                list(_TERMINAL_EVENT_TYPES),
+            )
+
+        assert len(rows) == 2, f"expected 2 wake_session jobs, got {len(rows)}: {rows}"
+        a_ended = rows[0]["ended_at"]
+        b_started = rows[1]["started_at"]
+        assert a_ended is not None and b_started is not None, f"missing timestamps: {rows}"
+
+        gap_s = (b_started - a_ended).total_seconds()
+        assert gap_s < 0.2, (
+            f"lock-release pickup gap is {gap_s:.3f}s, expected <0.2s — "
+            f"trigger aios_jobs_notify_lock_released_v1 may not be firing."
+        )

--- a/tests/e2e/test_wake_lock_release_latency.py
+++ b/tests/e2e/test_wake_lock_release_latency.py
@@ -17,32 +17,6 @@ from aios.services import sessions as sessions_service
 from tests.conftest import needs_docker
 from tests.e2e.conftest import wait_for_predicate
 
-_TERMINAL_STATUSES = ("succeeded", "failed", "aborted", "cancelled")
-_TERMINAL_EVENT_TYPES = ("succeeded", "failed", "aborted")
-
-
-async def _has_doing_wake(pool: asyncpg.Pool[Any], session_id: str) -> bool:
-    async with pool.acquire() as conn:
-        n = await conn.fetchval(
-            "SELECT count(*) FROM procrastinate_jobs "
-            "WHERE task_name = 'harness.wake_session' "
-            "AND args->>'session_id' = $1 AND status = 'doing'",
-            session_id,
-        )
-    return bool(n)
-
-
-async def _both_wakes_terminal(pool: asyncpg.Pool[Any], session_id: str) -> bool:
-    async with pool.acquire() as conn:
-        n = await conn.fetchval(
-            "SELECT count(*) FROM procrastinate_jobs "
-            "WHERE task_name = 'harness.wake_session' "
-            "AND args->>'session_id' = $1 AND status = ANY($2)",
-            session_id,
-            list(_TERMINAL_STATUSES),
-        )
-    return int(n or 0) >= 2
-
 
 @needs_docker
 class TestWakeLockReleaseLatencyE2E:
@@ -107,18 +81,28 @@ class TestWakeLockReleaseLatencyE2E:
                 await defer_wake(pool, session_id, cause="message")
                 worker_task = asyncio.create_task(worker.run())
 
-                await wait_for_predicate(
-                    lambda: _has_doing_wake(pool, session_id),
-                    max_wait_s=5.0,
-                    interval_s=0.02,
-                )
-                await defer_wake(pool, session_id, cause="message")
+                async def _count_wakes(statuses: tuple[str, ...]) -> int:
+                    async with pool.acquire() as conn:
+                        n = await conn.fetchval(
+                            "SELECT count(*) FROM procrastinate_jobs "
+                            "WHERE task_name = 'harness.wake_session' "
+                            "AND args->>'session_id' = $1 AND status = ANY($2)",
+                            session_id,
+                            list(statuses),
+                        )
+                    return int(n or 0)
 
-                await wait_for_predicate(
-                    lambda: _both_wakes_terminal(pool, session_id),
-                    max_wait_s=15.0,
-                    interval_s=0.02,
-                )
+                async def _has_doing() -> bool:
+                    return await _count_wakes(("doing",)) >= 1
+
+                # Procrastinate's job-status enum has 'cancelled' but its
+                # event-type enum does not.
+                async def _both_terminal() -> bool:
+                    return await _count_wakes(("succeeded", "failed", "aborted", "cancelled")) >= 2
+
+                await wait_for_predicate(_has_doing, max_wait_s=5.0, interval_s=0.02)
+                await defer_wake(pool, session_id, cause="message")
+                await wait_for_predicate(_both_terminal, max_wait_s=15.0, interval_s=0.02)
                 worker.stop()
                 await asyncio.wait_for(worker_task, timeout=5.0)
         finally:
@@ -137,7 +121,7 @@ class TestWakeLockReleaseLatencyE2E:
                 "AND j.args->>'session_id' = $1 "
                 "ORDER BY j.id ASC",
                 session_id,
-                list(_TERMINAL_EVENT_TYPES),
+                ["succeeded", "failed", "aborted"],
             )
 
         assert len(rows) == 2, f"expected 2 wake_session jobs, got {len(rows)}: {rows}"

--- a/tests/e2e/test_worker_concurrency.py
+++ b/tests/e2e/test_worker_concurrency.py
@@ -16,12 +16,10 @@ test fails.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
 from typing import Any
 from unittest import mock
 
 import asyncpg
-import pytest
 from procrastinate import PsycopgConnector
 
 from aios.models.agents import ToolSpec
@@ -29,25 +27,6 @@ from aios.services import agents as agents_service
 from aios.services import environments as environments_service
 from aios.services import sessions as sessions_service
 from tests.conftest import needs_docker
-from tests.e2e.conftest import ensure_procrastinate_schema
-
-
-@pytest.fixture
-async def real_wake_setup(aios_env: dict[str, str]) -> AsyncIterator[asyncpg.Pool[Any]]:
-    """Real pool + procrastinate schema, no harness mocks.
-
-    The standard ``harness`` fixture installs a no-op ``defer_wake``;
-    this test is the one place we *want* the real one to fire.
-    """
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    await ensure_procrastinate_schema(aios_env["AIOS_DB_URL"])
-    pool = await create_pool(get_settings().db_url, min_size=1, max_size=8)
-    try:
-        yield pool
-    finally:
-        await pool.close()
 
 
 async def _create_session(pool: asyncpg.Pool[Any], agent_id: str, env_id: str) -> str:


### PR DESCRIPTION
## Summary
- Add Postgres trigger that fires `'job_inserted'` NOTIFY when a `wake_session` job leaves `doing` status, eliminating the ~4s pickup gap (procrastinate's 5s polling fallback) that dominated the user-perceived wake-latency tail (issue #237).
- Trigger DDL is idempotent and lives in `src/aios/db/procrastinate_extensions.py`; applied during `aios migrate` and `ensure_procrastinate_schema` (tests).
- New e2e regression test `tests/e2e/test_wake_lock_release_latency.py` measures `prior_succeeded → next_started` gap under same-session lock contention; fails without the trigger (~4s) and passes with it (<100ms).
- Broken-windows pass on the e2e test layer: hoist `real_wake_setup` + `wait_for_predicate` to `tests/e2e/conftest.py` and refactor two pre-existing local copies; codify the broken-windows policy in CLAUDE.md.

## Investigation summary
See [#237 comment](https://github.com/eumemic/aios/issues/237#issuecomment-4382401727) for the full breakdown. Reproduction on the issue's session window:

| component | p50 | p90 | p99 |
|---|---|---|---|
| total user_msg → step_start | 24ms | 10.0s | 24.9s |
| ├ prior step's remaining runtime | 4.5s | 20.7s | 23.7s |
| └ worker pickup gap after lock release | 3.5s | 4.4s | **4.9s (ceiling 5.0s)** |

98% of tail events (65/66) had a sibling `wake_session` job in `doing` status at user-inbound time. The pickup gap clusters at 5.0s because procrastinate's `FETCH_JOB_POLLING_INTERVAL = 5.0` is the only mechanism re-checking the queue after a job's status leaves `doing` — there's no `AFTER UPDATE` NOTIFY trigger in procrastinate's schema.

## Mechanism
- Procrastinate's existing `_handle_notification` (`procrastinate/worker.py:402-408`) sets `_new_job_event` on `type="job_inserted"`. The new aios trigger emits the same payload on the same channels (`procrastinate_queue_v1#<queue>` and `procrastinate_any_queue_v1`) when a job's status leaves `doing`. No procrastinate code changes.
- The 5s polling stays as a correctness backstop; if a NOTIFY is ever missed, the worker still recovers within the polling interval.

## Test plan
- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1150 passed
- [x] `DOCKER_HOST=... uv run pytest tests/e2e -q` — 259/260 passed (one pre-existing flake on `test_memory_cross_session_sync` due to Docker resource pressure on full-suite runs; passes in isolation)
- [x] `tests/e2e/test_wake_lock_release_latency.py` fails without the trigger (~4s gap), passes with it (<100ms)
- [x] All four affected e2e tests pass: `test_wake_lock_release_latency`, `test_worker_concurrency`, `test_connector_supervisor`, `test_focal_required_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)