### PR TITLE
fix(harness): cross-process cancel for stuck litellm calls (#146)

### DIFF
--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -26,7 +26,7 @@ from aios.api.deps import (
 )
 from aios.api.sse import sse_event_stream
 from aios.db import queries
-from aios.db.listen import listen_for_events
+from aios.db.listen import SESSION_INTERRUPT_CHANNEL, listen_for_events
 from aios.errors import NotFoundError, ValidationError
 from aios.harness.wake import defer_wake
 from aios.ids import GITHUB_REPOSITORY, split_id
@@ -284,6 +284,7 @@ async def interrupt(
         "lifecycle",
         {"event": "interrupted", "status": "idle", "stop_reason": "interrupt"},
     )
+    await pool.execute("SELECT pg_notify($1, $2)", SESSION_INTERRUPT_CHANNEL, session_id)
     return await service.get_session(pool, session_id)
 
 

--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -180,3 +180,37 @@ async def listen_for_events(
             await conn.remove_listener(channel, _callback)
         with contextlib.suppress(Exception):
             await conn.close()
+
+
+SESSION_INTERRUPT_CHANNEL = "aios_session_interrupt"
+
+
+@asynccontextmanager
+async def listen_for_session_interrupts(
+    db_url: str,
+) -> AsyncIterator[asyncio.Queue[str]]:
+    """Yield a queue of session_id payloads from the interrupt channel."""
+    conn = await asyncpg.connect(normalize_dsn(db_url))
+    try:
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=1024)
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning("listen.session_interrupt_queue_full")
+
+        await conn.add_listener(SESSION_INTERRUPT_CHANNEL, _callback)
+        try:
+            yield queue
+        finally:
+            with contextlib.suppress(Exception):
+                await conn.remove_listener(SESSION_INTERRUPT_CHANNEL, _callback)
+    finally:
+        with contextlib.suppress(Exception):
+            await conn.close()

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -118,6 +118,9 @@ async def run_session_step(
         "span",
         {"event": "step_start", "cause": cause},
     )
+    current_task = asyncio.current_task()
+    assert current_task is not None
+    task_registry.register_step(session_id, current_task)
     retry_delay: float | None = None
     try:
         try:
@@ -134,6 +137,7 @@ async def run_session_step(
             log.exception("step.job_timeout", session_id=session_id, timeout=_JOB_TIMEOUT_S)
             retry_delay = await _handle_step_timeout(pool, session_id)
     finally:
+        task_registry.unregister_step(session_id)
         await sessions_service.append_event(
             pool,
             session_id,

--- a/src/aios/harness/task_registry.py
+++ b/src/aios/harness/task_registry.py
@@ -22,6 +22,7 @@ class TaskRegistry:
 
     def __init__(self) -> None:
         self._tasks: dict[str, dict[str, asyncio.Task[None]]] = {}
+        self._step_tasks: dict[str, asyncio.Task[None]] = {}
 
     def add(self, session_id: str, tool_call_id: str, task: asyncio.Task[None]) -> None:
         session_tasks = self._tasks.setdefault(session_id, {})
@@ -81,6 +82,20 @@ class TaskRegistry:
             if active:
                 result[sid] = active
         return result
+
+    def register_step(self, session_id: str, task: asyncio.Task[None]) -> None:
+        self._step_tasks[session_id] = task
+
+    def unregister_step(self, session_id: str) -> None:
+        self._step_tasks.pop(session_id, None)
+
+    def cancel_step(self, session_id: str) -> bool:
+        task = self._step_tasks.get(session_id)
+        if task is None or task.done():
+            return False
+        task.cancel()
+        log.info("step.cancelled", session_id=session_id)
+        return True
 
     async def shutdown(self) -> None:
         """Cancel all tasks and await them for cleanup (finally blocks)."""

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
+from aios.db.listen import listen_for_session_interrupts
 from aios.db.pool import create_pool, normalize_dsn
 from aios.harness import runtime
 from aios.harness.attachment_gc import sweep_orphan_attachments
@@ -96,6 +97,7 @@ async def worker_main() -> None:
     connector_registry: ConnectorSubprocessRegistry | None = None
     procrastinate_opened = False
     sweep_task: asyncio.Task[None] | None = None
+    interrupt_task: asyncio.Task[None] | None = None
 
     try:
         pool = await create_pool(settings.db_url, max_size=settings.db_pool_max_size)
@@ -175,6 +177,11 @@ async def worker_main() -> None:
             name="periodic_sweep",
         )
 
+        interrupt_task = asyncio.create_task(
+            _run_interrupt_listener(settings.db_url, task_registry),
+            name="interrupt_listener",
+        )
+
         await procrastinate_app.run_worker_async(
             queues=["sessions", "connectors"],
             concurrency=settings.worker_concurrency,
@@ -187,6 +194,10 @@ async def worker_main() -> None:
             sweep_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await sweep_task
+        if interrupt_task is not None:
+            interrupt_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await interrupt_task
         if sandbox_registry is not None:
             sandbox_registry.stop_reaper()
         if task_registry is not None:
@@ -265,3 +276,25 @@ async def _periodic_sweep(
                 )
         except Exception:
             log.exception("periodic_sweep.failed")
+
+
+async def _run_interrupt_listener(
+    db_url: str,
+    task_registry: TaskRegistry,
+) -> None:
+    """Drain pg_notify on the session-interrupt channel and cancel matching steps."""
+    log = get_logger("aios.worker.interrupt_listener")
+    try:
+        async with listen_for_session_interrupts(db_url) as queue:
+            while True:
+                session_id = await queue.get()
+                step_cancelled = task_registry.cancel_step(session_id)
+                tools_cancelled = task_registry.cancel_session(session_id)
+                log.info(
+                    "interrupt_listener.dispatch",
+                    session_id=session_id,
+                    step_cancelled=step_cancelled,
+                    tools_cancelled=tools_cancelled,
+                )
+    except Exception:
+        log.exception("interrupt_listener.failed")

--- a/tests/unit/test_task_registry.py
+++ b/tests/unit/test_task_registry.py
@@ -124,3 +124,56 @@ class TestShutdown:
         assert t2.cancelled()
         assert reg.in_flight_count("sess_1") == 0
         assert reg.in_flight_count("sess_2") == 0
+
+
+# ── step-task tracking ───────────────────────────────────────────────
+
+
+class TestStepTracking:
+    async def test_register_and_cancel_step(self) -> None:
+        reg = TaskRegistry()
+        task = asyncio.create_task(_sleeper())
+        reg.register_step("sess_1", task)
+        assert reg.cancel_step("sess_1") is True
+        await asyncio.sleep(0)
+        assert task.cancelled()
+
+    async def test_cancel_step_unknown_session_returns_false(self) -> None:
+        reg = TaskRegistry()
+        assert reg.cancel_step("sess_nope") is False
+
+    async def test_unregister_step_clears(self) -> None:
+        reg = TaskRegistry()
+        task = asyncio.create_task(_sleeper())
+        reg.register_step("sess_1", task)
+        reg.unregister_step("sess_1")
+        assert reg.cancel_step("sess_1") is False
+        task.cancel()  # cleanup
+        await asyncio.sleep(0)
+
+    async def test_register_step_replaces_prior(self) -> None:
+        reg = TaskRegistry()
+        old = asyncio.create_task(_sleeper())
+        new = asyncio.create_task(_sleeper())
+        reg.register_step("sess_1", old)
+        reg.register_step("sess_1", new)
+        assert reg.cancel_step("sess_1") is True
+        await asyncio.sleep(0)
+        assert new.cancelled()
+        assert not old.cancelled()
+        old.cancel()
+        await asyncio.sleep(0)
+
+    async def test_step_tracking_is_independent_of_tool_tasks(self) -> None:
+        reg = TaskRegistry()
+        step = asyncio.create_task(_sleeper())
+        tool = asyncio.create_task(_sleeper())
+        reg.register_step("sess_1", step)
+        reg.add("sess_1", "call_a", tool)
+        assert reg.cancel_step("sess_1") is True
+        await asyncio.sleep(0)
+        assert step.cancelled()
+        assert not tool.cancelled()
+        assert reg.in_flight_count("sess_1") == 1
+        tool.cancel()
+        await asyncio.sleep(0)


### PR DESCRIPTION
## Summary

Before: `aios sessions interrupt` flipped session state to `idle` but the running `asyncio.Task` inside the procrastinate worker kept streaming the model call until the upstream HTTP timeout (observed ~6 minutes on a hung qwen3-32b call). Subsequent wakes piled up behind the procrastinate session lock.

Wire interrupt across processes via Postgres `pg_notify`:

- `TaskRegistry` gains step-task tracking (`register_step` / `unregister_step` / `cancel_step`), keyed per session.
- `run_session_step` registers the current task at start, clears in the outer `finally` (so `step_end` still fires under cancel).
- New `listen_for_session_interrupts` in `src/aios/db/listen.py` opens a dedicated asyncpg listener on `aios_session_interrupt` (mirrors `listen_for_events` shape).
- Worker spawns `_run_interrupt_listener` at startup; on a notify, calls `cancel_step` AND `cancel_session` so both the model call and any in-flight tool tasks get `task.cancel()`.
- `/interrupt` endpoint sends one `pg_notify` after committing the interrupt event + idle state flip.

The procrastinate session lock releases cleanly because procrastinate maps `CancelledError` to `Status.ABORTED`.

Closes #146

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1165 passed
- [x] `DOCKER_HOST=... uv run pytest tests/e2e -q` — 271 passed
- [x] 5 new tests in `TestStepTracking` cover register+cancel, cancel-unknown, unregister, register-replaces-prior, and step/tool tracking independence

## Reviewer notes

- **Score 55** — Initial reviewer flag: docstring said "cancel all in-flight work" but only the step task was cancelled; broken-windows-applied by also calling `task_registry.cancel_session` in the listener so tool tasks get cancelled too.
- **Score 35** — `TaskRegistry.shutdown()` doesn't iterate `_step_tasks`. In practice procrastinate cancels its job tasks during shutdown before this finally runs, so no leak today; asymmetry could trip a future refactor. Not addressed in this PR.
- **Score 30** — `register_step` runs outside the outer `try:` block. Currently safe (no `await` between register and the try) but moving it inside would make the cleanup invariant syntactically obvious. Not addressed.

## Out of scope / known follow-ups

- The three `listen_for_*` helpers in `src/aios/db/listen.py` now hit rule-of-three and could share a private `_listen()` generator. /simplify flagged it; deferred to a refactor PR.
- Listener has no reconnect-with-backoff. `try/except + log.exception` makes the failure diagnosable; if asyncpg disconnects become flaky in production, follow-up adds reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)