### PR TITLE
fix(cli): scope SIGPIPE → SIG_DFL to client commands so server processes survive broken upstream sockets

### DIFF
--- a/.claude/skills/aios-smoke-setup/scripts/setup.sh
+++ b/.claude/skills/aios-smoke-setup/scripts/setup.sh
@@ -148,7 +148,9 @@ ensure_db() {
 # ── 4. start api + worker ─────────────────────────────────────────────
 start_runtime() {
   mkdir -p "$WORKTREE/.logs"
-  # Don't double-start: kill any previous OUR-worktree processes only.
+  # Kill the supervisor first (sentinel is in its bash command line) so
+  # it doesn't restart the worker we're about to kill.
+  pkill -f "AIOS_WORKER_SUPERVISOR_FOR=${WORKTREE}" 2>/dev/null || true
   pkill -f "${WORKTREE}.*-m aios api" 2>/dev/null || true
   pkill -f "${WORKTREE}.*-m aios worker" 2>/dev/null || true
   sleep 0.5
@@ -158,7 +160,24 @@ start_runtime() {
   : > "$WORKTREE/.logs/worker.log"
   ( set -a; source "$WORKTREE/.env"; set +a
     nohup uv run python -m aios api > "$WORKTREE/.logs/api.log" 2>&1 &
-    nohup uv run python -m aios worker > "$WORKTREE/.logs/worker.log" 2>&1 & )
+    # Worker runs under a supervisor loop with capped backoff.  Backoff
+    # protects against startup-failure storms (e.g. lock contention on
+    # an aborted prior run); a process that lives >30s is considered
+    # healthy and resets the backoff.
+    nohup bash -c '# AIOS_WORKER_SUPERVISOR_FOR='"$WORKTREE"'
+      delay=1
+      while true; do
+        started=$SECONDS
+        uv run python -m aios worker
+        ec=$?
+        ran=$((SECONDS - started))
+        if (( ran > 30 )); then delay=1; fi
+        echo "[supervisor] worker exited ec=$ec ran=${ran}s, restarting in ${delay}s" >&2
+        sleep "$delay"
+        if (( delay < 15 )); then delay=$((delay * 2)); fi
+        if (( delay > 15 )); then delay=15; fi
+      done
+    ' > "$WORKTREE/.logs/worker.log" 2>&1 & )
 
   # Wait for bot identification or fatal
   local deadline=$((SECONDS + 60))

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,4 +119,7 @@ RUN apt-get update \
 # user (currently root from `python:3.13-slim`; tightening that is
 # tracked separately).
 
+# Crash-only: state is in Postgres, advisory lock self-releases, boot is
+# idempotent.  The orchestrator (Coolify in prod) is responsible for
+# restart on exit; this image bakes no in-image supervisor.
 CMD ["aios", "worker"]

--- a/src/aios/cli/app.py
+++ b/src/aios/cli/app.py
@@ -8,7 +8,6 @@ the resolved state from :class:`typer.Context` via :func:`get_state` in
 
 from __future__ import annotations
 
-import signal
 from typing import Annotated
 
 import typer
@@ -16,24 +15,6 @@ import typer
 from aios.cli.config import resolve_base_url
 from aios.cli.output import OutputFormat
 from aios.cli.runtime import CliState
-
-# Restore the default SIGPIPE disposition so piping the CLI into a
-# consumer that exits early (``aios ... | head``, a scripted pipeline
-# that dies mid-read) terminates the process silently instead of raising
-# a Python BrokenPipeError traceback (issue #116).  The process exits
-# 141 (128 + SIGPIPE) — standard UNIX convention, same as ``yes | head``.
-# The explicit BrokenPipeError catch in :func:`aios.cli.runtime.run_or_die`
-# covers Windows (no SIGPIPE) and any buffered-stdout case where Python
-# observes the broken pipe before SIGPIPE is delivered; that path exits 0.
-#
-# IMPORTANT: this fires at module import.  The API and worker processes
-# (``aios api`` / ``aios worker``) must not import :mod:`aios.cli.app`
-# directly — SIGPIPE terminating the process is correct CLI behavior but
-# would silently kill a long-running server on a broken socket write.
-# Current entrypoints route through :mod:`aios.__main__` which only
-# imports this module for the CLI subcommands.
-if hasattr(signal, "SIGPIPE"):
-    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 app = typer.Typer(
     name="aios",

--- a/src/aios/cli/runtime.py
+++ b/src/aios/cli/runtime.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import signal
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -63,15 +64,18 @@ def get_state(ctx: typer.Context) -> CliState:
 
 
 def run_or_die(fn: Callable[[], int | None]) -> None:
-    """Execute ``fn`` and translate ``AiosApiError`` into a clean CLI exit.
+    """Execute ``fn`` with the CLI exit conventions: clean status text on
+    ``AiosApiError``, exit 0 on a buffered-stdout ``BrokenPipeError``
+    (issue #116), exit 130 on Ctrl-C.
 
-    Keeps tracebacks hidden and prints the server's error envelope.
-    ``BrokenPipeError`` during output rendering — raised when a downstream
-    consumer (pipe, pager, script) closed its end while we were writing —
-    resolves to a silent ``exit 0``; by the time we're rendering, any
-    server-side mutation has already landed, and we don't want pipe
-    failures to mask that (issue #116).  Non-API exceptions bubble.
+    Also installs SIGPIPE → ``SIG_DFL`` so a piped CLI exits 141 like
+    ``yes | head``.  Server entrypoints don't route through here and
+    keep Python's default ``SIG_IGN`` so a broken upstream socket
+    surfaces as ``BrokenPipeError`` rather than silently killing the
+    process.
     """
+    if hasattr(signal, "SIGPIPE"):
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
     try:
         rc = fn()
     except AiosApiError as exc:

--- a/tests/unit/cli/test_cli_broken_pipe.py
+++ b/tests/unit/cli/test_cli_broken_pipe.py
@@ -12,11 +12,28 @@ from __future__ import annotations
 import io
 import signal
 import sys
+from collections.abc import Iterator
 
 import pytest
 import typer
 
 from aios.cli.runtime import run_or_die
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sigpipe_handler() -> Iterator[None]:
+    """Force ``SIG_IGN`` before each test and restore after — earlier
+    tests (in this file or elsewhere) can leak ``SIG_DFL`` from
+    ``run_or_die`` into our pre-state."""
+    if not hasattr(signal, "SIGPIPE"):
+        yield
+        return
+    saved = signal.getsignal(signal.SIGPIPE)
+    signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGPIPE, saved)
 
 
 def test_run_or_die_swallows_brokenpipe_and_exits_clean(
@@ -65,26 +82,22 @@ def test_run_or_die_swallows_brokenpipe_raised_from_stdout_write(
     assert excinfo.value.exit_code == 0
 
 
-def test_sigpipe_handler_installed_at_cli_import() -> None:
-    """Importing the CLI app should restore the default SIGPIPE disposition.
-
-    Python by default turns SIGPIPE into a BrokenPipeError; that's
-    helpful for handling it in Python code, but it means ``aios | head``
-    leaves a BrokenPipeError traceback on stderr once the consumer
-    exits.  Restoring ``SIG_DFL`` lets the kernel kill us silently on
-    SIGPIPE, matching the behavior of standard UNIX tools.
-
-    Note: signal handlers are process-wide; this test is a sanity check
-    on the initial import's effect and does not guarantee isolation
-    from other tests that touch SIGPIPE.  No other code in the project
-    sets a SIGPIPE handler, so ordering flakes would indicate someone
-    added one.
+def test_run_or_die_installs_sig_dfl_for_client_commands() -> None:
+    """``run_or_die`` is the universal wrapper for client subcommands; it
+    installs ``SIG_DFL`` for SIGPIPE so ``aios sessions stream | head``
+    terminates with the standard UNIX exit-141 contract instead of a
+    Python ``BrokenPipeError`` traceback.  Server commands (``aios api``,
+    ``aios worker``) do NOT route through ``run_or_die`` and therefore
+    keep Python's default ``SIG_IGN`` — broken upstream sockets surface
+    as ``BrokenPipeError`` rather than killing the long-running process.
     """
     if not hasattr(signal, "SIGPIPE"):
         pytest.skip("SIGPIPE not available on this platform")
 
-    # Import for side-effect — this should install the handler.
-    import aios.cli.app  # noqa: F401
+    # Sanity check: the import of aios.cli.app no longer mutates SIGPIPE.
+    # The autouse fixture restored the handler before this test ran.
+    assert signal.getsignal(signal.SIGPIPE) == signal.SIG_IGN
 
-    handler = signal.getsignal(signal.SIGPIPE)
-    assert handler == signal.SIG_DFL
+    run_or_die(lambda: None)
+
+    assert signal.getsignal(signal.SIGPIPE) == signal.SIG_DFL

--- a/tests/unit/test_cli_sigpipe_kills_server.py
+++ b/tests/unit/test_cli_sigpipe_kills_server.py
@@ -1,0 +1,74 @@
+"""End-to-end pinning of the client-vs-server SIGPIPE contract.
+
+Server processes (``aios api`` / ``aios worker``) must keep Python's
+default ``SIG_IGN``.  Client subcommands install ``SIG_DFL`` inside
+``run_or_die`` to preserve ``yes | head`` exit-141 semantics.  The
+boot-import side and AST guard live in ``test_no_silent_kill_handlers.py``;
+this file's job is the runtime behavior at the broken-socket boundary.
+"""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+import sys
+import textwrap
+
+
+def _run_subprocess(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_broken_pipe_after_server_import_raises_not_kills() -> None:
+    """A subprocess on the server import path writes to a broken socket
+    and surfaces ``BrokenPipeError`` instead of being SIGPIPE-killed.
+    This is the inverted shape of the original silent-worker-exit
+    repro."""
+    result = _run_subprocess("""
+        import socket
+        import sys
+        import aios.cli.app  # noqa: F401
+
+        a, b = socket.socketpair()
+        b.close()
+        try:
+            for _ in range(10000):
+                a.send(b"x" * 4096)
+        except BrokenPipeError:
+            print("BROKEN_PIPE_RAISED")
+            sys.exit(0)
+        sys.exit(0)
+    """)
+    assert result.returncode == 0, (
+        f"server import path armed SIGPIPE-kill. "
+        f"rc={result.returncode}, stdout={result.stdout!r}, stderr={result.stderr!r}"
+    )
+    assert result.stdout.strip() == "BROKEN_PIPE_RAISED"
+
+
+def test_broken_pipe_inside_run_or_die_kills_with_sigpipe() -> None:
+    """Inside ``run_or_die``'s scope, a broken-socket write is
+    SIGPIPE-killed (rc == -SIGPIPE).  Preserves the standard UNIX
+    broken-pipe contract for client commands."""
+    result = _run_subprocess("""
+        import socket
+        from aios.cli.runtime import run_or_die
+
+        def fn() -> None:
+            a, b = socket.socketpair()
+            b.close()
+            for _ in range(10000):
+                a.send(b"x" * 4096)
+
+        run_or_die(fn)
+    """)
+    assert result.returncode == -signal.SIGPIPE, (
+        f"expected rc=-{int(signal.SIGPIPE)}; "
+        f"got rc={result.returncode}, stdout={result.stdout!r}, stderr={result.stderr!r}"
+    )
+    assert "Traceback" not in result.stderr

--- a/tests/unit/test_no_silent_kill_handlers.py
+++ b/tests/unit/test_no_silent_kill_handlers.py
@@ -1,0 +1,144 @@
+"""Audit guards against module-level signal manipulation in the server stack.
+
+The silent-worker-exit incident traced to a top-level
+``signal.signal(SIGPIPE, SIG_DFL)`` in a CLI module that the worker
+transitively imported.  Two checks pin this class of bug:
+boot-imports keep ``SIG_IGN`` at runtime, and no module under
+``src/aios/`` carries a module-scope ``signal.signal(SIGPIPE,
+SIG_DFL)`` in its AST.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_WORKER_BOOT_IMPORTS: tuple[str, ...] = (
+    "aios.__main__",
+    "aios.cli.app",
+    "aios.cli.runtime",
+    "aios.cli.commands.ops",
+    "aios.harness.worker",
+    "aios.harness.procrastinate_app",
+    "aios.harness.exit_diagnostics",
+    "aios.harness.loop",
+    "aios.harness.connector_supervisor",
+    "aios.harness.runtime",
+    "aios.mcp.pool",
+    "aios.mcp.stdio_transport",
+    "aios.config",
+    "aios.logging",
+)
+
+# Cheap typo guard at collection time: confirms each name resolves on
+# the import path without actually importing (which would run module
+# bodies — including ``Settings()`` validation in procrastinate_app).
+for _name in _WORKER_BOOT_IMPORTS:
+    assert importlib.util.find_spec(_name) is not None, f"missing module: {_name}"
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGPIPE"), reason="SIGPIPE not available")
+def test_sigpipe_handler_stays_default_for_server_imports() -> None:
+    """A clean subprocess that imports the worker boot path keeps SIGPIPE
+    at Python's default ``SIG_IGN``.  Any future module-level handler
+    install in a server-reachable file fails this test."""
+    lines = ["import signal"]
+    lines.extend(f"import {m}" for m in _WORKER_BOOT_IMPORTS)
+    lines.append("print(int(signal.getsignal(signal.SIGPIPE)))")
+    result = subprocess.run(
+        [sys.executable, "-c", "\n".join(lines)],
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, f"boot-imports failed: stderr={result.stderr!r}"
+    assert result.stdout.strip() == str(int(signal.SIG_IGN)), (
+        f"a server-reachable module mutated the SIGPIPE handler. "
+        f"got handler={result.stdout.strip()!r}"
+    )
+
+
+def _module_level_calls(tree: ast.Module) -> list[ast.Call]:
+    """Yield ``ast.Call`` nodes whose enclosing scope is the module body.
+
+    Descends through module-level ``If``/``Try``/``With`` chains at the
+    statement level so ``if hasattr(...): signal.signal(...)`` is still
+    caught — that's exactly the pattern the audit targets — but stops
+    at function/class boundaries so calls inside nested ``def``/``class``
+    bodies don't get falsely flagged.
+    """
+    calls: list[ast.Call] = []
+
+    def visit(node: ast.AST) -> None:
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+            calls.append(node.value)
+        elif isinstance(node, ast.If):
+            for child in (*node.body, *node.orelse):
+                visit(child)
+        elif isinstance(node, ast.Try):
+            for child in (*node.body, *node.orelse, *node.finalbody):
+                visit(child)
+            for handler in node.handlers:
+                for child in handler.body:
+                    visit(child)
+        elif isinstance(node, ast.With):
+            for child in node.body:
+                visit(child)
+
+    for node in tree.body:
+        visit(node)
+    return calls
+
+
+def _is_signal_signal_sigpipe_sig_dfl(call: ast.Call) -> bool:
+    """Match the canonical ``signal.signal(signal.SIGPIPE, signal.SIG_DFL)``."""
+    func = call.func
+    if not (
+        isinstance(func, ast.Attribute)
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "signal"
+        and func.attr == "signal"
+    ):
+        return False
+    if len(call.args) != 2:
+        return False
+    sig, handler = call.args
+    return (
+        isinstance(sig, ast.Attribute)
+        and isinstance(sig.value, ast.Name)
+        and sig.value.id == "signal"
+        and sig.attr == "SIGPIPE"
+        and isinstance(handler, ast.Attribute)
+        and isinstance(handler.value, ast.Name)
+        and handler.value.id == "signal"
+        and handler.attr == "SIG_DFL"
+    )
+
+
+def test_no_module_level_sigpipe_sig_dfl_in_aios() -> None:
+    """No ``src/aios/**/*.py`` module may install SIGPIPE → SIG_DFL at
+    module scope.  Even an ``if hasattr(signal, "SIGPIPE")`` guard at
+    module level fires at import time and leaks the process-fatal
+    handler into every entrypoint that imports the file.  Move installs
+    into a function (e.g. ``aios.cli.runtime.run_or_die``) so only
+    explicit client-CLI invocations get the kill-on-broken-pipe shape.
+    """
+    src_root = Path(__file__).resolve().parents[2] / "src" / "aios"
+    assert src_root.is_dir(), f"expected source root at {src_root}"
+
+    offenders: list[str] = []
+    for py in src_root.rglob("*.py"):
+        tree = ast.parse(py.read_text(), filename=str(py))
+        for call in _module_level_calls(tree):
+            if _is_signal_signal_sigpipe_sig_dfl(call):
+                offenders.append(f"{py.relative_to(src_root.parent.parent)}:{call.lineno}")
+
+    assert not offenders, "module-level signal.signal(SIGPIPE, SIG_DFL) found:\n" + "\n".join(
+        f"  - {o}" for o in offenders
+    )


### PR DESCRIPTION
## Summary

Closes the silent-worker-exit failure mode observed on 2026-05-07 during an ant-proxy deploy.

The worker silently terminated mid-step, leaving zero diagnostic output despite PR #285's instrumentation (no \`worker.exit\`, no \`worker.task_exception\`, no \`worker.unexpected_exit\`, no faulthandler dump). Root cause: \`src/aios/cli/app.py\` reset SIGPIPE to \`SIG_DFL\` at module-import time. The protective comment claimed the worker process didn't reach this code path; in fact \`python -m aios worker\` resolves to \`aios.__main__.main\`, which does \`from aios.cli.app import app\`, so the worker inherited \`SIG_DFL\`. When ant-proxy dropped a pooled httpx connection mid-deploy, the next write on the broken socket triggered SIGPIPE → SIG_DFL → instant kill — no atexit, no traceback, no log line.

## Three layers

- **Surgical: scope the SIGPIPE handler to client commands.** Move \`signal.signal(SIGPIPE, SIG_DFL)\` from module-import scope into \`aios.cli.runtime.run_or_die\`. Every client subcommand wraps through that function, so the \`yes | head\` exit-141 contract is preserved for piped CLI use. Server entrypoints (\`aios api\` / \`aios worker\` / \`aios migrate\`) do NOT route through \`run_or_die\` and keep Python's default \`SIG_IGN\`, so a broken upstream socket surfaces as \`BrokenPipeError\` at the call site instead of killing the long-running process.

- **Structural: supervisor for the dev smoke setup.** The aios worker is crash-only by design — state in Postgres, advisory lock self-releases on connection close, boot is idempotent. The missing piece was a restart loop. The supervisor wraps the worker with a capped-backoff loop (1s → 2s → 4s → 8s → 15s, resets to 1s after a 30-second healthy run) and an \`AIOS_WORKER_SUPERVISOR_FOR=<worktree>\` sentinel comment in the bash command line so \`pkill -f\` can target it. Coolify already supplies this contract for prod; the Dockerfile gains a brief comment acknowledging the image bakes no in-image supervisor.

- **Audit guards.** Two regression tests in \`tests/unit/test_no_silent_kill_handlers.py\`:
  - \`test_sigpipe_handler_stays_default_for_server_imports\` — clean subprocess imports the worker boot path, asserts SIGPIPE stays at \`SIG_IGN\`.
  - \`test_no_module_level_sigpipe_sig_dfl_in_aios\` — AST walker rejects any module-scope (or module-scope \`if\`/\`try\`/\`with\` block) call to \`signal.signal(signal.SIGPIPE, signal.SIG_DFL)\` anywhere in \`src/aios/\`. Walker descends through statement-level blocks but stops at function/class boundaries.

## Test plan

- [x] \`uv run mypy src\` — clean (395 files).
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean.
- [x] \`uv run pytest tests/unit -q\` — 1194 passed.
- [x] **High-fidelity repro** in \`tests/unit/test_cli_sigpipe_kills_server.py\`: subprocess on the server import path writing to a broken socket raises \`BrokenPipeError\` (post-fix) instead of being SIGPIPE-killed; subprocess inside \`run_or_die\`'s scope still SIGPIPE-kills with \`returncode == -SIGPIPE\` (preserves UNIX contract for client commands).
- [x] **Manual Layer 2 verification** on the live smoke worktree: SIGKILL'd the running worker; supervisor logged \`[supervisor] worker exited ec=137 ran=20s, restarting in 1s\` and a fresh worker came up within ~5s with both signal and telegram connectors reconnected (\`signal.account.ready\`, \`connector.running\`).

## Why three layers and not just one

The SIGPIPE scoping (Layer 1) closes today's bug. Layer 2 makes any *future* silent-exit a non-event — the worker is already crash-only; it just needed a restart loop. Layer 3 inoculates against re-introduction of the same module-level signal-manipulation pattern. Together these replace the incident-driven instrumentation pattern (PR #285 diagnostics, PR #288 healthcheck, the deferred "supervisor" item) with one structural answer: the worker is allowed to die, the supervisor restarts it, no signal handlers ambush it on the way down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)