### PR TITLE
fix(db/queries): treat memory list path_prefix as a literal prefix

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -200,6 +200,15 @@ def _parse_jsonb(raw: Any) -> Any:
     return json.loads(raw) if isinstance(raw, str) else raw
 
 
+def _escape_like(value: str) -> str:
+    """Escape ``\\``, ``%``, and ``_`` so ``value`` matches literally under SQL ``LIKE``.
+
+    Postgres' default LIKE escape is ``\\``, so no explicit ``ESCAPE`` clause is
+    needed at the call site. Order matters: escape the escape character first.
+    """
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 def _row_to_agent(row: asyncpg.Record) -> Agent:
     tools_data = _parse_jsonb(row["tools"])
     skills_data = _parse_jsonb(row["skills"])
@@ -3438,7 +3447,10 @@ async def list_memories(
     args: list[Any] = [store_id]
     if path_prefix:
         args.append(path_prefix)
-        where += f" AND (path = ${len(args)} OR path LIKE ${len(args)} || '%')"
+        # Escape LIKE metacharacters so the prefix matches literally — paths
+        # legitimately contain ``_`` and ``%`` per the schema CHECK regex.
+        args.append(_escape_like(path_prefix))
+        where += f" AND (path = ${len(args) - 1} OR path LIKE ${len(args)} || '%')"
     order_sql = "path ASC" if order_by == "path" else "created_at DESC"
     rows = await conn.fetch(f"SELECT * FROM memories WHERE {where} ORDER BY {order_sql}", *args)
 

--- a/tests/e2e/test_memory_stores_api.py
+++ b/tests/e2e/test_memory_stores_api.py
@@ -210,6 +210,34 @@ class TestMemoryCrud:
         )
         assert r.status_code == 409, r.text
 
+    async def test_list_path_prefix_treats_underscore_literally(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        """``path_prefix`` is a literal prefix, not a SQL ``LIKE`` pattern.
+
+        The schema allows ``_`` and ``%`` in path segments, so they must
+        not act as wildcards in filter queries.
+        """
+        store = await _create_store(http_client)
+        await _create_memory(http_client, store["id"], "/notes/draft_alice.md", "a")
+        await _create_memory(http_client, store["id"], "/notes/draftXalice.md", "b")
+
+        r = await http_client.get(
+            f"/v1/memory-stores/{store['id']}/memories",
+            params={"path_prefix": "/notes/draft_a"},
+        )
+        assert r.status_code == 200, r.text
+        paths = sorted(item["path"] for item in r.json()["data"])
+        assert paths == ["/notes/draft_alice.md"]
+
+        # ``%`` must not match every path in the store.
+        r = await http_client.get(
+            f"/v1/memory-stores/{store['id']}/memories",
+            params={"path_prefix": "%"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["data"] == []
+
 
 class TestVersionsAndRedact:
     async def test_redact_head_rejected(self, http_client: httpx.AsyncClient) -> None:


### PR DESCRIPTION
## Summary

- `list_memories` bound `path_prefix` straight into a Postgres `LIKE` pattern, so `_` and `%` in the value were interpreted as wildcards rather than literal characters. The schema allows both in path segments (`CHECK (path ~ '^(/[^/\x00]+)+$')`), so `?path_prefix=/notes/draft_alice` would also return `/notes/draftXalice.md`, and `?path_prefix=%` would leak every memory in the store regardless of prefix — a within-store cross-prefix data disclosure.
- Add a private `_escape_like` helper in `db/queries.py` and bind two parameters in `list_memories`: the unescaped value for the equality clause, the LIKE-escaped value for the prefix clause. Postgres' default LIKE escape is `\`, so no explicit `ESCAPE` clause is needed.
- New e2e test pins both wildcard cases (`_` matching arbitrary single chars, `%` matching everything) so future regressions fail visibly.

## Follow-up

A sibling site at `list_recent_chat_ids` (queries.py:2852) has the same shape but with connector/account inputs that are far less attacker-controllable. Left for a separate PR to keep this one scoped to a single bug.

## Test plan

- [x] `uv run mypy src` — clean (132 files)
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1157 passed
- [x] `pytest tests/e2e/test_memory_stores_api.py::TestMemoryCrud::test_list_path_prefix_treats_underscore_literally` — passes; without the fix, fails with both wildcard expansions
- [ ] CI runs full e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)