### PR TITLE
fix(deploy): HEALTHCHECK NONE on worker stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,13 @@ CMD ["aios", "api"]
 # Docker, not Docker-in-Docker.
 FROM base AS worker
 
+# Explicitly disable the parent image's healthcheck inheritance. The base
+# stage has no HEALTHCHECK, but Coolify parses the Dockerfile text and
+# treats the api stage's HEALTHCHECK as global, then waits for
+# `.State.Health` on the worker container too. Without this NONE the
+# wait fails with "map has no entry for key Health" on every deploy.
+HEALTHCHECK NONE
+
 USER root
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Coolify treats the api stage's HEALTHCHECK as global; the worker deploy fails on every attempt with `map has no entry for key "Health"` because there's no health to inspect on the worker container. Explicit `HEALTHCHECK NONE` on the worker stage disambiguates.

Caught during Server B bring-up. Sequel to #280, #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)