### PR TITLE
refactor(api): drop redundant ListResponse defaults at static-shape callers

### DIFF
--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -241,7 +241,7 @@ async def unbind_chat(connection_id: str, chat_id: str, pool: PoolDep, _auth: Au
 @router.get("/{connection_id}/bound-chats")
 async def bound_chats(connection_id: str, pool: PoolDep, _auth: AuthDep) -> ListResponse[BoundChat]:
     items = await service.list_bound_chats(pool, connection_id)
-    return ListResponse[BoundChat](data=items, has_more=False, next_after=None)
+    return ListResponse[BoundChat](data=items)
 
 
 @router.get("/{connection_id}/recent-chats")
@@ -252,4 +252,4 @@ async def recent_chats(
     limit: int = 50,
 ) -> ListResponse[RecentChat]:
     items = await service.list_recent_chats(pool, connection_id, limit=limit)
-    return ListResponse[RecentChat](data=items, has_more=False, next_after=None)
+    return ListResponse[RecentChat](data=items)

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -150,9 +150,7 @@ async def list_resources(
     # Reuse get_session for ordering + echo construction; resources are
     # already on the returned record.
     session = await service.get_session(pool, session_id)
-    return ListResponse[SessionResourceEcho](
-        data=session.resources, has_more=False, next_after=None
-    )
+    return ListResponse[SessionResourceEcho](data=session.resources)
 
 
 @router.get("/{session_id}/resources/{resource_id}")


### PR DESCRIPTION
## Summary

- `ListResponse[T]` already declares `has_more: bool = False` and `next_after: str | None = None` as defaults
- Three static-shape endpoints (`connections.bound_chats`, `connections.recent_chats`, `sessions.session_resources`) were redundantly passing both
- Drift from `memory_stores.list_*`, which already omits them
- Pure consistency fix — no behavior change

## Test plan

- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1157 passed
- [ ] CI runs e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)