### PR TITLE
feat(worker): exit-diagnostics infrastructure (#268)

### DIFF
--- a/src/aios/cli/commands/ops.py
+++ b/src/aios/cli/commands/ops.py
@@ -38,14 +38,8 @@ def _run_worker() -> int:
     except KeyboardInterrupt:
         pass
     except SystemExit:
-        # Already-logged refusal paths (e.g. duplicate worker locked out
-        # by ``_acquire_worker_lock``).  Don't double-report.
         raise
     except BaseException:
-        # Last-ditch logging before the process dies (#268). configure_logging
-        # may not have run if startup failed early, but structlog falls back
-        # to print-to-stderr and that still beats the silent-exit failure
-        # mode the issue describes.
         get_logger("aios.worker").exception("worker.unexpected_exit")
         raise
     return 0

--- a/src/aios/cli/commands/ops.py
+++ b/src/aios/cli/commands/ops.py
@@ -8,7 +8,6 @@ migrations — they do NOT talk to the HTTP API.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import subprocess
 import sys
 
@@ -32,9 +31,23 @@ def _run_api() -> int:
 
 def _run_worker() -> int:
     from aios.harness.worker import worker_main
+    from aios.logging import get_logger
 
-    with contextlib.suppress(KeyboardInterrupt):
+    try:
         asyncio.run(worker_main())
+    except KeyboardInterrupt:
+        pass
+    except SystemExit:
+        # Already-logged refusal paths (e.g. duplicate worker locked out
+        # by ``_acquire_worker_lock``).  Don't double-report.
+        raise
+    except BaseException:
+        # Last-ditch logging before the process dies (#268). configure_logging
+        # may not have run if startup failed early, but structlog falls back
+        # to print-to-stderr and that still beats the silent-exit failure
+        # mode the issue describes.
+        get_logger("aios.worker").exception("worker.unexpected_exit")
+        raise
     return 0
 
 

--- a/src/aios/harness/exit_diagnostics.py
+++ b/src/aios/harness/exit_diagnostics.py
@@ -1,0 +1,38 @@
+"""Wire faulthandler, asyncio loop exception handler, and atexit so any
+worker-process exit produces an auditable log line.
+
+Without these, native crashes, unretrieved task exceptions, and ordinary
+process exits can all leave zero trace in the structured log stream —
+exactly the failure shape that made the silent-exit incident
+undiagnosable. Lives in its own module (separate from
+:mod:`aios.harness.worker`) so unit tests can exercise it without
+pulling in :mod:`aios.harness.procrastinate_app`'s module-level
+``Settings()`` validation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import faulthandler
+from typing import Any
+
+import structlog
+
+
+def install_exit_diagnostics(log: structlog.stdlib.BoundLogger) -> None:
+    faulthandler.enable()
+
+    def _on_loop_exception(_loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        exc = context.get("exception")
+        log.error(
+            "worker.task_exception",
+            message=context.get("message"),
+            error_type=type(exc).__name__ if exc is not None else None,
+            error=str(exc) if exc is not None else None,
+            exc_info=exc,
+        )
+
+    asyncio.get_running_loop().set_exception_handler(_on_loop_exception)
+
+    atexit.register(lambda: log.info("worker.exit"))

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -31,6 +31,7 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 import asyncpg
+import structlog
 
 import aios.tools  # noqa: F401  — side-effect: register built-in tools
 
@@ -72,28 +73,14 @@ def _make_worker_id() -> str:
     return f"worker_{ULID()}"
 
 
-def install_exit_diagnostics(log: Any) -> None:
-    """Make every worker-process exit produce a log line we can audit.
+def install_exit_diagnostics(log: structlog.stdlib.BoundLogger) -> None:
+    """Wire faulthandler, asyncio loop exception handler, and atexit so any
+    worker-process exit produces an auditable log line.
 
-    The silent-exit bug (#268) surfaced because the process disappeared
-    with no graceful-shutdown line, no traceback, no signal log — leaving
-    the operator no way to tell from logs alone whether the worker had
-    exited or simply gone idle. This wires three mechanisms so that any
-    exit path produces something:
-
-    * :func:`faulthandler.enable` — dumps a Python traceback to stderr on
-      ``SIGSEGV`` / ``SIGABRT`` / ``SIGBUS`` / ``SIGFPE`` / ``SIGILL``,
-      which Python would otherwise silently die from.
-    * The asyncio loop exception handler — routes uncaught task
-      exceptions through structlog instead of stderr's
-      ``Task exception was never retrieved`` warning, which doesn't fire
-      until garbage-collection and never appears in the JSON log stream.
-    * :func:`atexit.register` — emits a final ``worker.exit`` line on any
-      interpreter-shutdown path (``sys.exit``, ``return`` from
-      ``asyncio.run``, ``BaseException`` propagation), so the absence
-      of an exit log unambiguously means the process was killed
-      externally (``SIGKILL``, OOM kill, host crash) rather than wound
-      down on its own.
+    Without these, native crashes, unretrieved task exceptions, and
+    ordinary process exits can all leave zero trace in the structured
+    log stream — exactly the failure shape that made the silent-exit
+    incident undiagnosable.
     """
     faulthandler.enable()
 

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -24,7 +24,9 @@ supervisor, and closes connections.
 from __future__ import annotations
 
 import asyncio
+import atexit
 import contextlib
+import faulthandler
 import sys
 from typing import TYPE_CHECKING, Any
 
@@ -70,10 +72,51 @@ def _make_worker_id() -> str:
     return f"worker_{ULID()}"
 
 
+def install_exit_diagnostics(log: Any) -> None:
+    """Make every worker-process exit produce a log line we can audit.
+
+    The silent-exit bug (#268) surfaced because the process disappeared
+    with no graceful-shutdown line, no traceback, no signal log — leaving
+    the operator no way to tell from logs alone whether the worker had
+    exited or simply gone idle. This wires three mechanisms so that any
+    exit path produces something:
+
+    * :func:`faulthandler.enable` — dumps a Python traceback to stderr on
+      ``SIGSEGV`` / ``SIGABRT`` / ``SIGBUS`` / ``SIGFPE`` / ``SIGILL``,
+      which Python would otherwise silently die from.
+    * The asyncio loop exception handler — routes uncaught task
+      exceptions through structlog instead of stderr's
+      ``Task exception was never retrieved`` warning, which doesn't fire
+      until garbage-collection and never appears in the JSON log stream.
+    * :func:`atexit.register` — emits a final ``worker.exit`` line on any
+      interpreter-shutdown path (``sys.exit``, ``return`` from
+      ``asyncio.run``, ``BaseException`` propagation), so the absence
+      of an exit log unambiguously means the process was killed
+      externally (``SIGKILL``, OOM kill, host crash) rather than wound
+      down on its own.
+    """
+    faulthandler.enable()
+
+    def _on_loop_exception(_loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        exc = context.get("exception")
+        log.error(
+            "worker.task_exception",
+            message=context.get("message"),
+            error_type=type(exc).__name__ if exc is not None else None,
+            error=str(exc) if exc is not None else None,
+            exc_info=exc,
+        )
+
+    asyncio.get_running_loop().set_exception_handler(_on_loop_exception)
+
+    atexit.register(lambda: log.info("worker.exit"))
+
+
 async def worker_main() -> None:
     settings = get_settings()
     configure_logging(settings.log_level)
     log = get_logger("aios.worker")
+    install_exit_diagnostics(log)
 
     # Single-instance guard.  Two `aios worker` processes against the same
     # database would race for connector subprocess ownership (signal-cli's

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -24,14 +24,11 @@ supervisor, and closes connections.
 from __future__ import annotations
 
 import asyncio
-import atexit
 import contextlib
-import faulthandler
 import sys
 from typing import TYPE_CHECKING, Any
 
 import asyncpg
-import structlog
 
 import aios.tools  # noqa: F401  — side-effect: register built-in tools
 
@@ -49,6 +46,7 @@ from aios.harness.connector_supervisor import (
     instance_label,
     resolve_connector_specs,
 )
+from aios.harness.exit_diagnostics import install_exit_diagnostics
 from aios.harness.procrastinate_app import app as procrastinate_app
 from aios.harness.sweep import (
     reap_stalled_jobs,
@@ -71,32 +69,6 @@ def _make_worker_id() -> str:
     from ulid import ULID
 
     return f"worker_{ULID()}"
-
-
-def install_exit_diagnostics(log: structlog.stdlib.BoundLogger) -> None:
-    """Wire faulthandler, asyncio loop exception handler, and atexit so any
-    worker-process exit produces an auditable log line.
-
-    Without these, native crashes, unretrieved task exceptions, and
-    ordinary process exits can all leave zero trace in the structured
-    log stream — exactly the failure shape that made the silent-exit
-    incident undiagnosable.
-    """
-    faulthandler.enable()
-
-    def _on_loop_exception(_loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
-        exc = context.get("exception")
-        log.error(
-            "worker.task_exception",
-            message=context.get("message"),
-            error_type=type(exc).__name__ if exc is not None else None,
-            error=str(exc) if exc is not None else None,
-            exc_info=exc,
-        )
-
-    asyncio.get_running_loop().set_exception_handler(_on_loop_exception)
-
-    atexit.register(lambda: log.info("worker.exit"))
 
 
 async def worker_main() -> None:

--- a/tests/unit/test_worker_exit_diagnostics.py
+++ b/tests/unit/test_worker_exit_diagnostics.py
@@ -1,11 +1,3 @@
-"""Worker exit-diagnostics wiring (#268).
-
-The silent-exit failure mode the issue describes was identifiable by *no*
-log output for ~2 hours after the worker died. These tests pin the three
-mechanisms :func:`install_exit_diagnostics` wires to ensure that any
-future exit produces something we can audit.
-"""
-
 from __future__ import annotations
 
 import asyncio
@@ -35,7 +27,6 @@ def captured_atexit(monkeypatch: pytest.MonkeyPatch) -> list[Callable[[], None]]
 
 @pytest.fixture
 def capture_logs() -> Iterator[structlog.testing.LogCapture]:
-    """Pin a structlog ``LogCapture`` so emitted events are inspectable."""
     cap = structlog.testing.LogCapture()
     structlog.configure(processors=[cap])
     try:
@@ -44,38 +35,30 @@ def capture_logs() -> Iterator[structlog.testing.LogCapture]:
         structlog.reset_defaults()
 
 
-def test_install_enables_faulthandler(captured_atexit: list[Callable[[], None]]) -> None:
-    """``faulthandler.enable()`` runs idempotently and stays enabled.
-
-    We can't synthesize a ``SIGSEGV`` without killing the test runner, so
-    we settle for the observable proxy: ``is_enabled()`` is True after
-    the helper runs.
-    """
+@pytest.fixture
+def installed(
+    captured_atexit: list[Callable[[], None]],
+    capture_logs: structlog.testing.LogCapture,
+) -> tuple[list[Callable[[], None]], structlog.testing.LogCapture]:
+    """Run :func:`install_exit_diagnostics` inside an asyncio loop."""
 
     async def _run() -> None:
-        log = structlog.get_logger("aios.worker")
-        install_exit_diagnostics(log)
+        install_exit_diagnostics(structlog.get_logger("aios.worker"))
 
     asyncio.run(_run())
+    return captured_atexit, capture_logs
+
+
+def test_enables_faulthandler(installed: object) -> None:
     assert faulthandler.is_enabled()
-    assert len(captured_atexit) == 1
 
 
-def test_install_routes_loop_exception_through_log(
+def test_routes_loop_exception_through_log(
     captured_atexit: list[Callable[[], None]],
     capture_logs: structlog.testing.LogCapture,
 ) -> None:
-    """Uncaught task exceptions land in structlog as ``worker.task_exception``.
-
-    Without this, asyncio's default handler prints a free-form
-    ``Task exception was never retrieved`` warning to stderr — invisible
-    to a JSON log consumer and absent until the offending Task is
-    garbage-collected.
-    """
-
     async def _run() -> None:
-        log = structlog.get_logger("aios.worker")
-        install_exit_diagnostics(log)
+        install_exit_diagnostics(structlog.get_logger("aios.worker"))
         loop = asyncio.get_running_loop()
         loop.call_exception_handler(
             {"message": "synthetic task failure", "exception": RuntimeError("boom")}
@@ -92,23 +75,11 @@ def test_install_routes_loop_exception_through_log(
     assert entry["error_type"] == "RuntimeError"
 
 
-def test_install_registers_atexit_hook(
-    captured_atexit: list[Callable[[], None]],
-    capture_logs: structlog.testing.LogCapture,
+def test_atexit_hook_emits_worker_exit(
+    installed: tuple[list[Callable[[], None]], structlog.testing.LogCapture],
 ) -> None:
-    """The atexit hook is the safety net for "did the process actually exit?"
-
-    Invokes the captured callback manually (rather than waiting for
-    interpreter shutdown) and asserts a ``worker.exit`` log line emerges.
-    """
-
-    async def _run() -> None:
-        log = structlog.get_logger("aios.worker")
-        install_exit_diagnostics(log)
-
-    asyncio.run(_run())
-
-    assert len(captured_atexit) == 1, "expected exactly one atexit registration"
+    captured_atexit, capture_logs = installed
+    assert len(captured_atexit) == 1
 
     capture_logs.entries.clear()
     captured_atexit[0]()

--- a/tests/unit/test_worker_exit_diagnostics.py
+++ b/tests/unit/test_worker_exit_diagnostics.py
@@ -1,0 +1,120 @@
+"""Worker exit-diagnostics wiring (#268).
+
+The silent-exit failure mode the issue describes was identifiable by *no*
+log output for ~2 hours after the worker died. These tests pin the three
+mechanisms :func:`install_exit_diagnostics` wires to ensure that any
+future exit produces something we can audit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import faulthandler
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import pytest
+import structlog
+
+from aios.harness.worker import install_exit_diagnostics
+
+
+@pytest.fixture
+def captured_atexit(monkeypatch: pytest.MonkeyPatch) -> list[Callable[[], None]]:
+    """Replace :func:`atexit.register` with a list-appender for the test.
+
+    Real registration would queue a callback that fires at interpreter
+    shutdown — long after pytest collects results — and would emit a
+    ``worker.exit`` line into whatever logger config is live then.
+    """
+    captured: list[Callable[[], None]] = []
+    monkeypatch.setattr(atexit, "register", lambda fn: captured.append(fn) or fn)
+    return captured
+
+
+@pytest.fixture
+def capture_logs() -> Iterator[structlog.testing.LogCapture]:
+    """Pin a structlog ``LogCapture`` so emitted events are inspectable."""
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    try:
+        yield cap
+    finally:
+        structlog.reset_defaults()
+
+
+def test_install_enables_faulthandler(captured_atexit: list[Callable[[], None]]) -> None:
+    """``faulthandler.enable()`` runs idempotently and stays enabled.
+
+    We can't synthesize a ``SIGSEGV`` without killing the test runner, so
+    we settle for the observable proxy: ``is_enabled()`` is True after
+    the helper runs.
+    """
+
+    async def _run() -> None:
+        log = structlog.get_logger("aios.worker")
+        install_exit_diagnostics(log)
+
+    asyncio.run(_run())
+    assert faulthandler.is_enabled()
+    assert len(captured_atexit) == 1
+
+
+def test_install_routes_loop_exception_through_log(
+    captured_atexit: list[Callable[[], None]],
+    capture_logs: structlog.testing.LogCapture,
+) -> None:
+    """Uncaught task exceptions land in structlog as ``worker.task_exception``.
+
+    Without this, asyncio's default handler prints a free-form
+    ``Task exception was never retrieved`` warning to stderr — invisible
+    to a JSON log consumer and absent until the offending Task is
+    garbage-collected.
+    """
+
+    async def _run() -> None:
+        log = structlog.get_logger("aios.worker")
+        install_exit_diagnostics(log)
+        loop = asyncio.get_running_loop()
+        loop.call_exception_handler(
+            {"message": "synthetic task failure", "exception": RuntimeError("boom")}
+        )
+
+    asyncio.run(_run())
+
+    matches = [e for e in capture_logs.entries if e.get("event") == "worker.task_exception"]
+    assert len(matches) == 1
+    entry = matches[0]
+    assert entry["log_level"] == "error"
+    assert entry["message"] == "synthetic task failure"
+    assert entry["error"] == "boom"
+    assert entry["error_type"] == "RuntimeError"
+
+
+def test_install_registers_atexit_hook(
+    captured_atexit: list[Callable[[], None]],
+    capture_logs: structlog.testing.LogCapture,
+) -> None:
+    """The atexit hook is the safety net for "did the process actually exit?"
+
+    Invokes the captured callback manually (rather than waiting for
+    interpreter shutdown) and asserts a ``worker.exit`` log line emerges.
+    """
+
+    async def _run() -> None:
+        log = structlog.get_logger("aios.worker")
+        install_exit_diagnostics(log)
+
+    asyncio.run(_run())
+
+    assert len(captured_atexit) == 1, "expected exactly one atexit registration"
+
+    capture_logs.entries.clear()
+    captured_atexit[0]()
+
+    matches: list[dict[str, Any]] = [
+        e for e in capture_logs.entries if e.get("event") == "worker.exit"
+    ]
+    assert len(matches) == 1
+    assert matches[0]["log_level"] == "info"

--- a/tests/unit/test_worker_exit_diagnostics.py
+++ b/tests/unit/test_worker_exit_diagnostics.py
@@ -9,7 +9,7 @@ from typing import Any
 import pytest
 import structlog
 
-from aios.harness.worker import install_exit_diagnostics
+from aios.harness.exit_diagnostics import install_exit_diagnostics
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #268 (partial — see "Out of scope" below).

## Summary

A worker silently exited mid-session and left the api answering normally for ~2 hours before anyone noticed. No graceful-shutdown line, no traceback, no signal log — only `ps` showed the worker process gone. Without diagnostic infrastructure in place the root cause is unidentifiable from the existing log stream.

This patch lays the infrastructure so the **next** occurrence is diagnosable, without changing the procrastinate-boundary behavior. The issue itself is explicit that band-aid try/excepts there would mask the bug rather than reveal it.

## What's wired

`install_exit_diagnostics(log)` is called once at the top of `worker_main`:

- **`faulthandler.enable()`** — Python traceback to stderr on `SIGSEGV` / `SIGABRT` / `SIGBUS` / `SIGFPE` / `SIGILL` (otherwise silent native deaths).
- **`loop.set_exception_handler`** — uncaught task exceptions land in structlog as `worker.task_exception` instead of asyncio's free-form `Task exception was never retrieved` warning, which fires only at garbage-collection and never appears in the JSON log stream.
- **`atexit.register`** — emits a final `worker.exit` line on any interpreter-shutdown path. The absence of an exit log unambiguously means the process was killed externally (`SIGKILL`, OOM, host crash).

Plus a top-level catchall in `ops._run_worker`: any `BaseException` escaping `asyncio.run` is logged as `worker.unexpected_exit` (with traceback) before re-raise. `SystemExit` and `KeyboardInterrupt` pass through without double-reporting.

## Out of scope

The issue lists three "Required for fix" items; this PR addresses only the first:

- ✅ **Always log on worker exit** — covered by this PR.
- ⏭️ **Worker self-supervisor / restart manager** — separate concern; aios should run under `systemd` / `supervisord` / `launchd` in production for automatic restart anyway. Issue stays open for documentation.
- ⏭️ **Identify and fix the actual root cause** — wait for the next occurrence with this infrastructure in place. The diagnostic logs from the next incident inform whether a try/except at the procrastinate-app boundary is justified.

## Commits

1. `4470eee` — initial diagnostics + tests (3 files, +178 lines)
2. `671f407` — /simplify pass: trim docstring, drop narration comments, type the `log` parameter, consolidate test boilerplate (-48 net)

## Test plan

- [x] `bash scripts/run-checks.sh` clean (mypy + ruff + 1178 unit tests including 3 new)
- [x] Tests pin: faulthandler enabled, asyncio handler routes through structlog, atexit hook emits `worker.exit`
- [ ] Manual: trigger a synthetic `BaseException` in worker_main and observe the `worker.unexpected_exit` line
- [ ] Wait for next silent-exit occurrence, capture the new diagnostic output, file follow-up issue with root cause

🤖 Generated with [Claude Code](https://claude.ai/code)