### PR TITLE
fix(deps): aios-connector is a runtime dep, not dev-only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dependencies = [
     "typer>=0.12",
     # Observability
     "structlog>=24.4",
+    # Connector SDK — imported unconditionally by harness/connector_supervisor.py
+    # at module load (whether or not any connectors are enabled), so it has to
+    # be a runtime dep rather than a dev-only workspace install.
+    "aios-connector",
 ]
 
 [dependency-groups]
@@ -49,11 +53,10 @@ dev = [
     "ruff>=0.8",
     "mypy>=1.13",
     "openapi-python-client>=0.21",
-    # Workspace-installed reference SDK + canonical echo example.  The
-    # echo connector exposes the ``aios.connectors`` entry point the
-    # supervisor's resolver looks up, so e2e tests exercising the full
-    # discovery → spawn → init pipeline can run.
-    "aios-connector",
+    # Canonical echo connector. Exposes the ``aios.connectors`` entry point
+    # the supervisor's resolver looks up, so e2e tests exercising the full
+    # discovery → spawn → init pipeline can run. Only needed in dev/test;
+    # production uses real connectors (signal, telegram, ...).
     "aios-echo",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -110,6 +110,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodocker" },
+    { name = "aios-connector" },
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "fastapi" },
@@ -132,7 +133,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "aios-connector" },
     { name = "aios-echo" },
     { name = "httpx" },
     { name = "mypy" },
@@ -147,6 +147,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiodocker", specifier = ">=0.23" },
+    { name = "aios-connector", editable = "packages/aios-connector" },
     { name = "alembic", specifier = ">=1.13" },
     { name = "asyncpg", specifier = ">=0.30" },
     { name = "fastapi", specifier = ">=0.115" },
@@ -169,7 +170,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aios-connector", editable = "packages/aios-connector" },
     { name = "aios-echo", editable = "packages/aios-echo" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", specifier = ">=1.13" },


### PR DESCRIPTION
## Summary
Move \`aios-connector\` from \`[dependency-groups.dev]\` to \`[project.dependencies]\` because \`harness/connector_supervisor.py:96\` imports it unconditionally at module load — every worker startup needs it, not just dev/test runs.

## What broke
First worker deploy on Server B (Coolify on Hetzner HIL) crashed at startup:

\`\`\`
File "/app/src/aios/harness/worker.py", line 44, in <module>
    from aios.harness.connector_supervisor import (
File "/app/src/aios/harness/connector_supervisor.py", line 96, in <module>
    from aios_connector import ConnectorSpec
ModuleNotFoundError: No module named 'aios_connector'
\`\`\`

The api process didn't crash because it never imports \`connector_supervisor\`; only the worker does.

## Why this came up now
PR #276 added the worker Dockerfile stage built with \`uv sync --frozen --no-dev\`. \`aios-connector\` being dev-only made the runtime import fail in the production image.

## Test plan
- [x] \`uv lock\` clean (just shifts \`aios-connector\` between groups, dependency tree unchanged)
- [x] \`uv run mypy src\` — Success
- [x] \`uv run ruff check src tests\` — All checks passed
- [x] \`uv run pytest tests/unit -q\` — 1153 passed
- [ ] After merge: Coolify webhook redeploys api + worker; worker starts cleanly. Verifying as part of the active aios deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)