### PR TITLE
refactor(api): Phase A route hygiene sweep across remaining unblocked routers (#267)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4291,7 +4291,7 @@
         ],
         "summary": "Create",
         "description": "Create a detached connection, **idempotent on ``(connector, account)``**.\n\nPer plan decision #5, this endpoint and the supervisor's\nauto-create-on-first-inbound path race-safely converge on a single row:\nposting twice with the same ``(connector, account)`` returns 201 with the\nexisting row rather than 409.  The ``id`` may differ from a freshly-allocated\none if a concurrent writer landed first; the response always reflects the\ncanonical active row.",
-        "operationId": "create_v1_connections_post",
+        "operationId": "create_connection",
         "parameters": [
           {
             "name": "Authorization",
@@ -4348,7 +4348,8 @@
           "connections"
         ],
         "summary": "List ",
-        "operationId": "list__v1_connections_get",
+        "description": "List connections, newest first, excluding archived. Cursor pagination via ``after``.\n\nFilters: ``connector`` (e.g. ``\"telegram\"``), ``session_id`` (only\nconnections in single_session mode bound to that session), ``mode``\n(``detached`` / ``single_session`` / ``per_chat``). Filters compose.",
+        "operationId": "list_connections",
         "parameters": [
           {
             "name": "connector",
@@ -4476,7 +4477,8 @@
           "connections"
         ],
         "summary": "Get",
-        "operationId": "get_v1_connections__connection_id__get",
+        "description": "Fetch one connection by id.",
+        "operationId": "get_connection",
         "parameters": [
           {
             "name": "connection_id",
@@ -4532,7 +4534,8 @@
           "connections"
         ],
         "summary": "Delete",
-        "operationId": "delete_v1_connections__connection_id__delete",
+        "description": "Archive a connection (DELETE soft-archives, only on detached connections).\n\nThe service layer rejects archive attempts on ``single_session`` or\n``per_chat`` connections \u2014 archiving those would silently break\ninbound delivery for live sessions or orphan\n``spawned_from_connection_id`` pointers on per_chat-spawned sessions.\nDetach or unconfigure first, then archive.",
+        "operationId": "archive_connection",
         "parameters": [
           {
             "name": "connection_id",
@@ -4584,7 +4587,7 @@
         ],
         "summary": "Attach",
         "description": "Attach a connection to a session, after validating the account against the snapshot.\n\nThe drift check runs BEFORE the DB write so a stale account can't\nmove into ``single_session`` mode and silently swallow inbound.",
-        "operationId": "attach_v1_connections__connection_id__attach_post",
+        "operationId": "attach_connection",
         "parameters": [
           {
             "name": "connection_id",
@@ -4652,7 +4655,8 @@
           "connections"
         ],
         "summary": "Detach",
-        "operationId": "detach_v1_connections__connection_id__detach_post",
+        "description": "Detach a single_session connection back to detached mode.\n\nThe bound session is unaffected (continues to exist); only the\nconnection's mode/binding changes. Inbound on this connection is\npaused until it's re-attached or configured for per_chat.",
+        "operationId": "detach_connection",
         "parameters": [
           {
             "name": "connection_id",
@@ -4710,7 +4714,8 @@
           "connections"
         ],
         "summary": "Configure Per Chat",
-        "operationId": "configure_per_chat_v1_connections__connection_id__configure_per_chat_post",
+        "description": "Move a detached connection into per_chat mode, pinned to a session template.\n\nInbound from new chat partners on this connection will spawn fresh\nsessions using the named template (agent + environment + vaults +\nmemory stores). Use ``unconfigure_connection`` to return to detached.",
+        "operationId": "configure_connection_per_chat",
         "parameters": [
           {
             "name": "connection_id",
@@ -4778,7 +4783,8 @@
           "connections"
         ],
         "summary": "Unconfigure",
-        "operationId": "unconfigure_v1_connections__connection_id__unconfigure_post",
+        "description": "Return a per_chat connection to detached mode.\n\nAlready-spawned sessions are unaffected and continue normally;\noperator-bound chat \u2192 session rows persist and continue to route\nthose specific chats. Only the per_chat fallback (spawn for unseen\nchats) is removed \u2014 inbound from new chat partners is paused until\nthe connection is reconfigured.",
+        "operationId": "unconfigure_connection",
         "parameters": [
           {
             "name": "connection_id",
@@ -4837,7 +4843,7 @@
         ],
         "summary": "Bind Chat",
         "description": "Operator-curate a chat \u2192 session mapping (#215).\n\nA row in ``connection_chat_sessions`` overrides the connection's\nmode-default fallback for that ``chat_id``.  Operators use this to\npoint different chats on a single account at different existing\nsessions \u2014 the middle case the unified ``connections`` shape didn't\ncover after #205.\n\nIdempotent on ``(connection_id, chat_id)``: a second call with the\nsame chat returns the existing row (its ``session_id`` may differ\nfrom the requested one if a concurrent writer landed first or the\nsupervisor pre-populated it via per_chat spawn).",
-        "operationId": "bind_chat_v1_connections__connection_id__bind_chat_post",
+        "operationId": "bind_chat",
         "parameters": [
           {
             "name": "connection_id",
@@ -4906,7 +4912,7 @@
         ],
         "summary": "Unbind Chat",
         "description": "Drop the operator-curated row.  Idempotent \u2014 repeat calls 204.",
-        "operationId": "unbind_chat_v1_connections__connection_id__bind_chat__chat_id__delete",
+        "operationId": "unbind_chat",
         "parameters": [
           {
             "name": "connection_id",
@@ -4966,7 +4972,8 @@
           "connections"
         ],
         "summary": "Bound Chats",
-        "operationId": "bound_chats_v1_connections__connection_id__bound_chats_get",
+        "description": "List operator-curated chat \u2192 session bindings on this connection.\n\nIncludes both manually-bound rows (via ``bind_chat``) and per_chat\nauto-spawned rows (via the supervisor on first inbound from a new\nchat partner).",
+        "operationId": "list_bound_chats",
         "parameters": [
           {
             "name": "connection_id",
@@ -5024,7 +5031,8 @@
           "connections"
         ],
         "summary": "Recent Chats",
-        "operationId": "recent_chats_v1_connections__connection_id__recent_chats_get",
+        "description": "List chats that recently sent inbound on this connection, newest first.\n\nUseful for picking a ``chat_id`` to bind via ``bind_chat`` \u2014\nenumerates the conversational counterparts that the connector has\ndelivered messages from.",
+        "operationId": "list_recent_chats",
         "parameters": [
           {
             "name": "connection_id",

--- a/openapi.json
+++ b/openapi.json
@@ -5478,7 +5478,8 @@
           "session-templates"
         ],
         "summary": "Create",
-        "operationId": "create_v1_session_templates_post",
+        "description": "Create a session template \u2014 a frozen recipe for per_chat session spawn.\n\nCaptures the agent + environment + vaults + memory stores that a\nper_chat connection will use when spawning a session for a new chat\npartner. Pin ``agent_version`` to a specific version for deterministic\nspawning, or leave unset to track the agent's latest.",
+        "operationId": "create_session_template",
         "parameters": [
           {
             "name": "Authorization",
@@ -5535,7 +5536,8 @@
           "session-templates"
         ],
         "summary": "List ",
-        "operationId": "list__v1_session_templates_get",
+        "description": "List session templates, newest first, excluding archived.\n\nCursor pagination via ``after``.",
+        "operationId": "list_session_templates",
         "parameters": [
           {
             "name": "limit",
@@ -5610,7 +5612,8 @@
           "session-templates"
         ],
         "summary": "Get",
-        "operationId": "get_v1_session_templates__template_id__get",
+        "description": "Fetch one session template by id.",
+        "operationId": "get_session_template",
         "parameters": [
           {
             "name": "template_id",
@@ -5666,7 +5669,8 @@
           "session-templates"
         ],
         "summary": "Update",
-        "operationId": "update_v1_session_templates__template_id__put",
+        "description": "Update a session template's recipe fields. Omitted fields are preserved.\n\nThe ``agent_version`` field uses sentinel-based partial-update semantics:\nomit it to preserve the current pin (or current \"track latest\" state),\npass null to switch to \"track latest,\" pass a number to pin to that\nspecific version. Already-spawned sessions are unaffected.",
+        "operationId": "update_session_template",
         "parameters": [
           {
             "name": "template_id",
@@ -5732,7 +5736,8 @@
           "session-templates"
         ],
         "summary": "Delete",
-        "operationId": "delete_v1_session_templates__template_id__delete",
+        "description": "Archive a session template (soft-delete via DELETE verb).\n\nAlready-spawned sessions are unaffected and continue normally. Per-chat\nconnections that reference this template by id keep their existing\nsessions but will fail to spawn new chat sessions at the inbound\nhandler until the connection is reconfigured to point at a different\ntemplate. There is no API surface to un-archive currently.",
+        "operationId": "archive_session_template",
         "parameters": [
           {
             "name": "template_id",

--- a/openapi.json
+++ b/openapi.json
@@ -2075,7 +2075,8 @@
           "skills"
         ],
         "summary": "Create",
-        "operationId": "create_v1_skills_post",
+        "description": "Create a new skill from an uploaded file bundle.\n\nThe bundle must include exactly one ``<directory>/SKILL.md`` file with\nYAML frontmatter containing at least a ``name`` field. The skill's\n``directory``, ``name``, and ``description`` are extracted from that\nfrontmatter; subsequent versions reuse this extraction.",
+        "operationId": "create_skill",
         "parameters": [
           {
             "name": "Authorization",
@@ -2132,7 +2133,8 @@
           "skills"
         ],
         "summary": "List ",
-        "operationId": "list__v1_skills_get",
+        "description": "List skills (latest version of each), newest first, excluding archived.\n\nCursor pagination via ``after``.",
+        "operationId": "list_skills",
         "parameters": [
           {
             "name": "limit",
@@ -2207,7 +2209,8 @@
           "skills"
         ],
         "summary": "Get",
-        "operationId": "get_v1_skills__skill_id__get",
+        "description": "Fetch one skill by id, returning the latest version's config.",
+        "operationId": "get_skill",
         "parameters": [
           {
             "name": "skill_id",
@@ -2263,7 +2266,8 @@
           "skills"
         ],
         "summary": "Archive",
-        "operationId": "archive_v1_skills__skill_id__delete",
+        "description": "Archive a skill: sets ``archived_at`` and hides it from default lists.\n\nThe row and version history persist; agents that reference this skill\nby id continue to resolve their pinned versions. There is no API\nsurface to un-archive currently.",
+        "operationId": "archive_skill",
         "parameters": [
           {
             "name": "skill_id",
@@ -2314,7 +2318,8 @@
           "skills"
         ],
         "summary": "Create Version",
-        "operationId": "create_version_v1_skills__skill_id__versions_post",
+        "description": "Upload a new immutable version of a skill's file bundle.\n\nThe bundle must include the same SKILL.md frontmatter shape as the\ninitial create: directory, ``name``, ``description``. Each version is\na complete snapshot \u2014 files not present in the upload are not carried\nover from previous versions.",
+        "operationId": "create_skill_version",
         "parameters": [
           {
             "name": "skill_id",
@@ -2380,7 +2385,8 @@
           "skills"
         ],
         "summary": "List Versions",
-        "operationId": "list_versions_v1_skills__skill_id__versions_get",
+        "description": "List historical versions of a skill, newest first.\n\nCursor pagination by version number: pass ``after`` from a previous\nresponse's ``next_after`` to get the next page. Each version is a\ncomplete file-bundle snapshot at the time it was created.",
+        "operationId": "list_skill_versions",
         "parameters": [
           {
             "name": "skill_id",
@@ -2464,7 +2470,8 @@
           "skills"
         ],
         "summary": "Get Version",
-        "operationId": "get_version_v1_skills__skill_id__versions__version__get",
+        "description": "Fetch one historical version's file bundle.\n\nThe bundle reflects the skill's state at the time the version was\nwritten and is unaffected by subsequent versions or archival.",
+        "operationId": "get_skill_version",
         "parameters": [
           {
             "name": "skill_id",

--- a/openapi.json
+++ b/openapi.json
@@ -9,7 +9,8 @@
     "/health": {
       "get": {
         "summary": "Health",
-        "operationId": "health_health_get",
+        "description": "Liveness probe. Unauthenticated; returns the running aios version.\n\nSuitable for load balancer health checks and monitoring probes. Always\nreturns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the\nprocess is up.",
+        "operationId": "get_health",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -20,7 +21,7 @@
                     "type": "string"
                   },
                   "type": "object",
-                  "title": "Response Health Health Get"
+                  "title": "Response Get Health"
                 }
               }
             }

--- a/openapi.json
+++ b/openapi.json
@@ -2531,7 +2531,8 @@
           "vaults"
         ],
         "summary": "Create",
-        "operationId": "create_v1_vaults_post",
+        "description": "Create a new vault \u2014 a named collection for MCP server credentials.\n\nCredentials are added separately via ``create_vault_credential``.",
+        "operationId": "create_vault",
         "parameters": [
           {
             "name": "Authorization",
@@ -2588,7 +2589,8 @@
           "vaults"
         ],
         "summary": "List ",
-        "operationId": "list__v1_vaults_get",
+        "description": "List vaults, newest first, excluding archived.\n\nCursor pagination: pass ``after`` from a previous response's\n``next_after`` to get the next page.",
+        "operationId": "list_vaults",
         "parameters": [
           {
             "name": "limit",
@@ -2663,7 +2665,8 @@
           "vaults"
         ],
         "summary": "Get",
-        "operationId": "get_v1_vaults__vault_id__get",
+        "description": "Fetch one vault by id.",
+        "operationId": "get_vault",
         "parameters": [
           {
             "name": "vault_id",
@@ -2719,7 +2722,8 @@
           "vaults"
         ],
         "summary": "Update",
-        "operationId": "update_v1_vaults__vault_id__put",
+        "description": "Update a vault's ``display_name`` and/or ``metadata``.\n\nOmitted fields are preserved.",
+        "operationId": "update_vault",
         "parameters": [
           {
             "name": "vault_id",
@@ -2785,7 +2789,8 @@
           "vaults"
         ],
         "summary": "Delete",
-        "operationId": "delete_v1_vaults__vault_id__delete",
+        "description": "Hard-delete a vault and all its credentials (``ON DELETE CASCADE``).\n\nReturns 204. Unlike ``archive_vault``, this removes the rows entirely\nand leaves no audit trail. Prefer archive unless you specifically need\nthe rows gone.",
+        "operationId": "delete_vault",
         "parameters": [
           {
             "name": "vault_id",
@@ -2836,7 +2841,8 @@
           "vaults"
         ],
         "summary": "Archive",
-        "operationId": "archive_v1_vaults__vault_id__archive_post",
+        "description": "Archive a vault and **purge the encrypted secret material** of its credentials.\n\nSets ``archived_at`` and hides the vault from default lists. In the same\ntransaction, every active credential is archived and its encrypted blob\nis zeroed \u2014 the credential rows persist for audit but the stored secrets\nare unrecoverable. Defense in depth: a future DB dump cannot leak\nsecrets that were already retired.\n\nUse ``delete_vault`` instead if you want to remove the rows entirely.",
+        "operationId": "archive_vault",
         "parameters": [
           {
             "name": "vault_id",
@@ -2894,7 +2900,8 @@
           "vaults"
         ],
         "summary": "Create Credential",
-        "operationId": "create_credential_v1_vaults__vault_id__credentials_post",
+        "description": "Add a credential to a vault. Secrets are encrypted at rest via the CryptoBox.\n\nValidates required fields per ``auth_type``: ``mcp_oauth`` requires\n``access_token`` (plus the refresh fields needed for rotation);\n``static_bearer`` requires ``token``. Caps at 20 active credentials per\nvault. The ``mcp_server_url`` is immutable after creation \u2014 to retarget\na credential, archive the existing one and create a new credential at\nthe new URL.",
+        "operationId": "create_vault_credential",
         "parameters": [
           {
             "name": "vault_id",
@@ -2960,7 +2967,8 @@
           "vaults"
         ],
         "summary": "List Credentials",
-        "operationId": "list_credentials_v1_vaults__vault_id__credentials_get",
+        "description": "List credentials in a vault, newest first, excluding archived.\n\nCursor pagination via ``after``. Secret material is never returned \u2014\nonly metadata (display name, mcp_server_url, auth_type, timestamps).",
+        "operationId": "list_vault_credentials",
         "parameters": [
           {
             "name": "vault_id",
@@ -3044,7 +3052,8 @@
           "vaults"
         ],
         "summary": "Get Credential",
-        "operationId": "get_credential_v1_vaults__vault_id__credentials__credential_id__get",
+        "description": "Fetch one credential's metadata. Secrets are never returned.\n\nInternal MCP clients resolve the secret directly through the service\nlayer (with OAuth refresh as needed); the HTTP API never exposes it.",
+        "operationId": "get_vault_credential",
         "parameters": [
           {
             "name": "vault_id",
@@ -3109,7 +3118,8 @@
           "vaults"
         ],
         "summary": "Update Credential",
-        "operationId": "update_credential_v1_vaults__vault_id__credentials__credential_id__put",
+        "description": "Update a credential's metadata and/or rotate its auth secrets.\n\nOmitted secret fields are preserved (decrypt-merge-encrypt cycle on the\nencrypted payload). ``mcp_server_url`` and ``auth_type`` are immutable\nand not accepted in the body. To rotate an OAuth refresh token, send\nonly the new ``refresh_token`` (and optional ``access_token`` /\n``expires_at``); other auth fields stay intact.",
+        "operationId": "update_vault_credential",
         "parameters": [
           {
             "name": "vault_id",
@@ -3184,7 +3194,8 @@
           "vaults"
         ],
         "summary": "Delete Credential",
-        "operationId": "delete_credential_v1_vaults__vault_id__credentials__credential_id__delete",
+        "description": "Hard-delete a credential row. Returns 204.\n\nUnlike ``archive_vault_credential``, removes the row entirely and\nleaves no audit trail. Prefer archive unless you specifically need the\nrow gone.",
+        "operationId": "delete_vault_credential",
         "parameters": [
           {
             "name": "vault_id",
@@ -3244,7 +3255,8 @@
           "vaults"
         ],
         "summary": "Archive Credential",
-        "operationId": "archive_credential_v1_vaults__vault_id__credentials__credential_id__archive_post",
+        "description": "Archive a credential and **zero its encrypted secret payload**.\n\nSets ``archived_at`` and hides the credential from default lists. The\nencrypted blob is scrubbed at archive time so a future DB dump cannot\nleak the secret. Use ``delete_vault_credential`` for full removal.",
+        "operationId": "archive_vault_credential",
         "parameters": [
           {
             "name": "vault_id",

--- a/openapi.json
+++ b/openapi.json
@@ -3335,7 +3335,8 @@
           "memory-stores"
         ],
         "summary": "Create Store",
-        "operationId": "create_store_v1_memory_stores_post",
+        "description": "Create a new memory store \u2014 a named collection of file-like memories.\n\nMemories created in this store are mirrored to a per-store host\ndirectory so that sessions referencing the store can read them through\nthe sandbox filesystem.",
+        "operationId": "create_memory_store",
         "parameters": [
           {
             "name": "Authorization",
@@ -3392,7 +3393,8 @@
           "memory-stores"
         ],
         "summary": "List Stores",
-        "operationId": "list_stores_v1_memory_stores_get",
+        "description": "List memory stores, newest first.\n\nUnlike most resources, archived stores can be included via\n``include_archived=true`` (default false). No cursor pagination \u2014 bumps\nthe default limit to 100 since stores are typically few.",
+        "operationId": "list_memory_stores",
         "parameters": [
           {
             "name": "include_archived",
@@ -3461,7 +3463,8 @@
           "memory-stores"
         ],
         "summary": "Get Store",
-        "operationId": "get_store_v1_memory_stores__store_id__get",
+        "description": "Fetch one memory store by id.",
+        "operationId": "get_memory_store",
         "parameters": [
           {
             "name": "store_id",
@@ -3517,7 +3520,8 @@
           "memory-stores"
         ],
         "summary": "Update Store",
-        "operationId": "update_store_v1_memory_stores__store_id__post",
+        "description": "Update a memory store's ``name``, ``description``, or ``metadata``.\n\nRejects with ``MemoryStoreArchivedError`` if the store is archived \u2014\narchived stores are read-only. Treat as partial update on the listed\nfields.",
+        "operationId": "update_memory_store",
         "parameters": [
           {
             "name": "store_id",
@@ -3583,7 +3587,8 @@
           "memory-stores"
         ],
         "summary": "Delete Store",
-        "operationId": "delete_store_v1_memory_stores__store_id__delete",
+        "description": "Hard-delete a memory store, all its memories, and its host mirror.\n\nCascade-deletes memories and versions in the database. After the DB\ntransaction commits, the per-store host mirror directory is removed\n(best-effort \u2014 a missing dir is fine, indicates no session ever\nprovisioned for this store). Returns 204.",
+        "operationId": "delete_memory_store",
         "parameters": [
           {
             "name": "store_id",
@@ -3634,7 +3639,8 @@
           "memory-stores"
         ],
         "summary": "Archive Store",
-        "operationId": "archive_store_v1_memory_stores__store_id__archive_post",
+        "description": "Archive a memory store: hides from default lists, makes it read-only.\n\nThe store and its memories persist; sessions can still resolve memory\ncontent. Subsequent ``update_memory_store`` calls fail until\nun-archived (no API surface for that currently). Use\n``delete_memory_store`` for full removal.",
+        "operationId": "archive_memory_store",
         "parameters": [
           {
             "name": "store_id",
@@ -3692,7 +3698,8 @@
           "memory-stores"
         ],
         "summary": "Create Memory",
-        "operationId": "create_memory_v1_memory_stores__store_id__memories_post",
+        "description": "Create a memory at the given path within a store.\n\nThe content is also mirrored to the store's host directory so that\nsandboxed sessions can read it through the filesystem. Creates an\ninitial version (every memory mutation creates a version).",
+        "operationId": "create_memory",
         "parameters": [
           {
             "name": "store_id",
@@ -3758,7 +3765,8 @@
           "memory-stores"
         ],
         "summary": "List Memories",
-        "operationId": "list_memories_v1_memory_stores__store_id__memories_get",
+        "description": "List memories in a store, optionally filtered and grouped by path.\n\n``path_prefix`` is a literal prefix match on the memory path. ``depth``\ngroups deeper paths into ``MemoryPrefix`` entries (directory-style\nlistings) \u2014 entries past the depth boundary are collapsed into a\nsingle prefix entry per shared directory. ``order_by`` accepts\n``created_at`` (default) or ``path``.",
+        "operationId": "list_memories",
         "parameters": [
           {
             "name": "store_id",
@@ -3858,7 +3866,8 @@
           "memory-stores"
         ],
         "summary": "Get Memory",
-        "operationId": "get_memory_v1_memory_stores__store_id__memories__memory_id__get",
+        "description": "Fetch one memory by id, including its current content.",
+        "operationId": "get_memory",
         "parameters": [
           {
             "name": "store_id",
@@ -3923,7 +3932,8 @@
           "memory-stores"
         ],
         "summary": "Update Memory",
-        "operationId": "update_memory_v1_memory_stores__store_id__memories__memory_id__post",
+        "description": "Update a memory's content and/or path. Creates a new version.\n\nOptionally honors a ``precondition.content_sha256`` for optimistic\nconcurrency \u2014 if the current content's SHA-256 differs, the update\nfails with a precondition error rather than overwriting. The host\nmirror is updated to match: renames delete the old path and write the\nnew one.",
+        "operationId": "update_memory",
         "parameters": [
           {
             "name": "store_id",
@@ -3998,7 +4008,8 @@
           "memory-stores"
         ],
         "summary": "Delete Memory",
-        "operationId": "delete_memory_v1_memory_stores__store_id__memories__memory_id__delete",
+        "description": "Soft-delete a memory and remove it from the host mirror.\n\nSets ``deleted_at`` on the memory and appends a ``deleted`` tombstone\nversion. The row and version history persist; live reads filter on\n``deleted_at IS NULL`` so the memory becomes invisible. Returns 204.",
+        "operationId": "delete_memory",
         "parameters": [
           {
             "name": "store_id",
@@ -4058,7 +4069,8 @@
           "memory-stores"
         ],
         "summary": "List Versions",
-        "operationId": "list_versions_v1_memory_stores__store_id__memory_versions_get",
+        "description": "List memory versions in a store, newest first.\n\nOptional ``memory_id`` filters to a single memory's version history.\nWithout the filter, returns versions across all memories in the store\n(useful for audit). No cursor pagination; bumps default limit to 100.",
+        "operationId": "list_memory_versions",
         "parameters": [
           {
             "name": "store_id",
@@ -4142,7 +4154,8 @@
           "memory-stores"
         ],
         "summary": "Get Version",
-        "operationId": "get_version_v1_memory_stores__store_id__memory_versions__version_id__get",
+        "description": "Fetch one historical memory version by id.",
+        "operationId": "get_memory_version",
         "parameters": [
           {
             "name": "store_id",
@@ -4209,7 +4222,8 @@
           "memory-stores"
         ],
         "summary": "Redact Version",
-        "operationId": "redact_version_v1_memory_stores__store_id__memory_versions__version_id__redact_post",
+        "description": "Redact the content of a historical memory version in place.\n\nThe version row persists for audit (with the actor and timestamp) but\nits content field is cleared. Use to scrub sensitive data that was\npreviously written into a memory. Live memory content is unaffected\n(only this specific historical version is redacted).",
+        "operationId": "redact_memory_version",
         "parameters": [
           {
             "name": "store_id",

--- a/openapi.json
+++ b/openapi.json
@@ -35,7 +35,8 @@
           "environments"
         ],
         "summary": "Create",
-        "operationId": "create_v1_environments_post",
+        "description": "Create a new environment \u2014 a reusable sandbox configuration template.\n\nThe ``config`` field describes the container the sessions running this\nenvironment will spawn (pre-installed packages, network access rules,\nbase image). Sessions reference environments by id; multiple sessions\ncan share one environment.",
+        "operationId": "create_environment",
         "parameters": [
           {
             "name": "Authorization",
@@ -92,7 +93,8 @@
           "environments"
         ],
         "summary": "List ",
-        "operationId": "list__v1_environments_get",
+        "description": "List environments, newest first, excluding archived.\n\nCursor pagination via ``after``.",
+        "operationId": "list_environments",
         "parameters": [
           {
             "name": "limit",
@@ -167,7 +169,8 @@
           "environments"
         ],
         "summary": "Get",
-        "operationId": "get_v1_environments__env_id__get",
+        "description": "Fetch one environment by id.",
+        "operationId": "get_environment",
         "parameters": [
           {
             "name": "env_id",
@@ -223,7 +226,8 @@
           "environments"
         ],
         "summary": "Update",
-        "operationId": "update_v1_environments__env_id__put",
+        "description": "Update an environment's ``name`` and/or ``config``.\n\nSessions resolve the environment config fresh each time their sandbox\nis provisioned (lazily, at the next session step that needs the\ncontainer), so updates take effect for existing sessions on their next\nprovision rather than at update time.",
+        "operationId": "update_environment",
         "parameters": [
           {
             "name": "env_id",
@@ -289,7 +293,8 @@
           "environments"
         ],
         "summary": "Archive",
-        "operationId": "archive_v1_environments__env_id__delete",
+        "description": "Archive an environment: hides from default lists, leaves the row in place.\n\nSessions referencing the archived environment continue to function \u2014 the\nsandbox provisioner reads the config by JOIN and does not filter by\narchive state. There is no API surface to un-archive currently.",
+        "operationId": "archive_environment",
         "parameters": [
           {
             "name": "env_id",

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -117,7 +117,7 @@ async def _assert_account_in_snapshot(db_url: str, *, connector: str, account: s
         )
 
 
-@router.post("", status_code=status.HTTP_201_CREATED)
+@router.post("", operation_id="create_connection", status_code=status.HTTP_201_CREATED)
 async def create(body: ConnectionCreate, pool: PoolDep, _auth: AuthDep) -> Connection:
     """Create a detached connection, **idempotent on ``(connector, account)``**.
 
@@ -136,7 +136,7 @@ async def create(body: ConnectionCreate, pool: PoolDep, _auth: AuthDep) -> Conne
     )
 
 
-@router.get("")
+@router.get("", operation_id="list_connections")
 async def list_(
     pool: PoolDep,
     _auth: AuthDep,
@@ -146,6 +146,12 @@ async def list_(
     limit: int = 50,
     after: str | None = None,
 ) -> ListResponse[Connection]:
+    """List connections, newest first, excluding archived. Cursor pagination via ``after``.
+
+    Filters: ``connector`` (e.g. ``"telegram"``), ``session_id`` (only
+    connections in single_session mode bound to that session), ``mode``
+    (``detached`` / ``single_session`` / ``per_chat``). Filters compose.
+    """
     items = await service.list_connections(
         pool,
         connector=connector,
@@ -161,17 +167,30 @@ async def list_(
     )
 
 
-@router.get("/{connection_id}")
+@router.get("/{connection_id}", operation_id="get_connection")
 async def get(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Connection:
+    """Fetch one connection by id."""
     return await service.get_connection(pool, connection_id)
 
 
-@router.delete("/{connection_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{connection_id}",
+    operation_id="archive_connection",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
 async def delete(connection_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+    """Archive a connection (DELETE soft-archives, only on detached connections).
+
+    The service layer rejects archive attempts on ``single_session`` or
+    ``per_chat`` connections — archiving those would silently break
+    inbound delivery for live sessions or orphan
+    ``spawned_from_connection_id`` pointers on per_chat-spawned sessions.
+    Detach or unconfigure first, then archive.
+    """
     await service.archive_connection(pool, connection_id)
 
 
-@router.post("/{connection_id}/attach")
+@router.post("/{connection_id}/attach", operation_id="attach_connection")
 async def attach(
     connection_id: str,
     body: ConnectionAttach,
@@ -191,26 +210,53 @@ async def attach(
     return await service.attach_connection(pool, connection_id, session_id=body.session_id)
 
 
-@router.post("/{connection_id}/detach")
+@router.post("/{connection_id}/detach", operation_id="detach_connection")
 async def detach(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Connection:
+    """Detach a single_session connection back to detached mode.
+
+    The bound session is unaffected (continues to exist); only the
+    connection's mode/binding changes. Inbound on this connection is
+    paused until it's re-attached or configured for per_chat.
+    """
     return await service.detach_connection(pool, connection_id)
 
 
-@router.post("/{connection_id}/configure-per-chat")
+@router.post(
+    "/{connection_id}/configure-per-chat",
+    operation_id="configure_connection_per_chat",
+)
 async def configure_per_chat(
     connection_id: str, body: ConnectionConfigurePerChat, pool: PoolDep, _auth: AuthDep
 ) -> Connection:
+    """Move a detached connection into per_chat mode, pinned to a session template.
+
+    Inbound from new chat partners on this connection will spawn fresh
+    sessions using the named template (agent + environment + vaults +
+    memory stores). Use ``unconfigure_connection`` to return to detached.
+    """
     return await service.configure_per_chat(
         pool, connection_id, session_template_id=body.session_template_id
     )
 
 
-@router.post("/{connection_id}/unconfigure")
+@router.post("/{connection_id}/unconfigure", operation_id="unconfigure_connection")
 async def unconfigure(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Connection:
+    """Return a per_chat connection to detached mode.
+
+    Already-spawned sessions are unaffected and continue normally;
+    operator-bound chat → session rows persist and continue to route
+    those specific chats. Only the per_chat fallback (spawn for unseen
+    chats) is removed — inbound from new chat partners is paused until
+    the connection is reconfigured.
+    """
     return await service.unconfigure_connection(pool, connection_id)
 
 
-@router.post("/{connection_id}/bind-chat", status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/{connection_id}/bind-chat",
+    operation_id="bind_chat",
+    status_code=status.HTTP_201_CREATED,
+)
 async def bind_chat(
     connection_id: str, body: BindChatRequest, pool: PoolDep, _auth: AuthDep
 ) -> BoundChat:
@@ -232,24 +278,40 @@ async def bind_chat(
     )
 
 
-@router.delete("/{connection_id}/bind-chat/{chat_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{connection_id}/bind-chat/{chat_id}",
+    operation_id="unbind_chat",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
 async def unbind_chat(connection_id: str, chat_id: str, pool: PoolDep, _auth: AuthDep) -> None:
     """Drop the operator-curated row.  Idempotent — repeat calls 204."""
     await service.unbind_chat(pool, connection_id, chat_id)
 
 
-@router.get("/{connection_id}/bound-chats")
+@router.get("/{connection_id}/bound-chats", operation_id="list_bound_chats")
 async def bound_chats(connection_id: str, pool: PoolDep, _auth: AuthDep) -> ListResponse[BoundChat]:
+    """List operator-curated chat → session bindings on this connection.
+
+    Includes both manually-bound rows (via ``bind_chat``) and per_chat
+    auto-spawned rows (via the supervisor on first inbound from a new
+    chat partner).
+    """
     items = await service.list_bound_chats(pool, connection_id)
     return ListResponse[BoundChat](data=items)
 
 
-@router.get("/{connection_id}/recent-chats")
+@router.get("/{connection_id}/recent-chats", operation_id="list_recent_chats")
 async def recent_chats(
     connection_id: str,
     pool: PoolDep,
     _auth: AuthDep,
     limit: int = 50,
 ) -> ListResponse[RecentChat]:
+    """List chats that recently sent inbound on this connection, newest first.
+
+    Useful for picking a ``chat_id`` to bind via ``bind_chat`` —
+    enumerates the conversational counterparts that the connector has
+    delivered messages from.
+    """
     items = await service.list_recent_chats(pool, connection_id, limit=limit)
     return ListResponse[RecentChat](data=items)

--- a/src/aios/api/routers/environments.py
+++ b/src/aios/api/routers/environments.py
@@ -12,18 +12,29 @@ from aios.services import environments as service
 router = APIRouter(prefix="/v1/environments", tags=["environments"])
 
 
-@router.post("", status_code=status.HTTP_201_CREATED)
+@router.post("", operation_id="create_environment", status_code=status.HTTP_201_CREATED)
 async def create(body: EnvironmentCreate, pool: PoolDep, _auth: AuthDep) -> Environment:
+    """Create a new environment — a reusable sandbox configuration template.
+
+    The ``config`` field describes the container the sessions running this
+    environment will spawn (pre-installed packages, network access rules,
+    base image). Sessions reference environments by id; multiple sessions
+    can share one environment.
+    """
     return await service.create_environment(pool, name=body.name, config=body.config)
 
 
-@router.get("")
+@router.get("", operation_id="list_environments")
 async def list_(
     pool: PoolDep,
     _auth: AuthDep,
     limit: int = 50,
     after: str | None = None,
 ) -> ListResponse[Environment]:
+    """List environments, newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+    """
     items = await service.list_environments(pool, limit=limit, after=after)
     return ListResponse[Environment](
         data=items,
@@ -32,18 +43,34 @@ async def list_(
     )
 
 
-@router.get("/{env_id}")
+@router.get("/{env_id}", operation_id="get_environment")
 async def get(env_id: str, pool: PoolDep, _auth: AuthDep) -> Environment:
+    """Fetch one environment by id."""
     return await service.get_environment(pool, env_id)
 
 
-@router.put("/{env_id}")
+@router.put("/{env_id}", operation_id="update_environment")
 async def update(
     env_id: str, body: EnvironmentUpdate, pool: PoolDep, _auth: AuthDep
 ) -> Environment:
+    """Update an environment's ``name`` and/or ``config``.
+
+    Sessions resolve the environment config fresh each time their sandbox
+    is provisioned (lazily, at the next session step that needs the
+    container), so updates take effect for existing sessions on their next
+    provision rather than at update time.
+    """
     return await service.update_environment(pool, env_id, name=body.name, config=body.config)
 
 
-@router.delete("/{env_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{env_id}", operation_id="archive_environment", status_code=status.HTTP_204_NO_CONTENT
+)
 async def archive(env_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+    """Archive an environment: hides from default lists, leaves the row in place.
+
+    Sessions referencing the archived environment continue to function — the
+    sandbox provisioner reads the config by JOIN and does not filter by
+    archive state. There is no API surface to un-archive currently.
+    """
     await service.archive_environment(pool, env_id)

--- a/src/aios/api/routers/health.py
+++ b/src/aios/api/routers/health.py
@@ -9,6 +9,12 @@ from aios import __version__
 router = APIRouter()
 
 
-@router.get("/health")
+@router.get("/health", operation_id="get_health")
 async def health() -> dict[str, str]:
+    """Liveness probe. Unauthenticated; returns the running aios version.
+
+    Suitable for load balancer health checks and monitoring probes. Always
+    returns 200 with ``{"status": "ok", "version": <version>}`` if the
+    process is up.
+    """
     return {"status": "ok", "version": __version__}

--- a/src/aios/api/routers/memory_stores.py
+++ b/src/aios/api/routers/memory_stores.py
@@ -24,20 +24,32 @@ router = APIRouter(prefix="/v1/memory-stores", tags=["memory-stores"])
 # ── stores ─────────────────────────────────────────────────────────────────
 
 
-@router.post("", status_code=status.HTTP_201_CREATED)
+@router.post("", operation_id="create_memory_store", status_code=status.HTTP_201_CREATED)
 async def create_store(body: MemoryStoreCreate, pool: PoolDep, _auth: AuthDep) -> MemoryStore:
+    """Create a new memory store — a named collection of file-like memories.
+
+    Memories created in this store are mirrored to a per-store host
+    directory so that sessions referencing the store can read them through
+    the sandbox filesystem.
+    """
     return await service.create_store(
         pool, name=body.name, description=body.description, metadata=body.metadata
     )
 
 
-@router.get("")
+@router.get("", operation_id="list_memory_stores")
 async def list_stores(
     pool: PoolDep,
     _auth: AuthDep,
     include_archived: bool = False,
     limit: int = 100,
 ) -> ListResponse[MemoryStore]:
+    """List memory stores, newest first.
+
+    Unlike most resources, archived stores can be included via
+    ``include_archived=true`` (default false). No cursor pagination — bumps
+    the default limit to 100 since stores are typically few.
+    """
     items = await service.list_stores(pool, include_archived=include_archived, limit=limit)
     return ListResponse[MemoryStore](
         data=items,
@@ -46,15 +58,22 @@ async def list_stores(
     )
 
 
-@router.get("/{store_id}")
+@router.get("/{store_id}", operation_id="get_memory_store")
 async def get_store(store_id: str, pool: PoolDep, _auth: AuthDep) -> MemoryStore:
+    """Fetch one memory store by id."""
     return await service.get_store(pool, store_id)
 
 
-@router.post("/{store_id}")
+@router.post("/{store_id}", operation_id="update_memory_store")
 async def update_store(
     store_id: str, body: MemoryStoreUpdate, pool: PoolDep, _auth: AuthDep
 ) -> MemoryStore:
+    """Update a memory store's ``name``, ``description``, or ``metadata``.
+
+    Rejects with ``MemoryStoreArchivedError`` if the store is archived —
+    archived stores are read-only. Treat as partial update on the listed
+    fields.
+    """
     return await service.update_store(
         pool,
         store_id,
@@ -64,21 +83,49 @@ async def update_store(
     )
 
 
-@router.post("/{store_id}/archive")
+@router.post("/{store_id}/archive", operation_id="archive_memory_store")
 async def archive_store(store_id: str, pool: PoolDep, _auth: AuthDep) -> MemoryStore:
+    """Archive a memory store: hides from default lists, makes it read-only.
+
+    The store and its memories persist; sessions can still resolve memory
+    content. Subsequent ``update_memory_store`` calls fail until
+    un-archived (no API surface for that currently). Use
+    ``delete_memory_store`` for full removal.
+    """
     return await service.archive_store(pool, store_id)
 
 
-@router.delete("/{store_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{store_id}",
+    operation_id="delete_memory_store",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
 async def delete_store(store_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+    """Hard-delete a memory store, all its memories, and its host mirror.
+
+    Cascade-deletes memories and versions in the database. After the DB
+    transaction commits, the per-store host mirror directory is removed
+    (best-effort — a missing dir is fine, indicates no session ever
+    provisioned for this store). Returns 204.
+    """
     await service.delete_store(pool, store_id)
 
 
 # ── memories ────────────────────────────────────────────────────────────────
 
 
-@router.post("/{store_id}/memories", status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/{store_id}/memories",
+    operation_id="create_memory",
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_memory(store_id: str, body: MemoryCreate, pool: PoolDep, _auth: AuthDep) -> Memory:
+    """Create a memory at the given path within a store.
+
+    The content is also mirrored to the store's host directory so that
+    sandboxed sessions can read it through the filesystem. Creates an
+    initial version (every memory mutation creates a version).
+    """
     return await service.create_memory(
         pool,
         store_id=store_id,
@@ -88,7 +135,7 @@ async def create_memory(store_id: str, body: MemoryCreate, pool: PoolDep, _auth:
     )
 
 
-@router.get("/{store_id}/memories")
+@router.get("/{store_id}/memories", operation_id="list_memories")
 async def list_memories(
     store_id: str,
     pool: PoolDep,
@@ -97,6 +144,14 @@ async def list_memories(
     order_by: str = "created_at",
     depth: int | None = None,
 ) -> ListResponse[Memory | MemoryPrefix]:
+    """List memories in a store, optionally filtered and grouped by path.
+
+    ``path_prefix`` is a literal prefix match on the memory path. ``depth``
+    groups deeper paths into ``MemoryPrefix`` entries (directory-style
+    listings) — entries past the depth boundary are collapsed into a
+    single prefix entry per shared directory. ``order_by`` accepts
+    ``created_at`` (default) or ``path``.
+    """
     items = await service.list_memories(
         pool,
         store_id,
@@ -107,12 +162,13 @@ async def list_memories(
     return ListResponse[Memory | MemoryPrefix](data=items)
 
 
-@router.get("/{store_id}/memories/{memory_id}")
+@router.get("/{store_id}/memories/{memory_id}", operation_id="get_memory")
 async def get_memory(store_id: str, memory_id: str, pool: PoolDep, _auth: AuthDep) -> Memory:
+    """Fetch one memory by id, including its current content."""
     return await service.get_memory(pool, store_id, memory_id, include_content=True)
 
 
-@router.post("/{store_id}/memories/{memory_id}")
+@router.post("/{store_id}/memories/{memory_id}", operation_id="update_memory")
 async def update_memory(
     store_id: str,
     memory_id: str,
@@ -120,6 +176,14 @@ async def update_memory(
     pool: PoolDep,
     _auth: AuthDep,
 ) -> Memory:
+    """Update a memory's content and/or path. Creates a new version.
+
+    Optionally honors a ``precondition.content_sha256`` for optimistic
+    concurrency — if the current content's SHA-256 differs, the update
+    fails with a precondition error rather than overwriting. The host
+    mirror is updated to match: renames delete the old path and write the
+    new one.
+    """
     return await service.update_memory(
         pool,
         store_id=store_id,
@@ -133,8 +197,18 @@ async def update_memory(
     )
 
 
-@router.delete("/{store_id}/memories/{memory_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{store_id}/memories/{memory_id}",
+    operation_id="delete_memory",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
 async def delete_memory(store_id: str, memory_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+    """Soft-delete a memory and remove it from the host mirror.
+
+    Sets ``deleted_at`` on the memory and appends a ``deleted`` tombstone
+    version. The row and version history persist; live reads filter on
+    ``deleted_at IS NULL`` so the memory becomes invisible. Returns 204.
+    """
     await service.delete_memory(
         pool,
         store_id=store_id,
@@ -146,7 +220,7 @@ async def delete_memory(store_id: str, memory_id: str, pool: PoolDep, _auth: Aut
 # ── versions ────────────────────────────────────────────────────────────────
 
 
-@router.get("/{store_id}/memory-versions")
+@router.get("/{store_id}/memory-versions", operation_id="list_memory_versions")
 async def list_versions(
     store_id: str,
     pool: PoolDep,
@@ -154,21 +228,38 @@ async def list_versions(
     memory_id: str | None = None,
     limit: int = 100,
 ) -> ListResponse[MemoryVersion]:
+    """List memory versions in a store, newest first.
+
+    Optional ``memory_id`` filters to a single memory's version history.
+    Without the filter, returns versions across all memories in the store
+    (useful for audit). No cursor pagination; bumps default limit to 100.
+    """
     items = await service.list_versions(pool, store_id, memory_id=memory_id, limit=limit)
     return ListResponse[MemoryVersion](data=items)
 
 
-@router.get("/{store_id}/memory-versions/{version_id}")
+@router.get("/{store_id}/memory-versions/{version_id}", operation_id="get_memory_version")
 async def get_version(
     store_id: str, version_id: str, pool: PoolDep, _auth: AuthDep
 ) -> MemoryVersion:
+    """Fetch one historical memory version by id."""
     return await service.get_version(pool, store_id, version_id)
 
 
-@router.post("/{store_id}/memory-versions/{version_id}/redact")
+@router.post(
+    "/{store_id}/memory-versions/{version_id}/redact",
+    operation_id="redact_memory_version",
+)
 async def redact_version(
     store_id: str, version_id: str, pool: PoolDep, _auth: AuthDep
 ) -> MemoryVersion:
+    """Redact the content of a historical memory version in place.
+
+    The version row persists for audit (with the actor and timestamp) but
+    its content field is cleared. Use to scrub sensitive data that was
+    previously written into a memory. Live memory content is unaffected
+    (only this specific historical version is redacted).
+    """
     return await service.redact_version(
         pool,
         store_id=store_id,

--- a/src/aios/api/routers/session_templates.py
+++ b/src/aios/api/routers/session_templates.py
@@ -25,8 +25,15 @@ from aios.services import session_templates as service
 router = APIRouter(prefix="/v1/session-templates", tags=["session-templates"])
 
 
-@router.post("", status_code=status.HTTP_201_CREATED)
+@router.post("", operation_id="create_session_template", status_code=status.HTTP_201_CREATED)
 async def create(body: SessionTemplateCreate, pool: PoolDep, _auth: AuthDep) -> SessionTemplate:
+    """Create a session template — a frozen recipe for per_chat session spawn.
+
+    Captures the agent + environment + vaults + memory stores that a
+    per_chat connection will use when spawning a session for a new chat
+    partner. Pin ``agent_version`` to a specific version for deterministic
+    spawning, or leave unset to track the agent's latest.
+    """
     return await service.create_session_template(
         pool,
         name=body.name,
@@ -39,13 +46,17 @@ async def create(body: SessionTemplateCreate, pool: PoolDep, _auth: AuthDep) -> 
     )
 
 
-@router.get("")
+@router.get("", operation_id="list_session_templates")
 async def list_(
     pool: PoolDep,
     _auth: AuthDep,
     limit: int = 50,
     after: str | None = None,
 ) -> ListResponse[SessionTemplate]:
+    """List session templates, newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+    """
     items = await service.list_session_templates(pool, limit=limit, after=after)
     return ListResponse[SessionTemplate](
         data=items,
@@ -54,15 +65,23 @@ async def list_(
     )
 
 
-@router.get("/{template_id}")
+@router.get("/{template_id}", operation_id="get_session_template")
 async def get(template_id: str, pool: PoolDep, _auth: AuthDep) -> SessionTemplate:
+    """Fetch one session template by id."""
     return await service.get_session_template(pool, template_id)
 
 
-@router.put("/{template_id}")
+@router.put("/{template_id}", operation_id="update_session_template")
 async def update(
     template_id: str, body: SessionTemplateUpdate, pool: PoolDep, _auth: AuthDep
 ) -> SessionTemplate:
+    """Update a session template's recipe fields. Omitted fields are preserved.
+
+    The ``agent_version`` field uses sentinel-based partial-update semantics:
+    omit it to preserve the current pin (or current "track latest" state),
+    pass null to switch to "track latest," pass a number to pin to that
+    specific version. Already-spawned sessions are unaffected.
+    """
     return await service.update_session_template(
         pool,
         template_id,
@@ -76,6 +95,18 @@ async def update(
     )
 
 
-@router.delete("/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{template_id}",
+    operation_id="archive_session_template",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
 async def delete(template_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+    """Archive a session template (soft-delete via DELETE verb).
+
+    Already-spawned sessions are unaffected and continue normally. Per-chat
+    connections that reference this template by id keep their existing
+    sessions but will fail to spawn new chat sessions at the inbound
+    handler until the connection is reconfigured to point at a different
+    template. There is no API surface to un-archive currently.
+    """
     await service.archive_session_template(pool, template_id)

--- a/src/aios/api/routers/skills.py
+++ b/src/aios/api/routers/skills.py
@@ -15,21 +15,32 @@ router = APIRouter(prefix="/v1/skills", tags=["skills"])
 # ── Skill endpoints ────────────────────────────────────────────────────────
 
 
-@router.post("", status_code=status.HTTP_201_CREATED)
+@router.post("", operation_id="create_skill", status_code=status.HTTP_201_CREATED)
 async def create(body: SkillCreate, pool: PoolDep, _auth: AuthDep) -> Skill:
+    """Create a new skill from an uploaded file bundle.
+
+    The bundle must include exactly one ``<directory>/SKILL.md`` file with
+    YAML frontmatter containing at least a ``name`` field. The skill's
+    ``directory``, ``name``, and ``description`` are extracted from that
+    frontmatter; subsequent versions reuse this extraction.
+    """
     skill, _version = await service.create_skill(
         pool, display_title=body.display_title, files=body.files
     )
     return skill
 
 
-@router.get("")
+@router.get("", operation_id="list_skills")
 async def list_(
     pool: PoolDep,
     _auth: AuthDep,
     limit: int = 50,
     after: str | None = None,
 ) -> ListResponse[Skill]:
+    """List skills (latest version of each), newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+    """
     items = await service.list_skills(pool, limit=limit, after=after)
     return ListResponse[Skill](
         data=items,
@@ -38,27 +49,45 @@ async def list_(
     )
 
 
-@router.get("/{skill_id}")
+@router.get("/{skill_id}", operation_id="get_skill")
 async def get(skill_id: str, pool: PoolDep, _auth: AuthDep) -> Skill:
+    """Fetch one skill by id, returning the latest version's config."""
     return await service.get_skill(pool, skill_id)
 
 
-@router.delete("/{skill_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{skill_id}", operation_id="archive_skill", status_code=status.HTTP_204_NO_CONTENT)
 async def archive(skill_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+    """Archive a skill: sets ``archived_at`` and hides it from default lists.
+
+    The row and version history persist; agents that reference this skill
+    by id continue to resolve their pinned versions. There is no API
+    surface to un-archive currently.
+    """
     await service.archive_skill(pool, skill_id)
 
 
 # ── Skill version endpoints ───────────────────────────────────────────────
 
 
-@router.post("/{skill_id}/versions", status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/{skill_id}/versions",
+    operation_id="create_skill_version",
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_version(
     skill_id: str, body: SkillVersionCreate, pool: PoolDep, _auth: AuthDep
 ) -> SkillVersion:
+    """Upload a new immutable version of a skill's file bundle.
+
+    The bundle must include the same SKILL.md frontmatter shape as the
+    initial create: directory, ``name``, ``description``. Each version is
+    a complete snapshot — files not present in the upload are not carried
+    over from previous versions.
+    """
     return await service.create_skill_version(pool, skill_id, files=body.files)
 
 
-@router.get("/{skill_id}/versions")
+@router.get("/{skill_id}/versions", operation_id="list_skill_versions")
 async def list_versions(
     skill_id: str,
     pool: PoolDep,
@@ -66,6 +95,12 @@ async def list_versions(
     limit: int = 50,
     after: int | None = None,
 ) -> ListResponse[SkillVersion]:
+    """List historical versions of a skill, newest first.
+
+    Cursor pagination by version number: pass ``after`` from a previous
+    response's ``next_after`` to get the next page. Each version is a
+    complete file-bundle snapshot at the time it was created.
+    """
     items = await service.list_skill_versions(pool, skill_id, limit=limit, after=after)
     return ListResponse[SkillVersion](
         data=items,
@@ -74,6 +109,11 @@ async def list_versions(
     )
 
 
-@router.get("/{skill_id}/versions/{version}")
+@router.get("/{skill_id}/versions/{version}", operation_id="get_skill_version")
 async def get_version(skill_id: str, version: int, pool: PoolDep, _auth: AuthDep) -> SkillVersion:
+    """Fetch one historical version's file bundle.
+
+    The bundle reflects the skill's state at the time the version was
+    written and is unaffected by subsequent versions or archival.
+    """
     return await service.get_skill_version(pool, skill_id, version)

--- a/src/aios/api/routers/vaults.py
+++ b/src/aios/api/routers/vaults.py
@@ -22,18 +22,27 @@ router = APIRouter(prefix="/v1/vaults", tags=["vaults"])
 # ── Vault endpoints ─────────────────────────────────────────────────────────
 
 
-@router.post("", status_code=status.HTTP_201_CREATED)
+@router.post("", operation_id="create_vault", status_code=status.HTTP_201_CREATED)
 async def create(body: VaultCreate, pool: PoolDep, _auth: AuthDep) -> Vault:
+    """Create a new vault — a named collection for MCP server credentials.
+
+    Credentials are added separately via ``create_vault_credential``.
+    """
     return await service.create_vault(pool, display_name=body.display_name, metadata=body.metadata)
 
 
-@router.get("")
+@router.get("", operation_id="list_vaults")
 async def list_(
     pool: PoolDep,
     _auth: AuthDep,
     limit: int = 50,
     after: str | None = None,
 ) -> ListResponse[Vault]:
+    """List vaults, newest first, excluding archived.
+
+    Cursor pagination: pass ``after`` from a previous response's
+    ``next_after`` to get the next page.
+    """
     items = await service.list_vaults(pool, limit=limit, after=after)
     return ListResponse[Vault](
         data=items,
@@ -42,32 +51,57 @@ async def list_(
     )
 
 
-@router.get("/{vault_id}")
+@router.get("/{vault_id}", operation_id="get_vault")
 async def get(vault_id: str, pool: PoolDep, _auth: AuthDep) -> Vault:
+    """Fetch one vault by id."""
     return await service.get_vault(pool, vault_id)
 
 
-@router.put("/{vault_id}")
+@router.put("/{vault_id}", operation_id="update_vault")
 async def update(vault_id: str, body: VaultUpdate, pool: PoolDep, _auth: AuthDep) -> Vault:
+    """Update a vault's ``display_name`` and/or ``metadata``.
+
+    Omitted fields are preserved.
+    """
     return await service.update_vault(
         pool, vault_id, display_name=body.display_name, metadata=body.metadata
     )
 
 
-@router.post("/{vault_id}/archive")
+@router.post("/{vault_id}/archive", operation_id="archive_vault")
 async def archive(vault_id: str, pool: PoolDep, _auth: AuthDep) -> Vault:
+    """Archive a vault and **purge the encrypted secret material** of its credentials.
+
+    Sets ``archived_at`` and hides the vault from default lists. In the same
+    transaction, every active credential is archived and its encrypted blob
+    is zeroed — the credential rows persist for audit but the stored secrets
+    are unrecoverable. Defense in depth: a future DB dump cannot leak
+    secrets that were already retired.
+
+    Use ``delete_vault`` instead if you want to remove the rows entirely.
+    """
     return await service.archive_vault(pool, vault_id)
 
 
-@router.delete("/{vault_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{vault_id}", operation_id="delete_vault", status_code=status.HTTP_204_NO_CONTENT)
 async def delete(vault_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+    """Hard-delete a vault and all its credentials (``ON DELETE CASCADE``).
+
+    Returns 204. Unlike ``archive_vault``, this removes the rows entirely
+    and leaves no audit trail. Prefer archive unless you specifically need
+    the rows gone.
+    """
     await service.delete_vault(pool, vault_id)
 
 
 # ── Vault credential endpoints ──────────────────────────────────────────────
 
 
-@router.post("/{vault_id}/credentials", status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/{vault_id}/credentials",
+    operation_id="create_vault_credential",
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_credential(
     vault_id: str,
     body: VaultCredentialCreate,
@@ -75,10 +109,19 @@ async def create_credential(
     crypto_box: CryptoBoxDep,
     _auth: AuthDep,
 ) -> VaultCredential:
+    """Add a credential to a vault. Secrets are encrypted at rest via the CryptoBox.
+
+    Validates required fields per ``auth_type``: ``mcp_oauth`` requires
+    ``access_token`` (plus the refresh fields needed for rotation);
+    ``static_bearer`` requires ``token``. Caps at 20 active credentials per
+    vault. The ``mcp_server_url`` is immutable after creation — to retarget
+    a credential, archive the existing one and create a new credential at
+    the new URL.
+    """
     return await service.create_vault_credential(pool, crypto_box, vault_id=vault_id, body=body)
 
 
-@router.get("/{vault_id}/credentials")
+@router.get("/{vault_id}/credentials", operation_id="list_vault_credentials")
 async def list_credentials(
     vault_id: str,
     pool: PoolDep,
@@ -86,6 +129,11 @@ async def list_credentials(
     limit: int = 50,
     after: str | None = None,
 ) -> ListResponse[VaultCredential]:
+    """List credentials in a vault, newest first, excluding archived.
+
+    Cursor pagination via ``after``. Secret material is never returned —
+    only metadata (display name, mcp_server_url, auth_type, timestamps).
+    """
     items = await service.list_vault_credentials(pool, vault_id, limit=limit, after=after)
     return ListResponse[VaultCredential](
         data=items,
@@ -94,14 +142,19 @@ async def list_credentials(
     )
 
 
-@router.get("/{vault_id}/credentials/{credential_id}")
+@router.get("/{vault_id}/credentials/{credential_id}", operation_id="get_vault_credential")
 async def get_credential(
     vault_id: str, credential_id: str, pool: PoolDep, _auth: AuthDep
 ) -> VaultCredential:
+    """Fetch one credential's metadata. Secrets are never returned.
+
+    Internal MCP clients resolve the secret directly through the service
+    layer (with OAuth refresh as needed); the HTTP API never exposes it.
+    """
     return await service.get_vault_credential(pool, vault_id, credential_id)
 
 
-@router.put("/{vault_id}/credentials/{credential_id}")
+@router.put("/{vault_id}/credentials/{credential_id}", operation_id="update_vault_credential")
 async def update_credential(
     vault_id: str,
     credential_id: str,
@@ -110,20 +163,47 @@ async def update_credential(
     crypto_box: CryptoBoxDep,
     _auth: AuthDep,
 ) -> VaultCredential:
+    """Update a credential's metadata and/or rotate its auth secrets.
+
+    Omitted secret fields are preserved (decrypt-merge-encrypt cycle on the
+    encrypted payload). ``mcp_server_url`` and ``auth_type`` are immutable
+    and not accepted in the body. To rotate an OAuth refresh token, send
+    only the new ``refresh_token`` (and optional ``access_token`` /
+    ``expires_at``); other auth fields stay intact.
+    """
     return await service.update_vault_credential(
         pool, crypto_box, vault_id=vault_id, credential_id=credential_id, body=body
     )
 
 
-@router.post("/{vault_id}/credentials/{credential_id}/archive")
+@router.post(
+    "/{vault_id}/credentials/{credential_id}/archive",
+    operation_id="archive_vault_credential",
+)
 async def archive_credential(
     vault_id: str, credential_id: str, pool: PoolDep, _auth: AuthDep
 ) -> VaultCredential:
+    """Archive a credential and **zero its encrypted secret payload**.
+
+    Sets ``archived_at`` and hides the credential from default lists. The
+    encrypted blob is scrubbed at archive time so a future DB dump cannot
+    leak the secret. Use ``delete_vault_credential`` for full removal.
+    """
     return await service.archive_vault_credential(pool, vault_id, credential_id)
 
 
-@router.delete("/{vault_id}/credentials/{credential_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{vault_id}/credentials/{credential_id}",
+    operation_id="delete_vault_credential",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
 async def delete_credential(
     vault_id: str, credential_id: str, pool: PoolDep, _auth: AuthDep
 ) -> None:
+    """Hard-delete a credential row. Returns 204.
+
+    Unlike ``archive_vault_credential``, removes the row entirely and
+    leaves no audit trail. Prefer archive unless you specifically need the
+    row gone.
+    """
     await service.delete_vault_credential(pool, vault_id, credential_id)


### PR DESCRIPTION
## Summary

Phase A of [#267](https://github.com/eumemic/aios/issues/267) — route hygiene (stable ``operation_id`` + docstrings) applied to the seven remaining unblocked routers, accumulated in one PR per the established practice for this kind of mechanical sweep.

| Router | Routes | Notes |
|---|---|---|
| ``health.py`` | 1 | Liveness probe |
| ``vaults.py`` | 12 | Vaults + nested credentials; documents the archive-zeros-secrets defense-in-depth behavior |
| ``skills.py`` | 7 | Skills + nested versions; documents SKILL.md frontmatter requirements + version-snapshot semantics |
| ``environments.py`` | 5 | Sandbox config templates; documents the JOIN-resolves-fresh behavior on update/archive |
| ``session_templates.py`` | 5 | Per_chat spawn recipes; documents the ``agent_version`` sentinel pattern |
| ``memory_stores.py`` | 14 | Stores + memories + versions; documents host-mirror, optimistic concurrency, soft-delete tombstones, redaction |
| ``connections.py`` | 12 | Connections + bind/unbind; documents archive-rejects-bound, unconfigure-preserves-bindings |

**Total: 56 routes stamped.** Combined with [#269](https://github.com/eumemic/aios/pull/269)'s agents.py (7 routes), this completes Phase A on the entire unblocked surface (63 of 87 routes). The remaining 24 are explicitly out of scope:

- ``sessions.py`` (18 routes) — blocked on [#270](https://github.com/eumemic/aios/issues/270) (PUT-replaces-list redesign for resource management); stamping operationIds before the route shapes are settled would lock in the trap with citable names.
- ``connectors.py`` (6 routes) — deferred per [#267](https://github.com/eumemic/aios/issues/267) (raw ``dict[str, Any]`` envelopes need Pydantic models authored first).

## Convention applied

- ``<verb>_<resource>`` for collection and item ops (``create_vault``, ``get_skill``, ``archive_environment``)
- ``<verb>_<parent>_<sub>`` for nested sub-resources where the sub-name needs disambiguation (``create_vault_credential``, ``list_skill_versions``)
- ``<verb>_<sub>`` for nested sub-resources whose name is already unambiguous in context (``create_memory``, ``list_memories``, ``redact_memory_version``)
- DELETE-as-archive routes get ``archive_<resource>`` operationIds (matching semantic, not HTTP verb) — consistent with the agents.py precedent
- Docstrings cover non-obvious WHY (concurrency models, side effects, cascade behaviors, mode-state preconditions); avoid restating verb + path

## openapi.json

The committed snapshot diffs cleanly per commit — each router commit produces operationId renames + new descriptions, no schema changes. End state has 56 of the 87 routes carrying clean operationIds; the remaining 24 (sessions + connectors) keep FastAPI's auto-derived form until they land separately.

## Test plan

- [x] ``bash scripts/run-checks.sh`` clean across the full sweep (mypy + ruff + 1158 unit tests including the openapi.json drift check)
- [x] ``bash scripts/regen-openapi.sh`` is idempotent at HEAD — no diff
- [x] All 56 new operationIds are unique (no collisions with each other or with the 31 unstamped auto-derived ones)
- [x] Per-commit per-router structure preserved for bisectability

## Per-commit structure

The branch has 7 atomic commits, one per router, each with the operationId stamp + docstrings + an updated openapi.json snapshot. Each commit is independently mypy/ruff/test clean. Reviewers can step through router-by-router or read the squashed diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)