### PR TITLE
test(harness): regression guard for litellm 502 step-level recovery

### DIFF
--- a/tests/e2e/test_litellm_502_recovery.py
+++ b/tests/e2e/test_litellm_502_recovery.py
@@ -1,0 +1,65 @@
+"""Regression guard: a transient litellm 502 must not corrupt step-level state.
+
+After a ``BadGatewayError`` on the first step, the next step must consume
+the next scripted response and end the turn cleanly.  Pins the in-process
+recovery path that hypothesis 3 of issue #289 questioned (and that the
+proposed repro confirmed is intact).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+import litellm
+
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness, assistant, last_assistant_content
+
+
+def _make_bad_gateway() -> litellm.exceptions.BadGatewayError:
+    return litellm.exceptions.BadGatewayError(
+        message="Server error '502 Bad Gateway' for url 'https://ant-proxy.eumemic.ai/v1/messages'",
+        llm_provider="anthropic",
+        model="anthropic/claude-opus-4-7",
+    )
+
+
+@needs_docker
+class TestLiteLLMBadGatewayRecovery:
+    async def test_second_step_runs_after_first_step_502(self, harness: Harness) -> None:
+        harness.script_model([assistant("Hello after retry.")])
+        first_call = True
+
+        async def fake_acompletion(**kwargs: Any) -> Any:
+            nonlocal first_call
+            if first_call:
+                first_call = False
+                raise _make_bad_gateway()
+            if kwargs.get("stream"):
+                return harness._pop_streaming_response(**kwargs)
+            return harness._pop_response(**kwargs)
+
+        # ``loop.py`` binds ``defer_wake`` via ``from … import …``, so the
+        # conftest's patch on ``aios.harness.wake.defer_wake`` doesn't reach
+        # the loop-level call site.  Patch the loop binding directly.
+        async def _noop_defer_wake(*args: Any, **kwargs: Any) -> None:
+            return None
+
+        with (
+            mock.patch("aios.harness.completion.litellm.acompletion", fake_acompletion),
+            mock.patch("aios.harness.loop.defer_wake", _noop_defer_wake),
+        ):
+            session = await harness.start("hello")
+
+            await harness.run_step(session.id)
+            s_after_first = await harness.session(session.id)
+            assert s_after_first.status == "rescheduling"
+
+            await harness.run_step(session.id)
+            s_after_second = await harness.session(session.id)
+            assert s_after_second.status == "idle"
+            assert s_after_second.stop_reason == {"type": "end_turn"}
+
+            events = await harness.events(session.id)
+            assert last_assistant_content(events) == "Hello after retry."


### PR DESCRIPTION
## Summary

- Adds an in-process e2e test that pins the recovery path after a transient `BadGatewayError` from `litellm.acompletion`: step 1 raises 502 → catch chain reschedules → step 2 consumes next scripted response → end_turn.
- Confirms hypothesis 3 of #289 does NOT reproduce — asyncio state does not leak past `_run_session_step_body`'s catch chain. The remaining hypotheses (connector-pool teardown deadlock, procrastinate listen-notify task crash, fd exhaustion) require subsystems the harness mocks out and await #285's exit-diagnostics on the next live occurrence.
- Side-find: `loop.py` / `sweep.py` use `from aios.harness.wake import defer_wake`, so the conftest's `mock.patch("aios.harness.wake.defer_wake", ...)` is silently ineffective for those modules. This test patches the loop binding directly. Follow-up candidate: change those imports to `from aios.harness import wake` so the conftest mock works as intended (would let the test drop the local `_noop_defer_wake`).

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1181 passed
- [x] `DOCKER_HOST=… uv run pytest tests/e2e/test_litellm_502_recovery.py -xvs` — 1 passed
- [ ] CI runs the full suite

## Reviewer findings (sub-80, surfaced for transparency)

- **#2, severity 55** — the test reaches into `harness._pop_response` / `_pop_streaming_response` (private) inside `fake_acompletion`. Matches existing house style in `tests/e2e/conftest.py:142-145`; cleanest follow-up is a public `Harness.fake_acompletion(**kwargs)` helper consumed by both conftest and this test.

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)