### PR TITLE
feat(worker): install signal-cli for the Signal connector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,27 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends docker-ce-cli \
  && rm -rf /var/lib/apt/lists/*
 
+# signal-cli for the Signal connector. The connector spawns ``signal-cli
+# daemon`` as a direct subprocess (see connectors/signal/src/aios_signal/
+# daemon.py), so the binary must be on PATH inside this image.
+#
+# We use the upstream GraalVM native-image build: a single self-contained
+# ELF binary, no JRE required. signal-cli isn't packaged in Debian, so
+# upstream tarball is the right source. The native tarball is just the
+# binary (no versioned directory wrapping it), so we install it directly
+# to /usr/local/bin. Pinned via build-arg so version bumps are a one-line
+# diff. Trailing `signal-cli --version` is a build-time smoke test: a
+# broken or glibc-incompatible binary fails the build instead of shipping
+# a quietly-broken image. If the native build ever has glibc trouble on
+# the Debian bookworm base, fall back to the JAR + Temurin JRE 21 path.
+ARG SIGNAL_CLI_VERSION=0.14.3
+RUN curl -fsSL "https://github.com/AsamK/signal-cli/releases/download/v${SIGNAL_CLI_VERSION}/signal-cli-${SIGNAL_CLI_VERSION}-Linux-native.tar.gz" \
+        -o /tmp/signal-cli.tar.gz \
+ && tar -xzf /tmp/signal-cli.tar.gz -C /usr/local/bin \
+ && chmod 0755 /usr/local/bin/signal-cli \
+ && rm /tmp/signal-cli.tar.gz \
+ && signal-cli --version
+
 # Worker runs as root because the bind-mounted /var/run/docker.sock is
 # owned by the host's docker group, whose GID isn't predictable across
 # host OSes (0 on Docker Desktop, 999 or 998 on most Linux distros).


### PR DESCRIPTION
## Summary

- Install `signal-cli` 0.14.3 in the worker target so the Signal connector can spawn its daemon. The connector calls `signal-cli` as a direct subprocess (`connectors/signal/src/aios_signal/daemon.py:323-328`), so the binary must be in the image — and today it isn't, breaking the Signal connector in prod.
- Path chosen: upstream GraalVM **native-image build** (single self-contained ELF, no JRE required). One layer, no Adoptium APT dance, instant startup. Image grows ~330 MB (652 MB → 982 MB on `linux/amd64`).
- Pinned via `ARG SIGNAL_CLI_VERSION=0.14.3` so version bumps are a one-line diff. Trailing `signal-cli --version` is a build-time smoke test — a broken or glibc-incompatible binary fails the build instead of shipping a quietly-broken image. JAR + Temurin JRE 21 is the documented fallback if the native build ever has trouble on the bookworm base.

### Caveat — amd64-only native asset

The upstream native tarball ships amd64 only. Production (Server B / `aios.eumemic.ai`) is amd64 (verified), so prod is unaffected. **Cross-arch local dev builds on Apple Silicon need `--platform=linux/amd64`** — the build will otherwise fail at the smoke-test step with a clear error. Worker dev usually happens via `uv run python -m aios worker` outside Docker per `CLAUDE.md`, so this shouldn't bite day-to-day.

## Test plan

- [x] `docker build --platform=linux/amd64 --target=worker .` succeeds
- [x] `signal-cli --version` runs in the resulting image (`signal-cli 0.14.3`)
- [x] `signal-cli daemon` subcommand is present in `signal-cli --help` output
- [ ] Deploy to Coolify after merge: `cd ~/code/eumemic-ops && ./scripts/deploy aios-worker`
- [ ] Verify in deployed worker: `ssh tom@aios.eumemic.ai docker exec $COOLIFY_AIOS_WORKER_UUID signal-cli --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)