### PR TITLE
fix(signal): refresh group roster cache on send-time miss

### DIFF
--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -272,7 +272,7 @@ class SignalConnector(Connector):
         assert self._daemon is not None
         phone = self._resolve_phone(account, "signal_send")
         host_paths: list[Path] = list(attachments or [])
-        member_uuids = self._group_member_uuids(phone, chat_id)
+        member_uuids = await self._group_member_uuids(phone, chat_id)
         params = _build_send_params(
             phone,
             chat_id,
@@ -392,16 +392,32 @@ class SignalConnector(Connector):
             raise ValueError(f"{tool_name}: unknown account {account!r}")
         return phone
 
-    def _group_member_uuids(self, phone: str, chat_id: str) -> list[str]:
-        """Member UUIDs of the focal group, or ``[]`` if the chat is a DM
-        or the group isn't in the cached roster (mentions become a no-op)."""
+    async def _group_member_uuids(self, phone: str, chat_id: str) -> list[str]:
+        """Member UUIDs of the focal group, or ``[]`` for a DM.
+
+        On cache miss, refreshes the per-account roster once via
+        ``listGroups`` and re-checks.  signal-cli sometimes returns an
+        empty group list at boot before the account's group state has
+        finished loading from disk; once the cache is empty the bot
+        never re-checks, so mentions stay broken for the lifetime of
+        the connector.  Refreshing on miss also picks up groups joined
+        after boot.
+        """
         chat_type, _ = decode_chat_id(chat_id)
         if chat_type != "group":
             return []
+        cached = self._lookup_group_members(phone, chat_id)
+        if cached is not None:
+            return cached
+        assert self._daemon is not None
+        self._groups_by_account[phone] = await self._daemon.list_groups(account=phone)
+        return self._lookup_group_members(phone, chat_id) or []
+
+    def _lookup_group_members(self, phone: str, chat_id: str) -> list[str] | None:
         for group in self._groups_by_account.get(phone, []):
             if group.id == chat_id:
                 return list(group.member_uuids)
-        return []
+        return None
 
     @tool()
     @focal_required

--- a/connectors/signal/tests/test_signal_send.py
+++ b/connectors/signal/tests/test_signal_send.py
@@ -297,3 +297,45 @@ async def test_signal_send_in_group_encodes_mentions(
     assert sent_params["message"] == f"hey {MENTION_PLACEHOLDER}, ready?"
     assert sent_params["mentions"] == [f"4:1:{ALICE_UUID}"]
     assert sent_params["groupId"] == GROUP_RAW_ID
+
+
+async def test_signal_send_refreshes_group_cache_on_miss(
+    connector: SignalConnector,
+) -> None:
+    # signal-cli sometimes returns an empty listGroups at boot before the
+    # account state has finished loading; the boot-time cache stays
+    # empty for the lifetime of the connector and outbound mentions
+    # silently degrade.  signal_send must refresh on miss so the second
+    # listGroups (now populated) populates the cache and the mention
+    # encodes correctly.
+    connector._groups_by_account["+15550001"] = []
+    connector._daemon.list_groups.return_value = [  # type: ignore[union-attr]
+        GroupInfo(id=GROUP_CHAT_ID, name="Tea Party", member_uuids=[ALICE_UUID, BOB_UUID])
+    ]
+    stub_focal(connector, f"bot-uuid/{GROUP_CHAT_ID}")
+    await connector._invoke_tool(
+        descriptor(connector, "signal_send"), {"text": f"hey @{ALICE_UUID[:8]}"}
+    )
+    connector._daemon.list_groups.assert_awaited_once_with(account="+15550001")  # type: ignore[union-attr]
+    sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
+    assert sent_params["mentions"] == [f"4:1:{ALICE_UUID}"]
+
+
+async def test_signal_send_skips_refresh_on_cache_hit(
+    connector: SignalConnector,
+) -> None:
+    connector._groups_by_account["+15550001"] = [
+        GroupInfo(id=GROUP_CHAT_ID, name="Tea Party", member_uuids=[ALICE_UUID, BOB_UUID])
+    ]
+    stub_focal(connector, f"bot-uuid/{GROUP_CHAT_ID}")
+    await connector._invoke_tool(descriptor(connector, "signal_send"), {"text": "no mentions"})
+    connector._daemon.list_groups.assert_not_awaited()  # type: ignore[union-attr]
+
+
+async def test_signal_send_dm_skips_refresh(connector: SignalConnector) -> None:
+    # DMs never need a group roster — refreshing on every DM send would
+    # be a wasted RPC.
+    connector._groups_by_account["+15550001"] = []
+    stub_focal(connector, f"bot-uuid/{ALICE_UUID}")
+    await connector._invoke_tool(descriptor(connector, "signal_send"), {"text": "hey"})
+    connector._daemon.list_groups.assert_not_awaited()  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary
- signal-cli's `listGroups` RPC returns an empty list at boot when the account state hasn't finished loading from disk
- The boot-time call in `SignalConnector.setup` caches the empty result, and outbound `@<uuid>` mentions silently degrade for the lifetime of the connector — `encode_mentions(text, [])` is a no-op so `@<uuid>` patterns pass through as plain text in `signal_send`
- Symptom observed live: connector reports `groups=0` at startup despite `account.db` having groups; messages with `@<uuid>` mentions arrived at recipients as literal text with no highlight or notification

## Fix
- Make `_group_member_uuids` async and re-call `list_groups` on cache miss, then re-check
- Hit path (cache populated) is unchanged
- Cost: one extra RPC the first time the bot sends to a previously-unknown group; bounded by the lazy refresh
- Side benefit: picks up groups joined after boot without needing a connector restart

## Test plan
- [x] New tests cover three paths: miss → refresh → encode mention; hit → no refresh; DM → no refresh
- [x] `uv run pytest connectors/signal -q` (123 passed)
- [x] `uv run pytest tests/unit -q` (1155 passed)
- [x] `uv run mypy src` clean
- [x] `uv run ruff check ... && format --check` clean
- [x] Smoke-tested live: confirmed outbound `@<uuid>` mentions render with highlight + notification on the running session

🤖 Generated with [Claude Code](https://claude.com/claude-code)