### PR TITLE
fix(harness): preserve thinking_blocks for thinking-capable targets (#196)

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -34,6 +34,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+import litellm
+
 from aios.harness.vision import (
     can_inline_image,
     make_image_url_part,
@@ -45,19 +47,19 @@ from aios.sandbox.volumes import resolve_to_host_path
 
 log = get_logger("aios.harness.context")
 
-# Chat-completions spec fields per role.  Only these are emitted in the
-# context; provider-specific extensions (reasoning_content, etc.) stay
-# in the event log but are excluded from the message list.
-#
-# `thinking_blocks` and `reasoning_content` are intentionally stripped even
-# on same-provider replays — see #196 for cost/benefit and the OpenRouter
-# transport gaps before re-litigating.
+# Chat-completions spec fields per role.  Provider-specific extensions
+# (reasoning, reasoning_details, internal reacting_to, etc.) stay in the
+# event log but are excluded from the message list.
 _ALLOWED_FIELDS: dict[str, frozenset[str]] = {
     "assistant": frozenset({"role", "content", "tool_calls"}),
     "tool": frozenset({"role", "tool_call_id", "content", "name"}),
     "user": frozenset({"role", "content", "name"}),
     "system": frozenset({"role", "content", "name"}),
 }
+
+# Anthropic's contract: thinking blocks must be preserved across turns
+# for the model to use them as continuation context.
+_THINKING_FIELDS: frozenset[str] = frozenset({"thinking_blocks", "reasoning_content"})
 
 # Notification markers truncate the source content to this many chars
 # (plus an ellipsis when truncated) so a busy non-focal channel
@@ -347,9 +349,20 @@ def _sanitize_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any
     return sanitized
 
 
-def _strip_to_spec(msg: dict[str, Any]) -> dict[str, Any]:
-    """Return a copy of *msg* with only chat-completions spec fields."""
-    allowed = _ALLOWED_FIELDS.get(msg.get("role", ""), frozenset())
+def _strip_to_spec(
+    msg: dict[str, Any],
+    *,
+    target_supports_thinking: bool,
+) -> dict[str, Any]:
+    """Return a copy of *msg* with only chat-completions spec fields.
+
+    When ``target_supports_thinking``, also preserve ``thinking_blocks``
+    and ``reasoning_content`` on assistant turns.
+    """
+    role = msg.get("role", "")
+    allowed = _ALLOWED_FIELDS.get(role, frozenset())
+    if role == "assistant" and target_supports_thinking:
+        allowed = allowed | _THINKING_FIELDS
     out = {k: v for k, v in msg.items() if k in allowed}
     if out.get("tool_calls"):
         out["tool_calls"] = _sanitize_tool_calls(out["tool_calls"])
@@ -609,8 +622,11 @@ def build_messages(
     if system_prompt:
         messages.insert(0, {"role": "system", "content": system_prompt})
 
+    target_supports_thinking = bool(model) and litellm.supports_reasoning(model)
     return ContextResult(
-        messages=[_strip_to_spec(m) for m in messages],
+        messages=[
+            _strip_to_spec(m, target_supports_thinking=target_supports_thinking) for m in messages
+        ],
         reacting_to=max_stimulus_seq,
     )
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -790,6 +790,75 @@ class TestFieldStripping:
         assert "reasoning_content" in events[1].data
 
 
+class TestThinkingBlockPreservation:
+    def test_thinking_blocks_preserved_for_thinking_capable_target(self) -> None:
+        events = [
+            _evt(1, "user", content="hi"),
+            _evt(2, "assistant", content="hey"),
+        ]
+        events[1].data["thinking_blocks"] = [
+            {"type": "thinking", "thinking": "user said hi", "signature": "abc"}
+        ]
+        msgs = build_messages(
+            events, system_prompt=None, model="anthropic/claude-haiku-4-5"
+        ).messages
+        assert msgs[1]["thinking_blocks"] == [
+            {"type": "thinking", "thinking": "user said hi", "signature": "abc"}
+        ]
+
+    def test_reasoning_content_preserved_for_thinking_capable_target(self) -> None:
+        events = [
+            _evt(1, "user", content="hi"),
+            _evt(2, "assistant", content="hey"),
+        ]
+        events[1].data["reasoning_content"] = "deep thoughts about hi"
+        msgs = build_messages(
+            events, system_prompt=None, model="anthropic/claude-haiku-4-5"
+        ).messages
+        assert msgs[1]["reasoning_content"] == "deep thoughts about hi"
+
+    def test_thinking_blocks_stripped_for_non_thinking_target(self) -> None:
+        events = [
+            _evt(1, "user", content="hi"),
+            _evt(2, "assistant", content="hey"),
+        ]
+        events[1].data["thinking_blocks"] = [{"type": "thinking", "thinking": "user said hi"}]
+        events[1].data["reasoning_content"] = "deep thoughts"
+        msgs = build_messages(events, system_prompt=None, model="openai/gpt-4o-mini").messages
+        assert "thinking_blocks" not in msgs[1]
+        assert "reasoning_content" not in msgs[1]
+
+    def test_thinking_blocks_stripped_when_model_arg_omitted(self) -> None:
+        events = [
+            _evt(1, "user", content="hi"),
+            _evt(2, "assistant", content="hey"),
+        ]
+        events[1].data["thinking_blocks"] = [{"type": "thinking", "thinking": "user said hi"}]
+        msgs = build_messages(events, system_prompt=None).messages
+        assert "thinking_blocks" not in msgs[1]
+
+    def test_other_provider_fields_still_stripped_on_thinking_target(self) -> None:
+        events = [
+            _evt(1, "user", content="hi"),
+            _evt(2, "assistant", content="hey"),
+        ]
+        events[1].data.update(
+            {
+                "thinking_blocks": [{"type": "thinking", "thinking": "..."}],
+                "reasoning": "step 1",
+                "reasoning_details": [{"type": "thinking", "content": "..."}],
+                "reacting_to": 1,
+            }
+        )
+        msgs = build_messages(
+            events, system_prompt=None, model="anthropic/claude-haiku-4-5"
+        ).messages
+        assert "thinking_blocks" in msgs[1]
+        assert "reasoning" not in msgs[1]
+        assert "reasoning_details" not in msgs[1]
+        assert "reacting_to" not in msgs[1]
+
+
 class TestToolCallSanitization:
     """_strip_to_spec sanitizes the inner structure of tool_calls so
     malformed entries from one model don't break cross-model replay."""


### PR DESCRIPTION
## Summary

The context builder was stripping `reasoning_content` and `thinking_blocks` from every assistant message before sending it back to the model. Thinking-enabled agents never saw their own prior reasoning, violating Anthropic's contract that *"once a thinking block has been completed, you must preserve its full content (including the signature) when continuing the conversation."*

Make the strip conditional on the target model's reasoning capability:

- `_strip_to_spec` now takes `target_supports_thinking: bool` (required keyword-only).
- When the role is `assistant` and the target supports reasoning, allow `thinking_blocks` + `reasoning_content` through.
- `build_messages` computes the flag once per call via `litellm.supports_reasoning(model)`.

The cross-provider compatibility property added in #25 is preserved (switching to a non-thinking provider still strips), and `stub_missing_reasoning_content` is unchanged (still needed for cross-provider transitions where the next provider requires the field be present).

Closes #196

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1161 passed
- [x] `DOCKER_HOST=... uv run pytest tests/e2e -q` — 271 passed
- [x] 5 new unit tests in `TestThinkingBlockPreservation`:
  - `test_thinking_blocks_preserved_for_thinking_capable_target`
  - `test_reasoning_content_preserved_for_thinking_capable_target`
  - `test_thinking_blocks_stripped_for_non_thinking_target`
  - `test_thinking_blocks_stripped_when_model_arg_omitted`
  - `test_other_provider_fields_still_stripped_on_thinking_target`
- [x] Existing cross-provider tests (`TestFieldStripping`) still pass

## Reviewer notes (sub-90 findings)

- **Score 65 — `litellm.supports_reasoning` writes a colorized "Provider List: ..." nag to stderr for unknown model strings.** Worth a follow-up if observed in production worker logs (e.g. agents pinned to local-stub model strings). Could be silenced by wrapping the call. Not a correctness issue.
- **Score 30/20 — comment + class-docstring nits.** Reviewer suggested adding a pointer in the `_ALLOWED_FIELDS` header back to `_strip_to_spec`, and a class docstring on `TestThinkingBlockPreservation`. The `/simplify` pass had just removed similar narration; not flipping it back twice. Score-triages-doesn't-suppress: noted, not applied.

## Out of scope

- OpenRouter still strips signed `reasoning_details` on relay (#203), so even with this fix, OR-Anthropic routes don't get true continuity until #203 lands upstream. The fix unconditionally helps direct-Anthropic; OR routes get a no-op (no harm, no gain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)