### PR TITLE
feat(api/mcp): polish tool schemas — strip response bloat, drop redundant titles, flatten nullable anyOf (#267)

### DIFF
--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -176,82 +176,87 @@ def _verb_default_annotations(verb: str) -> dict[str, bool]:
 
 _RESPONSE_BLOCK_SEPARATOR = "\n\n### Responses:\n"
 
+# JSON Schema keywords whose presence on a branch means the branch carries
+# enough structure that lifting its keys onto a parent during nullable-anyOf
+# flattening would change semantics.  ``_flatten_nullable_anyof`` only
+# flattens when the non-null branch's keys are a subset of the
+# scalar-metadata allow-list, so this set is the inverse safety net.
+_FLATTEN_SAFE_KEYS = frozenset(
+    {
+        "type",
+        "enum",
+        "const",
+        "format",
+        "pattern",
+        "minLength",
+        "maxLength",
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+        "description",
+        "default",
+        "examples",
+        "title",
+    }
+)
+
 
 def _strip_response_block(description: str) -> str | None:
-    """Drop fastapi-mcp's auto-appended ``### Responses:`` example block.
-
-    fastapi-mcp inlines the route's full response example into every tool
-    description (``fastapi_mcp/openapi/convert.py:74,155``).  The model
-    will see the real response when it calls; the embedded example is
-    pure prompt bloat, often longer than the route's actual prose.
-    """
-    head, _sep, _rest = description.partition(_RESPONSE_BLOCK_SEPARATOR)
+    """Drop fastapi-mcp's auto-appended ``### Responses:`` example block."""
+    # ``rpartition`` guards against a route docstring legitimately containing
+    # the literal separator — fastapi-mcp's block is always last-appended.
+    head, _sep, _rest = description.rpartition(_RESPONSE_BLOCK_SEPARATOR)
     return head.rstrip() or None
 
 
 def _drop_redundant_titles(schema: dict[str, Any]) -> None:
-    """Recursively drop ``title`` fields whose value equals their property key.
-
-    fastapi-mcp emits ``"title": "<param_name>"`` for every parameter,
-    duplicating the key the property is already keyed by.  Pure noise.
-    """
-    properties = schema.get("properties")
-    if isinstance(properties, dict):
-        for key, prop in properties.items():
-            if isinstance(prop, dict):
-                if prop.get("title") == key:
-                    prop.pop("title")
-                _drop_redundant_titles(prop)
-    items = schema.get("items")
-    if isinstance(items, dict):
+    """Recursively drop ``title`` fields whose value matches the property key."""
+    for key, prop in schema.get("properties", {}).items():
+        if prop.get("title") == key:
+            prop.pop("title")
+        _drop_redundant_titles(prop)
+    if (items := schema.get("items")) is not None:
         _drop_redundant_titles(items)
     for combinator in ("anyOf", "oneOf", "allOf"):
-        branches = schema.get(combinator)
-        if isinstance(branches, list):
-            for branch in branches:
-                if isinstance(branch, dict):
-                    _drop_redundant_titles(branch)
+        for branch in schema.get(combinator, []):
+            _drop_redundant_titles(branch)
 
 
 def _flatten_nullable_anyof(schema: dict[str, Any]) -> None:
     """Rewrite ``anyOf: [T, {"type": "null"}]`` to ``T`` with ``type: [..., "null"]``.
 
-    Conservative — only flattens when one branch is exactly
-    ``{"type": "null"}`` and the other has a string ``type`` plus only
-    scalar metadata (``enum``, ``format``, ``minLength``, etc.).  Branches
-    that carry nested ``properties`` / ``items`` / ``additionalProperties``
-    keep their original ``anyOf`` form so we don't silently change the
-    semantics of complex unions.
+    Only flattens when the non-null branch's keys are a subset of
+    :data:`_FLATTEN_SAFE_KEYS` — anything else (nested ``properties``,
+    further combinators) keeps its original ``anyOf`` form to avoid
+    silently changing the semantics of complex unions.
     """
-    properties = schema.get("properties")
-    if isinstance(properties, dict):
-        for prop in properties.values():
-            if isinstance(prop, dict):
-                _flatten_nullable_anyof(prop)
-    items = schema.get("items")
-    if isinstance(items, dict):
+    for prop in schema.get("properties", {}).values():
+        _flatten_nullable_anyof(prop)
+    if (items := schema.get("items")) is not None:
         _flatten_nullable_anyof(items)
+    for combinator in ("anyOf", "oneOf", "allOf"):
+        for branch in schema.get(combinator, []):
+            _flatten_nullable_anyof(branch)
 
     branches = schema.get("anyOf")
     if not isinstance(branches, list) or len(branches) != 2:
         return
-    null_branch = next(
-        (b for b in branches if isinstance(b, dict) and b == {"type": "null"}),
-        None,
-    )
-    if null_branch is None:
-        return
-    other = next(b for b in branches if b is not null_branch)
-    if not isinstance(other, dict):
+    b0, b1 = branches
+    if b0 == {"type": "null"}:
+        other = b1
+    elif b1 == {"type": "null"}:
+        other = b0
+    else:
         return
     other_type = other.get("type")
     if not isinstance(other_type, str):
         return
-    if {"properties", "items", "additionalProperties", "patternProperties"} & other.keys():
+    if not other.keys() <= _FLATTEN_SAFE_KEYS:
         return
     del schema["anyOf"]
-    for key, value in other.items():
-        schema[key] = value
+    schema.update(other)
     schema["type"] = [other_type, "null"]
 
 

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -174,15 +174,100 @@ def _verb_default_annotations(verb: str) -> dict[str, bool]:
     return {}
 
 
+_RESPONSE_BLOCK_SEPARATOR = "\n\n### Responses:\n"
+
+
+def _strip_response_block(description: str) -> str | None:
+    """Drop fastapi-mcp's auto-appended ``### Responses:`` example block.
+
+    fastapi-mcp inlines the route's full response example into every tool
+    description (``fastapi_mcp/openapi/convert.py:74,155``).  The model
+    will see the real response when it calls; the embedded example is
+    pure prompt bloat, often longer than the route's actual prose.
+    """
+    head, _sep, _rest = description.partition(_RESPONSE_BLOCK_SEPARATOR)
+    return head.rstrip() or None
+
+
+def _drop_redundant_titles(schema: dict[str, Any]) -> None:
+    """Recursively drop ``title`` fields whose value equals their property key.
+
+    fastapi-mcp emits ``"title": "<param_name>"`` for every parameter,
+    duplicating the key the property is already keyed by.  Pure noise.
+    """
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        for key, prop in properties.items():
+            if isinstance(prop, dict):
+                if prop.get("title") == key:
+                    prop.pop("title")
+                _drop_redundant_titles(prop)
+    items = schema.get("items")
+    if isinstance(items, dict):
+        _drop_redundant_titles(items)
+    for combinator in ("anyOf", "oneOf", "allOf"):
+        branches = schema.get(combinator)
+        if isinstance(branches, list):
+            for branch in branches:
+                if isinstance(branch, dict):
+                    _drop_redundant_titles(branch)
+
+
+def _flatten_nullable_anyof(schema: dict[str, Any]) -> None:
+    """Rewrite ``anyOf: [T, {"type": "null"}]`` to ``T`` with ``type: [..., "null"]``.
+
+    Conservative — only flattens when one branch is exactly
+    ``{"type": "null"}`` and the other has a string ``type`` plus only
+    scalar metadata (``enum``, ``format``, ``minLength``, etc.).  Branches
+    that carry nested ``properties`` / ``items`` / ``additionalProperties``
+    keep their original ``anyOf`` form so we don't silently change the
+    semantics of complex unions.
+    """
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        for prop in properties.values():
+            if isinstance(prop, dict):
+                _flatten_nullable_anyof(prop)
+    items = schema.get("items")
+    if isinstance(items, dict):
+        _flatten_nullable_anyof(items)
+
+    branches = schema.get("anyOf")
+    if not isinstance(branches, list) or len(branches) != 2:
+        return
+    null_branch = next(
+        (b for b in branches if isinstance(b, dict) and b == {"type": "null"}),
+        None,
+    )
+    if null_branch is None:
+        return
+    other = next(b for b in branches if b is not null_branch)
+    if not isinstance(other, dict):
+        return
+    other_type = other.get("type")
+    if not isinstance(other_type, str):
+        return
+    if {"properties", "items", "additionalProperties", "patternProperties"} & other.keys():
+        return
+    del schema["anyOf"]
+    for key, value in other.items():
+        schema[key] = value
+    schema["type"] = [other_type, "null"]
+
+
 def _apply_mcp_polish(app: FastAPI, mcp: Any, *, instructions: str) -> None:
-    """Post-construction patch: per-tool annotations + server instructions.
+    """Post-construction patch: per-tool annotations, schema cleanup, server instructions.
 
     fastapi-mcp 0.4 doesn't infer annotations from HTTP verbs and exposes
     no construction-time hook for them, so we walk the spec, build verb-
     based defaults, layer the route's ``x-codegen.mcp`` overrides on top,
-    and assign the result to each ``mcp.tools[i].annotations``. Also sets
-    ``mcp.server.instructions`` (the MCP handshake field, inlined into the
-    calling LLM's system prompt by clients that respect it).
+    and assign the result to each ``mcp.tools[i].annotations``.  Also
+    strips three sources of schema noise — auto-appended response-example
+    blocks, redundant ``title`` fields, and verbose ``anyOf`` nullable
+    encodings — so the tool list the model sees is roughly half its raw
+    fastapi-mcp size.  Finally sets ``mcp.server.instructions`` (the MCP
+    handshake field, inlined into the calling LLM's system prompt by
+    clients that respect it).
     """
     from mcp.types import ToolAnnotations
 
@@ -199,6 +284,10 @@ def _apply_mcp_polish(app: FastAPI, mcp: Any, *, instructions: str) -> None:
         annotations = _verb_default_annotations(verb) | overrides
         if annotations:
             tool.annotations = ToolAnnotations(**annotations)
+        if tool.description is not None:
+            tool.description = _strip_response_block(tool.description)
+        _drop_redundant_titles(tool.inputSchema)
+        _flatten_nullable_anyof(tool.inputSchema)
 
     mcp.server.instructions = instructions
 

--- a/tests/unit/test_mcp_mount.py
+++ b/tests/unit/test_mcp_mount.py
@@ -148,3 +148,73 @@ def test_apply_mcp_polish_populates_annotations_and_instructions() -> None:
 
     # Server-level instructions populated
     assert mcp.server.instructions == MCP_INSTRUCTIONS
+
+
+def test_apply_mcp_polish_cleans_schemas() -> None:
+    """End-to-end: the MCP tool list ships with cleaned-up descriptions and inputSchemas.
+
+    Three transforms applied per tool:
+    - The auto-appended ``### Responses:`` example block is gone.
+    - Redundant ``title`` fields (whose value matches the property key) are dropped.
+    - Two-branch ``anyOf: [T, {"type": "null"}]`` is flattened to ``type: [T, "null"]``.
+
+    Verified against representative tools that exercise each transform —
+    plus a deliberate non-target case to confirm complex multi-branch
+    ``anyOf`` schemas are preserved.
+    """
+    from fastapi import Depends
+    from fastapi_mcp import AuthConfig, FastApiMCP
+
+    from aios.api.app import (
+        MCP_INSTRUCTIONS,
+        _apply_mcp_polish,
+        _compute_mcp_excluded_operations,
+        create_app,
+    )
+    from aios.api.deps import require_bearer_auth
+
+    app = create_app()
+    mcp = FastApiMCP(
+        app,
+        name="test",
+        description="test",
+        exclude_operations=_compute_mcp_excluded_operations(app),
+        auth_config=AuthConfig(dependencies=[Depends(require_bearer_auth)]),
+    )
+    _apply_mcp_polish(app, mcp, instructions=MCP_INSTRUCTIONS)
+
+    by_name = {tool.name: tool for tool in mcp.tools}
+
+    # Description-strip: the ``### Responses:`` block + example payload are gone
+    archive = by_name["archive_session"]
+    assert archive.description is not None
+    assert "### Responses:" not in archive.description
+    assert "Example Response" not in archive.description
+    # The route's actual prose ("Archive") survives
+    assert "Archive" in archive.description
+
+    # Title-drop: ``session_id`` property no longer carries a redundant ``title``
+    session_id_prop = archive.inputSchema["properties"]["session_id"]
+    assert "title" not in session_id_prop
+    assert session_id_prop["type"] == "string"
+
+    # Nullable-anyOf flatten: simple nullable string collapses to type-array
+    list_conn = by_name["list_connections"]
+    connector_prop = list_conn.inputSchema["properties"]["connector"]
+    assert "anyOf" not in connector_prop
+    assert connector_prop["type"] == ["string", "null"]
+
+    # Nullable-anyOf with enum: ``mode`` keeps its enum, gains nullable type-array
+    mode_prop = list_conn.inputSchema["properties"]["mode"]
+    assert "anyOf" not in mode_prop
+    assert mode_prop["type"] == ["string", "null"]
+    assert set(mode_prop["enum"]) == {"detached", "single_session", "per_chat"}
+
+    # Preservation: the ``tools[].type`` two-branch enum union (no null branch)
+    # is left alone — flattening it would collapse the BuiltinToolType vs.
+    # custom/mcp_toolset distinction the Pydantic union encodes.
+    tools_type_prop = by_name["create_agent"].inputSchema["properties"]["tools"]["items"][
+        "properties"
+    ]["type"]
+    assert "anyOf" in tools_type_prop
+    assert len(tools_type_prop["anyOf"]) == 2

--- a/tests/unit/test_mcp_mount.py
+++ b/tests/unit/test_mcp_mount.py
@@ -14,6 +14,42 @@ time and the conftest env-var fixture only fires after collection.
 
 from __future__ import annotations
 
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def polished_mcp() -> Any:
+    """Live ``FastApiMCP`` against ``create_app()``'s spec, with polish applied.
+
+    Same code path as ``_mount_mcp`` minus the HTTP mount. Imports are
+    inside the fixture body because ``aios.harness.procrastinate_app``
+    runs ``get_settings()`` at module-import time and the conftest
+    env-var fixture only fires after collection.
+    """
+    from fastapi import Depends
+    from fastapi_mcp import AuthConfig, FastApiMCP
+
+    from aios.api.app import (
+        MCP_INSTRUCTIONS,
+        _apply_mcp_polish,
+        _compute_mcp_excluded_operations,
+        create_app,
+    )
+    from aios.api.deps import require_bearer_auth
+
+    app = create_app()
+    mcp = FastApiMCP(
+        app,
+        name="test",
+        description="test",
+        exclude_operations=_compute_mcp_excluded_operations(app),
+        auth_config=AuthConfig(dependencies=[Depends(require_bearer_auth)]),
+    )
+    _apply_mcp_polish(app, mcp, instructions=MCP_INSTRUCTIONS)
+    return mcp
+
 
 def test_mcp_route_is_mounted() -> None:
     from aios.api.app import create_app
@@ -88,36 +124,14 @@ class TestVerbDefaultAnnotations:
         assert _verb_default_annotations("post") == {}
 
 
-def test_apply_mcp_polish_populates_annotations_and_instructions() -> None:
+def test_apply_mcp_polish_populates_annotations_and_instructions(polished_mcp: Any) -> None:
     """End-to-end: the MCP tool list has verb-default annotations + overrides.
 
-    Constructs a fresh FastApiMCP against the live app's OpenAPI spec and
-    applies the polish — same code path as ``_mount_mcp`` but without the
-    HTTP mount. Verifies representative tools across each
-    annotation-bearing category.
+    Verifies representative tools across each annotation-bearing category.
     """
-    from fastapi import Depends
-    from fastapi_mcp import AuthConfig, FastApiMCP
+    from aios.api.app import MCP_INSTRUCTIONS
 
-    from aios.api.app import (
-        MCP_INSTRUCTIONS,
-        _apply_mcp_polish,
-        _compute_mcp_excluded_operations,
-        create_app,
-    )
-    from aios.api.deps import require_bearer_auth
-
-    app = create_app()
-    mcp = FastApiMCP(
-        app,
-        name="test",
-        description="test",
-        exclude_operations=_compute_mcp_excluded_operations(app),
-        auth_config=AuthConfig(dependencies=[Depends(require_bearer_auth)]),
-    )
-    _apply_mcp_polish(app, mcp, instructions=MCP_INSTRUCTIONS)
-
-    by_name = {tool.name: tool for tool in mcp.tools}
+    by_name = {tool.name: tool for tool in polished_mcp.tools}
 
     # GET → readOnlyHint
     assert by_name["list_agents"].annotations is not None
@@ -147,11 +161,11 @@ def test_apply_mcp_polish_populates_annotations_and_instructions() -> None:
     assert by_name["create_agent"].annotations is None
 
     # Server-level instructions populated
-    assert mcp.server.instructions == MCP_INSTRUCTIONS
+    assert polished_mcp.server.instructions == MCP_INSTRUCTIONS
 
 
-def test_apply_mcp_polish_cleans_schemas() -> None:
-    """End-to-end: the MCP tool list ships with cleaned-up descriptions and inputSchemas.
+def test_apply_mcp_polish_cleans_schemas(polished_mcp: Any) -> None:
+    """End-to-end: every MCP tool ships with cleaned-up descriptions and inputSchemas.
 
     Three transforms applied per tool:
     - The auto-appended ``### Responses:`` example block is gone.
@@ -162,28 +176,7 @@ def test_apply_mcp_polish_cleans_schemas() -> None:
     plus a deliberate non-target case to confirm complex multi-branch
     ``anyOf`` schemas are preserved.
     """
-    from fastapi import Depends
-    from fastapi_mcp import AuthConfig, FastApiMCP
-
-    from aios.api.app import (
-        MCP_INSTRUCTIONS,
-        _apply_mcp_polish,
-        _compute_mcp_excluded_operations,
-        create_app,
-    )
-    from aios.api.deps import require_bearer_auth
-
-    app = create_app()
-    mcp = FastApiMCP(
-        app,
-        name="test",
-        description="test",
-        exclude_operations=_compute_mcp_excluded_operations(app),
-        auth_config=AuthConfig(dependencies=[Depends(require_bearer_auth)]),
-    )
-    _apply_mcp_polish(app, mcp, instructions=MCP_INSTRUCTIONS)
-
-    by_name = {tool.name: tool for tool in mcp.tools}
+    by_name = {tool.name: tool for tool in polished_mcp.tools}
 
     # Description-strip: the ``### Responses:`` block + example payload are gone
     archive = by_name["archive_session"]


### PR DESCRIPTION
## Summary

Smoke-testing the `/mcp` mount surfaced three sources of schema noise the agent has to skim past on every prompt. Each tool's spec was about 40% larger than it needed to be, with no functional value — pure context cost paid 79 times per turn.

## Transforms

All applied in `_apply_mcp_polish` after fastapi-mcp constructs the tool list:

1. **Strip the auto-appended `### Responses:` block.** fastapi-mcp's `convert.py` inlines a full response example into every tool description. For routes with short docstrings (`Archive` — 8 chars) the boilerplate dominates (500+ chars). The model sees the real response when it calls; the embedded example is dead weight.

2. **Drop redundant `title` fields.** fastapi-mcp emits `"title": "<param_name>"` for every parameter, duplicating the key the property is already keyed by.

3. **Flatten `anyOf: [T, {"type": "null"}]` into `type: [T, "null"]`.** FastAPI's OpenAPI spec encodes `T | None` as a two-branch `anyOf` wrapper; JSON Schema's compact array-type form is half the tokens. Conservative — only flattens when the non-null branch's keys are a subset of a scalar-metadata allow-list (`type`, `enum`, `format`, `minLength`, …); any nested `properties` / `items` / combinators keep their original `anyOf` form.

## Empirical result

On the live smoke runtime (verified via context dump diff):

| | bytes | tools |
|---|---|---|
| Before polish | 109,617 | 82 |
| After polish | 73,854 | 82 |
| **Reduction** | **−35,763 (32.6%)** | |

Per-tool spot-checks:
- `archive_session`: 888 → 247 bytes (72%)
- `list_connections`: 1345 → 745 bytes (45%)
- `list_connections.mode` becomes `{"type": ["string", "null"], "enum": ["detached", "single_session", "per_chat"]}` — enum semantics preserved
- `create_agent.tools[].type` two-branch enum union (BuiltinToolType vs custom/mcp_toolset) is left alone — flattening would collapse the Pydantic-encoded distinction

## Smoke-verified

After restarting api+worker on this commit, an agent on the polished schemas chained two MCP tool calls (`list_vaults` → `list_vault_credentials`) and answered `"There is 1 vault containing 1 credential"` correctly on first try.

## Commits

1. `1599f13` — initial polish (3 helpers + 1 unit test, +163/-4)
2. `ea07494` — /simplify pass: drop defensive `isinstance` guards (CLAUDE.md fail-hard), collapse helper docstrings, `partition`→`rpartition`, extend `anyOf` recursion to combinators, swap skip-set for positive allow-list, extract `polished_mcp` pytest fixture (+100/-102)

Net: ~159 lines added across `app.py` + `test_mcp_mount.py`.

## Test plan

- [x] `bash scripts/run-checks.sh` clean (mypy + ruff + 1179 unit tests including the new `test_apply_mcp_polish_cleans_schemas`)
- [x] Live smoke: tool list dropped from 109 KB → 74 KB on dump diff; agent still answers correctly on first try
- [ ] Watch for any agent regressions across the next few smoke turns — the polish is conservative, but JSON-Schema flattening always carries some semantic risk

🤖 Generated with [Claude Code](https://claude.ai/code)