### PR TITLE
ci: skip validation pipeline for docs-only PRs

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -6,7 +6,69 @@ on:
   pull_request:
 
 jobs:
+  # Mirrors the pre-commit hook's short-circuit: docs-only changes skip
+  # the heavy validation pipeline.  Widened beyond the hook's `.py$`
+  # filter to also catch files that can break the build without
+  # touching a `.py` directly (lint config, pinned deps, sandbox image,
+  # the workflow itself).
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      run_checks: ${{ steps.filter.outputs.run_checks }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need both base and head reachable for the diff below.  Aios
+          # is small enough that a full fetch is cheap.
+          fetch-depth: 0
+
+      - name: Detect build-affecting changes
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base="$PR_BASE_SHA"
+            head="$PR_HEAD_SHA"
+          else
+            base="$PUSH_BEFORE_SHA"
+            head="$PUSH_HEAD_SHA"
+          fi
+
+          # First push to a new branch, force-push from a non-fast-forward,
+          # or any case where `before` is the all-zeros SHA: be conservative
+          # and run the full pipeline.
+          if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
+            echo "No usable base ref — running checks."
+            echo "run_checks=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed=$(git diff --name-only "$base" "$head")
+          echo "Changed files:"
+          echo "$changed"
+          echo
+
+          # Anything that can affect lint / types / tests / sandbox
+          # build / the workflow itself counts as build-affecting.
+          # Everything else (READMEs, LICENSE, prose docs) skips.
+          if echo "$changed" | grep -qE '\.py$|^pyproject\.toml$|^uv\.lock$|^alembic\.ini$|^migrations/|^docker/|^\.github/workflows/'; then
+            echo "Build-affecting changes detected — running checks."
+            echo "run_checks=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Docs/config-only changes — skipping checks."
+            echo "run_checks=false" >> "$GITHUB_OUTPUT"
+          fi
+
   validate:
+    needs: detect
+    if: needs.detect.outputs.run_checks == 'true'
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
## Summary

Mirrors `scripts/git-hooks/pre-commit`'s short-circuit at the CI level: when a PR or push touches no files that can affect lint/types/tests/sandbox/workflow, the heavy `validate` job (Postgres service + ruff + mypy + pytest unit/integration/e2e + sandbox docker build) skips entirely. The README-refresh PR proved the case: `git commit` returned in milliseconds locally but burned ~10 minutes of CI on a pure-prose change.

**Implementation** — split the workflow into two jobs:

- `detect` — always runs, fast. Checks out with `fetch-depth: 0`, diffs `base..head`, and sets a `run_checks` output via regex over changed paths.
- `validate` — `needs: detect` with `if: needs.detect.outputs.run_checks == 'true'`. When the condition is false the job is treated as ✓ skipped, which satisfies modern (post-2022) GitHub required-status-check rules — so docs-only PRs don't get stuck waiting on a check that will never run.

**Skip filter** — widened past the hook's `.py$`-only set so anything that can break the build counts:

- `*.py`
- `pyproject.toml`, `uv.lock` (lint config + pinned deps)
- `alembic.ini`, `migrations/**` (DB schema)
- `docker/**` (sandbox image)
- `.github/workflows/**` (so a workflow edit always validates itself)

Anything else (READMEs, LICENSE, prose docs) skips. First-push / unknown-base cases (zero SHA) fall back to the conservative "run everything" branch.

**Security hardening** — `run:` blocks pass GitHub context values (event name, SHAs) through `env:` instead of inline `${{ }}` interpolation, per the [GitHub Actions injection-prevention guide](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/). SHAs and event names aren't user-controllable, but defense-in-depth here keeps reviewers from having to second-guess the pattern in future edits.

## Test plan

- [ ] Open a docs-only PR (e.g. tiny README typo fix) on top of this branch; confirm `detect` runs and `validate` shows as skipped ✓
- [ ] Open a `.py`-changing PR; confirm both `detect` and `validate` run and the latter goes green
- [ ] Edit `pyproject.toml` only; confirm `validate` runs (build-affecting non-`.py` case)
- [ ] Push directly to a non-master branch with no `before` SHA history (new branch); confirm fallback runs full pipeline
- [ ] Confirm required-status-check settings on `master` still resolve when `validate` is skipped (no merge block on docs-only PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)