### PR TITLE
refactor(cli): port CRUD commands to consume the typed SDK (#267)

### DIFF
--- a/src/aios/cli/commands/_shared.py
+++ b/src/aios/cli/commands/_shared.py
@@ -1,14 +1,10 @@
-"""Helpers shared by every resource subcommand.
-
-Keeps the per-resource files tiny — they mostly declare columns and call
-the helpers here.
-"""
+"""Helpers shared by every resource subcommand."""
 
 from __future__ import annotations
 
 import json
 from collections.abc import Callable, Sequence
-from typing import Any, Protocol
+from typing import Any
 
 import typer
 from pydantic import ValidationError
@@ -17,7 +13,6 @@ from aios.cli.client import AiosApiError, AiosClient
 from aios.cli.output import OutputFormat, print_json, print_note, print_table
 from aios.cli.runtime import CliState, get_state
 from aios.models.common import ErrorResponse
-from aios.sdk import Client
 from aios.sdk._generated.types import Response, Unset
 
 
@@ -100,30 +95,8 @@ def fetch_all(
     return {"data": accumulated, "has_more": False, "next_after": None}
 
 
-class _ListPage(Protocol):
-    """Structural shape of every generated ``ListResponse<T>`` model."""
-
-    data: list[Any]
-    has_more: bool | Unset
-    next_after: None | str | Unset
-
-
 def unwrap(response: Response[Any]) -> Any:
-    """Translate an SDK ``Response`` into its parsed body or :class:`AiosApiError`.
-
-    Mirrors :meth:`AiosClient.request`: 2xx returns the parsed body (or
-    ``None`` for 204); non-2xx is decoded against the server's
-    ``ErrorResponse`` envelope and re-raised so ``run_or_die`` can render
-    the same friendly message regardless of whether the call went through
-    the hand-written client or the typed SDK.
-
-    Returns ``Any`` rather than the caller's ``T`` because the SDK's
-    ``Response[T]`` runs through ``attrs.define + Generic[T]``, a combo
-    mypy widens to ``Any`` anyway — preserving the generic in the helper
-    signature would be theatre. Callers that want the typed view assign
-    the result through a typed local (e.g. ``page: ListResponseAgent =
-    unwrap(...)``).
-    """
+    """2xx → parsed body (``None`` for 204); non-2xx → :class:`AiosApiError`."""
     status = int(response.status_code)
     if 200 <= status < 300:
         return response.parsed
@@ -151,55 +124,49 @@ def unwrap(response: Response[Any]) -> Any:
     )
 
 
-def fetch_all_sdk(
+def render_paginated(
+    ctx: typer.Context,
     fn: Callable[..., Response[Any]],
     *,
-    client: Client,
+    columns: Sequence[str],
+    all_: bool,
+    limit: int = 50,
+    after: Any = None,
+    max_widths: dict[str, int] | None = None,
     page_size: int = 200,
     **filters: Any,
-) -> list[Any]:
-    """Walk every page of an SDK list endpoint. Returns the accumulated typed items.
-
-    Mirrors :func:`fetch_all` for the SDK path: caller hands in the
-    operation module's ``sync_detailed``, this walker drives the cursor.
-    Filters pass through verbatim, so caller-side typing is preserved.
-    """
-    accumulated: list[Any] = []
-    cursor: str | None = None
-    while True:
-        kwargs: dict[str, Any] = dict(filters)
-        kwargs["limit"] = page_size
-        if cursor is not None:
-            kwargs["after"] = cursor
-        page: _ListPage = unwrap(fn(client=client, **kwargs))
-        accumulated.extend(page.data)
-        if isinstance(page.has_more, Unset) or not page.has_more:
-            break
-        if isinstance(page.next_after, Unset) or page.next_after is None:
-            break
-        cursor = page.next_after
-    return accumulated
-
-
-def render_sdk_list(
-    output_format: OutputFormat,
-    items: list[Any],
-    *,
-    columns: Sequence[str],
-    headers: Sequence[str] | None = None,
-    max_widths: dict[str, int] | None = None,
-    has_more: bool = False,
-    next_after: str | None = None,
 ) -> None:
-    """Render a list of typed SDK models. Models are dict-converted at the boundary.
+    """Render an SDK list endpoint, paginated or fully fetched per ``all_``.
 
-    The renderer below already speaks dicts; this is the join point where
-    SDK types lose their attribute-access affordance — acceptable since the
-    CLI only displays the values, never reads specific fields.
+    Single entry point used by every ``aios <resource> list`` command:
+    opens an SDK client, walks pages when ``all_`` is True (or fetches one
+    page otherwise), then renders through :func:`render_list`.
     """
-    rows = [item.to_dict() for item in items]
-    envelope = {"data": rows, "has_more": has_more, "next_after": next_after}
-    render_list(output_format, envelope, columns=columns, headers=headers, max_widths=max_widths)
+    state = get_state(ctx)
+    with state.sdk_client() as client:
+        if all_:
+            items: list[Any] = []
+            cursor: str | None = None
+            while True:
+                kwargs: dict[str, Any] = {**filters, "limit": page_size}
+                if cursor is not None:
+                    kwargs["after"] = cursor
+                page = unwrap(fn(client=client, **kwargs))
+                items.extend(page.data)
+                if isinstance(page.has_more, Unset) or not page.has_more:
+                    break
+                if isinstance(page.next_after, Unset) or page.next_after is None:
+                    break
+                cursor = page.next_after
+            envelope: dict[str, Any] = {
+                "data": [item.to_dict() for item in items],
+                "has_more": False,
+                "next_after": None,
+            }
+        else:
+            page = unwrap(fn(client=client, limit=limit, after=after, **filters))
+            envelope = page.to_dict()
+    render_list(state.output_format, envelope, columns=columns, max_widths=max_widths)
 
 
 def fetch_all_events(

--- a/src/aios/cli/commands/_shared.py
+++ b/src/aios/cli/commands/_shared.py
@@ -6,14 +6,19 @@ the helpers here.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any
+import json
+from collections.abc import Callable, Sequence
+from typing import Any, Protocol
 
 import typer
+from pydantic import ValidationError
 
-from aios.cli.client import AiosClient
+from aios.cli.client import AiosApiError, AiosClient
 from aios.cli.output import OutputFormat, print_json, print_note, print_table
 from aios.cli.runtime import CliState, get_state
+from aios.models.common import ErrorResponse
+from aios.sdk import Client
+from aios.sdk._generated.types import Response, Unset
 
 
 def with_client(ctx: typer.Context) -> tuple[CliState, AiosClient]:
@@ -93,6 +98,108 @@ def fetch_all(
         if cursor is None:
             break
     return {"data": accumulated, "has_more": False, "next_after": None}
+
+
+class _ListPage(Protocol):
+    """Structural shape of every generated ``ListResponse<T>`` model."""
+
+    data: list[Any]
+    has_more: bool | Unset
+    next_after: None | str | Unset
+
+
+def unwrap(response: Response[Any]) -> Any:
+    """Translate an SDK ``Response`` into its parsed body or :class:`AiosApiError`.
+
+    Mirrors :meth:`AiosClient.request`: 2xx returns the parsed body (or
+    ``None`` for 204); non-2xx is decoded against the server's
+    ``ErrorResponse`` envelope and re-raised so ``run_or_die`` can render
+    the same friendly message regardless of whether the call went through
+    the hand-written client or the typed SDK.
+
+    Returns ``Any`` rather than the caller's ``T`` because the SDK's
+    ``Response[T]`` runs through ``attrs.define + Generic[T]``, a combo
+    mypy widens to ``Any`` anyway — preserving the generic in the helper
+    signature would be theatre. Callers that want the typed view assign
+    the result through a typed local (e.g. ``page: ListResponseAgent =
+    unwrap(...)``).
+    """
+    status = int(response.status_code)
+    if 200 <= status < 300:
+        return response.parsed
+    try:
+        body = json.loads(response.content) if response.content else None
+    except (ValueError, json.JSONDecodeError):
+        body = None
+    if body is None:
+        raise AiosApiError(
+            status_code=status,
+            error_type="http_error",
+            message=response.content.decode(errors="replace") or f"HTTP {status}",
+        )
+    try:
+        envelope = ErrorResponse.model_validate(body)
+    except ValidationError:
+        raise AiosApiError(
+            status_code=status, error_type="http_error", message=json.dumps(body)
+        ) from None
+    raise AiosApiError(
+        status_code=status,
+        error_type=envelope.error.type,
+        message=envelope.error.message,
+        detail=envelope.error.detail,
+    )
+
+
+def fetch_all_sdk(
+    fn: Callable[..., Response[Any]],
+    *,
+    client: Client,
+    page_size: int = 200,
+    **filters: Any,
+) -> list[Any]:
+    """Walk every page of an SDK list endpoint. Returns the accumulated typed items.
+
+    Mirrors :func:`fetch_all` for the SDK path: caller hands in the
+    operation module's ``sync_detailed``, this walker drives the cursor.
+    Filters pass through verbatim, so caller-side typing is preserved.
+    """
+    accumulated: list[Any] = []
+    cursor: str | None = None
+    while True:
+        kwargs: dict[str, Any] = dict(filters)
+        kwargs["limit"] = page_size
+        if cursor is not None:
+            kwargs["after"] = cursor
+        page: _ListPage = unwrap(fn(client=client, **kwargs))
+        accumulated.extend(page.data)
+        if isinstance(page.has_more, Unset) or not page.has_more:
+            break
+        if isinstance(page.next_after, Unset) or page.next_after is None:
+            break
+        cursor = page.next_after
+    return accumulated
+
+
+def render_sdk_list(
+    output_format: OutputFormat,
+    items: list[Any],
+    *,
+    columns: Sequence[str],
+    headers: Sequence[str] | None = None,
+    max_widths: dict[str, int] | None = None,
+    has_more: bool = False,
+    next_after: str | None = None,
+) -> None:
+    """Render a list of typed SDK models. Models are dict-converted at the boundary.
+
+    The renderer below already speaks dicts; this is the join point where
+    SDK types lose their attribute-access affordance — acceptable since the
+    CLI only displays the values, never reads specific fields.
+    """
+    rows = [item.to_dict() for item in items]
+    envelope = {"data": rows, "has_more": has_more, "next_after": next_after}
+    render_list(output_format, envelope, columns=columns, headers=headers, max_widths=max_widths)
 
 
 def fetch_all_events(

--- a/src/aios/cli/commands/agents.py
+++ b/src/aios/cli/commands/agents.py
@@ -1,22 +1,39 @@
-"""``aios agents ...`` — CRUD + versions."""
+"""``aios agents ...`` — CRUD + versions.
+
+Hand-written CLI on top of the typed SDK at :mod:`aios.sdk._generated`.
+Each subcommand declares its own typer signature, calls the matching SDK
+operation module, and routes the parsed result through the shared
+renderers.
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 
 from aios.cli.commands._shared import (
-    fetch_all,
-    just_client,
+    fetch_all_sdk,
     render_list,
+    render_sdk_list,
     render_single,
-    with_client,
+    unwrap,
 )
 from aios.cli.files import PayloadError, load_payload
 from aios.cli.output import print_error, print_success
-from aios.cli.runtime import run_or_die
+from aios.cli.runtime import get_state, run_or_die
+from aios.sdk._generated.api.agents import (
+    archive_agent,
+    create_agent,
+    get_agent,
+    get_agent_version,
+    list_agent_versions,
+    list_agents,
+    update_agent,
+)
+from aios.sdk._generated.models.agent_create import AgentCreate
+from aios.sdk._generated.models.agent_update import AgentUpdate
 
 app = typer.Typer(name="agents", help="Manage agents.", no_args_is_help=True)
 
@@ -34,15 +51,14 @@ def list_(
     ] = False,
 ) -> None:
     def _run() -> None:
-        state, client = with_client(ctx)
-        with client:
+        state = get_state(ctx)
+        with state.sdk_client() as client:
             if all_:
-                envelope = fetch_all(client, "/v1/agents")
-            else:
-                envelope = client.request(
-                    "GET", "/v1/agents", params={"limit": limit, "after": after}
-                )
-        render_list(state.output_format, envelope, columns=_COLS, max_widths=_MAXW)
+                items = fetch_all_sdk(list_agents.sync_detailed, client=client)
+                render_sdk_list(state.output_format, items, columns=_COLS, max_widths=_MAXW)
+                return
+            page = unwrap(list_agents.sync_detailed(client=client, limit=limit, after=after))
+            render_list(state.output_format, page.to_dict(), columns=_COLS, max_widths=_MAXW)
 
     run_or_die(_run)
 
@@ -50,10 +66,9 @@ def list_(
 @app.command("get", help="Fetch a single agent by id.")
 def get(ctx: typer.Context, agent_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            agent = client.request("GET", f"/v1/agents/{agent_id}")
-        render_single(agent)
+        with get_state(ctx).sdk_client() as client:
+            agent = unwrap(get_agent.sync_detailed(client=client, agent_id=agent_id))
+        render_single(agent.to_dict())
 
     run_or_die(_run)
 
@@ -71,10 +86,10 @@ def create(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
-        client = just_client(ctx)
-        with client:
-            agent = client.request("POST", "/v1/agents", json_body=payload)
-        render_single(agent)
+        body = AgentCreate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            agent = unwrap(create_agent.sync_detailed(client=client, body=body))
+        render_single(agent.to_dict())
         return None
 
     run_or_die(_run)
@@ -94,10 +109,10 @@ def update(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
-        client = just_client(ctx)
-        with client:
-            agent = client.request("PUT", f"/v1/agents/{agent_id}", json_body=payload)
-        render_single(agent)
+        body = AgentUpdate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            agent = unwrap(update_agent.sync_detailed(client=client, agent_id=agent_id, body=body))
+        render_single(agent.to_dict())
         return None
 
     run_or_die(_run)
@@ -106,9 +121,8 @@ def update(
 @app.command("archive", help="Archive an agent (soft-delete, retained for audit).")
 def archive(ctx: typer.Context, agent_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            client.request("DELETE", f"/v1/agents/{agent_id}")
+        with get_state(ctx).sdk_client() as client:
+            unwrap(archive_agent.sync_detailed(client=client, agent_id=agent_id))
         print_success("archived", agent_id)
 
     run_or_die(_run)
@@ -119,26 +133,27 @@ def versions(
     ctx: typer.Context,
     agent_id: str,
     limit: Annotated[int, typer.Option("--limit", min=1, max=200)] = 50,
-    after: Annotated[str | None, typer.Option("--after")] = None,
+    after: Annotated[int | None, typer.Option("--after")] = None,
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
+    cols = ("version", "model", "created_at")
+    widths = {"model": 40}
+
     def _run() -> None:
-        state, client = with_client(ctx)
-        with client:
+        state = get_state(ctx)
+        with state.sdk_client() as client:
             if all_:
-                envelope = fetch_all(client, f"/v1/agents/{agent_id}/versions")
-            else:
-                envelope = client.request(
-                    "GET",
-                    f"/v1/agents/{agent_id}/versions",
-                    params={"limit": limit, "after": after},
+                items = fetch_all_sdk(
+                    list_agent_versions.sync_detailed, client=client, agent_id=agent_id
                 )
-        render_list(
-            state.output_format,
-            envelope,
-            columns=("version", "model", "created_at"),
-            max_widths={"model": 40},
-        )
+                render_sdk_list(state.output_format, items, columns=cols, max_widths=widths)
+                return
+            page = unwrap(
+                list_agent_versions.sync_detailed(
+                    client=client, agent_id=agent_id, limit=limit, after=after
+                )
+            )
+            render_list(state.output_format, page.to_dict(), columns=cols, max_widths=widths)
 
     run_or_die(_run)
 
@@ -146,9 +161,10 @@ def versions(
 @app.command("version", help="Fetch a specific agent version.")
 def version(ctx: typer.Context, agent_id: str, version: int) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request("GET", f"/v1/agents/{agent_id}/versions/{version}")
-        render_single(obj)
+        with get_state(ctx).sdk_client() as client:
+            obj: Any = unwrap(
+                get_agent_version.sync_detailed(client=client, agent_id=agent_id, version=version)
+            )
+        render_single(obj.to_dict())
 
     run_or_die(_run)

--- a/src/aios/cli/commands/agents.py
+++ b/src/aios/cli/commands/agents.py
@@ -1,10 +1,4 @@
-"""``aios agents ...`` — CRUD + versions.
-
-Hand-written CLI on top of the typed SDK at :mod:`aios.sdk._generated`.
-Each subcommand declares its own typer signature, calls the matching SDK
-operation module, and routes the parsed result through the shared
-renderers.
-"""
+"""``aios agents ...`` — CRUD + versions."""
 
 from __future__ import annotations
 
@@ -13,13 +7,7 @@ from typing import Annotated, Any
 
 import typer
 
-from aios.cli.commands._shared import (
-    fetch_all_sdk,
-    render_list,
-    render_sdk_list,
-    render_single,
-    unwrap,
-)
+from aios.cli.commands._shared import render_paginated, render_single, unwrap
 from aios.cli.files import PayloadError, load_payload
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
@@ -51,14 +39,15 @@ def list_(
     ] = False,
 ) -> None:
     def _run() -> None:
-        state = get_state(ctx)
-        with state.sdk_client() as client:
-            if all_:
-                items = fetch_all_sdk(list_agents.sync_detailed, client=client)
-                render_sdk_list(state.output_format, items, columns=_COLS, max_widths=_MAXW)
-                return
-            page = unwrap(list_agents.sync_detailed(client=client, limit=limit, after=after))
-            render_list(state.output_format, page.to_dict(), columns=_COLS, max_widths=_MAXW)
+        render_paginated(
+            ctx,
+            list_agents.sync_detailed,
+            columns=_COLS,
+            max_widths=_MAXW,
+            all_=all_,
+            limit=limit,
+            after=after,
+        )
 
     run_or_die(_run)
 
@@ -136,24 +125,17 @@ def versions(
     after: Annotated[int | None, typer.Option("--after")] = None,
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
-    cols = ("version", "model", "created_at")
-    widths = {"model": 40}
-
     def _run() -> None:
-        state = get_state(ctx)
-        with state.sdk_client() as client:
-            if all_:
-                items = fetch_all_sdk(
-                    list_agent_versions.sync_detailed, client=client, agent_id=agent_id
-                )
-                render_sdk_list(state.output_format, items, columns=cols, max_widths=widths)
-                return
-            page = unwrap(
-                list_agent_versions.sync_detailed(
-                    client=client, agent_id=agent_id, limit=limit, after=after
-                )
-            )
-            render_list(state.output_format, page.to_dict(), columns=cols, max_widths=widths)
+        render_paginated(
+            ctx,
+            list_agent_versions.sync_detailed,
+            columns=("version", "model", "created_at"),
+            max_widths={"model": 40},
+            all_=all_,
+            limit=limit,
+            after=after,
+            agent_id=agent_id,
+        )
 
     run_or_die(_run)
 

--- a/src/aios/cli/commands/connections.py
+++ b/src/aios/cli/commands/connections.py
@@ -14,20 +14,53 @@ from typing import Annotated, Any
 import typer
 
 from aios.cli.commands._shared import (
-    fetch_all,
-    just_client,
+    fetch_all_sdk,
     render_list,
+    render_sdk_list,
     render_single,
-    with_client,
+    unwrap,
 )
 from aios.cli.files import PayloadError, load_json_object, resolve_payload
 from aios.cli.output import print_error, print_success
-from aios.cli.runtime import run_or_die
+from aios.cli.runtime import get_state, run_or_die
+from aios.sdk._generated.api.connections import (
+    archive_connection,
+    attach_connection,
+    bind_chat,
+    configure_connection_per_chat,
+    create_connection,
+    detach_connection,
+    get_connection,
+    list_bound_chats,
+    list_connections,
+    list_recent_chats,
+    unbind_chat,
+    unconfigure_connection,
+)
+from aios.sdk._generated.models.bind_chat_request import BindChatRequest
+from aios.sdk._generated.models.connection_attach import ConnectionAttach
+from aios.sdk._generated.models.connection_configure_per_chat import ConnectionConfigurePerChat
+from aios.sdk._generated.models.connection_create import ConnectionCreate
+from aios.sdk._generated.models.list_connections_mode_type_0 import ListConnectionsModeType0
+from aios.sdk._generated.types import UNSET, Unset
 
 app = typer.Typer(name="connections", help="Manage connector connections.", no_args_is_help=True)
 
 _COLS = ("id", "connector", "account", "session_id", "session_template_id", "updated_at")
 _MAXW = {"connector": 20, "account": 40, "session_id": 24, "session_template_id": 24}
+
+
+def _coerce_mode(mode: str | None) -> ListConnectionsModeType0 | Unset:
+    """Accept the typer-side string and project to the typed SDK enum.
+
+    The SDK generates a per-operation enum (``ListConnectionsModeType0``)
+    rather than reusing :class:`aios.models.connections.ConnectionMode`,
+    so the surface here looks awkward — that's a generator artifact, not
+    a contract decision.
+    """
+    if mode is None:
+        return UNSET
+    return ListConnectionsModeType0(mode)
 
 
 @app.command("list")
@@ -44,23 +77,30 @@ def list_(
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
     def _run() -> None:
-        state, client = with_client(ctx)
-        params: dict[str, Any] = {
-            "connector": connector,
-            "session_id": session_id,
-            "mode": mode,
-        }
-        with client:
-            envelope = (
-                fetch_all(client, "/v1/connections", params=params)
-                if all_
-                else client.request(
-                    "GET",
-                    "/v1/connections",
-                    params={**params, "limit": limit, "after": after},
+        state = get_state(ctx)
+        sdk_mode = _coerce_mode(mode)
+        with state.sdk_client() as client:
+            if all_:
+                items = fetch_all_sdk(
+                    list_connections.sync_detailed,
+                    client=client,
+                    connector=connector,
+                    session_id=session_id,
+                    mode=sdk_mode,
+                )
+                render_sdk_list(state.output_format, items, columns=_COLS, max_widths=_MAXW)
+                return
+            page = unwrap(
+                list_connections.sync_detailed(
+                    client=client,
+                    connector=connector,
+                    session_id=session_id,
+                    mode=sdk_mode,
+                    limit=limit,
+                    after=after,
                 )
             )
-        render_list(state.output_format, envelope, columns=_COLS, max_widths=_MAXW)
+            render_list(state.output_format, page.to_dict(), columns=_COLS, max_widths=_MAXW)
 
     run_or_die(_run)
 
@@ -68,10 +108,9 @@ def list_(
 @app.command("get")
 def get(ctx: typer.Context, connection_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request("GET", f"/v1/connections/{connection_id}")
-        render_single(obj)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(get_connection.sync_detailed(client=client, connection_id=connection_id))
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -111,10 +150,10 @@ def create(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
-        client = just_client(ctx)
-        with client:
-            obj = client.request("POST", "/v1/connections", json_body=payload)
-        render_single(obj)
+        body = ConnectionCreate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(create_connection.sync_detailed(client=client, body=body))
+        render_single(obj.to_dict())
         return None
 
     run_or_die(_run)
@@ -127,14 +166,14 @@ def attach(
     session_id: Annotated[str, typer.Option("--session-id")],
 ) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request(
-                "POST",
-                f"/v1/connections/{connection_id}/attach",
-                json_body={"session_id": session_id},
+        body = ConnectionAttach(session_id=session_id)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(
+                attach_connection.sync_detailed(
+                    client=client, connection_id=connection_id, body=body
+                )
             )
-        render_single(obj)
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -142,10 +181,11 @@ def attach(
 @app.command("detach", help="Drop the single_session binding, leaving the connection detached.")
 def detach(ctx: typer.Context, connection_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request("POST", f"/v1/connections/{connection_id}/detach")
-        render_single(obj)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(
+                detach_connection.sync_detailed(client=client, connection_id=connection_id)
+            )
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -157,14 +197,14 @@ def configure_per_chat(
     template: Annotated[str, typer.Option("--template", help="Session template id.")],
 ) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request(
-                "POST",
-                f"/v1/connections/{connection_id}/configure-per-chat",
-                json_body={"session_template_id": template},
+        body = ConnectionConfigurePerChat(session_template_id=template)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(
+                configure_connection_per_chat.sync_detailed(
+                    client=client, connection_id=connection_id, body=body
+                )
             )
-        render_single(obj)
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -174,10 +214,11 @@ def configure_per_chat(
 )
 def unconfigure(ctx: typer.Context, connection_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request("POST", f"/v1/connections/{connection_id}/unconfigure")
-        render_single(obj)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(
+                unconfigure_connection.sync_detailed(client=client, connection_id=connection_id)
+            )
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -186,21 +227,19 @@ def unconfigure(ctx: typer.Context, connection_id: str) -> None:
     "bind-chat",
     help="Pre-bind a chat_id on a connection's account to an existing session.",
 )
-def bind_chat(
+def bind_chat_cmd(
     ctx: typer.Context,
     connection_id: str,
     chat_id: Annotated[str, typer.Option("--chat-id", help="Platform-native chat id.")],
     session_id: Annotated[str, typer.Option("--session-id", help="Target session id.")],
 ) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request(
-                "POST",
-                f"/v1/connections/{connection_id}/bind-chat",
-                json_body={"chat_id": chat_id, "session_id": session_id},
+        body = BindChatRequest(chat_id=chat_id, session_id=session_id)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(
+                bind_chat.sync_detailed(client=client, connection_id=connection_id, body=body)
             )
-        render_single(obj)
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -209,15 +248,18 @@ def bind_chat(
     "unbind-chat",
     help="Drop a chat → session binding, returning the chat to the connection's mode default.",
 )
-def unbind_chat(
+def unbind_chat_cmd(
     ctx: typer.Context,
     connection_id: str,
     chat_id: Annotated[str, typer.Option("--chat-id")],
 ) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            client.request("DELETE", f"/v1/connections/{connection_id}/bind-chat/{chat_id}")
+        with get_state(ctx).sdk_client() as client:
+            unwrap(
+                unbind_chat.sync_detailed(
+                    client=client, connection_id=connection_id, chat_id=chat_id
+                )
+            )
         print_success("unbound", f"{connection_id}:{chat_id}")
 
     run_or_die(_run)
@@ -229,12 +271,14 @@ def unbind_chat(
 )
 def bound_chats(ctx: typer.Context, connection_id: str) -> None:
     def _run() -> None:
-        state, client = with_client(ctx)
-        with client:
-            envelope = client.request("GET", f"/v1/connections/{connection_id}/bound-chats")
+        state = get_state(ctx)
+        with state.sdk_client() as client:
+            page = unwrap(
+                list_bound_chats.sync_detailed(client=client, connection_id=connection_id)
+            )
         render_list(
             state.output_format,
-            envelope,
+            page.to_dict(),
             columns=("chat_id", "session_id", "created_at"),
             max_widths={"chat_id": 40, "session_id": 24},
         )
@@ -252,16 +296,16 @@ def recent_chats(
     limit: Annotated[int, typer.Option("--limit", min=1, max=200)] = 50,
 ) -> None:
     def _run() -> None:
-        state, client = with_client(ctx)
-        with client:
-            envelope = client.request(
-                "GET",
-                f"/v1/connections/{connection_id}/recent-chats",
-                params={"limit": limit},
+        state = get_state(ctx)
+        with state.sdk_client() as client:
+            page = unwrap(
+                list_recent_chats.sync_detailed(
+                    client=client, connection_id=connection_id, limit=limit
+                )
             )
         render_list(
             state.output_format,
-            envelope,
+            page.to_dict(),
             columns=("chat_id", "last_seen_at"),
             max_widths={"chat_id": 40},
         )
@@ -272,9 +316,8 @@ def recent_chats(
 @app.command("archive", help="Archive a detached connection (soft-delete, retained for audit).")
 def archive(ctx: typer.Context, connection_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            client.request("DELETE", f"/v1/connections/{connection_id}")
+        with get_state(ctx).sdk_client() as client:
+            unwrap(archive_connection.sync_detailed(client=client, connection_id=connection_id))
         print_success("archived", connection_id)
 
     run_or_die(_run)

--- a/src/aios/cli/commands/connections.py
+++ b/src/aios/cli/commands/connections.py
@@ -13,13 +13,7 @@ from typing import Annotated, Any
 
 import typer
 
-from aios.cli.commands._shared import (
-    fetch_all_sdk,
-    render_list,
-    render_sdk_list,
-    render_single,
-    unwrap,
-)
+from aios.cli.commands._shared import render_list, render_paginated, render_single, unwrap
 from aios.cli.files import PayloadError, load_json_object, resolve_payload
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
@@ -42,25 +36,11 @@ from aios.sdk._generated.models.connection_attach import ConnectionAttach
 from aios.sdk._generated.models.connection_configure_per_chat import ConnectionConfigurePerChat
 from aios.sdk._generated.models.connection_create import ConnectionCreate
 from aios.sdk._generated.models.list_connections_mode_type_0 import ListConnectionsModeType0
-from aios.sdk._generated.types import UNSET, Unset
 
 app = typer.Typer(name="connections", help="Manage connector connections.", no_args_is_help=True)
 
 _COLS = ("id", "connector", "account", "session_id", "session_template_id", "updated_at")
 _MAXW = {"connector": 20, "account": 40, "session_id": 24, "session_template_id": 24}
-
-
-def _coerce_mode(mode: str | None) -> ListConnectionsModeType0 | Unset:
-    """Accept the typer-side string and project to the typed SDK enum.
-
-    The SDK generates a per-operation enum (``ListConnectionsModeType0``)
-    rather than reusing :class:`aios.models.connections.ConnectionMode`,
-    so the surface here looks awkward — that's a generator artifact, not
-    a contract decision.
-    """
-    if mode is None:
-        return UNSET
-    return ListConnectionsModeType0(mode)
 
 
 @app.command("list")
@@ -69,38 +49,26 @@ def list_(
     connector: Annotated[str | None, typer.Option("--connector")] = None,
     session_id: Annotated[str | None, typer.Option("--session-id")] = None,
     mode: Annotated[
-        str | None,
-        typer.Option("--mode", help="Filter by routing mode: detached, single_session, per_chat."),
+        ListConnectionsModeType0 | None,
+        typer.Option("--mode", help="Filter by routing mode."),
     ] = None,
     limit: Annotated[int, typer.Option("--limit", min=1, max=200)] = 50,
     after: Annotated[str | None, typer.Option("--after")] = None,
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
     def _run() -> None:
-        state = get_state(ctx)
-        sdk_mode = _coerce_mode(mode)
-        with state.sdk_client() as client:
-            if all_:
-                items = fetch_all_sdk(
-                    list_connections.sync_detailed,
-                    client=client,
-                    connector=connector,
-                    session_id=session_id,
-                    mode=sdk_mode,
-                )
-                render_sdk_list(state.output_format, items, columns=_COLS, max_widths=_MAXW)
-                return
-            page = unwrap(
-                list_connections.sync_detailed(
-                    client=client,
-                    connector=connector,
-                    session_id=session_id,
-                    mode=sdk_mode,
-                    limit=limit,
-                    after=after,
-                )
-            )
-            render_list(state.output_format, page.to_dict(), columns=_COLS, max_widths=_MAXW)
+        render_paginated(
+            ctx,
+            list_connections.sync_detailed,
+            columns=_COLS,
+            max_widths=_MAXW,
+            all_=all_,
+            limit=limit,
+            after=after,
+            connector=connector,
+            session_id=session_id,
+            mode=mode,
+        )
 
     run_or_die(_run)
 

--- a/src/aios/cli/commands/envs.py
+++ b/src/aios/cli/commands/envs.py
@@ -8,15 +8,24 @@ from typing import Annotated
 import typer
 
 from aios.cli.commands._shared import (
-    fetch_all,
-    just_client,
+    fetch_all_sdk,
     render_list,
+    render_sdk_list,
     render_single,
-    with_client,
+    unwrap,
 )
 from aios.cli.files import PayloadError, load_payload
 from aios.cli.output import print_error, print_success
-from aios.cli.runtime import run_or_die
+from aios.cli.runtime import get_state, run_or_die
+from aios.sdk._generated.api.environments import (
+    archive_environment,
+    create_environment,
+    get_environment,
+    list_environments,
+    update_environment,
+)
+from aios.sdk._generated.models.environment_create import EnvironmentCreate
+from aios.sdk._generated.models.environment_update import EnvironmentUpdate
 
 app = typer.Typer(name="envs", help="Manage environments (sandbox configs).", no_args_is_help=True)
 
@@ -31,16 +40,14 @@ def list_(
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
     def _run() -> None:
-        state, client = with_client(ctx)
-        with client:
-            envelope = (
-                fetch_all(client, "/v1/environments")
-                if all_
-                else client.request(
-                    "GET", "/v1/environments", params={"limit": limit, "after": after}
-                )
-            )
-        render_list(state.output_format, envelope, columns=_COLS)
+        state = get_state(ctx)
+        with state.sdk_client() as client:
+            if all_:
+                items = fetch_all_sdk(list_environments.sync_detailed, client=client)
+                render_sdk_list(state.output_format, items, columns=_COLS)
+                return
+            page = unwrap(list_environments.sync_detailed(client=client, limit=limit, after=after))
+            render_list(state.output_format, page.to_dict(), columns=_COLS)
 
     run_or_die(_run)
 
@@ -48,10 +55,9 @@ def list_(
 @app.command("get")
 def get(ctx: typer.Context, env_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request("GET", f"/v1/environments/{env_id}")
-        render_single(obj)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(get_environment.sync_detailed(client=client, env_id=env_id))
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -69,10 +75,10 @@ def create(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
-        client = just_client(ctx)
-        with client:
-            obj = client.request("POST", "/v1/environments", json_body=payload)
-        render_single(obj)
+        body = EnvironmentCreate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(create_environment.sync_detailed(client=client, body=body))
+        render_single(obj.to_dict())
         return None
 
     run_or_die(_run)
@@ -92,10 +98,10 @@ def update(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
-        client = just_client(ctx)
-        with client:
-            obj = client.request("PUT", f"/v1/environments/{env_id}", json_body=payload)
-        render_single(obj)
+        body = EnvironmentUpdate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(update_environment.sync_detailed(client=client, env_id=env_id, body=body))
+        render_single(obj.to_dict())
         return None
 
     run_or_die(_run)
@@ -104,9 +110,8 @@ def update(
 @app.command("archive", help="Archive an environment (soft-delete, retained for audit).")
 def archive(ctx: typer.Context, env_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            client.request("DELETE", f"/v1/environments/{env_id}")
+        with get_state(ctx).sdk_client() as client:
+            unwrap(archive_environment.sync_detailed(client=client, env_id=env_id))
         print_success("archived", env_id)
 
     run_or_die(_run)

--- a/src/aios/cli/commands/envs.py
+++ b/src/aios/cli/commands/envs.py
@@ -7,13 +7,7 @@ from typing import Annotated
 
 import typer
 
-from aios.cli.commands._shared import (
-    fetch_all_sdk,
-    render_list,
-    render_sdk_list,
-    render_single,
-    unwrap,
-)
+from aios.cli.commands._shared import render_paginated, render_single, unwrap
 from aios.cli.files import PayloadError, load_payload
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
@@ -40,14 +34,14 @@ def list_(
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
     def _run() -> None:
-        state = get_state(ctx)
-        with state.sdk_client() as client:
-            if all_:
-                items = fetch_all_sdk(list_environments.sync_detailed, client=client)
-                render_sdk_list(state.output_format, items, columns=_COLS)
-                return
-            page = unwrap(list_environments.sync_detailed(client=client, limit=limit, after=after))
-            render_list(state.output_format, page.to_dict(), columns=_COLS)
+        render_paginated(
+            ctx,
+            list_environments.sync_detailed,
+            columns=_COLS,
+            all_=all_,
+            limit=limit,
+            after=after,
+        )
 
     run_or_die(_run)
 

--- a/src/aios/cli/commands/session_templates.py
+++ b/src/aios/cli/commands/session_templates.py
@@ -8,15 +8,24 @@ from typing import Annotated, Any
 import typer
 
 from aios.cli.commands._shared import (
-    fetch_all,
-    just_client,
+    fetch_all_sdk,
     render_list,
+    render_sdk_list,
     render_single,
-    with_client,
+    unwrap,
 )
 from aios.cli.files import PayloadError, load_json_object, load_payload, resolve_payload
 from aios.cli.output import print_error, print_success
-from aios.cli.runtime import run_or_die
+from aios.cli.runtime import get_state, run_or_die
+from aios.sdk._generated.api.session_templates import (
+    archive_session_template,
+    create_session_template,
+    get_session_template,
+    list_session_templates,
+    update_session_template,
+)
+from aios.sdk._generated.models.session_template_create import SessionTemplateCreate
+from aios.sdk._generated.models.session_template_update import SessionTemplateUpdate
 
 app = typer.Typer(
     name="session-templates",
@@ -36,18 +45,16 @@ def list_(
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
     def _run() -> None:
-        state, client = with_client(ctx)
-        with client:
-            envelope = (
-                fetch_all(client, "/v1/session-templates")
-                if all_
-                else client.request(
-                    "GET",
-                    "/v1/session-templates",
-                    params={"limit": limit, "after": after},
-                )
+        state = get_state(ctx)
+        with state.sdk_client() as client:
+            if all_:
+                items = fetch_all_sdk(list_session_templates.sync_detailed, client=client)
+                render_sdk_list(state.output_format, items, columns=_COLS, max_widths=_MAXW)
+                return
+            page = unwrap(
+                list_session_templates.sync_detailed(client=client, limit=limit, after=after)
             )
-        render_list(state.output_format, envelope, columns=_COLS, max_widths=_MAXW)
+            render_list(state.output_format, page.to_dict(), columns=_COLS, max_widths=_MAXW)
 
     run_or_die(_run)
 
@@ -55,10 +62,9 @@ def list_(
 @app.command("get")
 def get(ctx: typer.Context, template_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request("GET", f"/v1/session-templates/{template_id}")
-        render_single(obj)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(get_session_template.sync_detailed(client=client, template_id=template_id))
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -111,10 +117,10 @@ def create(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
-        client = just_client(ctx)
-        with client:
-            obj = client.request("POST", "/v1/session-templates", json_body=payload)
-        render_single(obj)
+        body = SessionTemplateCreate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(create_session_template.sync_detailed(client=client, body=body))
+        render_single(obj.to_dict())
         return None
 
     run_or_die(_run)
@@ -134,10 +140,14 @@ def update(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
-        client = just_client(ctx)
-        with client:
-            obj = client.request("PUT", f"/v1/session-templates/{template_id}", json_body=payload)
-        render_single(obj)
+        body = SessionTemplateUpdate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(
+                update_session_template.sync_detailed(
+                    client=client, template_id=template_id, body=body
+                )
+            )
+        render_single(obj.to_dict())
         return None
 
     run_or_die(_run)
@@ -146,9 +156,8 @@ def update(
 @app.command("archive", help="Archive a session template (soft-delete, retained for audit).")
 def archive(ctx: typer.Context, template_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            client.request("DELETE", f"/v1/session-templates/{template_id}")
+        with get_state(ctx).sdk_client() as client:
+            unwrap(archive_session_template.sync_detailed(client=client, template_id=template_id))
         print_success("archived", template_id)
 
     run_or_die(_run)

--- a/src/aios/cli/commands/session_templates.py
+++ b/src/aios/cli/commands/session_templates.py
@@ -7,13 +7,7 @@ from typing import Annotated, Any
 
 import typer
 
-from aios.cli.commands._shared import (
-    fetch_all_sdk,
-    render_list,
-    render_sdk_list,
-    render_single,
-    unwrap,
-)
+from aios.cli.commands._shared import render_paginated, render_single, unwrap
 from aios.cli.files import PayloadError, load_json_object, load_payload, resolve_payload
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
@@ -45,16 +39,15 @@ def list_(
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
     def _run() -> None:
-        state = get_state(ctx)
-        with state.sdk_client() as client:
-            if all_:
-                items = fetch_all_sdk(list_session_templates.sync_detailed, client=client)
-                render_sdk_list(state.output_format, items, columns=_COLS, max_widths=_MAXW)
-                return
-            page = unwrap(
-                list_session_templates.sync_detailed(client=client, limit=limit, after=after)
-            )
-            render_list(state.output_format, page.to_dict(), columns=_COLS, max_widths=_MAXW)
+        render_paginated(
+            ctx,
+            list_session_templates.sync_detailed,
+            columns=_COLS,
+            max_widths=_MAXW,
+            all_=all_,
+            limit=limit,
+            after=after,
+        )
 
     run_or_die(_run)
 

--- a/src/aios/cli/commands/skills.py
+++ b/src/aios/cli/commands/skills.py
@@ -7,13 +7,7 @@ from typing import Annotated, Any
 
 import typer
 
-from aios.cli.commands._shared import (
-    fetch_all_sdk,
-    render_list,
-    render_sdk_list,
-    render_single,
-    unwrap,
-)
+from aios.cli.commands._shared import render_paginated, render_single, unwrap
 from aios.cli.files import PayloadError, load_payload, walk_skill_dir
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
@@ -42,14 +36,14 @@ def list_(
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
     def _run() -> None:
-        state = get_state(ctx)
-        with state.sdk_client() as client:
-            if all_:
-                items = fetch_all_sdk(list_skills.sync_detailed, client=client)
-                render_sdk_list(state.output_format, items, columns=_COLS)
-                return
-            page = unwrap(list_skills.sync_detailed(client=client, limit=limit, after=after))
-            render_list(state.output_format, page.to_dict(), columns=_COLS)
+        render_paginated(
+            ctx,
+            list_skills.sync_detailed,
+            columns=_COLS,
+            all_=all_,
+            limit=limit,
+            after=after,
+        )
 
     run_or_die(_run)
 
@@ -112,24 +106,17 @@ def versions(
     after: Annotated[int | None, typer.Option("--after")] = None,
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
-    cols = ("version", "name", "description", "created_at")
-    widths = {"description": 60, "name": 32}
-
     def _run() -> None:
-        state = get_state(ctx)
-        with state.sdk_client() as client:
-            if all_:
-                items = fetch_all_sdk(
-                    list_skill_versions.sync_detailed, client=client, skill_id=skill_id
-                )
-                render_sdk_list(state.output_format, items, columns=cols, max_widths=widths)
-                return
-            page = unwrap(
-                list_skill_versions.sync_detailed(
-                    client=client, skill_id=skill_id, limit=limit, after=after
-                )
-            )
-            render_list(state.output_format, page.to_dict(), columns=cols, max_widths=widths)
+        render_paginated(
+            ctx,
+            list_skill_versions.sync_detailed,
+            columns=("version", "name", "description", "created_at"),
+            max_widths={"description": 60, "name": 32},
+            all_=all_,
+            limit=limit,
+            after=after,
+            skill_id=skill_id,
+        )
 
     run_or_die(_run)
 

--- a/src/aios/cli/commands/skills.py
+++ b/src/aios/cli/commands/skills.py
@@ -8,15 +8,26 @@ from typing import Annotated, Any
 import typer
 
 from aios.cli.commands._shared import (
-    fetch_all,
-    just_client,
+    fetch_all_sdk,
     render_list,
+    render_sdk_list,
     render_single,
-    with_client,
+    unwrap,
 )
 from aios.cli.files import PayloadError, load_payload, walk_skill_dir
 from aios.cli.output import print_error, print_success
-from aios.cli.runtime import run_or_die
+from aios.cli.runtime import get_state, run_or_die
+from aios.sdk._generated.api.skills import (
+    archive_skill,
+    create_skill,
+    create_skill_version,
+    get_skill,
+    get_skill_version,
+    list_skill_versions,
+    list_skills,
+)
+from aios.sdk._generated.models.skill_create import SkillCreate
+from aios.sdk._generated.models.skill_version_create import SkillVersionCreate
 
 app = typer.Typer(name="skills", help="Manage skills.", no_args_is_help=True)
 
@@ -31,14 +42,14 @@ def list_(
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
     def _run() -> None:
-        state, client = with_client(ctx)
-        with client:
-            envelope = (
-                fetch_all(client, "/v1/skills")
-                if all_
-                else client.request("GET", "/v1/skills", params={"limit": limit, "after": after})
-            )
-        render_list(state.output_format, envelope, columns=_COLS)
+        state = get_state(ctx)
+        with state.sdk_client() as client:
+            if all_:
+                items = fetch_all_sdk(list_skills.sync_detailed, client=client)
+                render_sdk_list(state.output_format, items, columns=_COLS)
+                return
+            page = unwrap(list_skills.sync_detailed(client=client, limit=limit, after=after))
+            render_list(state.output_format, page.to_dict(), columns=_COLS)
 
     run_or_die(_run)
 
@@ -46,10 +57,9 @@ def list_(
 @app.command("get", help="Fetch a skill.")
 def get(ctx: typer.Context, skill_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request("GET", f"/v1/skills/{skill_id}")
-        render_single(obj)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(get_skill.sync_detailed(client=client, skill_id=skill_id))
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -75,10 +85,10 @@ def create(
         )
         if isinstance(payload, int):
             return payload
-        client = just_client(ctx)
-        with client:
-            obj = client.request("POST", "/v1/skills", json_body=payload)
-        render_single(obj)
+        body = SkillCreate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(create_skill.sync_detailed(client=client, body=body))
+        render_single(obj.to_dict())
         return None
 
     run_or_die(_run)
@@ -87,9 +97,8 @@ def create(
 @app.command("archive", help="Archive a skill (soft-delete, retained for audit).")
 def archive(ctx: typer.Context, skill_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            client.request("DELETE", f"/v1/skills/{skill_id}")
+        with get_state(ctx).sdk_client() as client:
+            unwrap(archive_skill.sync_detailed(client=client, skill_id=skill_id))
         print_success("archived", skill_id)
 
     run_or_die(_run)
@@ -100,24 +109,27 @@ def versions(
     ctx: typer.Context,
     skill_id: str,
     limit: Annotated[int, typer.Option("--limit", min=1, max=200)] = 50,
-    after: Annotated[str | None, typer.Option("--after")] = None,
+    after: Annotated[int | None, typer.Option("--after")] = None,
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
+    cols = ("version", "name", "description", "created_at")
+    widths = {"description": 60, "name": 32}
+
     def _run() -> None:
-        state, client = with_client(ctx)
-        path = f"/v1/skills/{skill_id}/versions"
-        with client:
-            envelope = (
-                fetch_all(client, path)
-                if all_
-                else client.request("GET", path, params={"limit": limit, "after": after})
+        state = get_state(ctx)
+        with state.sdk_client() as client:
+            if all_:
+                items = fetch_all_sdk(
+                    list_skill_versions.sync_detailed, client=client, skill_id=skill_id
+                )
+                render_sdk_list(state.output_format, items, columns=cols, max_widths=widths)
+                return
+            page = unwrap(
+                list_skill_versions.sync_detailed(
+                    client=client, skill_id=skill_id, limit=limit, after=after
+                )
             )
-        render_list(
-            state.output_format,
-            envelope,
-            columns=("version", "name", "description", "created_at"),
-            max_widths={"description": 60, "name": 32},
-        )
+            render_list(state.output_format, page.to_dict(), columns=cols, max_widths=widths)
 
     run_or_die(_run)
 
@@ -125,10 +137,11 @@ def versions(
 @app.command("version", help="Fetch a specific skill version.")
 def version(ctx: typer.Context, skill_id: str, version: int) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request("GET", f"/v1/skills/{skill_id}/versions/{version}")
-        render_single(obj)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(
+                get_skill_version.sync_detailed(client=client, skill_id=skill_id, version=version)
+            )
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -156,10 +169,12 @@ def version_create(
             except PayloadError as exc:
                 print_error(str(exc))
                 return 64
-        client = just_client(ctx)
-        with client:
-            obj = client.request("POST", f"/v1/skills/{skill_id}/versions", json_body=payload)
-        render_single(obj)
+        body = SkillVersionCreate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(
+                create_skill_version.sync_detailed(client=client, skill_id=skill_id, body=body)
+            )
+        render_single(obj.to_dict())
         return None
 
     run_or_die(_run)

--- a/src/aios/cli/commands/vaults.py
+++ b/src/aios/cli/commands/vaults.py
@@ -8,15 +8,33 @@ from typing import Annotated, Any
 import typer
 
 from aios.cli.commands._shared import (
-    fetch_all,
-    just_client,
+    fetch_all_sdk,
     render_list,
+    render_sdk_list,
     render_single,
-    with_client,
+    unwrap,
 )
 from aios.cli.files import PayloadError, load_json_object, load_payload, resolve_payload
 from aios.cli.output import print_error, print_success
-from aios.cli.runtime import run_or_die
+from aios.cli.runtime import get_state, run_or_die
+from aios.sdk._generated.api.vaults import (
+    archive_vault,
+    archive_vault_credential,
+    create_vault,
+    create_vault_credential,
+    delete_vault,
+    delete_vault_credential,
+    get_vault,
+    get_vault_credential,
+    list_vault_credentials,
+    list_vaults,
+    update_vault,
+    update_vault_credential,
+)
+from aios.sdk._generated.models.vault_create import VaultCreate
+from aios.sdk._generated.models.vault_credential_create import VaultCredentialCreate
+from aios.sdk._generated.models.vault_credential_update import VaultCredentialUpdate
+from aios.sdk._generated.models.vault_update import VaultUpdate
 
 app = typer.Typer(name="vaults", help="Manage vaults and credentials.", no_args_is_help=True)
 credentials = typer.Typer(
@@ -41,14 +59,14 @@ def list_(
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
     def _run() -> None:
-        state, client = with_client(ctx)
-        with client:
-            envelope = (
-                fetch_all(client, "/v1/vaults")
-                if all_
-                else client.request("GET", "/v1/vaults", params={"limit": limit, "after": after})
-            )
-        render_list(state.output_format, envelope, columns=_VAULT_COLS)
+        state = get_state(ctx)
+        with state.sdk_client() as client:
+            if all_:
+                items = fetch_all_sdk(list_vaults.sync_detailed, client=client)
+                render_sdk_list(state.output_format, items, columns=_VAULT_COLS)
+                return
+            page = unwrap(list_vaults.sync_detailed(client=client, limit=limit, after=after))
+            render_list(state.output_format, page.to_dict(), columns=_VAULT_COLS)
 
     run_or_die(_run)
 
@@ -56,10 +74,9 @@ def list_(
 @app.command("get")
 def get(ctx: typer.Context, vault_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request("GET", f"/v1/vaults/{vault_id}")
-        render_single(obj)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(get_vault.sync_detailed(client=client, vault_id=vault_id))
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -97,10 +114,10 @@ def create(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
-        client = just_client(ctx)
-        with client:
-            obj = client.request("POST", "/v1/vaults", json_body=payload)
-        render_single(obj)
+        body = VaultCreate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(create_vault.sync_detailed(client=client, body=body))
+        render_single(obj.to_dict())
         return None
 
     run_or_die(_run)
@@ -120,10 +137,10 @@ def update(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
-        client = just_client(ctx)
-        with client:
-            obj = client.request("PUT", f"/v1/vaults/{vault_id}", json_body=payload)
-        render_single(obj)
+        body = VaultUpdate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(update_vault.sync_detailed(client=client, vault_id=vault_id, body=body))
+        render_single(obj.to_dict())
         return None
 
     run_or_die(_run)
@@ -132,10 +149,9 @@ def update(
 @app.command("archive")
 def archive(ctx: typer.Context, vault_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request("POST", f"/v1/vaults/{vault_id}/archive")
-        render_single(obj)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(archive_vault.sync_detailed(client=client, vault_id=vault_id))
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -159,9 +175,8 @@ def delete(
                 "(or use `aios vaults archive` for a reversible soft-delete)"
             )
             return 2
-        client = just_client(ctx)
-        with client:
-            client.request("DELETE", f"/v1/vaults/{vault_id}")
+        with get_state(ctx).sdk_client() as client:
+            unwrap(delete_vault.sync_detailed(client=client, vault_id=vault_id))
         print_success("deleted", vault_id)
         return None
 
@@ -180,15 +195,20 @@ def cred_list(
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
     def _run() -> None:
-        state, client = with_client(ctx)
-        path = f"/v1/vaults/{vault_id}/credentials"
-        with client:
-            envelope = (
-                fetch_all(client, path)
-                if all_
-                else client.request("GET", path, params={"limit": limit, "after": after})
+        state = get_state(ctx)
+        with state.sdk_client() as client:
+            if all_:
+                items = fetch_all_sdk(
+                    list_vault_credentials.sync_detailed, client=client, vault_id=vault_id
+                )
+                render_sdk_list(state.output_format, items, columns=_CRED_COLS)
+                return
+            page = unwrap(
+                list_vault_credentials.sync_detailed(
+                    client=client, vault_id=vault_id, limit=limit, after=after
+                )
             )
-        render_list(state.output_format, envelope, columns=_CRED_COLS)
+            render_list(state.output_format, page.to_dict(), columns=_CRED_COLS)
 
     run_or_die(_run)
 
@@ -196,10 +216,13 @@ def cred_list(
 @credentials.command("get")
 def cred_get(ctx: typer.Context, vault_id: str, credential_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request("GET", f"/v1/vaults/{vault_id}/credentials/{credential_id}")
-        render_single(obj)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(
+                get_vault_credential.sync_detailed(
+                    client=client, vault_id=vault_id, credential_id=credential_id
+                )
+            )
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -230,10 +253,12 @@ def cred_create(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
-        client = just_client(ctx)
-        with client:
-            obj = client.request("POST", f"/v1/vaults/{vault_id}/credentials", json_body=payload)
-        render_single(obj)
+        body = VaultCredentialCreate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(
+                create_vault_credential.sync_detailed(client=client, vault_id=vault_id, body=body)
+            )
+        render_single(obj.to_dict())
         return None
 
     run_or_die(_run)
@@ -254,14 +279,14 @@ def cred_update(
         except PayloadError as exc:
             print_error(str(exc))
             return 64
-        client = just_client(ctx)
-        with client:
-            obj = client.request(
-                "PUT",
-                f"/v1/vaults/{vault_id}/credentials/{credential_id}",
-                json_body=payload,
+        body = VaultCredentialUpdate.from_dict(payload)
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(
+                update_vault_credential.sync_detailed(
+                    client=client, vault_id=vault_id, credential_id=credential_id, body=body
+                )
             )
-        render_single(obj)
+        render_single(obj.to_dict())
         return None
 
     run_or_die(_run)
@@ -270,12 +295,13 @@ def cred_update(
 @credentials.command("archive")
 def cred_archive(ctx: typer.Context, vault_id: str, credential_id: str) -> None:
     def _run() -> None:
-        client = just_client(ctx)
-        with client:
-            obj = client.request(
-                "POST", f"/v1/vaults/{vault_id}/credentials/{credential_id}/archive"
+        with get_state(ctx).sdk_client() as client:
+            obj = unwrap(
+                archive_vault_credential.sync_detailed(
+                    client=client, vault_id=vault_id, credential_id=credential_id
+                )
             )
-        render_single(obj)
+        render_single(obj.to_dict())
 
     run_or_die(_run)
 
@@ -300,9 +326,12 @@ def cred_delete(
                 "(or use `aios vaults credentials archive` for a reversible soft-delete)"
             )
             return 2
-        client = just_client(ctx)
-        with client:
-            client.request("DELETE", f"/v1/vaults/{vault_id}/credentials/{credential_id}")
+        with get_state(ctx).sdk_client() as client:
+            unwrap(
+                delete_vault_credential.sync_detailed(
+                    client=client, vault_id=vault_id, credential_id=credential_id
+                )
+            )
         print_success("deleted", credential_id)
         return None
 

--- a/src/aios/cli/commands/vaults.py
+++ b/src/aios/cli/commands/vaults.py
@@ -7,13 +7,7 @@ from typing import Annotated, Any
 
 import typer
 
-from aios.cli.commands._shared import (
-    fetch_all_sdk,
-    render_list,
-    render_sdk_list,
-    render_single,
-    unwrap,
-)
+from aios.cli.commands._shared import render_paginated, render_single, unwrap
 from aios.cli.files import PayloadError, load_json_object, load_payload, resolve_payload
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
@@ -59,14 +53,14 @@ def list_(
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
     def _run() -> None:
-        state = get_state(ctx)
-        with state.sdk_client() as client:
-            if all_:
-                items = fetch_all_sdk(list_vaults.sync_detailed, client=client)
-                render_sdk_list(state.output_format, items, columns=_VAULT_COLS)
-                return
-            page = unwrap(list_vaults.sync_detailed(client=client, limit=limit, after=after))
-            render_list(state.output_format, page.to_dict(), columns=_VAULT_COLS)
+        render_paginated(
+            ctx,
+            list_vaults.sync_detailed,
+            columns=_VAULT_COLS,
+            all_=all_,
+            limit=limit,
+            after=after,
+        )
 
     run_or_die(_run)
 
@@ -195,20 +189,15 @@ def cred_list(
     all_: Annotated[bool, typer.Option("--all")] = False,
 ) -> None:
     def _run() -> None:
-        state = get_state(ctx)
-        with state.sdk_client() as client:
-            if all_:
-                items = fetch_all_sdk(
-                    list_vault_credentials.sync_detailed, client=client, vault_id=vault_id
-                )
-                render_sdk_list(state.output_format, items, columns=_CRED_COLS)
-                return
-            page = unwrap(
-                list_vault_credentials.sync_detailed(
-                    client=client, vault_id=vault_id, limit=limit, after=after
-                )
-            )
-            render_list(state.output_format, page.to_dict(), columns=_CRED_COLS)
+        render_paginated(
+            ctx,
+            list_vault_credentials.sync_detailed,
+            columns=_CRED_COLS,
+            all_=all_,
+            limit=limit,
+            after=after,
+            vault_id=vault_id,
+        )
 
     run_or_die(_run)
 

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -99,47 +99,30 @@ def mocked_cli(monkeypatch: pytest.MonkeyPatch) -> MockedCli:
     return MockedCli(captured=captured, response_queue=responses)
 
 
-# ── full-shape response factories for SDK-backed CLI tests ───────────────────
-#
-# The CLI now parses responses through the typed SDK (``aios.sdk._generated``).
-# The SDK's ``<Model>.from_dict`` is strict about required fields, so tests
-# whose only goal is to assert the *request* shape still need to feed back a
-# minimally-complete response payload — otherwise the SDK parser raises before
-# the command's exit-code path runs.
+# Minimally-complete response payloads for SDK-backed CLI tests. The SDK's
+# ``<Model>.from_dict`` is strict about required fields, so tests asserting
+# only request shape still need a complete response to keep the parser from
+# raising before the exit-code assertion runs.
 
 _FIXED_TS = "2024-01-01T00:00:00+00:00"
 
-
-def connection_response(**overrides: Any) -> dict[str, Any]:
-    """Minimally-valid ``Connection`` JSON suitable for SDK parsing."""
-    base = {
+_RESOURCE_BASES: dict[str, dict[str, Any]] = {
+    "connection": {
         "id": "conn_01",
         "connector": "signal",
         "account": "acct-1",
         "metadata": {},
         "created_at": _FIXED_TS,
         "updated_at": _FIXED_TS,
-    }
-    base.update(overrides)
-    return base
-
-
-def vault_response(**overrides: Any) -> dict[str, Any]:
-    """Minimally-valid ``Vault`` JSON."""
-    base = {
+    },
+    "vault": {
         "id": "vlt_1",
         "display_name": "test",
         "metadata": {},
         "created_at": _FIXED_TS,
         "updated_at": _FIXED_TS,
-    }
-    base.update(overrides)
-    return base
-
-
-def vault_credential_response(**overrides: Any) -> dict[str, Any]:
-    """Minimally-valid ``VaultCredential`` JSON."""
-    base = {
+    },
+    "vault_credential": {
         "id": "cred_1",
         "vault_id": "vlt_1",
         "display_name": "test-cred",
@@ -148,6 +131,10 @@ def vault_credential_response(**overrides: Any) -> dict[str, Any]:
         "metadata": {},
         "created_at": _FIXED_TS,
         "updated_at": _FIXED_TS,
-    }
-    base.update(overrides)
-    return base
+    },
+}
+
+
+def resource_response(kind: str, **overrides: Any) -> dict[str, Any]:
+    """Return a minimally-valid SDK response payload for the given resource kind."""
+    return {**_RESOURCE_BASES[kind], **overrides}

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -97,3 +97,57 @@ def mocked_cli(monkeypatch: pytest.MonkeyPatch) -> MockedCli:
     monkeypatch.setenv("AIOS_API_KEY", "test-key")
     monkeypatch.setenv("AIOS_URL", "http://test.invalid")
     return MockedCli(captured=captured, response_queue=responses)
+
+
+# ── full-shape response factories for SDK-backed CLI tests ───────────────────
+#
+# The CLI now parses responses through the typed SDK (``aios.sdk._generated``).
+# The SDK's ``<Model>.from_dict`` is strict about required fields, so tests
+# whose only goal is to assert the *request* shape still need to feed back a
+# minimally-complete response payload — otherwise the SDK parser raises before
+# the command's exit-code path runs.
+
+_FIXED_TS = "2024-01-01T00:00:00+00:00"
+
+
+def connection_response(**overrides: Any) -> dict[str, Any]:
+    """Minimally-valid ``Connection`` JSON suitable for SDK parsing."""
+    base = {
+        "id": "conn_01",
+        "connector": "signal",
+        "account": "acct-1",
+        "metadata": {},
+        "created_at": _FIXED_TS,
+        "updated_at": _FIXED_TS,
+    }
+    base.update(overrides)
+    return base
+
+
+def vault_response(**overrides: Any) -> dict[str, Any]:
+    """Minimally-valid ``Vault`` JSON."""
+    base = {
+        "id": "vlt_1",
+        "display_name": "test",
+        "metadata": {},
+        "created_at": _FIXED_TS,
+        "updated_at": _FIXED_TS,
+    }
+    base.update(overrides)
+    return base
+
+
+def vault_credential_response(**overrides: Any) -> dict[str, Any]:
+    """Minimally-valid ``VaultCredential`` JSON."""
+    base = {
+        "id": "cred_1",
+        "vault_id": "vlt_1",
+        "display_name": "test-cred",
+        "mcp_server_url": "http://example.invalid",
+        "auth_type": "static_bearer",
+        "metadata": {},
+        "created_at": _FIXED_TS,
+        "updated_at": _FIXED_TS,
+    }
+    base.update(overrides)
+    return base

--- a/tests/unit/cli/test_cli_connections.py
+++ b/tests/unit/cli/test_cli_connections.py
@@ -11,6 +11,7 @@ import httpx
 from typer.testing import CliRunner
 
 from aios.cli.app import app
+from tests.unit.cli.conftest import connection_response
 
 runner = CliRunner()
 
@@ -47,7 +48,7 @@ def test_list_filters_pass_through(mocked_cli):
 
 
 def test_create_ergonomic(mocked_cli):
-    mocked_cli.queue_response(httpx.Response(201, json={"id": "conn_new"}))
+    mocked_cli.queue_response(httpx.Response(201, json=connection_response(id="conn_new")))
     result = runner.invoke(
         app,
         [
@@ -69,7 +70,7 @@ def test_create_ergonomic(mocked_cli):
 
 
 def test_create_ergonomic_with_metadata_json(mocked_cli):
-    mocked_cli.queue_response(httpx.Response(201, json={"id": "conn_new"}))
+    mocked_cli.queue_response(httpx.Response(201, json=connection_response(id="conn_new")))
     result = runner.invoke(
         app,
         [
@@ -131,7 +132,7 @@ def test_archive_uses_delete(mocked_cli):
 
 
 def test_attach_posts_session_id(mocked_cli):
-    mocked_cli.queue_response(httpx.Response(200, json={"id": "conn_01"}))
+    mocked_cli.queue_response(httpx.Response(200, json=connection_response()))
     result = runner.invoke(
         app,
         ["connections", "attach", "conn_01", "--session-id", "sess_1"],

--- a/tests/unit/cli/test_cli_connections.py
+++ b/tests/unit/cli/test_cli_connections.py
@@ -11,7 +11,7 @@ import httpx
 from typer.testing import CliRunner
 
 from aios.cli.app import app
-from tests.unit.cli.conftest import connection_response
+from tests.unit.cli.conftest import resource_response
 
 runner = CliRunner()
 
@@ -48,7 +48,9 @@ def test_list_filters_pass_through(mocked_cli):
 
 
 def test_create_ergonomic(mocked_cli):
-    mocked_cli.queue_response(httpx.Response(201, json=connection_response(id="conn_new")))
+    mocked_cli.queue_response(
+        httpx.Response(201, json=resource_response("connection", id="conn_new"))
+    )
     result = runner.invoke(
         app,
         [
@@ -70,7 +72,9 @@ def test_create_ergonomic(mocked_cli):
 
 
 def test_create_ergonomic_with_metadata_json(mocked_cli):
-    mocked_cli.queue_response(httpx.Response(201, json=connection_response(id="conn_new")))
+    mocked_cli.queue_response(
+        httpx.Response(201, json=resource_response("connection", id="conn_new"))
+    )
     result = runner.invoke(
         app,
         [
@@ -132,7 +136,7 @@ def test_archive_uses_delete(mocked_cli):
 
 
 def test_attach_posts_session_id(mocked_cli):
-    mocked_cli.queue_response(httpx.Response(200, json=connection_response()))
+    mocked_cli.queue_response(httpx.Response(200, json=resource_response("connection")))
     result = runner.invoke(
         app,
         ["connections", "attach", "conn_01", "--session-id", "sess_1"],

--- a/tests/unit/cli/test_cli_vault_credentials.py
+++ b/tests/unit/cli/test_cli_vault_credentials.py
@@ -6,7 +6,7 @@ import httpx
 from typer.testing import CliRunner
 
 from aios.cli.app import app
-from tests.unit.cli.conftest import vault_credential_response
+from tests.unit.cli.conftest import resource_response
 
 runner = CliRunner()
 
@@ -34,7 +34,9 @@ def test_create_via_body_file(mocked_cli, tmp_path):
         '{"display_name": "my-creds", "mcp_server_url": "http://x",'
         ' "auth_type": "static_bearer", "token": "t"}'
     )
-    mocked_cli.queue_response(httpx.Response(201, json=vault_credential_response(id="cred_new")))
+    mocked_cli.queue_response(
+        httpx.Response(201, json=resource_response("vault_credential", id="cred_new"))
+    )
     result = runner.invoke(
         app,
         [
@@ -58,7 +60,9 @@ def test_create_via_file_alias(mocked_cli, tmp_path):
     body.write_text(
         '{"display_name": "x", "mcp_server_url": "http://y", "auth_type": "static_bearer", "token": "t"}'
     )
-    mocked_cli.queue_response(httpx.Response(201, json=vault_credential_response(id="cred_new")))
+    mocked_cli.queue_response(
+        httpx.Response(201, json=resource_response("vault_credential", id="cred_new"))
+    )
     result = runner.invoke(
         app,
         ["vaults", "credentials", "create", "vlt_1", "--file", str(body)],
@@ -68,7 +72,7 @@ def test_create_via_file_alias(mocked_cli, tmp_path):
 
 
 def test_archive_uses_post(mocked_cli):
-    mocked_cli.queue_response(httpx.Response(200, json=vault_credential_response()))
+    mocked_cli.queue_response(httpx.Response(200, json=resource_response("vault_credential")))
     result = runner.invoke(app, ["vaults", "credentials", "archive", "vlt_1", "cred_1"])
     assert result.exit_code == 0, result.output
     assert mocked_cli.captured.method == "POST"

--- a/tests/unit/cli/test_cli_vault_credentials.py
+++ b/tests/unit/cli/test_cli_vault_credentials.py
@@ -6,6 +6,7 @@ import httpx
 from typer.testing import CliRunner
 
 from aios.cli.app import app
+from tests.unit.cli.conftest import vault_credential_response
 
 runner = CliRunner()
 
@@ -33,7 +34,7 @@ def test_create_via_body_file(mocked_cli, tmp_path):
         '{"display_name": "my-creds", "mcp_server_url": "http://x",'
         ' "auth_type": "static_bearer", "token": "t"}'
     )
-    mocked_cli.queue_response(httpx.Response(201, json={"id": "cred_new"}))
+    mocked_cli.queue_response(httpx.Response(201, json=vault_credential_response(id="cred_new")))
     result = runner.invoke(
         app,
         [
@@ -57,7 +58,7 @@ def test_create_via_file_alias(mocked_cli, tmp_path):
     body.write_text(
         '{"display_name": "x", "mcp_server_url": "http://y", "auth_type": "static_bearer", "token": "t"}'
     )
-    mocked_cli.queue_response(httpx.Response(201, json={"id": "cred_new"}))
+    mocked_cli.queue_response(httpx.Response(201, json=vault_credential_response(id="cred_new")))
     result = runner.invoke(
         app,
         ["vaults", "credentials", "create", "vlt_1", "--file", str(body)],
@@ -67,7 +68,7 @@ def test_create_via_file_alias(mocked_cli, tmp_path):
 
 
 def test_archive_uses_post(mocked_cli):
-    mocked_cli.queue_response(httpx.Response(200, json={"id": "cred_1"}))
+    mocked_cli.queue_response(httpx.Response(200, json=vault_credential_response()))
     result = runner.invoke(app, ["vaults", "credentials", "archive", "vlt_1", "cred_1"])
     assert result.exit_code == 0, result.output
     assert mocked_cli.captured.method == "POST"

--- a/tests/unit/cli/test_cli_vaults.py
+++ b/tests/unit/cli/test_cli_vaults.py
@@ -6,6 +6,7 @@ import httpx
 from typer.testing import CliRunner
 
 from aios.cli.app import app
+from tests.unit.cli.conftest import vault_response
 
 runner = CliRunner()
 
@@ -19,7 +20,7 @@ def test_list_with_pagination(mocked_cli):
 
 
 def test_create_ergonomic_with_display_name(mocked_cli):
-    mocked_cli.queue_response(httpx.Response(201, json={"id": "vlt_new"}))
+    mocked_cli.queue_response(httpx.Response(201, json=vault_response(id="vlt_new")))
     result = runner.invoke(
         app,
         ["vaults", "create", "--display-name", "prod-secrets"],
@@ -59,7 +60,9 @@ def test_create_requires_display_name_when_ergonomic(mocked_cli):
 
 
 def test_archive_uses_post(mocked_cli):
-    mocked_cli.queue_response(httpx.Response(200, json={"id": "vlt_1", "archived_at": "t"}))
+    mocked_cli.queue_response(
+        httpx.Response(200, json=vault_response(archived_at="2024-01-02T00:00:00+00:00"))
+    )
     result = runner.invoke(app, ["vaults", "archive", "vlt_1"])
     assert result.exit_code == 0, result.output
     assert mocked_cli.captured.method == "POST"

--- a/tests/unit/cli/test_cli_vaults.py
+++ b/tests/unit/cli/test_cli_vaults.py
@@ -6,7 +6,7 @@ import httpx
 from typer.testing import CliRunner
 
 from aios.cli.app import app
-from tests.unit.cli.conftest import vault_response
+from tests.unit.cli.conftest import resource_response
 
 runner = CliRunner()
 
@@ -20,7 +20,7 @@ def test_list_with_pagination(mocked_cli):
 
 
 def test_create_ergonomic_with_display_name(mocked_cli):
-    mocked_cli.queue_response(httpx.Response(201, json=vault_response(id="vlt_new")))
+    mocked_cli.queue_response(httpx.Response(201, json=resource_response("vault", id="vlt_new")))
     result = runner.invoke(
         app,
         ["vaults", "create", "--display-name", "prod-secrets"],
@@ -61,7 +61,9 @@ def test_create_requires_display_name_when_ergonomic(mocked_cli):
 
 def test_archive_uses_post(mocked_cli):
     mocked_cli.queue_response(
-        httpx.Response(200, json=vault_response(archived_at="2024-01-02T00:00:00+00:00"))
+        httpx.Response(
+            200, json=resource_response("vault", archived_at="2024-01-02T00:00:00+00:00")
+        )
     )
     result = runner.invoke(app, ["vaults", "archive", "vlt_1"])
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary

- Hand-write the SDK-eligible CLI CRUD modules (agents, envs, skills, vaults+credentials, connections, session-templates) on top of `aios.sdk._generated` instead of the dict-based `AiosClient`.
- Adds two helpers in `commands/_shared.py`:
  - `unwrap(response)` — translate SDK `Response` → typed parsed body, with non-2xx routed through `AiosApiError` so `run_or_die` keeps printing the same friendly errors.
  - `render_paginated(ctx, fn, *, columns, all_, ...)` — single entry point for every `aios <resource> list` command, replacing the six `if all_:` blocks the first commit introduced.
- Tightens two cursor types the SDK exposed: `list_agent_versions` and `list_skill_versions` use `int` cursors (version numbers), not `str` — the original CLI's typer signature was loose-typed and would have round-tripped to a 422 if anyone passed `--after foo`.

## Implementation

This is the implementation pass on issue #267's build-order step 5: *"plumbing CLI: generate or hand-write?"*. Proof-of-concept on agents.py was clean (LoC ≈ status quo, plus typed payload validation and one bug catch); the rest follow the same shape.

Each subcommand now imports the specific operation from `aios.sdk._generated.api.<router>`, builds the request body via the SDK's `<Model>.from_dict(payload)`, and calls `sync_detailed(client=..., body=...)` through `unwrap`.

## Deferred (intentionally not migrated)

- **`sessions.py`** — still on FastAPI auto-derived operationIds pending #270 / Phase A. Porting now would create unstable SDK imports we'd have to rewrite once that router is cleaned up.
- **`connectors.py`** — `x-codegen.targets:[]` per #267, raw `dict[str, Any]` envelopes that aren't generator-shaped.
- **`chat`/`tail`/`status`/`dev`** — porcelain modules, partly already on the SDK path.

## Commits

1. `7acecd7` — initial port of all 6 modules (583 +, 300 -)
2. `9696863` — /simplify pass: collapse list-command duplication into `render_paginated`, drop redundant `_coerce_mode` (typer handles enums natively), trim docstrings, parametrize test factories (169 +, 292 -)

Net: **+494, -346** across 12 files.

## Test plan

- [x] `bash scripts/run-checks.sh` clean (mypy + ruff + 1175 unit tests)
- [x] `aios agents --help` / `aios connections list --help` / etc. surface unchanged
- [ ] Manual smoke against a live runtime — verify list / create / update / archive on representative resources

🤖 Generated with [Claude Code](https://claude.ai/code)