### PR TITLE
feat(connectors): inbound endpoint + per-connector calls SSE (PR 3/6, #301)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5430,6 +5430,117 @@
         }
       }
     },
+    "/v1/connectors/inbound": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Post Inbound",
+        "description": "Append an inbound user message to the session bound to the caller's connection.\n\nIdempotent on ``body.event_id`` \u2014 replays return the original\nevent id with ``deduped=True``.  Drops surface as 4xx/5xx with\na body explaining the reason (operator-config issue vs server\nerror vs payload).",
+        "operationId": "post_connector_inbound",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorInboundRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorInboundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/connectors/calls": {
+      "get": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Get Calls",
+        "description": "SSE stream of pending custom tool calls for the caller's connection.\n\nBackfills any pending calls at subscribe time (calls already parked\nin some session's ``stop_reason.custom_tools``), then tails the\n``connector_calls_<connection_id>`` NOTIFY channel.  Each emitted\nevent is keyed ``call`` with a JSON body shaped::\n\n    {\n        \"session_id\": \"...\",\n        \"tool_call_id\": \"...\",\n        \"name\": \"...\",\n        \"arguments\": \"...\",       // JSON string from the model\n        \"focal_channel\": \"...\"\n    }\n\nConnector containers dedupe by ``tool_call_id`` client-side so SSE\nreconnects (which replay the backfill) don't double-execute.",
+        "operationId": "get_calls_v1_connectors_calls_get",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen": {
+          "targets": []
+        }
+      }
+    },
     "/v1/connectors": {
       "get": {
         "tags": [
@@ -6907,6 +7018,114 @@
           "tool"
         ],
         "title": "ConnectorCallBody"
+      },
+      "ConnectorInboundRequest": {
+        "properties": {
+          "event_id": {
+            "type": "string",
+            "title": "Event Id",
+            "description": "Client-supplied dedup key (ULID).  Replays return the original event id."
+          },
+          "chat_id": {
+            "type": "string",
+            "title": "Chat Id"
+          },
+          "sender": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Sender"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "attachments": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attachments"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "timestamp": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timestamp",
+            "description": "Optional ISO-8601 platform timestamp; stored in event metadata."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "event_id",
+          "chat_id",
+          "content"
+        ],
+        "title": "ConnectorInboundRequest",
+        "description": "Body for ``POST /v1/connectors/inbound``.\n\nAuthenticated via ``ConnectorAuthDep`` so the connection_id is\nserver-resolved from the bearer token \u2014 clients don't pick which\nconnection their inbound lands on."
+      },
+      "ConnectorInboundResponse": {
+        "properties": {
+          "appended_event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Appended Event Id"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          },
+          "deduped": {
+            "type": "boolean",
+            "title": "Deduped"
+          }
+        },
+        "type": "object",
+        "required": [
+          "appended_event_id",
+          "session_id",
+          "deduped"
+        ],
+        "title": "ConnectorInboundResponse",
+        "description": "Response for ``POST /v1/connectors/inbound``."
       },
       "ConnectorToken": {
         "properties": {

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -25,17 +25,145 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
+from sse_starlette import EventSourceResponse
 
 from aios.api.connector_rpc import connector_rpc
-from aios.api.deps import AuthDep, DbUrlDep
+from aios.api.deps import AuthDep, ConnectorAuthDep, DbUrlDep, PoolDep
+from aios.api.sse import connector_calls_stream
+from aios.errors import (
+    AiosError,
+    NotFoundError,
+    PayloadTooLargeError,
+    ValidationError,
+)
 from aios.harness.connector_tasks import (
     defer_connector_call,
     defer_connector_status,
     defer_connector_tools,
 )
+from aios.services import inbound as inbound_service
 
 router = APIRouter(prefix="/v1/connectors", tags=["connectors"])
+
+
+# ─── connector-facing endpoints (#301) ──────────────────────────────────────
+
+
+class ConnectorInboundRequest(BaseModel):
+    """Body for ``POST /v1/connectors/inbound``.
+
+    Authenticated via ``ConnectorAuthDep`` so the connection_id is
+    server-resolved from the bearer token — clients don't pick which
+    connection their inbound lands on.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str = Field(
+        description="Client-supplied dedup key (ULID).  Replays return the original event id.",
+    )
+    chat_id: str
+    sender: dict[str, Any] = Field(default_factory=dict)
+    content: str
+    attachments: list[dict[str, Any]] | None = None
+    metadata: dict[str, Any] | None = None
+    timestamp: str | None = Field(
+        default=None,
+        description="Optional ISO-8601 platform timestamp; stored in event metadata.",
+    )
+
+
+class ConnectorInboundResponse(BaseModel):
+    """Response for ``POST /v1/connectors/inbound``."""
+
+    appended_event_id: str | None
+    session_id: str | None
+    deduped: bool
+
+
+def _inbound_drop_error(drop_reason: str) -> AiosError:
+    """Pick the right :class:`AiosError` subclass for a drop_reason.
+
+    Each drop maps onto an existing error type — preserving HTTP status
+    contracts without inventing a new error_type for every reason.
+    Detail carries ``drop_reason`` so clients can branch on the
+    machine-readable value.
+    """
+    detail = {"drop_reason": drop_reason}
+    msg = f"inbound dropped ({drop_reason})"
+    if drop_reason == "payload_too_large":
+        return PayloadTooLargeError(msg, detail=detail)
+    if drop_reason in ("detached", "archived_template"):
+        return ValidationError(msg, detail=detail)
+    if drop_reason == "session_missing":
+        return NotFoundError(msg, detail=detail)
+    # attachment_staging_failed (and any unrecognised reason) → 500.
+    return AiosError(msg, detail=detail)
+
+
+@router.post("/inbound", operation_id="post_connector_inbound", status_code=status.HTTP_201_CREATED)
+async def post_inbound(
+    body: ConnectorInboundRequest,
+    pool: PoolDep,
+    connection_id: ConnectorAuthDep,
+) -> ConnectorInboundResponse:
+    """Append an inbound user message to the session bound to the caller's connection.
+
+    Idempotent on ``body.event_id`` — replays return the original
+    event id with ``deduped=True``.  Drops surface as 4xx/5xx with
+    a body explaining the reason (operator-config issue vs server
+    error vs payload).
+    """
+    result = await inbound_service.handle_inbound(
+        pool,
+        connection_id=connection_id,
+        event_id=body.event_id,
+        chat_id=body.chat_id,
+        sender=body.sender,
+        content=body.content,
+        attachments=body.attachments,
+        connector_metadata=body.metadata,
+        platform_timestamp=body.timestamp,
+    )
+    if result.drop_reason is not None:
+        raise _inbound_drop_error(result.drop_reason.value)
+    return ConnectorInboundResponse(
+        appended_event_id=result.appended_event_id,
+        session_id=result.session_id,
+        deduped=result.deduped,
+    )
+
+
+@router.get("/calls", openapi_extra={"x-codegen": {"targets": []}})
+async def get_calls(
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    connection_id: ConnectorAuthDep,
+) -> EventSourceResponse:
+    """SSE stream of pending custom tool calls for the caller's connection.
+
+    Backfills any pending calls at subscribe time (calls already parked
+    in some session's ``stop_reason.custom_tools``), then tails the
+    ``connector_calls_<connection_id>`` NOTIFY channel.  Each emitted
+    event is keyed ``call`` with a JSON body shaped::
+
+        {
+            "session_id": "...",
+            "tool_call_id": "...",
+            "name": "...",
+            "arguments": "...",       // JSON string from the model
+            "focal_channel": "..."
+        }
+
+    Connector containers dedupe by ``tool_call_id`` client-side so SSE
+    reconnects (which replay the backfill) don't double-execute.
+    """
+    return EventSourceResponse(
+        connector_calls_stream(db_url, pool, connection_id),
+        ping=15,
+    )
+
 
 _RESULT_TIMEOUT_S = 60.0
 

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -28,7 +28,7 @@ import asyncpg
 from sse_starlette import ServerSentEvent
 
 from aios.db import queries
-from aios.db.listen import listen_for_events
+from aios.db.listen import listen_for_connector_calls, listen_for_events
 from aios.logging import get_logger
 
 if TYPE_CHECKING:
@@ -133,6 +133,57 @@ async def sse_event_stream(
             if _is_terminal(event_data):
                 yield ServerSentEvent(data="{}", event="done")
                 return
+
+
+async def connector_calls_stream(
+    db_url: str,
+    pool: asyncpg.Pool[Any],
+    connection_id: str,
+) -> AsyncIterator[ServerSentEvent]:
+    """Yield SSE events for pending custom tool calls owned by ``connection_id``.
+
+    Backfills any pending calls at subscribe time, then tails the
+    ``connector_calls_<connection_id>`` NOTIFY channel.  When NOTIFY
+    fires (with a ``session_id`` payload), looks up that session's
+    pending tool calls and emits one SSE event per call.
+
+    Each emitted event is keyed ``"call"`` with a JSON body shaped::
+
+        {
+            "session_id": "sess_xxx",
+            "tool_call_id": "call_yyy",
+            "name": "telegram_send",
+            "arguments": "{...}",
+            "focal_channel": "telegram/bot1/chat123" | null
+        }
+
+    The connector dedupes by ``tool_call_id`` client-side so SSE
+    reconnects (which replay the backfill) don't double-execute.
+    """
+    import json as _json
+
+    async with listen_for_connector_calls(db_url, connection_id) as queue:
+        emitted: set[str] = set()
+
+        async with pool.acquire() as conn:
+            backfill = await queries.list_pending_calls_for_connection(conn, connection_id)
+        for call in backfill:
+            emitted.add(call["tool_call_id"])
+            yield ServerSentEvent(data=_json.dumps(call), event="call")
+
+        while True:
+            session_id = await queue.get()
+            async with pool.acquire() as conn:
+                pending = await queries.list_pending_calls_for_session_and_connection(
+                    conn,
+                    session_id=session_id,
+                    connection_id=connection_id,
+                )
+            for call in pending:
+                if call["tool_call_id"] in emitted:
+                    continue
+                emitted.add(call["tool_call_id"])
+                yield ServerSentEvent(data=_json.dumps(call), event="call")
 
 
 def _is_terminal(payload: dict[str, Any]) -> bool:

--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -182,6 +182,55 @@ async def listen_for_events(
             await conn.close()
 
 
+@asynccontextmanager
+async def listen_for_connector_calls(
+    db_url: str,
+    connection_id: str,
+    *,
+    queue_max: int = 1000,
+) -> AsyncIterator[asyncio.Queue[str]]:
+    """LISTEN ``connector_calls_<connection_id>``; yield a queue of session_ids.
+
+    Mirrors :func:`listen_for_events` but scoped per-connection (#301).
+    Payload on each notification is the ``session_id`` of the session
+    where an assistant tool-calls event just landed; the SSE consumer
+    fetches that session's pending tool calls and streams them.
+    """
+    conn = await asyncpg.connect(normalize_dsn(db_url))
+    queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
+    channel = f"connector_calls_{connection_id}"
+
+    def _callback(
+        _conn: asyncpg.Connection[object],
+        _pid: int,
+        _channel: str,
+        payload: str,
+    ) -> None:
+        # CRITICAL: invoked on asyncpg's read loop — must stay synchronous.
+        try:
+            queue.put_nowait(payload)
+        except asyncio.QueueFull:
+            log.warning(
+                "listen.connector_calls_queue_full_drop",
+                connection_id=connection_id,
+                queue_max=queue_max,
+            )
+            try:
+                queue.get_nowait()
+                queue.put_nowait(payload)
+            except (asyncio.QueueEmpty, asyncio.QueueFull):
+                pass
+
+    await conn.add_listener(channel, _callback)
+    try:
+        yield queue
+    finally:
+        with contextlib.suppress(Exception):
+            await conn.remove_listener(channel, _callback)
+        with contextlib.suppress(Exception):
+            await conn.close()
+
+
 SESSION_INTERRUPT_CHANNEL = "aios_session_interrupt"
 
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1469,7 +1469,223 @@ async def append_event(
     # preserving case, so the two would never match. pg_notify(text, text)
     # treats the channel as a string literal and preserves it byte-for-byte.
     await conn.execute("SELECT pg_notify($1, $2)", f"events_{session_id}", new_id)
+
+    # Connector-calls fan-out (#301): when an assistant message lands with
+    # tool_calls, every connection bound to this session that declares any
+    # custom tool is potentially affected.  The connector container's SSE
+    # subscriber (``GET /v1/connectors/calls``) listens on
+    # ``connector_calls_{connection_id}`` and filters incoming notifications
+    # against the tool names declared on its connection.
+    if (
+        kind == "message"
+        and isinstance(data, dict)
+        and data.get("role") == "assistant"
+        and data.get("tool_calls")
+    ):
+        bound = await _list_bound_connection_ids(conn, session_id)
+        for cid in bound:
+            await conn.execute("SELECT pg_notify($1, $2)", f"connector_calls_{cid}", session_id)
+
     return _row_to_event(row)
+
+
+async def list_pending_calls_for_connection(
+    conn: asyncpg.Connection[Any], connection_id: str
+) -> list[dict[str, Any]]:
+    """Pending custom tool calls for ``connection_id`` across bound sessions.
+
+    A "pending" call is one referenced in some session's
+    ``stop_reason.custom_tools`` array — i.e. the model called a custom
+    tool and the session is parked in ``requires_action``.  For each
+    such session, this returns one row per tool_call whose ``name``
+    matches a tool declared on the connection.
+
+    Output dict shape::
+
+        {
+            "session_id": "sess_xxx",
+            "tool_call_id": "call_yyy",
+            "name": "telegram_send",
+            "arguments": "{...}",        # JSON string from the model
+            "focal_channel": "telegram/bot1/chat123" | None,
+        }
+
+    Used by the connector calls SSE endpoint at subscribe-time backfill
+    and on each NOTIFY.
+    """
+    # First read the connection's tools and the bound sessions, then walk
+    # session state.  Two SELECTs because postgres can't efficiently fan
+    # one query across the lineage union with a jsonb tool-name filter.
+    conn_row = await conn.fetchrow(
+        "SELECT tools FROM connections WHERE id = $1 AND archived_at IS NULL",
+        connection_id,
+    )
+    if conn_row is None:
+        return []
+    tools_data = _parse_jsonb(conn_row["tools"])
+    tool_names = {t["name"] for t in tools_data if isinstance(t, dict) and "name" in t}
+    if not tool_names:
+        return []
+
+    rows = await conn.fetch(
+        """
+        SELECT s.id AS session_id, s.stop_reason, s.focal_channel
+          FROM sessions s
+         WHERE s.archived_at IS NULL
+           AND s.status = 'idle'
+           AND s.stop_reason->>'type' = 'requires_action'
+           AND EXISTS (
+               SELECT 1 FROM connections c
+                WHERE c.id = $1 AND c.archived_at IS NULL
+                  AND (c.session_id = s.id
+                       OR c.id = s.spawned_from_connection_id
+                       OR EXISTS (SELECT 1 FROM connection_chat_sessions ccs
+                                   WHERE ccs.connection_id = c.id
+                                     AND ccs.session_id = s.id))
+           )
+        """,
+        connection_id,
+    )
+
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        out.extend(
+            await _pending_calls_for_session(
+                conn,
+                session_id=row["session_id"],
+                stop_reason=_parse_jsonb(row["stop_reason"]),
+                focal_channel=row["focal_channel"],
+                tool_names=tool_names,
+            )
+        )
+    return out
+
+
+async def list_pending_calls_for_session_and_connection(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str,
+    connection_id: str,
+) -> list[dict[str, Any]]:
+    """Same shape as :func:`list_pending_calls_for_connection` but scoped
+    to one session.  Used by the SSE NOTIFY tail to fetch calls only for
+    the session that just emitted, instead of re-scanning all bound
+    sessions.
+    """
+    conn_row = await conn.fetchrow(
+        "SELECT tools FROM connections WHERE id = $1 AND archived_at IS NULL",
+        connection_id,
+    )
+    if conn_row is None:
+        return []
+    tools_data = _parse_jsonb(conn_row["tools"])
+    tool_names = {t["name"] for t in tools_data if isinstance(t, dict) and "name" in t}
+    if not tool_names:
+        return []
+
+    sess_row = await conn.fetchrow(
+        "SELECT stop_reason, status, focal_channel FROM sessions "
+        "WHERE id = $1 AND archived_at IS NULL",
+        session_id,
+    )
+    if sess_row is None:
+        return []
+    if sess_row["status"] != "idle":
+        return []
+    stop_reason = _parse_jsonb(sess_row["stop_reason"])
+    if not isinstance(stop_reason, dict) or stop_reason.get("type") != "requires_action":
+        return []
+
+    return await _pending_calls_for_session(
+        conn,
+        session_id=session_id,
+        stop_reason=stop_reason,
+        focal_channel=sess_row["focal_channel"],
+        tool_names=tool_names,
+    )
+
+
+async def _pending_calls_for_session(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str,
+    stop_reason: Any,
+    focal_channel: str | None,
+    tool_names: set[str],
+) -> list[dict[str, Any]]:
+    """Fetch the pending tool_call rows for one ``requires_action`` session."""
+    if not isinstance(stop_reason, dict):
+        return []
+    pending_ids = stop_reason.get("custom_tools") or []
+    if not pending_ids:
+        return []
+
+    # The pending call_ids are referenced in the most recent assistant
+    # event; walk that event's data->'tool_calls' array.  We could scan
+    # all assistant events but the loop only parks on the latest, so the
+    # latest assistant message owns every id in stop_reason.
+    rows = await conn.fetch(
+        """
+        SELECT data
+          FROM events
+         WHERE session_id = $1
+           AND kind = 'message'
+           AND data->>'role' = 'assistant'
+         ORDER BY seq DESC
+         LIMIT 5
+        """,
+        session_id,
+    )
+
+    pending_set = set(pending_ids)
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        data = _parse_jsonb(row["data"])
+        for tc in data.get("tool_calls") or []:
+            tc_id = tc.get("id")
+            if tc_id not in pending_set:
+                continue
+            fn = tc.get("function") or {}
+            name = fn.get("name")
+            if name not in tool_names:
+                continue
+            out.append(
+                {
+                    "session_id": session_id,
+                    "tool_call_id": tc_id,
+                    "name": name,
+                    "arguments": fn.get("arguments", "{}"),
+                    "focal_channel": focal_channel,
+                }
+            )
+    return out
+
+
+async def _list_bound_connection_ids(conn: asyncpg.Connection[Any], session_id: str) -> list[str]:
+    """IDs of active connections bound to ``session_id``.
+
+    Used by :func:`append_event` to fan an assistant-tool-calls event
+    out to per-connection NOTIFY channels.  Tools-less connections
+    receive notifications and harmlessly no-op them on the consumer
+    side — filtering by ``jsonb_array_length(tools) > 0`` here forces a
+    seq scan (function expressions aren't indexable), so we accept a
+    small amount of cross-connection notification noise instead.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT c.id
+          FROM connections c
+          LEFT JOIN sessions s ON s.id = $1
+         WHERE c.archived_at IS NULL
+           AND (c.session_id = $1
+                OR c.id = s.spawned_from_connection_id
+                OR EXISTS (SELECT 1 FROM connection_chat_sessions ccs
+                            WHERE ccs.connection_id = c.id
+                              AND ccs.session_id = $1))
+        """,
+        session_id,
+    )
+    return [row["id"] for row in rows]
 
 
 async def read_events(

--- a/src/aios/services/inbound.py
+++ b/src/aios/services/inbound.py
@@ -1,0 +1,241 @@
+"""Inbound message handling for connector containers (#301).
+
+The new ``POST /v1/connectors/inbound`` endpoint calls
+:func:`handle_inbound`, which wraps the dedup / attachment-staging /
+session-resolution logic that today also lives in
+``connector_supervisor._handle_inbound``.  Both paths share the same
+DB primitives (``try_record_inbound_ack``, ``append_event``,
+``stage_inbound_attachments``) so the supervisor and the new HTTP path
+produce indistinguishable event-log state.
+
+In PR 6 the supervisor is deleted and this is the only inbound path.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from enum import StrEnum
+from typing import Any, NamedTuple
+
+import asyncpg
+
+from aios.db import queries
+from aios.errors import NotFoundError
+from aios.harness.attachment_staging import (
+    AttachmentStagingError,
+    stage_inbound_attachments,
+)
+from aios.harness.wake import defer_wake
+from aios.models.connections import Connection
+from aios.models.sessions import MAX_USER_MESSAGE_CHARS
+from aios.services import sessions as sessions_service
+
+
+class _DedupRollback(Exception):
+    """Internal: signals the dedup-ledger conflict path inside the txn."""
+
+
+class InboundDrop(StrEnum):
+    """Why an inbound was not delivered to a session.
+
+    Each maps to an HTTP response in the router: PAYLOAD_TOO_LARGE → 413;
+    DETACHED and ARCHIVED_TEMPLATE → 422 (operator config issue);
+    ATTACHMENT_STAGING_FAILED and SESSION_MISSING → 500.  Replays of an
+    already-processed ``event_id`` are NOT a drop — they return 200
+    with ``deduped=True``.
+    """
+
+    PAYLOAD_TOO_LARGE = "payload_too_large"
+    DETACHED = "detached"
+    ARCHIVED_TEMPLATE = "archived_template"
+    ATTACHMENT_STAGING_FAILED = "attachment_staging_failed"
+    SESSION_MISSING = "session_missing"
+
+
+class InboundResult(NamedTuple):
+    appended_event_id: str | None
+    session_id: str | None
+    drop_reason: InboundDrop | None
+    deduped: bool
+
+
+class _PerChatResolution(NamedTuple):
+    session_id: str | None
+    drop: InboundDrop | None
+
+
+async def handle_inbound(
+    pool: asyncpg.Pool[Any],
+    *,
+    connection_id: str,
+    event_id: str,
+    chat_id: str,
+    sender: dict[str, Any],
+    content: str,
+    attachments: list[Any] | None = None,
+    connector_metadata: dict[str, Any] | None = None,
+    platform_timestamp: str | None = None,
+) -> InboundResult:
+    """Resolve target session, stage attachments, dedup-append, defer wake.
+
+    Idempotent on ``event_id``: a replay returns ``deduped=True`` and
+    re-defers the wake (procrastinate's queueing_lock coalesces).
+    """
+    if len(content) > MAX_USER_MESSAGE_CHARS:
+        return InboundResult(None, None, InboundDrop.PAYLOAD_TOO_LARGE, False)
+
+    async with pool.acquire() as conn:
+        connection = await queries.get_connection(conn, connection_id)
+        existing_session_id = await queries.lookup_chat_session(conn, connection.id, chat_id)
+
+    target_session_id = existing_session_id
+    if target_session_id is None:
+        if connection.session_id is not None:
+            target_session_id = connection.session_id
+        elif connection.session_template_id is not None:
+            resolution = await _resolve_per_chat(pool, connection=connection, chat_id=chat_id)
+            if resolution.drop is not None:
+                return InboundResult(None, None, resolution.drop, False)
+            target_session_id = resolution.session_id
+        else:
+            return InboundResult(None, None, InboundDrop.DETACHED, False)
+
+    assert target_session_id is not None  # both branches above either set it or returned
+
+    try:
+        staged_attachments, newly_staged_paths = stage_inbound_attachments(
+            session_id=target_session_id,
+            connector_name=connection.connector,
+            event_id=event_id,
+            raw_attachments=attachments,
+        )
+    except AttachmentStagingError:
+        return InboundResult(None, target_session_id, InboundDrop.ATTACHMENT_STAGING_FAILED, False)
+
+    try:
+        appended = await _append_with_dedup(
+            pool,
+            connector=connection.connector,
+            account=connection.account,
+            event_id=event_id,
+            session_id=target_session_id,
+            chat_id=chat_id,
+            sender=sender,
+            content=content,
+            attachments=staged_attachments,
+            connector_metadata=connector_metadata,
+            platform_timestamp=platform_timestamp,
+        )
+    except NotFoundError:
+        # Session vanished between resolution and append: clean up freshly
+        # materialized attachment bytes (replay-skipped paths are excluded
+        # by stage_inbound_attachments).
+        for path in newly_staged_paths:
+            with contextlib.suppress(OSError):
+                path.unlink(missing_ok=True)
+        return InboundResult(None, target_session_id, InboundDrop.SESSION_MISSING, False)
+
+    # Defer wake unconditionally — both first-append and dedup paths
+    # heal the case where a prior attempt committed but failed to wake.
+    await defer_wake(pool, target_session_id, cause="inbound")
+
+    return InboundResult(
+        appended_event_id=event_id,
+        session_id=target_session_id,
+        drop_reason=None,
+        deduped=not appended,
+    )
+
+
+async def _resolve_per_chat(
+    pool: asyncpg.Pool[Any], *, connection: Connection, chat_id: str
+) -> _PerChatResolution:
+    """Spawn (or reuse) a session for ``(connection.id, chat_id)`` per-chat mode."""
+    assert connection.session_template_id is not None
+    async with pool.acquire() as conn:
+        template = await queries.get_session_template(conn, connection.session_template_id)
+    if template.archived_at is not None:
+        return _PerChatResolution(session_id=None, drop=InboundDrop.ARCHIVED_TEMPLATE)
+
+    focal_channel = f"{connection.connector}/{connection.account}/{chat_id}"
+    session = await sessions_service.create_session(
+        pool,
+        agent_id=template.agent_id,
+        environment_id=template.environment_id,
+        agent_version=template.agent_version,
+        title=None,
+        metadata={},
+        vault_ids=template.vault_ids or None,
+        focal_channel=focal_channel,
+        spawned_from_connection_id=connection.id,
+    )
+
+    # Race-safe register: insert_chat_session returns the existing
+    # session_id if another writer beat us, and the just-spawned session
+    # is intentionally orphaned (operator can archive later).
+    async with pool.acquire() as conn:
+        registered = await queries.insert_chat_session(
+            conn,
+            connection_id=connection.id,
+            chat_id=chat_id,
+            session_id=session.id,
+        )
+    return _PerChatResolution(session_id=registered, drop=None)
+
+
+async def _append_with_dedup(
+    pool: asyncpg.Pool[Any],
+    *,
+    connector: str,
+    account: str,
+    event_id: str,
+    session_id: str,
+    chat_id: str,
+    sender: dict[str, Any],
+    content: str,
+    attachments: Any,
+    connector_metadata: dict[str, Any] | None,
+    platform_timestamp: str | None,
+) -> bool:
+    """Append the user-message event AND record the dedup ledger row.
+
+    Both writes run in one transaction so a replayed event_id rolls the
+    txn back via :class:`_DedupRollback`.  Returns True on first-append,
+    False on dedup hit.
+    """
+    channel = f"{connector}/{account}/{chat_id}"
+    sender_name = sender.get("display_name")
+    metadata: dict[str, Any] = {}
+    if connector_metadata is not None:
+        metadata.update(connector_metadata)
+    metadata["channel"] = channel
+    if isinstance(sender_name, str):
+        metadata["sender"] = sender_name
+    if isinstance(attachments, list) and attachments:
+        metadata["attachments"] = attachments
+    if platform_timestamp is not None:
+        metadata["platform_timestamp"] = platform_timestamp
+    data: dict[str, Any] = {"role": "user", "content": content, "metadata": metadata}
+
+    try:
+        async with pool.acquire() as conn, conn.transaction():
+            event = await queries.append_event(
+                conn,
+                session_id=session_id,
+                kind="message",
+                data=data,
+                orig_channel=channel,
+            )
+            inserted = await queries.try_record_inbound_ack(
+                conn,
+                connector=connector,
+                account=account,
+                event_id=event_id,
+                appended_seq=event.seq,
+            )
+            if not inserted:
+                raise _DedupRollback()
+            await queries.flip_idle_to_pending(conn, session_id)
+    except _DedupRollback:
+        return False
+    return True

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -253,9 +253,12 @@ async def http_client(aios_env: dict[str, str]) -> AsyncIterator[Any]:
     app.state.db_url = settings.db_url
     app.state.procrastinate = mock.MagicMock()
     transport = httpx.ASGITransport(app=app)
-    with mock.patch(
-        "aios.api.routers.sessions.defer_wake",
-        new_callable=mock.AsyncMock,
+    # Mock at every call site that imports ``defer_wake`` directly —
+    # patching the source (``aios.harness.wake``) is too late since the
+    # importing modules already captured the unmocked reference.
+    with (
+        mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock),
+        mock.patch("aios.services.inbound.defer_wake", new_callable=mock.AsyncMock),
     ):
         async with httpx.AsyncClient(
             transport=transport,

--- a/tests/e2e/test_connectors_io.py
+++ b/tests/e2e/test_connectors_io.py
@@ -1,0 +1,215 @@
+"""E2E tests for the connector-facing inbound + calls-stream endpoints (#301).
+
+Pins the contract a connector container talks to:
+
+* ``POST /v1/connectors/inbound`` appends a user-message event to the
+  session bound to the caller's connection.  Idempotent on ``event_id``
+  (replays are no-ops with ``deduped=True``).  Drops on detached /
+  oversized / archived-template / attachment-failure surface as 4xx/5xx
+  with a ``drop_reason`` body.
+
+* ``GET /v1/connectors/calls`` (SSE) emits one event per pending custom
+  tool call referencing a tool declared on the caller's connection.
+  Backfills at subscribe time, then tails ``connector_calls_<cid>``.
+
+Both routes use ``ConnectorAuthDep`` — the caller's bearer token
+resolves to a single connection_id, never the global API key.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from aios.ids import EVENT, make_id, split_id
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness
+
+
+def _new_event_id() -> str:
+    """A fresh 26-char ULID — the dedup-key shape connectors emit."""
+    return split_id(make_id(EVENT))[1]
+
+
+async def _create_connection(http_client: httpx.AsyncClient, account: str) -> str:
+    r = await http_client.post(
+        "/v1/connections",
+        json={"connector": "echo", "account": account},
+    )
+    assert r.status_code == 201, r.text
+    return str(r.json()["id"])
+
+
+async def _attach(harness: Harness, connection_id: str, session_id: str) -> None:
+    """Bypass the API attach (which calls into procrastinate for the
+    snapshot drift check, unavailable in tests) — go straight to the service.
+    """
+    from aios.services import connections as connections_service
+
+    await connections_service.attach_connection(harness._pool, connection_id, session_id=session_id)
+
+
+async def _set_tools(
+    http_client: httpx.AsyncClient, connection_id: str, tool_names: list[str]
+) -> None:
+    tools = [
+        {
+            "type": "custom",
+            "name": name,
+            "description": f"send via {name}",
+            "input_schema": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+                "required": ["text"],
+            },
+        }
+        for name in tool_names
+    ]
+    r = await http_client.put(
+        f"/v1/connections/{connection_id}/tools",
+        json={"tools": tools},
+    )
+    assert r.status_code == 200, r.text
+
+
+async def _issue_token(http_client: httpx.AsyncClient, connection_id: str) -> str:
+    r = await http_client.post("/v1/connector-tokens", json={"connection_id": connection_id})
+    assert r.status_code == 201, r.text
+    return str(r.json()["plaintext"])
+
+
+@needs_docker
+class TestPostInbound:
+    async def test_appends_user_event(
+        self, http_client: httpx.AsyncClient, harness: Harness
+    ) -> None:
+        from aios.services import agents as agents_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"inb-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-inb-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        connection_id = await _create_connection(http_client, f"acct-{id(self)}")
+        await _attach(harness, connection_id, session.id)
+        token = await _issue_token(http_client, connection_id)
+
+        r = await http_client.post(
+            "/v1/connectors/inbound",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "event_id": _new_event_id(),
+                "chat_id": "chat-1",
+                "sender": {"display_name": "Alice"},
+                "content": "hello",
+            },
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["session_id"] == session.id
+        assert body["deduped"] is False
+
+        events = await harness.events(session.id)
+        user_events = [e for e in events if e.kind == "message" and e.data.get("role") == "user"]
+        assert len(user_events) == 1
+        assert user_events[0].data["content"] == "hello"
+        assert user_events[0].data["metadata"]["sender"] == "Alice"
+
+    async def test_dedup_returns_same_event(
+        self, http_client: httpx.AsyncClient, harness: Harness
+    ) -> None:
+        from aios.services import agents as agents_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"dedup-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-dedup-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        connection_id = await _create_connection(http_client, f"acct-d-{id(self)}")
+        await _attach(harness, connection_id, session.id)
+        token = await _issue_token(http_client, connection_id)
+
+        event_id = _new_event_id()
+        body = {
+            "event_id": event_id,
+            "chat_id": "chat-1",
+            "sender": {"display_name": "Alice"},
+            "content": "hello",
+        }
+
+        r1 = await http_client.post(
+            "/v1/connectors/inbound",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+        assert r1.status_code == 201
+        assert r1.json()["deduped"] is False
+
+        r2 = await http_client.post(
+            "/v1/connectors/inbound",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+        assert r2.status_code == 201
+        assert r2.json()["deduped"] is True
+        assert r2.json()["session_id"] == session.id
+
+        # No duplicate event in the log.
+        events = await harness.events(session.id)
+        user_events = [e for e in events if e.kind == "message" and e.data.get("role") == "user"]
+        assert len(user_events) == 1
+
+    async def test_detached_connection_drops_with_422(self, http_client: httpx.AsyncClient) -> None:
+        connection_id = await _create_connection(http_client, f"acct-det-{id(self)}")
+        token = await _issue_token(http_client, connection_id)
+
+        r = await http_client.post(
+            "/v1/connectors/inbound",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "event_id": _new_event_id(),
+                "chat_id": "chat-1",
+                "sender": {},
+                "content": "hi",
+            },
+        )
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["detail"]["drop_reason"] == "detached"
+
+    async def test_operator_key_rejected(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        r = await http_client.post(
+            "/v1/connectors/inbound",
+            headers={"Authorization": f"Bearer {aios_env['AIOS_API_KEY']}"},
+            json={
+                "event_id": "01J00000000000000000000000",
+                "chat_id": "chat-1",
+                "sender": {},
+                "content": "hi",
+            },
+        )
+        assert r.status_code == 401, r.text

--- a/tests/e2e/test_pending_calls_query.py
+++ b/tests/e2e/test_pending_calls_query.py
@@ -1,0 +1,326 @@
+"""E2E tests for the connector-calls primitives (#301).
+
+The SSE endpoint at ``GET /v1/connectors/calls`` is glue over two
+primitives:
+
+1. ``queries.list_pending_calls_for_connection`` — backfill query
+2. ``listen_for_connector_calls(db_url, connection_id)`` — LISTEN on
+   the per-connection NOTIFY channel, fired by ``append_event`` when an
+   assistant tool-calls event lands on a bound session
+
+This file pins both primitives directly.  End-to-end SSE exercise with
+a real consumer lands in PR 4 with the reference echo-http connector,
+where the consumer's reconnect/dedup logic naturally drives the stream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from aios.config import get_settings
+from aios.db.listen import listen_for_connector_calls
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness
+
+
+@needs_docker
+class TestListPendingCalls:
+    async def test_returns_pending_call_for_attached_session(self, harness: Harness) -> None:
+        from aios.db import queries
+        from aios.models.agents import ToolSpec
+        from aios.services import agents as agents_service
+        from aios.services import connections as connections_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"q-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-q-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        conn = await connections_service.create_connection(
+            harness._pool,
+            connector="echo",
+            account=f"acct-q-{id(self)}",
+            metadata={},
+            tools=[
+                ToolSpec(
+                    type="custom",
+                    name="echo_send",
+                    description="",
+                    input_schema={"type": "object"},
+                ),
+            ],
+        )
+        await connections_service.attach_connection(harness._pool, conn.id, session_id=session.id)
+
+        # Seed an assistant tool_call + park session in requires_action.
+        await sess_svc.append_event(
+            harness._pool,
+            session.id,
+            "message",
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_q1",
+                        "type": "function",
+                        "function": {"name": "echo_send", "arguments": json.dumps({"text": "hi"})},
+                    }
+                ],
+            },
+        )
+        await sess_svc.set_session_status(
+            harness._pool,
+            session.id,
+            "idle",
+            stop_reason={
+                "type": "requires_action",
+                "event_ids": ["call_q1"],
+                "custom_tools": ["call_q1"],
+            },
+        )
+
+        async with harness._pool.acquire() as db_conn:
+            calls = await queries.list_pending_calls_for_connection(db_conn, conn.id)
+
+        assert len(calls) == 1
+        assert calls[0]["tool_call_id"] == "call_q1"
+        assert calls[0]["name"] == "echo_send"
+        assert calls[0]["session_id"] == session.id
+        assert json.loads(calls[0]["arguments"]) == {"text": "hi"}
+
+    async def test_returns_empty_for_unrelated_connection(self, harness: Harness) -> None:
+        from aios.db import queries
+        from aios.models.agents import ToolSpec
+        from aios.services import connections as connections_service
+
+        # A connection with tools but not bound to anything.
+        conn = await connections_service.create_connection(
+            harness._pool,
+            connector="echo",
+            account=f"acct-u-{id(self)}",
+            metadata={},
+            tools=[
+                ToolSpec(
+                    type="custom",
+                    name="echo_send",
+                    description="",
+                    input_schema={"type": "object"},
+                ),
+            ],
+        )
+        async with harness._pool.acquire() as db_conn:
+            calls = await queries.list_pending_calls_for_connection(db_conn, conn.id)
+        assert calls == []
+
+
+@needs_docker
+class TestConnectorCallsNotify:
+    """Verify ``append_event`` fires ``connector_calls_<cid>`` NOTIFY for
+    bound connections that declare any tool — and ONLY for those.
+    """
+
+    async def test_notify_fires_on_bound_assistant_event(self, harness: Harness) -> None:
+        from aios.models.agents import ToolSpec
+        from aios.services import agents as agents_service
+        from aios.services import connections as connections_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"n-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-n-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        conn = await connections_service.create_connection(
+            harness._pool,
+            connector="echo",
+            account=f"acct-n-{id(self)}",
+            metadata={},
+            tools=[
+                ToolSpec(
+                    type="custom",
+                    name="echo_send",
+                    description="",
+                    input_schema={"type": "object"},
+                ),
+            ],
+        )
+        await connections_service.attach_connection(harness._pool, conn.id, session_id=session.id)
+
+        settings = get_settings()
+        async with listen_for_connector_calls(settings.db_url, conn.id) as queue:
+            await sess_svc.append_event(
+                harness._pool,
+                session.id,
+                "message",
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_n1",
+                            "type": "function",
+                            "function": {
+                                "name": "echo_send",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                },
+            )
+            payload = await asyncio.wait_for(queue.get(), timeout=5.0)
+            assert payload == session.id
+
+    async def test_notify_silent_on_role_user_event(self, harness: Harness) -> None:
+        """User-message events MUST NOT trigger the connector-calls fan-out;
+        otherwise inbound POSTs would echo back as 'work' notifications.
+        """
+        from aios.models.agents import ToolSpec
+        from aios.services import agents as agents_service
+        from aios.services import connections as connections_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"nu-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-nu-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        conn = await connections_service.create_connection(
+            harness._pool,
+            connector="echo",
+            account=f"acct-nu-{id(self)}",
+            metadata={},
+            tools=[
+                ToolSpec(
+                    type="custom",
+                    name="echo_send",
+                    description="",
+                    input_schema={"type": "object"},
+                ),
+            ],
+        )
+        await connections_service.attach_connection(harness._pool, conn.id, session_id=session.id)
+
+        settings = get_settings()
+        async with listen_for_connector_calls(settings.db_url, conn.id) as queue:
+            await sess_svc.append_user_message(harness._pool, session.id, "hi")
+            try:
+                payload = await asyncio.wait_for(queue.get(), timeout=0.5)
+            except TimeoutError:
+                payload = None
+            assert payload is None, f"unexpected NOTIFY for user event: {payload}"
+
+    async def test_notify_silent_on_unrelated_connection(self, harness: Harness) -> None:
+        """An assistant tool_calls event on session A must NOT NOTIFY
+        a connection bound to session B.  Scope is the connection's
+        bound sessions, not all sessions.
+        """
+        from aios.models.agents import ToolSpec
+        from aios.services import agents as agents_service
+        from aios.services import connections as connections_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"nu-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-nu-{id(self)}")
+        session_a = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        session_b = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        # conn_b is bound only to session_b; conn_a is bound to session_a.
+        conn_a = await connections_service.create_connection(
+            harness._pool,
+            connector="echo",
+            account=f"acct-nu-A-{id(self)}",
+            metadata={},
+            tools=[
+                ToolSpec(type="custom", name="x", description="", input_schema={"type": "object"}),
+            ],
+        )
+        conn_b = await connections_service.create_connection(
+            harness._pool,
+            connector="echo",
+            account=f"acct-nu-B-{id(self)}",
+            metadata={},
+            tools=[
+                ToolSpec(type="custom", name="x", description="", input_schema={"type": "object"}),
+            ],
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_a.id, session_id=session_a.id
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_b.id, session_id=session_b.id
+        )
+
+        settings = get_settings()
+        # Listen as conn_b but emit on session_a — conn_b shouldn't see it.
+        async with listen_for_connector_calls(settings.db_url, conn_b.id) as queue:
+            await sess_svc.append_event(
+                harness._pool,
+                session_a.id,
+                "message",
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_nu1",
+                            "type": "function",
+                            "function": {"name": "x", "arguments": "{}"},
+                        }
+                    ],
+                },
+            )
+            try:
+                payload = await asyncio.wait_for(queue.get(), timeout=0.5)
+            except TimeoutError:
+                payload = None
+            assert payload is None, f"unexpected NOTIFY across connections: {payload}"


### PR DESCRIPTION
PR **3 of 6** in the connector rearchitecture stack (#301). The two HTTP endpoints a connector container talks to.

> **DO NOT MERGE** until the full stack lands and the end state is verified.

## What changes

- **\`src/aios/services/inbound.py\`** — \`handle_inbound(pool, *, connection_id, event_id, chat_id, sender, content, attachments, ...)\`. Session resolution (single_session / per_chat origin / operator-bound chat), attachment staging, dedup-with-event-append, defer_wake. Idempotent on \`event_id\`.
- **\`POST /v1/connectors/inbound\`** — uses \`ConnectorAuthDep\`. Drops surface as 4xx/5xx via existing \`AiosError\` subclasses (no new error_type).
- **\`GET /v1/connectors/calls\`** — SSE stream of pending custom tool calls for the caller's connection. Backfill at subscribe + tail \`connector_calls_<cid>\`.
- **\`append_event\`** fans out: assistant tool_calls events fire \`pg_notify('connector_calls_<cid>', session_id)\` for every bound connection. Connector filters client-side by tool name (no SQL filter to avoid seq scan).
- **\`listen_for_connector_calls\`** — per-connection LISTEN helper mirroring \`listen_for_events\`.

## Tests

9 new e2e tests across two files:
- \`test_connectors_io.py\` (4): inbound round-trip, dedup return, detached drops to 422, operator-key rejected.
- \`test_pending_calls_query.py\` (5): backfill query content, NOTIFY fires on bound assistant events, silent on user events, scoped per-connection.

The SSE wire is tested at primitives level (query + listen channel) rather than via httpx + ASGITransport + EventSourceResponse — that path hangs in the test transport. PR 4 (HTTP connector SDK + reference echo connector) exercises the full SSE consumer naturally.

All 1220 tests pass locally.

## Reuse

- \`_parse_jsonb\`, the 3-branch lineage WHERE clause (matches existing \`session_authorizes_connector_account\`), \`http_client\` fixture from PR 2, \`InboundResult\` + \`_PerChatResolution\` NamedTuples, \`_inbound_drop_error\` factory.

## Stack

\`\`\`
master
  └── wt/snappy-dreaming-wirth   ← #302 (foundation)
       └── feat/pr1-...           ← #303 (PR 1)
            └── feat/pr2-...      ← #304 (PR 2)
                 └── feat/pr3-... ← THIS PR
                      └── feat/pr4-... (PR 4: HTTP connector SDK + reference echo — coming)
\`\`\`

Refs #301 — supersedes #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)