### PR TITLE
feat(sdk): typed Python SDK + porcelain refactor (#267)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5895,7 +5895,7 @@
           },
           "tools": {
             "items": {
-              "$ref": "#/components/schemas/ToolSpec-Output"
+              "$ref": "#/components/schemas/ToolSpec"
             },
             "type": "array",
             "title": "Tools"
@@ -6007,7 +6007,7 @@
           },
           "tools": {
             "items": {
-              "$ref": "#/components/schemas/ToolSpec-Input"
+              "$ref": "#/components/schemas/ToolSpec"
             },
             "type": "array",
             "title": "Tools"
@@ -6144,7 +6144,7 @@
             "anyOf": [
               {
                 "items": {
-                  "$ref": "#/components/schemas/ToolSpec-Input"
+                  "$ref": "#/components/schemas/ToolSpec"
                 },
                 "type": "array"
               },
@@ -6270,7 +6270,7 @@
           },
           "tools": {
             "items": {
-              "$ref": "#/components/schemas/ToolSpec-Output"
+              "$ref": "#/components/schemas/ToolSpec"
             },
             "type": "array",
             "title": "Tools"
@@ -6767,10 +6767,54 @@
             "type": "object",
             "title": "Data"
           },
+          "cumulative_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cumulative Tokens"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
+          },
+          "orig_channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Orig Channel"
+          },
+          "focal_channel_at_arrival": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Channel At Arrival"
+          },
+          "channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Channel"
           }
         },
         "type": "object",
@@ -9152,135 +9196,7 @@
         "title": "ToolResultRequest",
         "description": "Request body for ``POST /v1/sessions/{id}/tool-results``."
       },
-      "ToolSpec-Input": {
-        "properties": {
-          "type": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "bash",
-                  "read",
-                  "write",
-                  "edit",
-                  "glob",
-                  "grep",
-                  "web_fetch",
-                  "web_search",
-                  "search_events",
-                  "cancel",
-                  "schedule_wake"
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "custom",
-                  "mcp_toolset"
-                ]
-              }
-            ],
-            "title": "Type"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "input_schema": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Input Schema"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "default": true
-          },
-          "permission": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "always_allow",
-                  "always_ask"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Permission"
-          },
-          "mcp_server_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Mcp Server Name"
-          },
-          "default_config": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/McpToolsetConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "configs": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/McpToolConfig"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Configs"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "title": "ToolSpec",
-        "description": "One entry in an agent's ``tools`` list.\n\nFor built-in tools, ``type`` is the tool name (``\"bash\"``, ``\"read\"``,\netc.). For custom (client-executed) tools, ``type`` is ``\"custom\"`` and\n``name``, ``description``, and ``input_schema`` are required. For MCP\ntoolsets, ``type`` is ``\"mcp_toolset\"`` and ``mcp_server_name`` is\nrequired.\n\n``enabled`` controls whether the tool is included in the schema sent to\nthe model. Disabled tools are invisible to the model.\n\n``permission`` controls execution policy for built-in tools:\n``None`` or ``\"always_allow\"`` executes immediately (current default);\n``\"always_ask\"`` idles the session with ``requires_action`` until the\nclient confirms or denies."
-      },
-      "ToolSpec-Output": {
+      "ToolSpec": {
         "properties": {
           "type": {
             "anyOf": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "testcontainers[postgres]>=4.8",
     "ruff>=0.8",
     "mypy>=1.13",
+    "openapi-python-client>=0.21",
     # Workspace-installed reference SDK + canonical echo example.  The
     # echo connector exposes the ``aios.connectors`` entry point the
     # supervisor's resolver looks up, so e2e tests exercising the full
@@ -88,6 +89,9 @@ aios-echo = { workspace = true }
 line-length = 100
 target-version = "py313"
 src = ["src", "tests"]
+# Build artifact from scripts/regen-client.sh; lint complaints belong
+# upstream in openapi-python-client, not in this repo.
+extend-exclude = ["src/aios/sdk/_generated"]
 
 [tool.ruff.lint]
 select = [
@@ -143,6 +147,13 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
+
+# Build artifact from scripts/regen-client.sh; type complaints belong
+# upstream in openapi-python-client, not here.
+[[tool.mypy.overrides]]
+module = "aios.sdk._generated.*"
+ignore_errors = true
+follow_imports = "skip"
 
 # ─── pytest ──────────────────────────────────────────────────────────────────
 [tool.pytest.ini_options]

--- a/scripts/regen-client.sh
+++ b/scripts/regen-client.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Regenerate the typed Python SDK at src/aios/sdk/_generated/ from the
+# canonical OpenAPI spec at openapi.json.
+#
+# Usage:
+#   ./scripts/regen-client.sh
+#
+# Run this after any change to FastAPI route signatures, response_models,
+# operation_ids, or response shapes. Commit both openapi.json and the
+# regenerated _generated/ together.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# 1. Refresh the spec snapshot (the SDK is downstream of openapi.json).
+bash scripts/regen-openapi.sh
+
+# 2. Generate into a tmp dir, then sync into src/aios/sdk/_generated/.
+#    --meta none drops the standalone-package wrapper (no pyproject/README);
+#    relative imports inside the generated code work no matter what name
+#    we mount it under.
+WORK=$(mktemp -d)
+trap "rm -rf $WORK" EXIT
+
+uv run openapi-python-client generate \
+  --path openapi.json \
+  --output-path "$WORK" \
+  --meta none \
+  --overwrite
+
+mkdir -p src/aios/sdk/_generated
+rsync -a --delete --exclude=".ruff_cache" "$WORK/" src/aios/sdk/_generated/
+
+py_count=$(find src/aios/sdk/_generated -name '*.py' | wc -l | awk '{print $1}')
+echo "regenerated src/aios/sdk/_generated/ ($py_count py files)"

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -73,6 +73,11 @@ def create_app() -> FastAPI:
         description="Open-source agent runtime: Postgres-backed sessions, "
         "Docker sandbox, any LiteLLM model.",
         lifespan=lifespan,
+        # One schema per Pydantic model (not a Foo-Input / Foo-Output pair).
+        # We use distinct ``Foo`` / ``FooCreate`` / ``FooUpdate`` types instead
+        # of the read-only-field split, and the hyphenated split-schema names
+        # break openapi-python-client when it generates the typed SDK.
+        separate_input_output_schemas=False,
     )
     install_exception_handlers(app)
     app.include_router(health.router)

--- a/src/aios/cli/commands/sessions.py
+++ b/src/aios/cli/commands/sessions.py
@@ -22,6 +22,7 @@ from aios.cli.output import cyan, dim, print_error, print_json, print_success
 from aios.cli.profile import compute_profile, profile_to_dict, render_profile
 from aios.cli.runtime import get_state, run_or_die
 from aios.cli.tail_format import iter_formatted_events
+from aios.sdk import stream_session
 
 app = typer.Typer(name="sessions", help="Manage sessions.", no_args_is_help=True)
 
@@ -352,8 +353,8 @@ def stream(
         if pretty:
             tail_session(ctx, session_id, after_seq=after_seq)
             return
-        client = get_state(ctx).client()
-        with client, client.stream_session(session_id, after_seq=after_seq) as messages:
+        client = get_state(ctx).sdk_client()
+        with client, stream_session(client, session_id, after_seq=after_seq) as messages:
             for msg in messages:
                 if raw:
                     sys.stdout.write(json.dumps({"event": msg.event, "data": msg.data}) + "\n")
@@ -383,8 +384,8 @@ def tail(
 
 def tail_session(ctx: typer.Context, session_id: str, *, after_seq: int) -> None:
     """Shared implementation for ``aios sessions tail`` / top-level ``aios tail``."""
-    client = get_state(ctx).client()
-    with client, client.stream_session(session_id, after_seq=after_seq) as messages:
+    client = get_state(ctx).sdk_client()
+    with client, stream_session(client, session_id, after_seq=after_seq) as messages:
         for line in iter_formatted_events(messages):
             sys.stdout.write(line + "\n")
             sys.stdout.flush()

--- a/src/aios/cli/commands/status.py
+++ b/src/aios/cli/commands/status.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import sys
 
+import httpx
 import typer
 
-from aios.cli.client import AiosApiError, NonJSONResponseError
 from aios.cli.output import cyan, green, print_json, red, yellow
-from aios.cli.runtime import get_state, run_or_die
+from aios.cli.runtime import CliState, get_state, run_or_die
+from aios.sdk._generated.api.agents import list_agents
+from aios.sdk._generated.api.default import get_health
 
 
 def register(app: typer.Typer) -> None:
@@ -26,63 +29,77 @@ def register(app: typer.Typer) -> None:
 
         run_or_die(_run)
 
-    def _run_text(state) -> int:  # type: ignore[no-untyped-def]
-        sys.stdout.write(f"url:     {cyan(state.base_url)}\n")
-        sys.stdout.write(
-            f"api key: {'set' if state.api_key else yellow('not set (no auth header sent)')}\n"
-        )
-        client = state.client()
-        try:
-            health = client.request("GET", "/health")
-            sys.stdout.write(f"health:  {green('ok')} ({health})\n")
-        except NonJSONResponseError:
-            sys.stdout.write(
-                f"health:  {red('fail')} (server returned non-JSON response (not aios?))\n"
-            )
-            return 1
-        except AiosApiError as exc:
-            sys.stdout.write(f"health:  {red('fail')} ({exc.message})\n")
-            return 1
-        if not state.api_key:
-            return 0
-        try:
-            client.request("GET", "/v1/agents", params={"limit": 1})
-            sys.stdout.write(f"auth:    {green('ok')}\n")
-        except AiosApiError as exc:
-            if exc.status_code == 401:
-                sys.stdout.write(f"auth:    {red('unauthorized')} — check AIOS_API_KEY\n")
-                return 2
-            sys.stdout.write(f"auth:    {red('fail')} ({exc.error_type}: {exc.message})\n")
-            return 1
-        return 0
 
-    def _run_json(state) -> int:  # type: ignore[no-untyped-def]
-        client = state.client()
-        payload: dict[str, object] = {"url": state.base_url, "api_key_set": bool(state.api_key)}
-        try:
-            payload["health"] = client.request("GET", "/health")
-        except NonJSONResponseError as exc:
-            payload["health_error"] = {
-                "type": "non_json_response",
-                "message": "server returned non-JSON response (not aios?)",
-                "content_type": exc.content_type,
-            }
-            print_json(payload)
-            return 1
-        except AiosApiError as exc:
-            payload["health_error"] = {"type": exc.error_type, "message": exc.message}
-            print_json(payload)
-            return 1
-        if not state.api_key:
-            print_json(payload)
-            return 0
-        try:
-            client.request("GET", "/v1/agents", params={"limit": 1})
-            payload["auth"] = "ok"
-        except AiosApiError as exc:
-            payload["auth"] = "unauthorized" if exc.status_code == 401 else "fail"
-            payload["auth_error"] = {"type": exc.error_type, "message": exc.message}
-            print_json(payload)
-            return 2 if exc.status_code == 401 else 1
+def _check_health(state: CliState) -> tuple[dict[str, str] | None, str, str | None]:
+    """Probe ``/health``. Returns ``(payload, kind, message)``.
+
+    ``kind`` is ``"ok"``, ``"non_json_response"`` (server returned non-JSON — likely
+    not aios), ``"connection"``, or ``"http"``. ``payload`` is non-None
+    only when ``kind == "ok"``; ``message`` is non-None on errors.
+    """
+    client = state.sdk_client()
+    try:
+        response = get_health.sync_detailed(client=client)
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        return None, "connection", f"connection error: {exc}"
+    except json.JSONDecodeError:
+        return None, "non_json_response", "server returned non-JSON response (not aios?)"
+    if response.status_code != 200:
+        return None, "http", f"HTTP {response.status_code}"
+    return json.loads(response.content), "ok", None
+
+
+def _check_auth(state: CliState) -> tuple[str, int]:
+    """Probe ``/v1/agents`` to verify the API key. Returns ``(kind, status_code)``.
+
+    ``kind`` is ``"ok"``, ``"unauthorized"`` (401), or ``"fail"``.
+    """
+    client = state.sdk_client()
+    response = list_agents.sync_detailed(client=client, limit=1)
+    if response.status_code == 200:
+        return "ok", 200
+    if response.status_code == 401:
+        return "unauthorized", 401
+    return "fail", int(response.status_code)
+
+
+def _run_text(state: CliState) -> int:
+    sys.stdout.write(f"url:     {cyan(state.base_url)}\n")
+    sys.stdout.write(
+        f"api key: {'set' if state.api_key else yellow('not set (no auth header sent)')}\n"
+    )
+    payload, kind, message = _check_health(state)
+    if kind != "ok":
+        sys.stdout.write(f"health:  {red('fail')} ({message})\n")
+        return 1
+    sys.stdout.write(f"health:  {green('ok')} ({payload})\n")
+    if not state.api_key:
+        return 0
+    auth_kind, status_code = _check_auth(state)
+    if auth_kind == "ok":
+        sys.stdout.write(f"auth:    {green('ok')}\n")
+        return 0
+    if auth_kind == "unauthorized":
+        sys.stdout.write(f"auth:    {red('unauthorized')} — check AIOS_API_KEY\n")
+        return 2
+    sys.stdout.write(f"auth:    {red('fail')} (HTTP {status_code})\n")
+    return 1
+
+
+def _run_json(state: CliState) -> int:
+    payload: dict[str, object] = {"url": state.base_url, "api_key_set": bool(state.api_key)}
+    health, kind, message = _check_health(state)
+    if kind != "ok":
+        payload["health_error"] = {"type": kind, "message": message}
+        print_json(payload)
+        return 1
+    payload["health"] = health
+    if not state.api_key:
         print_json(payload)
         return 0
+    auth_kind, status_code = _check_auth(state)
+    payload["auth"] = auth_kind
+    if auth_kind != "ok":
+        payload["auth_error"] = {"type": auth_kind, "status": status_code}
+    print_json(payload)
+    return 0 if auth_kind == "ok" else (2 if auth_kind == "unauthorized" else 1)

--- a/src/aios/cli/commands/status.py
+++ b/src/aios/cli/commands/status.py
@@ -10,6 +10,7 @@ import typer
 
 from aios.cli.output import cyan, green, print_json, red, yellow
 from aios.cli.runtime import CliState, get_state, run_or_die
+from aios.sdk import Client
 from aios.sdk._generated.api.agents import list_agents
 from aios.sdk._generated.api.default import get_health
 
@@ -23,38 +24,36 @@ def register(app: typer.Typer) -> None:
         state = get_state(ctx)
 
         def _run() -> int:
-            if state.output_format == "json":
-                return _run_json(state)
-            return _run_text(state)
+            with state.sdk_client() as client:
+                if state.output_format == "json":
+                    return _run_json(state, client)
+                return _run_text(state, client)
 
         run_or_die(_run)
 
 
-def _check_health(state: CliState) -> tuple[dict[str, str] | None, str, str | None]:
+def _check_health(client: Client) -> tuple[dict[str, str] | None, str, str | None]:
     """Probe ``/health``. Returns ``(payload, kind, message)``.
 
-    ``kind`` is ``"ok"``, ``"non_json_response"`` (server returned non-JSON — likely
-    not aios), ``"connection"``, or ``"http"``. ``payload`` is non-None
-    only when ``kind == "ok"``; ``message`` is non-None on errors.
+    ``kind`` is ``"ok"``, ``"non_json_response"`` (server returned
+    non-JSON — likely not aios), ``"connection"``, or ``"http"``.
     """
-    client = state.sdk_client()
     try:
         response = get_health.sync_detailed(client=client)
     except (httpx.ConnectError, httpx.TimeoutException) as exc:
         return None, "connection", f"connection error: {exc}"
     except json.JSONDecodeError:
         return None, "non_json_response", "server returned non-JSON response (not aios?)"
-    if response.status_code != 200:
+    if response.status_code != 200 or response.parsed is None:
         return None, "http", f"HTTP {response.status_code}"
-    return json.loads(response.content), "ok", None
+    return response.parsed.to_dict(), "ok", None
 
 
-def _check_auth(state: CliState) -> tuple[str, int]:
+def _check_auth(client: Client) -> tuple[str, int]:
     """Probe ``/v1/agents`` to verify the API key. Returns ``(kind, status_code)``.
 
     ``kind`` is ``"ok"``, ``"unauthorized"`` (401), or ``"fail"``.
     """
-    client = state.sdk_client()
     response = list_agents.sync_detailed(client=client, limit=1)
     if response.status_code == 200:
         return "ok", 200
@@ -63,19 +62,19 @@ def _check_auth(state: CliState) -> tuple[str, int]:
     return "fail", int(response.status_code)
 
 
-def _run_text(state: CliState) -> int:
+def _run_text(state: CliState, client: Client) -> int:
     sys.stdout.write(f"url:     {cyan(state.base_url)}\n")
     sys.stdout.write(
         f"api key: {'set' if state.api_key else yellow('not set (no auth header sent)')}\n"
     )
-    payload, kind, message = _check_health(state)
+    payload, kind, message = _check_health(client)
     if kind != "ok":
         sys.stdout.write(f"health:  {red('fail')} ({message})\n")
         return 1
     sys.stdout.write(f"health:  {green('ok')} ({payload})\n")
     if not state.api_key:
         return 0
-    auth_kind, status_code = _check_auth(state)
+    auth_kind, status_code = _check_auth(client)
     if auth_kind == "ok":
         sys.stdout.write(f"auth:    {green('ok')}\n")
         return 0
@@ -86,9 +85,9 @@ def _run_text(state: CliState) -> int:
     return 1
 
 
-def _run_json(state: CliState) -> int:
+def _run_json(state: CliState, client: Client) -> int:
     payload: dict[str, object] = {"url": state.base_url, "api_key_set": bool(state.api_key)}
-    health, kind, message = _check_health(state)
+    health, kind, message = _check_health(client)
     if kind != "ok":
         payload["health_error"] = {"type": kind, "message": message}
         print_json(payload)
@@ -97,7 +96,7 @@ def _run_json(state: CliState) -> int:
     if not state.api_key:
         print_json(payload)
         return 0
-    auth_kind, status_code = _check_auth(state)
+    auth_kind, status_code = _check_auth(client)
     payload["auth"] = auth_kind
     if auth_kind != "ok":
         payload["auth_error"] = {"type": auth_kind, "status": status_code}

--- a/src/aios/cli/config.py
+++ b/src/aios/cli/config.py
@@ -1,28 +1,16 @@
-"""CLI URL resolution.
+"""CLI URL resolution — re-export shim.
 
-The CLI reads ``AIOS_URL`` / ``AIOS_API_KEY`` / ``AIOS_API_PORT`` from the
+The canonical implementation lives in :mod:`aios.sdk.config` so the SDK
+package is import-root-clean (no transitive ``aios.cli`` pull-in). The
+CLI reads ``AIOS_URL`` / ``AIOS_API_KEY`` / ``AIOS_API_PORT`` from the
 process environment via typer's ``envvar=`` — there is deliberately no
 second config surface. For ``.env`` loading, callers run
-``set -a; source .env; set +a`` before invoking ``aios``, the same pattern
-used for the operator commands (alembic, procrastinate).
+``set -a; source .env; set +a`` before invoking ``aios``, the same
+pattern used for the operator commands (alembic, procrastinate).
 """
 
 from __future__ import annotations
 
-import os
+from aios.sdk.config import resolve_base_url
 
-
-def resolve_base_url(override: str | None) -> str:
-    """Pick the effective API base URL.
-
-    Priority: explicit flag > ``AIOS_URL`` env > ``http://127.0.0.1:{AIOS_API_PORT}``.
-    The last fallback mirrors the playground pattern where the operator sets
-    ``AIOS_API_PORT`` (e.g. 8090) but never ``AIOS_URL`` explicitly.
-    """
-    if override is not None:
-        return override.rstrip("/")
-    env_url = os.environ.get("AIOS_URL")
-    if env_url:
-        return env_url.rstrip("/")
-    port = os.environ.get("AIOS_API_PORT", "8080")
-    return f"http://127.0.0.1:{port}"
+__all__ = ["resolve_base_url"]

--- a/src/aios/cli/runtime.py
+++ b/src/aios/cli/runtime.py
@@ -12,11 +12,15 @@ import os
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import typer
 
 from aios.cli.client import AiosApiError, AiosClient
 from aios.cli.output import OutputFormat, print_error
+
+if TYPE_CHECKING:
+    from aios.sdk import Client
 
 
 @dataclass(slots=True)
@@ -30,6 +34,19 @@ class CliState:
 
     def client(self) -> AiosClient:
         return AiosClient(base_url=self.base_url, api_key=self.api_key)
+
+    def sdk_client(self) -> Client:
+        """Build a typed SDK ``Client`` from the resolved base_url + api_key.
+
+        Used by the porcelain modules that have migrated off the
+        hand-written ``AiosClient`` (``status``, ``tail``, the streaming
+        subcommands of ``sessions``). The hand-written client stays for
+        the remaining commands (CRUD modules, ``chat``, sessions
+        ``events``) until they migrate too.
+        """
+        from aios.sdk import Client
+
+        return Client(base_url=self.base_url, token=self.api_key or "")
 
 
 def get_state(ctx: typer.Context) -> CliState:

--- a/src/aios/cli/runtime.py
+++ b/src/aios/cli/runtime.py
@@ -43,6 +43,12 @@ class CliState:
         subcommands of ``sessions``). The hand-written client stays for
         the remaining commands (CRUD modules, ``chat``, sessions
         ``events``) until they migrate too.
+
+        Unlike :func:`aios.sdk.client_from_env`, this accepts a missing
+        ``api_key`` and constructs a Client with an empty Bearer token —
+        the ``aios status`` command needs to probe an unauthenticated
+        ``/health`` and report whether ``AIOS_API_KEY`` was set, so a
+        raise-on-missing surface here would be the wrong default.
         """
         from aios.sdk import Client
 

--- a/src/aios/cli/sse.py
+++ b/src/aios/cli/sse.py
@@ -1,62 +1,14 @@
-"""Synchronous Server-Sent Events parser for the client.
+"""SSE parser re-export shim.
 
-The aios API emits three event names on ``GET /v1/sessions/{id}/stream``:
-
-* ``event``  — a full event row (``{"id","session_id","seq","kind","data",...}``)
-* ``delta``  — a streaming text chunk for an in-progress assistant message
-  (``{"delta": "..."}``).
-* ``done``   — session-terminated marker; stream will close after this.
-
-Each SSE message is a block of lines followed by a blank line. We only
-care about ``event:`` and ``data:`` lines; other directives (``id:``,
-``retry:``, comments beginning with ``:``) are ignored.
+The canonical home for ``SseMessage`` and ``parse_sse_lines`` is
+:mod:`aios.sdk.streaming` — the SDK owns the streaming surface so plugin
+authors and external scripts have a single import root. This module
+stays as a thin re-export so existing imports inside ``aios.cli`` keep
+working without churn during the Phase C refactor (#267).
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
-from dataclasses import dataclass
+from aios.sdk.streaming import SseMessage, parse_sse_lines
 
-
-@dataclass(frozen=True, slots=True)
-class SseMessage:
-    """A single parsed SSE message."""
-
-    event: str
-    data: str
-
-
-def parse_sse_lines(lines: Iterable[str]) -> Iterator[SseMessage]:
-    """Yield :class:`SseMessage` values from an SSE line iterator.
-
-    ``lines`` is expected to be individual lines WITHOUT trailing newlines
-    (what ``httpx.Response.iter_lines()`` produces). A blank line closes the
-    current message. Missing ``event:`` defaults to ``"message"`` per the
-    SSE spec, but aios always sets it explicitly.
-    """
-    event: str = "message"
-    data_parts: list[str] = []
-
-    for raw in lines:
-        if raw == "":
-            if data_parts:
-                yield SseMessage(event=event, data="\n".join(data_parts))
-            event = "message"
-            data_parts = []
-            continue
-        if raw.startswith(":"):
-            # Comment / keep-alive ping. Ignore.
-            continue
-        field, _, value = raw.partition(":")
-        # Per SSE spec, a single leading space after the colon is stripped.
-        if value.startswith(" "):
-            value = value[1:]
-        if field == "event":
-            event = value
-        elif field == "data":
-            data_parts.append(value)
-        # Other fields (id, retry) are ignored.
-
-    # Flush any trailing message without a blank-line terminator.
-    if data_parts:
-        yield SseMessage(event=event, data="\n".join(data_parts))
+__all__ = ["SseMessage", "parse_sse_lines"]

--- a/src/aios/sdk/__init__.py
+++ b/src/aios/sdk/__init__.py
@@ -1,0 +1,35 @@
+"""Typed Python SDK for the aios management plane.
+
+The bulk of this package is auto-generated from ``openapi.json`` via
+``scripts/regen-client.sh`` and lives at :mod:`aios.sdk._generated`. This
+module re-exports the curated public surface; advanced callers wanting
+a specific operation module reach into ``aios.sdk._generated.api.<tag>.<op>``.
+
+Typical usage::
+
+    from aios.sdk import Client, client_from_env, stream_session
+    from aios.sdk._generated.api.agents import list_agents
+
+    client = client_from_env()
+    response = list_agents.sync_detailed(client=client)
+
+    with stream_session(client, session_id) as events:
+        for msg in events:
+            print(msg.event, msg.data)
+"""
+
+from __future__ import annotations
+
+from aios.sdk._generated import AuthenticatedClient as Client
+from aios.sdk._generated.errors import UnexpectedStatus
+from aios.sdk.factory import client_from_env
+from aios.sdk.streaming import SseMessage, parse_sse_lines, stream_session
+
+__all__ = [
+    "Client",
+    "SseMessage",
+    "UnexpectedStatus",
+    "client_from_env",
+    "parse_sse_lines",
+    "stream_session",
+]

--- a/src/aios/sdk/_generated/__init__.py
+++ b/src/aios/sdk/_generated/__init__.py
@@ -1,0 +1,8 @@
+"""A client library for accessing aios"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/src/aios/sdk/_generated/api/__init__.py
+++ b/src/aios/sdk/_generated/api/__init__.py
@@ -1,0 +1,1 @@
+"""Contains methods for accessing the API"""

--- a/src/aios/sdk/_generated/api/agents/__init__.py
+++ b/src/aios/sdk/_generated/api/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/src/aios/sdk/_generated/api/agents/archive_agent.py
+++ b/src/aios/sdk/_generated/api/agents/archive_agent.py
@@ -1,0 +1,197 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    agent_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/agents/{agent_id}".format(
+            agent_id=quote(str(agent_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Archive
+
+     Archive an agent: sets ``archived_at`` and hides it from default lists.
+
+    The row and all version history persist; sessions referencing the agent
+    continue to function. There is no API surface to un-archive currently.
+
+    Args:
+        agent_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Archive
+
+     Archive an agent: sets ``archived_at`` and hides it from default lists.
+
+    The row and all version history persist; sessions referencing the agent
+    continue to function. There is no API surface to un-archive currently.
+
+    Args:
+        agent_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        agent_id=agent_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Archive
+
+     Archive an agent: sets ``archived_at`` and hides it from default lists.
+
+    The row and all version history persist; sessions referencing the agent
+    continue to function. There is no API surface to un-archive currently.
+
+    Args:
+        agent_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Archive
+
+     Archive an agent: sets ``archived_at`` and hides it from default lists.
+
+    The row and all version history persist; sessions referencing the agent
+    continue to function. There is no API surface to un-archive currently.
+
+    Args:
+        agent_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            agent_id=agent_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/agents/create_agent.py
+++ b/src/aios/sdk/_generated/api/agents/create_agent.py
@@ -1,0 +1,201 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.agent import Agent
+from ...models.agent_create import AgentCreate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: AgentCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/agents",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Agent | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = Agent.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Agent | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: AgentCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Agent | HTTPValidationError]:
+    """Create
+
+     Create a new agent at version 1.
+
+    Subsequent updates produce new immutable versions in the history; see
+    ``update_agent`` and ``list_agent_versions``.
+
+    Args:
+        authorization (None | str | Unset):
+        body (AgentCreate): Request body for `POST /v1/agents`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Agent | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: AgentCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Agent | HTTPValidationError | None:
+    """Create
+
+     Create a new agent at version 1.
+
+    Subsequent updates produce new immutable versions in the history; see
+    ``update_agent`` and ``list_agent_versions``.
+
+    Args:
+        authorization (None | str | Unset):
+        body (AgentCreate): Request body for `POST /v1/agents`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Agent | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: AgentCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Agent | HTTPValidationError]:
+    """Create
+
+     Create a new agent at version 1.
+
+    Subsequent updates produce new immutable versions in the history; see
+    ``update_agent`` and ``list_agent_versions``.
+
+    Args:
+        authorization (None | str | Unset):
+        body (AgentCreate): Request body for `POST /v1/agents`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Agent | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: AgentCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Agent | HTTPValidationError | None:
+    """Create
+
+     Create a new agent at version 1.
+
+    Subsequent updates produce new immutable versions in the history; see
+    ``update_agent`` and ``list_agent_versions``.
+
+    Args:
+        authorization (None | str | Unset):
+        body (AgentCreate): Request body for `POST /v1/agents`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Agent | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/agents/get_agent.py
+++ b/src/aios/sdk/_generated/api/agents/get_agent.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.agent import Agent
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    agent_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/agents/{agent_id}".format(
+            agent_id=quote(str(agent_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Agent | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Agent.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Agent | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Agent | HTTPValidationError]:
+    """Get
+
+     Fetch one agent by id, returning the latest version's config.
+
+    Args:
+        agent_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Agent | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Agent | HTTPValidationError | None:
+    """Get
+
+     Fetch one agent by id, returning the latest version's config.
+
+    Args:
+        agent_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Agent | HTTPValidationError
+    """
+
+    return sync_detailed(
+        agent_id=agent_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Agent | HTTPValidationError]:
+    """Get
+
+     Fetch one agent by id, returning the latest version's config.
+
+    Args:
+        agent_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Agent | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Agent | HTTPValidationError | None:
+    """Get
+
+     Fetch one agent by id, returning the latest version's config.
+
+    Args:
+        agent_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Agent | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            agent_id=agent_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/agents/get_agent_version.py
+++ b/src/aios/sdk/_generated/api/agents/get_agent_version.py
@@ -1,0 +1,213 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.agent_version import AgentVersion
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    agent_id: str,
+    version: int,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/agents/{agent_id}/versions/{version}".format(
+            agent_id=quote(str(agent_id), safe=""),
+            version=quote(str(version), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> AgentVersion | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = AgentVersion.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[AgentVersion | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    agent_id: str,
+    version: int,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[AgentVersion | HTTPValidationError]:
+    """Get Version
+
+     Fetch one historical version's config snapshot.
+
+    The snapshot reflects the agent's config at the time the version was
+    written and is unaffected by subsequent updates or archival.
+
+    Args:
+        agent_id (str):
+        version (int):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AgentVersion | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+        version=version,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    agent_id: str,
+    version: int,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> AgentVersion | HTTPValidationError | None:
+    """Get Version
+
+     Fetch one historical version's config snapshot.
+
+    The snapshot reflects the agent's config at the time the version was
+    written and is unaffected by subsequent updates or archival.
+
+    Args:
+        agent_id (str):
+        version (int):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AgentVersion | HTTPValidationError
+    """
+
+    return sync_detailed(
+        agent_id=agent_id,
+        version=version,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    agent_id: str,
+    version: int,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[AgentVersion | HTTPValidationError]:
+    """Get Version
+
+     Fetch one historical version's config snapshot.
+
+    The snapshot reflects the agent's config at the time the version was
+    written and is unaffected by subsequent updates or archival.
+
+    Args:
+        agent_id (str):
+        version (int):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AgentVersion | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+        version=version,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    agent_id: str,
+    version: int,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> AgentVersion | HTTPValidationError | None:
+    """Get Version
+
+     Fetch one historical version's config snapshot.
+
+    The snapshot reflects the agent's config at the time the version was
+    written and is unaffected by subsequent updates or archival.
+
+    Args:
+        agent_id (str):
+        version (int):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AgentVersion | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            agent_id=agent_id,
+            version=version,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/agents/list_agent_versions.py
+++ b/src/aios/sdk/_generated/api/agents/list_agent_versions.py
@@ -1,0 +1,243 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_agent_version import ListResponseAgentVersion
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    agent_id: str,
+    *,
+    limit: int | Unset = 50,
+    after: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    json_after: int | None | Unset
+    if isinstance(after, Unset):
+        json_after = UNSET
+    else:
+        json_after = after
+    params["after"] = json_after
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/agents/{agent_id}/versions".format(
+            agent_id=quote(str(agent_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseAgentVersion | None:
+    if response.status_code == 200:
+        response_200 = ListResponseAgentVersion.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseAgentVersion]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseAgentVersion]:
+    """List Versions
+
+     List historical versions of an agent, newest first.
+
+    Cursor pagination by version number: pass ``after`` from a previous
+    response's ``next_after`` to get the next page. Each version is a
+    complete snapshot of the agent's config at the time it was created.
+
+    Args:
+        agent_id (str):
+        limit (int | Unset):  Default: 50.
+        after (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseAgentVersion]
+    """
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseAgentVersion | None:
+    """List Versions
+
+     List historical versions of an agent, newest first.
+
+    Cursor pagination by version number: pass ``after`` from a previous
+    response's ``next_after`` to get the next page. Each version is a
+    complete snapshot of the agent's config at the time it was created.
+
+    Args:
+        agent_id (str):
+        limit (int | Unset):  Default: 50.
+        after (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseAgentVersion
+    """
+
+    return sync_detailed(
+        agent_id=agent_id,
+        client=client,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseAgentVersion]:
+    """List Versions
+
+     List historical versions of an agent, newest first.
+
+    Cursor pagination by version number: pass ``after`` from a previous
+    response's ``next_after`` to get the next page. Each version is a
+    complete snapshot of the agent's config at the time it was created.
+
+    Args:
+        agent_id (str):
+        limit (int | Unset):  Default: 50.
+        after (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseAgentVersion]
+    """
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseAgentVersion | None:
+    """List Versions
+
+     List historical versions of an agent, newest first.
+
+    Cursor pagination by version number: pass ``after`` from a previous
+    response's ``next_after`` to get the next page. Each version is a
+    complete snapshot of the agent's config at the time it was created.
+
+    Args:
+        agent_id (str):
+        limit (int | Unset):  Default: 50.
+        after (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseAgentVersion
+    """
+
+    return (
+        await asyncio_detailed(
+            agent_id=agent_id,
+            client=client,
+            limit=limit,
+            after=after,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/agents/list_agents.py
+++ b/src/aios/sdk/_generated/api/agents/list_agents.py
@@ -1,0 +1,247 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_agent import ListResponseAgent
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    name: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    json_after: None | str | Unset
+    if isinstance(after, Unset):
+        json_after = UNSET
+    else:
+        json_after = after
+    params["after"] = json_after
+
+    json_name: None | str | Unset
+    if isinstance(name, Unset):
+        json_name = UNSET
+    else:
+        json_name = name
+    params["name"] = json_name
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/agents",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseAgent | None:
+    if response.status_code == 200:
+        response_200 = ListResponseAgent.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseAgent]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    name: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseAgent]:
+    """List
+
+     List agents (latest version of each), newest first, excluding archived.
+
+    Cursor pagination: pass ``after`` from a previous response's
+    ``next_after`` to get the next page. Optional ``name`` filter matches
+    exactly.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        name (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseAgent]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        after=after,
+        name=name,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    name: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseAgent | None:
+    """List
+
+     List agents (latest version of each), newest first, excluding archived.
+
+    Cursor pagination: pass ``after`` from a previous response's
+    ``next_after`` to get the next page. Optional ``name`` filter matches
+    exactly.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        name (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseAgent
+    """
+
+    return sync_detailed(
+        client=client,
+        limit=limit,
+        after=after,
+        name=name,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    name: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseAgent]:
+    """List
+
+     List agents (latest version of each), newest first, excluding archived.
+
+    Cursor pagination: pass ``after`` from a previous response's
+    ``next_after`` to get the next page. Optional ``name`` filter matches
+    exactly.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        name (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseAgent]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        after=after,
+        name=name,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    name: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseAgent | None:
+    """List
+
+     List agents (latest version of each), newest first, excluding archived.
+
+    Cursor pagination: pass ``after`` from a previous response's
+    ``next_after`` to get the next page. Optional ``name`` filter matches
+    exactly.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        name (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseAgent
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            limit=limit,
+            after=after,
+            name=name,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/agents/update_agent.py
+++ b/src/aios/sdk/_generated/api/agents/update_agent.py
@@ -1,0 +1,249 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.agent import Agent
+from ...models.agent_update import AgentUpdate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    agent_id: str,
+    *,
+    body: AgentUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/v1/agents/{agent_id}".format(
+            agent_id=quote(str(agent_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Agent | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Agent.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Agent | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: AgentUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Agent | HTTPValidationError]:
+    """Update
+
+     Update an agent, creating a new immutable version.
+
+    The ``version`` field on the body is required for optimistic concurrency
+    and must match the agent's current version. Omitted config fields are
+    preserved from the previous version. If the merged config is identical
+    to the current version, no new version is created and the existing one
+    is returned unchanged (no-op).
+
+    Args:
+        agent_id (str):
+        authorization (None | str | Unset):
+        body (AgentUpdate): Request body for ``PUT /v1/agents/{id}``.
+
+            All config fields are optional; omitted fields are preserved. The
+            ``version`` field is required for optimistic concurrency — it must match
+            the current version. If the update produces a change, a new version is
+            created; otherwise the existing version is returned unchanged.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Agent | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: AgentUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Agent | HTTPValidationError | None:
+    """Update
+
+     Update an agent, creating a new immutable version.
+
+    The ``version`` field on the body is required for optimistic concurrency
+    and must match the agent's current version. Omitted config fields are
+    preserved from the previous version. If the merged config is identical
+    to the current version, no new version is created and the existing one
+    is returned unchanged (no-op).
+
+    Args:
+        agent_id (str):
+        authorization (None | str | Unset):
+        body (AgentUpdate): Request body for ``PUT /v1/agents/{id}``.
+
+            All config fields are optional; omitted fields are preserved. The
+            ``version`` field is required for optimistic concurrency — it must match
+            the current version. If the update produces a change, a new version is
+            created; otherwise the existing version is returned unchanged.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Agent | HTTPValidationError
+    """
+
+    return sync_detailed(
+        agent_id=agent_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: AgentUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Agent | HTTPValidationError]:
+    """Update
+
+     Update an agent, creating a new immutable version.
+
+    The ``version`` field on the body is required for optimistic concurrency
+    and must match the agent's current version. Omitted config fields are
+    preserved from the previous version. If the merged config is identical
+    to the current version, no new version is created and the existing one
+    is returned unchanged (no-op).
+
+    Args:
+        agent_id (str):
+        authorization (None | str | Unset):
+        body (AgentUpdate): Request body for ``PUT /v1/agents/{id}``.
+
+            All config fields are optional; omitted fields are preserved. The
+            ``version`` field is required for optimistic concurrency — it must match
+            the current version. If the update produces a change, a new version is
+            created; otherwise the existing version is returned unchanged.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Agent | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    agent_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: AgentUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Agent | HTTPValidationError | None:
+    """Update
+
+     Update an agent, creating a new immutable version.
+
+    The ``version`` field on the body is required for optimistic concurrency
+    and must match the agent's current version. Omitted config fields are
+    preserved from the previous version. If the merged config is identical
+    to the current version, no new version is created and the existing one
+    is returned unchanged (no-op).
+
+    Args:
+        agent_id (str):
+        authorization (None | str | Unset):
+        body (AgentUpdate): Request body for ``PUT /v1/agents/{id}``.
+
+            All config fields are optional; omitted fields are preserved. The
+            ``version`` field is required for optimistic concurrency — it must match
+            the current version. If the update produces a change, a new version is
+            created; otherwise the existing version is returned unchanged.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Agent | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            agent_id=agent_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connections/__init__.py
+++ b/src/aios/sdk/_generated/api/connections/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/src/aios/sdk/_generated/api/connections/archive_connection.py
+++ b/src/aios/sdk/_generated/api/connections/archive_connection.py
@@ -1,0 +1,209 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connection_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/connections/{connection_id}".format(
+            connection_id=quote(str(connection_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete
+
+     Archive a connection (DELETE soft-archives, only on detached connections).
+
+    The service layer rejects archive attempts on ``single_session`` or
+    ``per_chat`` connections — archiving those would silently break
+    inbound delivery for live sessions or orphan
+    ``spawned_from_connection_id`` pointers on per_chat-spawned sessions.
+    Detach or unconfigure first, then archive.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete
+
+     Archive a connection (DELETE soft-archives, only on detached connections).
+
+    The service layer rejects archive attempts on ``single_session`` or
+    ``per_chat`` connections — archiving those would silently break
+    inbound delivery for live sessions or orphan
+    ``spawned_from_connection_id`` pointers on per_chat-spawned sessions.
+    Detach or unconfigure first, then archive.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        connection_id=connection_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete
+
+     Archive a connection (DELETE soft-archives, only on detached connections).
+
+    The service layer rejects archive attempts on ``single_session`` or
+    ``per_chat`` connections — archiving those would silently break
+    inbound delivery for live sessions or orphan
+    ``spawned_from_connection_id`` pointers on per_chat-spawned sessions.
+    Detach or unconfigure first, then archive.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete
+
+     Archive a connection (DELETE soft-archives, only on detached connections).
+
+    The service layer rejects archive attempts on ``single_session`` or
+    ``per_chat`` connections — archiving those would silently break
+    inbound delivery for live sessions or orphan
+    ``spawned_from_connection_id`` pointers on per_chat-spawned sessions.
+    Detach or unconfigure first, then archive.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            connection_id=connection_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connections/attach_connection.py
+++ b/src/aios/sdk/_generated/api/connections/attach_connection.py
@@ -1,0 +1,217 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.connection import Connection
+from ...models.connection_attach import ConnectionAttach
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connection_id: str,
+    *,
+    body: ConnectionAttach,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connections/{connection_id}/attach".format(
+            connection_id=quote(str(connection_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Connection | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Connection.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Connection | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectionAttach,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Connection | HTTPValidationError]:
+    """Attach
+
+     Attach a connection to a session, after validating the account against the snapshot.
+
+    The drift check runs BEFORE the DB write so a stale account can't
+    move into ``single_session`` mode and silently swallow inbound.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+        body (ConnectionAttach): Request body for ``POST /v1/connections/{id}/attach``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Connection | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectionAttach,
+    authorization: None | str | Unset = UNSET,
+) -> Connection | HTTPValidationError | None:
+    """Attach
+
+     Attach a connection to a session, after validating the account against the snapshot.
+
+    The drift check runs BEFORE the DB write so a stale account can't
+    move into ``single_session`` mode and silently swallow inbound.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+        body (ConnectionAttach): Request body for ``POST /v1/connections/{id}/attach``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Connection | HTTPValidationError
+    """
+
+    return sync_detailed(
+        connection_id=connection_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectionAttach,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Connection | HTTPValidationError]:
+    """Attach
+
+     Attach a connection to a session, after validating the account against the snapshot.
+
+    The drift check runs BEFORE the DB write so a stale account can't
+    move into ``single_session`` mode and silently swallow inbound.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+        body (ConnectionAttach): Request body for ``POST /v1/connections/{id}/attach``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Connection | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectionAttach,
+    authorization: None | str | Unset = UNSET,
+) -> Connection | HTTPValidationError | None:
+    """Attach
+
+     Attach a connection to a session, after validating the account against the snapshot.
+
+    The drift check runs BEFORE the DB write so a stale account can't
+    move into ``single_session`` mode and silently swallow inbound.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+        body (ConnectionAttach): Request body for ``POST /v1/connections/{id}/attach``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Connection | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            connection_id=connection_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connections/bind_chat.py
+++ b/src/aios/sdk/_generated/api/connections/bind_chat.py
@@ -1,0 +1,273 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.bind_chat_request import BindChatRequest
+from ...models.bound_chat import BoundChat
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connection_id: str,
+    *,
+    body: BindChatRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connections/{connection_id}/bind-chat".format(
+            connection_id=quote(str(connection_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> BoundChat | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = BoundChat.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[BoundChat | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: BindChatRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[BoundChat | HTTPValidationError]:
+    """Bind Chat
+
+     Operator-curate a chat → session mapping (#215).
+
+    A row in ``connection_chat_sessions`` overrides the connection's
+    mode-default fallback for that ``chat_id``.  Operators use this to
+    point different chats on a single account at different existing
+    sessions — the middle case the unified ``connections`` shape didn't
+    cover after #205.
+
+    Idempotent on ``(connection_id, chat_id)``: a second call with the
+    same chat returns the existing row (its ``session_id`` may differ
+    from the requested one if a concurrent writer landed first or the
+    supervisor pre-populated it via per_chat spawn).
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+        body (BindChatRequest): Request body for ``POST /v1/connections/{id}/bind-chat``.
+
+            Pre-populates a ``connection_chat_sessions`` row so inbound on
+            ``chat_id`` routes to ``session_id`` regardless of the connection's
+            mode-default fallback (#215).  Operators use this to point
+            different chats on a single account at different operator-curated
+            existing sessions.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[BoundChat | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: BindChatRequest,
+    authorization: None | str | Unset = UNSET,
+) -> BoundChat | HTTPValidationError | None:
+    """Bind Chat
+
+     Operator-curate a chat → session mapping (#215).
+
+    A row in ``connection_chat_sessions`` overrides the connection's
+    mode-default fallback for that ``chat_id``.  Operators use this to
+    point different chats on a single account at different existing
+    sessions — the middle case the unified ``connections`` shape didn't
+    cover after #205.
+
+    Idempotent on ``(connection_id, chat_id)``: a second call with the
+    same chat returns the existing row (its ``session_id`` may differ
+    from the requested one if a concurrent writer landed first or the
+    supervisor pre-populated it via per_chat spawn).
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+        body (BindChatRequest): Request body for ``POST /v1/connections/{id}/bind-chat``.
+
+            Pre-populates a ``connection_chat_sessions`` row so inbound on
+            ``chat_id`` routes to ``session_id`` regardless of the connection's
+            mode-default fallback (#215).  Operators use this to point
+            different chats on a single account at different operator-curated
+            existing sessions.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        BoundChat | HTTPValidationError
+    """
+
+    return sync_detailed(
+        connection_id=connection_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: BindChatRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[BoundChat | HTTPValidationError]:
+    """Bind Chat
+
+     Operator-curate a chat → session mapping (#215).
+
+    A row in ``connection_chat_sessions`` overrides the connection's
+    mode-default fallback for that ``chat_id``.  Operators use this to
+    point different chats on a single account at different existing
+    sessions — the middle case the unified ``connections`` shape didn't
+    cover after #205.
+
+    Idempotent on ``(connection_id, chat_id)``: a second call with the
+    same chat returns the existing row (its ``session_id`` may differ
+    from the requested one if a concurrent writer landed first or the
+    supervisor pre-populated it via per_chat spawn).
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+        body (BindChatRequest): Request body for ``POST /v1/connections/{id}/bind-chat``.
+
+            Pre-populates a ``connection_chat_sessions`` row so inbound on
+            ``chat_id`` routes to ``session_id`` regardless of the connection's
+            mode-default fallback (#215).  Operators use this to point
+            different chats on a single account at different operator-curated
+            existing sessions.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[BoundChat | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: BindChatRequest,
+    authorization: None | str | Unset = UNSET,
+) -> BoundChat | HTTPValidationError | None:
+    """Bind Chat
+
+     Operator-curate a chat → session mapping (#215).
+
+    A row in ``connection_chat_sessions`` overrides the connection's
+    mode-default fallback for that ``chat_id``.  Operators use this to
+    point different chats on a single account at different existing
+    sessions — the middle case the unified ``connections`` shape didn't
+    cover after #205.
+
+    Idempotent on ``(connection_id, chat_id)``: a second call with the
+    same chat returns the existing row (its ``session_id`` may differ
+    from the requested one if a concurrent writer landed first or the
+    supervisor pre-populated it via per_chat spawn).
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+        body (BindChatRequest): Request body for ``POST /v1/connections/{id}/bind-chat``.
+
+            Pre-populates a ``connection_chat_sessions`` row so inbound on
+            ``chat_id`` routes to ``session_id`` regardless of the connection's
+            mode-default fallback (#215).  Operators use this to point
+            different chats on a single account at different operator-curated
+            existing sessions.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        BoundChat | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            connection_id=connection_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connections/configure_connection_per_chat.py
+++ b/src/aios/sdk/_generated/api/connections/configure_connection_per_chat.py
@@ -1,0 +1,225 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.connection import Connection
+from ...models.connection_configure_per_chat import ConnectionConfigurePerChat
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connection_id: str,
+    *,
+    body: ConnectionConfigurePerChat,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connections/{connection_id}/configure-per-chat".format(
+            connection_id=quote(str(connection_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Connection | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Connection.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Connection | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectionConfigurePerChat,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Connection | HTTPValidationError]:
+    """Configure Per Chat
+
+     Move a detached connection into per_chat mode, pinned to a session template.
+
+    Inbound from new chat partners on this connection will spawn fresh
+    sessions using the named template (agent + environment + vaults +
+    memory stores). Use ``unconfigure_connection`` to return to detached.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+        body (ConnectionConfigurePerChat): Request body for ``POST /v1/connections/{id}/configure-
+            per-chat``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Connection | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectionConfigurePerChat,
+    authorization: None | str | Unset = UNSET,
+) -> Connection | HTTPValidationError | None:
+    """Configure Per Chat
+
+     Move a detached connection into per_chat mode, pinned to a session template.
+
+    Inbound from new chat partners on this connection will spawn fresh
+    sessions using the named template (agent + environment + vaults +
+    memory stores). Use ``unconfigure_connection`` to return to detached.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+        body (ConnectionConfigurePerChat): Request body for ``POST /v1/connections/{id}/configure-
+            per-chat``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Connection | HTTPValidationError
+    """
+
+    return sync_detailed(
+        connection_id=connection_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectionConfigurePerChat,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Connection | HTTPValidationError]:
+    """Configure Per Chat
+
+     Move a detached connection into per_chat mode, pinned to a session template.
+
+    Inbound from new chat partners on this connection will spawn fresh
+    sessions using the named template (agent + environment + vaults +
+    memory stores). Use ``unconfigure_connection`` to return to detached.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+        body (ConnectionConfigurePerChat): Request body for ``POST /v1/connections/{id}/configure-
+            per-chat``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Connection | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectionConfigurePerChat,
+    authorization: None | str | Unset = UNSET,
+) -> Connection | HTTPValidationError | None:
+    """Configure Per Chat
+
+     Move a detached connection into per_chat mode, pinned to a session template.
+
+    Inbound from new chat partners on this connection will spawn fresh
+    sessions using the named template (agent + environment + vaults +
+    memory stores). Use ``unconfigure_connection`` to return to detached.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+        body (ConnectionConfigurePerChat): Request body for ``POST /v1/connections/{id}/configure-
+            per-chat``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Connection | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            connection_id=connection_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connections/create_connection.py
+++ b/src/aios/sdk/_generated/api/connections/create_connection.py
@@ -1,0 +1,249 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.connection import Connection
+from ...models.connection_create import ConnectionCreate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: ConnectionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connections",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Connection | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = Connection.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Connection | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Connection | HTTPValidationError]:
+    """Create
+
+     Create a detached connection, **idempotent on ``(connector, account)``**.
+
+    Per plan decision #5, this endpoint and the supervisor's
+    auto-create-on-first-inbound path race-safely converge on a single row:
+    posting twice with the same ``(connector, account)`` returns 201 with the
+    existing row rather than 409.  The ``id`` may differ from a freshly-allocated
+    one if a concurrent writer landed first; the response always reflects the
+    canonical active row.
+
+    Args:
+        authorization (None | str | Unset):
+        body (ConnectionCreate): Request body for ``POST /v1/connections``.
+
+            Created in detached mode — neither ``session_id`` nor
+            ``session_template_id`` is set.  Use ``POST .../attach`` or
+            ``POST .../configure-per-chat`` afterward to bind a routing mode.
+
+            ``connector`` and ``account`` may not contain ``/`` — they're used
+            in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
+            and a ``/`` would create ambiguous segment boundaries.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Connection | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Connection | HTTPValidationError | None:
+    """Create
+
+     Create a detached connection, **idempotent on ``(connector, account)``**.
+
+    Per plan decision #5, this endpoint and the supervisor's
+    auto-create-on-first-inbound path race-safely converge on a single row:
+    posting twice with the same ``(connector, account)`` returns 201 with the
+    existing row rather than 409.  The ``id`` may differ from a freshly-allocated
+    one if a concurrent writer landed first; the response always reflects the
+    canonical active row.
+
+    Args:
+        authorization (None | str | Unset):
+        body (ConnectionCreate): Request body for ``POST /v1/connections``.
+
+            Created in detached mode — neither ``session_id`` nor
+            ``session_template_id`` is set.  Use ``POST .../attach`` or
+            ``POST .../configure-per-chat`` afterward to bind a routing mode.
+
+            ``connector`` and ``account`` may not contain ``/`` — they're used
+            in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
+            and a ``/`` would create ambiguous segment boundaries.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Connection | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Connection | HTTPValidationError]:
+    """Create
+
+     Create a detached connection, **idempotent on ``(connector, account)``**.
+
+    Per plan decision #5, this endpoint and the supervisor's
+    auto-create-on-first-inbound path race-safely converge on a single row:
+    posting twice with the same ``(connector, account)`` returns 201 with the
+    existing row rather than 409.  The ``id`` may differ from a freshly-allocated
+    one if a concurrent writer landed first; the response always reflects the
+    canonical active row.
+
+    Args:
+        authorization (None | str | Unset):
+        body (ConnectionCreate): Request body for ``POST /v1/connections``.
+
+            Created in detached mode — neither ``session_id`` nor
+            ``session_template_id`` is set.  Use ``POST .../attach`` or
+            ``POST .../configure-per-chat`` afterward to bind a routing mode.
+
+            ``connector`` and ``account`` may not contain ``/`` — they're used
+            in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
+            and a ``/`` would create ambiguous segment boundaries.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Connection | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Connection | HTTPValidationError | None:
+    """Create
+
+     Create a detached connection, **idempotent on ``(connector, account)``**.
+
+    Per plan decision #5, this endpoint and the supervisor's
+    auto-create-on-first-inbound path race-safely converge on a single row:
+    posting twice with the same ``(connector, account)`` returns 201 with the
+    existing row rather than 409.  The ``id`` may differ from a freshly-allocated
+    one if a concurrent writer landed first; the response always reflects the
+    canonical active row.
+
+    Args:
+        authorization (None | str | Unset):
+        body (ConnectionCreate): Request body for ``POST /v1/connections``.
+
+            Created in detached mode — neither ``session_id`` nor
+            ``session_template_id`` is set.  Use ``POST .../attach`` or
+            ``POST .../configure-per-chat`` afterward to bind a routing mode.
+
+            ``connector`` and ``account`` may not contain ``/`` — they're used
+            in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
+            and a ``/`` would create ambiguous segment boundaries.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Connection | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connections/detach_connection.py
+++ b/src/aios/sdk/_generated/api/connections/detach_connection.py
@@ -1,0 +1,203 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.connection import Connection
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connection_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connections/{connection_id}/detach".format(
+            connection_id=quote(str(connection_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Connection | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Connection.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Connection | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Connection | HTTPValidationError]:
+    """Detach
+
+     Detach a single_session connection back to detached mode.
+
+    The bound session is unaffected (continues to exist); only the
+    connection's mode/binding changes. Inbound on this connection is
+    paused until it's re-attached or configured for per_chat.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Connection | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Connection | HTTPValidationError | None:
+    """Detach
+
+     Detach a single_session connection back to detached mode.
+
+    The bound session is unaffected (continues to exist); only the
+    connection's mode/binding changes. Inbound on this connection is
+    paused until it's re-attached or configured for per_chat.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Connection | HTTPValidationError
+    """
+
+    return sync_detailed(
+        connection_id=connection_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Connection | HTTPValidationError]:
+    """Detach
+
+     Detach a single_session connection back to detached mode.
+
+    The bound session is unaffected (continues to exist); only the
+    connection's mode/binding changes. Inbound on this connection is
+    paused until it's re-attached or configured for per_chat.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Connection | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Connection | HTTPValidationError | None:
+    """Detach
+
+     Detach a single_session connection back to detached mode.
+
+    The bound session is unaffected (continues to exist); only the
+    connection's mode/binding changes. Inbound on this connection is
+    paused until it's re-attached or configured for per_chat.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Connection | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            connection_id=connection_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connections/get_connection.py
+++ b/src/aios/sdk/_generated/api/connections/get_connection.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.connection import Connection
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connection_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/connections/{connection_id}".format(
+            connection_id=quote(str(connection_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Connection | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Connection.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Connection | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Connection | HTTPValidationError]:
+    """Get
+
+     Fetch one connection by id.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Connection | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Connection | HTTPValidationError | None:
+    """Get
+
+     Fetch one connection by id.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Connection | HTTPValidationError
+    """
+
+    return sync_detailed(
+        connection_id=connection_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Connection | HTTPValidationError]:
+    """Get
+
+     Fetch one connection by id.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Connection | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Connection | HTTPValidationError | None:
+    """Get
+
+     Fetch one connection by id.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Connection | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            connection_id=connection_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connections/list_bound_chats.py
+++ b/src/aios/sdk/_generated/api/connections/list_bound_chats.py
@@ -1,0 +1,203 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_bound_chat import ListResponseBoundChat
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connection_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/connections/{connection_id}/bound-chats".format(
+            connection_id=quote(str(connection_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseBoundChat | None:
+    if response.status_code == 200:
+        response_200 = ListResponseBoundChat.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseBoundChat]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseBoundChat]:
+    """Bound Chats
+
+     List operator-curated chat → session bindings on this connection.
+
+    Includes both manually-bound rows (via ``bind_chat``) and per_chat
+    auto-spawned rows (via the supervisor on first inbound from a new
+    chat partner).
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseBoundChat]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseBoundChat | None:
+    """Bound Chats
+
+     List operator-curated chat → session bindings on this connection.
+
+    Includes both manually-bound rows (via ``bind_chat``) and per_chat
+    auto-spawned rows (via the supervisor on first inbound from a new
+    chat partner).
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseBoundChat
+    """
+
+    return sync_detailed(
+        connection_id=connection_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseBoundChat]:
+    """Bound Chats
+
+     List operator-curated chat → session bindings on this connection.
+
+    Includes both manually-bound rows (via ``bind_chat``) and per_chat
+    auto-spawned rows (via the supervisor on first inbound from a new
+    chat partner).
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseBoundChat]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseBoundChat | None:
+    """Bound Chats
+
+     List operator-curated chat → session bindings on this connection.
+
+    Includes both manually-bound rows (via ``bind_chat``) and per_chat
+    auto-spawned rows (via the supervisor on first inbound from a new
+    chat partner).
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseBoundChat
+    """
+
+    return (
+        await asyncio_detailed(
+            connection_id=connection_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connections/list_connections.py
+++ b/src/aios/sdk/_generated/api/connections/list_connections.py
@@ -1,0 +1,290 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_connections_mode_type_0 import ListConnectionsModeType0
+from ...models.list_response_connection import ListResponseConnection
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    connector: None | str | Unset = UNSET,
+    session_id: None | str | Unset = UNSET,
+    mode: ListConnectionsModeType0 | None | Unset = UNSET,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    json_connector: None | str | Unset
+    if isinstance(connector, Unset):
+        json_connector = UNSET
+    else:
+        json_connector = connector
+    params["connector"] = json_connector
+
+    json_session_id: None | str | Unset
+    if isinstance(session_id, Unset):
+        json_session_id = UNSET
+    else:
+        json_session_id = session_id
+    params["session_id"] = json_session_id
+
+    json_mode: None | str | Unset
+    if isinstance(mode, Unset):
+        json_mode = UNSET
+    elif isinstance(mode, ListConnectionsModeType0):
+        json_mode = mode.value
+    else:
+        json_mode = mode
+    params["mode"] = json_mode
+
+    params["limit"] = limit
+
+    json_after: None | str | Unset
+    if isinstance(after, Unset):
+        json_after = UNSET
+    else:
+        json_after = after
+    params["after"] = json_after
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/connections",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseConnection | None:
+    if response.status_code == 200:
+        response_200 = ListResponseConnection.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseConnection]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    connector: None | str | Unset = UNSET,
+    session_id: None | str | Unset = UNSET,
+    mode: ListConnectionsModeType0 | None | Unset = UNSET,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseConnection]:
+    r"""List
+
+     List connections, newest first, excluding archived. Cursor pagination via ``after``.
+
+    Filters: ``connector`` (e.g. ``\"telegram\"``), ``session_id`` (only
+    connections in single_session mode bound to that session), ``mode``
+    (``detached`` / ``single_session`` / ``per_chat``). Filters compose.
+
+    Args:
+        connector (None | str | Unset):
+        session_id (None | str | Unset):
+        mode (ListConnectionsModeType0 | None | Unset):
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseConnection]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        session_id=session_id,
+        mode=mode,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    connector: None | str | Unset = UNSET,
+    session_id: None | str | Unset = UNSET,
+    mode: ListConnectionsModeType0 | None | Unset = UNSET,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseConnection | None:
+    r"""List
+
+     List connections, newest first, excluding archived. Cursor pagination via ``after``.
+
+    Filters: ``connector`` (e.g. ``\"telegram\"``), ``session_id`` (only
+    connections in single_session mode bound to that session), ``mode``
+    (``detached`` / ``single_session`` / ``per_chat``). Filters compose.
+
+    Args:
+        connector (None | str | Unset):
+        session_id (None | str | Unset):
+        mode (ListConnectionsModeType0 | None | Unset):
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseConnection
+    """
+
+    return sync_detailed(
+        client=client,
+        connector=connector,
+        session_id=session_id,
+        mode=mode,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    connector: None | str | Unset = UNSET,
+    session_id: None | str | Unset = UNSET,
+    mode: ListConnectionsModeType0 | None | Unset = UNSET,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseConnection]:
+    r"""List
+
+     List connections, newest first, excluding archived. Cursor pagination via ``after``.
+
+    Filters: ``connector`` (e.g. ``\"telegram\"``), ``session_id`` (only
+    connections in single_session mode bound to that session), ``mode``
+    (``detached`` / ``single_session`` / ``per_chat``). Filters compose.
+
+    Args:
+        connector (None | str | Unset):
+        session_id (None | str | Unset):
+        mode (ListConnectionsModeType0 | None | Unset):
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseConnection]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        session_id=session_id,
+        mode=mode,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    connector: None | str | Unset = UNSET,
+    session_id: None | str | Unset = UNSET,
+    mode: ListConnectionsModeType0 | None | Unset = UNSET,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseConnection | None:
+    r"""List
+
+     List connections, newest first, excluding archived. Cursor pagination via ``after``.
+
+    Filters: ``connector`` (e.g. ``\"telegram\"``), ``session_id`` (only
+    connections in single_session mode bound to that session), ``mode``
+    (``detached`` / ``single_session`` / ``per_chat``). Filters compose.
+
+    Args:
+        connector (None | str | Unset):
+        session_id (None | str | Unset):
+        mode (ListConnectionsModeType0 | None | Unset):
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseConnection
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            connector=connector,
+            session_id=session_id,
+            mode=mode,
+            limit=limit,
+            after=after,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connections/list_recent_chats.py
+++ b/src/aios/sdk/_generated/api/connections/list_recent_chats.py
@@ -1,0 +1,223 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_recent_chat import ListResponseRecentChat
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connection_id: str,
+    *,
+    limit: int | Unset = 50,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/connections/{connection_id}/recent-chats".format(
+            connection_id=quote(str(connection_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseRecentChat | None:
+    if response.status_code == 200:
+        response_200 = ListResponseRecentChat.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseRecentChat]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseRecentChat]:
+    """Recent Chats
+
+     List chats that recently sent inbound on this connection, newest first.
+
+    Useful for picking a ``chat_id`` to bind via ``bind_chat`` —
+    enumerates the conversational counterparts that the connector has
+    delivered messages from.
+
+    Args:
+        connection_id (str):
+        limit (int | Unset):  Default: 50.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseRecentChat]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseRecentChat | None:
+    """Recent Chats
+
+     List chats that recently sent inbound on this connection, newest first.
+
+    Useful for picking a ``chat_id`` to bind via ``bind_chat`` —
+    enumerates the conversational counterparts that the connector has
+    delivered messages from.
+
+    Args:
+        connection_id (str):
+        limit (int | Unset):  Default: 50.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseRecentChat
+    """
+
+    return sync_detailed(
+        connection_id=connection_id,
+        client=client,
+        limit=limit,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseRecentChat]:
+    """Recent Chats
+
+     List chats that recently sent inbound on this connection, newest first.
+
+    Useful for picking a ``chat_id`` to bind via ``bind_chat`` —
+    enumerates the conversational counterparts that the connector has
+    delivered messages from.
+
+    Args:
+        connection_id (str):
+        limit (int | Unset):  Default: 50.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseRecentChat]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseRecentChat | None:
+    """Recent Chats
+
+     List chats that recently sent inbound on this connection, newest first.
+
+    Useful for picking a ``chat_id`` to bind via ``bind_chat`` —
+    enumerates the conversational counterparts that the connector has
+    delivered messages from.
+
+    Args:
+        connection_id (str):
+        limit (int | Unset):  Default: 50.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseRecentChat
+    """
+
+    return (
+        await asyncio_detailed(
+            connection_id=connection_id,
+            client=client,
+            limit=limit,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connections/unbind_chat.py
+++ b/src/aios/sdk/_generated/api/connections/unbind_chat.py
@@ -1,0 +1,199 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connection_id: str,
+    chat_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/connections/{connection_id}/bind-chat/{chat_id}".format(
+            connection_id=quote(str(connection_id), safe=""),
+            chat_id=quote(str(chat_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connection_id: str,
+    chat_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Unbind Chat
+
+     Drop the operator-curated row.  Idempotent — repeat calls 204.
+
+    Args:
+        connection_id (str):
+        chat_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        chat_id=chat_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connection_id: str,
+    chat_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Unbind Chat
+
+     Drop the operator-curated row.  Idempotent — repeat calls 204.
+
+    Args:
+        connection_id (str):
+        chat_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        connection_id=connection_id,
+        chat_id=chat_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connection_id: str,
+    chat_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Unbind Chat
+
+     Drop the operator-curated row.  Idempotent — repeat calls 204.
+
+    Args:
+        connection_id (str):
+        chat_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        chat_id=chat_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connection_id: str,
+    chat_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Unbind Chat
+
+     Drop the operator-curated row.  Idempotent — repeat calls 204.
+
+    Args:
+        connection_id (str):
+        chat_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            connection_id=connection_id,
+            chat_id=chat_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connections/unconfigure_connection.py
+++ b/src/aios/sdk/_generated/api/connections/unconfigure_connection.py
@@ -1,0 +1,211 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.connection import Connection
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connection_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connections/{connection_id}/unconfigure".format(
+            connection_id=quote(str(connection_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Connection | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Connection.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Connection | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Connection | HTTPValidationError]:
+    """Unconfigure
+
+     Return a per_chat connection to detached mode.
+
+    Already-spawned sessions are unaffected and continue normally;
+    operator-bound chat → session rows persist and continue to route
+    those specific chats. Only the per_chat fallback (spawn for unseen
+    chats) is removed — inbound from new chat partners is paused until
+    the connection is reconfigured.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Connection | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Connection | HTTPValidationError | None:
+    """Unconfigure
+
+     Return a per_chat connection to detached mode.
+
+    Already-spawned sessions are unaffected and continue normally;
+    operator-bound chat → session rows persist and continue to route
+    those specific chats. Only the per_chat fallback (spawn for unseen
+    chats) is removed — inbound from new chat partners is paused until
+    the connection is reconfigured.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Connection | HTTPValidationError
+    """
+
+    return sync_detailed(
+        connection_id=connection_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Connection | HTTPValidationError]:
+    """Unconfigure
+
+     Return a per_chat connection to detached mode.
+
+    Already-spawned sessions are unaffected and continue normally;
+    operator-bound chat → session rows persist and continue to route
+    those specific chats. Only the per_chat fallback (spawn for unseen
+    chats) is removed — inbound from new chat partners is paused until
+    the connection is reconfigured.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Connection | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connection_id=connection_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connection_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Connection | HTTPValidationError | None:
+    """Unconfigure
+
+     Return a per_chat connection to detached mode.
+
+    Already-spawned sessions are unaffected and continue normally;
+    operator-bound chat → session rows persist and continue to route
+    those specific chats. Only the per_chat fallback (spawn for unseen
+    chats) is removed — inbound from new chat partners is paused until
+    the connection is reconfigured.
+
+    Args:
+        connection_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Connection | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            connection_id=connection_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connectors/__init__.py
+++ b/src/aios/sdk/_generated/api/connectors/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/src/aios/sdk/_generated/api/connectors/call_v1_connectors_connector_instance_call_post.py
+++ b/src/aios/sdk/_generated/api/connectors/call_v1_connectors_connector_instance_call_post.py
@@ -1,0 +1,236 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.call_v1_connectors_connector_instance_call_post_response_call_v1_connectors_connector_instance_call_post import (
+    CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost,
+)
+from ...models.connector_call_body import ConnectorCallBody
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connector: str,
+    instance: str,
+    *,
+    body: ConnectorCallBody,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connectors/{connector}/{instance}/call".format(
+            connector=quote(str(connector), safe=""),
+            instance=quote(str(instance), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> (
+    CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost
+    | HTTPValidationError
+    | None
+):
+    if response.status_code == 200:
+        response_200 = CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost.from_dict(
+            response.json()
+        )
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[
+    CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost
+    | HTTPValidationError
+]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectorCallBody,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost
+    | HTTPValidationError
+]:
+    """Call
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+        body (ConnectorCallBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        instance=instance,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectorCallBody,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost
+    | HTTPValidationError
+    | None
+):
+    """Call
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+        body (ConnectorCallBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost | HTTPValidationError
+    """
+
+    return sync_detailed(
+        connector=connector,
+        instance=instance,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectorCallBody,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost
+    | HTTPValidationError
+]:
+    """Call
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+        body (ConnectorCallBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        instance=instance,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectorCallBody,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost
+    | HTTPValidationError
+    | None
+):
+    """Call
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+        body (ConnectorCallBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            connector=connector,
+            instance=instance,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connectors/get_instance_v1_connectors_connector_instance_get.py
+++ b/src/aios/sdk/_generated/api/connectors/get_instance_v1_connectors_connector_instance_get.py
@@ -1,0 +1,226 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.get_instance_v1_connectors_connector_instance_get_response_get_instance_v1_connectors_connector_instance_get import (
+    GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet,
+)
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connector: str,
+    instance: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/connectors/{connector}/{instance}".format(
+            connector=quote(str(connector), safe=""),
+            instance=quote(str(instance), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> (
+    GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet
+    | HTTPValidationError
+    | None
+):
+    if response.status_code == 200:
+        response_200 = GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet.from_dict(
+            response.json()
+        )
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[
+    GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet
+    | HTTPValidationError
+]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet
+    | HTTPValidationError
+]:
+    """Get Instance
+
+     Snapshot a single ``(connector, instance)`` pair.
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        instance=instance,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet
+    | HTTPValidationError
+    | None
+):
+    """Get Instance
+
+     Snapshot a single ``(connector, instance)`` pair.
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet | HTTPValidationError
+    """
+
+    return sync_detailed(
+        connector=connector,
+        instance=instance,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet
+    | HTTPValidationError
+]:
+    """Get Instance
+
+     Snapshot a single ``(connector, instance)`` pair.
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        instance=instance,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet
+    | HTTPValidationError
+    | None
+):
+    """Get Instance
+
+     Snapshot a single ``(connector, instance)`` pair.
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            connector=connector,
+            instance=instance,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connectors/list_accounts_v1_connectors_connector_instance_accounts_get.py
+++ b/src/aios/sdk/_generated/api/connectors/list_accounts_v1_connectors_connector_instance_accounts_get.py
@@ -1,0 +1,218 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_accounts_v1_connectors_connector_instance_accounts_get_response_list_accounts_v1_connectors_connector_instance_accounts_get import (
+    ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet,
+)
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connector: str,
+    instance: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/connectors/{connector}/{instance}/accounts".format(
+            connector=quote(str(connector), safe=""),
+            instance=quote(str(instance), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> (
+    HTTPValidationError
+    | ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet
+    | None
+):
+    if response.status_code == 200:
+        response_200 = ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet.from_dict(
+            response.json()
+        )
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[
+    HTTPValidationError
+    | ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet
+]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet
+]:
+    """List Accounts
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        instance=instance,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet
+    | None
+):
+    """List Accounts
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet
+    """
+
+    return sync_detailed(
+        connector=connector,
+        instance=instance,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet
+]:
+    """List Accounts
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        instance=instance,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet
+    | None
+):
+    """List Accounts
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet
+    """
+
+    return (
+        await asyncio_detailed(
+            connector=connector,
+            instance=instance,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connectors/list_for_connector_v1_connectors_connector_get.py
+++ b/src/aios/sdk/_generated/api/connectors/list_for_connector_v1_connectors_connector_get.py
@@ -1,0 +1,212 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_for_connector_v1_connectors_connector_get_response_list_for_connector_v1_connectors_connector_get import (
+    ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet,
+)
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connector: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/connectors/{connector}".format(
+            connector=quote(str(connector), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> (
+    HTTPValidationError
+    | ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet
+    | None
+):
+    if response.status_code == 200:
+        response_200 = ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet.from_dict(
+            response.json()
+        )
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[
+    HTTPValidationError
+    | ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet
+]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connector: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet
+]:
+    """List For Connector
+
+     Snapshot every instance of one connector type.
+
+    Args:
+        connector (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connector: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet
+    | None
+):
+    """List For Connector
+
+     Snapshot every instance of one connector type.
+
+    Args:
+        connector (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet
+    """
+
+    return sync_detailed(
+        connector=connector,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connector: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet
+]:
+    """List For Connector
+
+     Snapshot every instance of one connector type.
+
+    Args:
+        connector (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connector: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet
+    | None
+):
+    """List For Connector
+
+     Snapshot every instance of one connector type.
+
+    Args:
+        connector (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet
+    """
+
+    return (
+        await asyncio_detailed(
+            connector=connector,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connectors/list_tools_v1_connectors_connector_instance_tools_get.py
+++ b/src/aios/sdk/_generated/api/connectors/list_tools_v1_connectors_connector_instance_tools_get.py
@@ -1,0 +1,218 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_tools_v1_connectors_connector_instance_tools_get_response_list_tools_v1_connectors_connector_instance_tools_get import (
+    ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet,
+)
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connector: str,
+    instance: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/connectors/{connector}/{instance}/tools".format(
+            connector=quote(str(connector), safe=""),
+            instance=quote(str(instance), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> (
+    HTTPValidationError
+    | ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet
+    | None
+):
+    if response.status_code == 200:
+        response_200 = ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet.from_dict(
+            response.json()
+        )
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[
+    HTTPValidationError
+    | ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet
+]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet
+]:
+    """List Tools
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        instance=instance,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet
+    | None
+):
+    """List Tools
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet
+    """
+
+    return sync_detailed(
+        connector=connector,
+        instance=instance,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet
+]:
+    """List Tools
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        instance=instance,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connector: str,
+    instance: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet
+    | None
+):
+    """List Tools
+
+    Args:
+        connector (str):
+        instance (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet
+    """
+
+    return (
+        await asyncio_detailed(
+            connector=connector,
+            instance=instance,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connectors/list_v1_connectors_get.py
+++ b/src/aios/sdk/_generated/api/connectors/list_v1_connectors_get.py
@@ -1,0 +1,175 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_v1_connectors_get_response_list_v1_connectors_get import (
+    ListV1ConnectorsGetResponseListV1ConnectorsGet,
+)
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/connectors",
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListV1ConnectorsGetResponseListV1ConnectorsGet | None:
+    if response.status_code == 200:
+        response_200 = ListV1ConnectorsGetResponseListV1ConnectorsGet.from_dict(
+            response.json()
+        )
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListV1ConnectorsGetResponseListV1ConnectorsGet]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListV1ConnectorsGetResponseListV1ConnectorsGet]:
+    """List
+
+     Snapshot every enabled connector instance.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListV1ConnectorsGetResponseListV1ConnectorsGet]
+    """
+
+    kwargs = _get_kwargs(
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListV1ConnectorsGetResponseListV1ConnectorsGet | None:
+    """List
+
+     Snapshot every enabled connector instance.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListV1ConnectorsGetResponseListV1ConnectorsGet
+    """
+
+    return sync_detailed(
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListV1ConnectorsGetResponseListV1ConnectorsGet]:
+    """List
+
+     Snapshot every enabled connector instance.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListV1ConnectorsGetResponseListV1ConnectorsGet]
+    """
+
+    kwargs = _get_kwargs(
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListV1ConnectorsGetResponseListV1ConnectorsGet | None:
+    """List
+
+     Snapshot every enabled connector instance.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListV1ConnectorsGetResponseListV1ConnectorsGet
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/default/__init__.py
+++ b/src/aios/sdk/_generated/api/default/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/src/aios/sdk/_generated/api/default/get_health.py
+++ b/src/aios/sdk/_generated/api/default/get_health.py
@@ -1,0 +1,152 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.get_health_response_get_health import GetHealthResponseGetHealth
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/health",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> GetHealthResponseGetHealth | None:
+    if response.status_code == 200:
+        response_200 = GetHealthResponseGetHealth.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[GetHealthResponseGetHealth]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[GetHealthResponseGetHealth]:
+    r"""Health
+
+     Liveness probe. Unauthenticated; returns the running aios version.
+
+    Suitable for load balancer health checks and monitoring probes. Always
+    returns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the
+    process is up.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetHealthResponseGetHealth]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+) -> GetHealthResponseGetHealth | None:
+    r"""Health
+
+     Liveness probe. Unauthenticated; returns the running aios version.
+
+    Suitable for load balancer health checks and monitoring probes. Always
+    returns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the
+    process is up.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetHealthResponseGetHealth
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[GetHealthResponseGetHealth]:
+    r"""Health
+
+     Liveness probe. Unauthenticated; returns the running aios version.
+
+    Suitable for load balancer health checks and monitoring probes. Always
+    returns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the
+    process is up.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetHealthResponseGetHealth]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+) -> GetHealthResponseGetHealth | None:
+    r"""Health
+
+     Liveness probe. Unauthenticated; returns the running aios version.
+
+    Suitable for load balancer health checks and monitoring probes. Always
+    returns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the
+    process is up.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetHealthResponseGetHealth
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/environments/__init__.py
+++ b/src/aios/sdk/_generated/api/environments/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/src/aios/sdk/_generated/api/environments/archive_environment.py
+++ b/src/aios/sdk/_generated/api/environments/archive_environment.py
@@ -1,0 +1,201 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    env_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/environments/{env_id}".format(
+            env_id=quote(str(env_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    env_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Archive
+
+     Archive an environment: hides from default lists, leaves the row in place.
+
+    Sessions referencing the archived environment continue to function — the
+    sandbox provisioner reads the config by JOIN and does not filter by
+    archive state. There is no API surface to un-archive currently.
+
+    Args:
+        env_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        env_id=env_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    env_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Archive
+
+     Archive an environment: hides from default lists, leaves the row in place.
+
+    Sessions referencing the archived environment continue to function — the
+    sandbox provisioner reads the config by JOIN and does not filter by
+    archive state. There is no API surface to un-archive currently.
+
+    Args:
+        env_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        env_id=env_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    env_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Archive
+
+     Archive an environment: hides from default lists, leaves the row in place.
+
+    Sessions referencing the archived environment continue to function — the
+    sandbox provisioner reads the config by JOIN and does not filter by
+    archive state. There is no API surface to un-archive currently.
+
+    Args:
+        env_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        env_id=env_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    env_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Archive
+
+     Archive an environment: hides from default lists, leaves the row in place.
+
+    Sessions referencing the archived environment continue to function — the
+    sandbox provisioner reads the config by JOIN and does not filter by
+    archive state. There is no API surface to un-archive currently.
+
+    Args:
+        env_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            env_id=env_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/environments/create_environment.py
+++ b/src/aios/sdk/_generated/api/environments/create_environment.py
@@ -1,0 +1,209 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.environment import Environment
+from ...models.environment_create import EnvironmentCreate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: EnvironmentCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/environments",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Environment | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = Environment.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Environment | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: EnvironmentCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Environment | HTTPValidationError]:
+    """Create
+
+     Create a new environment — a reusable sandbox configuration template.
+
+    The ``config`` field describes the container the sessions running this
+    environment will spawn (pre-installed packages, network access rules,
+    base image). Sessions reference environments by id; multiple sessions
+    can share one environment.
+
+    Args:
+        authorization (None | str | Unset):
+        body (EnvironmentCreate): Request body for `POST /v1/environments`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Environment | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: EnvironmentCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Environment | HTTPValidationError | None:
+    """Create
+
+     Create a new environment — a reusable sandbox configuration template.
+
+    The ``config`` field describes the container the sessions running this
+    environment will spawn (pre-installed packages, network access rules,
+    base image). Sessions reference environments by id; multiple sessions
+    can share one environment.
+
+    Args:
+        authorization (None | str | Unset):
+        body (EnvironmentCreate): Request body for `POST /v1/environments`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Environment | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: EnvironmentCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Environment | HTTPValidationError]:
+    """Create
+
+     Create a new environment — a reusable sandbox configuration template.
+
+    The ``config`` field describes the container the sessions running this
+    environment will spawn (pre-installed packages, network access rules,
+    base image). Sessions reference environments by id; multiple sessions
+    can share one environment.
+
+    Args:
+        authorization (None | str | Unset):
+        body (EnvironmentCreate): Request body for `POST /v1/environments`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Environment | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: EnvironmentCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Environment | HTTPValidationError | None:
+    """Create
+
+     Create a new environment — a reusable sandbox configuration template.
+
+    The ``config`` field describes the container the sessions running this
+    environment will spawn (pre-installed packages, network access rules,
+    base image). Sessions reference environments by id; multiple sessions
+    can share one environment.
+
+    Args:
+        authorization (None | str | Unset):
+        body (EnvironmentCreate): Request body for `POST /v1/environments`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Environment | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/environments/get_environment.py
+++ b/src/aios/sdk/_generated/api/environments/get_environment.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.environment import Environment
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    env_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/environments/{env_id}".format(
+            env_id=quote(str(env_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Environment | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Environment.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Environment | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    env_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Environment | HTTPValidationError]:
+    """Get
+
+     Fetch one environment by id.
+
+    Args:
+        env_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Environment | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        env_id=env_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    env_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Environment | HTTPValidationError | None:
+    """Get
+
+     Fetch one environment by id.
+
+    Args:
+        env_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Environment | HTTPValidationError
+    """
+
+    return sync_detailed(
+        env_id=env_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    env_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Environment | HTTPValidationError]:
+    """Get
+
+     Fetch one environment by id.
+
+    Args:
+        env_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Environment | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        env_id=env_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    env_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Environment | HTTPValidationError | None:
+    """Get
+
+     Fetch one environment by id.
+
+    Args:
+        env_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Environment | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            env_id=env_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/environments/list_environments.py
+++ b/src/aios/sdk/_generated/api/environments/list_environments.py
@@ -1,0 +1,219 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_environment import ListResponseEnvironment
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    json_after: None | str | Unset
+    if isinstance(after, Unset):
+        json_after = UNSET
+    else:
+        json_after = after
+    params["after"] = json_after
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/environments",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseEnvironment | None:
+    if response.status_code == 200:
+        response_200 = ListResponseEnvironment.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseEnvironment]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseEnvironment]:
+    """List
+
+     List environments, newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseEnvironment]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseEnvironment | None:
+    """List
+
+     List environments, newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseEnvironment
+    """
+
+    return sync_detailed(
+        client=client,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseEnvironment]:
+    """List
+
+     List environments, newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseEnvironment]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseEnvironment | None:
+    """List
+
+     List environments, newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseEnvironment
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            limit=limit,
+            after=after,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/environments/update_environment.py
+++ b/src/aios/sdk/_generated/api/environments/update_environment.py
@@ -1,0 +1,233 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.environment import Environment
+from ...models.environment_update import EnvironmentUpdate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    env_id: str,
+    *,
+    body: EnvironmentUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/v1/environments/{env_id}".format(
+            env_id=quote(str(env_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Environment | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Environment.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Environment | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    env_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: EnvironmentUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Environment | HTTPValidationError]:
+    """Update
+
+     Update an environment's ``name`` and/or ``config``.
+
+    Sessions resolve the environment config fresh each time their sandbox
+    is provisioned (lazily, at the next session step that needs the
+    container), so updates take effect for existing sessions on their next
+    provision rather than at update time.
+
+    Args:
+        env_id (str):
+        authorization (None | str | Unset):
+        body (EnvironmentUpdate): Request body for ``PUT /v1/environments/{id}``.
+
+            All fields are optional; omitted fields are preserved.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Environment | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        env_id=env_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    env_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: EnvironmentUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Environment | HTTPValidationError | None:
+    """Update
+
+     Update an environment's ``name`` and/or ``config``.
+
+    Sessions resolve the environment config fresh each time their sandbox
+    is provisioned (lazily, at the next session step that needs the
+    container), so updates take effect for existing sessions on their next
+    provision rather than at update time.
+
+    Args:
+        env_id (str):
+        authorization (None | str | Unset):
+        body (EnvironmentUpdate): Request body for ``PUT /v1/environments/{id}``.
+
+            All fields are optional; omitted fields are preserved.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Environment | HTTPValidationError
+    """
+
+    return sync_detailed(
+        env_id=env_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    env_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: EnvironmentUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Environment | HTTPValidationError]:
+    """Update
+
+     Update an environment's ``name`` and/or ``config``.
+
+    Sessions resolve the environment config fresh each time their sandbox
+    is provisioned (lazily, at the next session step that needs the
+    container), so updates take effect for existing sessions on their next
+    provision rather than at update time.
+
+    Args:
+        env_id (str):
+        authorization (None | str | Unset):
+        body (EnvironmentUpdate): Request body for ``PUT /v1/environments/{id}``.
+
+            All fields are optional; omitted fields are preserved.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Environment | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        env_id=env_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    env_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: EnvironmentUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Environment | HTTPValidationError | None:
+    """Update
+
+     Update an environment's ``name`` and/or ``config``.
+
+    Sessions resolve the environment config fresh each time their sandbox
+    is provisioned (lazily, at the next session step that needs the
+    container), so updates take effect for existing sessions on their next
+    provision rather than at update time.
+
+    Args:
+        env_id (str):
+        authorization (None | str | Unset):
+        body (EnvironmentUpdate): Request body for ``PUT /v1/environments/{id}``.
+
+            All fields are optional; omitted fields are preserved.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Environment | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            env_id=env_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/__init__.py
+++ b/src/aios/sdk/_generated/api/memory_stores/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/src/aios/sdk/_generated/api/memory_stores/archive_memory_store.py
+++ b/src/aios/sdk/_generated/api/memory_stores/archive_memory_store.py
@@ -1,0 +1,207 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.memory_store import MemoryStore
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    store_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/memory-stores/{store_id}/archive".format(
+            store_id=quote(str(store_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MemoryStore | None:
+    if response.status_code == 200:
+        response_200 = MemoryStore.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MemoryStore]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MemoryStore]:
+    """Archive Store
+
+     Archive a memory store: hides from default lists, makes it read-only.
+
+    The store and its memories persist; sessions can still resolve memory
+    content. Subsequent ``update_memory_store`` calls fail until
+    un-archived (no API surface for that currently). Use
+    ``delete_memory_store`` for full removal.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryStore]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MemoryStore | None:
+    """Archive Store
+
+     Archive a memory store: hides from default lists, makes it read-only.
+
+    The store and its memories persist; sessions can still resolve memory
+    content. Subsequent ``update_memory_store`` calls fail until
+    un-archived (no API surface for that currently). Use
+    ``delete_memory_store`` for full removal.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryStore
+    """
+
+    return sync_detailed(
+        store_id=store_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MemoryStore]:
+    """Archive Store
+
+     Archive a memory store: hides from default lists, makes it read-only.
+
+    The store and its memories persist; sessions can still resolve memory
+    content. Subsequent ``update_memory_store`` calls fail until
+    un-archived (no API surface for that currently). Use
+    ``delete_memory_store`` for full removal.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryStore]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MemoryStore | None:
+    """Archive Store
+
+     Archive a memory store: hides from default lists, makes it read-only.
+
+    The store and its memories persist; sessions can still resolve memory
+    content. Subsequent ``update_memory_store`` calls fail until
+    un-archived (no API surface for that currently). Use
+    ``delete_memory_store`` for full removal.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryStore
+    """
+
+    return (
+        await asyncio_detailed(
+            store_id=store_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/create_memory.py
+++ b/src/aios/sdk/_generated/api/memory_stores/create_memory.py
@@ -1,0 +1,221 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.memory import Memory
+from ...models.memory_create import MemoryCreate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    store_id: str,
+    *,
+    body: MemoryCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/memory-stores/{store_id}/memories".format(
+            store_id=quote(str(store_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Memory | None:
+    if response.status_code == 201:
+        response_201 = Memory.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Memory]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Memory]:
+    """Create Memory
+
+     Create a memory at the given path within a store.
+
+    The content is also mirrored to the store's host directory so that
+    sandboxed sessions can read it through the filesystem. Creates an
+    initial version (every memory mutation creates a version).
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+        body (MemoryCreate): Request body for ``POST /v1/memory-stores/{store_id}/memories``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Memory]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Memory | None:
+    """Create Memory
+
+     Create a memory at the given path within a store.
+
+    The content is also mirrored to the store's host directory so that
+    sandboxed sessions can read it through the filesystem. Creates an
+    initial version (every memory mutation creates a version).
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+        body (MemoryCreate): Request body for ``POST /v1/memory-stores/{store_id}/memories``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Memory
+    """
+
+    return sync_detailed(
+        store_id=store_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Memory]:
+    """Create Memory
+
+     Create a memory at the given path within a store.
+
+    The content is also mirrored to the store's host directory so that
+    sandboxed sessions can read it through the filesystem. Creates an
+    initial version (every memory mutation creates a version).
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+        body (MemoryCreate): Request body for ``POST /v1/memory-stores/{store_id}/memories``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Memory]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Memory | None:
+    """Create Memory
+
+     Create a memory at the given path within a store.
+
+    The content is also mirrored to the store's host directory so that
+    sandboxed sessions can read it through the filesystem. Creates an
+    initial version (every memory mutation creates a version).
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+        body (MemoryCreate): Request body for ``POST /v1/memory-stores/{store_id}/memories``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Memory
+    """
+
+    return (
+        await asyncio_detailed(
+            store_id=store_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/create_memory_store.py
+++ b/src/aios/sdk/_generated/api/memory_stores/create_memory_store.py
@@ -1,0 +1,205 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.memory_store import MemoryStore
+from ...models.memory_store_create import MemoryStoreCreate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: MemoryStoreCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/memory-stores",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MemoryStore | None:
+    if response.status_code == 201:
+        response_201 = MemoryStore.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MemoryStore]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryStoreCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MemoryStore]:
+    """Create Store
+
+     Create a new memory store — a named collection of file-like memories.
+
+    Memories created in this store are mirrored to a per-store host
+    directory so that sessions referencing the store can read them through
+    the sandbox filesystem.
+
+    Args:
+        authorization (None | str | Unset):
+        body (MemoryStoreCreate): Request body for ``POST /v1/memory-stores``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryStore]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryStoreCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MemoryStore | None:
+    """Create Store
+
+     Create a new memory store — a named collection of file-like memories.
+
+    Memories created in this store are mirrored to a per-store host
+    directory so that sessions referencing the store can read them through
+    the sandbox filesystem.
+
+    Args:
+        authorization (None | str | Unset):
+        body (MemoryStoreCreate): Request body for ``POST /v1/memory-stores``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryStore
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryStoreCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MemoryStore]:
+    """Create Store
+
+     Create a new memory store — a named collection of file-like memories.
+
+    Memories created in this store are mirrored to a per-store host
+    directory so that sessions referencing the store can read them through
+    the sandbox filesystem.
+
+    Args:
+        authorization (None | str | Unset):
+        body (MemoryStoreCreate): Request body for ``POST /v1/memory-stores``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryStore]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryStoreCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MemoryStore | None:
+    """Create Store
+
+     Create a new memory store — a named collection of file-like memories.
+
+    Memories created in this store are mirrored to a per-store host
+    directory so that sessions referencing the store can read them through
+    the sandbox filesystem.
+
+    Args:
+        authorization (None | str | Unset):
+        body (MemoryStoreCreate): Request body for ``POST /v1/memory-stores``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryStore
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/delete_memory.py
+++ b/src/aios/sdk/_generated/api/memory_stores/delete_memory.py
@@ -1,0 +1,215 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    store_id: str,
+    memory_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/memory-stores/{store_id}/memories/{memory_id}".format(
+            store_id=quote(str(store_id), safe=""),
+            memory_id=quote(str(memory_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    store_id: str,
+    memory_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Memory
+
+     Soft-delete a memory and remove it from the host mirror.
+
+    Sets ``deleted_at`` on the memory and appends a ``deleted`` tombstone
+    version. The row and version history persist; live reads filter on
+    ``deleted_at IS NULL`` so the memory becomes invisible. Returns 204.
+
+    Args:
+        store_id (str):
+        memory_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        memory_id=memory_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    store_id: str,
+    memory_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete Memory
+
+     Soft-delete a memory and remove it from the host mirror.
+
+    Sets ``deleted_at`` on the memory and appends a ``deleted`` tombstone
+    version. The row and version history persist; live reads filter on
+    ``deleted_at IS NULL`` so the memory becomes invisible. Returns 204.
+
+    Args:
+        store_id (str):
+        memory_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        store_id=store_id,
+        memory_id=memory_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    store_id: str,
+    memory_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Memory
+
+     Soft-delete a memory and remove it from the host mirror.
+
+    Sets ``deleted_at`` on the memory and appends a ``deleted`` tombstone
+    version. The row and version history persist; live reads filter on
+    ``deleted_at IS NULL`` so the memory becomes invisible. Returns 204.
+
+    Args:
+        store_id (str):
+        memory_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        memory_id=memory_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    store_id: str,
+    memory_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete Memory
+
+     Soft-delete a memory and remove it from the host mirror.
+
+    Sets ``deleted_at`` on the memory and appends a ``deleted`` tombstone
+    version. The row and version history persist; live reads filter on
+    ``deleted_at IS NULL`` so the memory becomes invisible. Returns 204.
+
+    Args:
+        store_id (str):
+        memory_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            store_id=store_id,
+            memory_id=memory_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/delete_memory_store.py
+++ b/src/aios/sdk/_generated/api/memory_stores/delete_memory_store.py
@@ -1,0 +1,205 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    store_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/memory-stores/{store_id}".format(
+            store_id=quote(str(store_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Store
+
+     Hard-delete a memory store, all its memories, and its host mirror.
+
+    Cascade-deletes memories and versions in the database. After the DB
+    transaction commits, the per-store host mirror directory is removed
+    (best-effort — a missing dir is fine, indicates no session ever
+    provisioned for this store). Returns 204.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete Store
+
+     Hard-delete a memory store, all its memories, and its host mirror.
+
+    Cascade-deletes memories and versions in the database. After the DB
+    transaction commits, the per-store host mirror directory is removed
+    (best-effort — a missing dir is fine, indicates no session ever
+    provisioned for this store). Returns 204.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        store_id=store_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Store
+
+     Hard-delete a memory store, all its memories, and its host mirror.
+
+    Cascade-deletes memories and versions in the database. After the DB
+    transaction commits, the per-store host mirror directory is removed
+    (best-effort — a missing dir is fine, indicates no session ever
+    provisioned for this store). Returns 204.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete Store
+
+     Hard-delete a memory store, all its memories, and its host mirror.
+
+    Cascade-deletes memories and versions in the database. After the DB
+    transaction commits, the per-store host mirror directory is removed
+    (best-effort — a missing dir is fine, indicates no session ever
+    provisioned for this store). Returns 204.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            store_id=store_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/get_memory.py
+++ b/src/aios/sdk/_generated/api/memory_stores/get_memory.py
@@ -1,0 +1,201 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.memory import Memory
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    store_id: str,
+    memory_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/memory-stores/{store_id}/memories/{memory_id}".format(
+            store_id=quote(str(store_id), safe=""),
+            memory_id=quote(str(memory_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Memory | None:
+    if response.status_code == 200:
+        response_200 = Memory.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Memory]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    store_id: str,
+    memory_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Memory]:
+    """Get Memory
+
+     Fetch one memory by id, including its current content.
+
+    Args:
+        store_id (str):
+        memory_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Memory]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        memory_id=memory_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    store_id: str,
+    memory_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Memory | None:
+    """Get Memory
+
+     Fetch one memory by id, including its current content.
+
+    Args:
+        store_id (str):
+        memory_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Memory
+    """
+
+    return sync_detailed(
+        store_id=store_id,
+        memory_id=memory_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    store_id: str,
+    memory_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Memory]:
+    """Get Memory
+
+     Fetch one memory by id, including its current content.
+
+    Args:
+        store_id (str):
+        memory_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Memory]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        memory_id=memory_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    store_id: str,
+    memory_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Memory | None:
+    """Get Memory
+
+     Fetch one memory by id, including its current content.
+
+    Args:
+        store_id (str):
+        memory_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Memory
+    """
+
+    return (
+        await asyncio_detailed(
+            store_id=store_id,
+            memory_id=memory_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/get_memory_store.py
+++ b/src/aios/sdk/_generated/api/memory_stores/get_memory_store.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.memory_store import MemoryStore
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    store_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/memory-stores/{store_id}".format(
+            store_id=quote(str(store_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MemoryStore | None:
+    if response.status_code == 200:
+        response_200 = MemoryStore.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MemoryStore]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MemoryStore]:
+    """Get Store
+
+     Fetch one memory store by id.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryStore]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MemoryStore | None:
+    """Get Store
+
+     Fetch one memory store by id.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryStore
+    """
+
+    return sync_detailed(
+        store_id=store_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MemoryStore]:
+    """Get Store
+
+     Fetch one memory store by id.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryStore]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MemoryStore | None:
+    """Get Store
+
+     Fetch one memory store by id.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryStore
+    """
+
+    return (
+        await asyncio_detailed(
+            store_id=store_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/get_memory_version.py
+++ b/src/aios/sdk/_generated/api/memory_stores/get_memory_version.py
@@ -1,0 +1,201 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.memory_version import MemoryVersion
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    store_id: str,
+    version_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/memory-stores/{store_id}/memory-versions/{version_id}".format(
+            store_id=quote(str(store_id), safe=""),
+            version_id=quote(str(version_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MemoryVersion | None:
+    if response.status_code == 200:
+        response_200 = MemoryVersion.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MemoryVersion]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    store_id: str,
+    version_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MemoryVersion]:
+    """Get Version
+
+     Fetch one historical memory version by id.
+
+    Args:
+        store_id (str):
+        version_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryVersion]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        version_id=version_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    store_id: str,
+    version_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MemoryVersion | None:
+    """Get Version
+
+     Fetch one historical memory version by id.
+
+    Args:
+        store_id (str):
+        version_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryVersion
+    """
+
+    return sync_detailed(
+        store_id=store_id,
+        version_id=version_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    store_id: str,
+    version_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MemoryVersion]:
+    """Get Version
+
+     Fetch one historical memory version by id.
+
+    Args:
+        store_id (str):
+        version_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryVersion]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        version_id=version_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    store_id: str,
+    version_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MemoryVersion | None:
+    """Get Version
+
+     Fetch one historical memory version by id.
+
+    Args:
+        store_id (str):
+        version_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryVersion
+    """
+
+    return (
+        await asyncio_detailed(
+            store_id=store_id,
+            version_id=version_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/list_memories.py
+++ b/src/aios/sdk/_generated/api/memory_stores/list_memories.py
@@ -1,0 +1,273 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_union_memory_memory_prefix import (
+    ListResponseUnionMemoryMemoryPrefix,
+)
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    store_id: str,
+    *,
+    path_prefix: None | str | Unset = UNSET,
+    order_by: str | Unset = "created_at",
+    depth: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    json_path_prefix: None | str | Unset
+    if isinstance(path_prefix, Unset):
+        json_path_prefix = UNSET
+    else:
+        json_path_prefix = path_prefix
+    params["path_prefix"] = json_path_prefix
+
+    params["order_by"] = order_by
+
+    json_depth: int | None | Unset
+    if isinstance(depth, Unset):
+        json_depth = UNSET
+    else:
+        json_depth = depth
+    params["depth"] = json_depth
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/memory-stores/{store_id}/memories".format(
+            store_id=quote(str(store_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseUnionMemoryMemoryPrefix | None:
+    if response.status_code == 200:
+        response_200 = ListResponseUnionMemoryMemoryPrefix.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseUnionMemoryMemoryPrefix]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    path_prefix: None | str | Unset = UNSET,
+    order_by: str | Unset = "created_at",
+    depth: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseUnionMemoryMemoryPrefix]:
+    """List Memories
+
+     List memories in a store, optionally filtered and grouped by path.
+
+    ``path_prefix`` is a literal prefix match on the memory path. ``depth``
+    groups deeper paths into ``MemoryPrefix`` entries (directory-style
+    listings) — entries past the depth boundary are collapsed into a
+    single prefix entry per shared directory. ``order_by`` accepts
+    ``created_at`` (default) or ``path``.
+
+    Args:
+        store_id (str):
+        path_prefix (None | str | Unset):
+        order_by (str | Unset):  Default: 'created_at'.
+        depth (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseUnionMemoryMemoryPrefix]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        path_prefix=path_prefix,
+        order_by=order_by,
+        depth=depth,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    path_prefix: None | str | Unset = UNSET,
+    order_by: str | Unset = "created_at",
+    depth: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseUnionMemoryMemoryPrefix | None:
+    """List Memories
+
+     List memories in a store, optionally filtered and grouped by path.
+
+    ``path_prefix`` is a literal prefix match on the memory path. ``depth``
+    groups deeper paths into ``MemoryPrefix`` entries (directory-style
+    listings) — entries past the depth boundary are collapsed into a
+    single prefix entry per shared directory. ``order_by`` accepts
+    ``created_at`` (default) or ``path``.
+
+    Args:
+        store_id (str):
+        path_prefix (None | str | Unset):
+        order_by (str | Unset):  Default: 'created_at'.
+        depth (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseUnionMemoryMemoryPrefix
+    """
+
+    return sync_detailed(
+        store_id=store_id,
+        client=client,
+        path_prefix=path_prefix,
+        order_by=order_by,
+        depth=depth,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    path_prefix: None | str | Unset = UNSET,
+    order_by: str | Unset = "created_at",
+    depth: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseUnionMemoryMemoryPrefix]:
+    """List Memories
+
+     List memories in a store, optionally filtered and grouped by path.
+
+    ``path_prefix`` is a literal prefix match on the memory path. ``depth``
+    groups deeper paths into ``MemoryPrefix`` entries (directory-style
+    listings) — entries past the depth boundary are collapsed into a
+    single prefix entry per shared directory. ``order_by`` accepts
+    ``created_at`` (default) or ``path``.
+
+    Args:
+        store_id (str):
+        path_prefix (None | str | Unset):
+        order_by (str | Unset):  Default: 'created_at'.
+        depth (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseUnionMemoryMemoryPrefix]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        path_prefix=path_prefix,
+        order_by=order_by,
+        depth=depth,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    path_prefix: None | str | Unset = UNSET,
+    order_by: str | Unset = "created_at",
+    depth: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseUnionMemoryMemoryPrefix | None:
+    """List Memories
+
+     List memories in a store, optionally filtered and grouped by path.
+
+    ``path_prefix`` is a literal prefix match on the memory path. ``depth``
+    groups deeper paths into ``MemoryPrefix`` entries (directory-style
+    listings) — entries past the depth boundary are collapsed into a
+    single prefix entry per shared directory. ``order_by`` accepts
+    ``created_at`` (default) or ``path``.
+
+    Args:
+        store_id (str):
+        path_prefix (None | str | Unset):
+        order_by (str | Unset):  Default: 'created_at'.
+        depth (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseUnionMemoryMemoryPrefix
+    """
+
+    return (
+        await asyncio_detailed(
+            store_id=store_id,
+            client=client,
+            path_prefix=path_prefix,
+            order_by=order_by,
+            depth=depth,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/list_memory_stores.py
+++ b/src/aios/sdk/_generated/api/memory_stores/list_memory_stores.py
@@ -1,0 +1,222 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_memory_store import ListResponseMemoryStore
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    include_archived: bool | Unset = False,
+    limit: int | Unset = 100,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["include_archived"] = include_archived
+
+    params["limit"] = limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/memory-stores",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseMemoryStore | None:
+    if response.status_code == 200:
+        response_200 = ListResponseMemoryStore.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseMemoryStore]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    include_archived: bool | Unset = False,
+    limit: int | Unset = 100,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseMemoryStore]:
+    """List Stores
+
+     List memory stores, newest first.
+
+    Unlike most resources, archived stores can be included via
+    ``include_archived=true`` (default false). No cursor pagination — bumps
+    the default limit to 100 since stores are typically few.
+
+    Args:
+        include_archived (bool | Unset):  Default: False.
+        limit (int | Unset):  Default: 100.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseMemoryStore]
+    """
+
+    kwargs = _get_kwargs(
+        include_archived=include_archived,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    include_archived: bool | Unset = False,
+    limit: int | Unset = 100,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseMemoryStore | None:
+    """List Stores
+
+     List memory stores, newest first.
+
+    Unlike most resources, archived stores can be included via
+    ``include_archived=true`` (default false). No cursor pagination — bumps
+    the default limit to 100 since stores are typically few.
+
+    Args:
+        include_archived (bool | Unset):  Default: False.
+        limit (int | Unset):  Default: 100.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseMemoryStore
+    """
+
+    return sync_detailed(
+        client=client,
+        include_archived=include_archived,
+        limit=limit,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    include_archived: bool | Unset = False,
+    limit: int | Unset = 100,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseMemoryStore]:
+    """List Stores
+
+     List memory stores, newest first.
+
+    Unlike most resources, archived stores can be included via
+    ``include_archived=true`` (default false). No cursor pagination — bumps
+    the default limit to 100 since stores are typically few.
+
+    Args:
+        include_archived (bool | Unset):  Default: False.
+        limit (int | Unset):  Default: 100.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseMemoryStore]
+    """
+
+    kwargs = _get_kwargs(
+        include_archived=include_archived,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    include_archived: bool | Unset = False,
+    limit: int | Unset = 100,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseMemoryStore | None:
+    """List Stores
+
+     List memory stores, newest first.
+
+    Unlike most resources, archived stores can be included via
+    ``include_archived=true`` (default false). No cursor pagination — bumps
+    the default limit to 100 since stores are typically few.
+
+    Args:
+        include_archived (bool | Unset):  Default: False.
+        limit (int | Unset):  Default: 100.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseMemoryStore
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            include_archived=include_archived,
+            limit=limit,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/list_memory_versions.py
+++ b/src/aios/sdk/_generated/api/memory_stores/list_memory_versions.py
@@ -1,0 +1,243 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_memory_version import ListResponseMemoryVersion
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    store_id: str,
+    *,
+    memory_id: None | str | Unset = UNSET,
+    limit: int | Unset = 100,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    json_memory_id: None | str | Unset
+    if isinstance(memory_id, Unset):
+        json_memory_id = UNSET
+    else:
+        json_memory_id = memory_id
+    params["memory_id"] = json_memory_id
+
+    params["limit"] = limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/memory-stores/{store_id}/memory-versions".format(
+            store_id=quote(str(store_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseMemoryVersion | None:
+    if response.status_code == 200:
+        response_200 = ListResponseMemoryVersion.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseMemoryVersion]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    memory_id: None | str | Unset = UNSET,
+    limit: int | Unset = 100,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseMemoryVersion]:
+    """List Versions
+
+     List memory versions in a store, newest first.
+
+    Optional ``memory_id`` filters to a single memory's version history.
+    Without the filter, returns versions across all memories in the store
+    (useful for audit). No cursor pagination; bumps default limit to 100.
+
+    Args:
+        store_id (str):
+        memory_id (None | str | Unset):
+        limit (int | Unset):  Default: 100.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseMemoryVersion]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        memory_id=memory_id,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    memory_id: None | str | Unset = UNSET,
+    limit: int | Unset = 100,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseMemoryVersion | None:
+    """List Versions
+
+     List memory versions in a store, newest first.
+
+    Optional ``memory_id`` filters to a single memory's version history.
+    Without the filter, returns versions across all memories in the store
+    (useful for audit). No cursor pagination; bumps default limit to 100.
+
+    Args:
+        store_id (str):
+        memory_id (None | str | Unset):
+        limit (int | Unset):  Default: 100.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseMemoryVersion
+    """
+
+    return sync_detailed(
+        store_id=store_id,
+        client=client,
+        memory_id=memory_id,
+        limit=limit,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    memory_id: None | str | Unset = UNSET,
+    limit: int | Unset = 100,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseMemoryVersion]:
+    """List Versions
+
+     List memory versions in a store, newest first.
+
+    Optional ``memory_id`` filters to a single memory's version history.
+    Without the filter, returns versions across all memories in the store
+    (useful for audit). No cursor pagination; bumps default limit to 100.
+
+    Args:
+        store_id (str):
+        memory_id (None | str | Unset):
+        limit (int | Unset):  Default: 100.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseMemoryVersion]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        memory_id=memory_id,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    memory_id: None | str | Unset = UNSET,
+    limit: int | Unset = 100,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseMemoryVersion | None:
+    """List Versions
+
+     List memory versions in a store, newest first.
+
+    Optional ``memory_id`` filters to a single memory's version history.
+    Without the filter, returns versions across all memories in the store
+    (useful for audit). No cursor pagination; bumps default limit to 100.
+
+    Args:
+        store_id (str):
+        memory_id (None | str | Unset):
+        limit (int | Unset):  Default: 100.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseMemoryVersion
+    """
+
+    return (
+        await asyncio_detailed(
+            store_id=store_id,
+            client=client,
+            memory_id=memory_id,
+            limit=limit,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/redact_memory_version.py
+++ b/src/aios/sdk/_generated/api/memory_stores/redact_memory_version.py
@@ -1,0 +1,221 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.memory_version import MemoryVersion
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    store_id: str,
+    version_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/memory-stores/{store_id}/memory-versions/{version_id}/redact".format(
+            store_id=quote(str(store_id), safe=""),
+            version_id=quote(str(version_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MemoryVersion | None:
+    if response.status_code == 200:
+        response_200 = MemoryVersion.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MemoryVersion]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    store_id: str,
+    version_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MemoryVersion]:
+    """Redact Version
+
+     Redact the content of a historical memory version in place.
+
+    The version row persists for audit (with the actor and timestamp) but
+    its content field is cleared. Use to scrub sensitive data that was
+    previously written into a memory. Live memory content is unaffected
+    (only this specific historical version is redacted).
+
+    Args:
+        store_id (str):
+        version_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryVersion]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        version_id=version_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    store_id: str,
+    version_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MemoryVersion | None:
+    """Redact Version
+
+     Redact the content of a historical memory version in place.
+
+    The version row persists for audit (with the actor and timestamp) but
+    its content field is cleared. Use to scrub sensitive data that was
+    previously written into a memory. Live memory content is unaffected
+    (only this specific historical version is redacted).
+
+    Args:
+        store_id (str):
+        version_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryVersion
+    """
+
+    return sync_detailed(
+        store_id=store_id,
+        version_id=version_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    store_id: str,
+    version_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MemoryVersion]:
+    """Redact Version
+
+     Redact the content of a historical memory version in place.
+
+    The version row persists for audit (with the actor and timestamp) but
+    its content field is cleared. Use to scrub sensitive data that was
+    previously written into a memory. Live memory content is unaffected
+    (only this specific historical version is redacted).
+
+    Args:
+        store_id (str):
+        version_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryVersion]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        version_id=version_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    store_id: str,
+    version_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MemoryVersion | None:
+    """Redact Version
+
+     Redact the content of a historical memory version in place.
+
+    The version row persists for audit (with the actor and timestamp) but
+    its content field is cleared. Use to scrub sensitive data that was
+    previously written into a memory. Live memory content is unaffected
+    (only this specific historical version is redacted).
+
+    Args:
+        store_id (str):
+        version_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryVersion
+    """
+
+    return (
+        await asyncio_detailed(
+            store_id=store_id,
+            version_id=version_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/update_memory.py
+++ b/src/aios/sdk/_generated/api/memory_stores/update_memory.py
@@ -1,0 +1,259 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.memory import Memory
+from ...models.memory_update import MemoryUpdate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    store_id: str,
+    memory_id: str,
+    *,
+    body: MemoryUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/memory-stores/{store_id}/memories/{memory_id}".format(
+            store_id=quote(str(store_id), safe=""),
+            memory_id=quote(str(memory_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Memory | None:
+    if response.status_code == 200:
+        response_200 = Memory.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Memory]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    store_id: str,
+    memory_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Memory]:
+    """Update Memory
+
+     Update a memory's content and/or path. Creates a new version.
+
+    Optionally honors a ``precondition.content_sha256`` for optimistic
+    concurrency — if the current content's SHA-256 differs, the update
+    fails with a precondition error rather than overwriting. The host
+    mirror is updated to match: renames delete the old path and write the
+    new one.
+
+    Args:
+        store_id (str):
+        memory_id (str):
+        authorization (None | str | Unset):
+        body (MemoryUpdate): Request body for ``POST /v1/memory-stores/{store_id}/memories/{id}``.
+
+            Either ``content`` or ``path`` (or both) must be provided. Precondition
+            only gates the content half — renames are unconditional, matching the
+            Anthropic semantics confirmed by live probe.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Memory]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        memory_id=memory_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    store_id: str,
+    memory_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Memory | None:
+    """Update Memory
+
+     Update a memory's content and/or path. Creates a new version.
+
+    Optionally honors a ``precondition.content_sha256`` for optimistic
+    concurrency — if the current content's SHA-256 differs, the update
+    fails with a precondition error rather than overwriting. The host
+    mirror is updated to match: renames delete the old path and write the
+    new one.
+
+    Args:
+        store_id (str):
+        memory_id (str):
+        authorization (None | str | Unset):
+        body (MemoryUpdate): Request body for ``POST /v1/memory-stores/{store_id}/memories/{id}``.
+
+            Either ``content`` or ``path`` (or both) must be provided. Precondition
+            only gates the content half — renames are unconditional, matching the
+            Anthropic semantics confirmed by live probe.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Memory
+    """
+
+    return sync_detailed(
+        store_id=store_id,
+        memory_id=memory_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    store_id: str,
+    memory_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Memory]:
+    """Update Memory
+
+     Update a memory's content and/or path. Creates a new version.
+
+    Optionally honors a ``precondition.content_sha256`` for optimistic
+    concurrency — if the current content's SHA-256 differs, the update
+    fails with a precondition error rather than overwriting. The host
+    mirror is updated to match: renames delete the old path and write the
+    new one.
+
+    Args:
+        store_id (str):
+        memory_id (str):
+        authorization (None | str | Unset):
+        body (MemoryUpdate): Request body for ``POST /v1/memory-stores/{store_id}/memories/{id}``.
+
+            Either ``content`` or ``path`` (or both) must be provided. Precondition
+            only gates the content half — renames are unconditional, matching the
+            Anthropic semantics confirmed by live probe.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Memory]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        memory_id=memory_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    store_id: str,
+    memory_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Memory | None:
+    """Update Memory
+
+     Update a memory's content and/or path. Creates a new version.
+
+    Optionally honors a ``precondition.content_sha256`` for optimistic
+    concurrency — if the current content's SHA-256 differs, the update
+    fails with a precondition error rather than overwriting. The host
+    mirror is updated to match: renames delete the old path and write the
+    new one.
+
+    Args:
+        store_id (str):
+        memory_id (str):
+        authorization (None | str | Unset):
+        body (MemoryUpdate): Request body for ``POST /v1/memory-stores/{store_id}/memories/{id}``.
+
+            Either ``content`` or ``path`` (or both) must be provided. Precondition
+            only gates the content half — renames are unconditional, matching the
+            Anthropic semantics confirmed by live probe.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Memory
+    """
+
+    return (
+        await asyncio_detailed(
+            store_id=store_id,
+            memory_id=memory_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/memory_stores/update_memory_store.py
+++ b/src/aios/sdk/_generated/api/memory_stores/update_memory_store.py
@@ -1,0 +1,221 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.memory_store import MemoryStore
+from ...models.memory_store_update import MemoryStoreUpdate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    store_id: str,
+    *,
+    body: MemoryStoreUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/memory-stores/{store_id}".format(
+            store_id=quote(str(store_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MemoryStore | None:
+    if response.status_code == 200:
+        response_200 = MemoryStore.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MemoryStore]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryStoreUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MemoryStore]:
+    """Update Store
+
+     Update a memory store's ``name``, ``description``, or ``metadata``.
+
+    Rejects with ``MemoryStoreArchivedError`` if the store is archived —
+    archived stores are read-only. Treat as partial update on the listed
+    fields.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+        body (MemoryStoreUpdate): Request body for ``POST /v1/memory-stores/{id}``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryStore]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryStoreUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MemoryStore | None:
+    """Update Store
+
+     Update a memory store's ``name``, ``description``, or ``metadata``.
+
+    Rejects with ``MemoryStoreArchivedError`` if the store is archived —
+    archived stores are read-only. Treat as partial update on the listed
+    fields.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+        body (MemoryStoreUpdate): Request body for ``POST /v1/memory-stores/{id}``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryStore
+    """
+
+    return sync_detailed(
+        store_id=store_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryStoreUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MemoryStore]:
+    """Update Store
+
+     Update a memory store's ``name``, ``description``, or ``metadata``.
+
+    Rejects with ``MemoryStoreArchivedError`` if the store is archived —
+    archived stores are read-only. Treat as partial update on the listed
+    fields.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+        body (MemoryStoreUpdate): Request body for ``POST /v1/memory-stores/{id}``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MemoryStore]
+    """
+
+    kwargs = _get_kwargs(
+        store_id=store_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    store_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MemoryStoreUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MemoryStore | None:
+    """Update Store
+
+     Update a memory store's ``name``, ``description``, or ``metadata``.
+
+    Rejects with ``MemoryStoreArchivedError`` if the store is archived —
+    archived stores are read-only. Treat as partial update on the listed
+    fields.
+
+    Args:
+        store_id (str):
+        authorization (None | str | Unset):
+        body (MemoryStoreUpdate): Request body for ``POST /v1/memory-stores/{id}``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MemoryStore
+    """
+
+    return (
+        await asyncio_detailed(
+            store_id=store_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/session_templates/__init__.py
+++ b/src/aios/sdk/_generated/api/session_templates/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/src/aios/sdk/_generated/api/session_templates/archive_session_template.py
+++ b/src/aios/sdk/_generated/api/session_templates/archive_session_template.py
@@ -1,0 +1,209 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    template_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/session-templates/{template_id}".format(
+            template_id=quote(str(template_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    template_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete
+
+     Archive a session template (soft-delete via DELETE verb).
+
+    Already-spawned sessions are unaffected and continue normally. Per-chat
+    connections that reference this template by id keep their existing
+    sessions but will fail to spawn new chat sessions at the inbound
+    handler until the connection is reconfigured to point at a different
+    template. There is no API surface to un-archive currently.
+
+    Args:
+        template_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        template_id=template_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    template_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete
+
+     Archive a session template (soft-delete via DELETE verb).
+
+    Already-spawned sessions are unaffected and continue normally. Per-chat
+    connections that reference this template by id keep their existing
+    sessions but will fail to spawn new chat sessions at the inbound
+    handler until the connection is reconfigured to point at a different
+    template. There is no API surface to un-archive currently.
+
+    Args:
+        template_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        template_id=template_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    template_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete
+
+     Archive a session template (soft-delete via DELETE verb).
+
+    Already-spawned sessions are unaffected and continue normally. Per-chat
+    connections that reference this template by id keep their existing
+    sessions but will fail to spawn new chat sessions at the inbound
+    handler until the connection is reconfigured to point at a different
+    template. There is no API surface to un-archive currently.
+
+    Args:
+        template_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        template_id=template_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    template_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete
+
+     Archive a session template (soft-delete via DELETE verb).
+
+    Already-spawned sessions are unaffected and continue normally. Per-chat
+    connections that reference this template by id keep their existing
+    sessions but will fail to spawn new chat sessions at the inbound
+    handler until the connection is reconfigured to point at a different
+    template. There is no API surface to un-archive currently.
+
+    Args:
+        template_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            template_id=template_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/session_templates/create_session_template.py
+++ b/src/aios/sdk/_generated/api/session_templates/create_session_template.py
@@ -1,0 +1,209 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session_template import SessionTemplate
+from ...models.session_template_create import SessionTemplateCreate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: SessionTemplateCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/session-templates",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | SessionTemplate | None:
+    if response.status_code == 201:
+        response_201 = SessionTemplate.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | SessionTemplate]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionTemplateCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | SessionTemplate]:
+    """Create
+
+     Create a session template — a frozen recipe for per_chat session spawn.
+
+    Captures the agent + environment + vaults + memory stores that a
+    per_chat connection will use when spawning a session for a new chat
+    partner. Pin ``agent_version`` to a specific version for deterministic
+    spawning, or leave unset to track the agent's latest.
+
+    Args:
+        authorization (None | str | Unset):
+        body (SessionTemplateCreate): Request body for ``POST /v1/session-templates``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SessionTemplate]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionTemplateCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | SessionTemplate | None:
+    """Create
+
+     Create a session template — a frozen recipe for per_chat session spawn.
+
+    Captures the agent + environment + vaults + memory stores that a
+    per_chat connection will use when spawning a session for a new chat
+    partner. Pin ``agent_version`` to a specific version for deterministic
+    spawning, or leave unset to track the agent's latest.
+
+    Args:
+        authorization (None | str | Unset):
+        body (SessionTemplateCreate): Request body for ``POST /v1/session-templates``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SessionTemplate
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionTemplateCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | SessionTemplate]:
+    """Create
+
+     Create a session template — a frozen recipe for per_chat session spawn.
+
+    Captures the agent + environment + vaults + memory stores that a
+    per_chat connection will use when spawning a session for a new chat
+    partner. Pin ``agent_version`` to a specific version for deterministic
+    spawning, or leave unset to track the agent's latest.
+
+    Args:
+        authorization (None | str | Unset):
+        body (SessionTemplateCreate): Request body for ``POST /v1/session-templates``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SessionTemplate]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionTemplateCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | SessionTemplate | None:
+    """Create
+
+     Create a session template — a frozen recipe for per_chat session spawn.
+
+    Captures the agent + environment + vaults + memory stores that a
+    per_chat connection will use when spawning a session for a new chat
+    partner. Pin ``agent_version`` to a specific version for deterministic
+    spawning, or leave unset to track the agent's latest.
+
+    Args:
+        authorization (None | str | Unset):
+        body (SessionTemplateCreate): Request body for ``POST /v1/session-templates``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SessionTemplate
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/session_templates/get_session_template.py
+++ b/src/aios/sdk/_generated/api/session_templates/get_session_template.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session_template import SessionTemplate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    template_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/session-templates/{template_id}".format(
+            template_id=quote(str(template_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | SessionTemplate | None:
+    if response.status_code == 200:
+        response_200 = SessionTemplate.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | SessionTemplate]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    template_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | SessionTemplate]:
+    """Get
+
+     Fetch one session template by id.
+
+    Args:
+        template_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SessionTemplate]
+    """
+
+    kwargs = _get_kwargs(
+        template_id=template_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    template_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | SessionTemplate | None:
+    """Get
+
+     Fetch one session template by id.
+
+    Args:
+        template_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SessionTemplate
+    """
+
+    return sync_detailed(
+        template_id=template_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    template_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | SessionTemplate]:
+    """Get
+
+     Fetch one session template by id.
+
+    Args:
+        template_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SessionTemplate]
+    """
+
+    kwargs = _get_kwargs(
+        template_id=template_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    template_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | SessionTemplate | None:
+    """Get
+
+     Fetch one session template by id.
+
+    Args:
+        template_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SessionTemplate
+    """
+
+    return (
+        await asyncio_detailed(
+            template_id=template_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/session_templates/list_session_templates.py
+++ b/src/aios/sdk/_generated/api/session_templates/list_session_templates.py
@@ -1,0 +1,219 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_session_template import ListResponseSessionTemplate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    json_after: None | str | Unset
+    if isinstance(after, Unset):
+        json_after = UNSET
+    else:
+        json_after = after
+    params["after"] = json_after
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/session-templates",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseSessionTemplate | None:
+    if response.status_code == 200:
+        response_200 = ListResponseSessionTemplate.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseSessionTemplate]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseSessionTemplate]:
+    """List
+
+     List session templates, newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseSessionTemplate]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseSessionTemplate | None:
+    """List
+
+     List session templates, newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseSessionTemplate
+    """
+
+    return sync_detailed(
+        client=client,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseSessionTemplate]:
+    """List
+
+     List session templates, newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseSessionTemplate]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseSessionTemplate | None:
+    """List
+
+     List session templates, newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseSessionTemplate
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            limit=limit,
+            after=after,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/session_templates/update_session_template.py
+++ b/src/aios/sdk/_generated/api/session_templates/update_session_template.py
@@ -1,0 +1,237 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session_template import SessionTemplate
+from ...models.session_template_update import SessionTemplateUpdate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    template_id: str,
+    *,
+    body: SessionTemplateUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/v1/session-templates/{template_id}".format(
+            template_id=quote(str(template_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | SessionTemplate | None:
+    if response.status_code == 200:
+        response_200 = SessionTemplate.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | SessionTemplate]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    template_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionTemplateUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | SessionTemplate]:
+    r"""Update
+
+     Update a session template's recipe fields. Omitted fields are preserved.
+
+    The ``agent_version`` field uses sentinel-based partial-update semantics:
+    omit it to preserve the current pin (or current \"track latest\" state),
+    pass null to switch to \"track latest,\" pass a number to pin to that
+    specific version. Already-spawned sessions are unaffected.
+
+    Args:
+        template_id (str):
+        authorization (None | str | Unset):
+        body (SessionTemplateUpdate): Request body for ``PUT /v1/session-templates/{id}``.
+
+            Updates apply to future spawns only — already-spawned sessions are
+            not retroactively migrated (see module docstring).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SessionTemplate]
+    """
+
+    kwargs = _get_kwargs(
+        template_id=template_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    template_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionTemplateUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | SessionTemplate | None:
+    r"""Update
+
+     Update a session template's recipe fields. Omitted fields are preserved.
+
+    The ``agent_version`` field uses sentinel-based partial-update semantics:
+    omit it to preserve the current pin (or current \"track latest\" state),
+    pass null to switch to \"track latest,\" pass a number to pin to that
+    specific version. Already-spawned sessions are unaffected.
+
+    Args:
+        template_id (str):
+        authorization (None | str | Unset):
+        body (SessionTemplateUpdate): Request body for ``PUT /v1/session-templates/{id}``.
+
+            Updates apply to future spawns only — already-spawned sessions are
+            not retroactively migrated (see module docstring).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SessionTemplate
+    """
+
+    return sync_detailed(
+        template_id=template_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    template_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionTemplateUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | SessionTemplate]:
+    r"""Update
+
+     Update a session template's recipe fields. Omitted fields are preserved.
+
+    The ``agent_version`` field uses sentinel-based partial-update semantics:
+    omit it to preserve the current pin (or current \"track latest\" state),
+    pass null to switch to \"track latest,\" pass a number to pin to that
+    specific version. Already-spawned sessions are unaffected.
+
+    Args:
+        template_id (str):
+        authorization (None | str | Unset):
+        body (SessionTemplateUpdate): Request body for ``PUT /v1/session-templates/{id}``.
+
+            Updates apply to future spawns only — already-spawned sessions are
+            not retroactively migrated (see module docstring).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SessionTemplate]
+    """
+
+    kwargs = _get_kwargs(
+        template_id=template_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    template_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionTemplateUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | SessionTemplate | None:
+    r"""Update
+
+     Update a session template's recipe fields. Omitted fields are preserved.
+
+    The ``agent_version`` field uses sentinel-based partial-update semantics:
+    omit it to preserve the current pin (or current \"track latest\" state),
+    pass null to switch to \"track latest,\" pass a number to pin to that
+    specific version. Already-spawned sessions are unaffected.
+
+    Args:
+        template_id (str):
+        authorization (None | str | Unset):
+        body (SessionTemplateUpdate): Request body for ``PUT /v1/session-templates/{id}``.
+
+            Updates apply to future spawns only — already-spawned sessions are
+            not retroactively migrated (see module docstring).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SessionTemplate
+    """
+
+    return (
+        await asyncio_detailed(
+            template_id=template_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/__init__.py
+++ b/src/aios/sdk/_generated/api/sessions/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/src/aios/sdk/_generated/api/sessions/archive_v1_sessions_session_id_archive_post.py
+++ b/src/aios/sdk/_generated/api/sessions/archive_v1_sessions_session_id_archive_post.py
@@ -1,0 +1,179 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session import Session
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/sessions/{session_id}/archive".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Session | None:
+    if response.status_code == 200:
+        response_200 = Session.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Session]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Archive
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Archive
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Archive
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Archive
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/clone_v1_sessions_session_id_clone_post.py
+++ b/src/aios/sdk/_generated/api/sessions/clone_v1_sessions_session_id_clone_post.py
@@ -1,0 +1,241 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session import Session
+from ...models.session_clone_request import SessionCloneRequest
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    body: SessionCloneRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/sessions/{session_id}/clone".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Session | None:
+    if response.status_code == 201:
+        response_201 = Session.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Session]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionCloneRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Clone
+
+     Clone a session at its current state into a new session.
+
+    The clone inherits everything that defines the parent's next-step context
+    (events, agent binding, vaults, focal channel, status, stop_reason) but
+    has its own session_id and a fresh workspace volume by default.
+
+    Refuses if the parent isn't ``idle`` or ``terminated``.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionCloneRequest): Request body for ``POST /v1/sessions/{id}/clone``.
+
+            All fields optional; the clone inherits everything not overridden from
+            the parent at clone time.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionCloneRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Clone
+
+     Clone a session at its current state into a new session.
+
+    The clone inherits everything that defines the parent's next-step context
+    (events, agent binding, vaults, focal channel, status, stop_reason) but
+    has its own session_id and a fresh workspace volume by default.
+
+    Refuses if the parent isn't ``idle`` or ``terminated``.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionCloneRequest): Request body for ``POST /v1/sessions/{id}/clone``.
+
+            All fields optional; the clone inherits everything not overridden from
+            the parent at clone time.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionCloneRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Clone
+
+     Clone a session at its current state into a new session.
+
+    The clone inherits everything that defines the parent's next-step context
+    (events, agent binding, vaults, focal channel, status, stop_reason) but
+    has its own session_id and a fresh workspace volume by default.
+
+    Refuses if the parent isn't ``idle`` or ``terminated``.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionCloneRequest): Request body for ``POST /v1/sessions/{id}/clone``.
+
+            All fields optional; the clone inherits everything not overridden from
+            the parent at clone time.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionCloneRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Clone
+
+     Clone a session at its current state into a new session.
+
+    The clone inherits everything that defines the parent's next-step context
+    (events, agent binding, vaults, focal channel, status, stop_reason) but
+    has its own session_id and a fresh workspace volume by default.
+
+    Refuses if the parent isn't ``idle`` or ``terminated``.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionCloneRequest): Request body for ``POST /v1/sessions/{id}/clone``.
+
+            All fields optional; the clone inherits everything not overridden from
+            the parent at clone time.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/create_v1_sessions_post.py
+++ b/src/aios/sdk/_generated/api/sessions/create_v1_sessions_post.py
@@ -1,0 +1,181 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session import Session
+from ...models.session_create import SessionCreate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: SessionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/sessions",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Session | None:
+    if response.status_code == 201:
+        response_201 = Session.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Session]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Create
+
+    Args:
+        authorization (None | str | Unset):
+        body (SessionCreate): Request body for `POST /v1/sessions`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Create
+
+    Args:
+        authorization (None | str | Unset):
+        body (SessionCreate): Request body for `POST /v1/sessions`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Create
+
+    Args:
+        authorization (None | str | Unset):
+        body (SessionCreate): Request body for `POST /v1/sessions`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Create
+
+    Args:
+        authorization (None | str | Unset):
+        body (SessionCreate): Request body for `POST /v1/sessions`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/delete_v1_sessions_session_id_delete.py
+++ b/src/aios/sdk/_generated/api/sessions/delete_v1_sessions_session_id_delete.py
@@ -1,0 +1,177 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/sessions/{session_id}".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/get_context_v1_sessions_session_id_context_get.py
+++ b/src/aios/sdk/_generated/api/sessions/get_context_v1_sessions_session_id_context_get.py
@@ -1,0 +1,215 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.context_response import ContextResponse
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/sessions/{session_id}/context".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ContextResponse | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = ContextResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ContextResponse | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[ContextResponse | HTTPValidationError]:
+    """Get Context
+
+     Return the chat-completions payload the worker would send next.
+
+    Dry-run preview for debugging prompt construction.  Reuses the exact
+    composer the worker's step function uses (:func:`compose_step_context`)
+    so the endpoint's output is byte-identical to what the next model
+    call would see — no divergence.  Side effects (skill provisioning,
+    session-status bumps, event appends) are omitted; the endpoint is
+    read-only.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ContextResponse | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> ContextResponse | HTTPValidationError | None:
+    """Get Context
+
+     Return the chat-completions payload the worker would send next.
+
+    Dry-run preview for debugging prompt construction.  Reuses the exact
+    composer the worker's step function uses (:func:`compose_step_context`)
+    so the endpoint's output is byte-identical to what the next model
+    call would see — no divergence.  Side effects (skill provisioning,
+    session-status bumps, event appends) are omitted; the endpoint is
+    read-only.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ContextResponse | HTTPValidationError
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[ContextResponse | HTTPValidationError]:
+    """Get Context
+
+     Return the chat-completions payload the worker would send next.
+
+    Dry-run preview for debugging prompt construction.  Reuses the exact
+    composer the worker's step function uses (:func:`compose_step_context`)
+    so the endpoint's output is byte-identical to what the next model
+    call would see — no divergence.  Side effects (skill provisioning,
+    session-status bumps, event appends) are omitted; the endpoint is
+    read-only.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ContextResponse | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> ContextResponse | HTTPValidationError | None:
+    """Get Context
+
+     Return the chat-completions payload the worker would send next.
+
+    Dry-run preview for debugging prompt construction.  Reuses the exact
+    composer the worker's step function uses (:func:`compose_step_context`)
+    so the endpoint's output is byte-identical to what the next model
+    call would see — no divergence.  Side effects (skill provisioning,
+    session-status bumps, event appends) are omitted; the endpoint is
+    read-only.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ContextResponse | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/get_resource_v1_sessions_session_id_resources_resource_id_get.py
+++ b/src/aios/sdk/_generated/api/sessions/get_resource_v1_sessions_session_id_resources_resource_id_get.py
@@ -1,0 +1,217 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.github_repository_resource_echo import GithubRepositoryResourceEcho
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    resource_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/sessions/{session_id}/resources/{resource_id}".format(
+            session_id=quote(str(session_id), safe=""),
+            resource_id=quote(str(resource_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> GithubRepositoryResourceEcho | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = GithubRepositoryResourceEcho.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[GithubRepositoryResourceEcho | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    resource_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[GithubRepositoryResourceEcho | HTTPValidationError]:
+    """Get Resource
+
+     Fetch a single resource attached to ``session_id`` by its id.
+
+    v1 only supports ``github_repository`` (id prefix ``ghrepo_``) since
+    memory store attachments are keyed by ``(session_id, memory_store_id)``
+    and don't have a separate attachment id.
+
+    Args:
+        session_id (str):
+        resource_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GithubRepositoryResourceEcho | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        resource_id=resource_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    resource_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> GithubRepositoryResourceEcho | HTTPValidationError | None:
+    """Get Resource
+
+     Fetch a single resource attached to ``session_id`` by its id.
+
+    v1 only supports ``github_repository`` (id prefix ``ghrepo_``) since
+    memory store attachments are keyed by ``(session_id, memory_store_id)``
+    and don't have a separate attachment id.
+
+    Args:
+        session_id (str):
+        resource_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GithubRepositoryResourceEcho | HTTPValidationError
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        resource_id=resource_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    resource_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[GithubRepositoryResourceEcho | HTTPValidationError]:
+    """Get Resource
+
+     Fetch a single resource attached to ``session_id`` by its id.
+
+    v1 only supports ``github_repository`` (id prefix ``ghrepo_``) since
+    memory store attachments are keyed by ``(session_id, memory_store_id)``
+    and don't have a separate attachment id.
+
+    Args:
+        session_id (str):
+        resource_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GithubRepositoryResourceEcho | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        resource_id=resource_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    resource_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> GithubRepositoryResourceEcho | HTTPValidationError | None:
+    """Get Resource
+
+     Fetch a single resource attached to ``session_id`` by its id.
+
+    v1 only supports ``github_repository`` (id prefix ``ghrepo_``) since
+    memory store attachments are keyed by ``(session_id, memory_store_id)``
+    and don't have a separate attachment id.
+
+    Args:
+        session_id (str):
+        resource_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GithubRepositoryResourceEcho | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            resource_id=resource_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/get_v1_sessions_session_id_get.py
+++ b/src/aios/sdk/_generated/api/sessions/get_v1_sessions_session_id_get.py
@@ -1,0 +1,179 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session import Session
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/sessions/{session_id}".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Session | None:
+    if response.status_code == 200:
+        response_200 = Session.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Session]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Get
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Get
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Get
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Get
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/interrupt_v1_sessions_session_id_interrupt_post.py
+++ b/src/aios/sdk/_generated/api/sessions/interrupt_v1_sessions_session_id_interrupt_post.py
@@ -1,0 +1,205 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session import Session
+from ...models.session_interrupt_request import SessionInterruptRequest
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    body: SessionInterruptRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/sessions/{session_id}/interrupt".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Session | None:
+    if response.status_code == 200:
+        response_200 = Session.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Session]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionInterruptRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Interrupt
+
+     Interrupt a running session: cancel all in-flight work and idle it.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionInterruptRequest): Request body for `POST /v1/sessions/{id}/interrupt`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionInterruptRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Interrupt
+
+     Interrupt a running session: cancel all in-flight work and idle it.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionInterruptRequest): Request body for `POST /v1/sessions/{id}/interrupt`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionInterruptRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Interrupt
+
+     Interrupt a running session: cancel all in-flight work and idle it.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionInterruptRequest): Request body for `POST /v1/sessions/{id}/interrupt`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionInterruptRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Interrupt
+
+     Interrupt a running session: cancel all in-flight work and idle it.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionInterruptRequest): Request body for `POST /v1/sessions/{id}/interrupt`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/list_events_v1_sessions_session_id_events_get.py
+++ b/src/aios/sdk/_generated/api/sessions/list_events_v1_sessions_session_id_events_get.py
@@ -1,0 +1,239 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_events_v1_sessions_session_id_events_get_kind_type_0 import (
+    ListEventsV1SessionsSessionIdEventsGetKindType0,
+)
+from ...models.list_response_event import ListResponseEvent
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    after_seq: int | Unset = 0,
+    kind: ListEventsV1SessionsSessionIdEventsGetKindType0 | None | Unset = UNSET,
+    limit: int | Unset = 200,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["after_seq"] = after_seq
+
+    json_kind: None | str | Unset
+    if isinstance(kind, Unset):
+        json_kind = UNSET
+    elif isinstance(kind, ListEventsV1SessionsSessionIdEventsGetKindType0):
+        json_kind = kind.value
+    else:
+        json_kind = kind
+    params["kind"] = json_kind
+
+    params["limit"] = limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/sessions/{session_id}/events".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseEvent | None:
+    if response.status_code == 200:
+        response_200 = ListResponseEvent.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseEvent]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    kind: ListEventsV1SessionsSessionIdEventsGetKindType0 | None | Unset = UNSET,
+    limit: int | Unset = 200,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseEvent]:
+    """List Events
+
+    Args:
+        session_id (str):
+        after_seq (int | Unset):  Default: 0.
+        kind (ListEventsV1SessionsSessionIdEventsGetKindType0 | None | Unset):
+        limit (int | Unset):  Default: 200.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseEvent]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        after_seq=after_seq,
+        kind=kind,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    kind: ListEventsV1SessionsSessionIdEventsGetKindType0 | None | Unset = UNSET,
+    limit: int | Unset = 200,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseEvent | None:
+    """List Events
+
+    Args:
+        session_id (str):
+        after_seq (int | Unset):  Default: 0.
+        kind (ListEventsV1SessionsSessionIdEventsGetKindType0 | None | Unset):
+        limit (int | Unset):  Default: 200.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseEvent
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        after_seq=after_seq,
+        kind=kind,
+        limit=limit,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    kind: ListEventsV1SessionsSessionIdEventsGetKindType0 | None | Unset = UNSET,
+    limit: int | Unset = 200,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseEvent]:
+    """List Events
+
+    Args:
+        session_id (str):
+        after_seq (int | Unset):  Default: 0.
+        kind (ListEventsV1SessionsSessionIdEventsGetKindType0 | None | Unset):
+        limit (int | Unset):  Default: 200.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseEvent]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        after_seq=after_seq,
+        kind=kind,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    kind: ListEventsV1SessionsSessionIdEventsGetKindType0 | None | Unset = UNSET,
+    limit: int | Unset = 200,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseEvent | None:
+    """List Events
+
+    Args:
+        session_id (str):
+        after_seq (int | Unset):  Default: 0.
+        kind (ListEventsV1SessionsSessionIdEventsGetKindType0 | None | Unset):
+        limit (int | Unset):  Default: 200.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseEvent
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            after_seq=after_seq,
+            kind=kind,
+            limit=limit,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/list_resources_v1_sessions_session_id_resources_get.py
+++ b/src/aios/sdk/_generated/api/sessions/list_resources_v1_sessions_session_id_resources_get.py
@@ -1,0 +1,232 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_annotated_union_memory_store_resource_echo_github_repository_resource_echo_field_infoannotation_none_type_required_true_discriminatortype import (
+    ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype,
+)
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/sessions/{session_id}/resources".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> (
+    HTTPValidationError
+    | ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype
+    | None
+):
+    if response.status_code == 200:
+        response_200 = ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype.from_dict(
+            response.json()
+        )
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[
+    HTTPValidationError
+    | ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype
+]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype
+]:
+    """List Resources
+
+     List all resources attached to ``session_id``.
+
+    Returns the type-discriminated union of memory store and github
+    repository echoes, ordered by type (memory stores first) and rank.
+    Equivalent to reading the ``resources`` field on the full session
+    record, but cheaper if you don't need anything else.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype
+    | None
+):
+    """List Resources
+
+     List all resources attached to ``session_id``.
+
+    Returns the type-discriminated union of memory store and github
+    repository echoes, ordered by type (memory stores first) and rank.
+    Equivalent to reading the ``resources`` field on the full session
+    record, but cheaper if you don't need anything else.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype
+]:
+    """List Resources
+
+     List all resources attached to ``session_id``.
+
+    Returns the type-discriminated union of memory store and github
+    repository echoes, ordered by type (memory stores first) and rank.
+    Equivalent to reading the ``resources`` field on the full session
+    record, but cheaper if you don't need anything else.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype
+    | None
+):
+    """List Resources
+
+     List all resources attached to ``session_id``.
+
+    Returns the type-discriminated union of memory store and github
+    repository echoes, ordered by type (memory stores first) and rank.
+    Equivalent to reading the ``resources`` field on the full session
+    record, but cheaper if you don't need anything else.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/list_v1_sessions_get.py
+++ b/src/aios/sdk/_generated/api/sessions/list_v1_sessions_get.py
@@ -1,0 +1,246 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_session import ListResponseSession
+from ...models.list_v1_sessions_get_status_type_0 import ListV1SessionsGetStatusType0
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    agent_id: None | str | Unset = UNSET,
+    status: ListV1SessionsGetStatusType0 | None | Unset = UNSET,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    json_agent_id: None | str | Unset
+    if isinstance(agent_id, Unset):
+        json_agent_id = UNSET
+    else:
+        json_agent_id = agent_id
+    params["agent_id"] = json_agent_id
+
+    json_status: None | str | Unset
+    if isinstance(status, Unset):
+        json_status = UNSET
+    elif isinstance(status, ListV1SessionsGetStatusType0):
+        json_status = status.value
+    else:
+        json_status = status
+    params["status"] = json_status
+
+    params["limit"] = limit
+
+    json_after: None | str | Unset
+    if isinstance(after, Unset):
+        json_after = UNSET
+    else:
+        json_after = after
+    params["after"] = json_after
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/sessions",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseSession | None:
+    if response.status_code == 200:
+        response_200 = ListResponseSession.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseSession]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    agent_id: None | str | Unset = UNSET,
+    status: ListV1SessionsGetStatusType0 | None | Unset = UNSET,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseSession]:
+    """List
+
+    Args:
+        agent_id (None | str | Unset):
+        status (ListV1SessionsGetStatusType0 | None | Unset):
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseSession]
+    """
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+        status=status,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    agent_id: None | str | Unset = UNSET,
+    status: ListV1SessionsGetStatusType0 | None | Unset = UNSET,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseSession | None:
+    """List
+
+    Args:
+        agent_id (None | str | Unset):
+        status (ListV1SessionsGetStatusType0 | None | Unset):
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseSession
+    """
+
+    return sync_detailed(
+        client=client,
+        agent_id=agent_id,
+        status=status,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    agent_id: None | str | Unset = UNSET,
+    status: ListV1SessionsGetStatusType0 | None | Unset = UNSET,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseSession]:
+    """List
+
+    Args:
+        agent_id (None | str | Unset):
+        status (ListV1SessionsGetStatusType0 | None | Unset):
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseSession]
+    """
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+        status=status,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    agent_id: None | str | Unset = UNSET,
+    status: ListV1SessionsGetStatusType0 | None | Unset = UNSET,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseSession | None:
+    """List
+
+    Args:
+        agent_id (None | str | Unset):
+        status (ListV1SessionsGetStatusType0 | None | Unset):
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseSession
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            agent_id=agent_id,
+            status=status,
+            limit=limit,
+            after=after,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/post_message_v1_sessions_session_id_messages_post.py
+++ b/src/aios/sdk/_generated/api/sessions/post_message_v1_sessions_session_id_messages_post.py
@@ -1,0 +1,197 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.event import Event
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session_user_message import SessionUserMessage
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    body: SessionUserMessage,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/sessions/{session_id}/messages".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Event | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = Event.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Event | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionUserMessage,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Event | HTTPValidationError]:
+    """Post Message
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionUserMessage): Request body for `POST /v1/sessions/{id}/messages`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Event | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionUserMessage,
+    authorization: None | str | Unset = UNSET,
+) -> Event | HTTPValidationError | None:
+    """Post Message
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionUserMessage): Request body for `POST /v1/sessions/{id}/messages`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Event | HTTPValidationError
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionUserMessage,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Event | HTTPValidationError]:
+    """Post Message
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionUserMessage): Request body for `POST /v1/sessions/{id}/messages`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Event | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionUserMessage,
+    authorization: None | str | Unset = UNSET,
+) -> Event | HTTPValidationError | None:
+    """Post Message
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionUserMessage): Request body for `POST /v1/sessions/{id}/messages`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Event | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/stream_events_v1_sessions_session_id_stream_get.py
+++ b/src/aios/sdk/_generated/api/sessions/stream_events_v1_sessions_session_id_stream_get.py
@@ -1,0 +1,205 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    after_seq: int | Unset = 0,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["after_seq"] = after_seq
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/sessions/{session_id}/stream".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Stream Events
+
+     Stream session events as Server-Sent Events.
+
+    Args:
+        session_id (str):
+        after_seq (int | Unset):  Default: 0.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        after_seq=after_seq,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Stream Events
+
+     Stream session events as Server-Sent Events.
+
+    Args:
+        session_id (str):
+        after_seq (int | Unset):  Default: 0.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        after_seq=after_seq,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Stream Events
+
+     Stream session events as Server-Sent Events.
+
+    Args:
+        session_id (str):
+        after_seq (int | Unset):  Default: 0.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        after_seq=after_seq,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Stream Events
+
+     Stream session events as Server-Sent Events.
+
+    Args:
+        session_id (str):
+        after_seq (int | Unset):  Default: 0.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            after_seq=after_seq,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/submit_tool_confirmation_v1_sessions_session_id_tool_confirmations_post.py
+++ b/src/aios/sdk/_generated/api/sessions/submit_tool_confirmation_v1_sessions_session_id_tool_confirmations_post.py
@@ -1,0 +1,245 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.event import Event
+from ...models.http_validation_error import HTTPValidationError
+from ...models.tool_confirmation_request import ToolConfirmationRequest
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    body: ToolConfirmationRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/sessions/{session_id}/tool-confirmations".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Event | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = Event.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Event | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ToolConfirmationRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Event | HTTPValidationError]:
+    """Submit Tool Confirmation
+
+     Confirm or deny an ``always_ask`` built-in tool call.
+
+    ``allow`` records a lifecycle event; the worker dispatches the tool on
+    its next step.  ``deny`` appends a tool-role error event; the model
+    sees the denial message and can adapt.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (ToolConfirmationRequest): Request body for ``POST /v1/sessions/{id}/tool-
+            confirmations``.
+
+            Used for built-in tools with ``permission: "always_ask"``. The client
+            inspects the pending tool call and either allows it (the worker will
+            execute it) or denies it (the model receives an error with the deny
+            message).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Event | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ToolConfirmationRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Event | HTTPValidationError | None:
+    """Submit Tool Confirmation
+
+     Confirm or deny an ``always_ask`` built-in tool call.
+
+    ``allow`` records a lifecycle event; the worker dispatches the tool on
+    its next step.  ``deny`` appends a tool-role error event; the model
+    sees the denial message and can adapt.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (ToolConfirmationRequest): Request body for ``POST /v1/sessions/{id}/tool-
+            confirmations``.
+
+            Used for built-in tools with ``permission: "always_ask"``. The client
+            inspects the pending tool call and either allows it (the worker will
+            execute it) or denies it (the model receives an error with the deny
+            message).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Event | HTTPValidationError
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ToolConfirmationRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Event | HTTPValidationError]:
+    """Submit Tool Confirmation
+
+     Confirm or deny an ``always_ask`` built-in tool call.
+
+    ``allow`` records a lifecycle event; the worker dispatches the tool on
+    its next step.  ``deny`` appends a tool-role error event; the model
+    sees the denial message and can adapt.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (ToolConfirmationRequest): Request body for ``POST /v1/sessions/{id}/tool-
+            confirmations``.
+
+            Used for built-in tools with ``permission: "always_ask"``. The client
+            inspects the pending tool call and either allows it (the worker will
+            execute it) or denies it (the model receives an error with the deny
+            message).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Event | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ToolConfirmationRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Event | HTTPValidationError | None:
+    """Submit Tool Confirmation
+
+     Confirm or deny an ``always_ask`` built-in tool call.
+
+    ``allow`` records a lifecycle event; the worker dispatches the tool on
+    its next step.  ``deny`` appends a tool-role error event; the model
+    sees the denial message and can adapt.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (ToolConfirmationRequest): Request body for ``POST /v1/sessions/{id}/tool-
+            confirmations``.
+
+            Used for built-in tools with ``permission: "always_ask"``. The client
+            inspects the pending tool call and either allows it (the worker will
+            execute it) or denies it (the model receives an error with the deny
+            message).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Event | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/submit_tool_result_v1_sessions_session_id_tool_results_post.py
+++ b/src/aios/sdk/_generated/api/sessions/submit_tool_result_v1_sessions_session_id_tool_results_post.py
@@ -1,0 +1,233 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.event import Event
+from ...models.http_validation_error import HTTPValidationError
+from ...models.tool_result_request import ToolResultRequest
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    body: ToolResultRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/sessions/{session_id}/tool-results".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Event | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = Event.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Event | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ToolResultRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Event | HTTPValidationError]:
+    """Submit Tool Result
+
+     Submit a custom tool result. Appends a tool-role message and wakes the session.
+
+    Stamps the tool's ``name`` into the event data by looking it up on the
+    parent assistant's ``tool_calls`` array — same source the harness uses
+    for built-in/MCP results — so the derived ``tool_name`` column stays
+    populated for custom tools too (issue #133).  Returns 404 when the
+    ``tool_call_id`` has no matching parent assistant tool call, since a
+    result with no parent is a client bug that would leave an orphan row.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (ToolResultRequest): Request body for ``POST /v1/sessions/{id}/tool-results``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Event | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ToolResultRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Event | HTTPValidationError | None:
+    """Submit Tool Result
+
+     Submit a custom tool result. Appends a tool-role message and wakes the session.
+
+    Stamps the tool's ``name`` into the event data by looking it up on the
+    parent assistant's ``tool_calls`` array — same source the harness uses
+    for built-in/MCP results — so the derived ``tool_name`` column stays
+    populated for custom tools too (issue #133).  Returns 404 when the
+    ``tool_call_id`` has no matching parent assistant tool call, since a
+    result with no parent is a client bug that would leave an orphan row.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (ToolResultRequest): Request body for ``POST /v1/sessions/{id}/tool-results``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Event | HTTPValidationError
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ToolResultRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Event | HTTPValidationError]:
+    """Submit Tool Result
+
+     Submit a custom tool result. Appends a tool-role message and wakes the session.
+
+    Stamps the tool's ``name`` into the event data by looking it up on the
+    parent assistant's ``tool_calls`` array — same source the harness uses
+    for built-in/MCP results — so the derived ``tool_name`` column stays
+    populated for custom tools too (issue #133).  Returns 404 when the
+    ``tool_call_id`` has no matching parent assistant tool call, since a
+    result with no parent is a client bug that would leave an orphan row.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (ToolResultRequest): Request body for ``POST /v1/sessions/{id}/tool-results``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Event | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ToolResultRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Event | HTTPValidationError | None:
+    """Submit Tool Result
+
+     Submit a custom tool result. Appends a tool-role message and wakes the session.
+
+    Stamps the tool's ``name`` into the event data by looking it up on the
+    parent assistant's ``tool_calls`` array — same source the harness uses
+    for built-in/MCP results — so the derived ``tool_name`` column stays
+    populated for custom tools too (issue #133).  Returns 404 when the
+    ``tool_call_id`` has no matching parent assistant tool call, since a
+    result with no parent is a client bug that would leave an orphan row.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (ToolResultRequest): Request body for ``POST /v1/sessions/{id}/tool-results``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Event | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/update_resource_v1_sessions_session_id_resources_resource_id_post.py
+++ b/src/aios/sdk/_generated/api/sessions/update_resource_v1_sessions_session_id_resources_resource_id_post.py
@@ -1,0 +1,263 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.github_repository_resource_echo import GithubRepositoryResourceEcho
+from ...models.github_repository_update import GithubRepositoryUpdate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    resource_id: str,
+    *,
+    body: GithubRepositoryUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/sessions/{session_id}/resources/{resource_id}".format(
+            session_id=quote(str(session_id), safe=""),
+            resource_id=quote(str(resource_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> GithubRepositoryResourceEcho | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = GithubRepositoryResourceEcho.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[GithubRepositoryResourceEcho | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    resource_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: GithubRepositoryUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[GithubRepositoryResourceEcho | HTTPValidationError]:
+    """Update Resource
+
+     Rotate the auth token on a github_repository attachment.
+
+    The bumped ``updated_at`` propagates through the mount snapshot, so
+    the next sandbox provision recycles the container and re-clones the
+    working tree with the new token.
+
+    Args:
+        session_id (str):
+        resource_id (str):
+        authorization (None | str | Unset):
+        body (GithubRepositoryUpdate): Request body for ``POST
+            /v1/sessions/{sid}/resources/{rid}``.
+
+            Token rotation is the primary action; ``git_user_name`` /
+            ``git_user_email`` may also be supplied alongside, in which case the
+            stored identity is replaced.  ``url`` and ``mount_path`` are
+            immutable after creation — to change them, detach the resource and
+            attach a new one.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GithubRepositoryResourceEcho | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        resource_id=resource_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    resource_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: GithubRepositoryUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> GithubRepositoryResourceEcho | HTTPValidationError | None:
+    """Update Resource
+
+     Rotate the auth token on a github_repository attachment.
+
+    The bumped ``updated_at`` propagates through the mount snapshot, so
+    the next sandbox provision recycles the container and re-clones the
+    working tree with the new token.
+
+    Args:
+        session_id (str):
+        resource_id (str):
+        authorization (None | str | Unset):
+        body (GithubRepositoryUpdate): Request body for ``POST
+            /v1/sessions/{sid}/resources/{rid}``.
+
+            Token rotation is the primary action; ``git_user_name`` /
+            ``git_user_email`` may also be supplied alongside, in which case the
+            stored identity is replaced.  ``url`` and ``mount_path`` are
+            immutable after creation — to change them, detach the resource and
+            attach a new one.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GithubRepositoryResourceEcho | HTTPValidationError
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        resource_id=resource_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    resource_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: GithubRepositoryUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[GithubRepositoryResourceEcho | HTTPValidationError]:
+    """Update Resource
+
+     Rotate the auth token on a github_repository attachment.
+
+    The bumped ``updated_at`` propagates through the mount snapshot, so
+    the next sandbox provision recycles the container and re-clones the
+    working tree with the new token.
+
+    Args:
+        session_id (str):
+        resource_id (str):
+        authorization (None | str | Unset):
+        body (GithubRepositoryUpdate): Request body for ``POST
+            /v1/sessions/{sid}/resources/{rid}``.
+
+            Token rotation is the primary action; ``git_user_name`` /
+            ``git_user_email`` may also be supplied alongside, in which case the
+            stored identity is replaced.  ``url`` and ``mount_path`` are
+            immutable after creation — to change them, detach the resource and
+            attach a new one.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GithubRepositoryResourceEcho | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        resource_id=resource_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    resource_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: GithubRepositoryUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> GithubRepositoryResourceEcho | HTTPValidationError | None:
+    """Update Resource
+
+     Rotate the auth token on a github_repository attachment.
+
+    The bumped ``updated_at`` propagates through the mount snapshot, so
+    the next sandbox provision recycles the container and re-clones the
+    working tree with the new token.
+
+    Args:
+        session_id (str):
+        resource_id (str):
+        authorization (None | str | Unset):
+        body (GithubRepositoryUpdate): Request body for ``POST
+            /v1/sessions/{sid}/resources/{rid}``.
+
+            Token rotation is the primary action; ``git_user_name`` /
+            ``git_user_email`` may also be supplied alongside, in which case the
+            stored identity is replaced.  ``url`` and ``mount_path`` are
+            immutable after creation — to change them, detach the resource and
+            attach a new one.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GithubRepositoryResourceEcho | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            resource_id=resource_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/update_v1_sessions_session_id_put.py
+++ b/src/aios/sdk/_generated/api/sessions/update_v1_sessions_session_id_put.py
@@ -1,0 +1,225 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session import Session
+from ...models.session_update import SessionUpdate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    body: SessionUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/v1/sessions/{session_id}".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Session | None:
+    if response.status_code == 200:
+        response_200 = Session.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Session]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Update
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionUpdate): Request body for ``PUT /v1/sessions/{id}``.
+
+            All fields are optional; omitted fields are preserved. Changing
+            ``agent_id`` resets ``agent_version`` to null (latest) unless
+            ``agent_version`` is also provided. ``resources`` and ``vault_ids``
+            use full-list-replacement semantics: ``None`` (the default) leaves
+            the current set alone, ``[]`` detaches everything, and a non-empty
+            list replaces the bound set entirely.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Update
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionUpdate): Request body for ``PUT /v1/sessions/{id}``.
+
+            All fields are optional; omitted fields are preserved. Changing
+            ``agent_id`` resets ``agent_version`` to null (latest) unless
+            ``agent_version`` is also provided. ``resources`` and ``vault_ids``
+            use full-list-replacement semantics: ``None`` (the default) leaves
+            the current set alone, ``[]`` detaches everything, and a non-empty
+            list replaces the bound set entirely.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Session]:
+    """Update
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionUpdate): Request body for ``PUT /v1/sessions/{id}``.
+
+            All fields are optional; omitted fields are preserved. Changing
+            ``agent_id`` resets ``agent_version`` to null (latest) unless
+            ``agent_version`` is also provided. ``resources`` and ``vault_ids``
+            use full-list-replacement semantics: ``None`` (the default) leaves
+            the current set alone, ``[]`` detaches everything, and a non-empty
+            list replaces the bound set entirely.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Session]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SessionUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Session | None:
+    """Update
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (SessionUpdate): Request body for ``PUT /v1/sessions/{id}``.
+
+            All fields are optional; omitted fields are preserved. Changing
+            ``agent_id`` resets ``agent_version`` to null (latest) unless
+            ``agent_version`` is also provided. ``resources`` and ``vault_ids``
+            use full-list-replacement semantics: ``None`` (the default) leaves
+            the current set alone, ``[]`` detaches everything, and a non-empty
+            list replaces the bound set entirely.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Session
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/sessions/wait_for_events_v1_sessions_session_id_wait_get.py
+++ b/src/aios/sdk/_generated/api/sessions/wait_for_events_v1_sessions_session_id_wait_get.py
@@ -1,0 +1,242 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.wait_response import WaitResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    after_seq: int | Unset = 0,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["after_seq"] = after_seq
+
+    params["timeout"] = timeout
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/sessions/{session_id}/wait".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | WaitResponse | None:
+    if response.status_code == 200:
+        response_200 = WaitResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | WaitResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WaitResponse]:
+    """Wait For Events
+
+     Long-poll for new events past ``after_seq``.
+
+    Blocks up to ``timeout`` seconds for events to arrive; returns an empty
+    list if none land in time. Alternative to SSE for clients whose HTTP
+    stack can't reliably consume server-sent events (notably Node's
+    ``fetch`` — see issue #40).
+
+    Args:
+        session_id (str):
+        after_seq (int | Unset):  Default: 0.
+        timeout (int | Unset):  Default: 30.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WaitResponse]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        after_seq=after_seq,
+        timeout=timeout,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WaitResponse | None:
+    """Wait For Events
+
+     Long-poll for new events past ``after_seq``.
+
+    Blocks up to ``timeout`` seconds for events to arrive; returns an empty
+    list if none land in time. Alternative to SSE for clients whose HTTP
+    stack can't reliably consume server-sent events (notably Node's
+    ``fetch`` — see issue #40).
+
+    Args:
+        session_id (str):
+        after_seq (int | Unset):  Default: 0.
+        timeout (int | Unset):  Default: 30.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WaitResponse
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        after_seq=after_seq,
+        timeout=timeout,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WaitResponse]:
+    """Wait For Events
+
+     Long-poll for new events past ``after_seq``.
+
+    Blocks up to ``timeout`` seconds for events to arrive; returns an empty
+    list if none land in time. Alternative to SSE for clients whose HTTP
+    stack can't reliably consume server-sent events (notably Node's
+    ``fetch`` — see issue #40).
+
+    Args:
+        session_id (str):
+        after_seq (int | Unset):  Default: 0.
+        timeout (int | Unset):  Default: 30.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WaitResponse]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        after_seq=after_seq,
+        timeout=timeout,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WaitResponse | None:
+    """Wait For Events
+
+     Long-poll for new events past ``after_seq``.
+
+    Blocks up to ``timeout`` seconds for events to arrive; returns an empty
+    list if none land in time. Alternative to SSE for clients whose HTTP
+    stack can't reliably consume server-sent events (notably Node's
+    ``fetch`` — see issue #40).
+
+    Args:
+        session_id (str):
+        after_seq (int | Unset):  Default: 0.
+        timeout (int | Unset):  Default: 30.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WaitResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            after_seq=after_seq,
+            timeout=timeout,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/skills/__init__.py
+++ b/src/aios/sdk/_generated/api/skills/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/src/aios/sdk/_generated/api/skills/archive_skill.py
+++ b/src/aios/sdk/_generated/api/skills/archive_skill.py
@@ -1,0 +1,201 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    skill_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/skills/{skill_id}".format(
+            skill_id=quote(str(skill_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Archive
+
+     Archive a skill: sets ``archived_at`` and hides it from default lists.
+
+    The row and version history persist; agents that reference this skill
+    by id continue to resolve their pinned versions. There is no API
+    surface to un-archive currently.
+
+    Args:
+        skill_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        skill_id=skill_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Archive
+
+     Archive a skill: sets ``archived_at`` and hides it from default lists.
+
+    The row and version history persist; agents that reference this skill
+    by id continue to resolve their pinned versions. There is no API
+    surface to un-archive currently.
+
+    Args:
+        skill_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        skill_id=skill_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Archive
+
+     Archive a skill: sets ``archived_at`` and hides it from default lists.
+
+    The row and version history persist; agents that reference this skill
+    by id continue to resolve their pinned versions. There is no API
+    surface to un-archive currently.
+
+    Args:
+        skill_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        skill_id=skill_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Archive
+
+     Archive a skill: sets ``archived_at`` and hides it from default lists.
+
+    The row and version history persist; agents that reference this skill
+    by id continue to resolve their pinned versions. There is no API
+    surface to un-archive currently.
+
+    Args:
+        skill_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            skill_id=skill_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/skills/create_skill.py
+++ b/src/aios/sdk/_generated/api/skills/create_skill.py
@@ -1,0 +1,225 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.skill import Skill
+from ...models.skill_create import SkillCreate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: SkillCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/skills",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Skill | None:
+    if response.status_code == 201:
+        response_201 = Skill.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Skill]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: SkillCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Skill]:
+    """Create
+
+     Create a new skill from an uploaded file bundle.
+
+    The bundle must include exactly one ``<directory>/SKILL.md`` file with
+    YAML frontmatter containing at least a ``name`` field. The skill's
+    ``directory``, ``name``, and ``description`` are extracted from that
+    frontmatter; subsequent versions reuse this extraction.
+
+    Args:
+        authorization (None | str | Unset):
+        body (SkillCreate): Request body for ``POST /v1/skills``.
+
+            ``files`` must include exactly one ``{directory}/SKILL.md`` entry.
+            The server extracts ``name``, ``description``, and ``directory`` from
+            the SKILL.md frontmatter and file paths.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Skill]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: SkillCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Skill | None:
+    """Create
+
+     Create a new skill from an uploaded file bundle.
+
+    The bundle must include exactly one ``<directory>/SKILL.md`` file with
+    YAML frontmatter containing at least a ``name`` field. The skill's
+    ``directory``, ``name``, and ``description`` are extracted from that
+    frontmatter; subsequent versions reuse this extraction.
+
+    Args:
+        authorization (None | str | Unset):
+        body (SkillCreate): Request body for ``POST /v1/skills``.
+
+            ``files`` must include exactly one ``{directory}/SKILL.md`` entry.
+            The server extracts ``name``, ``description``, and ``directory`` from
+            the SKILL.md frontmatter and file paths.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Skill
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: SkillCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Skill]:
+    """Create
+
+     Create a new skill from an uploaded file bundle.
+
+    The bundle must include exactly one ``<directory>/SKILL.md`` file with
+    YAML frontmatter containing at least a ``name`` field. The skill's
+    ``directory``, ``name``, and ``description`` are extracted from that
+    frontmatter; subsequent versions reuse this extraction.
+
+    Args:
+        authorization (None | str | Unset):
+        body (SkillCreate): Request body for ``POST /v1/skills``.
+
+            ``files`` must include exactly one ``{directory}/SKILL.md`` entry.
+            The server extracts ``name``, ``description``, and ``directory`` from
+            the SKILL.md frontmatter and file paths.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Skill]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: SkillCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Skill | None:
+    """Create
+
+     Create a new skill from an uploaded file bundle.
+
+    The bundle must include exactly one ``<directory>/SKILL.md`` file with
+    YAML frontmatter containing at least a ``name`` field. The skill's
+    ``directory``, ``name``, and ``description`` are extracted from that
+    frontmatter; subsequent versions reuse this extraction.
+
+    Args:
+        authorization (None | str | Unset):
+        body (SkillCreate): Request body for ``POST /v1/skills``.
+
+            ``files`` must include exactly one ``{directory}/SKILL.md`` entry.
+            The server extracts ``name``, ``description``, and ``directory`` from
+            the SKILL.md frontmatter and file paths.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Skill
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/skills/create_skill_version.py
+++ b/src/aios/sdk/_generated/api/skills/create_skill_version.py
@@ -1,0 +1,237 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.skill_version import SkillVersion
+from ...models.skill_version_create import SkillVersionCreate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    skill_id: str,
+    *,
+    body: SkillVersionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/skills/{skill_id}/versions".format(
+            skill_id=quote(str(skill_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | SkillVersion | None:
+    if response.status_code == 201:
+        response_201 = SkillVersion.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | SkillVersion]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SkillVersionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | SkillVersion]:
+    """Create Version
+
+     Upload a new immutable version of a skill's file bundle.
+
+    The bundle must include the same SKILL.md frontmatter shape as the
+    initial create: directory, ``name``, ``description``. Each version is
+    a complete snapshot — files not present in the upload are not carried
+    over from previous versions.
+
+    Args:
+        skill_id (str):
+        authorization (None | str | Unset):
+        body (SkillVersionCreate): Request body for ``POST /v1/skills/{skill_id}/versions``.
+
+            Same file format as :class:`SkillCreate`. The directory, name, and
+            description are re-extracted from the new SKILL.md.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SkillVersion]
+    """
+
+    kwargs = _get_kwargs(
+        skill_id=skill_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SkillVersionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | SkillVersion | None:
+    """Create Version
+
+     Upload a new immutable version of a skill's file bundle.
+
+    The bundle must include the same SKILL.md frontmatter shape as the
+    initial create: directory, ``name``, ``description``. Each version is
+    a complete snapshot — files not present in the upload are not carried
+    over from previous versions.
+
+    Args:
+        skill_id (str):
+        authorization (None | str | Unset):
+        body (SkillVersionCreate): Request body for ``POST /v1/skills/{skill_id}/versions``.
+
+            Same file format as :class:`SkillCreate`. The directory, name, and
+            description are re-extracted from the new SKILL.md.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SkillVersion
+    """
+
+    return sync_detailed(
+        skill_id=skill_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SkillVersionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | SkillVersion]:
+    """Create Version
+
+     Upload a new immutable version of a skill's file bundle.
+
+    The bundle must include the same SKILL.md frontmatter shape as the
+    initial create: directory, ``name``, ``description``. Each version is
+    a complete snapshot — files not present in the upload are not carried
+    over from previous versions.
+
+    Args:
+        skill_id (str):
+        authorization (None | str | Unset):
+        body (SkillVersionCreate): Request body for ``POST /v1/skills/{skill_id}/versions``.
+
+            Same file format as :class:`SkillCreate`. The directory, name, and
+            description are re-extracted from the new SKILL.md.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SkillVersion]
+    """
+
+    kwargs = _get_kwargs(
+        skill_id=skill_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: SkillVersionCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | SkillVersion | None:
+    """Create Version
+
+     Upload a new immutable version of a skill's file bundle.
+
+    The bundle must include the same SKILL.md frontmatter shape as the
+    initial create: directory, ``name``, ``description``. Each version is
+    a complete snapshot — files not present in the upload are not carried
+    over from previous versions.
+
+    Args:
+        skill_id (str):
+        authorization (None | str | Unset):
+        body (SkillVersionCreate): Request body for ``POST /v1/skills/{skill_id}/versions``.
+
+            Same file format as :class:`SkillCreate`. The directory, name, and
+            description are re-extracted from the new SKILL.md.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SkillVersion
+    """
+
+    return (
+        await asyncio_detailed(
+            skill_id=skill_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/skills/get_skill.py
+++ b/src/aios/sdk/_generated/api/skills/get_skill.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.skill import Skill
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    skill_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/skills/{skill_id}".format(
+            skill_id=quote(str(skill_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Skill | None:
+    if response.status_code == 200:
+        response_200 = Skill.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Skill]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Skill]:
+    """Get
+
+     Fetch one skill by id, returning the latest version's config.
+
+    Args:
+        skill_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Skill]
+    """
+
+    kwargs = _get_kwargs(
+        skill_id=skill_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Skill | None:
+    """Get
+
+     Fetch one skill by id, returning the latest version's config.
+
+    Args:
+        skill_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Skill
+    """
+
+    return sync_detailed(
+        skill_id=skill_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Skill]:
+    """Get
+
+     Fetch one skill by id, returning the latest version's config.
+
+    Args:
+        skill_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Skill]
+    """
+
+    kwargs = _get_kwargs(
+        skill_id=skill_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Skill | None:
+    """Get
+
+     Fetch one skill by id, returning the latest version's config.
+
+    Args:
+        skill_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Skill
+    """
+
+    return (
+        await asyncio_detailed(
+            skill_id=skill_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/skills/get_skill_version.py
+++ b/src/aios/sdk/_generated/api/skills/get_skill_version.py
@@ -1,0 +1,213 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.skill_version import SkillVersion
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    skill_id: str,
+    version: int,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/skills/{skill_id}/versions/{version}".format(
+            skill_id=quote(str(skill_id), safe=""),
+            version=quote(str(version), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | SkillVersion | None:
+    if response.status_code == 200:
+        response_200 = SkillVersion.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | SkillVersion]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    skill_id: str,
+    version: int,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | SkillVersion]:
+    """Get Version
+
+     Fetch one historical version's file bundle.
+
+    The bundle reflects the skill's state at the time the version was
+    written and is unaffected by subsequent versions or archival.
+
+    Args:
+        skill_id (str):
+        version (int):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SkillVersion]
+    """
+
+    kwargs = _get_kwargs(
+        skill_id=skill_id,
+        version=version,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    skill_id: str,
+    version: int,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | SkillVersion | None:
+    """Get Version
+
+     Fetch one historical version's file bundle.
+
+    The bundle reflects the skill's state at the time the version was
+    written and is unaffected by subsequent versions or archival.
+
+    Args:
+        skill_id (str):
+        version (int):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SkillVersion
+    """
+
+    return sync_detailed(
+        skill_id=skill_id,
+        version=version,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    skill_id: str,
+    version: int,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | SkillVersion]:
+    """Get Version
+
+     Fetch one historical version's file bundle.
+
+    The bundle reflects the skill's state at the time the version was
+    written and is unaffected by subsequent versions or archival.
+
+    Args:
+        skill_id (str):
+        version (int):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SkillVersion]
+    """
+
+    kwargs = _get_kwargs(
+        skill_id=skill_id,
+        version=version,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    skill_id: str,
+    version: int,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | SkillVersion | None:
+    """Get Version
+
+     Fetch one historical version's file bundle.
+
+    The bundle reflects the skill's state at the time the version was
+    written and is unaffected by subsequent versions or archival.
+
+    Args:
+        skill_id (str):
+        version (int):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SkillVersion
+    """
+
+    return (
+        await asyncio_detailed(
+            skill_id=skill_id,
+            version=version,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/skills/list_skill_versions.py
+++ b/src/aios/sdk/_generated/api/skills/list_skill_versions.py
@@ -1,0 +1,243 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_skill_version import ListResponseSkillVersion
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    skill_id: str,
+    *,
+    limit: int | Unset = 50,
+    after: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    json_after: int | None | Unset
+    if isinstance(after, Unset):
+        json_after = UNSET
+    else:
+        json_after = after
+    params["after"] = json_after
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/skills/{skill_id}/versions".format(
+            skill_id=quote(str(skill_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseSkillVersion | None:
+    if response.status_code == 200:
+        response_200 = ListResponseSkillVersion.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseSkillVersion]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseSkillVersion]:
+    """List Versions
+
+     List historical versions of a skill, newest first.
+
+    Cursor pagination by version number: pass ``after`` from a previous
+    response's ``next_after`` to get the next page. Each version is a
+    complete file-bundle snapshot at the time it was created.
+
+    Args:
+        skill_id (str):
+        limit (int | Unset):  Default: 50.
+        after (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseSkillVersion]
+    """
+
+    kwargs = _get_kwargs(
+        skill_id=skill_id,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseSkillVersion | None:
+    """List Versions
+
+     List historical versions of a skill, newest first.
+
+    Cursor pagination by version number: pass ``after`` from a previous
+    response's ``next_after`` to get the next page. Each version is a
+    complete file-bundle snapshot at the time it was created.
+
+    Args:
+        skill_id (str):
+        limit (int | Unset):  Default: 50.
+        after (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseSkillVersion
+    """
+
+    return sync_detailed(
+        skill_id=skill_id,
+        client=client,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseSkillVersion]:
+    """List Versions
+
+     List historical versions of a skill, newest first.
+
+    Cursor pagination by version number: pass ``after`` from a previous
+    response's ``next_after`` to get the next page. Each version is a
+    complete file-bundle snapshot at the time it was created.
+
+    Args:
+        skill_id (str):
+        limit (int | Unset):  Default: 50.
+        after (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseSkillVersion]
+    """
+
+    kwargs = _get_kwargs(
+        skill_id=skill_id,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    skill_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseSkillVersion | None:
+    """List Versions
+
+     List historical versions of a skill, newest first.
+
+    Cursor pagination by version number: pass ``after`` from a previous
+    response's ``next_after`` to get the next page. Each version is a
+    complete file-bundle snapshot at the time it was created.
+
+    Args:
+        skill_id (str):
+        limit (int | Unset):  Default: 50.
+        after (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseSkillVersion
+    """
+
+    return (
+        await asyncio_detailed(
+            skill_id=skill_id,
+            client=client,
+            limit=limit,
+            after=after,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/skills/list_skills.py
+++ b/src/aios/sdk/_generated/api/skills/list_skills.py
@@ -1,0 +1,219 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_skill import ListResponseSkill
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    json_after: None | str | Unset
+    if isinstance(after, Unset):
+        json_after = UNSET
+    else:
+        json_after = after
+    params["after"] = json_after
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/skills",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseSkill | None:
+    if response.status_code == 200:
+        response_200 = ListResponseSkill.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseSkill]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseSkill]:
+    """List
+
+     List skills (latest version of each), newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseSkill]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseSkill | None:
+    """List
+
+     List skills (latest version of each), newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseSkill
+    """
+
+    return sync_detailed(
+        client=client,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseSkill]:
+    """List
+
+     List skills (latest version of each), newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseSkill]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseSkill | None:
+    """List
+
+     List skills (latest version of each), newest first, excluding archived.
+
+    Cursor pagination via ``after``.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseSkill
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            limit=limit,
+            after=after,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/vaults/__init__.py
+++ b/src/aios/sdk/_generated/api/vaults/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/src/aios/sdk/_generated/api/vaults/archive_vault.py
+++ b/src/aios/sdk/_generated/api/vaults/archive_vault.py
@@ -1,0 +1,219 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.vault import Vault
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    vault_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/vaults/{vault_id}/archive".format(
+            vault_id=quote(str(vault_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Vault | None:
+    if response.status_code == 200:
+        response_200 = Vault.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Vault]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Vault]:
+    """Archive
+
+     Archive a vault and **purge the encrypted secret material** of its credentials.
+
+    Sets ``archived_at`` and hides the vault from default lists. In the same
+    transaction, every active credential is archived and its encrypted blob
+    is zeroed — the credential rows persist for audit but the stored secrets
+    are unrecoverable. Defense in depth: a future DB dump cannot leak
+    secrets that were already retired.
+
+    Use ``delete_vault`` instead if you want to remove the rows entirely.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Vault]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Vault | None:
+    """Archive
+
+     Archive a vault and **purge the encrypted secret material** of its credentials.
+
+    Sets ``archived_at`` and hides the vault from default lists. In the same
+    transaction, every active credential is archived and its encrypted blob
+    is zeroed — the credential rows persist for audit but the stored secrets
+    are unrecoverable. Defense in depth: a future DB dump cannot leak
+    secrets that were already retired.
+
+    Use ``delete_vault`` instead if you want to remove the rows entirely.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Vault
+    """
+
+    return sync_detailed(
+        vault_id=vault_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Vault]:
+    """Archive
+
+     Archive a vault and **purge the encrypted secret material** of its credentials.
+
+    Sets ``archived_at`` and hides the vault from default lists. In the same
+    transaction, every active credential is archived and its encrypted blob
+    is zeroed — the credential rows persist for audit but the stored secrets
+    are unrecoverable. Defense in depth: a future DB dump cannot leak
+    secrets that were already retired.
+
+    Use ``delete_vault`` instead if you want to remove the rows entirely.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Vault]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Vault | None:
+    """Archive
+
+     Archive a vault and **purge the encrypted secret material** of its credentials.
+
+    Sets ``archived_at`` and hides the vault from default lists. In the same
+    transaction, every active credential is archived and its encrypted blob
+    is zeroed — the credential rows persist for audit but the stored secrets
+    are unrecoverable. Defense in depth: a future DB dump cannot leak
+    secrets that were already retired.
+
+    Use ``delete_vault`` instead if you want to remove the rows entirely.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Vault
+    """
+
+    return (
+        await asyncio_detailed(
+            vault_id=vault_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/vaults/archive_vault_credential.py
+++ b/src/aios/sdk/_generated/api/vaults/archive_vault_credential.py
@@ -1,0 +1,217 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.vault_credential import VaultCredential
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    vault_id: str,
+    credential_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/vaults/{vault_id}/credentials/{credential_id}/archive".format(
+            vault_id=quote(str(vault_id), safe=""),
+            credential_id=quote(str(credential_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | VaultCredential | None:
+    if response.status_code == 200:
+        response_200 = VaultCredential.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | VaultCredential]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | VaultCredential]:
+    """Archive Credential
+
+     Archive a credential and **zero its encrypted secret payload**.
+
+    Sets ``archived_at`` and hides the credential from default lists. The
+    encrypted blob is scrubbed at archive time so a future DB dump cannot
+    leak the secret. Use ``delete_vault_credential`` for full removal.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | VaultCredential]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        credential_id=credential_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | VaultCredential | None:
+    """Archive Credential
+
+     Archive a credential and **zero its encrypted secret payload**.
+
+    Sets ``archived_at`` and hides the credential from default lists. The
+    encrypted blob is scrubbed at archive time so a future DB dump cannot
+    leak the secret. Use ``delete_vault_credential`` for full removal.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | VaultCredential
+    """
+
+    return sync_detailed(
+        vault_id=vault_id,
+        credential_id=credential_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | VaultCredential]:
+    """Archive Credential
+
+     Archive a credential and **zero its encrypted secret payload**.
+
+    Sets ``archived_at`` and hides the credential from default lists. The
+    encrypted blob is scrubbed at archive time so a future DB dump cannot
+    leak the secret. Use ``delete_vault_credential`` for full removal.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | VaultCredential]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        credential_id=credential_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | VaultCredential | None:
+    """Archive Credential
+
+     Archive a credential and **zero its encrypted secret payload**.
+
+    Sets ``archived_at`` and hides the credential from default lists. The
+    encrypted blob is scrubbed at archive time so a future DB dump cannot
+    leak the secret. Use ``delete_vault_credential`` for full removal.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | VaultCredential
+    """
+
+    return (
+        await asyncio_detailed(
+            vault_id=vault_id,
+            credential_id=credential_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/vaults/create_vault.py
+++ b/src/aios/sdk/_generated/api/vaults/create_vault.py
@@ -1,0 +1,197 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.vault import Vault
+from ...models.vault_create import VaultCreate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: VaultCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/vaults",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Vault | None:
+    if response.status_code == 201:
+        response_201 = Vault.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Vault]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Vault]:
+    """Create
+
+     Create a new vault — a named collection for MCP server credentials.
+
+    Credentials are added separately via ``create_vault_credential``.
+
+    Args:
+        authorization (None | str | Unset):
+        body (VaultCreate): Request body for ``POST /v1/vaults``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Vault]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Vault | None:
+    """Create
+
+     Create a new vault — a named collection for MCP server credentials.
+
+    Credentials are added separately via ``create_vault_credential``.
+
+    Args:
+        authorization (None | str | Unset):
+        body (VaultCreate): Request body for ``POST /v1/vaults``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Vault
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Vault]:
+    """Create
+
+     Create a new vault — a named collection for MCP server credentials.
+
+    Credentials are added separately via ``create_vault_credential``.
+
+    Args:
+        authorization (None | str | Unset):
+        body (VaultCreate): Request body for ``POST /v1/vaults``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Vault]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Vault | None:
+    """Create
+
+     Create a new vault — a named collection for MCP server credentials.
+
+    Credentials are added separately via ``create_vault_credential``.
+
+    Args:
+        authorization (None | str | Unset):
+        body (VaultCreate): Request body for ``POST /v1/vaults``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Vault
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/vaults/create_vault_credential.py
+++ b/src/aios/sdk/_generated/api/vaults/create_vault_credential.py
@@ -1,0 +1,249 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.vault_credential import VaultCredential
+from ...models.vault_credential_create import VaultCredentialCreate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    vault_id: str,
+    *,
+    body: VaultCredentialCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/vaults/{vault_id}/credentials".format(
+            vault_id=quote(str(vault_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | VaultCredential | None:
+    if response.status_code == 201:
+        response_201 = VaultCredential.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | VaultCredential]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultCredentialCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | VaultCredential]:
+    """Create Credential
+
+     Add a credential to a vault. Secrets are encrypted at rest via the CryptoBox.
+
+    Validates required fields per ``auth_type``: ``mcp_oauth`` requires
+    ``access_token`` (plus the refresh fields needed for rotation);
+    ``static_bearer`` requires ``token``. Caps at 20 active credentials per
+    vault. The ``mcp_server_url`` is immutable after creation — to retarget
+    a credential, archive the existing one and create a new credential at
+    the new URL.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (VaultCredentialCreate): Request body for ``POST /v1/vaults/{vault_id}/credentials``.
+
+            All secret fields are write-only. The ``mcp_server_url`` is immutable
+            after creation. The service layer validates required fields per
+            ``auth_type``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | VaultCredential]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultCredentialCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | VaultCredential | None:
+    """Create Credential
+
+     Add a credential to a vault. Secrets are encrypted at rest via the CryptoBox.
+
+    Validates required fields per ``auth_type``: ``mcp_oauth`` requires
+    ``access_token`` (plus the refresh fields needed for rotation);
+    ``static_bearer`` requires ``token``. Caps at 20 active credentials per
+    vault. The ``mcp_server_url`` is immutable after creation — to retarget
+    a credential, archive the existing one and create a new credential at
+    the new URL.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (VaultCredentialCreate): Request body for ``POST /v1/vaults/{vault_id}/credentials``.
+
+            All secret fields are write-only. The ``mcp_server_url`` is immutable
+            after creation. The service layer validates required fields per
+            ``auth_type``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | VaultCredential
+    """
+
+    return sync_detailed(
+        vault_id=vault_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultCredentialCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | VaultCredential]:
+    """Create Credential
+
+     Add a credential to a vault. Secrets are encrypted at rest via the CryptoBox.
+
+    Validates required fields per ``auth_type``: ``mcp_oauth`` requires
+    ``access_token`` (plus the refresh fields needed for rotation);
+    ``static_bearer`` requires ``token``. Caps at 20 active credentials per
+    vault. The ``mcp_server_url`` is immutable after creation — to retarget
+    a credential, archive the existing one and create a new credential at
+    the new URL.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (VaultCredentialCreate): Request body for ``POST /v1/vaults/{vault_id}/credentials``.
+
+            All secret fields are write-only. The ``mcp_server_url`` is immutable
+            after creation. The service layer validates required fields per
+            ``auth_type``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | VaultCredential]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultCredentialCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | VaultCredential | None:
+    """Create Credential
+
+     Add a credential to a vault. Secrets are encrypted at rest via the CryptoBox.
+
+    Validates required fields per ``auth_type``: ``mcp_oauth`` requires
+    ``access_token`` (plus the refresh fields needed for rotation);
+    ``static_bearer`` requires ``token``. Caps at 20 active credentials per
+    vault. The ``mcp_server_url`` is immutable after creation — to retarget
+    a credential, archive the existing one and create a new credential at
+    the new URL.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (VaultCredentialCreate): Request body for ``POST /v1/vaults/{vault_id}/credentials``.
+
+            All secret fields are write-only. The ``mcp_server_url`` is immutable
+            after creation. The service layer validates required fields per
+            ``auth_type``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | VaultCredential
+    """
+
+    return (
+        await asyncio_detailed(
+            vault_id=vault_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/vaults/delete_vault.py
+++ b/src/aios/sdk/_generated/api/vaults/delete_vault.py
@@ -1,0 +1,201 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    vault_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/vaults/{vault_id}".format(
+            vault_id=quote(str(vault_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete
+
+     Hard-delete a vault and all its credentials (``ON DELETE CASCADE``).
+
+    Returns 204. Unlike ``archive_vault``, this removes the rows entirely
+    and leaves no audit trail. Prefer archive unless you specifically need
+    the rows gone.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete
+
+     Hard-delete a vault and all its credentials (``ON DELETE CASCADE``).
+
+    Returns 204. Unlike ``archive_vault``, this removes the rows entirely
+    and leaves no audit trail. Prefer archive unless you specifically need
+    the rows gone.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        vault_id=vault_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete
+
+     Hard-delete a vault and all its credentials (``ON DELETE CASCADE``).
+
+    Returns 204. Unlike ``archive_vault``, this removes the rows entirely
+    and leaves no audit trail. Prefer archive unless you specifically need
+    the rows gone.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete
+
+     Hard-delete a vault and all its credentials (``ON DELETE CASCADE``).
+
+    Returns 204. Unlike ``archive_vault``, this removes the rows entirely
+    and leaves no audit trail. Prefer archive unless you specifically need
+    the rows gone.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            vault_id=vault_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/vaults/delete_vault_credential.py
+++ b/src/aios/sdk/_generated/api/vaults/delete_vault_credential.py
@@ -1,0 +1,215 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    vault_id: str,
+    credential_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/vaults/{vault_id}/credentials/{credential_id}".format(
+            vault_id=quote(str(vault_id), safe=""),
+            credential_id=quote(str(credential_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Credential
+
+     Hard-delete a credential row. Returns 204.
+
+    Unlike ``archive_vault_credential``, removes the row entirely and
+    leaves no audit trail. Prefer archive unless you specifically need the
+    row gone.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        credential_id=credential_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete Credential
+
+     Hard-delete a credential row. Returns 204.
+
+    Unlike ``archive_vault_credential``, removes the row entirely and
+    leaves no audit trail. Prefer archive unless you specifically need the
+    row gone.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        vault_id=vault_id,
+        credential_id=credential_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Delete Credential
+
+     Hard-delete a credential row. Returns 204.
+
+    Unlike ``archive_vault_credential``, removes the row entirely and
+    leaves no audit trail. Prefer archive unless you specifically need the
+    row gone.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        credential_id=credential_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Delete Credential
+
+     Hard-delete a credential row. Returns 204.
+
+    Unlike ``archive_vault_credential``, removes the row entirely and
+    leaves no audit trail. Prefer archive unless you specifically need the
+    row gone.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            vault_id=vault_id,
+            credential_id=credential_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/vaults/get_vault.py
+++ b/src/aios/sdk/_generated/api/vaults/get_vault.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.vault import Vault
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    vault_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/vaults/{vault_id}".format(
+            vault_id=quote(str(vault_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Vault | None:
+    if response.status_code == 200:
+        response_200 = Vault.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Vault]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Vault]:
+    """Get
+
+     Fetch one vault by id.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Vault]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Vault | None:
+    """Get
+
+     Fetch one vault by id.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Vault
+    """
+
+    return sync_detailed(
+        vault_id=vault_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Vault]:
+    """Get
+
+     Fetch one vault by id.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Vault]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Vault | None:
+    """Get
+
+     Fetch one vault by id.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Vault
+    """
+
+    return (
+        await asyncio_detailed(
+            vault_id=vault_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/vaults/get_vault_credential.py
+++ b/src/aios/sdk/_generated/api/vaults/get_vault_credential.py
@@ -1,0 +1,213 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.vault_credential import VaultCredential
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    vault_id: str,
+    credential_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/vaults/{vault_id}/credentials/{credential_id}".format(
+            vault_id=quote(str(vault_id), safe=""),
+            credential_id=quote(str(credential_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | VaultCredential | None:
+    if response.status_code == 200:
+        response_200 = VaultCredential.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | VaultCredential]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | VaultCredential]:
+    """Get Credential
+
+     Fetch one credential's metadata. Secrets are never returned.
+
+    Internal MCP clients resolve the secret directly through the service
+    layer (with OAuth refresh as needed); the HTTP API never exposes it.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | VaultCredential]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        credential_id=credential_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | VaultCredential | None:
+    """Get Credential
+
+     Fetch one credential's metadata. Secrets are never returned.
+
+    Internal MCP clients resolve the secret directly through the service
+    layer (with OAuth refresh as needed); the HTTP API never exposes it.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | VaultCredential
+    """
+
+    return sync_detailed(
+        vault_id=vault_id,
+        credential_id=credential_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | VaultCredential]:
+    """Get Credential
+
+     Fetch one credential's metadata. Secrets are never returned.
+
+    Internal MCP clients resolve the secret directly through the service
+    layer (with OAuth refresh as needed); the HTTP API never exposes it.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | VaultCredential]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        credential_id=credential_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | VaultCredential | None:
+    """Get Credential
+
+     Fetch one credential's metadata. Secrets are never returned.
+
+    Internal MCP clients resolve the secret directly through the service
+    layer (with OAuth refresh as needed); the HTTP API never exposes it.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | VaultCredential
+    """
+
+    return (
+        await asyncio_detailed(
+            vault_id=vault_id,
+            credential_id=credential_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/vaults/list_vault_credentials.py
+++ b/src/aios/sdk/_generated/api/vaults/list_vault_credentials.py
@@ -1,0 +1,239 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_vault_credential import ListResponseVaultCredential
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    vault_id: str,
+    *,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    json_after: None | str | Unset
+    if isinstance(after, Unset):
+        json_after = UNSET
+    else:
+        json_after = after
+    params["after"] = json_after
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/vaults/{vault_id}/credentials".format(
+            vault_id=quote(str(vault_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseVaultCredential | None:
+    if response.status_code == 200:
+        response_200 = ListResponseVaultCredential.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseVaultCredential]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseVaultCredential]:
+    """List Credentials
+
+     List credentials in a vault, newest first, excluding archived.
+
+    Cursor pagination via ``after``. Secret material is never returned —
+    only metadata (display name, mcp_server_url, auth_type, timestamps).
+
+    Args:
+        vault_id (str):
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseVaultCredential]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseVaultCredential | None:
+    """List Credentials
+
+     List credentials in a vault, newest first, excluding archived.
+
+    Cursor pagination via ``after``. Secret material is never returned —
+    only metadata (display name, mcp_server_url, auth_type, timestamps).
+
+    Args:
+        vault_id (str):
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseVaultCredential
+    """
+
+    return sync_detailed(
+        vault_id=vault_id,
+        client=client,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseVaultCredential]:
+    """List Credentials
+
+     List credentials in a vault, newest first, excluding archived.
+
+    Cursor pagination via ``after``. Secret material is never returned —
+    only metadata (display name, mcp_server_url, auth_type, timestamps).
+
+    Args:
+        vault_id (str):
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseVaultCredential]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseVaultCredential | None:
+    """List Credentials
+
+     List credentials in a vault, newest first, excluding archived.
+
+    Cursor pagination via ``after``. Secret material is never returned —
+    only metadata (display name, mcp_server_url, auth_type, timestamps).
+
+    Args:
+        vault_id (str):
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseVaultCredential
+    """
+
+    return (
+        await asyncio_detailed(
+            vault_id=vault_id,
+            client=client,
+            limit=limit,
+            after=after,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/vaults/list_vaults.py
+++ b/src/aios/sdk/_generated/api/vaults/list_vaults.py
@@ -1,0 +1,223 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_vault import ListResponseVault
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    json_after: None | str | Unset
+    if isinstance(after, Unset):
+        json_after = UNSET
+    else:
+        json_after = after
+    params["after"] = json_after
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/vaults",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseVault | None:
+    if response.status_code == 200:
+        response_200 = ListResponseVault.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseVault]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseVault]:
+    """List
+
+     List vaults, newest first, excluding archived.
+
+    Cursor pagination: pass ``after`` from a previous response's
+    ``next_after`` to get the next page.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseVault]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseVault | None:
+    """List
+
+     List vaults, newest first, excluding archived.
+
+    Cursor pagination: pass ``after`` from a previous response's
+    ``next_after`` to get the next page.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseVault
+    """
+
+    return sync_detailed(
+        client=client,
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseVault]:
+    """List
+
+     List vaults, newest first, excluding archived.
+
+    Cursor pagination: pass ``after`` from a previous response's
+    ``next_after`` to get the next page.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseVault]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        after=after,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    limit: int | Unset = 50,
+    after: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseVault | None:
+    """List
+
+     List vaults, newest first, excluding archived.
+
+    Cursor pagination: pass ``after`` from a previous response's
+    ``next_after`` to get the next page.
+
+    Args:
+        limit (int | Unset):  Default: 50.
+        after (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseVault
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            limit=limit,
+            after=after,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/vaults/update_vault.py
+++ b/src/aios/sdk/_generated/api/vaults/update_vault.py
@@ -1,0 +1,213 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.vault import Vault
+from ...models.vault_update import VaultUpdate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    vault_id: str,
+    *,
+    body: VaultUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/v1/vaults/{vault_id}".format(
+            vault_id=quote(str(vault_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Vault | None:
+    if response.status_code == 200:
+        response_200 = Vault.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Vault]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Vault]:
+    """Update
+
+     Update a vault's ``display_name`` and/or ``metadata``.
+
+    Omitted fields are preserved.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (VaultUpdate): Request body for ``PUT /v1/vaults/{vault_id}``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Vault]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Vault | None:
+    """Update
+
+     Update a vault's ``display_name`` and/or ``metadata``.
+
+    Omitted fields are preserved.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (VaultUpdate): Request body for ``PUT /v1/vaults/{vault_id}``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Vault
+    """
+
+    return sync_detailed(
+        vault_id=vault_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Vault]:
+    """Update
+
+     Update a vault's ``display_name`` and/or ``metadata``.
+
+    Omitted fields are preserved.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (VaultUpdate): Request body for ``PUT /v1/vaults/{vault_id}``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Vault]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Vault | None:
+    """Update
+
+     Update a vault's ``display_name`` and/or ``metadata``.
+
+    Omitted fields are preserved.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (VaultUpdate): Request body for ``PUT /v1/vaults/{vault_id}``.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Vault
+    """
+
+    return (
+        await asyncio_detailed(
+            vault_id=vault_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/vaults/update_vault_credential.py
+++ b/src/aios/sdk/_generated/api/vaults/update_vault_credential.py
@@ -1,0 +1,259 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.vault_credential import VaultCredential
+from ...models.vault_credential_update import VaultCredentialUpdate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    vault_id: str,
+    credential_id: str,
+    *,
+    body: VaultCredentialUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/v1/vaults/{vault_id}/credentials/{credential_id}".format(
+            vault_id=quote(str(vault_id), safe=""),
+            credential_id=quote(str(credential_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | VaultCredential | None:
+    if response.status_code == 200:
+        response_200 = VaultCredential.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | VaultCredential]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultCredentialUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | VaultCredential]:
+    """Update Credential
+
+     Update a credential's metadata and/or rotate its auth secrets.
+
+    Omitted secret fields are preserved (decrypt-merge-encrypt cycle on the
+    encrypted payload). ``mcp_server_url`` and ``auth_type`` are immutable
+    and not accepted in the body. To rotate an OAuth refresh token, send
+    only the new ``refresh_token`` (and optional ``access_token`` /
+    ``expires_at``); other auth fields stay intact.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+        body (VaultCredentialUpdate): Request body for ``PUT
+            /v1/vaults/{vault_id}/credentials/{id}``.
+
+            ``mcp_server_url`` and ``auth_type`` are immutable — not accepted here.
+            Omitted secret fields are preserved (decrypt-merge-encrypt).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | VaultCredential]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        credential_id=credential_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultCredentialUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | VaultCredential | None:
+    """Update Credential
+
+     Update a credential's metadata and/or rotate its auth secrets.
+
+    Omitted secret fields are preserved (decrypt-merge-encrypt cycle on the
+    encrypted payload). ``mcp_server_url`` and ``auth_type`` are immutable
+    and not accepted in the body. To rotate an OAuth refresh token, send
+    only the new ``refresh_token`` (and optional ``access_token`` /
+    ``expires_at``); other auth fields stay intact.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+        body (VaultCredentialUpdate): Request body for ``PUT
+            /v1/vaults/{vault_id}/credentials/{id}``.
+
+            ``mcp_server_url`` and ``auth_type`` are immutable — not accepted here.
+            Omitted secret fields are preserved (decrypt-merge-encrypt).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | VaultCredential
+    """
+
+    return sync_detailed(
+        vault_id=vault_id,
+        credential_id=credential_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultCredentialUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | VaultCredential]:
+    """Update Credential
+
+     Update a credential's metadata and/or rotate its auth secrets.
+
+    Omitted secret fields are preserved (decrypt-merge-encrypt cycle on the
+    encrypted payload). ``mcp_server_url`` and ``auth_type`` are immutable
+    and not accepted in the body. To rotate an OAuth refresh token, send
+    only the new ``refresh_token`` (and optional ``access_token`` /
+    ``expires_at``); other auth fields stay intact.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+        body (VaultCredentialUpdate): Request body for ``PUT
+            /v1/vaults/{vault_id}/credentials/{id}``.
+
+            ``mcp_server_url`` and ``auth_type`` are immutable — not accepted here.
+            Omitted secret fields are preserved (decrypt-merge-encrypt).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | VaultCredential]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        credential_id=credential_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    vault_id: str,
+    credential_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: VaultCredentialUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | VaultCredential | None:
+    """Update Credential
+
+     Update a credential's metadata and/or rotate its auth secrets.
+
+    Omitted secret fields are preserved (decrypt-merge-encrypt cycle on the
+    encrypted payload). ``mcp_server_url`` and ``auth_type`` are immutable
+    and not accepted in the body. To rotate an OAuth refresh token, send
+    only the new ``refresh_token`` (and optional ``access_token`` /
+    ``expires_at``); other auth fields stay intact.
+
+    Args:
+        vault_id (str):
+        credential_id (str):
+        authorization (None | str | Unset):
+        body (VaultCredentialUpdate): Request body for ``PUT
+            /v1/vaults/{vault_id}/credentials/{id}``.
+
+            ``mcp_server_url`` and ``auth_type`` are immutable — not accepted here.
+            Omitted secret fields are preserved (decrypt-merge-encrypt).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | VaultCredential
+    """
+
+    return (
+        await asyncio_detailed(
+            vault_id=vault_id,
+            credential_id=credential_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/client.py
+++ b/src/aios/sdk/_generated/client.py
@@ -1,0 +1,282 @@
+import ssl
+from typing import Any
+
+import httpx
+from attrs import define, evolve, field
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(
+        default=True, kw_only=True, alias="verify_ssl"
+    )
+    _follow_redirects: bool = field(
+        default=False, kw_only=True, alias="follow_redirects"
+    )
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "Client":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "Client":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "Client":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(
+        default=True, kw_only=True, alias="verify_ssl"
+    )
+    _follow_redirects: bool = field(
+        default=False, kw_only=True, alias="follow_redirects"
+    )
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            )
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(
+        self, async_client: httpx.AsyncClient
+    ) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            )
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/src/aios/sdk/_generated/errors.py
+++ b/src/aios/sdk/_generated/errors.py
@@ -1,0 +1,16 @@
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/src/aios/sdk/_generated/models/__init__.py
+++ b/src/aios/sdk/_generated/models/__init__.py
@@ -1,0 +1,323 @@
+"""Contains all the data models used in inputs/outputs"""
+
+from .actor import Actor
+from .actor_type import ActorType
+from .agent import Agent
+from .agent_create import AgentCreate
+from .agent_create_litellm_extra import AgentCreateLitellmExtra
+from .agent_create_metadata import AgentCreateMetadata
+from .agent_litellm_extra import AgentLitellmExtra
+from .agent_metadata import AgentMetadata
+from .agent_skill_ref import AgentSkillRef
+from .agent_update import AgentUpdate
+from .agent_update_litellm_extra_type_0 import AgentUpdateLitellmExtraType0
+from .agent_update_metadata_type_0 import AgentUpdateMetadataType0
+from .agent_version import AgentVersion
+from .agent_version_litellm_extra import AgentVersionLitellmExtra
+from .bind_chat_request import BindChatRequest
+from .bound_chat import BoundChat
+from .call_v1_connectors_connector_instance_call_post_response_call_v1_connectors_connector_instance_call_post import (
+    CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost,
+)
+from .connection import Connection
+from .connection_attach import ConnectionAttach
+from .connection_configure_per_chat import ConnectionConfigurePerChat
+from .connection_create import ConnectionCreate
+from .connection_create_metadata import ConnectionCreateMetadata
+from .connection_metadata import ConnectionMetadata
+from .connector_call_body import ConnectorCallBody
+from .connector_call_body_arguments import ConnectorCallBodyArguments
+from .connector_call_body_meta_type_0 import ConnectorCallBodyMetaType0
+from .context_response import ContextResponse
+from .context_response_messages_item import ContextResponseMessagesItem
+from .context_response_tools_item import ContextResponseToolsItem
+from .environment import Environment
+from .environment_config import EnvironmentConfig
+from .environment_config_env_type_0 import EnvironmentConfigEnvType0
+from .environment_config_packages_type_0 import EnvironmentConfigPackagesType0
+from .environment_create import EnvironmentCreate
+from .environment_update import EnvironmentUpdate
+from .event import Event
+from .event_data import EventData
+from .event_kind import EventKind
+from .get_health_response_get_health import GetHealthResponseGetHealth
+from .get_instance_v1_connectors_connector_instance_get_response_get_instance_v1_connectors_connector_instance_get import (
+    GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet,
+)
+from .github_repository_resource import GithubRepositoryResource
+from .github_repository_resource_echo import GithubRepositoryResourceEcho
+from .github_repository_update import GithubRepositoryUpdate
+from .http_validation_error import HTTPValidationError
+from .limited_networking import LimitedNetworking
+from .list_accounts_v1_connectors_connector_instance_accounts_get_response_list_accounts_v1_connectors_connector_instance_accounts_get import (
+    ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet,
+)
+from .list_connections_mode_type_0 import ListConnectionsModeType0
+from .list_events_v1_sessions_session_id_events_get_kind_type_0 import (
+    ListEventsV1SessionsSessionIdEventsGetKindType0,
+)
+from .list_for_connector_v1_connectors_connector_get_response_list_for_connector_v1_connectors_connector_get import (
+    ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet,
+)
+from .list_response_agent import ListResponseAgent
+from .list_response_agent_version import ListResponseAgentVersion
+from .list_response_annotated_union_memory_store_resource_echo_github_repository_resource_echo_field_infoannotation_none_type_required_true_discriminatortype import (
+    ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype,
+)
+from .list_response_bound_chat import ListResponseBoundChat
+from .list_response_connection import ListResponseConnection
+from .list_response_environment import ListResponseEnvironment
+from .list_response_event import ListResponseEvent
+from .list_response_memory_store import ListResponseMemoryStore
+from .list_response_memory_version import ListResponseMemoryVersion
+from .list_response_recent_chat import ListResponseRecentChat
+from .list_response_session import ListResponseSession
+from .list_response_session_template import ListResponseSessionTemplate
+from .list_response_skill import ListResponseSkill
+from .list_response_skill_version import ListResponseSkillVersion
+from .list_response_union_memory_memory_prefix import (
+    ListResponseUnionMemoryMemoryPrefix,
+)
+from .list_response_vault import ListResponseVault
+from .list_response_vault_credential import ListResponseVaultCredential
+from .list_tools_v1_connectors_connector_instance_tools_get_response_list_tools_v1_connectors_connector_instance_tools_get import (
+    ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet,
+)
+from .list_v1_connectors_get_response_list_v1_connectors_get import (
+    ListV1ConnectorsGetResponseListV1ConnectorsGet,
+)
+from .list_v1_sessions_get_status_type_0 import ListV1SessionsGetStatusType0
+from .mcp_permission_policy import McpPermissionPolicy
+from .mcp_permission_policy_type import McpPermissionPolicyType
+from .mcp_server_spec import McpServerSpec
+from .mcp_tool_config import McpToolConfig
+from .mcp_toolset_config import McpToolsetConfig
+from .memory import Memory
+from .memory_create import MemoryCreate
+from .memory_prefix import MemoryPrefix
+from .memory_store import MemoryStore
+from .memory_store_create import MemoryStoreCreate
+from .memory_store_create_metadata import MemoryStoreCreateMetadata
+from .memory_store_metadata import MemoryStoreMetadata
+from .memory_store_resource import MemoryStoreResource
+from .memory_store_resource_access import MemoryStoreResourceAccess
+from .memory_store_resource_echo import MemoryStoreResourceEcho
+from .memory_store_resource_echo_access import MemoryStoreResourceEchoAccess
+from .memory_store_update import MemoryStoreUpdate
+from .memory_store_update_metadata_type_0 import MemoryStoreUpdateMetadataType0
+from .memory_update import MemoryUpdate
+from .memory_update_precondition import MemoryUpdatePrecondition
+from .memory_version import MemoryVersion
+from .memory_version_operation import MemoryVersionOperation
+from .recent_chat import RecentChat
+from .session import Session
+from .session_clone_request import SessionCloneRequest
+from .session_create import SessionCreate
+from .session_create_env import SessionCreateEnv
+from .session_create_metadata import SessionCreateMetadata
+from .session_interrupt_request import SessionInterruptRequest
+from .session_metadata import SessionMetadata
+from .session_status import SessionStatus
+from .session_stop_reason_type_0 import SessionStopReasonType0
+from .session_template import SessionTemplate
+from .session_template_create import SessionTemplateCreate
+from .session_template_create_metadata import SessionTemplateCreateMetadata
+from .session_template_metadata import SessionTemplateMetadata
+from .session_template_update import SessionTemplateUpdate
+from .session_template_update_metadata_type_0 import SessionTemplateUpdateMetadataType0
+from .session_update import SessionUpdate
+from .session_update_metadata_type_0 import SessionUpdateMetadataType0
+from .session_usage import SessionUsage
+from .session_user_message import SessionUserMessage
+from .session_user_message_metadata import SessionUserMessageMetadata
+from .skill import Skill
+from .skill_create import SkillCreate
+from .skill_create_files import SkillCreateFiles
+from .skill_version import SkillVersion
+from .skill_version_create import SkillVersionCreate
+from .skill_version_create_files import SkillVersionCreateFiles
+from .skill_version_files import SkillVersionFiles
+from .token_endpoint_auth_basic import TokenEndpointAuthBasic
+from .token_endpoint_auth_none import TokenEndpointAuthNone
+from .token_endpoint_auth_post import TokenEndpointAuthPost
+from .tool_confirmation_request import ToolConfirmationRequest
+from .tool_confirmation_request_result import ToolConfirmationRequestResult
+from .tool_result_request import ToolResultRequest
+from .tool_spec import ToolSpec
+from .tool_spec_input_schema_type_0 import ToolSpecInputSchemaType0
+from .tool_spec_permission_type_0 import ToolSpecPermissionType0
+from .tool_spec_type_type_0 import ToolSpecTypeType0
+from .tool_spec_type_type_1 import ToolSpecTypeType1
+from .unrestricted_networking import UnrestrictedNetworking
+from .validation_error import ValidationError
+from .validation_error_context import ValidationErrorContext
+from .vault import Vault
+from .vault_create import VaultCreate
+from .vault_create_metadata import VaultCreateMetadata
+from .vault_credential import VaultCredential
+from .vault_credential_auth_type import VaultCredentialAuthType
+from .vault_credential_create import VaultCredentialCreate
+from .vault_credential_create_auth_type import VaultCredentialCreateAuthType
+from .vault_credential_create_metadata import VaultCredentialCreateMetadata
+from .vault_credential_metadata import VaultCredentialMetadata
+from .vault_credential_update import VaultCredentialUpdate
+from .vault_credential_update_metadata_type_0 import VaultCredentialUpdateMetadataType0
+from .vault_metadata import VaultMetadata
+from .vault_update import VaultUpdate
+from .vault_update_metadata_type_0 import VaultUpdateMetadataType0
+from .wait_response import WaitResponse
+from .wait_response_session_status import WaitResponseSessionStatus
+from .wait_response_session_stop_reason_type_0 import WaitResponseSessionStopReasonType0
+
+__all__ = (
+    "Actor",
+    "ActorType",
+    "Agent",
+    "AgentCreate",
+    "AgentCreateLitellmExtra",
+    "AgentCreateMetadata",
+    "AgentLitellmExtra",
+    "AgentMetadata",
+    "AgentSkillRef",
+    "AgentUpdate",
+    "AgentUpdateLitellmExtraType0",
+    "AgentUpdateMetadataType0",
+    "AgentVersion",
+    "AgentVersionLitellmExtra",
+    "BindChatRequest",
+    "BoundChat",
+    "CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost",
+    "Connection",
+    "ConnectionAttach",
+    "ConnectionConfigurePerChat",
+    "ConnectionCreate",
+    "ConnectionCreateMetadata",
+    "ConnectionMetadata",
+    "ConnectorCallBody",
+    "ConnectorCallBodyArguments",
+    "ConnectorCallBodyMetaType0",
+    "ContextResponse",
+    "ContextResponseMessagesItem",
+    "ContextResponseToolsItem",
+    "Environment",
+    "EnvironmentConfig",
+    "EnvironmentConfigEnvType0",
+    "EnvironmentConfigPackagesType0",
+    "EnvironmentCreate",
+    "EnvironmentUpdate",
+    "Event",
+    "EventData",
+    "EventKind",
+    "GetHealthResponseGetHealth",
+    "GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet",
+    "GithubRepositoryResource",
+    "GithubRepositoryResourceEcho",
+    "GithubRepositoryUpdate",
+    "HTTPValidationError",
+    "LimitedNetworking",
+    "ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet",
+    "ListConnectionsModeType0",
+    "ListEventsV1SessionsSessionIdEventsGetKindType0",
+    "ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet",
+    "ListResponseAgent",
+    "ListResponseAgentVersion",
+    "ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype",
+    "ListResponseBoundChat",
+    "ListResponseConnection",
+    "ListResponseEnvironment",
+    "ListResponseEvent",
+    "ListResponseMemoryStore",
+    "ListResponseMemoryVersion",
+    "ListResponseRecentChat",
+    "ListResponseSession",
+    "ListResponseSessionTemplate",
+    "ListResponseSkill",
+    "ListResponseSkillVersion",
+    "ListResponseUnionMemoryMemoryPrefix",
+    "ListResponseVault",
+    "ListResponseVaultCredential",
+    "ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet",
+    "ListV1ConnectorsGetResponseListV1ConnectorsGet",
+    "ListV1SessionsGetStatusType0",
+    "McpPermissionPolicy",
+    "McpPermissionPolicyType",
+    "McpServerSpec",
+    "McpToolConfig",
+    "McpToolsetConfig",
+    "Memory",
+    "MemoryCreate",
+    "MemoryPrefix",
+    "MemoryStore",
+    "MemoryStoreCreate",
+    "MemoryStoreCreateMetadata",
+    "MemoryStoreMetadata",
+    "MemoryStoreResource",
+    "MemoryStoreResourceAccess",
+    "MemoryStoreResourceEcho",
+    "MemoryStoreResourceEchoAccess",
+    "MemoryStoreUpdate",
+    "MemoryStoreUpdateMetadataType0",
+    "MemoryUpdate",
+    "MemoryUpdatePrecondition",
+    "MemoryVersion",
+    "MemoryVersionOperation",
+    "RecentChat",
+    "Session",
+    "SessionCloneRequest",
+    "SessionCreate",
+    "SessionCreateEnv",
+    "SessionCreateMetadata",
+    "SessionInterruptRequest",
+    "SessionMetadata",
+    "SessionStatus",
+    "SessionStopReasonType0",
+    "SessionTemplate",
+    "SessionTemplateCreate",
+    "SessionTemplateCreateMetadata",
+    "SessionTemplateMetadata",
+    "SessionTemplateUpdate",
+    "SessionTemplateUpdateMetadataType0",
+    "SessionUpdate",
+    "SessionUpdateMetadataType0",
+    "SessionUsage",
+    "SessionUserMessage",
+    "SessionUserMessageMetadata",
+    "Skill",
+    "SkillCreate",
+    "SkillCreateFiles",
+    "SkillVersion",
+    "SkillVersionCreate",
+    "SkillVersionCreateFiles",
+    "SkillVersionFiles",
+    "TokenEndpointAuthBasic",
+    "TokenEndpointAuthNone",
+    "TokenEndpointAuthPost",
+    "ToolConfirmationRequest",
+    "ToolConfirmationRequestResult",
+    "ToolResultRequest",
+    "ToolSpec",
+    "ToolSpecInputSchemaType0",
+    "ToolSpecPermissionType0",
+    "ToolSpecTypeType0",
+    "ToolSpecTypeType1",
+    "UnrestrictedNetworking",
+    "ValidationError",
+    "ValidationErrorContext",
+    "Vault",
+    "VaultCreate",
+    "VaultCreateMetadata",
+    "VaultCredential",
+    "VaultCredentialAuthType",
+    "VaultCredentialCreate",
+    "VaultCredentialCreateAuthType",
+    "VaultCredentialCreateMetadata",
+    "VaultCredentialMetadata",
+    "VaultCredentialUpdate",
+    "VaultCredentialUpdateMetadataType0",
+    "VaultMetadata",
+    "VaultUpdate",
+    "VaultUpdateMetadataType0",
+    "WaitResponse",
+    "WaitResponseSessionStatus",
+    "WaitResponseSessionStopReasonType0",
+)

--- a/src/aios/sdk/_generated/models/actor.py
+++ b/src/aios/sdk/_generated/models/actor.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.actor_type import ActorType
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Actor")
+
+
+@_attrs_define
+class Actor:
+    """``created_by`` / ``redacted_by`` shape on memory versions.
+
+    Attributes:
+        type_ (ActorType):
+        api_key_id (None | str | Unset):
+        session_id (None | str | Unset):
+    """
+
+    type_: ActorType
+    api_key_id: None | str | Unset = UNSET
+    session_id: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_.value
+
+        api_key_id: None | str | Unset
+        if isinstance(self.api_key_id, Unset):
+            api_key_id = UNSET
+        else:
+            api_key_id = self.api_key_id
+
+        session_id: None | str | Unset
+        if isinstance(self.session_id, Unset):
+            session_id = UNSET
+        else:
+            session_id = self.session_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "type": type_,
+            }
+        )
+        if api_key_id is not UNSET:
+            field_dict["api_key_id"] = api_key_id
+        if session_id is not UNSET:
+            field_dict["session_id"] = session_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = ActorType(d.pop("type"))
+
+        def _parse_api_key_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        api_key_id = _parse_api_key_id(d.pop("api_key_id", UNSET))
+
+        def _parse_session_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        session_id = _parse_session_id(d.pop("session_id", UNSET))
+
+        actor = cls(
+            type_=type_,
+            api_key_id=api_key_id,
+            session_id=session_id,
+        )
+
+        actor.additional_properties = d
+        return actor
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/actor_type.py
+++ b/src/aios/sdk/_generated/models/actor_type.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ActorType(str, Enum):
+    API_ACTOR = "api_actor"
+    SESSION_ACTOR = "session_actor"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/agent.py
+++ b/src/aios/sdk/_generated/models/agent.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent_litellm_extra import AgentLitellmExtra
+    from ..models.agent_metadata import AgentMetadata
+    from ..models.agent_skill_ref import AgentSkillRef
+    from ..models.mcp_server_spec import McpServerSpec
+    from ..models.tool_spec import ToolSpec
+
+
+T = TypeVar("T", bound="Agent")
+
+
+@_attrs_define
+class Agent:
+    """Read view of an agent (always the latest version).
+
+    Attributes:
+        id (str):
+        version (int):
+        name (str):
+        model (str):
+        system (str):
+        tools (list[ToolSpec]):
+        mcp_servers (list[McpServerSpec]):
+        description (None | str):
+        metadata (AgentMetadata):
+        window_min (int):
+        window_max (int):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        skills (list[AgentSkillRef] | Unset):
+        litellm_extra (AgentLitellmExtra | Unset):
+        archived_at (datetime.datetime | None | Unset):
+    """
+
+    id: str
+    version: int
+    name: str
+    model: str
+    system: str
+    tools: list[ToolSpec]
+    mcp_servers: list[McpServerSpec]
+    description: None | str
+    metadata: AgentMetadata
+    window_min: int
+    window_max: int
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    skills: list[AgentSkillRef] | Unset = UNSET
+    litellm_extra: AgentLitellmExtra | Unset = UNSET
+    archived_at: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        version = self.version
+
+        name = self.name
+
+        model = self.model
+
+        system = self.system
+
+        tools = []
+        for tools_item_data in self.tools:
+            tools_item = tools_item_data.to_dict()
+            tools.append(tools_item)
+
+        mcp_servers = []
+        for mcp_servers_item_data in self.mcp_servers:
+            mcp_servers_item = mcp_servers_item_data.to_dict()
+            mcp_servers.append(mcp_servers_item)
+
+        description: None | str
+        description = self.description
+
+        metadata = self.metadata.to_dict()
+
+        window_min = self.window_min
+
+        window_max = self.window_max
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        skills: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.skills, Unset):
+            skills = []
+            for skills_item_data in self.skills:
+                skills_item = skills_item_data.to_dict()
+                skills.append(skills_item)
+
+        litellm_extra: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.litellm_extra, Unset):
+            litellm_extra = self.litellm_extra.to_dict()
+
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "version": version,
+                "name": name,
+                "model": model,
+                "system": system,
+                "tools": tools,
+                "mcp_servers": mcp_servers,
+                "description": description,
+                "metadata": metadata,
+                "window_min": window_min,
+                "window_max": window_max,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if skills is not UNSET:
+            field_dict["skills"] = skills
+        if litellm_extra is not UNSET:
+            field_dict["litellm_extra"] = litellm_extra
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent_litellm_extra import AgentLitellmExtra
+        from ..models.agent_metadata import AgentMetadata
+        from ..models.agent_skill_ref import AgentSkillRef
+        from ..models.mcp_server_spec import McpServerSpec
+        from ..models.tool_spec import ToolSpec
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        version = d.pop("version")
+
+        name = d.pop("name")
+
+        model = d.pop("model")
+
+        system = d.pop("system")
+
+        tools = []
+        _tools = d.pop("tools")
+        for tools_item_data in _tools:
+            tools_item = ToolSpec.from_dict(tools_item_data)
+
+            tools.append(tools_item)
+
+        mcp_servers = []
+        _mcp_servers = d.pop("mcp_servers")
+        for mcp_servers_item_data in _mcp_servers:
+            mcp_servers_item = McpServerSpec.from_dict(mcp_servers_item_data)
+
+            mcp_servers.append(mcp_servers_item)
+
+        def _parse_description(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        description = _parse_description(d.pop("description"))
+
+        metadata = AgentMetadata.from_dict(d.pop("metadata"))
+
+        window_min = d.pop("window_min")
+
+        window_max = d.pop("window_max")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        _skills = d.pop("skills", UNSET)
+        skills: list[AgentSkillRef] | Unset = UNSET
+        if _skills is not UNSET:
+            skills = []
+            for skills_item_data in _skills:
+                skills_item = AgentSkillRef.from_dict(skills_item_data)
+
+                skills.append(skills_item)
+
+        _litellm_extra = d.pop("litellm_extra", UNSET)
+        litellm_extra: AgentLitellmExtra | Unset
+        if isinstance(_litellm_extra, Unset):
+            litellm_extra = UNSET
+        else:
+            litellm_extra = AgentLitellmExtra.from_dict(_litellm_extra)
+
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
+        agent = cls(
+            id=id,
+            version=version,
+            name=name,
+            model=model,
+            system=system,
+            tools=tools,
+            mcp_servers=mcp_servers,
+            description=description,
+            metadata=metadata,
+            window_min=window_min,
+            window_max=window_max,
+            created_at=created_at,
+            updated_at=updated_at,
+            skills=skills,
+            litellm_extra=litellm_extra,
+            archived_at=archived_at,
+        )
+
+        agent.additional_properties = d
+        return agent
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/agent_create.py
+++ b/src/aios/sdk/_generated/models/agent_create.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent_create_litellm_extra import AgentCreateLitellmExtra
+    from ..models.agent_create_metadata import AgentCreateMetadata
+    from ..models.agent_skill_ref import AgentSkillRef
+    from ..models.mcp_server_spec import McpServerSpec
+    from ..models.tool_spec import ToolSpec
+
+
+T = TypeVar("T", bound="AgentCreate")
+
+
+@_attrs_define
+class AgentCreate:
+    """Request body for `POST /v1/agents`.
+
+    Attributes:
+        name (str):
+        model (str): LiteLLM model string, e.g. 'anthropic/claude-opus-4-6'.
+        system (str | Unset): System prompt; empty by default. Default: ''.
+        tools (list[ToolSpec] | Unset):
+        skills (list[AgentSkillRef] | Unset):
+        mcp_servers (list[McpServerSpec] | Unset):
+        description (None | str | Unset):
+        metadata (AgentCreateMetadata | Unset):
+        litellm_extra (AgentCreateLitellmExtra | Unset): Provider-specific LiteLLM kwargs merged into every model
+            request for this agent.  Common shapes: OpenRouter ``extra_body.provider.order`` for provider pinning, Anthropic
+            ``thinking``, OpenAI ``reasoning_effort``, raw sampling knobs (``temperature``, ``max_tokens``), ``api_base``
+            for self-hosted inference.  Validated by LiteLLM / the provider; bad kwargs surface as tool-path errors the
+            model sees.  Security: ``api_base`` redirects the model call — treat operator-set agents as trusted and don't
+            accept this field from untrusted principals.
+        window_min (int | Unset):  Default: 50000.
+        window_max (int | Unset):  Default: 150000.
+    """
+
+    name: str
+    model: str
+    system: str | Unset = ""
+    tools: list[ToolSpec] | Unset = UNSET
+    skills: list[AgentSkillRef] | Unset = UNSET
+    mcp_servers: list[McpServerSpec] | Unset = UNSET
+    description: None | str | Unset = UNSET
+    metadata: AgentCreateMetadata | Unset = UNSET
+    litellm_extra: AgentCreateLitellmExtra | Unset = UNSET
+    window_min: int | Unset = 50000
+    window_max: int | Unset = 150000
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        model = self.model
+
+        system = self.system
+
+        tools: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.tools, Unset):
+            tools = []
+            for tools_item_data in self.tools:
+                tools_item = tools_item_data.to_dict()
+                tools.append(tools_item)
+
+        skills: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.skills, Unset):
+            skills = []
+            for skills_item_data in self.skills:
+                skills_item = skills_item_data.to_dict()
+                skills.append(skills_item)
+
+        mcp_servers: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.mcp_servers, Unset):
+            mcp_servers = []
+            for mcp_servers_item_data in self.mcp_servers:
+                mcp_servers_item = mcp_servers_item_data.to_dict()
+                mcp_servers.append(mcp_servers_item)
+
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        metadata: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        litellm_extra: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.litellm_extra, Unset):
+            litellm_extra = self.litellm_extra.to_dict()
+
+        window_min = self.window_min
+
+        window_max = self.window_max
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "name": name,
+                "model": model,
+            }
+        )
+        if system is not UNSET:
+            field_dict["system"] = system
+        if tools is not UNSET:
+            field_dict["tools"] = tools
+        if skills is not UNSET:
+            field_dict["skills"] = skills
+        if mcp_servers is not UNSET:
+            field_dict["mcp_servers"] = mcp_servers
+        if description is not UNSET:
+            field_dict["description"] = description
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if litellm_extra is not UNSET:
+            field_dict["litellm_extra"] = litellm_extra
+        if window_min is not UNSET:
+            field_dict["window_min"] = window_min
+        if window_max is not UNSET:
+            field_dict["window_max"] = window_max
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent_create_litellm_extra import AgentCreateLitellmExtra
+        from ..models.agent_create_metadata import AgentCreateMetadata
+        from ..models.agent_skill_ref import AgentSkillRef
+        from ..models.mcp_server_spec import McpServerSpec
+        from ..models.tool_spec import ToolSpec
+
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        model = d.pop("model")
+
+        system = d.pop("system", UNSET)
+
+        _tools = d.pop("tools", UNSET)
+        tools: list[ToolSpec] | Unset = UNSET
+        if _tools is not UNSET:
+            tools = []
+            for tools_item_data in _tools:
+                tools_item = ToolSpec.from_dict(tools_item_data)
+
+                tools.append(tools_item)
+
+        _skills = d.pop("skills", UNSET)
+        skills: list[AgentSkillRef] | Unset = UNSET
+        if _skills is not UNSET:
+            skills = []
+            for skills_item_data in _skills:
+                skills_item = AgentSkillRef.from_dict(skills_item_data)
+
+                skills.append(skills_item)
+
+        _mcp_servers = d.pop("mcp_servers", UNSET)
+        mcp_servers: list[McpServerSpec] | Unset = UNSET
+        if _mcp_servers is not UNSET:
+            mcp_servers = []
+            for mcp_servers_item_data in _mcp_servers:
+                mcp_servers_item = McpServerSpec.from_dict(mcp_servers_item_data)
+
+                mcp_servers.append(mcp_servers_item)
+
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        _metadata = d.pop("metadata", UNSET)
+        metadata: AgentCreateMetadata | Unset
+        if isinstance(_metadata, Unset):
+            metadata = UNSET
+        else:
+            metadata = AgentCreateMetadata.from_dict(_metadata)
+
+        _litellm_extra = d.pop("litellm_extra", UNSET)
+        litellm_extra: AgentCreateLitellmExtra | Unset
+        if isinstance(_litellm_extra, Unset):
+            litellm_extra = UNSET
+        else:
+            litellm_extra = AgentCreateLitellmExtra.from_dict(_litellm_extra)
+
+        window_min = d.pop("window_min", UNSET)
+
+        window_max = d.pop("window_max", UNSET)
+
+        agent_create = cls(
+            name=name,
+            model=model,
+            system=system,
+            tools=tools,
+            skills=skills,
+            mcp_servers=mcp_servers,
+            description=description,
+            metadata=metadata,
+            litellm_extra=litellm_extra,
+            window_min=window_min,
+            window_max=window_max,
+        )
+
+        return agent_create

--- a/src/aios/sdk/_generated/models/agent_create_litellm_extra.py
+++ b/src/aios/sdk/_generated/models/agent_create_litellm_extra.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="AgentCreateLitellmExtra")
+
+
+@_attrs_define
+class AgentCreateLitellmExtra:
+    """Provider-specific LiteLLM kwargs merged into every model request for this agent.  Common shapes: OpenRouter
+    ``extra_body.provider.order`` for provider pinning, Anthropic ``thinking``, OpenAI ``reasoning_effort``, raw
+    sampling knobs (``temperature``, ``max_tokens``), ``api_base`` for self-hosted inference.  Validated by LiteLLM /
+    the provider; bad kwargs surface as tool-path errors the model sees.  Security: ``api_base`` redirects the model
+    call — treat operator-set agents as trusted and don't accept this field from untrusted principals.
+
+    """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        agent_create_litellm_extra = cls()
+
+        agent_create_litellm_extra.additional_properties = d
+        return agent_create_litellm_extra
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/agent_create_metadata.py
+++ b/src/aios/sdk/_generated/models/agent_create_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="AgentCreateMetadata")
+
+
+@_attrs_define
+class AgentCreateMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        agent_create_metadata = cls()
+
+        agent_create_metadata.additional_properties = d
+        return agent_create_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/agent_litellm_extra.py
+++ b/src/aios/sdk/_generated/models/agent_litellm_extra.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="AgentLitellmExtra")
+
+
+@_attrs_define
+class AgentLitellmExtra:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        agent_litellm_extra = cls()
+
+        agent_litellm_extra.additional_properties = d
+        return agent_litellm_extra
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/agent_metadata.py
+++ b/src/aios/sdk/_generated/models/agent_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="AgentMetadata")
+
+
+@_attrs_define
+class AgentMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        agent_metadata = cls()
+
+        agent_metadata.additional_properties = d
+        return agent_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/agent_skill_ref.py
+++ b/src/aios/sdk/_generated/models/agent_skill_ref.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AgentSkillRef")
+
+
+@_attrs_define
+class AgentSkillRef:
+    """One entry in an agent's ``skills`` list.
+
+    ``version`` is ``None`` for "latest" (auto-updating — the session uses
+    whatever version is current at step time). When an agent version is
+    snapshotted, null versions are resolved to the concrete latest version
+    at that moment.
+
+        Attributes:
+            skill_id (str):
+            version (int | None | Unset): Pin to a specific version. Omit or null for latest.
+    """
+
+    skill_id: str
+    version: int | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        skill_id = self.skill_id
+
+        version: int | None | Unset
+        if isinstance(self.version, Unset):
+            version = UNSET
+        else:
+            version = self.version
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "skill_id": skill_id,
+            }
+        )
+        if version is not UNSET:
+            field_dict["version"] = version
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        skill_id = d.pop("skill_id")
+
+        def _parse_version(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        version = _parse_version(d.pop("version", UNSET))
+
+        agent_skill_ref = cls(
+            skill_id=skill_id,
+            version=version,
+        )
+
+        return agent_skill_ref

--- a/src/aios/sdk/_generated/models/agent_update.py
+++ b/src/aios/sdk/_generated/models/agent_update.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent_skill_ref import AgentSkillRef
+    from ..models.agent_update_litellm_extra_type_0 import AgentUpdateLitellmExtraType0
+    from ..models.agent_update_metadata_type_0 import AgentUpdateMetadataType0
+    from ..models.mcp_server_spec import McpServerSpec
+    from ..models.tool_spec import ToolSpec
+
+
+T = TypeVar("T", bound="AgentUpdate")
+
+
+@_attrs_define
+class AgentUpdate:
+    """Request body for ``PUT /v1/agents/{id}``.
+
+    All config fields are optional; omitted fields are preserved. The
+    ``version`` field is required for optimistic concurrency — it must match
+    the current version. If the update produces a change, a new version is
+    created; otherwise the existing version is returned unchanged.
+
+        Attributes:
+            version (int): Current version for optimistic concurrency.
+            name (None | str | Unset):
+            model (None | str | Unset):
+            system (None | str | Unset):
+            tools (list[ToolSpec] | None | Unset):
+            skills (list[AgentSkillRef] | None | Unset):
+            mcp_servers (list[McpServerSpec] | None | Unset):
+            description (None | str | Unset):
+            metadata (AgentUpdateMetadataType0 | None | Unset):
+            litellm_extra (AgentUpdateLitellmExtraType0 | None | Unset):
+            window_min (int | None | Unset):
+            window_max (int | None | Unset):
+    """
+
+    version: int
+    name: None | str | Unset = UNSET
+    model: None | str | Unset = UNSET
+    system: None | str | Unset = UNSET
+    tools: list[ToolSpec] | None | Unset = UNSET
+    skills: list[AgentSkillRef] | None | Unset = UNSET
+    mcp_servers: list[McpServerSpec] | None | Unset = UNSET
+    description: None | str | Unset = UNSET
+    metadata: AgentUpdateMetadataType0 | None | Unset = UNSET
+    litellm_extra: AgentUpdateLitellmExtraType0 | None | Unset = UNSET
+    window_min: int | None | Unset = UNSET
+    window_max: int | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.agent_update_litellm_extra_type_0 import (
+            AgentUpdateLitellmExtraType0,
+        )
+        from ..models.agent_update_metadata_type_0 import AgentUpdateMetadataType0
+
+        version = self.version
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
+
+        model: None | str | Unset
+        if isinstance(self.model, Unset):
+            model = UNSET
+        else:
+            model = self.model
+
+        system: None | str | Unset
+        if isinstance(self.system, Unset):
+            system = UNSET
+        else:
+            system = self.system
+
+        tools: list[dict[str, Any]] | None | Unset
+        if isinstance(self.tools, Unset):
+            tools = UNSET
+        elif isinstance(self.tools, list):
+            tools = []
+            for tools_type_0_item_data in self.tools:
+                tools_type_0_item = tools_type_0_item_data.to_dict()
+                tools.append(tools_type_0_item)
+
+        else:
+            tools = self.tools
+
+        skills: list[dict[str, Any]] | None | Unset
+        if isinstance(self.skills, Unset):
+            skills = UNSET
+        elif isinstance(self.skills, list):
+            skills = []
+            for skills_type_0_item_data in self.skills:
+                skills_type_0_item = skills_type_0_item_data.to_dict()
+                skills.append(skills_type_0_item)
+
+        else:
+            skills = self.skills
+
+        mcp_servers: list[dict[str, Any]] | None | Unset
+        if isinstance(self.mcp_servers, Unset):
+            mcp_servers = UNSET
+        elif isinstance(self.mcp_servers, list):
+            mcp_servers = []
+            for mcp_servers_type_0_item_data in self.mcp_servers:
+                mcp_servers_type_0_item = mcp_servers_type_0_item_data.to_dict()
+                mcp_servers.append(mcp_servers_type_0_item)
+
+        else:
+            mcp_servers = self.mcp_servers
+
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, AgentUpdateMetadataType0):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
+
+        litellm_extra: dict[str, Any] | None | Unset
+        if isinstance(self.litellm_extra, Unset):
+            litellm_extra = UNSET
+        elif isinstance(self.litellm_extra, AgentUpdateLitellmExtraType0):
+            litellm_extra = self.litellm_extra.to_dict()
+        else:
+            litellm_extra = self.litellm_extra
+
+        window_min: int | None | Unset
+        if isinstance(self.window_min, Unset):
+            window_min = UNSET
+        else:
+            window_min = self.window_min
+
+        window_max: int | None | Unset
+        if isinstance(self.window_max, Unset):
+            window_max = UNSET
+        else:
+            window_max = self.window_max
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "version": version,
+            }
+        )
+        if name is not UNSET:
+            field_dict["name"] = name
+        if model is not UNSET:
+            field_dict["model"] = model
+        if system is not UNSET:
+            field_dict["system"] = system
+        if tools is not UNSET:
+            field_dict["tools"] = tools
+        if skills is not UNSET:
+            field_dict["skills"] = skills
+        if mcp_servers is not UNSET:
+            field_dict["mcp_servers"] = mcp_servers
+        if description is not UNSET:
+            field_dict["description"] = description
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if litellm_extra is not UNSET:
+            field_dict["litellm_extra"] = litellm_extra
+        if window_min is not UNSET:
+            field_dict["window_min"] = window_min
+        if window_max is not UNSET:
+            field_dict["window_max"] = window_max
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent_skill_ref import AgentSkillRef
+        from ..models.agent_update_litellm_extra_type_0 import (
+            AgentUpdateLitellmExtraType0,
+        )
+        from ..models.agent_update_metadata_type_0 import AgentUpdateMetadataType0
+        from ..models.mcp_server_spec import McpServerSpec
+        from ..models.tool_spec import ToolSpec
+
+        d = dict(src_dict)
+        version = d.pop("version")
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
+
+        def _parse_model(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        model = _parse_model(d.pop("model", UNSET))
+
+        def _parse_system(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        system = _parse_system(d.pop("system", UNSET))
+
+        def _parse_tools(data: object) -> list[ToolSpec] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                tools_type_0 = []
+                _tools_type_0 = data
+                for tools_type_0_item_data in _tools_type_0:
+                    tools_type_0_item = ToolSpec.from_dict(tools_type_0_item_data)
+
+                    tools_type_0.append(tools_type_0_item)
+
+                return tools_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[ToolSpec] | None | Unset, data)
+
+        tools = _parse_tools(d.pop("tools", UNSET))
+
+        def _parse_skills(data: object) -> list[AgentSkillRef] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                skills_type_0 = []
+                _skills_type_0 = data
+                for skills_type_0_item_data in _skills_type_0:
+                    skills_type_0_item = AgentSkillRef.from_dict(
+                        skills_type_0_item_data
+                    )
+
+                    skills_type_0.append(skills_type_0_item)
+
+                return skills_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[AgentSkillRef] | None | Unset, data)
+
+        skills = _parse_skills(d.pop("skills", UNSET))
+
+        def _parse_mcp_servers(data: object) -> list[McpServerSpec] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                mcp_servers_type_0 = []
+                _mcp_servers_type_0 = data
+                for mcp_servers_type_0_item_data in _mcp_servers_type_0:
+                    mcp_servers_type_0_item = McpServerSpec.from_dict(
+                        mcp_servers_type_0_item_data
+                    )
+
+                    mcp_servers_type_0.append(mcp_servers_type_0_item)
+
+                return mcp_servers_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[McpServerSpec] | None | Unset, data)
+
+        mcp_servers = _parse_mcp_servers(d.pop("mcp_servers", UNSET))
+
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_metadata(data: object) -> AgentUpdateMetadataType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = AgentUpdateMetadataType0.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(AgentUpdateMetadataType0 | None | Unset, data)
+
+        metadata = _parse_metadata(d.pop("metadata", UNSET))
+
+        def _parse_litellm_extra(
+            data: object,
+        ) -> AgentUpdateLitellmExtraType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                litellm_extra_type_0 = AgentUpdateLitellmExtraType0.from_dict(data)
+
+                return litellm_extra_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(AgentUpdateLitellmExtraType0 | None | Unset, data)
+
+        litellm_extra = _parse_litellm_extra(d.pop("litellm_extra", UNSET))
+
+        def _parse_window_min(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        window_min = _parse_window_min(d.pop("window_min", UNSET))
+
+        def _parse_window_max(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        window_max = _parse_window_max(d.pop("window_max", UNSET))
+
+        agent_update = cls(
+            version=version,
+            name=name,
+            model=model,
+            system=system,
+            tools=tools,
+            skills=skills,
+            mcp_servers=mcp_servers,
+            description=description,
+            metadata=metadata,
+            litellm_extra=litellm_extra,
+            window_min=window_min,
+            window_max=window_max,
+        )
+
+        return agent_update

--- a/src/aios/sdk/_generated/models/agent_update_litellm_extra_type_0.py
+++ b/src/aios/sdk/_generated/models/agent_update_litellm_extra_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="AgentUpdateLitellmExtraType0")
+
+
+@_attrs_define
+class AgentUpdateLitellmExtraType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        agent_update_litellm_extra_type_0 = cls()
+
+        agent_update_litellm_extra_type_0.additional_properties = d
+        return agent_update_litellm_extra_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/agent_update_metadata_type_0.py
+++ b/src/aios/sdk/_generated/models/agent_update_metadata_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="AgentUpdateMetadataType0")
+
+
+@_attrs_define
+class AgentUpdateMetadataType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        agent_update_metadata_type_0 = cls()
+
+        agent_update_metadata_type_0.additional_properties = d
+        return agent_update_metadata_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/agent_version.py
+++ b/src/aios/sdk/_generated/models/agent_version.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent_skill_ref import AgentSkillRef
+    from ..models.agent_version_litellm_extra import AgentVersionLitellmExtra
+    from ..models.mcp_server_spec import McpServerSpec
+    from ..models.tool_spec import ToolSpec
+
+
+T = TypeVar("T", bound="AgentVersion")
+
+
+@_attrs_define
+class AgentVersion:
+    """Read view of a specific agent version from the version history.
+
+    Attributes:
+        agent_id (str):
+        version (int):
+        model (str):
+        system (str):
+        tools (list[ToolSpec]):
+        mcp_servers (list[McpServerSpec]):
+        window_min (int):
+        window_max (int):
+        created_at (datetime.datetime):
+        skills (list[AgentSkillRef] | Unset):
+        litellm_extra (AgentVersionLitellmExtra | Unset):
+    """
+
+    agent_id: str
+    version: int
+    model: str
+    system: str
+    tools: list[ToolSpec]
+    mcp_servers: list[McpServerSpec]
+    window_min: int
+    window_max: int
+    created_at: datetime.datetime
+    skills: list[AgentSkillRef] | Unset = UNSET
+    litellm_extra: AgentVersionLitellmExtra | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        agent_id = self.agent_id
+
+        version = self.version
+
+        model = self.model
+
+        system = self.system
+
+        tools = []
+        for tools_item_data in self.tools:
+            tools_item = tools_item_data.to_dict()
+            tools.append(tools_item)
+
+        mcp_servers = []
+        for mcp_servers_item_data in self.mcp_servers:
+            mcp_servers_item = mcp_servers_item_data.to_dict()
+            mcp_servers.append(mcp_servers_item)
+
+        window_min = self.window_min
+
+        window_max = self.window_max
+
+        created_at = self.created_at.isoformat()
+
+        skills: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.skills, Unset):
+            skills = []
+            for skills_item_data in self.skills:
+                skills_item = skills_item_data.to_dict()
+                skills.append(skills_item)
+
+        litellm_extra: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.litellm_extra, Unset):
+            litellm_extra = self.litellm_extra.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "agent_id": agent_id,
+                "version": version,
+                "model": model,
+                "system": system,
+                "tools": tools,
+                "mcp_servers": mcp_servers,
+                "window_min": window_min,
+                "window_max": window_max,
+                "created_at": created_at,
+            }
+        )
+        if skills is not UNSET:
+            field_dict["skills"] = skills
+        if litellm_extra is not UNSET:
+            field_dict["litellm_extra"] = litellm_extra
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent_skill_ref import AgentSkillRef
+        from ..models.agent_version_litellm_extra import AgentVersionLitellmExtra
+        from ..models.mcp_server_spec import McpServerSpec
+        from ..models.tool_spec import ToolSpec
+
+        d = dict(src_dict)
+        agent_id = d.pop("agent_id")
+
+        version = d.pop("version")
+
+        model = d.pop("model")
+
+        system = d.pop("system")
+
+        tools = []
+        _tools = d.pop("tools")
+        for tools_item_data in _tools:
+            tools_item = ToolSpec.from_dict(tools_item_data)
+
+            tools.append(tools_item)
+
+        mcp_servers = []
+        _mcp_servers = d.pop("mcp_servers")
+        for mcp_servers_item_data in _mcp_servers:
+            mcp_servers_item = McpServerSpec.from_dict(mcp_servers_item_data)
+
+            mcp_servers.append(mcp_servers_item)
+
+        window_min = d.pop("window_min")
+
+        window_max = d.pop("window_max")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        _skills = d.pop("skills", UNSET)
+        skills: list[AgentSkillRef] | Unset = UNSET
+        if _skills is not UNSET:
+            skills = []
+            for skills_item_data in _skills:
+                skills_item = AgentSkillRef.from_dict(skills_item_data)
+
+                skills.append(skills_item)
+
+        _litellm_extra = d.pop("litellm_extra", UNSET)
+        litellm_extra: AgentVersionLitellmExtra | Unset
+        if isinstance(_litellm_extra, Unset):
+            litellm_extra = UNSET
+        else:
+            litellm_extra = AgentVersionLitellmExtra.from_dict(_litellm_extra)
+
+        agent_version = cls(
+            agent_id=agent_id,
+            version=version,
+            model=model,
+            system=system,
+            tools=tools,
+            mcp_servers=mcp_servers,
+            window_min=window_min,
+            window_max=window_max,
+            created_at=created_at,
+            skills=skills,
+            litellm_extra=litellm_extra,
+        )
+
+        agent_version.additional_properties = d
+        return agent_version
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/agent_version_litellm_extra.py
+++ b/src/aios/sdk/_generated/models/agent_version_litellm_extra.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="AgentVersionLitellmExtra")
+
+
+@_attrs_define
+class AgentVersionLitellmExtra:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        agent_version_litellm_extra = cls()
+
+        agent_version_litellm_extra.additional_properties = d
+        return agent_version_litellm_extra
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/bind_chat_request.py
+++ b/src/aios/sdk/_generated/models/bind_chat_request.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="BindChatRequest")
+
+
+@_attrs_define
+class BindChatRequest:
+    """Request body for ``POST /v1/connections/{id}/bind-chat``.
+
+    Pre-populates a ``connection_chat_sessions`` row so inbound on
+    ``chat_id`` routes to ``session_id`` regardless of the connection's
+    mode-default fallback (#215).  Operators use this to point
+    different chats on a single account at different operator-curated
+    existing sessions.
+
+        Attributes:
+            chat_id (str):
+            session_id (str):
+    """
+
+    chat_id: str
+    session_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        chat_id = self.chat_id
+
+        session_id = self.session_id
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "chat_id": chat_id,
+                "session_id": session_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        chat_id = d.pop("chat_id")
+
+        session_id = d.pop("session_id")
+
+        bind_chat_request = cls(
+            chat_id=chat_id,
+            session_id=session_id,
+        )
+
+        return bind_chat_request

--- a/src/aios/sdk/_generated/models/bound_chat.py
+++ b/src/aios/sdk/_generated/models/bound_chat.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+T = TypeVar("T", bound="BoundChat")
+
+
+@_attrs_define
+class BoundChat:
+    """Read view of one ``connection_chat_sessions`` row.
+
+    Returned by ``GET /v1/connections/{id}/bound-chats``.  Operator-bound
+    rows and supervisor-spawned rows are returned together — the table
+    doesn't tag the writer.
+
+        Attributes:
+            chat_id (str):
+            session_id (str):
+            created_at (datetime.datetime):
+    """
+
+    chat_id: str
+    session_id: str
+    created_at: datetime.datetime
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        chat_id = self.chat_id
+
+        session_id = self.session_id
+
+        created_at = self.created_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "chat_id": chat_id,
+                "session_id": session_id,
+                "created_at": created_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        chat_id = d.pop("chat_id")
+
+        session_id = d.pop("session_id")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        bound_chat = cls(
+            chat_id=chat_id,
+            session_id=session_id,
+            created_at=created_at,
+        )
+
+        bound_chat.additional_properties = d
+        return bound_chat
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/call_v1_connectors_connector_instance_call_post_response_call_v1_connectors_connector_instance_call_post.py
+++ b/src/aios/sdk/_generated/models/call_v1_connectors_connector_instance_call_post_response_call_v1_connectors_connector_instance_call_post.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar(
+    "T",
+    bound="CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost",
+)
+
+
+@_attrs_define
+class CallV1ConnectorsConnectorInstanceCallPostResponseCallV1ConnectorsConnectorInstanceCallPost:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        call_v1_connectors_connector_instance_call_post_response_call_v1_connectors_connector_instance_call_post = cls()
+
+        call_v1_connectors_connector_instance_call_post_response_call_v1_connectors_connector_instance_call_post.additional_properties = d
+        return call_v1_connectors_connector_instance_call_post_response_call_v1_connectors_connector_instance_call_post
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/connection.py
+++ b/src/aios/sdk/_generated/models/connection.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.connection_metadata import ConnectionMetadata
+
+
+T = TypeVar("T", bound="Connection")
+
+
+@_attrs_define
+class Connection:
+    """Read view of a connection.
+
+    Mode is implicit in the populated field:
+
+    * ``session_id`` set → single_session
+    * ``session_template_id`` set → per_chat
+    * neither → detached
+
+        Attributes:
+            id (str):
+            connector (str):
+            account (str):
+            metadata (ConnectionMetadata):
+            created_at (datetime.datetime):
+            updated_at (datetime.datetime):
+            session_id (None | str | Unset):
+            session_template_id (None | str | Unset):
+            attached_at (datetime.datetime | None | Unset):
+            archived_at (datetime.datetime | None | Unset):
+    """
+
+    id: str
+    connector: str
+    account: str
+    metadata: ConnectionMetadata
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    session_id: None | str | Unset = UNSET
+    session_template_id: None | str | Unset = UNSET
+    attached_at: datetime.datetime | None | Unset = UNSET
+    archived_at: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        connector = self.connector
+
+        account = self.account
+
+        metadata = self.metadata.to_dict()
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        session_id: None | str | Unset
+        if isinstance(self.session_id, Unset):
+            session_id = UNSET
+        else:
+            session_id = self.session_id
+
+        session_template_id: None | str | Unset
+        if isinstance(self.session_template_id, Unset):
+            session_template_id = UNSET
+        else:
+            session_template_id = self.session_template_id
+
+        attached_at: None | str | Unset
+        if isinstance(self.attached_at, Unset):
+            attached_at = UNSET
+        elif isinstance(self.attached_at, datetime.datetime):
+            attached_at = self.attached_at.isoformat()
+        else:
+            attached_at = self.attached_at
+
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "connector": connector,
+                "account": account,
+                "metadata": metadata,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if session_id is not UNSET:
+            field_dict["session_id"] = session_id
+        if session_template_id is not UNSET:
+            field_dict["session_template_id"] = session_template_id
+        if attached_at is not UNSET:
+            field_dict["attached_at"] = attached_at
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.connection_metadata import ConnectionMetadata
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        connector = d.pop("connector")
+
+        account = d.pop("account")
+
+        metadata = ConnectionMetadata.from_dict(d.pop("metadata"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        def _parse_session_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        session_id = _parse_session_id(d.pop("session_id", UNSET))
+
+        def _parse_session_template_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        session_template_id = _parse_session_template_id(
+            d.pop("session_template_id", UNSET)
+        )
+
+        def _parse_attached_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                attached_at_type_0 = isoparse(data)
+
+                return attached_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        attached_at = _parse_attached_at(d.pop("attached_at", UNSET))
+
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
+        connection = cls(
+            id=id,
+            connector=connector,
+            account=account,
+            metadata=metadata,
+            created_at=created_at,
+            updated_at=updated_at,
+            session_id=session_id,
+            session_template_id=session_template_id,
+            attached_at=attached_at,
+            archived_at=archived_at,
+        )
+
+        connection.additional_properties = d
+        return connection
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/connection_attach.py
+++ b/src/aios/sdk/_generated/models/connection_attach.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="ConnectionAttach")
+
+
+@_attrs_define
+class ConnectionAttach:
+    """Request body for ``POST /v1/connections/{id}/attach``.
+
+    Attributes:
+        session_id (str):
+    """
+
+    session_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        session_id = self.session_id
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "session_id": session_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_id = d.pop("session_id")
+
+        connection_attach = cls(
+            session_id=session_id,
+        )
+
+        return connection_attach

--- a/src/aios/sdk/_generated/models/connection_configure_per_chat.py
+++ b/src/aios/sdk/_generated/models/connection_configure_per_chat.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="ConnectionConfigurePerChat")
+
+
+@_attrs_define
+class ConnectionConfigurePerChat:
+    """Request body for ``POST /v1/connections/{id}/configure-per-chat``.
+
+    Attributes:
+        session_template_id (str):
+    """
+
+    session_template_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        session_template_id = self.session_template_id
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "session_template_id": session_template_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_template_id = d.pop("session_template_id")
+
+        connection_configure_per_chat = cls(
+            session_template_id=session_template_id,
+        )
+
+        return connection_configure_per_chat

--- a/src/aios/sdk/_generated/models/connection_create.py
+++ b/src/aios/sdk/_generated/models/connection_create.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.connection_create_metadata import ConnectionCreateMetadata
+
+
+T = TypeVar("T", bound="ConnectionCreate")
+
+
+@_attrs_define
+class ConnectionCreate:
+    """Request body for ``POST /v1/connections``.
+
+    Created in detached mode — neither ``session_id`` nor
+    ``session_template_id`` is set.  Use ``POST .../attach`` or
+    ``POST .../configure-per-chat`` afterward to bind a routing mode.
+
+    ``connector`` and ``account`` may not contain ``/`` — they're used
+    in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
+    and a ``/`` would create ambiguous segment boundaries.
+
+        Attributes:
+            connector (str):
+            account (str):
+            metadata (ConnectionCreateMetadata | Unset):
+    """
+
+    connector: str
+    account: str
+    metadata: ConnectionCreateMetadata | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        connector = self.connector
+
+        account = self.account
+
+        metadata: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "connector": connector,
+                "account": account,
+            }
+        )
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.connection_create_metadata import ConnectionCreateMetadata
+
+        d = dict(src_dict)
+        connector = d.pop("connector")
+
+        account = d.pop("account")
+
+        _metadata = d.pop("metadata", UNSET)
+        metadata: ConnectionCreateMetadata | Unset
+        if isinstance(_metadata, Unset):
+            metadata = UNSET
+        else:
+            metadata = ConnectionCreateMetadata.from_dict(_metadata)
+
+        connection_create = cls(
+            connector=connector,
+            account=account,
+            metadata=metadata,
+        )
+
+        return connection_create

--- a/src/aios/sdk/_generated/models/connection_create_metadata.py
+++ b/src/aios/sdk/_generated/models/connection_create_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ConnectionCreateMetadata")
+
+
+@_attrs_define
+class ConnectionCreateMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        connection_create_metadata = cls()
+
+        connection_create_metadata.additional_properties = d
+        return connection_create_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/connection_metadata.py
+++ b/src/aios/sdk/_generated/models/connection_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ConnectionMetadata")
+
+
+@_attrs_define
+class ConnectionMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        connection_metadata = cls()
+
+        connection_metadata.additional_properties = d
+        return connection_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/connector_call_body.py
+++ b/src/aios/sdk/_generated/models/connector_call_body.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.connector_call_body_arguments import ConnectorCallBodyArguments
+    from ..models.connector_call_body_meta_type_0 import ConnectorCallBodyMetaType0
+
+
+T = TypeVar("T", bound="ConnectorCallBody")
+
+
+@_attrs_define
+class ConnectorCallBody:
+    """
+    Attributes:
+        tool (str):
+        arguments (ConnectorCallBodyArguments | Unset):
+        meta (ConnectorCallBodyMetaType0 | None | Unset):
+    """
+
+    tool: str
+    arguments: ConnectorCallBodyArguments | Unset = UNSET
+    meta: ConnectorCallBodyMetaType0 | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.connector_call_body_meta_type_0 import ConnectorCallBodyMetaType0
+
+        tool = self.tool
+
+        arguments: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.arguments, Unset):
+            arguments = self.arguments.to_dict()
+
+        meta: dict[str, Any] | None | Unset
+        if isinstance(self.meta, Unset):
+            meta = UNSET
+        elif isinstance(self.meta, ConnectorCallBodyMetaType0):
+            meta = self.meta.to_dict()
+        else:
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "tool": tool,
+            }
+        )
+        if arguments is not UNSET:
+            field_dict["arguments"] = arguments
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.connector_call_body_arguments import ConnectorCallBodyArguments
+        from ..models.connector_call_body_meta_type_0 import ConnectorCallBodyMetaType0
+
+        d = dict(src_dict)
+        tool = d.pop("tool")
+
+        _arguments = d.pop("arguments", UNSET)
+        arguments: ConnectorCallBodyArguments | Unset
+        if isinstance(_arguments, Unset):
+            arguments = UNSET
+        else:
+            arguments = ConnectorCallBodyArguments.from_dict(_arguments)
+
+        def _parse_meta(data: object) -> ConnectorCallBodyMetaType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                meta_type_0 = ConnectorCallBodyMetaType0.from_dict(data)
+
+                return meta_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(ConnectorCallBodyMetaType0 | None | Unset, data)
+
+        meta = _parse_meta(d.pop("meta", UNSET))
+
+        connector_call_body = cls(
+            tool=tool,
+            arguments=arguments,
+            meta=meta,
+        )
+
+        return connector_call_body

--- a/src/aios/sdk/_generated/models/connector_call_body_arguments.py
+++ b/src/aios/sdk/_generated/models/connector_call_body_arguments.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ConnectorCallBodyArguments")
+
+
+@_attrs_define
+class ConnectorCallBodyArguments:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        connector_call_body_arguments = cls()
+
+        connector_call_body_arguments.additional_properties = d
+        return connector_call_body_arguments
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/connector_call_body_meta_type_0.py
+++ b/src/aios/sdk/_generated/models/connector_call_body_meta_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ConnectorCallBodyMetaType0")
+
+
+@_attrs_define
+class ConnectorCallBodyMetaType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        connector_call_body_meta_type_0 = cls()
+
+        connector_call_body_meta_type_0.additional_properties = d
+        return connector_call_body_meta_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/context_response.py
+++ b/src/aios/sdk/_generated/models/context_response.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.context_response_messages_item import ContextResponseMessagesItem
+    from ..models.context_response_tools_item import ContextResponseToolsItem
+
+
+T = TypeVar("T", bound="ContextResponse")
+
+
+@_attrs_define
+class ContextResponse:
+    """Response for ``GET /v1/sessions/{id}/context``.
+
+    The exact chat-completions payload the worker would send to LiteLLM
+    if a step ran right now.  Dry-run: no side effects — no events
+    appended, no status bump, no skill files provisioned.
+
+        Attributes:
+            session_id (str):
+            model (str):
+            messages (list[ContextResponseMessagesItem]):
+            tools (list[ContextResponseToolsItem]):
+    """
+
+    session_id: str
+    model: str
+    messages: list[ContextResponseMessagesItem]
+    tools: list[ContextResponseToolsItem]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        session_id = self.session_id
+
+        model = self.model
+
+        messages = []
+        for messages_item_data in self.messages:
+            messages_item = messages_item_data.to_dict()
+            messages.append(messages_item)
+
+        tools = []
+        for tools_item_data in self.tools:
+            tools_item = tools_item_data.to_dict()
+            tools.append(tools_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "session_id": session_id,
+                "model": model,
+                "messages": messages,
+                "tools": tools,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.context_response_messages_item import ContextResponseMessagesItem
+        from ..models.context_response_tools_item import ContextResponseToolsItem
+
+        d = dict(src_dict)
+        session_id = d.pop("session_id")
+
+        model = d.pop("model")
+
+        messages = []
+        _messages = d.pop("messages")
+        for messages_item_data in _messages:
+            messages_item = ContextResponseMessagesItem.from_dict(messages_item_data)
+
+            messages.append(messages_item)
+
+        tools = []
+        _tools = d.pop("tools")
+        for tools_item_data in _tools:
+            tools_item = ContextResponseToolsItem.from_dict(tools_item_data)
+
+            tools.append(tools_item)
+
+        context_response = cls(
+            session_id=session_id,
+            model=model,
+            messages=messages,
+            tools=tools,
+        )
+
+        context_response.additional_properties = d
+        return context_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/context_response_messages_item.py
+++ b/src/aios/sdk/_generated/models/context_response_messages_item.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ContextResponseMessagesItem")
+
+
+@_attrs_define
+class ContextResponseMessagesItem:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        context_response_messages_item = cls()
+
+        context_response_messages_item.additional_properties = d
+        return context_response_messages_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/context_response_tools_item.py
+++ b/src/aios/sdk/_generated/models/context_response_tools_item.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ContextResponseToolsItem")
+
+
+@_attrs_define
+class ContextResponseToolsItem:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        context_response_tools_item = cls()
+
+        context_response_tools_item.additional_properties = d
+        return context_response_tools_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/environment.py
+++ b/src/aios/sdk/_generated/models/environment.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.environment_config import EnvironmentConfig
+
+
+T = TypeVar("T", bound="Environment")
+
+
+@_attrs_define
+class Environment:
+    """Read view of an environment.
+
+    Attributes:
+        id (str):
+        name (str):
+        config (EnvironmentConfig): Container configuration for an environment.
+        created_at (datetime.datetime):
+        archived_at (datetime.datetime | None | Unset):
+    """
+
+    id: str
+    name: str
+    config: EnvironmentConfig
+    created_at: datetime.datetime
+    archived_at: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        name = self.name
+
+        config = self.config.to_dict()
+
+        created_at = self.created_at.isoformat()
+
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "name": name,
+                "config": config,
+                "created_at": created_at,
+            }
+        )
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.environment_config import EnvironmentConfig
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        name = d.pop("name")
+
+        config = EnvironmentConfig.from_dict(d.pop("config"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
+        environment = cls(
+            id=id,
+            name=name,
+            config=config,
+            created_at=created_at,
+            archived_at=archived_at,
+        )
+
+        environment.additional_properties = d
+        return environment
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/environment_config.py
+++ b/src/aios/sdk/_generated/models/environment_config.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.environment_config_env_type_0 import EnvironmentConfigEnvType0
+    from ..models.environment_config_packages_type_0 import (
+        EnvironmentConfigPackagesType0,
+    )
+    from ..models.limited_networking import LimitedNetworking
+    from ..models.unrestricted_networking import UnrestrictedNetworking
+
+
+T = TypeVar("T", bound="EnvironmentConfig")
+
+
+@_attrs_define
+class EnvironmentConfig:
+    """Container configuration for an environment.
+
+    Attributes:
+        packages (EnvironmentConfigPackagesType0 | None | Unset): Package manager → package list, e.g. {"pip":
+            ["pandas"], "npm": ["express"]}.
+        networking (LimitedNetworking | None | UnrestrictedNetworking | Unset): Network access rules.  None or {"type":
+            "unrestricted"} for full access; {"type": "limited", "allowed_hosts": [...]} to restrict.
+        env (EnvironmentConfigEnvType0 | None | Unset): Environment variables injected into every session container
+            using this environment.  Per-session env overrides these.
+    """
+
+    packages: EnvironmentConfigPackagesType0 | None | Unset = UNSET
+    networking: LimitedNetworking | None | UnrestrictedNetworking | Unset = UNSET
+    env: EnvironmentConfigEnvType0 | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.environment_config_env_type_0 import EnvironmentConfigEnvType0
+        from ..models.environment_config_packages_type_0 import (
+            EnvironmentConfigPackagesType0,
+        )
+        from ..models.limited_networking import LimitedNetworking
+        from ..models.unrestricted_networking import UnrestrictedNetworking
+
+        packages: dict[str, Any] | None | Unset
+        if isinstance(self.packages, Unset):
+            packages = UNSET
+        elif isinstance(self.packages, EnvironmentConfigPackagesType0):
+            packages = self.packages.to_dict()
+        else:
+            packages = self.packages
+
+        networking: dict[str, Any] | None | Unset
+        if isinstance(self.networking, Unset):
+            networking = UNSET
+        elif isinstance(self.networking, UnrestrictedNetworking):
+            networking = self.networking.to_dict()
+        elif isinstance(self.networking, LimitedNetworking):
+            networking = self.networking.to_dict()
+        else:
+            networking = self.networking
+
+        env: dict[str, Any] | None | Unset
+        if isinstance(self.env, Unset):
+            env = UNSET
+        elif isinstance(self.env, EnvironmentConfigEnvType0):
+            env = self.env.to_dict()
+        else:
+            env = self.env
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if packages is not UNSET:
+            field_dict["packages"] = packages
+        if networking is not UNSET:
+            field_dict["networking"] = networking
+        if env is not UNSET:
+            field_dict["env"] = env
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.environment_config_env_type_0 import EnvironmentConfigEnvType0
+        from ..models.environment_config_packages_type_0 import (
+            EnvironmentConfigPackagesType0,
+        )
+        from ..models.limited_networking import LimitedNetworking
+        from ..models.unrestricted_networking import UnrestrictedNetworking
+
+        d = dict(src_dict)
+
+        def _parse_packages(
+            data: object,
+        ) -> EnvironmentConfigPackagesType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                packages_type_0 = EnvironmentConfigPackagesType0.from_dict(data)
+
+                return packages_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(EnvironmentConfigPackagesType0 | None | Unset, data)
+
+        packages = _parse_packages(d.pop("packages", UNSET))
+
+        def _parse_networking(
+            data: object,
+        ) -> LimitedNetworking | None | UnrestrictedNetworking | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                networking_type_0_type_0 = UnrestrictedNetworking.from_dict(data)
+
+                return networking_type_0_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                networking_type_0_type_1 = LimitedNetworking.from_dict(data)
+
+                return networking_type_0_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(LimitedNetworking | None | UnrestrictedNetworking | Unset, data)
+
+        networking = _parse_networking(d.pop("networking", UNSET))
+
+        def _parse_env(data: object) -> EnvironmentConfigEnvType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                env_type_0 = EnvironmentConfigEnvType0.from_dict(data)
+
+                return env_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(EnvironmentConfigEnvType0 | None | Unset, data)
+
+        env = _parse_env(d.pop("env", UNSET))
+
+        environment_config = cls(
+            packages=packages,
+            networking=networking,
+            env=env,
+        )
+
+        return environment_config

--- a/src/aios/sdk/_generated/models/environment_config_env_type_0.py
+++ b/src/aios/sdk/_generated/models/environment_config_env_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="EnvironmentConfigEnvType0")
+
+
+@_attrs_define
+class EnvironmentConfigEnvType0:
+    """ """
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        environment_config_env_type_0 = cls()
+
+        environment_config_env_type_0.additional_properties = d
+        return environment_config_env_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/environment_config_packages_type_0.py
+++ b/src/aios/sdk/_generated/models/environment_config_packages_type_0.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="EnvironmentConfigPackagesType0")
+
+
+@_attrs_define
+class EnvironmentConfigPackagesType0:
+    """ """
+
+    additional_properties: dict[str, list[str]] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        for prop_name, prop in self.additional_properties.items():
+            field_dict[prop_name] = prop
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        environment_config_packages_type_0 = cls()
+
+        additional_properties = {}
+        for prop_name, prop_dict in d.items():
+            additional_property = cast(list[str], prop_dict)
+
+            additional_properties[prop_name] = additional_property
+
+        environment_config_packages_type_0.additional_properties = additional_properties
+        return environment_config_packages_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> list[str]:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: list[str]) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/environment_create.py
+++ b/src/aios/sdk/_generated/models/environment_create.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.environment_config import EnvironmentConfig
+
+
+T = TypeVar("T", bound="EnvironmentCreate")
+
+
+@_attrs_define
+class EnvironmentCreate:
+    """Request body for `POST /v1/environments`.
+
+    Attributes:
+        name (str):
+        config (EnvironmentConfig | Unset): Container configuration for an environment.
+    """
+
+    name: str
+    config: EnvironmentConfig | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        config: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.config, Unset):
+            config = self.config.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "name": name,
+            }
+        )
+        if config is not UNSET:
+            field_dict["config"] = config
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.environment_config import EnvironmentConfig
+
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        _config = d.pop("config", UNSET)
+        config: EnvironmentConfig | Unset
+        if isinstance(_config, Unset):
+            config = UNSET
+        else:
+            config = EnvironmentConfig.from_dict(_config)
+
+        environment_create = cls(
+            name=name,
+            config=config,
+        )
+
+        return environment_create

--- a/src/aios/sdk/_generated/models/environment_update.py
+++ b/src/aios/sdk/_generated/models/environment_update.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.environment_config import EnvironmentConfig
+
+
+T = TypeVar("T", bound="EnvironmentUpdate")
+
+
+@_attrs_define
+class EnvironmentUpdate:
+    """Request body for ``PUT /v1/environments/{id}``.
+
+    All fields are optional; omitted fields are preserved.
+
+        Attributes:
+            name (None | str | Unset):
+            config (EnvironmentConfig | None | Unset):
+    """
+
+    name: None | str | Unset = UNSET
+    config: EnvironmentConfig | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.environment_config import EnvironmentConfig
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
+
+        config: dict[str, Any] | None | Unset
+        if isinstance(self.config, Unset):
+            config = UNSET
+        elif isinstance(self.config, EnvironmentConfig):
+            config = self.config.to_dict()
+        else:
+            config = self.config
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if config is not UNSET:
+            field_dict["config"] = config
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.environment_config import EnvironmentConfig
+
+        d = dict(src_dict)
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
+
+        def _parse_config(data: object) -> EnvironmentConfig | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                config_type_0 = EnvironmentConfig.from_dict(data)
+
+                return config_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(EnvironmentConfig | None | Unset, data)
+
+        config = _parse_config(d.pop("config", UNSET))
+
+        environment_update = cls(
+            name=name,
+            config=config,
+        )
+
+        return environment_update

--- a/src/aios/sdk/_generated/models/event.py
+++ b/src/aios/sdk/_generated/models/event.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..models.event_kind import EventKind
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.event_data import EventData
+
+
+T = TypeVar("T", bound="Event")
+
+
+@_attrs_define
+class Event:
+    """Read view of a single event from the session log.
+
+    Attributes:
+        id (str):
+        session_id (str):
+        seq (int):
+        kind (EventKind):
+        data (EventData):
+        created_at (datetime.datetime):
+        cumulative_tokens (int | None | Unset):
+        orig_channel (None | str | Unset):
+        focal_channel_at_arrival (None | str | Unset):
+        channel (None | str | Unset):
+    """
+
+    id: str
+    session_id: str
+    seq: int
+    kind: EventKind
+    data: EventData
+    created_at: datetime.datetime
+    cumulative_tokens: int | None | Unset = UNSET
+    orig_channel: None | str | Unset = UNSET
+    focal_channel_at_arrival: None | str | Unset = UNSET
+    channel: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        session_id = self.session_id
+
+        seq = self.seq
+
+        kind = self.kind.value
+
+        data = self.data.to_dict()
+
+        created_at = self.created_at.isoformat()
+
+        cumulative_tokens: int | None | Unset
+        if isinstance(self.cumulative_tokens, Unset):
+            cumulative_tokens = UNSET
+        else:
+            cumulative_tokens = self.cumulative_tokens
+
+        orig_channel: None | str | Unset
+        if isinstance(self.orig_channel, Unset):
+            orig_channel = UNSET
+        else:
+            orig_channel = self.orig_channel
+
+        focal_channel_at_arrival: None | str | Unset
+        if isinstance(self.focal_channel_at_arrival, Unset):
+            focal_channel_at_arrival = UNSET
+        else:
+            focal_channel_at_arrival = self.focal_channel_at_arrival
+
+        channel: None | str | Unset
+        if isinstance(self.channel, Unset):
+            channel = UNSET
+        else:
+            channel = self.channel
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "session_id": session_id,
+                "seq": seq,
+                "kind": kind,
+                "data": data,
+                "created_at": created_at,
+            }
+        )
+        if cumulative_tokens is not UNSET:
+            field_dict["cumulative_tokens"] = cumulative_tokens
+        if orig_channel is not UNSET:
+            field_dict["orig_channel"] = orig_channel
+        if focal_channel_at_arrival is not UNSET:
+            field_dict["focal_channel_at_arrival"] = focal_channel_at_arrival
+        if channel is not UNSET:
+            field_dict["channel"] = channel
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.event_data import EventData
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        session_id = d.pop("session_id")
+
+        seq = d.pop("seq")
+
+        kind = EventKind(d.pop("kind"))
+
+        data = EventData.from_dict(d.pop("data"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        def _parse_cumulative_tokens(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        cumulative_tokens = _parse_cumulative_tokens(d.pop("cumulative_tokens", UNSET))
+
+        def _parse_orig_channel(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        orig_channel = _parse_orig_channel(d.pop("orig_channel", UNSET))
+
+        def _parse_focal_channel_at_arrival(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        focal_channel_at_arrival = _parse_focal_channel_at_arrival(
+            d.pop("focal_channel_at_arrival", UNSET)
+        )
+
+        def _parse_channel(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        channel = _parse_channel(d.pop("channel", UNSET))
+
+        event = cls(
+            id=id,
+            session_id=session_id,
+            seq=seq,
+            kind=kind,
+            data=data,
+            created_at=created_at,
+            cumulative_tokens=cumulative_tokens,
+            orig_channel=orig_channel,
+            focal_channel_at_arrival=focal_channel_at_arrival,
+            channel=channel,
+        )
+
+        event.additional_properties = d
+        return event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/event_data.py
+++ b/src/aios/sdk/_generated/models/event_data.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="EventData")
+
+
+@_attrs_define
+class EventData:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        event_data = cls()
+
+        event_data.additional_properties = d
+        return event_data
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/event_kind.py
+++ b/src/aios/sdk/_generated/models/event_kind.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class EventKind(str, Enum):
+    INTERRUPT = "interrupt"
+    LIFECYCLE = "lifecycle"
+    MESSAGE = "message"
+    SPAN = "span"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/get_health_response_get_health.py
+++ b/src/aios/sdk/_generated/models/get_health_response_get_health.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="GetHealthResponseGetHealth")
+
+
+@_attrs_define
+class GetHealthResponseGetHealth:
+    """ """
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        get_health_response_get_health = cls()
+
+        get_health_response_get_health.additional_properties = d
+        return get_health_response_get_health
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/get_instance_v1_connectors_connector_instance_get_response_get_instance_v1_connectors_connector_instance_get.py
+++ b/src/aios/sdk/_generated/models/get_instance_v1_connectors_connector_instance_get_response_get_instance_v1_connectors_connector_instance_get.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar(
+    "T",
+    bound="GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet",
+)
+
+
+@_attrs_define
+class GetInstanceV1ConnectorsConnectorInstanceGetResponseGetInstanceV1ConnectorsConnectorInstanceGet:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        get_instance_v1_connectors_connector_instance_get_response_get_instance_v1_connectors_connector_instance_get = cls()
+
+        get_instance_v1_connectors_connector_instance_get_response_get_instance_v1_connectors_connector_instance_get.additional_properties = d
+        return get_instance_v1_connectors_connector_instance_get_response_get_instance_v1_connectors_connector_instance_get
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/github_repository_resource.py
+++ b/src/aios/sdk/_generated/models/github_repository_resource.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GithubRepositoryResource")
+
+
+@_attrs_define
+class GithubRepositoryResource:
+    """Item in ``Session.resources[]`` request shape (create + update).
+
+    The ``authorization_token`` is a write-only ``SecretStr`` — present on
+    request, encrypted on the way to the DB, and never returned in API
+    responses (see :class:`GithubRepositoryResourceEcho`).
+
+    ``git_user_name`` / ``git_user_email`` are optional and stamped via
+    ``git config`` after clone so commits made inside the sandbox carry
+    a deterministic identity per resource without the agent needing to
+    self-correct from git's "Please tell me who you are" error.  Absent
+    means "no identity configured" — the v1 default.
+
+        Attributes:
+            type_ (Literal['github_repository']):
+            url (str):
+            mount_path (str):
+            authorization_token (str):
+            git_user_name (None | str | Unset):
+            git_user_email (None | str | Unset):
+    """
+
+    type_: Literal["github_repository"]
+    url: str
+    mount_path: str
+    authorization_token: str
+    git_user_name: None | str | Unset = UNSET
+    git_user_email: None | str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        url = self.url
+
+        mount_path = self.mount_path
+
+        authorization_token = self.authorization_token
+
+        git_user_name: None | str | Unset
+        if isinstance(self.git_user_name, Unset):
+            git_user_name = UNSET
+        else:
+            git_user_name = self.git_user_name
+
+        git_user_email: None | str | Unset
+        if isinstance(self.git_user_email, Unset):
+            git_user_email = UNSET
+        else:
+            git_user_email = self.git_user_email
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "type": type_,
+                "url": url,
+                "mount_path": mount_path,
+                "authorization_token": authorization_token,
+            }
+        )
+        if git_user_name is not UNSET:
+            field_dict["git_user_name"] = git_user_name
+        if git_user_email is not UNSET:
+            field_dict["git_user_email"] = git_user_email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = cast(Literal["github_repository"], d.pop("type"))
+        if type_ != "github_repository":
+            raise ValueError(
+                f"type must match const 'github_repository', got '{type_}'"
+            )
+
+        url = d.pop("url")
+
+        mount_path = d.pop("mount_path")
+
+        authorization_token = d.pop("authorization_token")
+
+        def _parse_git_user_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        git_user_name = _parse_git_user_name(d.pop("git_user_name", UNSET))
+
+        def _parse_git_user_email(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        git_user_email = _parse_git_user_email(d.pop("git_user_email", UNSET))
+
+        github_repository_resource = cls(
+            type_=type_,
+            url=url,
+            mount_path=mount_path,
+            authorization_token=authorization_token,
+            git_user_name=git_user_name,
+            git_user_email=git_user_email,
+        )
+
+        return github_repository_resource

--- a/src/aios/sdk/_generated/models/github_repository_resource_echo.py
+++ b/src/aios/sdk/_generated/models/github_repository_resource_echo.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GithubRepositoryResourceEcho")
+
+
+@_attrs_define
+class GithubRepositoryResourceEcho:
+    """Read view of an attached github repository as echoed on
+    ``Session.resources`` and on the per-resource sub-collection endpoints.
+
+    Token is intentionally absent; ``id`` is the per-attachment ULID
+    (prefix ``ghrepo``) used by the rotation endpoint.  ``git_user_name``
+    / ``git_user_email`` echo back as plaintext (they aren't secrets).
+
+        Attributes:
+            id (str):
+            url (str):
+            mount_path (str):
+            created_at (datetime.datetime):
+            updated_at (datetime.datetime):
+            type_ (Literal['github_repository'] | Unset):  Default: 'github_repository'.
+            git_user_name (None | str | Unset):
+            git_user_email (None | str | Unset):
+    """
+
+    id: str
+    url: str
+    mount_path: str
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    type_: Literal["github_repository"] | Unset = "github_repository"
+    git_user_name: None | str | Unset = UNSET
+    git_user_email: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        url = self.url
+
+        mount_path = self.mount_path
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        type_ = self.type_
+
+        git_user_name: None | str | Unset
+        if isinstance(self.git_user_name, Unset):
+            git_user_name = UNSET
+        else:
+            git_user_name = self.git_user_name
+
+        git_user_email: None | str | Unset
+        if isinstance(self.git_user_email, Unset):
+            git_user_email = UNSET
+        else:
+            git_user_email = self.git_user_email
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "url": url,
+                "mount_path": mount_path,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if git_user_name is not UNSET:
+            field_dict["git_user_name"] = git_user_name
+        if git_user_email is not UNSET:
+            field_dict["git_user_email"] = git_user_email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        url = d.pop("url")
+
+        mount_path = d.pop("mount_path")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        type_ = cast(Literal["github_repository"] | Unset, d.pop("type", UNSET))
+        if type_ != "github_repository" and not isinstance(type_, Unset):
+            raise ValueError(
+                f"type must match const 'github_repository', got '{type_}'"
+            )
+
+        def _parse_git_user_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        git_user_name = _parse_git_user_name(d.pop("git_user_name", UNSET))
+
+        def _parse_git_user_email(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        git_user_email = _parse_git_user_email(d.pop("git_user_email", UNSET))
+
+        github_repository_resource_echo = cls(
+            id=id,
+            url=url,
+            mount_path=mount_path,
+            created_at=created_at,
+            updated_at=updated_at,
+            type_=type_,
+            git_user_name=git_user_name,
+            git_user_email=git_user_email,
+        )
+
+        github_repository_resource_echo.additional_properties = d
+        return github_repository_resource_echo
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/github_repository_update.py
+++ b/src/aios/sdk/_generated/models/github_repository_update.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GithubRepositoryUpdate")
+
+
+@_attrs_define
+class GithubRepositoryUpdate:
+    """Request body for ``POST /v1/sessions/{sid}/resources/{rid}``.
+
+    Token rotation is the primary action; ``git_user_name`` /
+    ``git_user_email`` may also be supplied alongside, in which case the
+    stored identity is replaced.  ``url`` and ``mount_path`` are
+    immutable after creation — to change them, detach the resource and
+    attach a new one.
+
+        Attributes:
+            authorization_token (str):
+            git_user_name (None | str | Unset):
+            git_user_email (None | str | Unset):
+    """
+
+    authorization_token: str
+    git_user_name: None | str | Unset = UNSET
+    git_user_email: None | str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        authorization_token = self.authorization_token
+
+        git_user_name: None | str | Unset
+        if isinstance(self.git_user_name, Unset):
+            git_user_name = UNSET
+        else:
+            git_user_name = self.git_user_name
+
+        git_user_email: None | str | Unset
+        if isinstance(self.git_user_email, Unset):
+            git_user_email = UNSET
+        else:
+            git_user_email = self.git_user_email
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "authorization_token": authorization_token,
+            }
+        )
+        if git_user_name is not UNSET:
+            field_dict["git_user_name"] = git_user_name
+        if git_user_email is not UNSET:
+            field_dict["git_user_email"] = git_user_email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        authorization_token = d.pop("authorization_token")
+
+        def _parse_git_user_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        git_user_name = _parse_git_user_name(d.pop("git_user_name", UNSET))
+
+        def _parse_git_user_email(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        git_user_email = _parse_git_user_email(d.pop("git_user_email", UNSET))
+
+        github_repository_update = cls(
+            authorization_token=authorization_token,
+            git_user_name=git_user_name,
+            git_user_email=git_user_email,
+        )
+
+        return github_repository_update

--- a/src/aios/sdk/_generated/models/http_validation_error.py
+++ b/src/aios/sdk/_generated/models/http_validation_error.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.validation_error import ValidationError
+
+
+T = TypeVar("T", bound="HTTPValidationError")
+
+
+@_attrs_define
+class HTTPValidationError:
+    """
+    Attributes:
+        detail (list[ValidationError] | Unset):
+    """
+
+    detail: list[ValidationError] | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        detail: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.detail, Unset):
+            detail = []
+            for detail_item_data in self.detail:
+                detail_item = detail_item_data.to_dict()
+                detail.append(detail_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if detail is not UNSET:
+            field_dict["detail"] = detail
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.validation_error import ValidationError
+
+        d = dict(src_dict)
+        _detail = d.pop("detail", UNSET)
+        detail: list[ValidationError] | Unset = UNSET
+        if _detail is not UNSET:
+            detail = []
+            for detail_item_data in _detail:
+                detail_item = ValidationError.from_dict(detail_item_data)
+
+                detail.append(detail_item)
+
+        http_validation_error = cls(
+            detail=detail,
+        )
+
+        http_validation_error.additional_properties = d
+        return http_validation_error
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/limited_networking.py
+++ b/src/aios/sdk/_generated/models/limited_networking.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="LimitedNetworking")
+
+
+@_attrs_define
+class LimitedNetworking:
+    """Deny-all with domain allowlist.
+
+    Outbound HTTP/HTTPS is restricted to ``allowed_hosts`` plus any hosts
+    implied by the boolean flags.  DNS (port 53) remains open so tools
+    like ``curl`` can resolve names.
+
+        Attributes:
+            type_ (Literal['limited']):
+            allowed_hosts (list[str] | Unset):
+            allow_package_managers (bool | Unset):  Default: False.
+            allow_mcp_servers (bool | Unset):  Default: False.
+    """
+
+    type_: Literal["limited"]
+    allowed_hosts: list[str] | Unset = UNSET
+    allow_package_managers: bool | Unset = False
+    allow_mcp_servers: bool | Unset = False
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        allowed_hosts: list[str] | Unset = UNSET
+        if not isinstance(self.allowed_hosts, Unset):
+            allowed_hosts = self.allowed_hosts
+
+        allow_package_managers = self.allow_package_managers
+
+        allow_mcp_servers = self.allow_mcp_servers
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "type": type_,
+            }
+        )
+        if allowed_hosts is not UNSET:
+            field_dict["allowed_hosts"] = allowed_hosts
+        if allow_package_managers is not UNSET:
+            field_dict["allow_package_managers"] = allow_package_managers
+        if allow_mcp_servers is not UNSET:
+            field_dict["allow_mcp_servers"] = allow_mcp_servers
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = cast(Literal["limited"], d.pop("type"))
+        if type_ != "limited":
+            raise ValueError(f"type must match const 'limited', got '{type_}'")
+
+        allowed_hosts = cast(list[str], d.pop("allowed_hosts", UNSET))
+
+        allow_package_managers = d.pop("allow_package_managers", UNSET)
+
+        allow_mcp_servers = d.pop("allow_mcp_servers", UNSET)
+
+        limited_networking = cls(
+            type_=type_,
+            allowed_hosts=allowed_hosts,
+            allow_package_managers=allow_package_managers,
+            allow_mcp_servers=allow_mcp_servers,
+        )
+
+        return limited_networking

--- a/src/aios/sdk/_generated/models/list_accounts_v1_connectors_connector_instance_accounts_get_response_list_accounts_v1_connectors_connector_instance_accounts_get.py
+++ b/src/aios/sdk/_generated/models/list_accounts_v1_connectors_connector_instance_accounts_get_response_list_accounts_v1_connectors_connector_instance_accounts_get.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar(
+    "T",
+    bound="ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet",
+)
+
+
+@_attrs_define
+class ListAccountsV1ConnectorsConnectorInstanceAccountsGetResponseListAccountsV1ConnectorsConnectorInstanceAccountsGet:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        list_accounts_v1_connectors_connector_instance_accounts_get_response_list_accounts_v1_connectors_connector_instance_accounts_get = cls()
+
+        list_accounts_v1_connectors_connector_instance_accounts_get_response_list_accounts_v1_connectors_connector_instance_accounts_get.additional_properties = d
+        return list_accounts_v1_connectors_connector_instance_accounts_get_response_list_accounts_v1_connectors_connector_instance_accounts_get
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_connections_mode_type_0.py
+++ b/src/aios/sdk/_generated/models/list_connections_mode_type_0.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class ListConnectionsModeType0(str, Enum):
+    DETACHED = "detached"
+    PER_CHAT = "per_chat"
+    SINGLE_SESSION = "single_session"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/list_events_v1_sessions_session_id_events_get_kind_type_0.py
+++ b/src/aios/sdk/_generated/models/list_events_v1_sessions_session_id_events_get_kind_type_0.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ListEventsV1SessionsSessionIdEventsGetKindType0(str, Enum):
+    INTERRUPT = "interrupt"
+    LIFECYCLE = "lifecycle"
+    MESSAGE = "message"
+    SPAN = "span"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/list_for_connector_v1_connectors_connector_get_response_list_for_connector_v1_connectors_connector_get.py
+++ b/src/aios/sdk/_generated/models/list_for_connector_v1_connectors_connector_get_response_list_for_connector_v1_connectors_connector_get.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar(
+    "T",
+    bound="ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet",
+)
+
+
+@_attrs_define
+class ListForConnectorV1ConnectorsConnectorGetResponseListForConnectorV1ConnectorsConnectorGet:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        list_for_connector_v1_connectors_connector_get_response_list_for_connector_v1_connectors_connector_get = cls()
+
+        list_for_connector_v1_connectors_connector_get_response_list_for_connector_v1_connectors_connector_get.additional_properties = d
+        return list_for_connector_v1_connectors_connector_get_response_list_for_connector_v1_connectors_connector_get
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_agent.py
+++ b/src/aios/sdk/_generated/models/list_response_agent.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent import Agent
+
+
+T = TypeVar("T", bound="ListResponseAgent")
+
+
+@_attrs_define
+class ListResponseAgent:
+    """
+    Attributes:
+        data (list[Agent]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[Agent]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent import Agent
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = Agent.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_agent = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_agent.additional_properties = d
+        return list_response_agent
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_agent_version.py
+++ b/src/aios/sdk/_generated/models/list_response_agent_version.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent_version import AgentVersion
+
+
+T = TypeVar("T", bound="ListResponseAgentVersion")
+
+
+@_attrs_define
+class ListResponseAgentVersion:
+    """
+    Attributes:
+        data (list[AgentVersion]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[AgentVersion]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent_version import AgentVersion
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = AgentVersion.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_agent_version = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_agent_version.additional_properties = d
+        return list_response_agent_version
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_annotated_union_memory_store_resource_echo_github_repository_resource_echo_field_infoannotation_none_type_required_true_discriminatortype.py
+++ b/src/aios/sdk/_generated/models/list_response_annotated_union_memory_store_resource_echo_github_repository_resource_echo_field_infoannotation_none_type_required_true_discriminatortype.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.github_repository_resource_echo import GithubRepositoryResourceEcho
+    from ..models.memory_store_resource_echo import MemoryStoreResourceEcho
+
+
+T = TypeVar(
+    "T",
+    bound="ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype",
+)
+
+
+@_attrs_define
+class ListResponseAnnotatedUnionMemoryStoreResourceEchoGithubRepositoryResourceEchoFieldInfoannotationNoneTypeRequiredTrueDiscriminatortype:
+    """
+    Attributes:
+        data (list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.memory_store_resource_echo import MemoryStoreResourceEcho
+
+        data = []
+        for data_item_data in self.data:
+            data_item: dict[str, Any]
+            if isinstance(data_item_data, MemoryStoreResourceEcho):
+                data_item = data_item_data.to_dict()
+            else:
+                data_item = data_item_data.to_dict()
+
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.github_repository_resource_echo import (
+            GithubRepositoryResourceEcho,
+        )
+        from ..models.memory_store_resource_echo import MemoryStoreResourceEcho
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+
+            def _parse_data_item(
+                data: object,
+            ) -> GithubRepositoryResourceEcho | MemoryStoreResourceEcho:
+                try:
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    data_item_type_0 = MemoryStoreResourceEcho.from_dict(data)
+
+                    return data_item_type_0
+                except (TypeError, ValueError, AttributeError, KeyError):
+                    pass
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_item_type_1 = GithubRepositoryResourceEcho.from_dict(data)
+
+                return data_item_type_1
+
+            data_item = _parse_data_item(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_annotated_union_memory_store_resource_echo_github_repository_resource_echo_field_infoannotation_none_type_required_true_discriminatortype = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_annotated_union_memory_store_resource_echo_github_repository_resource_echo_field_infoannotation_none_type_required_true_discriminatortype.additional_properties = d
+        return list_response_annotated_union_memory_store_resource_echo_github_repository_resource_echo_field_infoannotation_none_type_required_true_discriminatortype
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_bound_chat.py
+++ b/src/aios/sdk/_generated/models/list_response_bound_chat.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.bound_chat import BoundChat
+
+
+T = TypeVar("T", bound="ListResponseBoundChat")
+
+
+@_attrs_define
+class ListResponseBoundChat:
+    """
+    Attributes:
+        data (list[BoundChat]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[BoundChat]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.bound_chat import BoundChat
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = BoundChat.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_bound_chat = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_bound_chat.additional_properties = d
+        return list_response_bound_chat
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_connection.py
+++ b/src/aios/sdk/_generated/models/list_response_connection.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.connection import Connection
+
+
+T = TypeVar("T", bound="ListResponseConnection")
+
+
+@_attrs_define
+class ListResponseConnection:
+    """
+    Attributes:
+        data (list[Connection]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[Connection]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.connection import Connection
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = Connection.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_connection = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_connection.additional_properties = d
+        return list_response_connection
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_environment.py
+++ b/src/aios/sdk/_generated/models/list_response_environment.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.environment import Environment
+
+
+T = TypeVar("T", bound="ListResponseEnvironment")
+
+
+@_attrs_define
+class ListResponseEnvironment:
+    """
+    Attributes:
+        data (list[Environment]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[Environment]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.environment import Environment
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = Environment.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_environment = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_environment.additional_properties = d
+        return list_response_environment
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_event.py
+++ b/src/aios/sdk/_generated/models/list_response_event.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.event import Event
+
+
+T = TypeVar("T", bound="ListResponseEvent")
+
+
+@_attrs_define
+class ListResponseEvent:
+    """
+    Attributes:
+        data (list[Event]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[Event]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.event import Event
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = Event.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_event = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_event.additional_properties = d
+        return list_response_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_memory_store.py
+++ b/src/aios/sdk/_generated/models/list_response_memory_store.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.memory_store import MemoryStore
+
+
+T = TypeVar("T", bound="ListResponseMemoryStore")
+
+
+@_attrs_define
+class ListResponseMemoryStore:
+    """
+    Attributes:
+        data (list[MemoryStore]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[MemoryStore]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.memory_store import MemoryStore
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = MemoryStore.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_memory_store = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_memory_store.additional_properties = d
+        return list_response_memory_store
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_memory_version.py
+++ b/src/aios/sdk/_generated/models/list_response_memory_version.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.memory_version import MemoryVersion
+
+
+T = TypeVar("T", bound="ListResponseMemoryVersion")
+
+
+@_attrs_define
+class ListResponseMemoryVersion:
+    """
+    Attributes:
+        data (list[MemoryVersion]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[MemoryVersion]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.memory_version import MemoryVersion
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = MemoryVersion.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_memory_version = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_memory_version.additional_properties = d
+        return list_response_memory_version
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_recent_chat.py
+++ b/src/aios/sdk/_generated/models/list_response_recent_chat.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.recent_chat import RecentChat
+
+
+T = TypeVar("T", bound="ListResponseRecentChat")
+
+
+@_attrs_define
+class ListResponseRecentChat:
+    """
+    Attributes:
+        data (list[RecentChat]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[RecentChat]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.recent_chat import RecentChat
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = RecentChat.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_recent_chat = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_recent_chat.additional_properties = d
+        return list_response_recent_chat
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_session.py
+++ b/src/aios/sdk/_generated/models/list_response_session.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.session import Session
+
+
+T = TypeVar("T", bound="ListResponseSession")
+
+
+@_attrs_define
+class ListResponseSession:
+    """
+    Attributes:
+        data (list[Session]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[Session]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.session import Session
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = Session.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_session = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_session.additional_properties = d
+        return list_response_session
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_session_template.py
+++ b/src/aios/sdk/_generated/models/list_response_session_template.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.session_template import SessionTemplate
+
+
+T = TypeVar("T", bound="ListResponseSessionTemplate")
+
+
+@_attrs_define
+class ListResponseSessionTemplate:
+    """
+    Attributes:
+        data (list[SessionTemplate]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[SessionTemplate]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.session_template import SessionTemplate
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = SessionTemplate.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_session_template = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_session_template.additional_properties = d
+        return list_response_session_template
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_skill.py
+++ b/src/aios/sdk/_generated/models/list_response_skill.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.skill import Skill
+
+
+T = TypeVar("T", bound="ListResponseSkill")
+
+
+@_attrs_define
+class ListResponseSkill:
+    """
+    Attributes:
+        data (list[Skill]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[Skill]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.skill import Skill
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = Skill.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_skill = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_skill.additional_properties = d
+        return list_response_skill
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_skill_version.py
+++ b/src/aios/sdk/_generated/models/list_response_skill_version.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.skill_version import SkillVersion
+
+
+T = TypeVar("T", bound="ListResponseSkillVersion")
+
+
+@_attrs_define
+class ListResponseSkillVersion:
+    """
+    Attributes:
+        data (list[SkillVersion]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[SkillVersion]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.skill_version import SkillVersion
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = SkillVersion.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_skill_version = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_skill_version.additional_properties = d
+        return list_response_skill_version
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_union_memory_memory_prefix.py
+++ b/src/aios/sdk/_generated/models/list_response_union_memory_memory_prefix.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.memory import Memory
+    from ..models.memory_prefix import MemoryPrefix
+
+
+T = TypeVar("T", bound="ListResponseUnionMemoryMemoryPrefix")
+
+
+@_attrs_define
+class ListResponseUnionMemoryMemoryPrefix:
+    """
+    Attributes:
+        data (list[Memory | MemoryPrefix]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[Memory | MemoryPrefix]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.memory import Memory
+
+        data = []
+        for data_item_data in self.data:
+            data_item: dict[str, Any]
+            if isinstance(data_item_data, Memory):
+                data_item = data_item_data.to_dict()
+            else:
+                data_item = data_item_data.to_dict()
+
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.memory import Memory
+        from ..models.memory_prefix import MemoryPrefix
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+
+            def _parse_data_item(data: object) -> Memory | MemoryPrefix:
+                try:
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    data_item_type_0 = Memory.from_dict(data)
+
+                    return data_item_type_0
+                except (TypeError, ValueError, AttributeError, KeyError):
+                    pass
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_item_type_1 = MemoryPrefix.from_dict(data)
+
+                return data_item_type_1
+
+            data_item = _parse_data_item(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_union_memory_memory_prefix = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_union_memory_memory_prefix.additional_properties = d
+        return list_response_union_memory_memory_prefix
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_vault.py
+++ b/src/aios/sdk/_generated/models/list_response_vault.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.vault import Vault
+
+
+T = TypeVar("T", bound="ListResponseVault")
+
+
+@_attrs_define
+class ListResponseVault:
+    """
+    Attributes:
+        data (list[Vault]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[Vault]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.vault import Vault
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = Vault.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_vault = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_vault.additional_properties = d
+        return list_response_vault
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_response_vault_credential.py
+++ b/src/aios/sdk/_generated/models/list_response_vault_credential.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.vault_credential import VaultCredential
+
+
+T = TypeVar("T", bound="ListResponseVaultCredential")
+
+
+@_attrs_define
+class ListResponseVaultCredential:
+    """
+    Attributes:
+        data (list[VaultCredential]):
+        has_more (bool | Unset):  Default: False.
+        next_after (None | str | Unset):
+    """
+
+    data: list[VaultCredential]
+    has_more: bool | Unset = False
+    next_after: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_after: None | str | Unset
+        if isinstance(self.next_after, Unset):
+            next_after = UNSET
+        else:
+            next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_after is not UNSET:
+            field_dict["next_after"] = next_after
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.vault_credential import VaultCredential
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = VaultCredential.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_after(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_after = _parse_next_after(d.pop("next_after", UNSET))
+
+        list_response_vault_credential = cls(
+            data=data,
+            has_more=has_more,
+            next_after=next_after,
+        )
+
+        list_response_vault_credential.additional_properties = d
+        return list_response_vault_credential
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_tools_v1_connectors_connector_instance_tools_get_response_list_tools_v1_connectors_connector_instance_tools_get.py
+++ b/src/aios/sdk/_generated/models/list_tools_v1_connectors_connector_instance_tools_get_response_list_tools_v1_connectors_connector_instance_tools_get.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar(
+    "T",
+    bound="ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet",
+)
+
+
+@_attrs_define
+class ListToolsV1ConnectorsConnectorInstanceToolsGetResponseListToolsV1ConnectorsConnectorInstanceToolsGet:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        list_tools_v1_connectors_connector_instance_tools_get_response_list_tools_v1_connectors_connector_instance_tools_get = cls()
+
+        list_tools_v1_connectors_connector_instance_tools_get_response_list_tools_v1_connectors_connector_instance_tools_get.additional_properties = d
+        return list_tools_v1_connectors_connector_instance_tools_get_response_list_tools_v1_connectors_connector_instance_tools_get
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_v1_connectors_get_response_list_v1_connectors_get.py
+++ b/src/aios/sdk/_generated/models/list_v1_connectors_get_response_list_v1_connectors_get.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ListV1ConnectorsGetResponseListV1ConnectorsGet")
+
+
+@_attrs_define
+class ListV1ConnectorsGetResponseListV1ConnectorsGet:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        list_v1_connectors_get_response_list_v1_connectors_get = cls()
+
+        list_v1_connectors_get_response_list_v1_connectors_get.additional_properties = d
+        return list_v1_connectors_get_response_list_v1_connectors_get
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/list_v1_sessions_get_status_type_0.py
+++ b/src/aios/sdk/_generated/models/list_v1_sessions_get_status_type_0.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class ListV1SessionsGetStatusType0(str, Enum):
+    IDLE = "idle"
+    PENDING = "pending"
+    RESCHEDULING = "rescheduling"
+    RUNNING = "running"
+    TERMINATED = "terminated"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/mcp_permission_policy.py
+++ b/src/aios/sdk/_generated/models/mcp_permission_policy.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..models.mcp_permission_policy_type import McpPermissionPolicyType
+
+T = TypeVar("T", bound="McpPermissionPolicy")
+
+
+@_attrs_define
+class McpPermissionPolicy:
+    """Wrapper matching Anthropic's ``{type: "always_allow"}`` shape.
+
+    Attributes:
+        type_ (McpPermissionPolicyType):
+    """
+
+    type_: McpPermissionPolicyType
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_.value
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "type": type_,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = McpPermissionPolicyType(d.pop("type"))
+
+        mcp_permission_policy = cls(
+            type_=type_,
+        )
+
+        return mcp_permission_policy

--- a/src/aios/sdk/_generated/models/mcp_permission_policy_type.py
+++ b/src/aios/sdk/_generated/models/mcp_permission_policy_type.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class McpPermissionPolicyType(str, Enum):
+    ALWAYS_ALLOW = "always_allow"
+    ALWAYS_ASK = "always_ask"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/mcp_server_spec.py
+++ b/src/aios/sdk/_generated/models/mcp_server_spec.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="McpServerSpec")
+
+
+@_attrs_define
+class McpServerSpec:
+    """One entry in an agent's ``mcp_servers`` list.
+
+    Declares a remote MCP server reachable via streamable HTTP transport.
+    The ``name`` is used to cross-reference from ``mcp_toolset`` tool entries
+    and to namespace discovered tools as ``mcp__<name>__<tool_name>``.
+
+    ``include_instructions`` controls whether the server's
+    ``InitializeResult.instructions`` (per MCP spec) is rendered into the
+    system prompt.  Defaults true so connector-mounted servers — and any
+    third-party server that ships useful affordance prose — light up
+    automatically.  Set false to opt out per agent (unfamiliar prose,
+    noisy servers).
+
+        Attributes:
+            name (str):
+            url (str):
+            type_ (Literal['url'] | Unset):  Default: 'url'.
+            include_instructions (bool | Unset):  Default: True.
+    """
+
+    name: str
+    url: str
+    type_: Literal["url"] | Unset = "url"
+    include_instructions: bool | Unset = True
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        url = self.url
+
+        type_ = self.type_
+
+        include_instructions = self.include_instructions
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "name": name,
+                "url": url,
+            }
+        )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if include_instructions is not UNSET:
+            field_dict["include_instructions"] = include_instructions
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        url = d.pop("url")
+
+        type_ = cast(Literal["url"] | Unset, d.pop("type", UNSET))
+        if type_ != "url" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'url', got '{type_}'")
+
+        include_instructions = d.pop("include_instructions", UNSET)
+
+        mcp_server_spec = cls(
+            name=name,
+            url=url,
+            type_=type_,
+            include_instructions=include_instructions,
+        )
+
+        return mcp_server_spec

--- a/src/aios/sdk/_generated/models/mcp_tool_config.py
+++ b/src/aios/sdk/_generated/models/mcp_tool_config.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.mcp_permission_policy import McpPermissionPolicy
+
+
+T = TypeVar("T", bound="McpToolConfig")
+
+
+@_attrs_define
+class McpToolConfig:
+    """Per-tool override within an ``mcp_toolset`` entry.
+
+    Attributes:
+        name (str):
+        enabled (bool | Unset):  Default: True.
+        permission_policy (McpPermissionPolicy | None | Unset):
+    """
+
+    name: str
+    enabled: bool | Unset = True
+    permission_policy: McpPermissionPolicy | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.mcp_permission_policy import McpPermissionPolicy
+
+        name = self.name
+
+        enabled = self.enabled
+
+        permission_policy: dict[str, Any] | None | Unset
+        if isinstance(self.permission_policy, Unset):
+            permission_policy = UNSET
+        elif isinstance(self.permission_policy, McpPermissionPolicy):
+            permission_policy = self.permission_policy.to_dict()
+        else:
+            permission_policy = self.permission_policy
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "name": name,
+            }
+        )
+        if enabled is not UNSET:
+            field_dict["enabled"] = enabled
+        if permission_policy is not UNSET:
+            field_dict["permission_policy"] = permission_policy
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.mcp_permission_policy import McpPermissionPolicy
+
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        enabled = d.pop("enabled", UNSET)
+
+        def _parse_permission_policy(
+            data: object,
+        ) -> McpPermissionPolicy | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                permission_policy_type_0 = McpPermissionPolicy.from_dict(data)
+
+                return permission_policy_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(McpPermissionPolicy | None | Unset, data)
+
+        permission_policy = _parse_permission_policy(d.pop("permission_policy", UNSET))
+
+        mcp_tool_config = cls(
+            name=name,
+            enabled=enabled,
+            permission_policy=permission_policy,
+        )
+
+        return mcp_tool_config

--- a/src/aios/sdk/_generated/models/mcp_toolset_config.py
+++ b/src/aios/sdk/_generated/models/mcp_toolset_config.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.mcp_permission_policy import McpPermissionPolicy
+
+
+T = TypeVar("T", bound="McpToolsetConfig")
+
+
+@_attrs_define
+class McpToolsetConfig:
+    """Default config for all tools discovered from an MCP server.
+
+    Attributes:
+        enabled (bool | Unset):  Default: True.
+        permission_policy (McpPermissionPolicy | None | Unset):
+    """
+
+    enabled: bool | Unset = True
+    permission_policy: McpPermissionPolicy | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.mcp_permission_policy import McpPermissionPolicy
+
+        enabled = self.enabled
+
+        permission_policy: dict[str, Any] | None | Unset
+        if isinstance(self.permission_policy, Unset):
+            permission_policy = UNSET
+        elif isinstance(self.permission_policy, McpPermissionPolicy):
+            permission_policy = self.permission_policy.to_dict()
+        else:
+            permission_policy = self.permission_policy
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if enabled is not UNSET:
+            field_dict["enabled"] = enabled
+        if permission_policy is not UNSET:
+            field_dict["permission_policy"] = permission_policy
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.mcp_permission_policy import McpPermissionPolicy
+
+        d = dict(src_dict)
+        enabled = d.pop("enabled", UNSET)
+
+        def _parse_permission_policy(
+            data: object,
+        ) -> McpPermissionPolicy | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                permission_policy_type_0 = McpPermissionPolicy.from_dict(data)
+
+                return permission_policy_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(McpPermissionPolicy | None | Unset, data)
+
+        permission_policy = _parse_permission_policy(d.pop("permission_policy", UNSET))
+
+        mcp_toolset_config = cls(
+            enabled=enabled,
+            permission_policy=permission_policy,
+        )
+
+        return mcp_toolset_config

--- a/src/aios/sdk/_generated/models/memory.py
+++ b/src/aios/sdk/_generated/models/memory.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Memory")
+
+
+@_attrs_define
+class Memory:
+    """Read view of a memory. ``content`` only on retrieve.
+
+    Attributes:
+        id (str):
+        memory_store_id (str):
+        memory_version_id (str):
+        path (str):
+        content_sha256 (str):
+        content_size_bytes (int):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        type_ (Literal['memory'] | Unset):  Default: 'memory'.
+        content (None | str | Unset):
+    """
+
+    id: str
+    memory_store_id: str
+    memory_version_id: str
+    path: str
+    content_sha256: str
+    content_size_bytes: int
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    type_: Literal["memory"] | Unset = "memory"
+    content: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        memory_store_id = self.memory_store_id
+
+        memory_version_id = self.memory_version_id
+
+        path = self.path
+
+        content_sha256 = self.content_sha256
+
+        content_size_bytes = self.content_size_bytes
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        type_ = self.type_
+
+        content: None | str | Unset
+        if isinstance(self.content, Unset):
+            content = UNSET
+        else:
+            content = self.content
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "memory_store_id": memory_store_id,
+                "memory_version_id": memory_version_id,
+                "path": path,
+                "content_sha256": content_sha256,
+                "content_size_bytes": content_size_bytes,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if content is not UNSET:
+            field_dict["content"] = content
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        memory_store_id = d.pop("memory_store_id")
+
+        memory_version_id = d.pop("memory_version_id")
+
+        path = d.pop("path")
+
+        content_sha256 = d.pop("content_sha256")
+
+        content_size_bytes = d.pop("content_size_bytes")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        type_ = cast(Literal["memory"] | Unset, d.pop("type", UNSET))
+        if type_ != "memory" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'memory', got '{type_}'")
+
+        def _parse_content(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        content = _parse_content(d.pop("content", UNSET))
+
+        memory = cls(
+            id=id,
+            memory_store_id=memory_store_id,
+            memory_version_id=memory_version_id,
+            path=path,
+            content_sha256=content_sha256,
+            content_size_bytes=content_size_bytes,
+            created_at=created_at,
+            updated_at=updated_at,
+            type_=type_,
+            content=content,
+        )
+
+        memory.additional_properties = d
+        return memory
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/memory_create.py
+++ b/src/aios/sdk/_generated/models/memory_create.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="MemoryCreate")
+
+
+@_attrs_define
+class MemoryCreate:
+    """Request body for ``POST /v1/memory-stores/{store_id}/memories``.
+
+    Attributes:
+        path (str): Absolute, slash-separated path. Segments may not contain / or NUL, and `.` and `..` are not allowed
+            as segments.
+        content (str):
+    """
+
+    path: str
+    content: str
+
+    def to_dict(self) -> dict[str, Any]:
+        path = self.path
+
+        content = self.content
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "path": path,
+                "content": content,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        path = d.pop("path")
+
+        content = d.pop("content")
+
+        memory_create = cls(
+            path=path,
+            content=content,
+        )
+
+        return memory_create

--- a/src/aios/sdk/_generated/models/memory_prefix.py
+++ b/src/aios/sdk/_generated/models/memory_prefix.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="MemoryPrefix")
+
+
+@_attrs_define
+class MemoryPrefix:
+    """Synthetic directory entry returned by depth-clipped list queries.
+
+    Attributes:
+        path (str):
+        type_ (Literal['memory_prefix'] | Unset):  Default: 'memory_prefix'.
+    """
+
+    path: str
+    type_: Literal["memory_prefix"] | Unset = "memory_prefix"
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        path = self.path
+
+        type_ = self.type_
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "path": path,
+            }
+        )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        path = d.pop("path")
+
+        type_ = cast(Literal["memory_prefix"] | Unset, d.pop("type", UNSET))
+        if type_ != "memory_prefix" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'memory_prefix', got '{type_}'")
+
+        memory_prefix = cls(
+            path=path,
+            type_=type_,
+        )
+
+        memory_prefix.additional_properties = d
+        return memory_prefix
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/memory_store.py
+++ b/src/aios/sdk/_generated/models/memory_store.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.memory_store_metadata import MemoryStoreMetadata
+
+
+T = TypeVar("T", bound="MemoryStore")
+
+
+@_attrs_define
+class MemoryStore:
+    """Read view of a memory store.
+
+    Attributes:
+        id (str):
+        name (str):
+        description (str):
+        metadata (MemoryStoreMetadata):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        type_ (Literal['memory_store'] | Unset):  Default: 'memory_store'.
+        archived_at (datetime.datetime | None | Unset):
+    """
+
+    id: str
+    name: str
+    description: str
+    metadata: MemoryStoreMetadata
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    type_: Literal["memory_store"] | Unset = "memory_store"
+    archived_at: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        name = self.name
+
+        description = self.description
+
+        metadata = self.metadata.to_dict()
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        type_ = self.type_
+
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "name": name,
+                "description": description,
+                "metadata": metadata,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.memory_store_metadata import MemoryStoreMetadata
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        name = d.pop("name")
+
+        description = d.pop("description")
+
+        metadata = MemoryStoreMetadata.from_dict(d.pop("metadata"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        type_ = cast(Literal["memory_store"] | Unset, d.pop("type", UNSET))
+        if type_ != "memory_store" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'memory_store', got '{type_}'")
+
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
+        memory_store = cls(
+            id=id,
+            name=name,
+            description=description,
+            metadata=metadata,
+            created_at=created_at,
+            updated_at=updated_at,
+            type_=type_,
+            archived_at=archived_at,
+        )
+
+        memory_store.additional_properties = d
+        return memory_store
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/memory_store_create.py
+++ b/src/aios/sdk/_generated/models/memory_store_create.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.memory_store_create_metadata import MemoryStoreCreateMetadata
+
+
+T = TypeVar("T", bound="MemoryStoreCreate")
+
+
+@_attrs_define
+class MemoryStoreCreate:
+    """Request body for ``POST /v1/memory-stores``.
+
+    Attributes:
+        name (str):
+        description (str | Unset):  Default: ''.
+        metadata (MemoryStoreCreateMetadata | Unset):
+    """
+
+    name: str
+    description: str | Unset = ""
+    metadata: MemoryStoreCreateMetadata | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        description = self.description
+
+        metadata: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "name": name,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.memory_store_create_metadata import MemoryStoreCreateMetadata
+
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        description = d.pop("description", UNSET)
+
+        _metadata = d.pop("metadata", UNSET)
+        metadata: MemoryStoreCreateMetadata | Unset
+        if isinstance(_metadata, Unset):
+            metadata = UNSET
+        else:
+            metadata = MemoryStoreCreateMetadata.from_dict(_metadata)
+
+        memory_store_create = cls(
+            name=name,
+            description=description,
+            metadata=metadata,
+        )
+
+        return memory_store_create

--- a/src/aios/sdk/_generated/models/memory_store_create_metadata.py
+++ b/src/aios/sdk/_generated/models/memory_store_create_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="MemoryStoreCreateMetadata")
+
+
+@_attrs_define
+class MemoryStoreCreateMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        memory_store_create_metadata = cls()
+
+        memory_store_create_metadata.additional_properties = d
+        return memory_store_create_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/memory_store_metadata.py
+++ b/src/aios/sdk/_generated/models/memory_store_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="MemoryStoreMetadata")
+
+
+@_attrs_define
+class MemoryStoreMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        memory_store_metadata = cls()
+
+        memory_store_metadata.additional_properties = d
+        return memory_store_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/memory_store_resource.py
+++ b/src/aios/sdk/_generated/models/memory_store_resource.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..models.memory_store_resource_access import MemoryStoreResourceAccess
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="MemoryStoreResource")
+
+
+@_attrs_define
+class MemoryStoreResource:
+    """Item in ``Session.resources[]`` request shape.
+
+    Only ``memory_store`` for now; the discriminator field keeps the door
+    open for future ``file`` / ``repo`` resource types.
+
+        Attributes:
+            type_ (Literal['memory_store']):
+            memory_store_id (str):
+            access (MemoryStoreResourceAccess | Unset):  Default: MemoryStoreResourceAccess.READ_WRITE.
+            instructions (str | Unset):  Default: ''.
+    """
+
+    type_: Literal["memory_store"]
+    memory_store_id: str
+    access: MemoryStoreResourceAccess | Unset = MemoryStoreResourceAccess.READ_WRITE
+    instructions: str | Unset = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        memory_store_id = self.memory_store_id
+
+        access: str | Unset = UNSET
+        if not isinstance(self.access, Unset):
+            access = self.access.value
+
+        instructions = self.instructions
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "type": type_,
+                "memory_store_id": memory_store_id,
+            }
+        )
+        if access is not UNSET:
+            field_dict["access"] = access
+        if instructions is not UNSET:
+            field_dict["instructions"] = instructions
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = cast(Literal["memory_store"], d.pop("type"))
+        if type_ != "memory_store":
+            raise ValueError(f"type must match const 'memory_store', got '{type_}'")
+
+        memory_store_id = d.pop("memory_store_id")
+
+        _access = d.pop("access", UNSET)
+        access: MemoryStoreResourceAccess | Unset
+        if isinstance(_access, Unset):
+            access = UNSET
+        else:
+            access = MemoryStoreResourceAccess(_access)
+
+        instructions = d.pop("instructions", UNSET)
+
+        memory_store_resource = cls(
+            type_=type_,
+            memory_store_id=memory_store_id,
+            access=access,
+            instructions=instructions,
+        )
+
+        return memory_store_resource

--- a/src/aios/sdk/_generated/models/memory_store_resource_access.py
+++ b/src/aios/sdk/_generated/models/memory_store_resource_access.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class MemoryStoreResourceAccess(str, Enum):
+    READ_ONLY = "read_only"
+    READ_WRITE = "read_write"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/memory_store_resource_echo.py
+++ b/src/aios/sdk/_generated/models/memory_store_resource_echo.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.memory_store_resource_echo_access import MemoryStoreResourceEchoAccess
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="MemoryStoreResourceEcho")
+
+
+@_attrs_define
+class MemoryStoreResourceEcho:
+    """Read view of an attached memory store as echoed on ``Session.resources``.
+
+    Carries the snapshotted ``name`` / ``description`` from the store at
+    attach time, plus the derived ``mount_path``. These do not update if the
+    underlying store is renamed or its description changes.
+
+        Attributes:
+            memory_store_id (str):
+            access (MemoryStoreResourceEchoAccess):
+            instructions (str):
+            name (str):
+            description (str):
+            mount_path (str):
+            type_ (Literal['memory_store'] | Unset):  Default: 'memory_store'.
+    """
+
+    memory_store_id: str
+    access: MemoryStoreResourceEchoAccess
+    instructions: str
+    name: str
+    description: str
+    mount_path: str
+    type_: Literal["memory_store"] | Unset = "memory_store"
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        memory_store_id = self.memory_store_id
+
+        access = self.access.value
+
+        instructions = self.instructions
+
+        name = self.name
+
+        description = self.description
+
+        mount_path = self.mount_path
+
+        type_ = self.type_
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "memory_store_id": memory_store_id,
+                "access": access,
+                "instructions": instructions,
+                "name": name,
+                "description": description,
+                "mount_path": mount_path,
+            }
+        )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        memory_store_id = d.pop("memory_store_id")
+
+        access = MemoryStoreResourceEchoAccess(d.pop("access"))
+
+        instructions = d.pop("instructions")
+
+        name = d.pop("name")
+
+        description = d.pop("description")
+
+        mount_path = d.pop("mount_path")
+
+        type_ = cast(Literal["memory_store"] | Unset, d.pop("type", UNSET))
+        if type_ != "memory_store" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'memory_store', got '{type_}'")
+
+        memory_store_resource_echo = cls(
+            memory_store_id=memory_store_id,
+            access=access,
+            instructions=instructions,
+            name=name,
+            description=description,
+            mount_path=mount_path,
+            type_=type_,
+        )
+
+        memory_store_resource_echo.additional_properties = d
+        return memory_store_resource_echo
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/memory_store_resource_echo_access.py
+++ b/src/aios/sdk/_generated/models/memory_store_resource_echo_access.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class MemoryStoreResourceEchoAccess(str, Enum):
+    READ_ONLY = "read_only"
+    READ_WRITE = "read_write"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/memory_store_update.py
+++ b/src/aios/sdk/_generated/models/memory_store_update.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.memory_store_update_metadata_type_0 import (
+        MemoryStoreUpdateMetadataType0,
+    )
+
+
+T = TypeVar("T", bound="MemoryStoreUpdate")
+
+
+@_attrs_define
+class MemoryStoreUpdate:
+    """Request body for ``POST /v1/memory-stores/{id}``.
+
+    Attributes:
+        name (None | str | Unset):
+        description (None | str | Unset):
+        metadata (MemoryStoreUpdateMetadataType0 | None | Unset):
+    """
+
+    name: None | str | Unset = UNSET
+    description: None | str | Unset = UNSET
+    metadata: MemoryStoreUpdateMetadataType0 | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.memory_store_update_metadata_type_0 import (
+            MemoryStoreUpdateMetadataType0,
+        )
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
+
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, MemoryStoreUpdateMetadataType0):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.memory_store_update_metadata_type_0 import (
+            MemoryStoreUpdateMetadataType0,
+        )
+
+        d = dict(src_dict)
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
+
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_metadata(
+            data: object,
+        ) -> MemoryStoreUpdateMetadataType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = MemoryStoreUpdateMetadataType0.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(MemoryStoreUpdateMetadataType0 | None | Unset, data)
+
+        metadata = _parse_metadata(d.pop("metadata", UNSET))
+
+        memory_store_update = cls(
+            name=name,
+            description=description,
+            metadata=metadata,
+        )
+
+        return memory_store_update

--- a/src/aios/sdk/_generated/models/memory_store_update_metadata_type_0.py
+++ b/src/aios/sdk/_generated/models/memory_store_update_metadata_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="MemoryStoreUpdateMetadataType0")
+
+
+@_attrs_define
+class MemoryStoreUpdateMetadataType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        memory_store_update_metadata_type_0 = cls()
+
+        memory_store_update_metadata_type_0.additional_properties = d
+        return memory_store_update_metadata_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/memory_update.py
+++ b/src/aios/sdk/_generated/models/memory_update.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.memory_update_precondition import MemoryUpdatePrecondition
+
+
+T = TypeVar("T", bound="MemoryUpdate")
+
+
+@_attrs_define
+class MemoryUpdate:
+    """Request body for ``POST /v1/memory-stores/{store_id}/memories/{id}``.
+
+    Either ``content`` or ``path`` (or both) must be provided. Precondition
+    only gates the content half — renames are unconditional, matching the
+    Anthropic semantics confirmed by live probe.
+
+        Attributes:
+            content (None | str | Unset):
+            path (None | str | Unset):
+            precondition (MemoryUpdatePrecondition | None | Unset):
+    """
+
+    content: None | str | Unset = UNSET
+    path: None | str | Unset = UNSET
+    precondition: MemoryUpdatePrecondition | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.memory_update_precondition import MemoryUpdatePrecondition
+
+        content: None | str | Unset
+        if isinstance(self.content, Unset):
+            content = UNSET
+        else:
+            content = self.content
+
+        path: None | str | Unset
+        if isinstance(self.path, Unset):
+            path = UNSET
+        else:
+            path = self.path
+
+        precondition: dict[str, Any] | None | Unset
+        if isinstance(self.precondition, Unset):
+            precondition = UNSET
+        elif isinstance(self.precondition, MemoryUpdatePrecondition):
+            precondition = self.precondition.to_dict()
+        else:
+            precondition = self.precondition
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if content is not UNSET:
+            field_dict["content"] = content
+        if path is not UNSET:
+            field_dict["path"] = path
+        if precondition is not UNSET:
+            field_dict["precondition"] = precondition
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.memory_update_precondition import MemoryUpdatePrecondition
+
+        d = dict(src_dict)
+
+        def _parse_content(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        content = _parse_content(d.pop("content", UNSET))
+
+        def _parse_path(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        path = _parse_path(d.pop("path", UNSET))
+
+        def _parse_precondition(
+            data: object,
+        ) -> MemoryUpdatePrecondition | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                precondition_type_0 = MemoryUpdatePrecondition.from_dict(data)
+
+                return precondition_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(MemoryUpdatePrecondition | None | Unset, data)
+
+        precondition = _parse_precondition(d.pop("precondition", UNSET))
+
+        memory_update = cls(
+            content=content,
+            path=path,
+            precondition=precondition,
+        )
+
+        return memory_update

--- a/src/aios/sdk/_generated/models/memory_update_precondition.py
+++ b/src/aios/sdk/_generated/models/memory_update_precondition.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="MemoryUpdatePrecondition")
+
+
+@_attrs_define
+class MemoryUpdatePrecondition:
+    """``content_sha256`` precondition envelope.
+
+    Attributes:
+        type_ (Literal['content_sha256']):
+        content_sha256 (str):
+    """
+
+    type_: Literal["content_sha256"]
+    content_sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        content_sha256 = self.content_sha256
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "type": type_,
+                "content_sha256": content_sha256,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = cast(Literal["content_sha256"], d.pop("type"))
+        if type_ != "content_sha256":
+            raise ValueError(f"type must match const 'content_sha256', got '{type_}'")
+
+        content_sha256 = d.pop("content_sha256")
+
+        memory_update_precondition = cls(
+            type_=type_,
+            content_sha256=content_sha256,
+        )
+
+        return memory_update_precondition

--- a/src/aios/sdk/_generated/models/memory_version.py
+++ b/src/aios/sdk/_generated/models/memory_version.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..models.memory_version_operation import MemoryVersionOperation
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.actor import Actor
+
+
+T = TypeVar("T", bound="MemoryVersion")
+
+
+@_attrs_define
+class MemoryVersion:
+    """Read view of an immutable memory version. Redacted versions null the
+    ``path`` / ``content`` / ``content_sha256`` / ``content_size_bytes`` fields
+    while preserving the audit trail.
+
+        Attributes:
+            id (str):
+            memory_store_id (str):
+            memory_id (str):
+            operation (MemoryVersionOperation):
+            created_by (Actor): ``created_by`` / ``redacted_by`` shape on memory versions.
+            created_at (datetime.datetime):
+            type_ (Literal['memory_version'] | Unset):  Default: 'memory_version'.
+            path (None | str | Unset):
+            content (None | str | Unset):
+            content_sha256 (None | str | Unset):
+            content_size_bytes (int | None | Unset):
+            redacted_at (datetime.datetime | None | Unset):
+            redacted_by (Actor | None | Unset):
+    """
+
+    id: str
+    memory_store_id: str
+    memory_id: str
+    operation: MemoryVersionOperation
+    created_by: Actor
+    created_at: datetime.datetime
+    type_: Literal["memory_version"] | Unset = "memory_version"
+    path: None | str | Unset = UNSET
+    content: None | str | Unset = UNSET
+    content_sha256: None | str | Unset = UNSET
+    content_size_bytes: int | None | Unset = UNSET
+    redacted_at: datetime.datetime | None | Unset = UNSET
+    redacted_by: Actor | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.actor import Actor
+
+        id = self.id
+
+        memory_store_id = self.memory_store_id
+
+        memory_id = self.memory_id
+
+        operation = self.operation.value
+
+        created_by = self.created_by.to_dict()
+
+        created_at = self.created_at.isoformat()
+
+        type_ = self.type_
+
+        path: None | str | Unset
+        if isinstance(self.path, Unset):
+            path = UNSET
+        else:
+            path = self.path
+
+        content: None | str | Unset
+        if isinstance(self.content, Unset):
+            content = UNSET
+        else:
+            content = self.content
+
+        content_sha256: None | str | Unset
+        if isinstance(self.content_sha256, Unset):
+            content_sha256 = UNSET
+        else:
+            content_sha256 = self.content_sha256
+
+        content_size_bytes: int | None | Unset
+        if isinstance(self.content_size_bytes, Unset):
+            content_size_bytes = UNSET
+        else:
+            content_size_bytes = self.content_size_bytes
+
+        redacted_at: None | str | Unset
+        if isinstance(self.redacted_at, Unset):
+            redacted_at = UNSET
+        elif isinstance(self.redacted_at, datetime.datetime):
+            redacted_at = self.redacted_at.isoformat()
+        else:
+            redacted_at = self.redacted_at
+
+        redacted_by: dict[str, Any] | None | Unset
+        if isinstance(self.redacted_by, Unset):
+            redacted_by = UNSET
+        elif isinstance(self.redacted_by, Actor):
+            redacted_by = self.redacted_by.to_dict()
+        else:
+            redacted_by = self.redacted_by
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "memory_store_id": memory_store_id,
+                "memory_id": memory_id,
+                "operation": operation,
+                "created_by": created_by,
+                "created_at": created_at,
+            }
+        )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if path is not UNSET:
+            field_dict["path"] = path
+        if content is not UNSET:
+            field_dict["content"] = content
+        if content_sha256 is not UNSET:
+            field_dict["content_sha256"] = content_sha256
+        if content_size_bytes is not UNSET:
+            field_dict["content_size_bytes"] = content_size_bytes
+        if redacted_at is not UNSET:
+            field_dict["redacted_at"] = redacted_at
+        if redacted_by is not UNSET:
+            field_dict["redacted_by"] = redacted_by
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.actor import Actor
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        memory_store_id = d.pop("memory_store_id")
+
+        memory_id = d.pop("memory_id")
+
+        operation = MemoryVersionOperation(d.pop("operation"))
+
+        created_by = Actor.from_dict(d.pop("created_by"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        type_ = cast(Literal["memory_version"] | Unset, d.pop("type", UNSET))
+        if type_ != "memory_version" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'memory_version', got '{type_}'")
+
+        def _parse_path(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        path = _parse_path(d.pop("path", UNSET))
+
+        def _parse_content(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        content = _parse_content(d.pop("content", UNSET))
+
+        def _parse_content_sha256(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        content_sha256 = _parse_content_sha256(d.pop("content_sha256", UNSET))
+
+        def _parse_content_size_bytes(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        content_size_bytes = _parse_content_size_bytes(
+            d.pop("content_size_bytes", UNSET)
+        )
+
+        def _parse_redacted_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                redacted_at_type_0 = isoparse(data)
+
+                return redacted_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        redacted_at = _parse_redacted_at(d.pop("redacted_at", UNSET))
+
+        def _parse_redacted_by(data: object) -> Actor | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                redacted_by_type_0 = Actor.from_dict(data)
+
+                return redacted_by_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(Actor | None | Unset, data)
+
+        redacted_by = _parse_redacted_by(d.pop("redacted_by", UNSET))
+
+        memory_version = cls(
+            id=id,
+            memory_store_id=memory_store_id,
+            memory_id=memory_id,
+            operation=operation,
+            created_by=created_by,
+            created_at=created_at,
+            type_=type_,
+            path=path,
+            content=content,
+            content_sha256=content_sha256,
+            content_size_bytes=content_size_bytes,
+            redacted_at=redacted_at,
+            redacted_by=redacted_by,
+        )
+
+        memory_version.additional_properties = d
+        return memory_version
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/memory_version_operation.py
+++ b/src/aios/sdk/_generated/models/memory_version_operation.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class MemoryVersionOperation(str, Enum):
+    CREATED = "created"
+    DELETED = "deleted"
+    MODIFIED = "modified"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/recent_chat.py
+++ b/src/aios/sdk/_generated/models/recent_chat.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+T = TypeVar("T", bound="RecentChat")
+
+
+@_attrs_define
+class RecentChat:
+    """Distinct chat_id observed on a connection's account, with the
+    most-recent inbound timestamp.
+
+    Returned by ``GET /v1/connections/{id}/recent-chats`` so operators
+    can find the chat_id for a specific peer without digging through
+    event logs before calling ``bind-chat``.
+
+        Attributes:
+            chat_id (str):
+            last_seen_at (datetime.datetime):
+    """
+
+    chat_id: str
+    last_seen_at: datetime.datetime
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        chat_id = self.chat_id
+
+        last_seen_at = self.last_seen_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "chat_id": chat_id,
+                "last_seen_at": last_seen_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        chat_id = d.pop("chat_id")
+
+        last_seen_at = isoparse(d.pop("last_seen_at"))
+
+        recent_chat = cls(
+            chat_id=chat_id,
+            last_seen_at=last_seen_at,
+        )
+
+        recent_chat.additional_properties = d
+        return recent_chat
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/session.py
+++ b/src/aios/sdk/_generated/models/session.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..models.session_status import SessionStatus
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.github_repository_resource_echo import GithubRepositoryResourceEcho
+    from ..models.memory_store_resource_echo import MemoryStoreResourceEcho
+    from ..models.session_metadata import SessionMetadata
+    from ..models.session_stop_reason_type_0 import SessionStopReasonType0
+    from ..models.session_usage import SessionUsage
+
+
+T = TypeVar("T", bound="Session")
+
+
+@_attrs_define
+class Session:
+    """Read view of a session. Internal-only columns are not exposed.
+
+    Attributes:
+        id (str):
+        agent_id (str):
+        environment_id (str):
+        agent_version (int | None):
+        title (None | str):
+        metadata (SessionMetadata):
+        status (SessionStatus):
+        stop_reason (None | SessionStopReasonType0):
+        last_event_seq (int):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        vault_ids (list[str] | Unset):
+        usage (SessionUsage | Unset): Cumulative token usage across all model calls in a session.
+        resources (list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho] | Unset):
+        archived_at (datetime.datetime | None | Unset):
+        focal_channel (None | str | Unset):
+    """
+
+    id: str
+    agent_id: str
+    environment_id: str
+    agent_version: int | None
+    title: None | str
+    metadata: SessionMetadata
+    status: SessionStatus
+    stop_reason: None | SessionStopReasonType0
+    last_event_seq: int
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    vault_ids: list[str] | Unset = UNSET
+    usage: SessionUsage | Unset = UNSET
+    resources: list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho] | Unset = (
+        UNSET
+    )
+    archived_at: datetime.datetime | None | Unset = UNSET
+    focal_channel: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.memory_store_resource_echo import MemoryStoreResourceEcho
+        from ..models.session_stop_reason_type_0 import SessionStopReasonType0
+
+        id = self.id
+
+        agent_id = self.agent_id
+
+        environment_id = self.environment_id
+
+        agent_version: int | None
+        agent_version = self.agent_version
+
+        title: None | str
+        title = self.title
+
+        metadata = self.metadata.to_dict()
+
+        status = self.status.value
+
+        stop_reason: dict[str, Any] | None
+        if isinstance(self.stop_reason, SessionStopReasonType0):
+            stop_reason = self.stop_reason.to_dict()
+        else:
+            stop_reason = self.stop_reason
+
+        last_event_seq = self.last_event_seq
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        vault_ids: list[str] | Unset = UNSET
+        if not isinstance(self.vault_ids, Unset):
+            vault_ids = self.vault_ids
+
+        usage: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.usage, Unset):
+            usage = self.usage.to_dict()
+
+        resources: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.resources, Unset):
+            resources = []
+            for resources_item_data in self.resources:
+                resources_item: dict[str, Any]
+                if isinstance(resources_item_data, MemoryStoreResourceEcho):
+                    resources_item = resources_item_data.to_dict()
+                else:
+                    resources_item = resources_item_data.to_dict()
+
+                resources.append(resources_item)
+
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
+        focal_channel: None | str | Unset
+        if isinstance(self.focal_channel, Unset):
+            focal_channel = UNSET
+        else:
+            focal_channel = self.focal_channel
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "agent_id": agent_id,
+                "environment_id": environment_id,
+                "agent_version": agent_version,
+                "title": title,
+                "metadata": metadata,
+                "status": status,
+                "stop_reason": stop_reason,
+                "last_event_seq": last_event_seq,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if vault_ids is not UNSET:
+            field_dict["vault_ids"] = vault_ids
+        if usage is not UNSET:
+            field_dict["usage"] = usage
+        if resources is not UNSET:
+            field_dict["resources"] = resources
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
+        if focal_channel is not UNSET:
+            field_dict["focal_channel"] = focal_channel
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.github_repository_resource_echo import (
+            GithubRepositoryResourceEcho,
+        )
+        from ..models.memory_store_resource_echo import MemoryStoreResourceEcho
+        from ..models.session_metadata import SessionMetadata
+        from ..models.session_stop_reason_type_0 import SessionStopReasonType0
+        from ..models.session_usage import SessionUsage
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        agent_id = d.pop("agent_id")
+
+        environment_id = d.pop("environment_id")
+
+        def _parse_agent_version(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
+
+        agent_version = _parse_agent_version(d.pop("agent_version"))
+
+        def _parse_title(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        title = _parse_title(d.pop("title"))
+
+        metadata = SessionMetadata.from_dict(d.pop("metadata"))
+
+        status = SessionStatus(d.pop("status"))
+
+        def _parse_stop_reason(data: object) -> None | SessionStopReasonType0:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                stop_reason_type_0 = SessionStopReasonType0.from_dict(data)
+
+                return stop_reason_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | SessionStopReasonType0, data)
+
+        stop_reason = _parse_stop_reason(d.pop("stop_reason"))
+
+        last_event_seq = d.pop("last_event_seq")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        vault_ids = cast(list[str], d.pop("vault_ids", UNSET))
+
+        _usage = d.pop("usage", UNSET)
+        usage: SessionUsage | Unset
+        if isinstance(_usage, Unset):
+            usage = UNSET
+        else:
+            usage = SessionUsage.from_dict(_usage)
+
+        _resources = d.pop("resources", UNSET)
+        resources: (
+            list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho] | Unset
+        ) = UNSET
+        if _resources is not UNSET:
+            resources = []
+            for resources_item_data in _resources:
+
+                def _parse_resources_item(
+                    data: object,
+                ) -> GithubRepositoryResourceEcho | MemoryStoreResourceEcho:
+                    try:
+                        if not isinstance(data, dict):
+                            raise TypeError()
+                        resources_item_type_0 = MemoryStoreResourceEcho.from_dict(data)
+
+                        return resources_item_type_0
+                    except (TypeError, ValueError, AttributeError, KeyError):
+                        pass
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    resources_item_type_1 = GithubRepositoryResourceEcho.from_dict(data)
+
+                    return resources_item_type_1
+
+                resources_item = _parse_resources_item(resources_item_data)
+
+                resources.append(resources_item)
+
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
+        def _parse_focal_channel(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        focal_channel = _parse_focal_channel(d.pop("focal_channel", UNSET))
+
+        session = cls(
+            id=id,
+            agent_id=agent_id,
+            environment_id=environment_id,
+            agent_version=agent_version,
+            title=title,
+            metadata=metadata,
+            status=status,
+            stop_reason=stop_reason,
+            last_event_seq=last_event_seq,
+            created_at=created_at,
+            updated_at=updated_at,
+            vault_ids=vault_ids,
+            usage=usage,
+            resources=resources,
+            archived_at=archived_at,
+            focal_channel=focal_channel,
+        )
+
+        session.additional_properties = d
+        return session
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/session_clone_request.py
+++ b/src/aios/sdk/_generated/models/session_clone_request.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="SessionCloneRequest")
+
+
+@_attrs_define
+class SessionCloneRequest:
+    """Request body for ``POST /v1/sessions/{id}/clone``.
+
+    All fields optional; the clone inherits everything not overridden from
+    the parent at clone time.
+
+        Attributes:
+            workspace_path (None | str | Unset): Override the clone's workspace volume path. Defaults to a fresh
+                ``workspace_root/<new_session_id>`` so clones don't fight over files. The directory must exist; aios will not
+                create it.
+    """
+
+    workspace_path: None | str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        workspace_path: None | str | Unset
+        if isinstance(self.workspace_path, Unset):
+            workspace_path = UNSET
+        else:
+            workspace_path = self.workspace_path
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if workspace_path is not UNSET:
+            field_dict["workspace_path"] = workspace_path
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+
+        def _parse_workspace_path(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        workspace_path = _parse_workspace_path(d.pop("workspace_path", UNSET))
+
+        session_clone_request = cls(
+            workspace_path=workspace_path,
+        )
+
+        return session_clone_request

--- a/src/aios/sdk/_generated/models/session_create.py
+++ b/src/aios/sdk/_generated/models/session_create.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.github_repository_resource import GithubRepositoryResource
+    from ..models.memory_store_resource import MemoryStoreResource
+    from ..models.session_create_env import SessionCreateEnv
+    from ..models.session_create_metadata import SessionCreateMetadata
+
+
+T = TypeVar("T", bound="SessionCreate")
+
+
+@_attrs_define
+class SessionCreate:
+    """Request body for `POST /v1/sessions`.
+
+    Attributes:
+        agent_id (str):
+        environment_id (str):
+        agent_version (int | None | Unset): Pin to a specific agent version. Omit or pass null for 'latest' (auto-
+            updating — the session uses whatever version is current).
+        title (None | str | Unset):
+        metadata (SessionCreateMetadata | Unset):
+        vault_ids (list[str] | Unset): Vault ids to bind to this session for MCP credential resolution.
+        workspace_path (None | str | Unset): Absolute host path to use as the session workspace. If omitted, defaults to
+            workspace_root/<session_id>. The directory must exist; aios will not create it.
+        env (SessionCreateEnv | Unset): Environment variables injected into the sandbox container.
+        initial_message (None | str | Unset): Convenience: when set, the server appends a user.message event with this
+            content immediately after creating the session and enqueues a wake job. Equivalent to a follow-up POST
+            /messages.
+        resources (list[GithubRepositoryResource | MemoryStoreResource] | Unset): Resources to attach. Mix of memory
+            stores (mounted under /mnt/memory/<name>/) and github repositories (cloned to a user-specified mount_path). Each
+            type has its own per-session cap; duplicates within a type are rejected. Use ``PUT /v1/sessions/{id}`` with
+            ``resources`` to detach or replace the set after creation.
+    """
+
+    agent_id: str
+    environment_id: str
+    agent_version: int | None | Unset = UNSET
+    title: None | str | Unset = UNSET
+    metadata: SessionCreateMetadata | Unset = UNSET
+    vault_ids: list[str] | Unset = UNSET
+    workspace_path: None | str | Unset = UNSET
+    env: SessionCreateEnv | Unset = UNSET
+    initial_message: None | str | Unset = UNSET
+    resources: list[GithubRepositoryResource | MemoryStoreResource] | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.memory_store_resource import MemoryStoreResource
+
+        agent_id = self.agent_id
+
+        environment_id = self.environment_id
+
+        agent_version: int | None | Unset
+        if isinstance(self.agent_version, Unset):
+            agent_version = UNSET
+        else:
+            agent_version = self.agent_version
+
+        title: None | str | Unset
+        if isinstance(self.title, Unset):
+            title = UNSET
+        else:
+            title = self.title
+
+        metadata: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        vault_ids: list[str] | Unset = UNSET
+        if not isinstance(self.vault_ids, Unset):
+            vault_ids = self.vault_ids
+
+        workspace_path: None | str | Unset
+        if isinstance(self.workspace_path, Unset):
+            workspace_path = UNSET
+        else:
+            workspace_path = self.workspace_path
+
+        env: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.env, Unset):
+            env = self.env.to_dict()
+
+        initial_message: None | str | Unset
+        if isinstance(self.initial_message, Unset):
+            initial_message = UNSET
+        else:
+            initial_message = self.initial_message
+
+        resources: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.resources, Unset):
+            resources = []
+            for resources_item_data in self.resources:
+                resources_item: dict[str, Any]
+                if isinstance(resources_item_data, MemoryStoreResource):
+                    resources_item = resources_item_data.to_dict()
+                else:
+                    resources_item = resources_item_data.to_dict()
+
+                resources.append(resources_item)
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "agent_id": agent_id,
+                "environment_id": environment_id,
+            }
+        )
+        if agent_version is not UNSET:
+            field_dict["agent_version"] = agent_version
+        if title is not UNSET:
+            field_dict["title"] = title
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if vault_ids is not UNSET:
+            field_dict["vault_ids"] = vault_ids
+        if workspace_path is not UNSET:
+            field_dict["workspace_path"] = workspace_path
+        if env is not UNSET:
+            field_dict["env"] = env
+        if initial_message is not UNSET:
+            field_dict["initial_message"] = initial_message
+        if resources is not UNSET:
+            field_dict["resources"] = resources
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.github_repository_resource import GithubRepositoryResource
+        from ..models.memory_store_resource import MemoryStoreResource
+        from ..models.session_create_env import SessionCreateEnv
+        from ..models.session_create_metadata import SessionCreateMetadata
+
+        d = dict(src_dict)
+        agent_id = d.pop("agent_id")
+
+        environment_id = d.pop("environment_id")
+
+        def _parse_agent_version(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        agent_version = _parse_agent_version(d.pop("agent_version", UNSET))
+
+        def _parse_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        title = _parse_title(d.pop("title", UNSET))
+
+        _metadata = d.pop("metadata", UNSET)
+        metadata: SessionCreateMetadata | Unset
+        if isinstance(_metadata, Unset):
+            metadata = UNSET
+        else:
+            metadata = SessionCreateMetadata.from_dict(_metadata)
+
+        vault_ids = cast(list[str], d.pop("vault_ids", UNSET))
+
+        def _parse_workspace_path(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        workspace_path = _parse_workspace_path(d.pop("workspace_path", UNSET))
+
+        _env = d.pop("env", UNSET)
+        env: SessionCreateEnv | Unset
+        if isinstance(_env, Unset):
+            env = UNSET
+        else:
+            env = SessionCreateEnv.from_dict(_env)
+
+        def _parse_initial_message(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        initial_message = _parse_initial_message(d.pop("initial_message", UNSET))
+
+        _resources = d.pop("resources", UNSET)
+        resources: list[GithubRepositoryResource | MemoryStoreResource] | Unset = UNSET
+        if _resources is not UNSET:
+            resources = []
+            for resources_item_data in _resources:
+
+                def _parse_resources_item(
+                    data: object,
+                ) -> GithubRepositoryResource | MemoryStoreResource:
+                    try:
+                        if not isinstance(data, dict):
+                            raise TypeError()
+                        resources_item_type_0 = MemoryStoreResource.from_dict(data)
+
+                        return resources_item_type_0
+                    except (TypeError, ValueError, AttributeError, KeyError):
+                        pass
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    resources_item_type_1 = GithubRepositoryResource.from_dict(data)
+
+                    return resources_item_type_1
+
+                resources_item = _parse_resources_item(resources_item_data)
+
+                resources.append(resources_item)
+
+        session_create = cls(
+            agent_id=agent_id,
+            environment_id=environment_id,
+            agent_version=agent_version,
+            title=title,
+            metadata=metadata,
+            vault_ids=vault_ids,
+            workspace_path=workspace_path,
+            env=env,
+            initial_message=initial_message,
+            resources=resources,
+        )
+
+        return session_create

--- a/src/aios/sdk/_generated/models/session_create_env.py
+++ b/src/aios/sdk/_generated/models/session_create_env.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SessionCreateEnv")
+
+
+@_attrs_define
+class SessionCreateEnv:
+    """Environment variables injected into the sandbox container."""
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_create_env = cls()
+
+        session_create_env.additional_properties = d
+        return session_create_env
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/session_create_metadata.py
+++ b/src/aios/sdk/_generated/models/session_create_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SessionCreateMetadata")
+
+
+@_attrs_define
+class SessionCreateMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_create_metadata = cls()
+
+        session_create_metadata.additional_properties = d
+        return session_create_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/session_interrupt_request.py
+++ b/src/aios/sdk/_generated/models/session_interrupt_request.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="SessionInterruptRequest")
+
+
+@_attrs_define
+class SessionInterruptRequest:
+    """Request body for `POST /v1/sessions/{id}/interrupt`.
+
+    Attributes:
+        reason (None | str | Unset):
+    """
+
+    reason: None | str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        reason: None | str | Unset
+        if isinstance(self.reason, Unset):
+            reason = UNSET
+        else:
+            reason = self.reason
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if reason is not UNSET:
+            field_dict["reason"] = reason
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+
+        def _parse_reason(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        reason = _parse_reason(d.pop("reason", UNSET))
+
+        session_interrupt_request = cls(
+            reason=reason,
+        )
+
+        return session_interrupt_request

--- a/src/aios/sdk/_generated/models/session_metadata.py
+++ b/src/aios/sdk/_generated/models/session_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SessionMetadata")
+
+
+@_attrs_define
+class SessionMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_metadata = cls()
+
+        session_metadata.additional_properties = d
+        return session_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/session_status.py
+++ b/src/aios/sdk/_generated/models/session_status.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class SessionStatus(str, Enum):
+    IDLE = "idle"
+    PENDING = "pending"
+    RESCHEDULING = "rescheduling"
+    RUNNING = "running"
+    TERMINATED = "terminated"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/session_stop_reason_type_0.py
+++ b/src/aios/sdk/_generated/models/session_stop_reason_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SessionStopReasonType0")
+
+
+@_attrs_define
+class SessionStopReasonType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_stop_reason_type_0 = cls()
+
+        session_stop_reason_type_0.additional_properties = d
+        return session_stop_reason_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/session_template.py
+++ b/src/aios/sdk/_generated/models/session_template.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.session_template_metadata import SessionTemplateMetadata
+
+
+T = TypeVar("T", bound="SessionTemplate")
+
+
+@_attrs_define
+class SessionTemplate:
+    """Read view of a session template.
+
+    Attributes:
+        id (str):
+        name (str):
+        agent_id (str):
+        agent_version (int | None):
+        environment_id (str):
+        vault_ids (list[str]):
+        memory_store_ids (list[str]):
+        metadata (SessionTemplateMetadata):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        archived_at (datetime.datetime | None | Unset):
+    """
+
+    id: str
+    name: str
+    agent_id: str
+    agent_version: int | None
+    environment_id: str
+    vault_ids: list[str]
+    memory_store_ids: list[str]
+    metadata: SessionTemplateMetadata
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    archived_at: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        name = self.name
+
+        agent_id = self.agent_id
+
+        agent_version: int | None
+        agent_version = self.agent_version
+
+        environment_id = self.environment_id
+
+        vault_ids = self.vault_ids
+
+        memory_store_ids = self.memory_store_ids
+
+        metadata = self.metadata.to_dict()
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "name": name,
+                "agent_id": agent_id,
+                "agent_version": agent_version,
+                "environment_id": environment_id,
+                "vault_ids": vault_ids,
+                "memory_store_ids": memory_store_ids,
+                "metadata": metadata,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.session_template_metadata import SessionTemplateMetadata
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        name = d.pop("name")
+
+        agent_id = d.pop("agent_id")
+
+        def _parse_agent_version(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
+
+        agent_version = _parse_agent_version(d.pop("agent_version"))
+
+        environment_id = d.pop("environment_id")
+
+        vault_ids = cast(list[str], d.pop("vault_ids"))
+
+        memory_store_ids = cast(list[str], d.pop("memory_store_ids"))
+
+        metadata = SessionTemplateMetadata.from_dict(d.pop("metadata"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
+        session_template = cls(
+            id=id,
+            name=name,
+            agent_id=agent_id,
+            agent_version=agent_version,
+            environment_id=environment_id,
+            vault_ids=vault_ids,
+            memory_store_ids=memory_store_ids,
+            metadata=metadata,
+            created_at=created_at,
+            updated_at=updated_at,
+            archived_at=archived_at,
+        )
+
+        session_template.additional_properties = d
+        return session_template
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/session_template_create.py
+++ b/src/aios/sdk/_generated/models/session_template_create.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.session_template_create_metadata import SessionTemplateCreateMetadata
+
+
+T = TypeVar("T", bound="SessionTemplateCreate")
+
+
+@_attrs_define
+class SessionTemplateCreate:
+    """Request body for ``POST /v1/session-templates``.
+
+    Attributes:
+        name (str):
+        agent_id (str):
+        environment_id (str):
+        agent_version (int | None | Unset): Pin to a specific agent version. Omit or pass null for 'latest' — the spawn
+            captures whatever version is current at spawn time.
+        vault_ids (list[str] | Unset):
+        memory_store_ids (list[str] | Unset):
+        metadata (SessionTemplateCreateMetadata | Unset):
+    """
+
+    name: str
+    agent_id: str
+    environment_id: str
+    agent_version: int | None | Unset = UNSET
+    vault_ids: list[str] | Unset = UNSET
+    memory_store_ids: list[str] | Unset = UNSET
+    metadata: SessionTemplateCreateMetadata | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        agent_id = self.agent_id
+
+        environment_id = self.environment_id
+
+        agent_version: int | None | Unset
+        if isinstance(self.agent_version, Unset):
+            agent_version = UNSET
+        else:
+            agent_version = self.agent_version
+
+        vault_ids: list[str] | Unset = UNSET
+        if not isinstance(self.vault_ids, Unset):
+            vault_ids = self.vault_ids
+
+        memory_store_ids: list[str] | Unset = UNSET
+        if not isinstance(self.memory_store_ids, Unset):
+            memory_store_ids = self.memory_store_ids
+
+        metadata: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "name": name,
+                "agent_id": agent_id,
+                "environment_id": environment_id,
+            }
+        )
+        if agent_version is not UNSET:
+            field_dict["agent_version"] = agent_version
+        if vault_ids is not UNSET:
+            field_dict["vault_ids"] = vault_ids
+        if memory_store_ids is not UNSET:
+            field_dict["memory_store_ids"] = memory_store_ids
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.session_template_create_metadata import (
+            SessionTemplateCreateMetadata,
+        )
+
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        agent_id = d.pop("agent_id")
+
+        environment_id = d.pop("environment_id")
+
+        def _parse_agent_version(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        agent_version = _parse_agent_version(d.pop("agent_version", UNSET))
+
+        vault_ids = cast(list[str], d.pop("vault_ids", UNSET))
+
+        memory_store_ids = cast(list[str], d.pop("memory_store_ids", UNSET))
+
+        _metadata = d.pop("metadata", UNSET)
+        metadata: SessionTemplateCreateMetadata | Unset
+        if isinstance(_metadata, Unset):
+            metadata = UNSET
+        else:
+            metadata = SessionTemplateCreateMetadata.from_dict(_metadata)
+
+        session_template_create = cls(
+            name=name,
+            agent_id=agent_id,
+            environment_id=environment_id,
+            agent_version=agent_version,
+            vault_ids=vault_ids,
+            memory_store_ids=memory_store_ids,
+            metadata=metadata,
+        )
+
+        return session_template_create

--- a/src/aios/sdk/_generated/models/session_template_create_metadata.py
+++ b/src/aios/sdk/_generated/models/session_template_create_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SessionTemplateCreateMetadata")
+
+
+@_attrs_define
+class SessionTemplateCreateMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_template_create_metadata = cls()
+
+        session_template_create_metadata.additional_properties = d
+        return session_template_create_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/session_template_metadata.py
+++ b/src/aios/sdk/_generated/models/session_template_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SessionTemplateMetadata")
+
+
+@_attrs_define
+class SessionTemplateMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_template_metadata = cls()
+
+        session_template_metadata.additional_properties = d
+        return session_template_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/session_template_update.py
+++ b/src/aios/sdk/_generated/models/session_template_update.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.session_template_update_metadata_type_0 import (
+        SessionTemplateUpdateMetadataType0,
+    )
+
+
+T = TypeVar("T", bound="SessionTemplateUpdate")
+
+
+@_attrs_define
+class SessionTemplateUpdate:
+    """Request body for ``PUT /v1/session-templates/{id}``.
+
+    Updates apply to future spawns only — already-spawned sessions are
+    not retroactively migrated (see module docstring).
+
+        Attributes:
+            name (None | str | Unset):
+            agent_id (None | str | Unset):
+            agent_version (int | None | Unset):
+            environment_id (None | str | Unset):
+            vault_ids (list[str] | None | Unset):
+            memory_store_ids (list[str] | None | Unset):
+            metadata (None | SessionTemplateUpdateMetadataType0 | Unset):
+    """
+
+    name: None | str | Unset = UNSET
+    agent_id: None | str | Unset = UNSET
+    agent_version: int | None | Unset = UNSET
+    environment_id: None | str | Unset = UNSET
+    vault_ids: list[str] | None | Unset = UNSET
+    memory_store_ids: list[str] | None | Unset = UNSET
+    metadata: None | SessionTemplateUpdateMetadataType0 | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.session_template_update_metadata_type_0 import (
+            SessionTemplateUpdateMetadataType0,
+        )
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
+
+        agent_id: None | str | Unset
+        if isinstance(self.agent_id, Unset):
+            agent_id = UNSET
+        else:
+            agent_id = self.agent_id
+
+        agent_version: int | None | Unset
+        if isinstance(self.agent_version, Unset):
+            agent_version = UNSET
+        else:
+            agent_version = self.agent_version
+
+        environment_id: None | str | Unset
+        if isinstance(self.environment_id, Unset):
+            environment_id = UNSET
+        else:
+            environment_id = self.environment_id
+
+        vault_ids: list[str] | None | Unset
+        if isinstance(self.vault_ids, Unset):
+            vault_ids = UNSET
+        elif isinstance(self.vault_ids, list):
+            vault_ids = self.vault_ids
+
+        else:
+            vault_ids = self.vault_ids
+
+        memory_store_ids: list[str] | None | Unset
+        if isinstance(self.memory_store_ids, Unset):
+            memory_store_ids = UNSET
+        elif isinstance(self.memory_store_ids, list):
+            memory_store_ids = self.memory_store_ids
+
+        else:
+            memory_store_ids = self.memory_store_ids
+
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, SessionTemplateUpdateMetadataType0):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if agent_id is not UNSET:
+            field_dict["agent_id"] = agent_id
+        if agent_version is not UNSET:
+            field_dict["agent_version"] = agent_version
+        if environment_id is not UNSET:
+            field_dict["environment_id"] = environment_id
+        if vault_ids is not UNSET:
+            field_dict["vault_ids"] = vault_ids
+        if memory_store_ids is not UNSET:
+            field_dict["memory_store_ids"] = memory_store_ids
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.session_template_update_metadata_type_0 import (
+            SessionTemplateUpdateMetadataType0,
+        )
+
+        d = dict(src_dict)
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
+
+        def _parse_agent_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        agent_id = _parse_agent_id(d.pop("agent_id", UNSET))
+
+        def _parse_agent_version(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        agent_version = _parse_agent_version(d.pop("agent_version", UNSET))
+
+        def _parse_environment_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        environment_id = _parse_environment_id(d.pop("environment_id", UNSET))
+
+        def _parse_vault_ids(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                vault_ids_type_0 = cast(list[str], data)
+
+                return vault_ids_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        vault_ids = _parse_vault_ids(d.pop("vault_ids", UNSET))
+
+        def _parse_memory_store_ids(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                memory_store_ids_type_0 = cast(list[str], data)
+
+                return memory_store_ids_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        memory_store_ids = _parse_memory_store_ids(d.pop("memory_store_ids", UNSET))
+
+        def _parse_metadata(
+            data: object,
+        ) -> None | SessionTemplateUpdateMetadataType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = SessionTemplateUpdateMetadataType0.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | SessionTemplateUpdateMetadataType0 | Unset, data)
+
+        metadata = _parse_metadata(d.pop("metadata", UNSET))
+
+        session_template_update = cls(
+            name=name,
+            agent_id=agent_id,
+            agent_version=agent_version,
+            environment_id=environment_id,
+            vault_ids=vault_ids,
+            memory_store_ids=memory_store_ids,
+            metadata=metadata,
+        )
+
+        return session_template_update

--- a/src/aios/sdk/_generated/models/session_template_update_metadata_type_0.py
+++ b/src/aios/sdk/_generated/models/session_template_update_metadata_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SessionTemplateUpdateMetadataType0")
+
+
+@_attrs_define
+class SessionTemplateUpdateMetadataType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_template_update_metadata_type_0 = cls()
+
+        session_template_update_metadata_type_0.additional_properties = d
+        return session_template_update_metadata_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/session_update.py
+++ b/src/aios/sdk/_generated/models/session_update.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.github_repository_resource import GithubRepositoryResource
+    from ..models.memory_store_resource import MemoryStoreResource
+    from ..models.session_update_metadata_type_0 import SessionUpdateMetadataType0
+
+
+T = TypeVar("T", bound="SessionUpdate")
+
+
+@_attrs_define
+class SessionUpdate:
+    """Request body for ``PUT /v1/sessions/{id}``.
+
+    All fields are optional; omitted fields are preserved. Changing
+    ``agent_id`` resets ``agent_version`` to null (latest) unless
+    ``agent_version`` is also provided. ``resources`` and ``vault_ids``
+    use full-list-replacement semantics: ``None`` (the default) leaves
+    the current set alone, ``[]`` detaches everything, and a non-empty
+    list replaces the bound set entirely.
+
+        Attributes:
+            agent_id (None | str | Unset):
+            agent_version (int | None | Unset):
+            title (None | str | Unset):
+            metadata (None | SessionUpdateMetadataType0 | Unset):
+            vault_ids (list[str] | None | Unset):
+            resources (list[GithubRepositoryResource | MemoryStoreResource] | None | Unset):
+    """
+
+    agent_id: None | str | Unset = UNSET
+    agent_version: int | None | Unset = UNSET
+    title: None | str | Unset = UNSET
+    metadata: None | SessionUpdateMetadataType0 | Unset = UNSET
+    vault_ids: list[str] | None | Unset = UNSET
+    resources: list[GithubRepositoryResource | MemoryStoreResource] | None | Unset = (
+        UNSET
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.memory_store_resource import MemoryStoreResource
+        from ..models.session_update_metadata_type_0 import SessionUpdateMetadataType0
+
+        agent_id: None | str | Unset
+        if isinstance(self.agent_id, Unset):
+            agent_id = UNSET
+        else:
+            agent_id = self.agent_id
+
+        agent_version: int | None | Unset
+        if isinstance(self.agent_version, Unset):
+            agent_version = UNSET
+        else:
+            agent_version = self.agent_version
+
+        title: None | str | Unset
+        if isinstance(self.title, Unset):
+            title = UNSET
+        else:
+            title = self.title
+
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, SessionUpdateMetadataType0):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
+
+        vault_ids: list[str] | None | Unset
+        if isinstance(self.vault_ids, Unset):
+            vault_ids = UNSET
+        elif isinstance(self.vault_ids, list):
+            vault_ids = self.vault_ids
+
+        else:
+            vault_ids = self.vault_ids
+
+        resources: list[dict[str, Any]] | None | Unset
+        if isinstance(self.resources, Unset):
+            resources = UNSET
+        elif isinstance(self.resources, list):
+            resources = []
+            for resources_type_0_item_data in self.resources:
+                resources_type_0_item: dict[str, Any]
+                if isinstance(resources_type_0_item_data, MemoryStoreResource):
+                    resources_type_0_item = resources_type_0_item_data.to_dict()
+                else:
+                    resources_type_0_item = resources_type_0_item_data.to_dict()
+
+                resources.append(resources_type_0_item)
+
+        else:
+            resources = self.resources
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if agent_id is not UNSET:
+            field_dict["agent_id"] = agent_id
+        if agent_version is not UNSET:
+            field_dict["agent_version"] = agent_version
+        if title is not UNSET:
+            field_dict["title"] = title
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if vault_ids is not UNSET:
+            field_dict["vault_ids"] = vault_ids
+        if resources is not UNSET:
+            field_dict["resources"] = resources
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.github_repository_resource import GithubRepositoryResource
+        from ..models.memory_store_resource import MemoryStoreResource
+        from ..models.session_update_metadata_type_0 import SessionUpdateMetadataType0
+
+        d = dict(src_dict)
+
+        def _parse_agent_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        agent_id = _parse_agent_id(d.pop("agent_id", UNSET))
+
+        def _parse_agent_version(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        agent_version = _parse_agent_version(d.pop("agent_version", UNSET))
+
+        def _parse_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        title = _parse_title(d.pop("title", UNSET))
+
+        def _parse_metadata(data: object) -> None | SessionUpdateMetadataType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = SessionUpdateMetadataType0.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | SessionUpdateMetadataType0 | Unset, data)
+
+        metadata = _parse_metadata(d.pop("metadata", UNSET))
+
+        def _parse_vault_ids(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                vault_ids_type_0 = cast(list[str], data)
+
+                return vault_ids_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        vault_ids = _parse_vault_ids(d.pop("vault_ids", UNSET))
+
+        def _parse_resources(
+            data: object,
+        ) -> list[GithubRepositoryResource | MemoryStoreResource] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                resources_type_0 = []
+                _resources_type_0 = data
+                for resources_type_0_item_data in _resources_type_0:
+
+                    def _parse_resources_type_0_item(
+                        data: object,
+                    ) -> GithubRepositoryResource | MemoryStoreResource:
+                        try:
+                            if not isinstance(data, dict):
+                                raise TypeError()
+                            resources_type_0_item_type_0 = (
+                                MemoryStoreResource.from_dict(data)
+                            )
+
+                            return resources_type_0_item_type_0
+                        except (TypeError, ValueError, AttributeError, KeyError):
+                            pass
+                        if not isinstance(data, dict):
+                            raise TypeError()
+                        resources_type_0_item_type_1 = (
+                            GithubRepositoryResource.from_dict(data)
+                        )
+
+                        return resources_type_0_item_type_1
+
+                    resources_type_0_item = _parse_resources_type_0_item(
+                        resources_type_0_item_data
+                    )
+
+                    resources_type_0.append(resources_type_0_item)
+
+                return resources_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                list[GithubRepositoryResource | MemoryStoreResource] | None | Unset,
+                data,
+            )
+
+        resources = _parse_resources(d.pop("resources", UNSET))
+
+        session_update = cls(
+            agent_id=agent_id,
+            agent_version=agent_version,
+            title=title,
+            metadata=metadata,
+            vault_ids=vault_ids,
+            resources=resources,
+        )
+
+        return session_update

--- a/src/aios/sdk/_generated/models/session_update_metadata_type_0.py
+++ b/src/aios/sdk/_generated/models/session_update_metadata_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SessionUpdateMetadataType0")
+
+
+@_attrs_define
+class SessionUpdateMetadataType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_update_metadata_type_0 = cls()
+
+        session_update_metadata_type_0.additional_properties = d
+        return session_update_metadata_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/session_usage.py
+++ b/src/aios/sdk/_generated/models/session_usage.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="SessionUsage")
+
+
+@_attrs_define
+class SessionUsage:
+    """Cumulative token usage across all model calls in a session.
+
+    Attributes:
+        input_tokens (int | Unset):  Default: 0.
+        output_tokens (int | Unset):  Default: 0.
+        cache_read_input_tokens (int | Unset):  Default: 0.
+        cache_creation_input_tokens (int | Unset):  Default: 0.
+    """
+
+    input_tokens: int | Unset = 0
+    output_tokens: int | Unset = 0
+    cache_read_input_tokens: int | Unset = 0
+    cache_creation_input_tokens: int | Unset = 0
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        input_tokens = self.input_tokens
+
+        output_tokens = self.output_tokens
+
+        cache_read_input_tokens = self.cache_read_input_tokens
+
+        cache_creation_input_tokens = self.cache_creation_input_tokens
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if input_tokens is not UNSET:
+            field_dict["input_tokens"] = input_tokens
+        if output_tokens is not UNSET:
+            field_dict["output_tokens"] = output_tokens
+        if cache_read_input_tokens is not UNSET:
+            field_dict["cache_read_input_tokens"] = cache_read_input_tokens
+        if cache_creation_input_tokens is not UNSET:
+            field_dict["cache_creation_input_tokens"] = cache_creation_input_tokens
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        input_tokens = d.pop("input_tokens", UNSET)
+
+        output_tokens = d.pop("output_tokens", UNSET)
+
+        cache_read_input_tokens = d.pop("cache_read_input_tokens", UNSET)
+
+        cache_creation_input_tokens = d.pop("cache_creation_input_tokens", UNSET)
+
+        session_usage = cls(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+        )
+
+        session_usage.additional_properties = d
+        return session_usage
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/session_user_message.py
+++ b/src/aios/sdk/_generated/models/session_user_message.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.session_user_message_metadata import SessionUserMessageMetadata
+
+
+T = TypeVar("T", bound="SessionUserMessage")
+
+
+@_attrs_define
+class SessionUserMessage:
+    """Request body for `POST /v1/sessions/{id}/messages`.
+
+    Attributes:
+        content (str):
+        metadata (SessionUserMessageMetadata | Unset):
+    """
+
+    content: str
+    metadata: SessionUserMessageMetadata | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        content = self.content
+
+        metadata: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "content": content,
+            }
+        )
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.session_user_message_metadata import SessionUserMessageMetadata
+
+        d = dict(src_dict)
+        content = d.pop("content")
+
+        _metadata = d.pop("metadata", UNSET)
+        metadata: SessionUserMessageMetadata | Unset
+        if isinstance(_metadata, Unset):
+            metadata = UNSET
+        else:
+            metadata = SessionUserMessageMetadata.from_dict(_metadata)
+
+        session_user_message = cls(
+            content=content,
+            metadata=metadata,
+        )
+
+        return session_user_message

--- a/src/aios/sdk/_generated/models/session_user_message_metadata.py
+++ b/src/aios/sdk/_generated/models/session_user_message_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SessionUserMessageMetadata")
+
+
+@_attrs_define
+class SessionUserMessageMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_user_message_metadata = cls()
+
+        session_user_message_metadata.additional_properties = d
+        return session_user_message_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/skill.py
+++ b/src/aios/sdk/_generated/models/skill.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Skill")
+
+
+@_attrs_define
+class Skill:
+    """Read view of a skill (head row).
+
+    Attributes:
+        id (str):
+        display_title (str):
+        latest_version (int):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        archived_at (datetime.datetime | None | Unset):
+    """
+
+    id: str
+    display_title: str
+    latest_version: int
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    archived_at: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        display_title = self.display_title
+
+        latest_version = self.latest_version
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "display_title": display_title,
+                "latest_version": latest_version,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        display_title = d.pop("display_title")
+
+        latest_version = d.pop("latest_version")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
+        skill = cls(
+            id=id,
+            display_title=display_title,
+            latest_version=latest_version,
+            created_at=created_at,
+            updated_at=updated_at,
+            archived_at=archived_at,
+        )
+
+        skill.additional_properties = d
+        return skill
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/skill_create.py
+++ b/src/aios/sdk/_generated/models/skill_create.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+
+if TYPE_CHECKING:
+    from ..models.skill_create_files import SkillCreateFiles
+
+
+T = TypeVar("T", bound="SkillCreate")
+
+
+@_attrs_define
+class SkillCreate:
+    """Request body for ``POST /v1/skills``.
+
+    ``files`` must include exactly one ``{directory}/SKILL.md`` entry.
+    The server extracts ``name``, ``description``, and ``directory`` from
+    the SKILL.md frontmatter and file paths.
+
+        Attributes:
+            display_title (str):
+            files (SkillCreateFiles): Skill files as {path: content}. Must include exactly one {directory}/SKILL.md entry
+                with YAML frontmatter.
+    """
+
+    display_title: str
+    files: SkillCreateFiles
+
+    def to_dict(self) -> dict[str, Any]:
+        display_title = self.display_title
+
+        files = self.files.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "display_title": display_title,
+                "files": files,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.skill_create_files import SkillCreateFiles
+
+        d = dict(src_dict)
+        display_title = d.pop("display_title")
+
+        files = SkillCreateFiles.from_dict(d.pop("files"))
+
+        skill_create = cls(
+            display_title=display_title,
+            files=files,
+        )
+
+        return skill_create

--- a/src/aios/sdk/_generated/models/skill_create_files.py
+++ b/src/aios/sdk/_generated/models/skill_create_files.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SkillCreateFiles")
+
+
+@_attrs_define
+class SkillCreateFiles:
+    """Skill files as {path: content}. Must include exactly one {directory}/SKILL.md entry with YAML frontmatter."""
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        skill_create_files = cls()
+
+        skill_create_files.additional_properties = d
+        return skill_create_files
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/skill_version.py
+++ b/src/aios/sdk/_generated/models/skill_version.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+if TYPE_CHECKING:
+    from ..models.skill_version_files import SkillVersionFiles
+
+
+T = TypeVar("T", bound="SkillVersion")
+
+
+@_attrs_define
+class SkillVersion:
+    """Read view of a specific skill version.
+
+    Attributes:
+        skill_id (str):
+        version (int):
+        directory (str):
+        name (str):
+        description (str):
+        files (SkillVersionFiles):
+        created_at (datetime.datetime):
+    """
+
+    skill_id: str
+    version: int
+    directory: str
+    name: str
+    description: str
+    files: SkillVersionFiles
+    created_at: datetime.datetime
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        skill_id = self.skill_id
+
+        version = self.version
+
+        directory = self.directory
+
+        name = self.name
+
+        description = self.description
+
+        files = self.files.to_dict()
+
+        created_at = self.created_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "skill_id": skill_id,
+                "version": version,
+                "directory": directory,
+                "name": name,
+                "description": description,
+                "files": files,
+                "created_at": created_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.skill_version_files import SkillVersionFiles
+
+        d = dict(src_dict)
+        skill_id = d.pop("skill_id")
+
+        version = d.pop("version")
+
+        directory = d.pop("directory")
+
+        name = d.pop("name")
+
+        description = d.pop("description")
+
+        files = SkillVersionFiles.from_dict(d.pop("files"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        skill_version = cls(
+            skill_id=skill_id,
+            version=version,
+            directory=directory,
+            name=name,
+            description=description,
+            files=files,
+            created_at=created_at,
+        )
+
+        skill_version.additional_properties = d
+        return skill_version
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/skill_version_create.py
+++ b/src/aios/sdk/_generated/models/skill_version_create.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+
+if TYPE_CHECKING:
+    from ..models.skill_version_create_files import SkillVersionCreateFiles
+
+
+T = TypeVar("T", bound="SkillVersionCreate")
+
+
+@_attrs_define
+class SkillVersionCreate:
+    """Request body for ``POST /v1/skills/{skill_id}/versions``.
+
+    Same file format as :class:`SkillCreate`. The directory, name, and
+    description are re-extracted from the new SKILL.md.
+
+        Attributes:
+            files (SkillVersionCreateFiles):
+    """
+
+    files: SkillVersionCreateFiles
+
+    def to_dict(self) -> dict[str, Any]:
+        files = self.files.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "files": files,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.skill_version_create_files import SkillVersionCreateFiles
+
+        d = dict(src_dict)
+        files = SkillVersionCreateFiles.from_dict(d.pop("files"))
+
+        skill_version_create = cls(
+            files=files,
+        )
+
+        return skill_version_create

--- a/src/aios/sdk/_generated/models/skill_version_create_files.py
+++ b/src/aios/sdk/_generated/models/skill_version_create_files.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SkillVersionCreateFiles")
+
+
+@_attrs_define
+class SkillVersionCreateFiles:
+    """ """
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        skill_version_create_files = cls()
+
+        skill_version_create_files.additional_properties = d
+        return skill_version_create_files
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/skill_version_files.py
+++ b/src/aios/sdk/_generated/models/skill_version_files.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SkillVersionFiles")
+
+
+@_attrs_define
+class SkillVersionFiles:
+    """ """
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        skill_version_files = cls()
+
+        skill_version_files.additional_properties = d
+        return skill_version_files
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/token_endpoint_auth_basic.py
+++ b/src/aios/sdk/_generated/models/token_endpoint_auth_basic.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="TokenEndpointAuthBasic")
+
+
+@_attrs_define
+class TokenEndpointAuthBasic:
+    """OAuth client_secret_basic — HTTP Basic header on the refresh call.
+
+    Attributes:
+        method (Literal['client_secret_basic']):
+        client_secret (str):
+    """
+
+    method: Literal["client_secret_basic"]
+    client_secret: str
+
+    def to_dict(self) -> dict[str, Any]:
+        method = self.method
+
+        client_secret = self.client_secret
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "method": method,
+                "client_secret": client_secret,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        method = cast(Literal["client_secret_basic"], d.pop("method"))
+        if method != "client_secret_basic":
+            raise ValueError(
+                f"method must match const 'client_secret_basic', got '{method}'"
+            )
+
+        client_secret = d.pop("client_secret")
+
+        token_endpoint_auth_basic = cls(
+            method=method,
+            client_secret=client_secret,
+        )
+
+        return token_endpoint_auth_basic

--- a/src/aios/sdk/_generated/models/token_endpoint_auth_none.py
+++ b/src/aios/sdk/_generated/models/token_endpoint_auth_none.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="TokenEndpointAuthNone")
+
+
+@_attrs_define
+class TokenEndpointAuthNone:
+    """Public OAuth client — no credentials sent on the refresh call.
+
+    Attributes:
+        method (Literal['none']):
+    """
+
+    method: Literal["none"]
+
+    def to_dict(self) -> dict[str, Any]:
+        method = self.method
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "method": method,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        method = cast(Literal["none"], d.pop("method"))
+        if method != "none":
+            raise ValueError(f"method must match const 'none', got '{method}'")
+
+        token_endpoint_auth_none = cls(
+            method=method,
+        )
+
+        return token_endpoint_auth_none

--- a/src/aios/sdk/_generated/models/token_endpoint_auth_post.py
+++ b/src/aios/sdk/_generated/models/token_endpoint_auth_post.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="TokenEndpointAuthPost")
+
+
+@_attrs_define
+class TokenEndpointAuthPost:
+    """OAuth client_secret_post — client_secret in the form body.
+
+    Attributes:
+        method (Literal['client_secret_post']):
+        client_secret (str):
+    """
+
+    method: Literal["client_secret_post"]
+    client_secret: str
+
+    def to_dict(self) -> dict[str, Any]:
+        method = self.method
+
+        client_secret = self.client_secret
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "method": method,
+                "client_secret": client_secret,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        method = cast(Literal["client_secret_post"], d.pop("method"))
+        if method != "client_secret_post":
+            raise ValueError(
+                f"method must match const 'client_secret_post', got '{method}'"
+            )
+
+        client_secret = d.pop("client_secret")
+
+        token_endpoint_auth_post = cls(
+            method=method,
+            client_secret=client_secret,
+        )
+
+        return token_endpoint_auth_post

--- a/src/aios/sdk/_generated/models/tool_confirmation_request.py
+++ b/src/aios/sdk/_generated/models/tool_confirmation_request.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..models.tool_confirmation_request_result import ToolConfirmationRequestResult
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ToolConfirmationRequest")
+
+
+@_attrs_define
+class ToolConfirmationRequest:
+    """Request body for ``POST /v1/sessions/{id}/tool-confirmations``.
+
+    Used for built-in tools with ``permission: "always_ask"``. The client
+    inspects the pending tool call and either allows it (the worker will
+    execute it) or denies it (the model receives an error with the deny
+    message).
+
+        Attributes:
+            tool_call_id (str): The tool_call_id to confirm or deny.
+            result (ToolConfirmationRequestResult):
+            deny_message (None | str | Unset): When result='deny', an optional message explaining why. Shown to the model.
+    """
+
+    tool_call_id: str
+    result: ToolConfirmationRequestResult
+    deny_message: None | str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        tool_call_id = self.tool_call_id
+
+        result = self.result.value
+
+        deny_message: None | str | Unset
+        if isinstance(self.deny_message, Unset):
+            deny_message = UNSET
+        else:
+            deny_message = self.deny_message
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "tool_call_id": tool_call_id,
+                "result": result,
+            }
+        )
+        if deny_message is not UNSET:
+            field_dict["deny_message"] = deny_message
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        tool_call_id = d.pop("tool_call_id")
+
+        result = ToolConfirmationRequestResult(d.pop("result"))
+
+        def _parse_deny_message(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        deny_message = _parse_deny_message(d.pop("deny_message", UNSET))
+
+        tool_confirmation_request = cls(
+            tool_call_id=tool_call_id,
+            result=result,
+            deny_message=deny_message,
+        )
+
+        return tool_confirmation_request

--- a/src/aios/sdk/_generated/models/tool_confirmation_request_result.py
+++ b/src/aios/sdk/_generated/models/tool_confirmation_request_result.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ToolConfirmationRequestResult(str, Enum):
+    ALLOW = "allow"
+    DENY = "deny"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/tool_result_request.py
+++ b/src/aios/sdk/_generated/models/tool_result_request.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ToolResultRequest")
+
+
+@_attrs_define
+class ToolResultRequest:
+    """Request body for ``POST /v1/sessions/{id}/tool-results``.
+
+    Attributes:
+        tool_call_id (str): The tool_call_id from the assistant's tool_calls.
+        content (str): The result of executing the tool.
+        is_error (bool | Unset): True if the tool execution failed. Default: False.
+    """
+
+    tool_call_id: str
+    content: str
+    is_error: bool | Unset = False
+
+    def to_dict(self) -> dict[str, Any]:
+        tool_call_id = self.tool_call_id
+
+        content = self.content
+
+        is_error = self.is_error
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "tool_call_id": tool_call_id,
+                "content": content,
+            }
+        )
+        if is_error is not UNSET:
+            field_dict["is_error"] = is_error
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        tool_call_id = d.pop("tool_call_id")
+
+        content = d.pop("content")
+
+        is_error = d.pop("is_error", UNSET)
+
+        tool_result_request = cls(
+            tool_call_id=tool_call_id,
+            content=content,
+            is_error=is_error,
+        )
+
+        return tool_result_request

--- a/src/aios/sdk/_generated/models/tool_spec.py
+++ b/src/aios/sdk/_generated/models/tool_spec.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..models.tool_spec_permission_type_0 import ToolSpecPermissionType0
+from ..models.tool_spec_type_type_0 import ToolSpecTypeType0
+from ..models.tool_spec_type_type_1 import ToolSpecTypeType1
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.mcp_tool_config import McpToolConfig
+    from ..models.mcp_toolset_config import McpToolsetConfig
+    from ..models.tool_spec_input_schema_type_0 import ToolSpecInputSchemaType0
+
+
+T = TypeVar("T", bound="ToolSpec")
+
+
+@_attrs_define
+class ToolSpec:
+    """One entry in an agent's ``tools`` list.
+
+    For built-in tools, ``type`` is the tool name (``"bash"``, ``"read"``,
+    etc.). For custom (client-executed) tools, ``type`` is ``"custom"`` and
+    ``name``, ``description``, and ``input_schema`` are required. For MCP
+    toolsets, ``type`` is ``"mcp_toolset"`` and ``mcp_server_name`` is
+    required.
+
+    ``enabled`` controls whether the tool is included in the schema sent to
+    the model. Disabled tools are invisible to the model.
+
+    ``permission`` controls execution policy for built-in tools:
+    ``None`` or ``"always_allow"`` executes immediately (current default);
+    ``"always_ask"`` idles the session with ``requires_action`` until the
+    client confirms or denies.
+
+        Attributes:
+            type_ (ToolSpecTypeType0 | ToolSpecTypeType1):
+            name (None | str | Unset):
+            description (None | str | Unset):
+            input_schema (None | ToolSpecInputSchemaType0 | Unset):
+            enabled (bool | Unset):  Default: True.
+            permission (None | ToolSpecPermissionType0 | Unset):
+            mcp_server_name (None | str | Unset):
+            default_config (McpToolsetConfig | None | Unset):
+            configs (list[McpToolConfig] | None | Unset):
+    """
+
+    type_: ToolSpecTypeType0 | ToolSpecTypeType1
+    name: None | str | Unset = UNSET
+    description: None | str | Unset = UNSET
+    input_schema: None | ToolSpecInputSchemaType0 | Unset = UNSET
+    enabled: bool | Unset = True
+    permission: None | ToolSpecPermissionType0 | Unset = UNSET
+    mcp_server_name: None | str | Unset = UNSET
+    default_config: McpToolsetConfig | None | Unset = UNSET
+    configs: list[McpToolConfig] | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.mcp_toolset_config import McpToolsetConfig
+        from ..models.tool_spec_input_schema_type_0 import ToolSpecInputSchemaType0
+
+        type_: str
+        if isinstance(self.type_, ToolSpecTypeType0):
+            type_ = self.type_.value
+        else:
+            type_ = self.type_.value
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
+
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        input_schema: dict[str, Any] | None | Unset
+        if isinstance(self.input_schema, Unset):
+            input_schema = UNSET
+        elif isinstance(self.input_schema, ToolSpecInputSchemaType0):
+            input_schema = self.input_schema.to_dict()
+        else:
+            input_schema = self.input_schema
+
+        enabled = self.enabled
+
+        permission: None | str | Unset
+        if isinstance(self.permission, Unset):
+            permission = UNSET
+        elif isinstance(self.permission, ToolSpecPermissionType0):
+            permission = self.permission.value
+        else:
+            permission = self.permission
+
+        mcp_server_name: None | str | Unset
+        if isinstance(self.mcp_server_name, Unset):
+            mcp_server_name = UNSET
+        else:
+            mcp_server_name = self.mcp_server_name
+
+        default_config: dict[str, Any] | None | Unset
+        if isinstance(self.default_config, Unset):
+            default_config = UNSET
+        elif isinstance(self.default_config, McpToolsetConfig):
+            default_config = self.default_config.to_dict()
+        else:
+            default_config = self.default_config
+
+        configs: list[dict[str, Any]] | None | Unset
+        if isinstance(self.configs, Unset):
+            configs = UNSET
+        elif isinstance(self.configs, list):
+            configs = []
+            for configs_type_0_item_data in self.configs:
+                configs_type_0_item = configs_type_0_item_data.to_dict()
+                configs.append(configs_type_0_item)
+
+        else:
+            configs = self.configs
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "type": type_,
+            }
+        )
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if input_schema is not UNSET:
+            field_dict["input_schema"] = input_schema
+        if enabled is not UNSET:
+            field_dict["enabled"] = enabled
+        if permission is not UNSET:
+            field_dict["permission"] = permission
+        if mcp_server_name is not UNSET:
+            field_dict["mcp_server_name"] = mcp_server_name
+        if default_config is not UNSET:
+            field_dict["default_config"] = default_config
+        if configs is not UNSET:
+            field_dict["configs"] = configs
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.mcp_tool_config import McpToolConfig
+        from ..models.mcp_toolset_config import McpToolsetConfig
+        from ..models.tool_spec_input_schema_type_0 import ToolSpecInputSchemaType0
+
+        d = dict(src_dict)
+
+        def _parse_type_(data: object) -> ToolSpecTypeType0 | ToolSpecTypeType1:
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                type_type_0 = ToolSpecTypeType0(data)
+
+                return type_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            if not isinstance(data, str):
+                raise TypeError()
+            type_type_1 = ToolSpecTypeType1(data)
+
+            return type_type_1
+
+        type_ = _parse_type_(d.pop("type"))
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
+
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_input_schema(
+            data: object,
+        ) -> None | ToolSpecInputSchemaType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                input_schema_type_0 = ToolSpecInputSchemaType0.from_dict(data)
+
+                return input_schema_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | ToolSpecInputSchemaType0 | Unset, data)
+
+        input_schema = _parse_input_schema(d.pop("input_schema", UNSET))
+
+        enabled = d.pop("enabled", UNSET)
+
+        def _parse_permission(data: object) -> None | ToolSpecPermissionType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                permission_type_0 = ToolSpecPermissionType0(data)
+
+                return permission_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | ToolSpecPermissionType0 | Unset, data)
+
+        permission = _parse_permission(d.pop("permission", UNSET))
+
+        def _parse_mcp_server_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        mcp_server_name = _parse_mcp_server_name(d.pop("mcp_server_name", UNSET))
+
+        def _parse_default_config(data: object) -> McpToolsetConfig | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                default_config_type_0 = McpToolsetConfig.from_dict(data)
+
+                return default_config_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(McpToolsetConfig | None | Unset, data)
+
+        default_config = _parse_default_config(d.pop("default_config", UNSET))
+
+        def _parse_configs(data: object) -> list[McpToolConfig] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                configs_type_0 = []
+                _configs_type_0 = data
+                for configs_type_0_item_data in _configs_type_0:
+                    configs_type_0_item = McpToolConfig.from_dict(
+                        configs_type_0_item_data
+                    )
+
+                    configs_type_0.append(configs_type_0_item)
+
+                return configs_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[McpToolConfig] | None | Unset, data)
+
+        configs = _parse_configs(d.pop("configs", UNSET))
+
+        tool_spec = cls(
+            type_=type_,
+            name=name,
+            description=description,
+            input_schema=input_schema,
+            enabled=enabled,
+            permission=permission,
+            mcp_server_name=mcp_server_name,
+            default_config=default_config,
+            configs=configs,
+        )
+
+        return tool_spec

--- a/src/aios/sdk/_generated/models/tool_spec_input_schema_type_0.py
+++ b/src/aios/sdk/_generated/models/tool_spec_input_schema_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ToolSpecInputSchemaType0")
+
+
+@_attrs_define
+class ToolSpecInputSchemaType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        tool_spec_input_schema_type_0 = cls()
+
+        tool_spec_input_schema_type_0.additional_properties = d
+        return tool_spec_input_schema_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/tool_spec_permission_type_0.py
+++ b/src/aios/sdk/_generated/models/tool_spec_permission_type_0.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ToolSpecPermissionType0(str, Enum):
+    ALWAYS_ALLOW = "always_allow"
+    ALWAYS_ASK = "always_ask"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/tool_spec_type_type_0.py
+++ b/src/aios/sdk/_generated/models/tool_spec_type_type_0.py
@@ -1,0 +1,18 @@
+from enum import Enum
+
+
+class ToolSpecTypeType0(str, Enum):
+    BASH = "bash"
+    CANCEL = "cancel"
+    EDIT = "edit"
+    GLOB = "glob"
+    GREP = "grep"
+    READ = "read"
+    SCHEDULE_WAKE = "schedule_wake"
+    SEARCH_EVENTS = "search_events"
+    WEB_FETCH = "web_fetch"
+    WEB_SEARCH = "web_search"
+    WRITE = "write"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/tool_spec_type_type_1.py
+++ b/src/aios/sdk/_generated/models/tool_spec_type_type_1.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ToolSpecTypeType1(str, Enum):
+    CUSTOM = "custom"
+    MCP_TOOLSET = "mcp_toolset"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/unrestricted_networking.py
+++ b/src/aios/sdk/_generated/models/unrestricted_networking.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="UnrestrictedNetworking")
+
+
+@_attrs_define
+class UnrestrictedNetworking:
+    """Full outbound network access (default).
+
+    Attributes:
+        type_ (Literal['unrestricted'] | Unset):  Default: 'unrestricted'.
+    """
+
+    type_: Literal["unrestricted"] | Unset = "unrestricted"
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = cast(Literal["unrestricted"] | Unset, d.pop("type", UNSET))
+        if type_ != "unrestricted" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'unrestricted', got '{type_}'")
+
+        unrestricted_networking = cls(
+            type_=type_,
+        )
+
+        return unrestricted_networking

--- a/src/aios/sdk/_generated/models/validation_error.py
+++ b/src/aios/sdk/_generated/models/validation_error.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.validation_error_context import ValidationErrorContext
+
+
+T = TypeVar("T", bound="ValidationError")
+
+
+@_attrs_define
+class ValidationError:
+    """
+    Attributes:
+        loc (list[int | str]):
+        msg (str):
+        type_ (str):
+        input_ (Any | Unset):
+        ctx (ValidationErrorContext | Unset):
+    """
+
+    loc: list[int | str]
+    msg: str
+    type_: str
+    input_: Any | Unset = UNSET
+    ctx: ValidationErrorContext | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        loc = []
+        for loc_item_data in self.loc:
+            loc_item: int | str
+            loc_item = loc_item_data
+            loc.append(loc_item)
+
+        msg = self.msg
+
+        type_ = self.type_
+
+        input_ = self.input_
+
+        ctx: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.ctx, Unset):
+            ctx = self.ctx.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "loc": loc,
+                "msg": msg,
+                "type": type_,
+            }
+        )
+        if input_ is not UNSET:
+            field_dict["input"] = input_
+        if ctx is not UNSET:
+            field_dict["ctx"] = ctx
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.validation_error_context import ValidationErrorContext
+
+        d = dict(src_dict)
+        loc = []
+        _loc = d.pop("loc")
+        for loc_item_data in _loc:
+
+            def _parse_loc_item(data: object) -> int | str:
+                return cast(int | str, data)
+
+            loc_item = _parse_loc_item(loc_item_data)
+
+            loc.append(loc_item)
+
+        msg = d.pop("msg")
+
+        type_ = d.pop("type")
+
+        input_ = d.pop("input", UNSET)
+
+        _ctx = d.pop("ctx", UNSET)
+        ctx: ValidationErrorContext | Unset
+        if isinstance(_ctx, Unset):
+            ctx = UNSET
+        else:
+            ctx = ValidationErrorContext.from_dict(_ctx)
+
+        validation_error = cls(
+            loc=loc,
+            msg=msg,
+            type_=type_,
+            input_=input_,
+            ctx=ctx,
+        )
+
+        validation_error.additional_properties = d
+        return validation_error
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/validation_error_context.py
+++ b/src/aios/sdk/_generated/models/validation_error_context.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ValidationErrorContext")
+
+
+@_attrs_define
+class ValidationErrorContext:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        validation_error_context = cls()
+
+        validation_error_context.additional_properties = d
+        return validation_error_context
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/vault.py
+++ b/src/aios/sdk/_generated/models/vault.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.vault_metadata import VaultMetadata
+
+
+T = TypeVar("T", bound="Vault")
+
+
+@_attrs_define
+class Vault:
+    """Read view of a vault.
+
+    Attributes:
+        id (str):
+        display_name (str):
+        metadata (VaultMetadata):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        archived_at (datetime.datetime | None | Unset):
+    """
+
+    id: str
+    display_name: str
+    metadata: VaultMetadata
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    archived_at: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        display_name = self.display_name
+
+        metadata = self.metadata.to_dict()
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "display_name": display_name,
+                "metadata": metadata,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.vault_metadata import VaultMetadata
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        display_name = d.pop("display_name")
+
+        metadata = VaultMetadata.from_dict(d.pop("metadata"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
+        vault = cls(
+            id=id,
+            display_name=display_name,
+            metadata=metadata,
+            created_at=created_at,
+            updated_at=updated_at,
+            archived_at=archived_at,
+        )
+
+        vault.additional_properties = d
+        return vault
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/vault_create.py
+++ b/src/aios/sdk/_generated/models/vault_create.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.vault_create_metadata import VaultCreateMetadata
+
+
+T = TypeVar("T", bound="VaultCreate")
+
+
+@_attrs_define
+class VaultCreate:
+    """Request body for ``POST /v1/vaults``.
+
+    Attributes:
+        display_name (str):
+        metadata (VaultCreateMetadata | Unset):
+    """
+
+    display_name: str
+    metadata: VaultCreateMetadata | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        display_name = self.display_name
+
+        metadata: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "display_name": display_name,
+            }
+        )
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.vault_create_metadata import VaultCreateMetadata
+
+        d = dict(src_dict)
+        display_name = d.pop("display_name")
+
+        _metadata = d.pop("metadata", UNSET)
+        metadata: VaultCreateMetadata | Unset
+        if isinstance(_metadata, Unset):
+            metadata = UNSET
+        else:
+            metadata = VaultCreateMetadata.from_dict(_metadata)
+
+        vault_create = cls(
+            display_name=display_name,
+            metadata=metadata,
+        )
+
+        return vault_create

--- a/src/aios/sdk/_generated/models/vault_create_metadata.py
+++ b/src/aios/sdk/_generated/models/vault_create_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="VaultCreateMetadata")
+
+
+@_attrs_define
+class VaultCreateMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        vault_create_metadata = cls()
+
+        vault_create_metadata.additional_properties = d
+        return vault_create_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/vault_credential.py
+++ b/src/aios/sdk/_generated/models/vault_credential.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..models.vault_credential_auth_type import VaultCredentialAuthType
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.vault_credential_metadata import VaultCredentialMetadata
+
+
+T = TypeVar("T", bound="VaultCredential")
+
+
+@_attrs_define
+class VaultCredential:
+    """Read view of a vault credential. Secrets are never returned.
+
+    Attributes:
+        id (str):
+        vault_id (str):
+        display_name (None | str):
+        mcp_server_url (str):
+        auth_type (VaultCredentialAuthType):
+        metadata (VaultCredentialMetadata):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        archived_at (datetime.datetime | None | Unset):
+    """
+
+    id: str
+    vault_id: str
+    display_name: None | str
+    mcp_server_url: str
+    auth_type: VaultCredentialAuthType
+    metadata: VaultCredentialMetadata
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    archived_at: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        vault_id = self.vault_id
+
+        display_name: None | str
+        display_name = self.display_name
+
+        mcp_server_url = self.mcp_server_url
+
+        auth_type = self.auth_type.value
+
+        metadata = self.metadata.to_dict()
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "vault_id": vault_id,
+                "display_name": display_name,
+                "mcp_server_url": mcp_server_url,
+                "auth_type": auth_type,
+                "metadata": metadata,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.vault_credential_metadata import VaultCredentialMetadata
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        vault_id = d.pop("vault_id")
+
+        def _parse_display_name(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        display_name = _parse_display_name(d.pop("display_name"))
+
+        mcp_server_url = d.pop("mcp_server_url")
+
+        auth_type = VaultCredentialAuthType(d.pop("auth_type"))
+
+        metadata = VaultCredentialMetadata.from_dict(d.pop("metadata"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
+        vault_credential = cls(
+            id=id,
+            vault_id=vault_id,
+            display_name=display_name,
+            mcp_server_url=mcp_server_url,
+            auth_type=auth_type,
+            metadata=metadata,
+            created_at=created_at,
+            updated_at=updated_at,
+            archived_at=archived_at,
+        )
+
+        vault_credential.additional_properties = d
+        return vault_credential
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/vault_credential_auth_type.py
+++ b/src/aios/sdk/_generated/models/vault_credential_auth_type.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class VaultCredentialAuthType(str, Enum):
+    MCP_OAUTH = "mcp_oauth"
+    STATIC_BEARER = "static_bearer"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/vault_credential_create.py
+++ b/src/aios/sdk/_generated/models/vault_credential_create.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from dateutil.parser import isoparse
+
+from ..models.vault_credential_create_auth_type import VaultCredentialCreateAuthType
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.token_endpoint_auth_basic import TokenEndpointAuthBasic
+    from ..models.token_endpoint_auth_none import TokenEndpointAuthNone
+    from ..models.token_endpoint_auth_post import TokenEndpointAuthPost
+    from ..models.vault_credential_create_metadata import VaultCredentialCreateMetadata
+
+
+T = TypeVar("T", bound="VaultCredentialCreate")
+
+
+@_attrs_define
+class VaultCredentialCreate:
+    """Request body for ``POST /v1/vaults/{vault_id}/credentials``.
+
+    All secret fields are write-only. The ``mcp_server_url`` is immutable
+    after creation. The service layer validates required fields per
+    ``auth_type``.
+
+        Attributes:
+            mcp_server_url (str):
+            auth_type (VaultCredentialCreateAuthType):
+            display_name (None | str | Unset):
+            metadata (VaultCredentialCreateMetadata | Unset):
+            access_token (None | str | Unset):
+            expires_at (datetime.datetime | None | Unset):
+            client_id (None | str | Unset):
+            refresh_token (None | str | Unset):
+            token_endpoint (None | str | Unset):
+            token_endpoint_auth (None | TokenEndpointAuthBasic | TokenEndpointAuthNone | TokenEndpointAuthPost | Unset):
+            scope (None | str | Unset):
+            resource (None | str | Unset):
+            token (None | str | Unset):
+    """
+
+    mcp_server_url: str
+    auth_type: VaultCredentialCreateAuthType
+    display_name: None | str | Unset = UNSET
+    metadata: VaultCredentialCreateMetadata | Unset = UNSET
+    access_token: None | str | Unset = UNSET
+    expires_at: datetime.datetime | None | Unset = UNSET
+    client_id: None | str | Unset = UNSET
+    refresh_token: None | str | Unset = UNSET
+    token_endpoint: None | str | Unset = UNSET
+    token_endpoint_auth: (
+        None
+        | TokenEndpointAuthBasic
+        | TokenEndpointAuthNone
+        | TokenEndpointAuthPost
+        | Unset
+    ) = UNSET
+    scope: None | str | Unset = UNSET
+    resource: None | str | Unset = UNSET
+    token: None | str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.token_endpoint_auth_basic import TokenEndpointAuthBasic
+        from ..models.token_endpoint_auth_none import TokenEndpointAuthNone
+        from ..models.token_endpoint_auth_post import TokenEndpointAuthPost
+
+        mcp_server_url = self.mcp_server_url
+
+        auth_type = self.auth_type.value
+
+        display_name: None | str | Unset
+        if isinstance(self.display_name, Unset):
+            display_name = UNSET
+        else:
+            display_name = self.display_name
+
+        metadata: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        access_token: None | str | Unset
+        if isinstance(self.access_token, Unset):
+            access_token = UNSET
+        else:
+            access_token = self.access_token
+
+        expires_at: None | str | Unset
+        if isinstance(self.expires_at, Unset):
+            expires_at = UNSET
+        elif isinstance(self.expires_at, datetime.datetime):
+            expires_at = self.expires_at.isoformat()
+        else:
+            expires_at = self.expires_at
+
+        client_id: None | str | Unset
+        if isinstance(self.client_id, Unset):
+            client_id = UNSET
+        else:
+            client_id = self.client_id
+
+        refresh_token: None | str | Unset
+        if isinstance(self.refresh_token, Unset):
+            refresh_token = UNSET
+        else:
+            refresh_token = self.refresh_token
+
+        token_endpoint: None | str | Unset
+        if isinstance(self.token_endpoint, Unset):
+            token_endpoint = UNSET
+        else:
+            token_endpoint = self.token_endpoint
+
+        token_endpoint_auth: dict[str, Any] | None | Unset
+        if isinstance(self.token_endpoint_auth, Unset):
+            token_endpoint_auth = UNSET
+        elif isinstance(self.token_endpoint_auth, TokenEndpointAuthNone):
+            token_endpoint_auth = self.token_endpoint_auth.to_dict()
+        elif isinstance(self.token_endpoint_auth, TokenEndpointAuthBasic):
+            token_endpoint_auth = self.token_endpoint_auth.to_dict()
+        elif isinstance(self.token_endpoint_auth, TokenEndpointAuthPost):
+            token_endpoint_auth = self.token_endpoint_auth.to_dict()
+        else:
+            token_endpoint_auth = self.token_endpoint_auth
+
+        scope: None | str | Unset
+        if isinstance(self.scope, Unset):
+            scope = UNSET
+        else:
+            scope = self.scope
+
+        resource: None | str | Unset
+        if isinstance(self.resource, Unset):
+            resource = UNSET
+        else:
+            resource = self.resource
+
+        token: None | str | Unset
+        if isinstance(self.token, Unset):
+            token = UNSET
+        else:
+            token = self.token
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "mcp_server_url": mcp_server_url,
+                "auth_type": auth_type,
+            }
+        )
+        if display_name is not UNSET:
+            field_dict["display_name"] = display_name
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if access_token is not UNSET:
+            field_dict["access_token"] = access_token
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
+        if client_id is not UNSET:
+            field_dict["client_id"] = client_id
+        if refresh_token is not UNSET:
+            field_dict["refresh_token"] = refresh_token
+        if token_endpoint is not UNSET:
+            field_dict["token_endpoint"] = token_endpoint
+        if token_endpoint_auth is not UNSET:
+            field_dict["token_endpoint_auth"] = token_endpoint_auth
+        if scope is not UNSET:
+            field_dict["scope"] = scope
+        if resource is not UNSET:
+            field_dict["resource"] = resource
+        if token is not UNSET:
+            field_dict["token"] = token
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.token_endpoint_auth_basic import TokenEndpointAuthBasic
+        from ..models.token_endpoint_auth_none import TokenEndpointAuthNone
+        from ..models.token_endpoint_auth_post import TokenEndpointAuthPost
+        from ..models.vault_credential_create_metadata import (
+            VaultCredentialCreateMetadata,
+        )
+
+        d = dict(src_dict)
+        mcp_server_url = d.pop("mcp_server_url")
+
+        auth_type = VaultCredentialCreateAuthType(d.pop("auth_type"))
+
+        def _parse_display_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        display_name = _parse_display_name(d.pop("display_name", UNSET))
+
+        _metadata = d.pop("metadata", UNSET)
+        metadata: VaultCredentialCreateMetadata | Unset
+        if isinstance(_metadata, Unset):
+            metadata = UNSET
+        else:
+            metadata = VaultCredentialCreateMetadata.from_dict(_metadata)
+
+        def _parse_access_token(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        access_token = _parse_access_token(d.pop("access_token", UNSET))
+
+        def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                expires_at_type_0 = isoparse(data)
+
+                return expires_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
+
+        def _parse_client_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        client_id = _parse_client_id(d.pop("client_id", UNSET))
+
+        def _parse_refresh_token(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        refresh_token = _parse_refresh_token(d.pop("refresh_token", UNSET))
+
+        def _parse_token_endpoint(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        token_endpoint = _parse_token_endpoint(d.pop("token_endpoint", UNSET))
+
+        def _parse_token_endpoint_auth(
+            data: object,
+        ) -> (
+            None
+            | TokenEndpointAuthBasic
+            | TokenEndpointAuthNone
+            | TokenEndpointAuthPost
+            | Unset
+        ):
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                token_endpoint_auth_type_0_type_0 = TokenEndpointAuthNone.from_dict(
+                    data
+                )
+
+                return token_endpoint_auth_type_0_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                token_endpoint_auth_type_0_type_1 = TokenEndpointAuthBasic.from_dict(
+                    data
+                )
+
+                return token_endpoint_auth_type_0_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                token_endpoint_auth_type_0_type_2 = TokenEndpointAuthPost.from_dict(
+                    data
+                )
+
+                return token_endpoint_auth_type_0_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                None
+                | TokenEndpointAuthBasic
+                | TokenEndpointAuthNone
+                | TokenEndpointAuthPost
+                | Unset,
+                data,
+            )
+
+        token_endpoint_auth = _parse_token_endpoint_auth(
+            d.pop("token_endpoint_auth", UNSET)
+        )
+
+        def _parse_scope(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        scope = _parse_scope(d.pop("scope", UNSET))
+
+        def _parse_resource(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        resource = _parse_resource(d.pop("resource", UNSET))
+
+        def _parse_token(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        token = _parse_token(d.pop("token", UNSET))
+
+        vault_credential_create = cls(
+            mcp_server_url=mcp_server_url,
+            auth_type=auth_type,
+            display_name=display_name,
+            metadata=metadata,
+            access_token=access_token,
+            expires_at=expires_at,
+            client_id=client_id,
+            refresh_token=refresh_token,
+            token_endpoint=token_endpoint,
+            token_endpoint_auth=token_endpoint_auth,
+            scope=scope,
+            resource=resource,
+            token=token,
+        )
+
+        return vault_credential_create

--- a/src/aios/sdk/_generated/models/vault_credential_create_auth_type.py
+++ b/src/aios/sdk/_generated/models/vault_credential_create_auth_type.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class VaultCredentialCreateAuthType(str, Enum):
+    MCP_OAUTH = "mcp_oauth"
+    STATIC_BEARER = "static_bearer"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/vault_credential_create_metadata.py
+++ b/src/aios/sdk/_generated/models/vault_credential_create_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="VaultCredentialCreateMetadata")
+
+
+@_attrs_define
+class VaultCredentialCreateMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        vault_credential_create_metadata = cls()
+
+        vault_credential_create_metadata.additional_properties = d
+        return vault_credential_create_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/vault_credential_metadata.py
+++ b/src/aios/sdk/_generated/models/vault_credential_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="VaultCredentialMetadata")
+
+
+@_attrs_define
+class VaultCredentialMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        vault_credential_metadata = cls()
+
+        vault_credential_metadata.additional_properties = d
+        return vault_credential_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/vault_credential_update.py
+++ b/src/aios/sdk/_generated/models/vault_credential_update.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.token_endpoint_auth_basic import TokenEndpointAuthBasic
+    from ..models.token_endpoint_auth_none import TokenEndpointAuthNone
+    from ..models.token_endpoint_auth_post import TokenEndpointAuthPost
+    from ..models.vault_credential_update_metadata_type_0 import (
+        VaultCredentialUpdateMetadataType0,
+    )
+
+
+T = TypeVar("T", bound="VaultCredentialUpdate")
+
+
+@_attrs_define
+class VaultCredentialUpdate:
+    """Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.
+
+    ``mcp_server_url`` and ``auth_type`` are immutable — not accepted here.
+    Omitted secret fields are preserved (decrypt-merge-encrypt).
+
+        Attributes:
+            display_name (None | str | Unset):
+            metadata (None | Unset | VaultCredentialUpdateMetadataType0):
+            access_token (None | str | Unset):
+            expires_at (datetime.datetime | None | Unset):
+            client_id (None | str | Unset):
+            refresh_token (None | str | Unset):
+            token_endpoint (None | str | Unset):
+            token_endpoint_auth (None | TokenEndpointAuthBasic | TokenEndpointAuthNone | TokenEndpointAuthPost | Unset):
+            scope (None | str | Unset):
+            resource (None | str | Unset):
+            token (None | str | Unset):
+    """
+
+    display_name: None | str | Unset = UNSET
+    metadata: None | Unset | VaultCredentialUpdateMetadataType0 = UNSET
+    access_token: None | str | Unset = UNSET
+    expires_at: datetime.datetime | None | Unset = UNSET
+    client_id: None | str | Unset = UNSET
+    refresh_token: None | str | Unset = UNSET
+    token_endpoint: None | str | Unset = UNSET
+    token_endpoint_auth: (
+        None
+        | TokenEndpointAuthBasic
+        | TokenEndpointAuthNone
+        | TokenEndpointAuthPost
+        | Unset
+    ) = UNSET
+    scope: None | str | Unset = UNSET
+    resource: None | str | Unset = UNSET
+    token: None | str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.token_endpoint_auth_basic import TokenEndpointAuthBasic
+        from ..models.token_endpoint_auth_none import TokenEndpointAuthNone
+        from ..models.token_endpoint_auth_post import TokenEndpointAuthPost
+        from ..models.vault_credential_update_metadata_type_0 import (
+            VaultCredentialUpdateMetadataType0,
+        )
+
+        display_name: None | str | Unset
+        if isinstance(self.display_name, Unset):
+            display_name = UNSET
+        else:
+            display_name = self.display_name
+
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, VaultCredentialUpdateMetadataType0):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
+
+        access_token: None | str | Unset
+        if isinstance(self.access_token, Unset):
+            access_token = UNSET
+        else:
+            access_token = self.access_token
+
+        expires_at: None | str | Unset
+        if isinstance(self.expires_at, Unset):
+            expires_at = UNSET
+        elif isinstance(self.expires_at, datetime.datetime):
+            expires_at = self.expires_at.isoformat()
+        else:
+            expires_at = self.expires_at
+
+        client_id: None | str | Unset
+        if isinstance(self.client_id, Unset):
+            client_id = UNSET
+        else:
+            client_id = self.client_id
+
+        refresh_token: None | str | Unset
+        if isinstance(self.refresh_token, Unset):
+            refresh_token = UNSET
+        else:
+            refresh_token = self.refresh_token
+
+        token_endpoint: None | str | Unset
+        if isinstance(self.token_endpoint, Unset):
+            token_endpoint = UNSET
+        else:
+            token_endpoint = self.token_endpoint
+
+        token_endpoint_auth: dict[str, Any] | None | Unset
+        if isinstance(self.token_endpoint_auth, Unset):
+            token_endpoint_auth = UNSET
+        elif isinstance(self.token_endpoint_auth, TokenEndpointAuthNone):
+            token_endpoint_auth = self.token_endpoint_auth.to_dict()
+        elif isinstance(self.token_endpoint_auth, TokenEndpointAuthBasic):
+            token_endpoint_auth = self.token_endpoint_auth.to_dict()
+        elif isinstance(self.token_endpoint_auth, TokenEndpointAuthPost):
+            token_endpoint_auth = self.token_endpoint_auth.to_dict()
+        else:
+            token_endpoint_auth = self.token_endpoint_auth
+
+        scope: None | str | Unset
+        if isinstance(self.scope, Unset):
+            scope = UNSET
+        else:
+            scope = self.scope
+
+        resource: None | str | Unset
+        if isinstance(self.resource, Unset):
+            resource = UNSET
+        else:
+            resource = self.resource
+
+        token: None | str | Unset
+        if isinstance(self.token, Unset):
+            token = UNSET
+        else:
+            token = self.token
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if display_name is not UNSET:
+            field_dict["display_name"] = display_name
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if access_token is not UNSET:
+            field_dict["access_token"] = access_token
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
+        if client_id is not UNSET:
+            field_dict["client_id"] = client_id
+        if refresh_token is not UNSET:
+            field_dict["refresh_token"] = refresh_token
+        if token_endpoint is not UNSET:
+            field_dict["token_endpoint"] = token_endpoint
+        if token_endpoint_auth is not UNSET:
+            field_dict["token_endpoint_auth"] = token_endpoint_auth
+        if scope is not UNSET:
+            field_dict["scope"] = scope
+        if resource is not UNSET:
+            field_dict["resource"] = resource
+        if token is not UNSET:
+            field_dict["token"] = token
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.token_endpoint_auth_basic import TokenEndpointAuthBasic
+        from ..models.token_endpoint_auth_none import TokenEndpointAuthNone
+        from ..models.token_endpoint_auth_post import TokenEndpointAuthPost
+        from ..models.vault_credential_update_metadata_type_0 import (
+            VaultCredentialUpdateMetadataType0,
+        )
+
+        d = dict(src_dict)
+
+        def _parse_display_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        display_name = _parse_display_name(d.pop("display_name", UNSET))
+
+        def _parse_metadata(
+            data: object,
+        ) -> None | Unset | VaultCredentialUpdateMetadataType0:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = VaultCredentialUpdateMetadataType0.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | VaultCredentialUpdateMetadataType0, data)
+
+        metadata = _parse_metadata(d.pop("metadata", UNSET))
+
+        def _parse_access_token(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        access_token = _parse_access_token(d.pop("access_token", UNSET))
+
+        def _parse_expires_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                expires_at_type_0 = isoparse(data)
+
+                return expires_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
+
+        def _parse_client_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        client_id = _parse_client_id(d.pop("client_id", UNSET))
+
+        def _parse_refresh_token(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        refresh_token = _parse_refresh_token(d.pop("refresh_token", UNSET))
+
+        def _parse_token_endpoint(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        token_endpoint = _parse_token_endpoint(d.pop("token_endpoint", UNSET))
+
+        def _parse_token_endpoint_auth(
+            data: object,
+        ) -> (
+            None
+            | TokenEndpointAuthBasic
+            | TokenEndpointAuthNone
+            | TokenEndpointAuthPost
+            | Unset
+        ):
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                token_endpoint_auth_type_0_type_0 = TokenEndpointAuthNone.from_dict(
+                    data
+                )
+
+                return token_endpoint_auth_type_0_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                token_endpoint_auth_type_0_type_1 = TokenEndpointAuthBasic.from_dict(
+                    data
+                )
+
+                return token_endpoint_auth_type_0_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                token_endpoint_auth_type_0_type_2 = TokenEndpointAuthPost.from_dict(
+                    data
+                )
+
+                return token_endpoint_auth_type_0_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                None
+                | TokenEndpointAuthBasic
+                | TokenEndpointAuthNone
+                | TokenEndpointAuthPost
+                | Unset,
+                data,
+            )
+
+        token_endpoint_auth = _parse_token_endpoint_auth(
+            d.pop("token_endpoint_auth", UNSET)
+        )
+
+        def _parse_scope(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        scope = _parse_scope(d.pop("scope", UNSET))
+
+        def _parse_resource(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        resource = _parse_resource(d.pop("resource", UNSET))
+
+        def _parse_token(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        token = _parse_token(d.pop("token", UNSET))
+
+        vault_credential_update = cls(
+            display_name=display_name,
+            metadata=metadata,
+            access_token=access_token,
+            expires_at=expires_at,
+            client_id=client_id,
+            refresh_token=refresh_token,
+            token_endpoint=token_endpoint,
+            token_endpoint_auth=token_endpoint_auth,
+            scope=scope,
+            resource=resource,
+            token=token,
+        )
+
+        return vault_credential_update

--- a/src/aios/sdk/_generated/models/vault_credential_update_metadata_type_0.py
+++ b/src/aios/sdk/_generated/models/vault_credential_update_metadata_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="VaultCredentialUpdateMetadataType0")
+
+
+@_attrs_define
+class VaultCredentialUpdateMetadataType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        vault_credential_update_metadata_type_0 = cls()
+
+        vault_credential_update_metadata_type_0.additional_properties = d
+        return vault_credential_update_metadata_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/vault_metadata.py
+++ b/src/aios/sdk/_generated/models/vault_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="VaultMetadata")
+
+
+@_attrs_define
+class VaultMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        vault_metadata = cls()
+
+        vault_metadata.additional_properties = d
+        return vault_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/vault_update.py
+++ b/src/aios/sdk/_generated/models/vault_update.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.vault_update_metadata_type_0 import VaultUpdateMetadataType0
+
+
+T = TypeVar("T", bound="VaultUpdate")
+
+
+@_attrs_define
+class VaultUpdate:
+    """Request body for ``PUT /v1/vaults/{vault_id}``.
+
+    Attributes:
+        display_name (None | str | Unset):
+        metadata (None | Unset | VaultUpdateMetadataType0):
+    """
+
+    display_name: None | str | Unset = UNSET
+    metadata: None | Unset | VaultUpdateMetadataType0 = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.vault_update_metadata_type_0 import VaultUpdateMetadataType0
+
+        display_name: None | str | Unset
+        if isinstance(self.display_name, Unset):
+            display_name = UNSET
+        else:
+            display_name = self.display_name
+
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, VaultUpdateMetadataType0):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if display_name is not UNSET:
+            field_dict["display_name"] = display_name
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.vault_update_metadata_type_0 import VaultUpdateMetadataType0
+
+        d = dict(src_dict)
+
+        def _parse_display_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        display_name = _parse_display_name(d.pop("display_name", UNSET))
+
+        def _parse_metadata(data: object) -> None | Unset | VaultUpdateMetadataType0:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = VaultUpdateMetadataType0.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | VaultUpdateMetadataType0, data)
+
+        metadata = _parse_metadata(d.pop("metadata", UNSET))
+
+        vault_update = cls(
+            display_name=display_name,
+            metadata=metadata,
+        )
+
+        return vault_update

--- a/src/aios/sdk/_generated/models/vault_update_metadata_type_0.py
+++ b/src/aios/sdk/_generated/models/vault_update_metadata_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="VaultUpdateMetadataType0")
+
+
+@_attrs_define
+class VaultUpdateMetadataType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        vault_update_metadata_type_0 = cls()
+
+        vault_update_metadata_type_0.additional_properties = d
+        return vault_update_metadata_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/wait_response.py
+++ b/src/aios/sdk/_generated/models/wait_response.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.wait_response_session_status import WaitResponseSessionStatus
+
+if TYPE_CHECKING:
+    from ..models.event import Event
+    from ..models.wait_response_session_stop_reason_type_0 import (
+        WaitResponseSessionStopReasonType0,
+    )
+
+
+T = TypeVar("T", bound="WaitResponse")
+
+
+@_attrs_define
+class WaitResponse:
+    """Response for ``GET /v1/sessions/{id}/wait``.
+
+    Attributes:
+        events (list[Event]):
+        session_status (WaitResponseSessionStatus):
+        session_stop_reason (None | WaitResponseSessionStopReasonType0):
+        next_after (int):
+    """
+
+    events: list[Event]
+    session_status: WaitResponseSessionStatus
+    session_stop_reason: None | WaitResponseSessionStopReasonType0
+    next_after: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.wait_response_session_stop_reason_type_0 import (
+            WaitResponseSessionStopReasonType0,
+        )
+
+        events = []
+        for events_item_data in self.events:
+            events_item = events_item_data.to_dict()
+            events.append(events_item)
+
+        session_status = self.session_status.value
+
+        session_stop_reason: dict[str, Any] | None
+        if isinstance(self.session_stop_reason, WaitResponseSessionStopReasonType0):
+            session_stop_reason = self.session_stop_reason.to_dict()
+        else:
+            session_stop_reason = self.session_stop_reason
+
+        next_after = self.next_after
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "events": events,
+                "session_status": session_status,
+                "session_stop_reason": session_stop_reason,
+                "next_after": next_after,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.event import Event
+        from ..models.wait_response_session_stop_reason_type_0 import (
+            WaitResponseSessionStopReasonType0,
+        )
+
+        d = dict(src_dict)
+        events = []
+        _events = d.pop("events")
+        for events_item_data in _events:
+            events_item = Event.from_dict(events_item_data)
+
+            events.append(events_item)
+
+        session_status = WaitResponseSessionStatus(d.pop("session_status"))
+
+        def _parse_session_stop_reason(
+            data: object,
+        ) -> None | WaitResponseSessionStopReasonType0:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                session_stop_reason_type_0 = (
+                    WaitResponseSessionStopReasonType0.from_dict(data)
+                )
+
+                return session_stop_reason_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | WaitResponseSessionStopReasonType0, data)
+
+        session_stop_reason = _parse_session_stop_reason(d.pop("session_stop_reason"))
+
+        next_after = d.pop("next_after")
+
+        wait_response = cls(
+            events=events,
+            session_status=session_status,
+            session_stop_reason=session_stop_reason,
+            next_after=next_after,
+        )
+
+        wait_response.additional_properties = d
+        return wait_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/wait_response_session_status.py
+++ b/src/aios/sdk/_generated/models/wait_response_session_status.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class WaitResponseSessionStatus(str, Enum):
+    IDLE = "idle"
+    PENDING = "pending"
+    RESCHEDULING = "rescheduling"
+    RUNNING = "running"
+    TERMINATED = "terminated"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/sdk/_generated/models/wait_response_session_stop_reason_type_0.py
+++ b/src/aios/sdk/_generated/models/wait_response_session_stop_reason_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="WaitResponseSessionStopReasonType0")
+
+
+@_attrs_define
+class WaitResponseSessionStopReasonType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        wait_response_session_stop_reason_type_0 = cls()
+
+        wait_response_session_stop_reason_type_0.additional_properties = d
+        return wait_response_session_stop_reason_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/types.py
+++ b/src/aios/sdk/_generated/types.py
@@ -1,0 +1,54 @@
+"""Contains some shared types for properties"""
+
+from collections.abc import Mapping, MutableMapping
+from http import HTTPStatus
+from typing import IO, BinaryIO, Generic, Literal, TypeVar
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = IO[bytes] | bytes | str
+FileTypes = (
+    # (filename, file (or bytes), content_type)
+    tuple[str | None, FileContent, str | None]
+    # (filename, file (or bytes), content_type, headers)
+    | tuple[str | None, FileContent, str | None, Mapping[str, str]]
+)
+RequestFiles = list[tuple[str, FileTypes]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: str | None = None
+    mime_type: str | None = None
+
+    def to_tuple(self) -> FileTypes:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: T | None
+
+
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/src/aios/sdk/config.py
+++ b/src/aios/sdk/config.py
@@ -1,0 +1,21 @@
+"""SDK-level configuration helpers — env-resolution rules shared with the CLI."""
+
+from __future__ import annotations
+
+import os
+
+
+def resolve_base_url(override: str | None = None) -> str:
+    """Pick the effective API base URL.
+
+    Priority: explicit override > ``AIOS_URL`` env > ``http://127.0.0.1:{AIOS_API_PORT}``.
+    The last fallback mirrors the playground pattern where the operator sets
+    ``AIOS_API_PORT`` (e.g. 8090) but never ``AIOS_URL`` explicitly.
+    """
+    if override is not None:
+        return override.rstrip("/")
+    env_url = os.environ.get("AIOS_URL")
+    if env_url:
+        return env_url.rstrip("/")
+    port = os.environ.get("AIOS_API_PORT", "8080")
+    return f"http://127.0.0.1:{port}"

--- a/src/aios/sdk/factory.py
+++ b/src/aios/sdk/factory.py
@@ -4,21 +4,24 @@ from __future__ import annotations
 
 import os
 
-from aios.cli.config import resolve_base_url
 from aios.sdk._generated import AuthenticatedClient
+from aios.sdk.config import resolve_base_url
 
 
 def client_from_env() -> AuthenticatedClient:
     """Build a Client from ``AIOS_URL`` (or ``AIOS_API_PORT``) and ``AIOS_API_KEY``.
 
     URL resolution mirrors the CLI: explicit env > ``http://127.0.0.1:{AIOS_API_PORT}``
-    > ``http://127.0.0.1:8080``. Reuses
-    :func:`aios.cli.config.resolve_base_url` so CLI and SDK never disagree
-    about the resolved base URL.
+    > ``http://127.0.0.1:8080``. The SDK and the CLI share
+    :func:`aios.sdk.config.resolve_base_url` so they never disagree about
+    the resolved base URL.
 
     Raises ``RuntimeError`` if ``AIOS_API_KEY`` isn't set — the SDK uses
     Bearer auth on every endpoint, so an unset key is operator error rather
-    than a usable default.
+    than a usable default. (The CLI's ``CliState.sdk_client()`` accepts an
+    unset key on purpose — the ``aios status`` command needs to probe an
+    unauthenticated ``/health`` endpoint and report auth-key state. Plugins
+    and scripts have no equivalent need.)
     """
     api_key = os.environ.get("AIOS_API_KEY")
     if not api_key:
@@ -26,4 +29,4 @@ def client_from_env() -> AuthenticatedClient:
             "AIOS_API_KEY is not set. Export it, or pass token=... to "
             "AuthenticatedClient(...) directly."
         )
-    return AuthenticatedClient(base_url=resolve_base_url(None), token=api_key)
+    return AuthenticatedClient(base_url=resolve_base_url(), token=api_key)

--- a/src/aios/sdk/factory.py
+++ b/src/aios/sdk/factory.py
@@ -1,0 +1,29 @@
+"""Convenience constructors for the aios SDK Client."""
+
+from __future__ import annotations
+
+import os
+
+from aios.cli.config import resolve_base_url
+from aios.sdk._generated import AuthenticatedClient
+
+
+def client_from_env() -> AuthenticatedClient:
+    """Build a Client from ``AIOS_URL`` (or ``AIOS_API_PORT``) and ``AIOS_API_KEY``.
+
+    URL resolution mirrors the CLI: explicit env > ``http://127.0.0.1:{AIOS_API_PORT}``
+    > ``http://127.0.0.1:8080``. Reuses
+    :func:`aios.cli.config.resolve_base_url` so CLI and SDK never disagree
+    about the resolved base URL.
+
+    Raises ``RuntimeError`` if ``AIOS_API_KEY`` isn't set — the SDK uses
+    Bearer auth on every endpoint, so an unset key is operator error rather
+    than a usable default.
+    """
+    api_key = os.environ.get("AIOS_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "AIOS_API_KEY is not set. Export it, or pass token=... to "
+            "AuthenticatedClient(...) directly."
+        )
+    return AuthenticatedClient(base_url=resolve_base_url(None), token=api_key)

--- a/src/aios/sdk/streaming.py
+++ b/src/aios/sdk/streaming.py
@@ -1,0 +1,97 @@
+"""Hand-written SSE consumer for the aios session-event stream.
+
+The generated SDK at ``aios.sdk._generated`` covers JSON request/response
+operations only — the session-event stream endpoint
+(``GET /v1/sessions/{id}/stream``) is annotated
+``x-codegen.targets: []`` because Server-Sent Events don't fit
+``openapi-python-client``'s response-shape model. This module provides
+the streaming surface as a companion to the generated client.
+
+Three event names are emitted on the wire:
+
+* ``event``  — a full event row (``{"id","session_id","seq","kind","data",...}``)
+* ``delta``  — a streaming text chunk for an in-progress assistant message
+  (``{"delta": "..."}``)
+* ``done``   — session-terminated marker; stream will close after this
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+import httpx
+
+from aios.sdk._generated import AuthenticatedClient
+
+
+@dataclass(frozen=True, slots=True)
+class SseMessage:
+    """A single parsed SSE message."""
+
+    event: str
+    data: str
+
+
+@contextmanager
+def stream_session(
+    client: AuthenticatedClient,
+    session_id: str,
+    *,
+    after_seq: int = 0,
+) -> Iterator[Iterator[SseMessage]]:
+    """Stream events for a session as :class:`SseMessage` values.
+
+    Used as a context manager so the underlying HTTP connection closes when
+    iteration ends. The yielded iterator is consumed lazily.
+
+    Auth is taken from the SDK client (the underlying ``httpx.Client``
+    already carries the Bearer token in its default headers). Read
+    timeout is unbounded — the stream can sit idle waiting for the next
+    event without tripping a client-side timeout.
+    """
+    params: dict[str, int] = {"after_seq": after_seq} if after_seq else {}
+    httpx_client = client.get_httpx_client()
+    with httpx_client.stream(
+        "GET",
+        f"/v1/sessions/{session_id}/stream",
+        params=params,
+        headers={"Accept": "text/event-stream"},
+        timeout=httpx.Timeout(60.0, read=None),
+    ) as response:
+        response.raise_for_status()
+        yield parse_sse_lines(response.iter_lines())
+
+
+def parse_sse_lines(lines: Iterable[str]) -> Iterator[SseMessage]:
+    """Yield :class:`SseMessage` values from an SSE line iterator.
+
+    ``lines`` is expected to be individual lines WITHOUT trailing newlines
+    (what ``httpx.Response.iter_lines()`` produces). A blank line closes
+    the current message. Missing ``event:`` defaults to ``"message"`` per
+    the SSE spec, but aios always sets it explicitly.
+    """
+    event: str = "message"
+    data_parts: list[str] = []
+
+    for raw in lines:
+        if raw == "":
+            if data_parts:
+                yield SseMessage(event=event, data="\n".join(data_parts))
+            event = "message"
+            data_parts = []
+            continue
+        if raw.startswith(":"):
+            # Comment / keep-alive ping.
+            continue
+        field, _, value = raw.partition(":")
+        if value.startswith(" "):
+            value = value[1:]
+        if field == "event":
+            event = value
+        elif field == "data":
+            data_parts.append(value)
+
+    if data_parts:
+        yield SseMessage(event=event, data="\n".join(data_parts))

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -14,6 +14,7 @@ import pytest
 
 from aios.cli.client import AiosClient
 from aios.cli.runtime import CliState
+from aios.sdk import Client as SdkClient
 
 
 @dataclass
@@ -84,7 +85,15 @@ def mocked_cli(monkeypatch: pytest.MonkeyPatch) -> MockedCli:
             transport=httpx.MockTransport(handler),
         )
 
+    def _sdk_client(self: CliState) -> SdkClient:
+        client = SdkClient(base_url=self.base_url, token=self.api_key or "")
+        client.set_httpx_client(
+            httpx.Client(base_url=self.base_url, transport=httpx.MockTransport(handler))
+        )
+        return client
+
     monkeypatch.setattr(CliState, "client", _client)
+    monkeypatch.setattr(CliState, "sdk_client", _sdk_client)
     monkeypatch.setenv("AIOS_API_KEY", "test-key")
     monkeypatch.setenv("AIOS_URL", "http://test.invalid")
     return MockedCli(captured=captured, response_queue=responses)

--- a/tests/unit/test_sdk_smoke.py
+++ b/tests/unit/test_sdk_smoke.py
@@ -1,0 +1,78 @@
+"""Smoke checks for the typed Python SDK.
+
+Verifies the curated public surface imports cleanly, the generated
+``Client`` constructs, and a representative operation can be invoked
+against an httpx ``MockTransport``. The deeper coverage lives in the
+generated tree itself (openapi-python-client emits typed signatures
+that mypy already validates) — this file is the boundary check.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+
+def test_curated_public_surface_imports() -> None:
+    from aios.sdk import (
+        Client,
+        SseMessage,
+        UnexpectedStatus,
+        client_from_env,
+        parse_sse_lines,
+        stream_session,
+    )
+
+    assert Client.__name__ == "AuthenticatedClient"
+    assert callable(client_from_env)
+    assert callable(stream_session)
+    assert callable(parse_sse_lines)
+    assert SseMessage(event="x", data="y").event == "x"
+    assert issubclass(UnexpectedStatus, Exception)
+
+
+def test_client_constructs_with_base_url_and_token() -> None:
+    from aios.sdk import Client
+
+    client = Client(base_url="http://example.test", token="t")
+    assert client._base_url == "http://example.test"
+    assert client.token == "t"
+
+
+def test_get_health_operation_against_mocked_transport() -> None:
+    from aios.sdk import Client
+    from aios.sdk._generated.api.default import get_health
+
+    payload = {"status": "ok", "version": "0.1.0"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/health"
+        return httpx.Response(200, json=payload)
+
+    client = Client(base_url="http://test", token="t")
+    client.set_httpx_client(
+        httpx.Client(base_url="http://test", transport=httpx.MockTransport(handler))
+    )
+    response = get_health.sync_detailed(client=client)
+    assert response.status_code == 200
+    assert json.loads(response.content) == payload
+
+
+def test_client_from_env_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aios.sdk import client_from_env
+
+    monkeypatch.delenv("AIOS_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="AIOS_API_KEY"):
+        client_from_env()
+
+
+def test_client_from_env_succeeds_when_api_key_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aios.sdk import client_from_env
+
+    monkeypatch.setenv("AIOS_API_KEY", "test-key")
+    monkeypatch.setenv("AIOS_URL", "http://example.test")
+    client = client_from_env()
+    assert client._base_url == "http://example.test"
+    assert client.token == "test-key"

--- a/uv.lock
+++ b/uv.lock
@@ -136,6 +136,7 @@ dev = [
     { name = "aios-echo" },
     { name = "httpx" },
     { name = "mypy" },
+    { name = "openapi-python-client" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -172,6 +173,7 @@ dev = [
     { name = "aios-echo", editable = "packages/aios-echo" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", specifier = ">=1.13" },
+    { name = "openapi-python-client", specifier = ">=0.21" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-mock", specifier = ">=3.14" },
@@ -1409,6 +1411,27 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-python-client"
+version = "0.28.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "ruamel-yaml" },
+    { name = "ruff" },
+    { name = "shellingham" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/3c/03b6a9f8a056c748e151d3ff9dbc78236051fb7f8d48129aa19dce239e7b/openapi_python_client-0.28.3.tar.gz", hash = "sha256:c443df7cabf7d260feddb21626c0ff7bd83f5747453d10164f7c88d98e89c3d7", size = 125957, upload-time = "2026-03-05T23:45:13.043Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/a0/99db160a52ee98302c9e231d33afce350386eb2b6ee21de2b329f7bd4286/openapi_python_client-0.28.3-py3-none-any.whl", hash = "sha256:fbb29976a3d0fcea2822fdd7504b7437825dd4f075f2412dd234882c4a56d469", size = 183193, upload-time = "2026-03-05T23:45:11.458Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2050,6 +2073,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
     { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
     { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase C of [#267](https://github.com/eumemic/aios/issues/267) — generate the typed Python SDK from the committed `openapi.json` and start migrating the porcelain CLI to consume it.

This PR ships the SDK substrate and migrates the porcelain modules whose endpoints have stable operationIds. `chat.py` and the `events` subcommand are deferred (they touch sessions ops still carrying FastAPI's auto-derived names; will migrate post-[#270](https://github.com/eumemic/aios/issues/270) when sessions.py Phase A unblocks).

## Three commits, in order

1. **`fix(api): collapse Pydantic Input/Output schema split`** — `separate_input_output_schemas=False` on the FastAPI app. The hyphenated `Foo-Input` / `Foo-Output` schema names break `openapi-python-client`'s reference resolver. aios uses distinct `Foo` / `FooCreate` / `FooUpdate` types instead, so the collapse is safe.

2. **`feat(sdk): generate typed Python SDK from openapi.json`** — adds `scripts/regen-client.sh` (mirrors ant-proxy's pattern), the generated `src/aios/sdk/_generated/` tree (committed verbatim, excluded from ruff/mypy), the hand-written companions (`streaming.py` for SSE, `factory.py` for `client_from_env`), and the curated `__init__.py` public surface. `cli/sse.py` becomes a thin re-export shim. Smoke test in `tests/unit/test_sdk_smoke.py`.

3. **`refactor(cli): port status + sessions stream/tail onto the typed SDK`** — `status.py`, the `stream` and `tail` subcommands of `sessions.py`, and the new `CliState.sdk_client()` helper.

## Public SDK surface

```python
from aios.sdk import (
    Client,                 # AuthenticatedClient
    UnexpectedStatus,
    SseMessage,
    stream_session,         # SSE consumer (hand-written)
    client_from_env,        # convenience constructor for plugins/scripts
)
```

Plugin authors / advanced callers reach into `aios.sdk._generated.api.<tag>.<op>` directly for specific operations.

## Out of scope (deferred)

- **`chat.py`** — 4 sessions ops with auto-derived operationIds (`create_v1_sessions_post` etc.); refactor will be a single find-and-replace post-#270.
- **`sessions.py` `events` subcommand** — same reason.
- **9 hand-written CRUD modules** (`agents`, `connections`, `connectors`, `envs`, `session_templates`, `sessions` CRUD, `skills`, `vaults`, `ops`) — wait for the deferred `plumbing CLI: generate or hand-write?` decision in #267.
- **`cli/client.py` removal** — stays as long as anything in `cli/commands/` uses it.
- **CI drift check on `_generated/`** — skipping. ant-proxy doesn't have one; drift becomes obvious quickly when openapi.json changes don't propagate.
- **Per-tool MCP annotations** (`destructiveHint` etc.) — separate Phase D follow-up.

## Test plan

- [x] `bash scripts/regen-client.sh` produces `_generated/` cleanly (~250 .py files); idempotent at HEAD
- [x] `bash scripts/run-checks.sh` clean — mypy + ruff + 1170 unit tests pass
- [x] New `test_sdk_smoke.py` covers public-surface imports, `Client` construction, an end-to-end operation against `MockTransport`, and `client_from_env` env-var resolution
- [x] Existing status / vaults / sessions / connections CLI tests still pass — both `CliState.client` and `CliState.sdk_client` are patched against the same `MockTransport` in `conftest.py`
- [ ] Manual smoke against a live aios instance (operator):
  - `uv run aios status` — connects, auth check passes
  - `uv run aios status` against bad URL → `non_json_response` preserved
  - `uv run aios sessions stream <id>` / `aios tail <id>` — streams events
  - Existing `aios chat` still works (still on `cli/client.py`)

## Looking ahead

- Per-tool MCP annotations follow-up (small Phase D follow-up; observe what fastapi-mcp infers by default, override only where wrong)
- Once #270 lands and sessions.py gets clean operationIds: regen the SDK, migrate `chat.py` + `events` subcommand
- The deferred `plumbing CLI: generate or hand-write?` decision can finally be made with the SDK substrate visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)