### PR TITLE
refactor(harness): delete dead should_call_model and orphaned helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Both share Postgres: same database, same `LISTEN/NOTIFY`, same procrastinate job
 - **Monotonicity invariant**: appending events only appends to the context, never rewrites earlier messages (prompt cache stability).
 - **Pending-result synthesis**: in-flight tool calls get synthetic `"pending"` results so the message structure is valid.
 - **Blind-spot injection**: tool results that arrived during inference are injected as user messages at the tail.
-- **`reacting_to` watermark**: each assistant message records the max seq of events it saw, so `should_call_model` knows what's "new."
+- **`reacting_to` watermark**: each assistant message records the max seq of events it saw, so `find_sessions_needing_inference` knows what's "new."
 
 ### Custom tools (client-executed)
 
@@ -94,7 +94,7 @@ When the model calls a custom tool (type="custom"), the harness does NOT execute
 3. Client POSTs result to `POST /sessions/:id/tool-results`
 4. Result appended → wake deferred → next step fires
 
-Built-in and custom tools can be called in the same response. `should_call_model`'s batch gating waits for ALL tool_call_ids to have results.
+Built-in and custom tools can be called in the same response. The inference gate's batch logic waits for ALL tool_call_ids to have results.
 
 ### Two pools in one process
 

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -1,28 +1,23 @@
 """Context builder for the step function.
 
-Two public functions:
+:func:`build_messages` assembles the chat-completions message list
+from the event log, synthesizing ``"pending"`` results for in-flight
+tool calls and reordering tool results so they appear immediately
+after their requesting assistant message.
 
-* :func:`should_call_model` — predicate: should the current wake result
-  in an inference call, or should the step early-out?
-
-* :func:`build_messages` — assemble the chat-completions message list
-  from the event log, synthesizing ``"pending"`` results for in-flight
-  tool calls and reordering tool results so they appear immediately
-  after their requesting assistant message.
-
-Both are pure functions of the event log + caller-supplied vision
-policy inputs (``model``, ``session_id``).  They DO read host bytes
-when an image attachment can be inlined for the bound model — that I/O
-is the cost of producing an ``image_url`` content part.  No DB access,
-no async.
+It is a pure function of the event log + caller-supplied vision policy
+inputs (``model``, ``session_id``).  It DOES read host bytes when an
+image attachment can be inlined for the bound model — that I/O is the
+cost of producing an ``image_url`` content part.  No DB access, no async.
 
 The ``reacting_to`` field on assistant messages is the key coordination
 mechanism. Each assistant message records the seq of the latest user or
-tool_result event that was in its context. ``should_call_model`` uses
-this to define "new" as events after ``reacting_to``, not after the
-assistant's own seq. This correctly handles the race where a tool result
-arrives during inference — the model's response has a ``reacting_to``
-that predates the tool result, so the result is "new" and triggers a
+tool_result event that was in its context.
+:func:`~aios.harness.sweep.find_sessions_needing_inference` uses this
+to define "new" as events after ``reacting_to``, not after the assistant's
+own seq. This correctly handles the race where a tool result arrives
+during inference — the model's response has a ``reacting_to`` that
+predates the tool result, so the result is "new" and triggers a
 follow-up step.
 """
 
@@ -369,75 +364,6 @@ def _strip_to_spec(
     return out
 
 
-# ─── should_call_model ──────────────────────────────────────────────────────
-
-
-def should_call_model(events: list[Event]) -> bool:
-    """Decide whether this wake should produce an inference call.
-
-    Returns ``True`` when:
-
-    1. There are no assistant messages yet (first turn).
-    2. A user message or completed tool batch exists that the model
-       hasn't reacted to (determined via the ``reacting_to`` field).
-
-    ``reacting_to`` is the seq of the latest user/tool event in the
-    context the model was given. Events after ``reacting_to`` (excluding
-    the assistant message itself) are "new." This handles the race where
-    a tool result arrives during inference — the result has a seq after
-    ``reacting_to`` and triggers a follow-up step.
-    """
-    if not events:
-        return False
-
-    # Find the most recent assistant message.
-    last_asst: Event | None = None
-    for e in reversed(events):
-        if e.kind == "message" and e.data.get("role") == "assistant":
-            last_asst = e
-            break
-
-    if last_asst is None:
-        return True  # first turn — no assistant response yet
-
-    # Use reacting_to if available; fall back to the assistant's own seq
-    # (backward compat with events written before this field existed).
-    reacting_to: int = last_asst.data.get("reacting_to", last_asst.seq)
-
-    # "New" = events the model hasn't reacted to.
-    new_events = [e for e in events if e.seq > reacting_to and e.seq != last_asst.seq]
-    if not new_events:
-        return False  # duplicate / stale wake
-
-    # User injection → always proceed.
-    if any(e.kind == "message" and e.data.get("role") == "user" for e in new_events):
-        return True
-
-    # Collect ALL real tool_result tool_call_ids from the full log.
-    all_real_results: set[str] = set()
-    for e in events:
-        if e.kind == "message" and e.data.get("role") == "tool":
-            tcid = e.data.get("tool_call_id")
-            if tcid:
-                all_real_results.add(tcid)
-
-    # Check if any tool batch became fully resolved in the "new" window.
-    new_tool_results = [
-        e
-        for e in new_events
-        if e.kind == "message" and e.data.get("role") == "tool" and e.data.get("tool_call_id")
-    ]
-    for tr in new_tool_results:
-        parent = _find_assistant_for_tool_call(events, tr.data["tool_call_id"])
-        if parent is None:
-            continue
-        parent_call_ids = {tc["id"] for tc in (parent.data.get("tool_calls") or [])}
-        if parent_call_ids <= all_real_results:
-            return True  # this batch is complete
-
-    return False
-
-
 # ─── build_messages ──────────────────────────────────────────────────────────
 
 
@@ -724,14 +650,3 @@ def separate_adjacent_user_messages(
             result.append({"role": "assistant", "content": ""})
         result.append(msg)
     return result
-
-
-def _find_assistant_for_tool_call(events: list[Event], tool_call_id: str) -> Event | None:
-    """Find the assistant message that contains ``tool_call_id``."""
-    for e in reversed(events):
-        if e.kind != "message" or e.data.get("role") != "assistant":
-            continue
-        for tc in e.data.get("tool_calls") or []:
-            if tc.get("id") == tool_call_id:
-                return e
-    return None

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -4,7 +4,8 @@ Phase 5 replaces the synchronous multi-turn loop with an event-driven
 step function. Each procrastinate ``wake_session`` job calls
 :func:`run_session_step`, which:
 
-1. Checks whether the model needs to be called (:func:`should_call_model`).
+1. Checks whether the model needs to be called
+   (:func:`~aios.harness.sweep.find_sessions_needing_inference`).
 2. Builds the chat-completions message list with pending-result synthesis.
 3. Calls LiteLLM exactly once.
 4. Appends the assistant message to the session log.
@@ -15,8 +16,8 @@ Tool completion triggers a new ``wake_session`` job, which runs another
 step. The "loop" is the job queue re-entering this function.
 
 Mid-turn user injection is free: a new user message is just another
-event in the log. The next step's :func:`should_call_model` sees it
-and proceeds.
+event in the log. The next step's gate sees it via the ``reacting_to``
+watermark and proceeds.
 """
 
 from __future__ import annotations
@@ -435,9 +436,9 @@ async def _run_session_step_body(
 
         assistant_msg = apply_monologue_prefix(assistant_msg)
 
-    # Inject reacting_to so should_call_model knows what this response
-    # was based on. This is the seq of the latest user/tool event in the
-    # context — events after this seq are "new" on the next wake.
+    # Record the seq of the latest user/tool event in the context this
+    # response was based on; events after this seq are "new" on the next
+    # wake. ``find_sessions_needing_inference`` uses it as the watermark.
     assistant_msg["reacting_to"] = step_ctx.reacting_to
 
     # Append assistant message to the session log (unfenced — procrastinate

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -1,7 +1,6 @@
 """Unified session wake/recovery sweep.
 
-Replaces the per-session ``defer_wake`` + ``should_call_model`` +
-``recover_orphans`` triad with a single function that:
+A single function that:
 
 1. **Repairs ghosts** — tool calls that were dispatched but never
    completed (SIGKILL, crash before launch, etc.).

--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -272,8 +272,7 @@ def _switch_channel_tool_result_tcids(all_events: list[Event]) -> set[str]:
     """Collect tool_call_ids whose parent assistant requested ``switch_channel``.
 
     A single O(N) walk builds the set once; the recap filter then does
-    O(1) membership checks per event — replacing the prior O(K*N)
-    per-tool-result reverse scan into ``_find_assistant_for_tool_call``.
+    O(1) membership checks per event.
 
     Recap rendering excludes tool_result events whose id is in the
     returned set to prevent recursive embedding (each prior recap's

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -165,7 +165,7 @@ class TestMidTurnInjection:
         tool_proceed.set()
         await harness.wait_for_tools(session.id)
 
-        # Step 2: should_call_model sees both tool result AND user injection
+        # Step 2: gate sees both tool result AND user injection
         await harness.run_step(session.id)
 
         events = await harness.events(session.id)
@@ -390,7 +390,7 @@ class TestContextOrdering:
 @needs_docker
 class TestBatchGating:
     async def test_partial_batch_does_not_trigger_model(self, harness: Harness) -> None:
-        """If 2 of 3 tools in a batch complete, should_call_model returns False."""
+        """If 2 of 3 tools in a batch complete, the inference gate returns False."""
         completed = asyncio.Event()
         gate = asyncio.Event()
 
@@ -565,8 +565,8 @@ class TestReactingTo:
         tool_proceed.set()
         await harness.wait_for_tools(session.id)
 
-        # Step 3: should_call_model should return True because the model's
-        # last response (step 2) has reacting_to < the tool result's seq.
+        # Step 3: the inference gate returns True because the model's last
+        # response (step 2) has reacting_to < the tool result's seq.
         # The tool result is "new" relative to what the model reacted to.
         await harness.run_step(session.id)
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,4 +1,4 @@
-"""Unit tests for the context builder (should_call_model + build_messages).
+"""Unit tests for the context builder (build_messages).
 
 Uses lightweight FakeEvent objects to avoid touching the DB.
 """
@@ -13,7 +13,6 @@ from aios.harness.channels import build_channels_tail_block
 from aios.harness.context import (
     build_messages,
     separate_adjacent_user_messages,
-    should_call_model,
     stub_missing_reasoning_content,
 )
 from aios.models.events import Event
@@ -79,86 +78,6 @@ def _evt(
 def _tc(call_id: str, name: str = "bash") -> dict[str, Any]:
     """Build a tool_call dict."""
     return {"id": call_id, "type": "function", "function": {"name": name, "arguments": "{}"}}
-
-
-# ─── should_call_model ──────────────────────────────────────────────────────
-
-
-class TestShouldCallModel:
-    def test_empty_events_returns_false(self) -> None:
-        assert should_call_model([]) is False
-
-    def test_first_user_message_returns_true(self) -> None:
-        events = [_evt(1, "user", content="hello")]
-        assert should_call_model(events) is True
-
-    def test_duplicate_wake_no_new_events(self) -> None:
-        events = [
-            _evt(1, "user", content="hello"),
-            _evt(2, "assistant", content="hi"),
-        ]
-        assert should_call_model(events) is False
-
-    def test_user_injection_returns_true(self) -> None:
-        events = [
-            _evt(1, "user", content="do X"),
-            _evt(2, "assistant", tool_calls=[_tc("a")]),
-            _evt(3, "user", content="also do Y"),
-        ]
-        assert should_call_model(events) is True
-
-    def test_all_tools_resolved_returns_true(self) -> None:
-        events = [
-            _evt(1, "user", content="do X"),
-            _evt(2, "assistant", tool_calls=[_tc("a"), _tc("b")]),
-            _evt(3, "tool", tool_call_id="a", content="result a"),
-            _evt(4, "tool", tool_call_id="b", content="result b"),
-        ]
-        assert should_call_model(events) is True
-
-    def test_partial_tools_returns_false(self) -> None:
-        events = [
-            _evt(1, "user", content="do X"),
-            _evt(2, "assistant", tool_calls=[_tc("a"), _tc("b"), _tc("c")]),
-            _evt(3, "tool", tool_call_id="a", content="result a"),
-        ]
-        assert should_call_model(events) is False
-
-    def test_batch_from_earlier_assistant_completes(self) -> None:
-        """The scenario from the design conversation: assistant at seq=2 requested
-        tool X. A later assistant at seq=4 has no tool_calls. X completes at seq=5.
-        should_call_model should see that batch (seq=2) is fully resolved."""
-        events = [
-            _evt(1, "user", content="do X"),
-            _evt(2, "assistant", tool_calls=[_tc("x")]),
-            _evt(3, "user", content="how's it going?"),
-            _evt(4, "assistant", content="still working on it"),
-            _evt(5, "tool", tool_call_id="x", content="done"),
-        ]
-        assert should_call_model(events) is True
-
-    def test_stale_tool_result_only_returns_false(self) -> None:
-        """Tool result for an already-responded-to batch doesn't trigger."""
-        events = [
-            _evt(1, "user", content="do X"),
-            _evt(2, "assistant", tool_calls=[_tc("a")]),
-            _evt(3, "tool", tool_call_id="a", content="done"),
-            _evt(4, "assistant", content="X is done"),
-            # No new events after seq=4 that need a response
-        ]
-        assert should_call_model(events) is False
-
-    def test_two_batches_one_complete(self) -> None:
-        """Two assistant messages with tool_calls. Only batch 2 is fully resolved."""
-        events = [
-            _evt(1, "user", content="do X and Y"),
-            _evt(2, "assistant", tool_calls=[_tc("x1"), _tc("x2")]),
-            _evt(3, "tool", tool_call_id="x1", content="done"),
-            _evt(4, "tool", tool_call_id="x2", content="done"),
-            _evt(5, "assistant", tool_calls=[_tc("y1")]),
-            _evt(6, "tool", tool_call_id="y1", content="done"),
-        ]
-        assert should_call_model(events) is True
 
 
 # ─── build_messages ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `should_call_model` in `harness/context.py` was the Python twin of `find_sessions_needing_inference` (SQL CTE in `harness/sweep.py`) — both predicates answer the same question. Production has called the SQL gate since the sweep refactor in #258, leaving the Python predicate dead with only its own ~80 lines of unit tests still keeping it alive.
- Deleted the function, its only helper `_find_assistant_for_tool_call` (orphaned by the deletion, no other callers), and the unit-test class. Updated stale references in `CLAUDE.md`, `loop.py`, `sweep.py`, `switch_channel.py`, and three e2e test comments.
- The `reacting_to` watermark concept is preserved — it's CLAUDE.md invariant #3 and still consumed by the SQL gate. Only the redundant Python implementation is gone.

Net **−167 lines**, no behavior change. Two implementations of the same predicate were a drift risk; one is correct-by-construction.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1156 passed
- [ ] CI runs e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)