### PR TITLE
fix(signal): refresh group roster on inbound group_update events (#248)

### DIFF
--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -52,7 +52,7 @@ from .config import Settings
 from .daemon import GroupInfo, SignalDaemon
 from .markdown import convert_markdown_to_signal_styles
 from .mentions import build_mention_strings, encode_mentions
-from .parse import InboundMessage, build_content_text, parse_envelope
+from .parse import InboundMessage, build_content_text, is_group_update_envelope, parse_envelope
 from .prompts import build_instructions
 
 log = structlog.get_logger(__name__)
@@ -198,6 +198,7 @@ class SignalConnector(Connector):
                 # otherwise self-message filtering would misbehave.
                 log.warning("signal.inbound.unknown_account", account=phone)
                 continue
+            await self._maybe_refresh_roster(phone, envelope)
             msg = parse_envelope(envelope, bot_account_uuid=bot_uuid)
             if msg is None:
                 continue
@@ -354,7 +355,7 @@ class SignalConnector(Connector):
         # new group can resolve ``@<uuid_prefix>`` mentions against its
         # members.  Without the refresh the next send would silently drop
         # any mentions (group missing from cache → empty member_uuids).
-        self._groups_by_account[phone] = await self._daemon.list_groups(account=phone)
+        await self._refresh_roster(phone)
         return {"group_id": result["groupId"]}
 
     @tool()
@@ -392,6 +393,16 @@ class SignalConnector(Connector):
             raise ValueError(f"{tool_name}: unknown account {account!r}")
         return phone
 
+    async def _maybe_refresh_roster(self, phone: str, envelope: dict[str, Any]) -> None:
+        """Refresh the cached roster when Signal reports a group metadata change."""
+        if is_group_update_envelope(envelope):
+            await self._refresh_roster(phone)
+
+    async def _refresh_roster(self, phone: str) -> None:
+        """Overwrite the cached group roster for *phone* with a fresh listGroups."""
+        assert self._daemon is not None
+        self._groups_by_account[phone] = await self._daemon.list_groups(account=phone)
+
     async def _group_member_uuids(self, phone: str, chat_id: str) -> list[str]:
         """Member UUIDs of the focal group, or ``[]`` for a DM.
 
@@ -409,8 +420,7 @@ class SignalConnector(Connector):
         cached = self._lookup_group_members(phone, chat_id)
         if cached is not None:
             return cached
-        assert self._daemon is not None
-        self._groups_by_account[phone] = await self._daemon.list_groups(account=phone)
+        await self._refresh_roster(phone)
         return self._lookup_group_members(phone, chat_id) or []
 
     def _lookup_group_members(self, phone: str, chat_id: str) -> list[str] | None:

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -394,12 +394,10 @@ class SignalConnector(Connector):
         return phone
 
     async def _maybe_refresh_roster(self, phone: str, envelope: dict[str, Any]) -> None:
-        """Refresh the cached roster when Signal reports a group metadata change."""
         if is_group_update_envelope(envelope):
             await self._refresh_roster(phone)
 
     async def _refresh_roster(self, phone: str) -> None:
-        """Overwrite the cached group roster for *phone* with a fresh listGroups."""
         assert self._daemon is not None
         self._groups_by_account[phone] = await self._daemon.list_groups(account=phone)
 

--- a/connectors/signal/src/aios_signal/parse.py
+++ b/connectors/signal/src/aios_signal/parse.py
@@ -19,6 +19,17 @@ from .addressing import ChatType
 MENTION_PLACEHOLDER = "\ufffc"
 
 
+def is_group_update_envelope(envelope: dict[str, Any]) -> bool:
+    """True when *envelope* signals a Signal group metadata change
+    (membership add/remove, rename).
+    """
+    data_message = envelope.get("dataMessage")
+    if not isinstance(data_message, dict):
+        return False
+    group_info = data_message.get("groupInfo")
+    return isinstance(group_info, dict) and group_info.get("type") == "UPDATE"
+
+
 @dataclass(slots=True, frozen=True)
 class Attachment:
     content_type: str

--- a/connectors/signal/src/aios_signal/parse.py
+++ b/connectors/signal/src/aios_signal/parse.py
@@ -20,9 +20,6 @@ MENTION_PLACEHOLDER = "\ufffc"
 
 
 def is_group_update_envelope(envelope: dict[str, Any]) -> bool:
-    """True when *envelope* signals a Signal group metadata change
-    (membership add/remove, rename).
-    """
     data_message = envelope.get("dataMessage")
     if not isinstance(data_message, dict):
         return False

--- a/connectors/signal/tests/test_parse.py
+++ b/connectors/signal/tests/test_parse.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from aios_signal.parse import build_content_text, parse_envelope
+from aios_signal.parse import build_content_text, is_group_update_envelope, parse_envelope
 
 
 def test_text_dm(envelope_text_dm: dict[str, Any], bot_uuid: str) -> None:
@@ -133,3 +133,32 @@ def test_attachment_no_file_field_carries_id(
     assert msg is not None
     assert msg.attachments[0].host_path is None
     assert msg.attachments[0].id == "xyz-789"
+
+
+# ── is_group_update_envelope ──────────────────────────────────────────
+
+
+def test_is_group_update_envelope_detects_update() -> None:
+    envelope = {"dataMessage": {"groupInfo": {"groupId": "abc==", "type": "UPDATE"}}}
+    assert is_group_update_envelope(envelope) is True
+
+
+def test_is_group_update_envelope_false_for_deliver(
+    envelope_text_group: dict[str, Any],
+) -> None:
+    """A regular group-message envelope (type=DELIVER) is not a roster-altering update."""
+    assert is_group_update_envelope(envelope_text_group) is False
+
+
+def test_is_group_update_envelope_false_for_dm(
+    envelope_text_dm: dict[str, Any],
+) -> None:
+    assert is_group_update_envelope(envelope_text_dm) is False
+
+
+def test_is_group_update_envelope_false_for_no_data_message() -> None:
+    assert is_group_update_envelope({"sourceUuid": "xxx"}) is False
+
+
+def test_is_group_update_envelope_false_for_no_group_info() -> None:
+    assert is_group_update_envelope({"dataMessage": {"message": "hi"}}) is False

--- a/connectors/signal/tests/test_parse.py
+++ b/connectors/signal/tests/test_parse.py
@@ -146,7 +146,6 @@ def test_is_group_update_envelope_detects_update() -> None:
 def test_is_group_update_envelope_false_for_deliver(
     envelope_text_group: dict[str, Any],
 ) -> None:
-    """A regular group-message envelope (type=DELIVER) is not a roster-altering update."""
     assert is_group_update_envelope(envelope_text_group) is False
 
 

--- a/connectors/signal/tests/test_signal_groups.py
+++ b/connectors/signal/tests/test_signal_groups.py
@@ -82,3 +82,33 @@ async def test_rename_group_unknown_account_raises(connector: SignalConnector) -
     stub_focal(connector, f"nope/{GROUP_CHAT_ID}")
     with pytest.raises(ValueError, match="unknown account"):
         await connector._invoke_tool(descriptor(connector, "signal_rename_group"), {"name": "X"})
+
+
+# ── _maybe_refresh_roster (group-update steady-state refresh, #248) ────
+
+
+async def test_maybe_refresh_roster_calls_list_groups_on_update(
+    connector: SignalConnector,
+) -> None:
+    from aios_signal.daemon import GroupInfo
+
+    fresh = [GroupInfo(id="abc", name="QA", member_uuids=[ALICE_UUID, BOB_UUID])]
+    connector._daemon.list_groups.return_value = fresh  # type: ignore[union-attr]
+    envelope = {"dataMessage": {"groupInfo": {"groupId": "abc==", "type": "UPDATE"}}}
+    await connector._maybe_refresh_roster("+15550001", envelope)
+    connector._daemon.list_groups.assert_awaited_once_with(account="+15550001")  # type: ignore[union-attr]
+    assert connector._groups_by_account["+15550001"] == fresh
+
+
+async def test_maybe_refresh_roster_no_op_for_regular_message(
+    connector: SignalConnector,
+) -> None:
+    envelope = {
+        "dataMessage": {
+            "message": "hi",
+            "groupInfo": {"groupId": "abc==", "type": "DELIVER"},
+        }
+    }
+    await connector._maybe_refresh_roster("+15550001", envelope)
+    connector._daemon.list_groups.assert_not_awaited()  # type: ignore[union-attr]
+    assert "+15550001" not in connector._groups_by_account

--- a/connectors/signal/tests/test_signal_groups.py
+++ b/connectors/signal/tests/test_signal_groups.py
@@ -84,7 +84,7 @@ async def test_rename_group_unknown_account_raises(connector: SignalConnector) -
         await connector._invoke_tool(descriptor(connector, "signal_rename_group"), {"name": "X"})
 
 
-# ── _maybe_refresh_roster (group-update steady-state refresh, #248) ────
+# ── _maybe_refresh_roster ──────────────────────────────────────────────
 
 
 async def test_maybe_refresh_roster_calls_list_groups_on_update(


### PR DESCRIPTION
## Summary

PR #244 added lazy-refresh-on-cache-miss for the Signal group roster, which covers the boot-time race but not the steady-state case where group membership changes during the connector's lifetime. Once a group is in the cache with a stale member list, mention encoding silently drops new members until the connector restarts.

signal-cli surfaces membership add/remove and rename via `dataMessage.groupInfo.type == "UPDATE"`. Detect those envelopes in the inbound pump and refresh the cached roster reactively, so the cache is correct-by-construction (one invalidator on the one event that can stale it).

While here, factor out the duplicated `self._groups_by_account[phone] = await self._daemon.list_groups(...)` line — 3 call sites (post-create-group, lazy-miss, new UPDATE handler) collapse to one `_refresh_roster(phone)` helper.

Closes #248

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests connectors && uv run ruff format --check src tests connectors` — clean
- [x] `uv run pytest tests/unit -q` — 1161 passed
- [x] `cd connectors/signal && uv run pytest -q` — 130 passed (5 new helper tests + 2 new connector-method tests)
- [x] `DOCKER_HOST=... uv run pytest tests/e2e -q` — 271 passed
- [x] New tests:
  - `test_is_group_update_envelope_*` (5) — pure helper: positive UPDATE, DELIVER negative, DM negative, missing dataMessage, missing groupInfo
  - `test_maybe_refresh_roster_calls_list_groups_on_update` — UPDATE → `list_groups` called + cache populated
  - `test_maybe_refresh_roster_no_op_for_regular_message` — DELIVER → no-op

## Reviewer notes (sub-90 findings, all nits)

- **Score 35** — Bulk-membership change emits one UPDATE per delta → N `listGroups` RPCs. Acceptable until it bites; debounce can be added later. Fire-and-forget would defeat the purpose (next outbound mention needs the fresh roster).
- **Score 30** — `_refresh_roster` propagates RPC errors up through `serve()`'s `async for`, killing the listener. Matches existing fail-hard posture (parse_envelope and other call sites would do the same); supervisor surfaces the death.
- **Score 25** — `is_group_update_envelope` is intentionally broader than `parse_envelope`'s existing UPDATE-no-content drop branch (parse.py:124-132 requires empty message/reaction/attachments). Different concerns: parse drops "no forwardable content"; the new helper detects "roster mutation."
- **Score 20** — `_maybe_refresh_roster` runs *before* `parse_envelope` so a future outbound `signal_send` triggered by this turn sees the refreshed roster.

## Out of scope

- The optional follow-up in the issue body — emit a structured admin event so the model sees membership changes — is left for a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)