### PR TITLE
feat(skills): aios-live-monitor for persistent session observation

### DIFF
--- a/.claude/skills/aios-live-monitor/SKILL.md
+++ b/.claude/skills/aios-live-monitor/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: aios-live-monitor
+description: This skill should be used when the user asks to "watch the live aios session", "tail factchecker", "set up live monitoring on aios", "monitor the chat", "tail worker errors", "narrate aios session activity", or runs a smoke test that requires persistent observation of a running aios api+worker pair. Provides a chat-stream filter, error-grep pattern, and pre-flight probe to arm Monitor-tool tasks safely (always with --after-seq to avoid backfill blowing up the context window).
+---
+
+# aios live monitoring
+
+Persistent observation of a running aios session (api + worker pair) for live-testing, smoke runs, and AFK narration. Two streams are usually armed in parallel: a per-session **chat monitor** (one line per turn) and a worker-log **error filter** (silent-failure detector).
+
+## When to use
+
+- Smoke-testing a PR stack against real sessions before merging
+- Watching a fix land in a running session (did the connector behavior change?)
+- AFK monitoring with proactive narration (per saved feedback memory: post a one-liner per turn)
+- Diagnosing a stuck session, hang, or unexpected silence
+
+Skip the chat monitor for one-off snapshots — `aios sessions events` is faster.
+
+## The fast path
+
+From the running aios worktree (the one whose `.env` points at the api), arm both monitors via the bundled preflight script:
+
+```bash
+.claude/skills/aios-live-monitor/scripts/preflight.sh <session_id>
+```
+
+It checks api reachability, reads `last_event_seq` directly via `aios sessions get` (single RTT), and prints two ready-to-paste commands — one for the chat monitor, one for the error filter. Wrap each in a `Monitor(... persistent=True, timeout_ms=3600000 ...)` call.
+
+## The --after-seq rule (critical)
+
+`aios sessions stream <id>` SSE-backfills the **entire** session before live frames. For a 50k-event session that becomes ~50k notifications — each one a `<task-notification>` injected into context. Cost: ~200k tokens of pure noise.
+
+**Always** pass `--after-seq <current_tail>` so the stream starts at the live edge with no backfill. The preflight script computes this automatically. If a monitor accidentally fires without `--after-seq`, stop it immediately with `TaskStop` and re-arm with the correct seq.
+
+## Chat monitor invocation shape
+
+```
+Monitor(
+  description="<session> chat from seq <N>",
+  command="cd <worktree> && set -a && source .env && set +a && \\
+    uv run aios sessions stream <session_id> --after-seq <N> --raw 2>&1 | \\
+    python3 .claude/skills/aios-live-monitor/scripts/chat_filter.py",
+  timeout_ms=3600000,
+  persistent=True,
+)
+```
+
+The filter at `scripts/chat_filter.py` formats one line per message-kind event (user / assistant text / tool call / tool result / monologue). It reads from stdin only — invoking it with positional args by mistake exits silently with no output.
+
+## Error filter invocation shape
+
+```
+Monitor(
+  description="worker errors",
+  command="tail -f <worktree>/.logs/worker.log | grep --line-buffered -E 'error|ERROR|exception|Exception|traceback|Traceback|RuntimeError|KeyError|FAILED'",
+  timeout_ms=3600000,
+  persistent=True,
+)
+```
+
+`--line-buffered` is essential — without it `grep` batches and event timing is lost.
+
+## Restart cadence
+
+Per saved project feedback, every commit on the smoke branch auto-triggers a stop+restart on the new HEAD. Protocol:
+
+1. `pkill -f "aios api"; pkill -f "aios worker"`
+2. Restart api+worker in the smoke worktree, redirect to `.logs/`
+3. Wait ~5s, confirm `signal.account.ready` and `connector.running` in worker.log
+4. **Stop the existing chat monitor with `TaskStop`** — its SSE stream points at a dead API
+5. Re-run `preflight.sh` to get the new tail seq
+6. Re-arm with the new `--after-seq`
+
+## Narration etiquette during AFK monitoring
+
+When the user is AFK (e.g., gave a "Dev, ..." instruction via Signal), per saved feedback:
+
+- One-liner per turn: who spoke, what tool fired, what landed
+- Don't narrate every internal monologue — only flag when the model is engaging or something looks off
+- Flag real errors from the error filter promptly; don't auto-act on benign false positives (see references for the known set)
+
+## Additional resources
+
+- **`scripts/preflight.sh`** — reachability + tail-seq probe; emits ready-to-paste Monitor commands
+- **`scripts/chat_filter.py`** — stdin-only formatting filter for `aios sessions stream --raw`
+- **`references/patterns.md`** — chat-line shapes, error-filter false positives to ignore, gap-bridging probes after restart, customization conventions for the filter

--- a/.claude/skills/aios-live-monitor/references/patterns.md
+++ b/.claude/skills/aios-live-monitor/references/patterns.md
@@ -1,0 +1,75 @@
+# aios live-monitor patterns
+
+Detail not covered in SKILL.md. Read this when needed.
+
+## Chat-filter output format
+
+The filter at `scripts/chat_filter.py` emits one line per message-kind event:
+
+| event | line shape |
+|---|---|
+| `role: user` (text) | `[<seq>] USER<sender@channel> <text preview, 200 chars>` |
+| `role: user` (multipart) | `[<seq>] USER<sender@channel> [<part-types>] <first text part, 200>` |
+| `role: user` w/ attachments | additional `      ATT: <fn> <ct> <sz>B in_sandbox=<path>` rows beneath |
+| `role: assistant` text (visible) | `[<seq>] ASSISTANT <text preview, 200>` |
+| `role: assistant` text (`INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER` prefix) | `[<seq>] ASSISTANT [monologue: <preview, 140>]` |
+| `role: assistant` tool call | `[<seq>] ASSISTANT call <name>(<k=v, k=v, ...>)` (first 3 args, values ≤80 each) |
+| `role: tool` (text result) | `[<seq>] TOOL <name> -> <preview, 200>` |
+| `role: tool` (multipart) | `[<seq>] TOOL <name> -> [<part-types>]` |
+
+Spans, lifecycle, and metadata frames are dropped. Stdin is parsed line-by-line; the filter unwraps the SSE envelope (`{"event":"event","data":"<JSON of the event>"}`) once before parsing the inner event.
+
+## Error-filter false positives to ignore
+
+The grep pattern `error|ERROR|exception|Exception|traceback|Traceback|RuntimeError|KeyError|FAILED` is intentionally broad. Known benign matches (investigate only if pattern looks new):
+
+- `signal.daemon.stderr` lines containing `NotRegisteredException` for unregistered phones in `MultiAccountManager` — signal-cli's normal startup chatter on multi-account mode.
+- `mcp_tool.completed` info lines that happen to contain `is_error: false`.
+- The literal string `Exception` appearing inside JSON-encoded inbound envelopes (signal-cli serializes typing/receipt envelopes containing class names).
+- `mcp_pool.close_entry_failed` warnings during graceful shutdown — cleanup noise, not a crash trigger.
+
+If a real error fires, look for surrounding context — the grep buffers per-line, so the line above/below isn't visible in the notification. Use `Read` on `.logs/worker.log` around the timestamp.
+
+## Why the chat monitor sometimes ends silently
+
+The Monitor stream completes (sends a "stream ended" notification) when:
+
+- The api process dies — SSE connection closed by server
+- The script gets EOF on stdin — usually because invoked without the upstream `aios sessions stream` pipe (e.g., positional args mistake)
+- `aios sessions stream` itself exits — the session was deleted, or the server shut down between events
+
+The chat filter never crashes on bad input — bad lines are silently dropped via `try: json.loads except JSONDecodeError: continue`. So a "stream ended" with no events almost always means stdin was empty or the api was unreachable.
+
+## Bridging the gap after a restart
+
+After step 5 of the restart cadence, the new chat monitor starts at the new tail seq — events between old and new are not backfilled. To inspect what happened during downtime + replay:
+
+```bash
+uv run aios --format json sessions events <id> --after-seq <old_tail> --limit 200 \
+  | python3 -c "
+import json, sys
+for e in json.load(sys.stdin)['data']:
+    if e.get('kind') != 'message': continue
+    d = e['data']; r = d['role']
+    md = d.get('metadata') or {}
+    s = md.get('sender') or 'asst'
+    print(f'[{e[\"seq\"]}] {r} {s}: {str(d.get(\"content\",\"\"))[:200]}')"
+```
+
+Pages by setting `--after-seq` to the last seq of the previous batch.
+
+## Customizing the chat filter
+
+The filter is intentionally simple (98 lines, no deps beyond stdlib). To extend (e.g., decode tool-call args differently, surface span events, change preview width), edit a fork in the smoke worktree under `/tmp/` first, validate against a live stream, then update the in-skill copy.
+
+Output conventions to preserve:
+
+- Lines start with `[<seq>] <ROLE>` so the user can grep notifications.
+- Truncate previews to `[:200]` (or `[:140]` for monologues) — wider notifications wrap badly in chat.
+- `print(..., flush=True)` so the runtime's 200ms batcher sees lines as they arrive.
+
+## Cost rationale for the --after-seq rule
+
+`aios sessions stream <id>` SSE-backfills via `LISTEN/NOTIFY` plus an initial replay of the events table from the requested seq. Without `--after-seq`, the replay covers the whole session. Each backfilled event becomes a Monitor stdout line, then a `<task-notification>` injected into the assistant's context.
+
+For the long-running factchecker session (51k+ events), that's ~200k tokens of pure noise injected on a single arm. Use the preflight script.

--- a/.claude/skills/aios-live-monitor/scripts/chat_filter.py
+++ b/.claude/skills/aios-live-monitor/scripts/chat_filter.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Filter aios sessions stream output to a one-line-per-message chat view."""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def fmt_attachments(atts: list[dict]) -> list[str]:
+    out = []
+    for a in atts:
+        out.append(
+            "      ATT: {fn!r} {ct} {sz}B in_sandbox={p}".format(
+                fn=a.get("filename"),
+                ct=a.get("content_type"),
+                sz=a.get("size"),
+                p=a.get("in_sandbox_path"),
+            )
+        )
+    return out
+
+
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw or not raw.startswith("{"):
+        continue
+    try:
+        outer = json.loads(raw)
+    except json.JSONDecodeError:
+        continue
+    # `aios sessions stream --raw` emits SSE-shape:
+    # {"event":"event","data":"<JSON-string of the actual event>"}
+    # for backfill + live frames.  Unwrap once; events from the static
+    # `sessions events` array path are already at top level so fall back
+    # to the outer dict if there's no nested data string.
+    inner = outer.get("data")
+    if isinstance(inner, str):
+        try:
+            e = json.loads(inner)
+        except json.JSONDecodeError:
+            continue
+    else:
+        e = outer
+    if e.get("kind") != "message":
+        continue
+    data = e.get("data") or {}
+    role = data.get("role")
+    seq = e.get("seq")
+    md = data.get("metadata") or {}
+
+    if role == "user":
+        content = data.get("content", "")
+        sender = md.get("sender_name") or md.get("sender") or "?"
+        channel = md.get("channel", "?")
+        if isinstance(content, list):
+            text = next(
+                (p.get("text", "") for p in content if p.get("type") == "text"), ""
+            )
+            kinds = ",".join(p.get("type", "?") for p in content)
+            print(f"[{seq}] USER<{sender}@{channel}> [{kinds}] {text[:200]}", flush=True)
+        else:
+            print(f"[{seq}] USER<{sender}@{channel}> {str(content)[:300]}", flush=True)
+        for line in fmt_attachments(md.get("attachments") or []):
+            print(line, flush=True)
+
+    elif role == "assistant":
+        content = data.get("content", "")
+        if isinstance(content, str) and content.startswith("INTERNAL_MONOLOGUE"):
+            mono = content.split(":", 1)[1].strip()[:140]
+            content = f"[monologue: {mono}]"
+        elif content:
+            content = (content if isinstance(content, str) else str(content))[:200]
+        for tc in data.get("tool_calls") or []:
+            f = tc.get("function") or {}
+            args_str = f.get("arguments", "")
+            try:
+                args = json.loads(args_str)
+                args_summary = ", ".join(
+                    f"{k}={str(v)[:80]!r}" for k, v in list(args.items())[:3]
+                )
+            except json.JSONDecodeError:
+                args_summary = args_str[:200]
+            print(
+                f"[{seq}] ASSISTANT call {f.get('name', '?')}({args_summary})",
+                flush=True,
+            )
+        if content:
+            print(f"[{seq}] ASSISTANT {content}", flush=True)
+
+    elif role == "tool":
+        c = data.get("content", "")
+        name = data.get("name", "?")
+        if isinstance(c, list):
+            kinds = ",".join(p.get("type", "?") for p in c)
+            print(f"[{seq}] TOOL {name} -> [{kinds}]", flush=True)
+        else:
+            preview = (c if isinstance(c, str) else str(c))[:200]
+            print(f"[{seq}] TOOL {name} -> {preview}", flush=True)

--- a/.claude/skills/aios-live-monitor/scripts/preflight.sh
+++ b/.claude/skills/aios-live-monitor/scripts/preflight.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Pre-flight check before arming the live chat monitor on an aios session.
+#
+# Verifies api/worker reachability, prints the session's current
+# last_event_seq (single round-trip via `sessions get`), and emits the exact
+# Monitor commands (chat stream + worker error filter) to copy-paste.
+#
+# Usage:
+#   preflight.sh <session_id> [worktree_dir]
+#
+# worktree_dir defaults to the current directory; must contain a .env (or
+# symlink to one) with AIOS_URL / AIOS_API_KEY.
+set -euo pipefail
+
+SESSION_ID="${1:-}"
+WORKTREE="${2:-$(pwd)}"
+
+if [[ -z "$SESSION_ID" ]]; then
+  echo "usage: preflight.sh <session_id> [worktree_dir]" >&2
+  exit 2
+fi
+
+cd "$WORKTREE"
+if [[ ! -e .env ]]; then
+  echo "ERROR: no .env in $WORKTREE — chat monitor needs AIOS_URL/AIOS_API_KEY" >&2
+  exit 2
+fi
+set -a; source .env; set +a
+
+# 1. Reachability
+if ! uv run aios status >/dev/null 2>&1; then
+  echo "ERROR: aios api unreachable at ${AIOS_URL:-default} — start with 'uv run python -m aios api'" >&2
+  exit 1
+fi
+
+# 2. Tail seq via the session-info endpoint (single RTT — `last_event_seq` is
+#    returned directly).  Walking the events page would touch every row in
+#    the log, defeating the cost rationale this skill exists to avoid.
+TAIL_SEQ=$(uv run aios --format json sessions get "$SESSION_ID" 2>/dev/null \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['last_event_seq'])")
+
+if [[ -z "$TAIL_SEQ" || "$TAIL_SEQ" == "None" ]]; then
+  echo "ERROR: could not read last_event_seq for $SESSION_ID — does the session exist?" >&2
+  exit 1
+fi
+
+SKILL_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG="$WORKTREE/.logs/worker.log"
+
+echo "session : $SESSION_ID"
+echo "tail seq: $TAIL_SEQ"
+echo
+echo "── chat monitor (Monitor tool, persistent: true) ──"
+echo "cd $WORKTREE && set -a && source .env && set +a && \\"
+echo "  uv run aios sessions stream $SESSION_ID --after-seq $TAIL_SEQ --raw 2>&1 | \\"
+echo "  python3 $SKILL_DIR/chat_filter.py"
+echo
+echo "── error filter (Monitor tool, persistent: true) ──"
+if [[ -f "$LOG" ]]; then
+  echo "tail -f $LOG | grep --line-buffered -E 'error|ERROR|exception|Exception|traceback|Traceback|RuntimeError|KeyError|FAILED'"
+else
+  echo "(worker.log not found at $LOG — check the worktree's logs dir)"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ venv/
 !.claude/settings.json
 !.claude/hooks/
 !.claude/hooks/**
+!.claude/skills/
+!.claude/skills/**
 
 # aios runtime state
 /var/lib/aios/


### PR DESCRIPTION
## Summary
- New repo-level skill at `.claude/skills/aios-live-monitor/` capturing the live-watching workflow used during smoke testing — chat-stream filter (one line per message-kind event) + worker-log error grep, both armed via Claude Code's Monitor tool with `persistent: true`.
- Headline rule the skill enforces: **always pass `--after-seq <last_event_seq>` to `aios sessions stream`**. Without it, SSE backfills the entire session before going live; for a 50k-event session that's ~200k tokens of pure noise injected into the assistant's context as `<task-notification>` blocks.
- `.gitignore` grows two `!` exemptions for `.claude/skills/` alongside the existing `.claude/hooks/` carve-out — skills are a shared per-repo artifact, not per-developer state.

## What's bundled
- **`SKILL.md`** (645 words) — fast-path invocation, the `--after-seq` rule, Monitor command shapes, restart cadence, narration etiquette. Frontmatter triggers scoped to aios-specific phrasings (`"watch the live aios session"`, `"tail factchecker"`, `"smoke test that requires persistent observation of a running aios api+worker pair"`) to avoid overfiring on unrelated monitoring asks.
- **`scripts/preflight.sh`** — single-RTT probe via `aios sessions get` that reads `last_event_seq` directly and prints copy-paste-ready Monitor commands. Uses the session-info endpoint deliberately rather than paging through events (paging defeats the cost rule the skill exists to enforce).
- **`scripts/chat_filter.py`** — stdin-only formatter (98 lines) that unwraps SSE envelopes once and emits `[<seq>] <ROLE> <preview>` lines, one per message-kind event. Spans / lifecycle / metadata frames dropped.
- **`references/patterns.md`** (657 words) — line-format table per role, known benign error-grep matches to ignore (signal-cli `NotRegisteredException`, `mcp_pool.close_entry_failed` cleanup, etc.), and gap-bridging probe for events between an old and new tail seq after a restart.

## Test plan
- [x] `preflight.sh sess_01KQ8NQ3HP4XB9D0F4GW9JKYWF /Users/tom/tmp/worktrees/worktree-recursive-weaving-smoke` returned `tail seq: 51756` in <1s and printed valid copy-paste Monitor commands
- [x] `chat_filter.py` already in production use throughout the smoke session — handles user/assistant/tool/monologue events, SSE envelope unwrap
- [x] Reviewed by `plugin-dev:skill-reviewer` agent (preflight bug + dedup + trigger scoping all addressed)
- [x] `uv run pytest tests/unit -q` clean (1155 passed)
- [x] `uv run mypy src && uv run ruff check src tests` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)