### PR TITLE
fix(harness): unblock direct-Anthropic context replay (reasoning_content + image mime)

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -53,8 +53,14 @@ _ALLOWED_FIELDS: dict[str, frozenset[str]] = {
 }
 
 # Anthropic's contract: thinking blocks must be preserved across turns
-# for the model to use them as continuation context.
-_THINKING_FIELDS: frozenset[str] = frozenset({"thinking_blocks", "reasoning_content"})
+# for the model to use them as continuation context.  Only ``thinking_blocks``
+# is the real continuation handle — Anthropic's ``/v1/messages`` API rejects
+# ``reasoning_content`` outright (``extra_forbid``: "Extra inputs are not
+# permitted"), and direct-Anthropic is the only target whose contract this
+# preservation is for.  ``reasoning_content`` is a LiteLLM cross-provider
+# abstraction; surfacing it back into the next request is provider-specific
+# and currently breaks direct-Anthropic — see #196 / #289.
+_THINKING_FIELDS: frozenset[str] = frozenset({"thinking_blocks"})
 
 # Notification markers truncate the source content to this many chars
 # (plus an ellipsis when truncated) so a busy non-focal channel
@@ -601,29 +607,6 @@ def _prune_leading_orphans(messages: list[dict[str, Any]]) -> list[dict[str, Any
         start += 1
 
     return messages[start:]
-
-
-def stub_missing_reasoning_content(
-    messages: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
-    """Ensure every assistant message carries ``reasoning_content``.
-
-    Thinking-mode models (DeepSeek V4 Flash, etc.) reject transcripts
-    whose assistant turns lack this field: ``The reasoning_content in the
-    thinking mode must be passed back to the API``.  Non-thinking models
-    (Anthropic / OpenAI / Gemini / Llama / DeepSeek v3 — all probed)
-    ignore the field entirely, so setting an empty stub unconditionally
-    costs nothing and lets cross-model sessions use thinking models for
-    a single turn without poisoning their replay on other providers.
-
-    Mutates messages in place and returns the list for chaining.  Skips
-    messages that already have a reasoning_content set (from a prior
-    thinking-model turn whose output we preserved opaquely in the log).
-    """
-    for msg in messages:
-        if msg.get("role") == "assistant" and "reasoning_content" not in msg:
-            msg["reasoning_content"] = ""
-    return messages
 
 
 def separate_adjacent_user_messages(

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -33,8 +33,8 @@ import litellm
 
 from aios.harness.vision import (
     can_inline_image,
+    correct_image_mime,
     make_image_url_part,
-    sniff_image_mime,
     text_marker,
 )
 from aios.logging import get_logger
@@ -53,14 +53,9 @@ _ALLOWED_FIELDS: dict[str, frozenset[str]] = {
     "system": frozenset({"role", "content", "name"}),
 }
 
-# Anthropic's contract: thinking blocks must be preserved across turns
-# for the model to use them as continuation context.  Only ``thinking_blocks``
-# is the real continuation handle — Anthropic's ``/v1/messages`` API rejects
-# ``reasoning_content`` outright (``extra_forbid``: "Extra inputs are not
-# permitted"), and direct-Anthropic is the only target whose contract this
-# preservation is for.  ``reasoning_content`` is a LiteLLM cross-provider
-# abstraction; surfacing it back into the next request is provider-specific
-# and currently breaks direct-Anthropic — see #196 / #289.
+# Anthropic's continuation handle.  ``reasoning_content`` is a LiteLLM
+# cross-provider abstraction that Anthropic's /v1/messages rejects; it
+# is not in this set.
 _THINKING_FIELDS: frozenset[str] = frozenset({"thinking_blocks"})
 
 # Notification markers truncate the source content to this many chars
@@ -359,7 +354,7 @@ def _strip_to_spec(
     """Return a copy of *msg* with only chat-completions spec fields.
 
     When ``target_supports_thinking``, also preserve ``thinking_blocks``
-    and ``reasoning_content`` on assistant turns.
+    on assistant turns.
     """
     role = msg.get("role", "")
     allowed = _ALLOWED_FIELDS.get(role, frozenset())
@@ -372,19 +367,8 @@ def _strip_to_spec(
 
 
 def _correct_image_data_url_mimes(messages: list[dict[str, Any]]) -> None:
-    """Rewrite ``data:<mime>;base64,...`` URLs whose declared mime conflicts
-    with the actual image bytes.
-
-    Anthropic's ``/v1/messages`` rejects content where the declared mime
-    doesn't match the magic-byte-detected format ("The image was specified
-    using the image/png media type, but the image appears to be a
-    image/jpeg image" — 400 invalid_request_error).  This walks every
-    image_url part (including those nested inside tool messages and
-    user-message content lists) and replaces the declared mime with the
-    sniffed mime when they disagree.  Unrecognized magic leaves the
-    declared mime untouched (callers handle their own fallback).
-
-    Mutates messages in place.
+    """Rewrite mismatched mime declarations on ``data:<mime>;base64,...``
+    image URLs already in the persisted event log.  Mutates in place.
     """
     for msg in messages:
         content = msg.get("content")
@@ -403,15 +387,9 @@ def _correct_image_data_url_mimes(messages: list[dict[str, Any]]) -> None:
             if not sep or ";base64" not in head:
                 continue
             declared = head.removeprefix("data:").split(";", 1)[0]
-            actual = sniff_image_mime(data_b64)
-            if actual is None or actual == declared:
-                continue
-            log.warning(
-                "context.image_mime_corrected",
-                declared=declared,
-                actual=actual,
-            )
-            image_url["url"] = f"data:{actual};base64,{data_b64}"
+            corrected = correct_image_mime(declared, data_b64)
+            if corrected != declared:
+                image_url["url"] = f"data:{corrected};base64,{data_b64}"
 
 
 # ─── build_messages ──────────────────────────────────────────────────────────

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -34,6 +34,7 @@ import litellm
 from aios.harness.vision import (
     can_inline_image,
     make_image_url_part,
+    sniff_image_mime,
     text_marker,
 )
 from aios.logging import get_logger
@@ -370,6 +371,49 @@ def _strip_to_spec(
     return out
 
 
+def _correct_image_data_url_mimes(messages: list[dict[str, Any]]) -> None:
+    """Rewrite ``data:<mime>;base64,...`` URLs whose declared mime conflicts
+    with the actual image bytes.
+
+    Anthropic's ``/v1/messages`` rejects content where the declared mime
+    doesn't match the magic-byte-detected format ("The image was specified
+    using the image/png media type, but the image appears to be a
+    image/jpeg image" — 400 invalid_request_error).  This walks every
+    image_url part (including those nested inside tool messages and
+    user-message content lists) and replaces the declared mime with the
+    sniffed mime when they disagree.  Unrecognized magic leaves the
+    declared mime untouched (callers handle their own fallback).
+
+    Mutates messages in place.
+    """
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict) or part.get("type") != "image_url":
+                continue
+            image_url = part.get("image_url")
+            if not isinstance(image_url, dict):
+                continue
+            url = image_url.get("url")
+            if not isinstance(url, str) or not url.startswith("data:"):
+                continue
+            head, sep, data_b64 = url.partition(",")
+            if not sep or ";base64" not in head:
+                continue
+            declared = head.removeprefix("data:").split(";", 1)[0]
+            actual = sniff_image_mime(data_b64)
+            if actual is None or actual == declared:
+                continue
+            log.warning(
+                "context.image_mime_corrected",
+                declared=declared,
+                actual=actual,
+            )
+            image_url["url"] = f"data:{actual};base64,{data_b64}"
+
+
 # ─── build_messages ──────────────────────────────────────────────────────────
 
 
@@ -553,6 +597,8 @@ def build_messages(
 
     if system_prompt:
         messages.insert(0, {"role": "system", "content": system_prompt})
+
+    _correct_image_data_url_mimes(messages)
 
     target_supports_thinking = bool(model) and litellm.supports_reasoning(model)
     return ContextResult(

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -31,7 +31,6 @@ from typing import TYPE_CHECKING, Any
 from aios.harness.context import (
     build_messages,
     separate_adjacent_user_messages,
-    stub_missing_reasoning_content,
 )
 from aios.tools.registry import to_openai_tools
 
@@ -197,12 +196,6 @@ async def compose_step_context(
     # Block LiteLLM's adjacent-same-role merge on Anthropic so the tail
     # isn't concatenated into the preceding user inbound.
     messages = separate_adjacent_user_messages(ctx.messages)
-
-    # Unblock thinking-mode models: DeepSeek V4 Flash rejects assistant
-    # turns without reasoning_content.  Empty stub is ignored by all
-    # non-thinking providers we've tested (Anthropic, OpenAI, Gemini,
-    # Llama, non-thinking DeepSeek).
-    stub_missing_reasoning_content(messages)
 
     return StepContext(
         model=agent.model,

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -9,6 +9,7 @@ recoverable.
 from __future__ import annotations
 
 import base64
+import binascii
 from typing import Any
 
 import litellm
@@ -21,11 +22,9 @@ INLINE_SIZE_CAP_BYTES = 2 * 1024 * 1024
 
 _VISION_OVERRIDES: dict[str, bool] = {}
 
-# Magic-byte signatures for the image formats Anthropic accepts.  Used to
-# correct mismatched ``Content-Type`` declarations that creep in from
-# inbound platform metadata or extension-based guesses (Anthropic's
-# ``/v1/messages`` strictly validates declared mime against actual bytes
-# and 400s on mismatch — see #294 incident).
+# Anthropic's ``/v1/messages`` validates declared mime against actual
+# magic bytes and 400s on mismatch.  WebP needs offset 8-11 (RIFF/WEBP)
+# rather than a leading prefix — add it if it ever shows up in the wild.
 _IMAGE_MAGIC: tuple[tuple[bytes, str], ...] = (
     (b"\x89PNG\r\n\x1a\n", "image/png"),
     (b"\xff\xd8\xff", "image/jpeg"),
@@ -35,24 +34,31 @@ _IMAGE_MAGIC: tuple[tuple[bytes, str], ...] = (
 
 
 def sniff_image_mime(data_b64: str) -> str | None:
-    """Return the actual mime type of the base64-encoded image, or None.
-
-    Decodes only the first ~16 bytes (24 base64 chars) — enough to
-    discriminate the four formats Anthropic supports.  WebP is not in
-    the magic table because it requires reading offset 8-11; if we hit
-    a real WebP we add it.  Unknown signatures return ``None`` so the
-    caller can leave the declared mime untouched.
+    """Return the actual mime of the base64-encoded image, or ``None``
+    when the magic bytes don't match a known format.  Decodes only the
+    first ~16 bytes (24 base64 chars).
     """
     head_b64 = data_b64[:24]
     pad = (-len(head_b64)) % 4
     try:
         head = base64.b64decode(head_b64 + "=" * pad)
-    except Exception:
+    except binascii.Error:
         return None
     for sig, mime in _IMAGE_MAGIC:
         if head.startswith(sig):
             return mime
     return None
+
+
+def correct_image_mime(declared: str, data_b64: str) -> str:
+    """Return the magic-byte-detected mime, or ``declared`` unchanged
+    when sniffing yields nothing recognizable.  Logs the substitution.
+    """
+    actual = sniff_image_mime(data_b64)
+    if actual is None or actual == declared:
+        return declared
+    log.warning("vision.image_mime_corrected", declared=declared, actual=actual)
+    return actual
 
 
 def supports_vision(model: str) -> bool:
@@ -98,23 +104,11 @@ def make_image_url_part(*, content_type: str, data_b64: str) -> dict[str, Any]:
     """Build a chat-completions ``image_url`` content part.
 
     The declared ``content_type`` is reconciled against the actual magic
-    bytes — inbound platform metadata and extension-based guesses both
-    occasionally lie ("png" extension on a JPEG, Telegram reporting
-    image/jpeg for a PNG photo, etc.).  Anthropic's ``/v1/messages``
-    rejects mismatches outright and that error round-trips into a tight
-    retry loop because the bad mime is baked into the persisted event.
-    Sniffing here means new events carry the correct mime from the
-    start; ``_correct_image_data_url_mimes`` in context.py handles
-    historical events whose mime was already wrong.
+    bytes; inbound platform metadata and extension-based guesses both
+    occasionally lie.  ``_correct_image_data_url_mimes`` in context.py
+    fixes the same mismatch on historical events at replay time.
     """
-    actual = sniff_image_mime(data_b64)
-    if actual is not None and actual != content_type:
-        log.warning(
-            "vision.image_mime_corrected_at_write",
-            declared=content_type,
-            actual=actual,
-        )
-        content_type = actual
+    content_type = correct_image_mime(content_type, data_b64)
     return {
         "type": "image_url",
         "image_url": {"url": f"data:{content_type};base64,{data_b64}"},

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -8,6 +8,7 @@ recoverable.
 
 from __future__ import annotations
 
+import base64
 from typing import Any
 
 import litellm
@@ -19,6 +20,39 @@ log = get_logger("aios.harness.vision")
 INLINE_SIZE_CAP_BYTES = 2 * 1024 * 1024
 
 _VISION_OVERRIDES: dict[str, bool] = {}
+
+# Magic-byte signatures for the image formats Anthropic accepts.  Used to
+# correct mismatched ``Content-Type`` declarations that creep in from
+# inbound platform metadata or extension-based guesses (Anthropic's
+# ``/v1/messages`` strictly validates declared mime against actual bytes
+# and 400s on mismatch — see #294 incident).
+_IMAGE_MAGIC: tuple[tuple[bytes, str], ...] = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+)
+
+
+def sniff_image_mime(data_b64: str) -> str | None:
+    """Return the actual mime type of the base64-encoded image, or None.
+
+    Decodes only the first ~16 bytes (24 base64 chars) — enough to
+    discriminate the four formats Anthropic supports.  WebP is not in
+    the magic table because it requires reading offset 8-11; if we hit
+    a real WebP we add it.  Unknown signatures return ``None`` so the
+    caller can leave the declared mime untouched.
+    """
+    head_b64 = data_b64[:24]
+    pad = (-len(head_b64)) % 4
+    try:
+        head = base64.b64decode(head_b64 + "=" * pad)
+    except Exception:
+        return None
+    for sig, mime in _IMAGE_MAGIC:
+        if head.startswith(sig):
+            return mime
+    return None
 
 
 def supports_vision(model: str) -> bool:

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -95,7 +95,26 @@ def can_inline_image(*, model: str, content_type: str, size_bytes: int) -> bool:
 
 
 def make_image_url_part(*, content_type: str, data_b64: str) -> dict[str, Any]:
-    """Build a chat-completions ``image_url`` content part."""
+    """Build a chat-completions ``image_url`` content part.
+
+    The declared ``content_type`` is reconciled against the actual magic
+    bytes — inbound platform metadata and extension-based guesses both
+    occasionally lie ("png" extension on a JPEG, Telegram reporting
+    image/jpeg for a PNG photo, etc.).  Anthropic's ``/v1/messages``
+    rejects mismatches outright and that error round-trips into a tight
+    retry loop because the bad mime is baked into the persisted event.
+    Sniffing here means new events carry the correct mime from the
+    start; ``_correct_image_data_url_mimes`` in context.py handles
+    historical events whose mime was already wrong.
+    """
+    actual = sniff_image_mime(data_b64)
+    if actual is not None and actual != content_type:
+        log.warning(
+            "vision.image_mime_corrected_at_write",
+            declared=content_type,
+            actual=actual,
+        )
+        content_type = actual
     return {
         "type": "image_url",
         "image_url": {"url": f"data:{content_type};base64,{data_b64}"},

--- a/tests/e2e/test_step_separator.py
+++ b/tests/e2e/test_step_separator.py
@@ -56,14 +56,9 @@ class TestSeparatorAtLiteLLMBoundary:
         assert tail_idx > 0, "tail block should not be first — there's an inbound before it"
 
         prev = msgs[tail_idx - 1]
-        # The separator is an empty-assistant message.  ``reasoning_content``
-        # is stubbed empty too so thinking-mode providers don't reject the
-        # transcript (see ``stub_missing_reasoning_content``).
+        # The separator is an empty-assistant message.
         assert prev.get("role") == "assistant" and prev.get("content") == "", (
             f"expected empty-assistant separator before tail, got prev={prev!r}, tail={msgs[tail_idx]!r}"
-        )
-        assert prev.get("reasoning_content") == "", (
-            f"expected reasoning_content stub on separator, got prev={prev!r}"
         )
 
     async def test_no_separator_when_tail_block_absent(self, harness: Harness) -> None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -57,3 +57,22 @@ def fake_pool_yielding_conn(conn: Any) -> Any:
     cm.__aexit__ = AsyncMock(return_value=None)
     pool.acquire.return_value = cm
     return pool
+
+
+# ── image magic-byte fixtures (shared across vision + context tests) ──
+
+
+def png_b64(payload: bytes = b"\x00" * 32) -> str:
+    """Base64-encoded PNG with valid magic header followed by *payload*."""
+    return base64.b64encode(b"\x89PNG\r\n\x1a\n" + payload).decode()
+
+
+def jpeg_b64(payload: bytes = b"\x00" * 24) -> str:
+    """Base64-encoded JPEG with a valid SOI + JFIF prefix followed by *payload*."""
+    return base64.b64encode(b"\xff\xd8\xff\xe0\x00\x10JFIF" + payload).decode()
+
+
+def gif_b64(payload: bytes = b"\x00" * 32, *, version: bytes = b"89a") -> str:
+    """Base64-encoded GIF with a valid magic header followed by *payload*."""
+    assert version in (b"87a", b"89a")
+    return base64.b64encode(b"GIF" + version + payload).decode()

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -13,7 +13,6 @@ from aios.harness.channels import build_channels_tail_block
 from aios.harness.context import (
     build_messages,
     separate_adjacent_user_messages,
-    stub_missing_reasoning_content,
 )
 from aios.models.events import Event
 
@@ -725,7 +724,12 @@ class TestThinkingBlockPreservation:
             {"type": "thinking", "thinking": "user said hi", "signature": "abc"}
         ]
 
-    def test_reasoning_content_preserved_for_thinking_capable_target(self) -> None:
+    def test_reasoning_content_stripped_even_for_thinking_capable_target(self) -> None:
+        # reasoning_content is a LiteLLM cross-provider abstraction that
+        # direct-Anthropic rejects with a 400 (extra_forbid).  The real
+        # Anthropic continuation handle is ``thinking_blocks``; preserving
+        # ``reasoning_content`` was the regression that produced the 400
+        # retry loop on factchecker (see #196 / #289 trail).
         events = [
             _evt(1, "user", content="hi"),
             _evt(2, "assistant", content="hey"),
@@ -734,7 +738,7 @@ class TestThinkingBlockPreservation:
         msgs = build_messages(
             events, system_prompt=None, model="anthropic/claude-haiku-4-5"
         ).messages
-        assert msgs[1]["reasoning_content"] == "deep thoughts about hi"
+        assert "reasoning_content" not in msgs[1]
 
     def test_thinking_blocks_stripped_for_non_thinking_target(self) -> None:
         events = [
@@ -1153,58 +1157,6 @@ class TestSeparateAdjacentUserMessages:
             {"role": "assistant", "content": ""},
             {"role": "user", "content": "two"},
         ]
-
-
-class TestStubMissingReasoningContent:
-    def test_adds_empty_stub_to_assistant_without_reasoning(self) -> None:
-        msgs = [
-            {"role": "user", "content": "hi"},
-            {"role": "assistant", "content": "hello"},
-        ]
-        stub_missing_reasoning_content(msgs)
-        assert msgs[1] == {"role": "assistant", "content": "hello", "reasoning_content": ""}
-
-    def test_preserves_existing_reasoning_content(self) -> None:
-        msgs = [
-            {"role": "assistant", "content": "ok", "reasoning_content": "deep thoughts"},
-        ]
-        stub_missing_reasoning_content(msgs)
-        assert msgs[0]["reasoning_content"] == "deep thoughts"
-
-    def test_ignores_user_messages(self) -> None:
-        msgs = [{"role": "user", "content": "hi"}]
-        stub_missing_reasoning_content(msgs)
-        assert msgs[0] == {"role": "user", "content": "hi"}
-
-    def test_ignores_tool_messages(self) -> None:
-        msgs = [{"role": "tool", "tool_call_id": "x", "content": "result"}]
-        stub_missing_reasoning_content(msgs)
-        assert msgs[0] == {"role": "tool", "tool_call_id": "x", "content": "result"}
-
-    def test_stubs_empty_assistant_separator(self) -> None:
-        """The empty-assistant separator inserted by
-        :func:`separate_adjacent_user_messages` is still an assistant
-        message and must also carry the stub."""
-        msgs = [
-            {"role": "user", "content": "a"},
-            {"role": "assistant", "content": ""},
-            {"role": "user", "content": "b"},
-        ]
-        stub_missing_reasoning_content(msgs)
-        assert msgs[1] == {"role": "assistant", "content": "", "reasoning_content": ""}
-
-    def test_mutates_in_place_and_returns(self) -> None:
-        msgs = [{"role": "assistant", "content": "x"}]
-        returned = stub_missing_reasoning_content(msgs)
-        assert returned is msgs
-
-    def test_handles_tool_call_assistants(self) -> None:
-        msgs = [
-            {"role": "assistant", "content": "", "tool_calls": [{"id": "a"}]},
-        ]
-        stub_missing_reasoning_content(msgs)
-        assert msgs[0]["reasoning_content"] == ""
-        assert msgs[0]["tool_calls"] == [{"id": "a"}]
 
 
 class TestSeparateAdjacentUserMessagesPipeline:

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -5,6 +5,7 @@ Uses lightweight FakeEvent objects to avoid touching the DB.
 
 from __future__ import annotations
 
+import base64
 import json
 from datetime import UTC, datetime
 from typing import Any
@@ -1096,6 +1097,75 @@ class TestFocalRendering:
         msgs = build_messages([ev_early, ev_late], system_prompt=None).messages
         assert msgs[0]["content"].startswith(f"🔔 channel_id={self._CHAN_B}")
         assert msgs[1]["content"].startswith(f"[channel={self._CHAN_A}")
+
+
+class TestImageMimeCorrection:
+    """Anthropic 400s when the declared content-type of an inlined image
+    disagrees with the actual bytes.  ``build_messages`` rewrites the
+    declared mime to the magic-byte-detected one to avoid the rejection.
+    """
+
+    # Real magic-byte prefixes for each format, base64-encoded.
+    _PNG_HEAD = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32).decode()
+    _JPEG_HEAD = base64.b64encode(b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 24).decode()
+    _GIF_HEAD = base64.b64encode(b"GIF89a" + b"\x00" * 32).decode()
+
+    def _image_msg(self, declared: str, b64: str) -> dict[str, Any]:
+        return {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{declared};base64,{b64}"},
+                },
+            ],
+        }
+
+    def test_jpeg_bytes_with_png_declaration_corrected(self) -> None:
+        ev = _evt(1, "user", content=self._image_msg("image/png", self._JPEG_HEAD)["content"])
+        msgs = build_messages([ev], system_prompt=None).messages
+        url = msgs[0]["content"][1]["image_url"]["url"]
+        assert url.startswith("data:image/jpeg;base64,")
+
+    def test_png_bytes_with_jpeg_declaration_corrected(self) -> None:
+        ev = _evt(1, "user", content=self._image_msg("image/jpeg", self._PNG_HEAD)["content"])
+        msgs = build_messages([ev], system_prompt=None).messages
+        url = msgs[0]["content"][1]["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+
+    def test_matching_mime_unchanged(self) -> None:
+        ev = _evt(1, "user", content=self._image_msg("image/png", self._PNG_HEAD)["content"])
+        msgs = build_messages([ev], system_prompt=None).messages
+        url = msgs[0]["content"][1]["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+
+    def test_gif_bytes_corrected(self) -> None:
+        ev = _evt(1, "user", content=self._image_msg("image/png", self._GIF_HEAD)["content"])
+        msgs = build_messages([ev], system_prompt=None).messages
+        url = msgs[0]["content"][1]["image_url"]["url"]
+        assert url.startswith("data:image/gif;base64,")
+
+    def test_unrecognized_magic_leaves_declared_alone(self) -> None:
+        random_b64 = base64.b64encode(b"\x00" * 32).decode()
+        ev = _evt(1, "user", content=self._image_msg("image/png", random_b64)["content"])
+        msgs = build_messages([ev], system_prompt=None).messages
+        url = msgs[0]["content"][1]["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+
+    def test_non_data_url_unchanged(self) -> None:
+        ev = _evt(
+            1,
+            "user",
+            content=[
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/cat.png"},
+                }
+            ],
+        )
+        msgs = build_messages([ev], system_prompt=None).messages
+        assert msgs[0]["content"][0]["image_url"]["url"] == "https://example.com/cat.png"
 
 
 class TestSeparateAdjacentUserMessages:

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -17,6 +17,8 @@ from aios.harness.context import (
 )
 from aios.models.events import Event
 
+from .conftest import gif_b64, jpeg_b64, png_b64
+
 
 def _full_pipeline(
     events: list[Event],
@@ -726,11 +728,7 @@ class TestThinkingBlockPreservation:
         ]
 
     def test_reasoning_content_stripped_even_for_thinking_capable_target(self) -> None:
-        # reasoning_content is a LiteLLM cross-provider abstraction that
-        # direct-Anthropic rejects with a 400 (extra_forbid).  The real
-        # Anthropic continuation handle is ``thinking_blocks``; preserving
-        # ``reasoning_content`` was the regression that produced the 400
-        # retry loop on factchecker (see #196 / #289 trail).
+        # Anthropic /v1/messages rejects ``reasoning_content`` (extra_forbid).
         events = [
             _evt(1, "user", content="hi"),
             _evt(2, "assistant", content="hey"),
@@ -1100,17 +1098,12 @@ class TestFocalRendering:
 
 
 class TestImageMimeCorrection:
-    """Anthropic 400s when the declared content-type of an inlined image
-    disagrees with the actual bytes.  ``build_messages`` rewrites the
-    declared mime to the magic-byte-detected one to avoid the rejection.
+    """``build_messages`` rewrites mismatched mime declarations on
+    image data URLs (Anthropic 400s when the declared mime disagrees
+    with the actual bytes).
     """
 
-    # Real magic-byte prefixes for each format, base64-encoded.
-    _PNG_HEAD = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32).decode()
-    _JPEG_HEAD = base64.b64encode(b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 24).decode()
-    _GIF_HEAD = base64.b64encode(b"GIF89a" + b"\x00" * 32).decode()
-
-    def _image_msg(self, declared: str, b64: str) -> dict[str, Any]:
+    def _msg(self, declared: str, b64: str) -> dict[str, Any]:
         return {
             "role": "user",
             "content": [
@@ -1122,36 +1115,26 @@ class TestImageMimeCorrection:
             ],
         }
 
-    def test_jpeg_bytes_with_png_declaration_corrected(self) -> None:
-        ev = _evt(1, "user", content=self._image_msg("image/png", self._JPEG_HEAD)["content"])
+    def _build_url(self, declared: str, b64: str) -> str:
+        ev = _evt(1, "user", content=self._msg(declared, b64)["content"])
         msgs = build_messages([ev], system_prompt=None).messages
-        url = msgs[0]["content"][1]["image_url"]["url"]
-        assert url.startswith("data:image/jpeg;base64,")
+        return str(msgs[0]["content"][1]["image_url"]["url"])
+
+    def test_jpeg_bytes_with_png_declaration_corrected(self) -> None:
+        assert self._build_url("image/png", jpeg_b64()).startswith("data:image/jpeg;base64,")
 
     def test_png_bytes_with_jpeg_declaration_corrected(self) -> None:
-        ev = _evt(1, "user", content=self._image_msg("image/jpeg", self._PNG_HEAD)["content"])
-        msgs = build_messages([ev], system_prompt=None).messages
-        url = msgs[0]["content"][1]["image_url"]["url"]
-        assert url.startswith("data:image/png;base64,")
+        assert self._build_url("image/jpeg", png_b64()).startswith("data:image/png;base64,")
 
     def test_matching_mime_unchanged(self) -> None:
-        ev = _evt(1, "user", content=self._image_msg("image/png", self._PNG_HEAD)["content"])
-        msgs = build_messages([ev], system_prompt=None).messages
-        url = msgs[0]["content"][1]["image_url"]["url"]
-        assert url.startswith("data:image/png;base64,")
+        assert self._build_url("image/png", png_b64()).startswith("data:image/png;base64,")
 
     def test_gif_bytes_corrected(self) -> None:
-        ev = _evt(1, "user", content=self._image_msg("image/png", self._GIF_HEAD)["content"])
-        msgs = build_messages([ev], system_prompt=None).messages
-        url = msgs[0]["content"][1]["image_url"]["url"]
-        assert url.startswith("data:image/gif;base64,")
+        assert self._build_url("image/png", gif_b64()).startswith("data:image/gif;base64,")
 
     def test_unrecognized_magic_leaves_declared_alone(self) -> None:
         random_b64 = base64.b64encode(b"\x00" * 32).decode()
-        ev = _evt(1, "user", content=self._image_msg("image/png", random_b64)["content"])
-        msgs = build_messages([ev], system_prompt=None).messages
-        url = msgs[0]["content"][1]["image_url"]["url"]
-        assert url.startswith("data:image/png;base64,")
+        assert self._build_url("image/png", random_b64).startswith("data:image/png;base64,")
 
     def test_non_data_url_unchanged(self) -> None:
         ev = _evt(

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -13,6 +13,8 @@ import pytest
 
 from aios.harness import vision
 
+from .conftest import gif_b64, jpeg_b64, png_b64
+
 
 @pytest.fixture(autouse=True)
 def _clear_vision_overrides() -> Any:
@@ -125,10 +127,7 @@ class TestMakeImageUrlPart:
         }
 
     def test_sniff_corrects_mismatched_declared_type(self) -> None:
-        import base64
-
-        jpeg = base64.b64encode(b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 24).decode()
-        part = vision.make_image_url_part(content_type="image/png", data_b64=jpeg)
+        part = vision.make_image_url_part(content_type="image/png", data_b64=jpeg_b64())
         assert part["image_url"]["url"].startswith("data:image/jpeg;base64,")
 
     def test_unrecognized_magic_passes_through(self) -> None:
@@ -138,34 +137,21 @@ class TestMakeImageUrlPart:
 
 class TestSniffImageMime:
     def test_png(self) -> None:
-        import base64
-
-        b64 = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\x00" * 20).decode()
-        assert vision.sniff_image_mime(b64) == "image/png"
+        assert vision.sniff_image_mime(png_b64()) == "image/png"
 
     def test_jpeg(self) -> None:
-        import base64
-
-        b64 = base64.b64encode(b"\xff\xd8\xff\xe0\x00\x10JFIF").decode()
-        assert vision.sniff_image_mime(b64) == "image/jpeg"
+        assert vision.sniff_image_mime(jpeg_b64()) == "image/jpeg"
 
     def test_gif87(self) -> None:
-        import base64
-
-        b64 = base64.b64encode(b"GIF87a" + b"\x00" * 20).decode()
-        assert vision.sniff_image_mime(b64) == "image/gif"
+        assert vision.sniff_image_mime(gif_b64(version=b"87a")) == "image/gif"
 
     def test_gif89(self) -> None:
-        import base64
-
-        b64 = base64.b64encode(b"GIF89a" + b"\x00" * 20).decode()
-        assert vision.sniff_image_mime(b64) == "image/gif"
+        assert vision.sniff_image_mime(gif_b64(version=b"89a")) == "image/gif"
 
     def test_unknown_returns_none(self) -> None:
         import base64
 
-        b64 = base64.b64encode(b"\x00" * 32).decode()
-        assert vision.sniff_image_mime(b64) is None
+        assert vision.sniff_image_mime(base64.b64encode(b"\x00" * 32).decode()) is None
 
     def test_short_input_returns_none(self) -> None:
         assert vision.sniff_image_mime("") is None

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -124,6 +124,55 @@ class TestMakeImageUrlPart:
             "image_url": {"url": "data:image/png;base64,ZmFrZQ=="},
         }
 
+    def test_sniff_corrects_mismatched_declared_type(self) -> None:
+        import base64
+
+        jpeg = base64.b64encode(b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 24).decode()
+        part = vision.make_image_url_part(content_type="image/png", data_b64=jpeg)
+        assert part["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+    def test_unrecognized_magic_passes_through(self) -> None:
+        part = vision.make_image_url_part(content_type="image/png", data_b64="ZmFrZQ==")
+        assert part["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+class TestSniffImageMime:
+    def test_png(self) -> None:
+        import base64
+
+        b64 = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\x00" * 20).decode()
+        assert vision.sniff_image_mime(b64) == "image/png"
+
+    def test_jpeg(self) -> None:
+        import base64
+
+        b64 = base64.b64encode(b"\xff\xd8\xff\xe0\x00\x10JFIF").decode()
+        assert vision.sniff_image_mime(b64) == "image/jpeg"
+
+    def test_gif87(self) -> None:
+        import base64
+
+        b64 = base64.b64encode(b"GIF87a" + b"\x00" * 20).decode()
+        assert vision.sniff_image_mime(b64) == "image/gif"
+
+    def test_gif89(self) -> None:
+        import base64
+
+        b64 = base64.b64encode(b"GIF89a" + b"\x00" * 20).decode()
+        assert vision.sniff_image_mime(b64) == "image/gif"
+
+    def test_unknown_returns_none(self) -> None:
+        import base64
+
+        b64 = base64.b64encode(b"\x00" * 32).decode()
+        assert vision.sniff_image_mime(b64) is None
+
+    def test_short_input_returns_none(self) -> None:
+        assert vision.sniff_image_mime("") is None
+
+    def test_invalid_base64_returns_none(self) -> None:
+        assert vision.sniff_image_mime("!!!!not-base64!!!!") is None
+
 
 class TestTextMarker:
     def test_image_with_path(self) -> None:


### PR DESCRIPTION
## Summary

The long-running factchecker session hit two distinct 400 retry-loops against direct-Anthropic in quick succession. Both root causes are persisted-event content fields that Anthropic's \`/v1/messages\` rejects via \`extra_forbid\` / mime-vs-magic validation. Each replay through the harness reconstructs the same bad payload, so the retry loop can't self-heal.

This PR closes both surfaces:

### 1. \`reasoning_content\` rejected as \"Extra inputs are not permitted\"

\`\`\`
{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",
 \"message\":\"messages.0.reasoning_content: Extra inputs are not permitted\"}}
\`\`\`

PR #255's fix for #196 preserved \`reasoning_content\` (LiteLLM's cross-provider abstraction) when the target model supported reasoning. Anthropic doesn't accept it — the actual continuation handle is \`thinking_blocks\`. The empty \`reasoning_content=\"\"\` stubbed by \`stub_missing_reasoning_content\` (PR #173, premise: \"non-thinking models ignore the field\" — empirically wrong now) was preserved end-to-end into every request and caused the 400.

**Changes:**
- Drop \`reasoning_content\` from \`_THINKING_FIELDS\` (\`thinking_blocks\` alone carries Anthropic's contract — the actual #196 fix path).
- Remove \`stub_missing_reasoning_content\` and its callsite. No current target requires the empty stub; if a future provider does, that's a per-provider transformation belonging at the LiteLLM boundary.
- Update / remove the tests added in PR #255 and the \`TestStubMissingReasoningContent\` class.

### 2. Image data-URL mime mismatched against actual bytes

\`\`\`
messages.125.content.0.tool_result.content.2.image.source.base64:
The image was specified using the image/png media type,
but the image appears to be a image/jpeg image
\`\`\`

A historical tool_result in the same session had a JPEG declared as \`image/png\`. Inbound platform metadata (Telegram, Signal) and extension-based guesses both occasionally lie. Once persisted, every replay re-sent the bad declaration.

**Changes:**
- New \`sniff_image_mime\` (vision.py) — magic-byte detector for PNG / JPEG / GIF (the formats Anthropic supports). WebP can be added when we hit it.
- New \`_correct_image_data_url_mimes\` (context.py) — walks every \`image_url\` part in the built message list, decodes the first ~16 bytes of any \`data:<mime>;base64,...\` URL, rewrites the declared mime when it disagrees with the sniffed one. Hooked into \`build_messages\` before \`_strip_to_spec\`.
- \`make_image_url_part\` now also sniffs at write time, so new events carry the correct mime from the start. Read-side correction handles historical events whose mime was already wrong.
- Existing test using random base64 (\`\"ZmFrZQ==\"\`) is unaffected (sniff returns None on unrecognized magic).

## Live verification

Smoke-tested on the active factchecker session (sess_01KQ8NQ3HP4XB9D0F4GW9JKYWF):

- **Pre-fix (20:02-20:14)**: ~9 \`step.litellm_failed\` events, 0 \`step.turn_ended\`, session stuck in retry loop.
- **Post-fix (20:17 onward)**: 1 \`step.litellm_failed\` (in-flight at restart), 1 \`step.turn_ended\` (full turn completed), 1 \`tool.completed\`, 3 \`context.image_mime_corrected\` log lines firing.
- Session moved from \`status: rescheduling\` to \`status: running\`.

## Test plan
- [x] \`uv run mypy src\` — clean (395 source files)
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1190 passed
- [x] Live verification on the running factchecker session

## Issue trail (the \`reasoning_content\` flip-flop)
- **#26** (Apr 15): strip provider-specific fields incl. \`reasoning_content\`
- **#173** (Apr 24): stub \`reasoning_content=\"\"\` on assistant turns
- **#255** (May 6, closed #196): preserve \`reasoning_content\` for thinking-capable targets — **the regression that produced today's 400**
- **This PR** (May 7): strip \`reasoning_content\` unconditionally; \`thinking_blocks\` continuity preserved per #196

Closes #289 (the active retry-loop incident).
#196's thinking-block continuity for direct-Anthropic is preserved. Cross-provider replay of \`reasoning_content\` from thinking models is dropped here and would need provider-specific handling if it ever becomes a real workload.

🤖 Generated with [Claude Code](https://claude.ai/code)