### PR TITLE
feat(skills): aios-smoke-setup for isolated runtime bring-up in worktrees

### DIFF
--- a/.claude/skills/aios-smoke-setup/SKILL.md
+++ b/.claude/skills/aios-smoke-setup/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: aios-smoke-setup
+description: This skill should be used when the user asks to "smoke test the connector", "DM the bot in this worktree", "set up a fresh aios runtime", "spin up aios", "prep a smoke session", "bring up aios on this branch", or otherwise wants to point a real Telegram (or Signal) bot at the code in the current worktree.  Bundles the pre-flight checks (bot getUpdates conflict, sibling worktree non-interference, free port), the isolated `.env` overrides (separate DB + port + ``AIOS_DEFAULT_MCP_PERMISSION_POLICY=always_allow``), the right migration command (``aios migrate``, not ``alembic upgrade head``), and the env/agent/connection/session/attach resource chain in one ``setup.sh`` so the first DM round-trips in seconds instead of forty-five minutes.  Hand off to ``aios-live-monitor`` once the runtime is up.
+---
+
+# aios smoke session setup
+
+Bring up an isolated aios runtime in a worktree, ready to receive real Telegram (or Signal) messages and respond.  The "isolated" part is load-bearing: parallel smoke sessions in sibling worktrees share the same Postgres instance and would otherwise fight over the supervisor lock + API port.
+
+## When to use
+
+- Smoke-testing a connector / harness PR against a live bot before merging
+- Reproducing a user-reported issue on a real platform account
+- Demoing a feature end-to-end on a fresh branch
+
+Skip this skill if you're just running unit / e2e tests — `uv run pytest` is the right tool, no runtime setup needed.
+
+## The fast path
+
+```bash
+.claude/skills/aios-smoke-setup/scripts/setup.sh \
+  --bot-token <telegram_token> \
+  [--agent-name smoke] \
+  [--system-prompt-file <path>]
+```
+
+Reads source `.env` from `~/code/aios/.env`, writes a worktree-scoped `.env` with overrides, creates a fresh `aios_smoke_<branch_short>` Postgres database, runs migrations, starts api + worker, builds the env/agent/connection/session resource chain, and prints `session_id` + the focal-channel address on stdout.
+
+## Pre-flight rules (every smoke run)
+
+1. **Telegram getUpdates conflict.** Telegram's bot polling is exclusive — if the token is already being polled by a remote deployment / coworker / stale process, the connector spawns and dies in a `Conflict 409` loop.  The script tests this with `curl …/getUpdates?timeout=2` before starting the worker; if it returns `409`, ask the user to either rotate the token or stop the rogue poller.
+
+2. **Sibling worktree non-interference.** Run `ps -ef | grep -E "aios (api|worker)" | grep -v grep`.  If a process is running from a *different* worktree path, **do not kill it** — it might be a managed monitor session another Claude Code instance is driving.  Choose a port that doesn't conflict (the script auto-finds the first free port from 8091).
+
+3. **Bot identity.** The connector calls `Bot.get_me()` at startup; the returned `bot_id` becomes the `account` field of every connection and the `<account>` segment of channel addresses.  The script captures this from `aios connectors list` and uses it for `aios connections create --account=<bot_id>`.
+
+## The four overrides that always belong in the worktree's .env
+
+```dotenv
+AIOS_DB_URL=postgresql://aios:aios@localhost:5433/aios_smoke_<branch_short>
+AIOS_API_PORT=8091   # or next free port from 8091
+AIOS_CONNECTORS_ENABLED=telegram   # narrow to what's actually installed in this venv
+AIOS_DEFAULT_MCP_PERMISSION_POLICY=always_allow
+```
+
+Without the **DB** and **port** overrides, two parallel smoke sessions will deadlock each other on the procrastinate supervisor lock and the uvicorn bind.  Without **`always_allow`**, every model tool call parks in `requires_action` until you POST a `tool-confirmation` — fine for production, terrible for unattended smoke.  Without **narrowing `AIOS_CONNECTORS_ENABLED`**, a missing connector entry-point in this worktree's venv (e.g. signal not installed) crashes the worker at startup.
+
+## The migration step is `aios migrate`, not `alembic upgrade head`
+
+CLAUDE.md mentions `alembic upgrade head` for migrations — that creates aios tables but **not** the procrastinate schema.  The worker then crashes on first job with `procrastinate.exceptions.ConnectorException`.  Run `uv run aios migrate` instead; it does both in one shot.
+
+## The resource chain
+
+A fresh DB has zero envs, agents, connections, sessions.  In order:
+
+```bash
+uv run aios envs create --data '{"name":"smoke"}'                               # → env_<id>
+uv run aios agents create --file agent.json                                     # → agent_<id>
+uv run aios connections create --connector=telegram --account=<bot_id>          # → conn_<id>
+uv run aios sessions create --agent <agent_id> --environment-id <env_id>        # → sess_<id>
+uv run aios connections attach <conn_id> --session-id=<sess_id>                 # binds connection
+```
+
+CLI quirks: `envs` is plural; `--session-id` not `--session`; `sessions create` requires both `--agent` AND `--environment-id`; the `agent.json` `tools[]` items must use bare type names (`bash`, `read`, `write`, …) and **`switch_channel` is auto-included — do not list it** (the API rejects it).
+
+## After setup: hand off to aios-live-monitor
+
+`scripts/setup.sh` ends by printing the `session_id` and a hint:
+
+```
+✓ smoke runtime ready
+  session: sess_01...
+  focal:   telegram/<bot_id>/<chat_id-pending>
+  api:     http://127.0.0.1:8091
+  port-free: yes  bot-uncontested: yes  always_allow: yes
+
+Next: arm monitors via .claude/skills/aios-live-monitor/scripts/preflight.sh sess_01...
+```
+
+Then DM the bot from your phone.  The first inbound message triggers the supervisor's auto-route to the attached session.
+
+## Restart cadence
+
+Per saved feedback (`feedback_restart_after_commit.md`), every commit on the smoke branch auto-triggers a stop+restart on the new HEAD.  The script's `--restart` flag short-circuits the DB+fixtures phases (they're already there) and just re-runs the api/worker:
+
+```bash
+.claude/skills/aios-smoke-setup/scripts/setup.sh --restart
+```
+
+## Common gotchas
+
+See **`references/gotchas.md`** for the eight that cost ~5–15 min each during the parity-PR smoke session, with the symptom → root cause → one-liner fix table.
+
+## Known CLI/API affordance gaps
+
+See **`references/missing-affordances.md`** — wishlist of admin-side ergonomics that would have shaved an hour off the parity-PR smoke.  Worth filing as enhancement issues; high-impact ones include `aios sessions confirm <id> <tool_call_id>`, `aios connectors check <name>` (bot pre-flight), supervisor auto-creating connections on `accounts_updated` (not just on first inbound), and consistent CLI flag naming (`envs`/`environments`, `--session`/`--session-id`).
+
+## Additional resources
+
+- **`scripts/setup.sh`** — the all-in-one bring-up; idempotent on re-run, supports `--restart` for commit-cycle re-deploys
+- **`references/gotchas.md`** — symptom-to-fix table for the eight common failure modes
+- **`references/missing-affordances.md`** — admin CLI/API gaps surfaced by smoke testing; candidate enhancement issues

--- a/.claude/skills/aios-smoke-setup/references/gotchas.md
+++ b/.claude/skills/aios-smoke-setup/references/gotchas.md
@@ -1,0 +1,21 @@
+# Smoke-setup gotchas
+
+The eight failure modes that cost ~5–15 min each during the openclaw-parity PR smoke session.  Symptom → root cause → one-liner fix.
+
+| # | Symptom | Root cause | Fix |
+|---|---------|------------|-----|
+| 1 | `worker.duplicate_instance_refused` | A sibling worktree's `aios worker` holds the supervisor advisory lock on the shared `aios` Postgres database. | Use a dedicated DB per worktree (`AIOS_DB_URL=…/aios_smoke_<branch>`).  Don't kill the sibling's worker — it might be a managed monitor session another Claude Code instance is driving. |
+| 2 | `[Errno 48] address already in use` on `:8090` | Sibling worktree's api on the default port. | Pick a different port (`AIOS_API_PORT=8091`).  Probe with `lsof -iTCP:<port> -sTCP:LISTEN` first. |
+| 3 | `procrastinate.exceptions.ConnectorException` after a successful alembic migration | `alembic upgrade head` creates aios tables but **not** the procrastinate schema. | Use `uv run aios migrate` instead — it does both. CLAUDE.md is misleading on this point. |
+| 4 | `telegram.error.Conflict: terminated by other getUpdates request` in worker.log | Bot token is being polled by an unknown remote (fly.io, render, coworker's box, stale local process you can't grep for). | Pre-flight with `curl …/getUpdates?timeout=2` before starting the worker.  If `error_code: 409`, the user must rotate the token (Telegram invalidates the old one) or stop the rogue poller. |
+| 5 | `RuntimeError: connector 'signal' listed in connectors_enabled but no aios.connectors entry point` | Source `.env` has `AIOS_CONNECTORS_ENABLED=signal,telegram` but this worktree's venv only installed telegram. | Narrow `AIOS_CONNECTORS_ENABLED` to the connectors actually present (`uv pip list \| grep aios-`). |
+| 6 | Bot replies never arrive; session stuck in `status=idle stop_reason={"type":"requires_action"}` after first `telegram_send` | `AIOS_DEFAULT_MCP_PERMISSION_POLICY` defaults to `always_ask`; every MCP tool call parks for human confirmation. | Add `AIOS_DEFAULT_MCP_PERMISSION_POLICY=always_allow` to `.env` for unattended smoke runs.  In production, leave it default and configure per-toolset on the agent. |
+| 7 | `connections attach` returns `connector 'X' is None; snapshot unavailable` even though `aios connectors list` shows status=running | Pre-existing bug in `_assert_account_in_snapshot` reading the wrong envelope key (singular `connector` instead of plural `connectors`). | Fixed in #242.  If you hit this on a branch off pre-`bff6660` master, cherry-pick the fix or use `--phase post-attach` to skip the validation. |
+| 8 | `aios sessions create` rejects with "either provide --agent and --environment-id" | Subcommand needs **both** flags; `--agent` alone isn't enough. | `aios sessions create --agent <agent_id> --environment-id <env_id>`.  See also: `envs` (plural) not `environments`; `--session-id` not `--session` on connections attach.  See `references/missing-affordances.md` for the wishlist of CLI naming consistency. |
+
+## Less-frequent pitfalls
+
+- **Pre-commit hook gates on the whole working tree**, not just staged files.  Splitting two logical changes into separate commits requires `git stash` of the file you don't want gated.
+- **Tool confirmation manual unblock**: if you find yourself stuck with `requires_action` and need to release a single tool call without restarting, POST to `/v1/sessions/<id>/tool-confirmations` with `{"tool_call_id": "...", "result": "allow"}` (note: `result`, not `decision`; both `allow` and `deny` accepted; `deny_message` optional).
+- **`-f json` is a global flag**, must come before the subcommand chain: `aios -f json sessions get <id>` ✓, `aios sessions -f json get <id>` ✗.
+- **`message.video_note` vs `message.video`**: regular videos (paperclip → photo/video, file like `IMG_3802.MOV`) hit the `video` slot.  Round circular video notes (long-press the mic icon to switch to camera mode on mobile) hit `video_note` and only ship from mobile clients.

--- a/.claude/skills/aios-smoke-setup/references/missing-affordances.md
+++ b/.claude/skills/aios-smoke-setup/references/missing-affordances.md
@@ -1,0 +1,72 @@
+# Admin CLI/API affordance gaps surfaced by smoke testing
+
+Each item below cost real time during the openclaw-parity smoke session.  Listed as candidate enhancement issues with a one-line proposal and rough impact estimate.  Highest-value items at the top.
+
+## High value
+
+### 1. `aios connectors check <name>` — pre-flight health probe
+
+**Today:** the only signal that a connector is healthy is `aios connectors list` showing `status: running`.  But a connector can be "running" while its inner poll loop is failing (e.g., Telegram getUpdates 409 conflict in a tight respawn loop).  No way to detect this short of reading worker.log.
+
+**Proposal:** `aios connectors check <connector>[:<instance>]` performs a synthetic round-trip against the platform (Telegram: `getMe` + a one-shot `getUpdates?timeout=2`; Signal: a `getDevices` etc.) and reports `ok` / `bot_uncontested: true|false` / `last_poll_error: <str|null>` / `auth_ok: true|false`.
+
+**Impact:** ~10 min of bot-token-conflict diagnosis avoided per smoke session.
+
+### 2. `aios sessions confirm <id> <tool_call_id> --allow|--deny` 
+
+**Today:** unblocking a `requires_action` tool call requires a manual `curl POST /v1/sessions/<id>/tool-confirmations` with hand-crafted JSON (and the schema field is `result` not `decision`, which trips up first-time users).
+
+**Proposal:** thin CLI wrapper.  Default `--allow`; `--deny` takes optional `--message`.
+
+**Impact:** ~5 min the first time, and removes the curl-vs-CLI dissonance.
+
+### 3. Auto-create connection on `accounts_updated` (not just on first inbound)
+
+**Today:** when the connector reports a new account via `notifications/aios/accounts`, the supervisor records it in the snapshot but doesn't create the `connections` row.  The operator must `aios connections create --connector=X --account=<bot_id>` manually before they can attach.  The auto-create-on-first-inbound path mentioned in `connections.py` only fires after a real user message arrives — chicken-and-egg for an attach-before-DM flow.
+
+**Proposal:** when `accounts_updated` lands, idempotent-create a detached connection per (connector, account) tuple.  The operator only ever needs to `attach` it.
+
+**Impact:** ~5 min per fresh-DB smoke; removes one of five steps in the resource chain.
+
+### 4. CLI flag and noun consistency
+
+- `aios envs` ↔ `aios environments` — only `envs` works; `environments` returns "No such command".  Add an alias.
+- `aios connections attach --session-id` ↔ `--session` — only `--session-id` works.  Add `--session` alias for symmetry with `aios sessions stream <id>`.
+- `aios connections list --account=<id>` — currently rejected with "No such option"; only `--connector` filter exists.  Add `--account`.
+- `aios -f json sessions get <id>` works; `aios sessions -f json get <id>` doesn't.  This is a typer convention but worth a one-line note in `--help`.
+
+**Impact:** ~3 min trial-and-error per command, repeated.
+
+## Medium value
+
+### 5. Connector status surfaces `last_poll_error`
+
+`aios connectors list` JSON includes `last_error`, but it's null in the cases I observed (the worker silently respawned the connector subprocess on `Conflict 409` rather than holding the error).  Surface the most recent poll-loop error string here so `connectors check` can read it without reading log files.
+
+### 6. `aios envs create --name <str>` shorthand
+
+Today requires `--data '{"name":"smoke"}'` or a file.  A one-flag shorthand for the trivial case would make the resource-chain script half a line shorter.
+
+### 7. `aios agents create --name <str> --model <str> --system <str> --tool <type>...` shorthand
+
+Same idea.  For the smoke scenario the JSON is always trivial — env vars or repeated `--tool` flags would let the script skip the temp-file dance.
+
+### 8. `--instructions` parameter on `agents create` to override system prompt at session level
+
+When connecting an existing well-loved agent (e.g., `ultron`) to a new platform for smoke testing, the agent's system prompt may be platform-specific (Signal phone number, etc.).  Letting `aios sessions create` pass an `additional_system` would avoid forking the agent for each smoke run.
+
+## Low value (style)
+
+### 9. `aios envs list` returning `(none)` literally
+
+Could be `0 environments` or an empty-table-with-headers shape consistent with other list commands.  Cosmetic.
+
+### 10. Document `aios migrate` in CLAUDE.md as the canonical migration command
+
+`alembic upgrade head` is currently in CLAUDE.md but it's insufficient on its own (misses procrastinate schema).  Replace with `aios migrate`.
+
+---
+
+## Filing strategy
+
+If filing each as a separate issue, items 1–4 are the worth-doing-now bucket.  5–10 are nice-to-haves; bundle them as a single "smoke-setup CLI ergonomics" tracking issue if filing at all.

--- a/.claude/skills/aios-smoke-setup/scripts/setup.sh
+++ b/.claude/skills/aios-smoke-setup/scripts/setup.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# Bring up an isolated aios smoke runtime in this worktree, ready to
+# receive real Telegram messages and respond.
+#
+# Idempotent.  Re-running with the same flags refreshes the DB + fixtures.
+# Use --restart to reload api/worker on the new HEAD without rebuilding the
+# DB (the smoke-branch commit-cycle pattern).
+#
+# Usage:
+#   setup.sh --bot-token <token> [--connector telegram] \
+#            [--agent-name smoke] [--system-prompt-file <path>] \
+#            [--source-env ~/code/aios/.env] [--port <num>] \
+#            [--db <name>] [--restart]
+#
+# Output (last line):
+#   smoke_session_id=sess_01...
+
+set -euo pipefail
+
+# ── arg parsing ───────────────────────────────────────────────────────
+BOT_TOKEN=""
+CONNECTOR="telegram"
+AGENT_NAME="smoke"
+SYSTEM_PROMPT_FILE=""
+SOURCE_ENV="${HOME}/code/aios/.env"
+PORT=""
+DB=""
+RESTART_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bot-token) BOT_TOKEN="$2"; shift 2;;
+    --connector) CONNECTOR="$2"; shift 2;;
+    --agent-name) AGENT_NAME="$2"; shift 2;;
+    --system-prompt-file) SYSTEM_PROMPT_FILE="$2"; shift 2;;
+    --source-env) SOURCE_ENV="$2"; shift 2;;
+    --port) PORT="$2"; shift 2;;
+    --db) DB="$2"; shift 2;;
+    --restart) RESTART_ONLY=true; shift;;
+    -h|--help) sed -n '2,15p' "$0"; exit 0;;
+    *) echo "unknown flag: $1" >&2; exit 2;;
+  esac
+done
+
+WORKTREE="$(pwd)"
+BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo nobranch)"
+BRANCH_SHORT="$(echo "$BRANCH" | sed 's|wt/||; s|/|-|g; s/[^a-z0-9_-]/_/g' | head -c 30)"
+
+[[ -z "$DB" ]] && DB="aios_smoke_${BRANCH_SHORT//-/_}"
+
+say()   { printf "\033[36m▸\033[0m %s\n" "$*"; }
+warn()  { printf "\033[33m⚠\033[0m %s\n" "$*"; }
+fail()  { printf "\033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+ok()    { printf "\033[32m✓\033[0m %s\n" "$*"; }
+
+# ── 1. preflight ──────────────────────────────────────────────────────
+preflight() {
+  say "preflight"
+
+  # 1a. Bot token uncontested
+  if [[ "$CONNECTOR" == "telegram" && -n "$BOT_TOKEN" ]]; then
+    local resp
+    resp="$(curl -sS "https://api.telegram.org/bot${BOT_TOKEN}/getUpdates?timeout=2&limit=1" 2>&1 || echo '{"ok":false}')"
+    if echo "$resp" | grep -q '"error_code":409'; then
+      fail "telegram bot getUpdates returns 409 Conflict — token is being polled elsewhere; rotate the token or stop the rogue poller"
+    fi
+    if ! echo "$resp" | grep -q '"ok":true'; then
+      fail "telegram getMe/getUpdates rejected: $resp"
+    fi
+    ok "telegram bot uncontested"
+  fi
+
+  # 1b. Sibling worktree warning (don't kill, just warn)
+  local siblings
+  siblings="$(ps -ef | grep -E "aios (api|worker)" | grep -v grep | grep -v "$WORKTREE" || true)"
+  if [[ -n "$siblings" ]]; then
+    warn "sibling aios runtime detected (different worktree) — leaving it alone:"
+    echo "$siblings" | head -3 | sed 's/^/    /'
+  fi
+
+  # 1c. Pick a free port if not provided
+  if [[ -z "$PORT" ]]; then
+    for candidate in 8091 8092 8093 8094 8095; do
+      if ! lsof -iTCP:"$candidate" -sTCP:LISTEN >/dev/null 2>&1; then
+        PORT="$candidate"
+        break
+      fi
+    done
+    [[ -z "$PORT" ]] && fail "no free port in 8091..8095"
+  elif lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    fail "port $PORT already in use"
+  fi
+  ok "port $PORT free"
+}
+
+# ── 2. write .env with overrides ──────────────────────────────────────
+write_env() {
+  say "writing .env (db=$DB port=$PORT)"
+  [[ -e "$SOURCE_ENV" ]] || fail "source env $SOURCE_ENV missing"
+
+  # Start from source env, then override the four critical lines.  Any
+  # existing .env is overwritten — this script owns it on smoke runtimes.
+  cp "$SOURCE_ENV" "$WORKTREE/.env"
+
+  python3 - "$WORKTREE/.env" "$DB" "$PORT" "$CONNECTOR" "$BOT_TOKEN" <<'PY'
+import sys, pathlib
+path, db, port, connector, token = sys.argv[1:6]
+overrides = {
+    "AIOS_DB_URL": f"postgresql://aios:aios@localhost:5433/{db}",
+    "AIOS_API_PORT": port,
+    "AIOS_CONNECTORS_ENABLED": connector,
+    "AIOS_DEFAULT_MCP_PERMISSION_POLICY": "always_allow",
+}
+if connector == "telegram" and token:
+    overrides["AIOS_TELEGRAM_BOT_TOKEN"] = token
+
+lines = pathlib.Path(path).read_text().splitlines()
+seen = set()
+out = []
+for line in lines:
+    key = line.split("=", 1)[0] if "=" in line and not line.startswith("#") else None
+    if key and key in overrides:
+        out.append(f"{key}={overrides[key]}")
+        seen.add(key)
+    else:
+        out.append(line)
+for key, val in overrides.items():
+    if key not in seen:
+        out.append(f"{key}={val}")
+pathlib.Path(path).write_text("\n".join(out) + "\n")
+PY
+  ok ".env written"
+}
+
+# ── 3. fresh DB + migrate ─────────────────────────────────────────────
+ensure_db() {
+  say "creating database $DB"
+  DOCKER_HOST="${DOCKER_HOST:-unix:///Users/tom/.docker/run/docker.sock}" \
+    docker exec aios-pg psql -U aios -d postgres -c "DROP DATABASE IF EXISTS \"$DB\"" >/dev/null
+  DOCKER_HOST="${DOCKER_HOST:-unix:///Users/tom/.docker/run/docker.sock}" \
+    docker exec aios-pg psql -U aios -d postgres -c "CREATE DATABASE \"$DB\" OWNER aios" >/dev/null
+
+  say "applying schemas (alembic + procrastinate via 'aios migrate')"
+  ( set -a; source "$WORKTREE/.env"; set +a; uv run aios migrate >/dev/null )
+  ok "schemas applied"
+}
+
+# ── 4. start api + worker ─────────────────────────────────────────────
+start_runtime() {
+  mkdir -p "$WORKTREE/.logs"
+  # Don't double-start: kill any previous OUR-worktree processes only.
+  pkill -f "${WORKTREE}.*-m aios api" 2>/dev/null || true
+  pkill -f "${WORKTREE}.*-m aios worker" 2>/dev/null || true
+  sleep 0.5
+
+  say "starting api + worker"
+  : > "$WORKTREE/.logs/api.log"
+  : > "$WORKTREE/.logs/worker.log"
+  ( set -a; source "$WORKTREE/.env"; set +a
+    nohup uv run python -m aios api > "$WORKTREE/.logs/api.log" 2>&1 &
+    nohup uv run python -m aios worker > "$WORKTREE/.logs/worker.log" 2>&1 & )
+
+  # Wait for bot identification or fatal
+  local deadline=$((SECONDS + 60))
+  while (( SECONDS < deadline )); do
+    if grep -q "telegram\.bot\.identified\|signal\.account\.ready" "$WORKTREE/.logs/worker.log" 2>/dev/null; then
+      ok "connector running"
+      return 0
+    fi
+    if grep -qE "RuntimeError|Conflict|Errno 48|duplicate_instance" "$WORKTREE/.logs/worker.log" "$WORKTREE/.logs/api.log" 2>/dev/null; then
+      tail -20 "$WORKTREE/.logs/worker.log"
+      fail "runtime startup failed — see .logs/"
+    fi
+    sleep 0.5
+  done
+  fail "runtime didn't identify within 60s — see .logs/"
+}
+
+# ── 5. fixtures: env + agent + connection + session + attach ──────────
+build_fixtures() {
+  ( set -a; source "$WORKTREE/.env"; set +a
+
+    say "creating env"
+    local env_id
+    env_id="$(uv run aios -f json envs create --data '{"name":"smoke"}' 2>/dev/null \
+              | python3 -c "import json,sys;print(json.load(sys.stdin)['id'])")"
+    [[ -z "$env_id" ]] && fail "env create failed"
+
+    say "creating agent"
+    local agent_json
+    agent_json="$(mktemp)"
+    local sysprompt
+    if [[ -n "$SYSTEM_PROMPT_FILE" && -e "$SYSTEM_PROMPT_FILE" ]]; then
+      sysprompt="$(cat "$SYSTEM_PROMPT_FILE")"
+    else
+      sysprompt="You are a smoke-test assistant on Telegram. Speak in your own voice; never claim to be Claude Code. Keep replies brief and conversational."
+    fi
+    python3 - "$agent_json" "$AGENT_NAME" "$sysprompt" <<'PY'
+import json, sys
+path, name, system = sys.argv[1:4]
+json.dump({
+    "name": name,
+    "model": "anthropic/claude-sonnet-4-6",
+    "system": system,
+    "tools": [
+        {"type": "bash", "enabled": True},
+        {"type": "read", "enabled": True},
+        {"type": "write", "enabled": True},
+    ],
+}, open(path, "w"))
+PY
+    local agent_id
+    agent_id="$(uv run aios -f json agents create --file "$agent_json" 2>/dev/null \
+                | python3 -c "import json,sys;print(json.load(sys.stdin)['id'])")"
+    rm -f "$agent_json"
+    [[ -z "$agent_id" ]] && fail "agent create failed"
+
+    say "fetching bot account id"
+    local bot_id
+    bot_id="$(uv run aios -f json connectors list 2>/dev/null \
+              | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+for c in data['connectors']:
+    if c['connector'] == '$CONNECTOR' and c['accounts']:
+        print(c['accounts'][0]['id']); break")"
+    [[ -z "$bot_id" ]] && fail "no account in $CONNECTOR snapshot"
+
+    say "creating connection"
+    local conn_id
+    conn_id="$(uv run aios -f json connections create --connector="$CONNECTOR" --account="$bot_id" 2>/dev/null \
+               | python3 -c "import json,sys;print(json.load(sys.stdin)['id'])")"
+
+    say "creating session"
+    local sess_id
+    sess_id="$(uv run aios -f json sessions create --agent "$agent_id" --environment-id "$env_id" 2>/dev/null \
+               | python3 -c "import json,sys;print(json.load(sys.stdin)['id'])")"
+
+    say "attaching connection → session"
+    uv run aios connections attach "$conn_id" --session-id="$sess_id" >/dev/null
+
+    cat <<EOF
+
+✓ smoke runtime ready
+  session:   $sess_id
+  agent:     $agent_id
+  connector: $CONNECTOR/$bot_id
+  api:       http://127.0.0.1:$PORT
+  db:        $DB
+
+Next: arm monitors via .claude/skills/aios-live-monitor/scripts/preflight.sh $sess_id
+
+smoke_session_id=$sess_id
+EOF
+  )
+}
+
+# ── main ──────────────────────────────────────────────────────────────
+if $RESTART_ONLY; then
+  start_runtime
+  exit 0
+fi
+
+if [[ -z "$BOT_TOKEN" && "$CONNECTOR" == "telegram" ]]; then
+  fail "--bot-token is required for connector=telegram"
+fi
+
+preflight
+write_env
+ensure_db
+start_runtime
+build_fixtures


### PR DESCRIPTION
## Summary

Companion skill to `aios-live-monitor` (#246).  The monitor skill assumed a running api/worker pair; this skill is what gets you there in a sibling-safe, conflict-free way.

**The fast path is one command:**
```bash
.claude/skills/aios-smoke-setup/scripts/setup.sh --bot-token <token>
```

It picks a free port, configures a worktree-scoped `.env` with the four critical overrides (separate DB / port / narrowed `CONNECTORS_ENABLED` / `always_allow` MCP policy), creates a fresh `aios_smoke_<branch>` Postgres database, runs `aios migrate` (not just alembic — that misses procrastinate's schema), starts api+worker, builds the env→agent→connection→session resource chain, attaches the connection, and prints the session_id + hand-off pointer to the live-monitor skill.

## Background

This skill exists because the openclaw-parity smoke session (#242) ran into ~8 separate ~10-minute gotchas during runtime bring-up — DB lock from sibling worktree, port conflict, alembic-vs-aios-migrate, getUpdates conflict from a remote bot poller, missing connector entry-points, MCP permission default, attach drift-check envelope shape, and CLI flag idiom mismatches.  The retro identified this as the highest-value missing skill in the toolkit.

## What's bundled

- `SKILL.md` — when to use, the four critical `.env` overrides explained, the migration step, the resource-chain reference, hand-off to `aios-live-monitor`
- `scripts/setup.sh` — the one-command bring-up; idempotent, supports `--restart` for the commit-cycle re-deploy pattern
- `references/gotchas.md` — symptom→fix table for the eight failure modes
- `references/missing-affordances.md` — wishlist of admin CLI/API ergonomics worth filing as enhancement issues; top four:
  1. `aios connectors check <name>` — pre-flight bot-token health probe (catches silent getUpdates-conflict respawn loops)
  2. `aios sessions confirm <id> <tool_call_id>` — replace the hand-crafted curl POST for `requires_action`
  3. Auto-create connection on `accounts_updated` (not just on first inbound)
  4. CLI flag and noun consistency (`envs`/`environments`, `--session`/`--session-id`, `connections list --account`)

## Test plan

- [ ] Run `setup.sh --bot-token <token>` on a fresh worktree; verify session_id printed and bot identification in worker log
- [ ] Re-run with `--restart` after a commit; verify api/worker reload without rebuilding the DB
- [ ] Trigger each of the 8 gotchas (e.g., omit `--bot-token` → fail; pass a contested token → 409 detected) and confirm error messages match `references/gotchas.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)