### PR TITLE
fix(harness/completion): tolerate usage-summary chunks with empty choices

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -365,6 +365,10 @@ async def stream_litellm(
             break
         first = False
         chunks.append(chunk)
+        # Some providers (OpenRouter, Grok, vLLM, OpenAI with stream_options.
+        # include_usage) emit a terminal usage-summary chunk with empty choices.
+        if not chunk.choices:
+            continue
         content = chunk.choices[0].delta.content
         if content:
             await _notify_delta(pool, session_id, content)

--- a/tests/unit/test_completion_timeouts.py
+++ b/tests/unit/test_completion_timeouts.py
@@ -217,3 +217,56 @@ async def test_extra_overrides_default_timeout(
     )
 
     assert captured["timeout"] == 1234.0
+
+
+def _make_empty_choices_chunk() -> object:
+    """Build a usage-summary chunk: ``choices=[]`` with usage metadata.
+
+    OpenAI with ``stream_options.include_usage=True``, OpenRouter, Grok,
+    and OpenAI-compatible vLLM all emit a final chunk of this shape that
+    carries usage but no delta.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(choices=[], usage=SimpleNamespace(total_tokens=42))
+
+
+@pytest.mark.asyncio
+async def test_stream_litellm_tolerates_empty_choices_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A streaming response that includes a chunk with ``choices=[]`` (a
+    usage-summary chunk emitted by OpenRouter/Grok/vLLM/OpenAI-with-usage)
+    must not crash the stream loop."""
+
+    async def fake_stream() -> AsyncIterator[object]:
+        yield _make_chunk("hello")
+        yield _make_empty_choices_chunk()
+
+    async def fake_acompletion(**kwargs: object) -> AsyncIterator[object]:
+        return fake_stream()
+
+    captured: dict[str, list[object]] = {}
+
+    def fake_builder(chunks: list[object]) -> dict[str, object]:
+        captured["chunks"] = list(chunks)
+        return {
+            "usage": {"total_tokens": 42},
+            "choices": [{"message": {"role": "assistant", "content": "hello"}}],
+        }
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(completion.litellm, "stream_chunk_builder", fake_builder)
+
+    message, _, _ = await completion.stream_litellm(
+        model="openrouter/anthropic/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "ping"}],
+        pool=_StubPool(),  # type: ignore[arg-type]
+        session_id="sess_test",
+    )
+
+    assert message["content"] == "hello"
+    # The usage-summary chunk must reach stream_chunk_builder so usage data
+    # isn't dropped — the guard skips notify, not collection.
+    assert len(captured["chunks"]) == 2
+    assert captured["chunks"][-1].choices == []  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- Some LiteLLM-fronted providers (OpenRouter, Grok, vLLM, OpenAI with `stream_options.include_usage=True`) emit a terminal usage-summary chunk with `choices=[]` and `usage` populated. `stream_litellm` was unconditionally accessing `chunk.choices[0].delta.content` and crashing with `IndexError` mid-stream — the model had already completed successfully, but the harness failed the turn before appending the assistant message.
- Skip the delta-extraction when `choices` is empty, but **keep appending the chunk** to the assembled list so `litellm.stream_chunk_builder` still receives the usage data.
- One unit test pins both properties: survivability (no `IndexError`) and forwarding (the empty-choices chunk reaches the builder, so a future refactor that drops the append wouldn't silently regress usage tracking).

## Test plan

- [x] `uv run mypy src` — clean (132 files)
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1166 passed
- [ ] CI runs e2e suite

## Reviewer notes

- Sub-70 review finding noted but not actioned: the new test lives in `test_completion_timeouts.py`, which is themed around hang prevention rather than chunk shape. Co-located because the file already has the `_StubPool` / `_make_chunk` scaffolding the test reuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)