### PR TITLE
feat(connectors): HTTP connector SDK + reference echo (PR 4/6, #301) — VALIDATION GATE

### DIFF
--- a/connectors/echo-http/Dockerfile
+++ b/connectors/echo-http/Dockerfile
@@ -1,0 +1,24 @@
+# Reference HTTP-client connector — proves the deployment shape (#301).
+#
+# Real connectors (telegram, signal) follow the same pattern: thin
+# python-slim base + only that connector's deps. The aios worker image
+# stays free of connector-specific runtimes.
+
+FROM python:3.13-slim AS base
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+
+# Copy the SDK package first so it's a stable layer; then the connector.
+COPY packages/aios-connector-http /app/packages/aios-connector-http
+COPY connectors/echo-http /app/connectors/echo-http
+
+RUN uv pip install --system --no-cache \
+    /app/packages/aios-connector-http \
+    /app/connectors/echo-http
+
+CMD ["python", "-m", "aios_echo_http"]

--- a/connectors/echo-http/README.md
+++ b/connectors/echo-http/README.md
@@ -1,0 +1,13 @@
+# aios-echo-http
+
+Reference connector built on `aios-connector-http`.  The canonical
+example for #301: a connector that's a pure HTTP client of the aios
+management API.
+
+Three model-facing tools:
+
+* `ping` — returns `pong`.  Verifies the connector is alive.
+* `echo` — returns the input `text` back.  Verifies tool dispatch.
+* `trigger_inbound` — synthesizes an inbound message.  Useful for
+  integration tests that need to drive the inbound path without a
+  real chat platform.

--- a/connectors/echo-http/aios_echo_http/__init__.py
+++ b/connectors/echo-http/aios_echo_http/__init__.py
@@ -1,0 +1,7 @@
+"""Reference connector built on aios-connector-http (#301)."""
+
+from __future__ import annotations
+
+from .connector import EchoConnector
+
+__all__ = ["EchoConnector"]

--- a/connectors/echo-http/aios_echo_http/__main__.py
+++ b/connectors/echo-http/aios_echo_http/__main__.py
@@ -1,0 +1,8 @@
+"""``python -m aios_echo_http`` entrypoint."""
+
+from __future__ import annotations
+
+from .connector import main
+
+if __name__ == "__main__":
+    main()

--- a/connectors/echo-http/aios_echo_http/connector.py
+++ b/connectors/echo-http/aios_echo_http/connector.py
@@ -1,0 +1,48 @@
+"""Reference connector — three tools, no real platform.
+
+Mirrors :class:`aios_echo.EchoConnector` (the legacy MCP-stdio echo)
+so existing parity tests can carry over.  The model calls these tools
+through the standard ``requires_action`` flow; the connector executes
+them as plain Python and POSTs the result back.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios_connector_http import HttpConnector, tool
+
+
+class EchoConnector(HttpConnector):
+    """Three tools: ping, echo, trigger_inbound."""
+
+    @tool()
+    async def ping(self) -> dict[str, Any]:
+        """Return ``{"status": "pong"}`` — verifies the connector is alive."""
+        return {"status": "pong"}
+
+    @tool()
+    async def echo(self, *, text: str) -> dict[str, Any]:
+        """Echo ``text`` back; verifies tool dispatch + result POST."""
+        return {"text": text}
+
+    @tool()
+    async def trigger_inbound(
+        self, *, chat_id: str, sender_name: str, content: str
+    ) -> dict[str, Any]:
+        """Synthesize an inbound message — used by integration tests, not
+        by the model in production (the connector author wires real
+        platform inbounds in :meth:`serve`)."""
+        result = await self.emit_inbound(
+            chat_id=chat_id,
+            sender={"display_name": sender_name},
+            content=content,
+        )
+        return {"event_id": result.get("appended_event_id")}
+
+
+def main() -> None:
+    """Module-level entry point: ``python -m aios_echo_http``."""
+    import asyncio
+
+    asyncio.run(EchoConnector().run())

--- a/connectors/echo-http/pyproject.toml
+++ b/connectors/echo-http/pyproject.toml
@@ -1,0 +1,51 @@
+[project]
+name = "aios-echo-http"
+version = "0.1.0"
+description = "Reference connector built on aios-connector-http (#301)"
+readme = "README.md"
+requires-python = ">=3.13"
+license = { text = "MIT" }
+authors = [{ name = "aios contributors" }]
+
+dependencies = [
+    "aios-connector-http",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3",
+    "pytest-asyncio>=0.24",
+    "ruff>=0.8",
+    "mypy>=1.13",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["aios_echo_http"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py313"
+src = ["aios_echo_http", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "UP", "SIM", "RUF", "TID", "ASYNC"]
+ignore = ["E501"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.mypy]
+python_version = "3.13"
+strict = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = ["-ra", "--strict-markers", "--strict-config"]

--- a/openapi.json
+++ b/openapi.json
@@ -5430,6 +5430,117 @@
         }
       }
     },
+    "/v1/connectors/inbound": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Post Inbound",
+        "description": "Append an inbound user message to the session bound to the caller's connection.\n\nIdempotent on ``body.event_id`` \u2014 replays return the original\nevent id with ``deduped=True``.  Drops surface as 4xx/5xx with\na body explaining the reason (operator-config issue vs server\nerror vs payload).",
+        "operationId": "post_connector_inbound",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorInboundRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorInboundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/connectors/calls": {
+      "get": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Get Calls",
+        "description": "SSE stream of pending custom tool calls for the caller's connection.\n\nBackfills any pending calls at subscribe time (calls already parked\nin some session's ``stop_reason.custom_tools``), then tails the\n``connector_calls_<connection_id>`` NOTIFY channel.  Each emitted\nevent is keyed ``call`` with a JSON body shaped::\n\n    {\n        \"session_id\": \"...\",\n        \"tool_call_id\": \"...\",\n        \"name\": \"...\",\n        \"arguments\": \"...\",       // JSON string from the model\n        \"focal_channel\": \"...\"\n    }\n\nConnector containers dedupe by ``tool_call_id`` client-side so SSE\nreconnects (which replay the backfill) don't double-execute.",
+        "operationId": "get_calls_v1_connectors_calls_get",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen": {
+          "targets": []
+        }
+      }
+    },
     "/v1/connectors": {
       "get": {
         "tags": [
@@ -6907,6 +7018,114 @@
           "tool"
         ],
         "title": "ConnectorCallBody"
+      },
+      "ConnectorInboundRequest": {
+        "properties": {
+          "event_id": {
+            "type": "string",
+            "title": "Event Id",
+            "description": "Client-supplied dedup key (ULID).  Replays return the original event id."
+          },
+          "chat_id": {
+            "type": "string",
+            "title": "Chat Id"
+          },
+          "sender": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Sender"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "attachments": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attachments"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "timestamp": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timestamp",
+            "description": "Optional ISO-8601 platform timestamp; stored in event metadata."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "event_id",
+          "chat_id",
+          "content"
+        ],
+        "title": "ConnectorInboundRequest",
+        "description": "Body for ``POST /v1/connectors/inbound``.\n\nAuthenticated via ``ConnectorAuthDep`` so the connection_id is\nserver-resolved from the bearer token \u2014 clients don't pick which\nconnection their inbound lands on."
+      },
+      "ConnectorInboundResponse": {
+        "properties": {
+          "appended_event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Appended Event Id"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          },
+          "deduped": {
+            "type": "boolean",
+            "title": "Deduped"
+          }
+        },
+        "type": "object",
+        "required": [
+          "appended_event_id",
+          "session_id",
+          "deduped"
+        ],
+        "title": "ConnectorInboundResponse",
+        "description": "Response for ``POST /v1/connectors/inbound``."
       },
       "ConnectorToken": {
         "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -5490,6 +5490,66 @@
         }
       }
     },
+    "/v1/connectors/tool-results": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Post Tool Result",
+        "description": "Submit a custom tool result from a connector container.\n\nAuthorization: the session must be bound to the caller's connection\n(single_session attach, per_chat origin, or operator-bound chat).\nOtherwise \u2192 403.",
+        "operationId": "post_connector_tool_result",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorToolResultRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Post Connector Tool Result"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/connectors/calls": {
       "get": {
         "tags": [
@@ -7256,6 +7316,47 @@
         ],
         "title": "ConnectorTokenIssued",
         "description": "Response body for ``POST /v1/connector-tokens``.\n\nIncludes the plaintext token \u2014 this is the ONLY time it's surfaced.\nSubsequent ``GET`` returns the read view without plaintext."
+      },
+      "ConnectorToolResultRequest": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "tool_call_id": {
+            "type": "string",
+            "title": "Tool Call Id"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            ],
+            "title": "Content"
+          },
+          "is_error": {
+            "type": "boolean",
+            "title": "Is Error",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "session_id",
+          "tool_call_id",
+          "content"
+        ],
+        "title": "ConnectorToolResultRequest",
+        "description": "Body for ``POST /v1/connectors/tool-results``.\n\nMirrors the operator-facing :class:`ToolResultRequest` but adds\n``session_id`` since connector tokens aren't path-scoped to a\nsession.  The handler validates the session is bound to the\ncaller's connection (preventing a connector from posting results\nfor sessions outside its scope)."
       },
       "ContextResponse": {
         "properties": {

--- a/packages/aios-connector-http/README.md
+++ b/packages/aios-connector-http/README.md
@@ -1,0 +1,41 @@
+# aios-connector-http
+
+Pure-HTTP-client SDK for building aios connectors. Supersedes the
+MCP-stdio `aios-connector` SDK (deleted in PR 6 of the connector
+rearchitecture, #301).
+
+A connector is a process that:
+
+1. Bridges an external chat platform (Telegram, Signal, Discord, …) to
+   an aios connection's session(s).
+2. POSTs inbound user messages to `POST /v1/connectors/inbound`.
+3. Subscribes to `GET /v1/connectors/calls` (SSE) for pending custom
+   tool calls referencing tools the connection declares; executes each
+   tool by sending the right thing to the platform; POSTs the result
+   to `POST /v1/sessions/:id/tool-results`.
+
+The aios management API is the entire contract — connectors don't
+share a process or a database with the worker.
+
+## Quick start
+
+```python
+from aios_connector_http import HttpConnector, tool
+
+
+class MyConnector(HttpConnector):
+    @tool()
+    async def my_send(self, *, chat_id: str, text: str) -> str:
+        # send message via the platform; return the ack string the
+        # session log will store.
+        return "ok"
+
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(MyConnector().run())
+```
+
+The connector reads `AIOS_URL` and `AIOS_CONNECTOR_TOKEN` from env to
+locate and authenticate to the aios API. Platform credentials are read
+from connector-specific env vars (e.g. `TELEGRAM_BOT_TOKEN`).

--- a/packages/aios-connector-http/aios_connector_http/__init__.py
+++ b/packages/aios-connector-http/aios_connector_http/__init__.py
@@ -1,0 +1,9 @@
+"""Pure-HTTP-client SDK for aios connectors (#301)."""
+
+from __future__ import annotations
+
+from .client import AiosClient
+from .runner import HttpConnector, tool
+from .spool import SqliteAnsweredSpool
+
+__all__ = ["AiosClient", "HttpConnector", "SqliteAnsweredSpool", "tool"]

--- a/packages/aios-connector-http/aios_connector_http/client.py
+++ b/packages/aios-connector-http/aios_connector_http/client.py
@@ -1,0 +1,150 @@
+"""Thin HTTP client for the aios connector-facing endpoints (#301).
+
+A connector container talks to aios via three endpoints:
+
+* ``POST /v1/connectors/inbound`` — submit an inbound user message.
+* ``GET /v1/connectors/calls`` (SSE) — stream pending custom tool calls.
+* ``POST /v1/sessions/:id/tool-results`` — submit a tool result.
+
+The bearer token resolves server-side to a single ``connection_id``;
+clients don't pick which connection their requests act on.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+
+
+class AiosClient:
+    """Minimal aios HTTP client for connector containers."""
+
+    def __init__(self, base_url: str, token: str, *, timeout: float = 30.0) -> None:
+        self._base_url = base_url
+        self._headers = {"Authorization": f"Bearer {token}"}
+        self._timeout = timeout
+        self._client: httpx.AsyncClient | None = None
+
+    async def __aenter__(self) -> AiosClient:
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url, headers=self._headers, timeout=self._timeout
+        )
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    @property
+    def _http(self) -> httpx.AsyncClient:
+        if self._client is None:
+            raise RuntimeError("AiosClient must be used as an async context manager")
+        return self._client
+
+    async def post_inbound(
+        self,
+        *,
+        event_id: str,
+        chat_id: str,
+        sender: dict[str, Any],
+        content: str,
+        attachments: list[dict[str, Any]] | None = None,
+        metadata: dict[str, Any] | None = None,
+        timestamp: str | None = None,
+    ) -> dict[str, Any]:
+        """POST a user message; idempotent on ``event_id``.  Raises on 4xx/5xx."""
+        body: dict[str, Any] = {
+            "event_id": event_id,
+            "chat_id": chat_id,
+            "sender": sender,
+            "content": content,
+        }
+        if attachments is not None:
+            body["attachments"] = attachments
+        if metadata is not None:
+            body["metadata"] = metadata
+        if timestamp is not None:
+            body["timestamp"] = timestamp
+        r = await self._http.post("/v1/connectors/inbound", json=body)
+        r.raise_for_status()
+        return dict(r.json())
+
+    async def post_tool_result(
+        self,
+        *,
+        session_id: str,
+        tool_call_id: str,
+        content: str | list[dict[str, Any]],
+        is_error: bool = False,
+    ) -> None:
+        """POST a custom tool result.  Resumes the session.
+
+        Uses the connector-scoped ``/v1/connectors/tool-results``
+        endpoint (not the operator-scoped session route) so the
+        connector's bearer token authorizes — the route validates that
+        the session is bound to the caller's connection.
+        """
+        body: dict[str, Any] = {
+            "session_id": session_id,
+            "tool_call_id": tool_call_id,
+            "content": content,
+            "is_error": is_error,
+        }
+        r = await self._http.post("/v1/connectors/tool-results", json=body)
+        r.raise_for_status()
+
+    async def whoami(self) -> str:
+        """Resolve the bearer token to its ``connection_id``."""
+        r = await self._http.get("/v1/connector-tokens/whoami")
+        r.raise_for_status()
+        connection_id: str = r.json()["connection_id"]
+        return connection_id
+
+    async def stream_calls(self) -> AsyncIterator[dict[str, Any]]:
+        """Yield each ``event: call`` payload from the SSE calls stream.
+
+        The stream is long-lived; the iterator runs until the underlying
+        HTTP connection drops.  Callers wrap it in retry-with-backoff
+        logic so transient network blips don't kill the connector.
+        """
+        async with self._http.stream("GET", "/v1/connectors/calls") as r:
+            r.raise_for_status()
+            buf = ""
+            async for chunk in r.aiter_bytes():
+                # Normalise CRLF → LF so frame parsing works the same
+                # whether we're talking to a real HTTP server (CRLF, the
+                # SSE spec form) or an ASGI test transport (LF).
+                buf += chunk.decode("utf-8").replace("\r\n", "\n")
+                while "\n\n" in buf:
+                    frame, buf = buf.split("\n\n", 1)
+                    parsed = _parse_sse_frame(frame)
+                    if parsed is not None and parsed[0] == "call":
+                        yield parsed[1]
+
+
+def _parse_sse_frame(frame: str) -> tuple[str, dict[str, Any]] | None:
+    """Parse one SSE frame; return ``(event_name, data_dict)`` or ``None``.
+
+    Skips comment-only frames (sse-starlette pings) and frames missing
+    an ``event:`` line.
+    """
+    event_name: str | None = None
+    data_lines: list[str] = []
+    for line in frame.splitlines():
+        if line.startswith("event:"):
+            event_name = line[6:].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+    if event_name is None or not data_lines:
+        return None
+    try:
+        data = json.loads("\n".join(data_lines))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return event_name, data

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -1,0 +1,228 @@
+"""Base class connector authors subclass.
+
+Subclass :class:`HttpConnector`, decorate methods with :func:`tool`,
+implement any platform-specific lifecycle by overriding :meth:`setup`,
+:meth:`teardown`, or :meth:`serve`.  Then::
+
+    if __name__ == "__main__":
+        import asyncio
+        asyncio.run(MyConnector().run())
+
+The runner reads ``AIOS_URL`` and ``AIOS_CONNECTOR_TOKEN`` from env,
+spins an :class:`AiosClient`, and runs an SSE-tail loop that dispatches
+incoming tool-call events to your decorated methods.  Inbound is
+emitted by your code calling :meth:`emit_inbound`.
+
+The runner tracks answered ``tool_call_id``s in memory so SSE
+reconnects (which replay the backfill) don't double-execute.  For
+durability across container restart, override :meth:`load_answered` /
+:meth:`save_answered` (a small SQLite spool ships at ``spool.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import os
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from ulid import ULID
+
+from .client import AiosClient
+
+ToolFn = Callable[..., Awaitable[Any]]
+
+_TOOL_ATTR = "__aios_http_tool__"
+
+
+def tool(
+    *,
+    name: str | None = None,
+) -> Callable[[ToolFn], ToolFn]:
+    """Decorate a method as a connector tool.
+
+    The method's name becomes the published tool name (or the explicit
+    ``name=`` override).  Arguments come from the model's tool_call
+    arguments, parsed as JSON and passed as kwargs.  The method's
+    return value is the tool result string the session log stores.
+
+    The connector container must POST a matching ``ConnectionSetTools``
+    body to ``PUT /v1/connections/{id}/tools`` so the model's tool list
+    includes this tool — the SDK doesn't auto-publish schemas in v1.
+    """
+
+    def _wrap(f: ToolFn) -> ToolFn:
+        setattr(f, _TOOL_ATTR, name or f.__name__)
+        return f
+
+    return _wrap
+
+
+class HttpConnector:
+    """Base class for HTTP-client connectors.
+
+    Subclass and decorate methods with :func:`tool`.  Override the
+    lifecycle hooks if you need them.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        token: str | None = None,
+    ) -> None:
+        self._base_url = base_url or os.environ["AIOS_URL"]
+        self._token = token or os.environ["AIOS_CONNECTOR_TOKEN"]
+        self._client: AiosClient | None = None
+        self._connection_id: str | None = None
+        self._tools = self._collect_tools()
+        self._answered: set[str] = set()
+
+    # ─── lifecycle hooks (override as needed) ────────────────────────
+
+    async def setup(self) -> None:
+        """Override: open platform connections, start polling, etc."""
+
+    async def teardown(self) -> None:
+        """Override: close platform connections cleanly."""
+
+    async def serve(self) -> None:
+        """Override: long-running platform task that emits inbounds.
+
+        Default is a no-op — connectors that only respond to outbound
+        tool calls (no inbound) leave this empty.
+        """
+        await asyncio.Event().wait()  # block forever
+
+    async def load_answered(self) -> set[str]:
+        """Override: persisted tool_call_ids from a previous lifetime."""
+        return set()
+
+    async def save_answered(self, tool_call_id: str) -> None:
+        """Override: persist a freshly-answered tool_call_id."""
+
+    # ─── connector → aios glue ───────────────────────────────────────
+
+    async def emit_inbound(
+        self,
+        *,
+        chat_id: str,
+        sender: dict[str, Any],
+        content: str,
+        attachments: list[dict[str, Any]] | None = None,
+        metadata: dict[str, Any] | None = None,
+        timestamp: str | None = None,
+        event_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Forward a platform inbound to aios.  Idempotent on event_id."""
+        assert self._client is not None
+        eid = event_id or str(ULID())
+        return await self._client.post_inbound(
+            event_id=eid,
+            chat_id=chat_id,
+            sender=sender,
+            content=content,
+            attachments=attachments,
+            metadata=metadata,
+            timestamp=timestamp,
+        )
+
+    # ─── runner ──────────────────────────────────────────────────────
+
+    async def run(self) -> None:
+        """Open the client, run setup → serve + tool-loop, then teardown."""
+        async with AiosClient(self._base_url, self._token) as client:
+            self._client = client
+            self._connection_id = await client.whoami()
+            self._answered = await self.load_answered()
+            await self.setup()
+            try:
+                async with asyncio.TaskGroup() as tg:
+                    tg.create_task(self._tool_loop(), name="aios-tool-loop")
+                    tg.create_task(self.serve(), name="aios-platform-serve")
+            finally:
+                await self.teardown()
+
+    async def _tool_loop(self) -> None:
+        """Tail the calls SSE stream and dispatch each call.
+
+        Wraps the stream in exponential-backoff reconnect: a transient
+        network blip drops the SSE iterator, but doesn't kill the
+        connector.  The next reconnect's backfill replays any pending
+        calls, and the answered-id set deduplicates so we never
+        double-execute.
+        """
+        assert self._client is not None
+        backoff = 1.0
+        while True:
+            try:
+                async for call in self._client.stream_calls():
+                    backoff = 1.0  # reset on first successful event
+                    tool_call_id = call.get("tool_call_id", "")
+                    if not tool_call_id or tool_call_id in self._answered:
+                        continue
+                    await self._dispatch_call(call)
+                    self._answered.add(tool_call_id)
+                    await self.save_answered(tool_call_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # Stream dropped; backoff and reconnect.
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 60.0)
+                continue
+            # Stream returned cleanly (server closed without error) — also
+            # reconnect, but with a small delay to avoid a tight loop.
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 60.0)
+
+    async def _dispatch_call(self, call: dict[str, Any]) -> None:
+        """Run the right tool method for ``call`` and POST the result."""
+        assert self._client is not None
+        name = call.get("name", "")
+        tool_call_id = call.get("tool_call_id", "")
+        session_id = call.get("session_id", "")
+        fn = self._tools.get(name)
+        if fn is None:
+            await self._client.post_tool_result(
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                content=json.dumps({"error": f"unknown tool {name!r}"}),
+                is_error=True,
+            )
+            return
+        try:
+            args = json.loads(call.get("arguments") or "{}")
+        except json.JSONDecodeError:
+            args = {}
+        try:
+            result = await fn(**args)
+        except Exception as exc:
+            await self._client.post_tool_result(
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                content=json.dumps({"error": str(exc)}),
+                is_error=True,
+            )
+            return
+        # Tool-result schema accepts ``str`` or a multimodal content array
+        # (``list[dict]``).  Ints, dicts, etc. JSON-serialize to a string —
+        # convenient for tool methods that return rich Python values.
+        if not isinstance(result, str | list):
+            result = json.dumps(result)
+        await self._client.post_tool_result(
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            content=result,
+        )
+
+    def _collect_tools(self) -> dict[str, ToolFn]:
+        """Walk ``self`` and pick up every method tagged with @tool."""
+        out: dict[str, ToolFn] = {}
+        for _, member in inspect.getmembers(self):
+            if callable(member) and hasattr(member, _TOOL_ATTR):
+                tool_name: str = getattr(member, _TOOL_ATTR)
+                out[tool_name] = member
+        return out

--- a/packages/aios-connector-http/aios_connector_http/spool.py
+++ b/packages/aios-connector-http/aios_connector_http/spool.py
@@ -1,0 +1,56 @@
+"""SQLite-backed answered-tool_call_id spool.
+
+A connector container that keeps memory-only state loses its set of
+answered tool_call_ids on restart.  When the SSE stream reconnects it
+backfills every pending call again — including ones we already
+executed — and we'd double-execute (e.g. send a Telegram message
+twice).
+
+The spool persists the answered ids on disk.  Subclass
+:class:`HttpConnector` and wire it in::
+
+    class MyConnector(HttpConnector):
+        def __init__(self) -> None:
+            super().__init__()
+            self._spool = SqliteAnsweredSpool("/var/lib/myconn/answered.sqlite")
+
+        async def load_answered(self) -> set[str]:
+            return self._spool.load()
+
+        async def save_answered(self, tool_call_id: str) -> None:
+            self._spool.add(tool_call_id)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+class SqliteAnsweredSpool:
+    """Tiny on-disk set of ``tool_call_id`` strings."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self._path, check_same_thread=False)
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS answered ("
+            "  tool_call_id TEXT PRIMARY KEY,"
+            "  added_at REAL NOT NULL DEFAULT (unixepoch('subsec'))"
+            ")"
+        )
+        self._conn.commit()
+
+    def load(self) -> set[str]:
+        rows = self._conn.execute("SELECT tool_call_id FROM answered").fetchall()
+        return {row[0] for row in rows}
+
+    def add(self, tool_call_id: str) -> None:
+        self._conn.execute(
+            "INSERT OR IGNORE INTO answered (tool_call_id) VALUES (?)", (tool_call_id,)
+        )
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()

--- a/packages/aios-connector-http/pyproject.toml
+++ b/packages/aios-connector-http/pyproject.toml
@@ -1,0 +1,56 @@
+[project]
+name = "aios-connector-http"
+version = "0.1.0"
+description = "Pure-HTTP-client SDK for building aios connectors (#301)"
+readme = "README.md"
+requires-python = ">=3.13"
+license = { text = "MIT" }
+authors = [{ name = "aios contributors" }]
+
+dependencies = [
+    "httpx>=0.27",
+    "python-ulid>=3.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3",
+    "pytest-asyncio>=0.24",
+    "ruff>=0.8",
+    "mypy>=1.13",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["aios_connector_http"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py313"
+src = ["aios_connector_http", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "UP", "SIM", "RUF", "TID", "ASYNC"]
+ignore = ["E501"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.mypy]
+python_version = "3.13"
+strict = true
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+disallow_any_generics = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = ["-ra", "--strict-markers", "--strict-config"]

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -1,0 +1,169 @@
+"""Unit tests for the HttpConnector runner.
+
+Verifies the dispatch logic and tool-registration without an actual HTTP
+roundtrip: an :class:`AiosClient` mock stand-in lets us assert the
+runner POSTs the right tool-result for each call.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from aios_connector_http import HttpConnector, tool
+
+
+class _ProbeConnector(HttpConnector):
+    """Three tools — happy path, error, returns dict."""
+
+    def __init__(self) -> None:
+        super().__init__(base_url="http://x", token="aios_conn_x")
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    @tool()
+    async def shout(self, *, text: str) -> str:
+        self.calls.append(("shout", {"text": text}))
+        return text.upper()
+
+    @tool()
+    async def boom(self) -> str:
+        self.calls.append(("boom", {}))
+        raise RuntimeError("kaboom")
+
+    @tool(name="say_struct")
+    async def returns_dict(self, *, n: int) -> dict[str, int]:
+        self.calls.append(("say_struct", {"n": n}))
+        return {"doubled": n * 2}
+
+
+@pytest.fixture
+def probe() -> _ProbeConnector:
+    c = _ProbeConnector()
+    c._client = AsyncMock()  # type: ignore[assignment]
+    return c
+
+
+class TestDispatch:
+    async def test_routes_call_to_decorated_method(self, probe: _ProbeConnector) -> None:
+        await probe._dispatch_call(
+            {
+                "tool_call_id": "call_1",
+                "session_id": "sess_1",
+                "name": "shout",
+                "arguments": json.dumps({"text": "hi"}),
+            }
+        )
+        assert probe.calls == [("shout", {"text": "hi"})]
+        probe._client.post_tool_result.assert_awaited_once_with(  # type: ignore[union-attr]
+            session_id="sess_1", tool_call_id="call_1", content="HI"
+        )
+
+    async def test_dict_result_serialized_as_json(self, probe: _ProbeConnector) -> None:
+        await probe._dispatch_call(
+            {
+                "tool_call_id": "call_2",
+                "session_id": "sess_2",
+                "name": "say_struct",
+                "arguments": json.dumps({"n": 3}),
+            }
+        )
+        probe._client.post_tool_result.assert_awaited_once()  # type: ignore[union-attr]
+        kwargs = probe._client.post_tool_result.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["content"] == json.dumps({"doubled": 6})
+        assert kwargs.get("is_error", False) is False
+
+    async def test_unknown_tool_returns_error(self, probe: _ProbeConnector) -> None:
+        await probe._dispatch_call(
+            {
+                "tool_call_id": "call_x",
+                "session_id": "sess_x",
+                "name": "no_such_tool",
+                "arguments": "{}",
+            }
+        )
+        kwargs = probe._client.post_tool_result.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["is_error"] is True
+        body = json.loads(kwargs["content"])
+        assert "unknown tool" in body["error"]
+
+    async def test_exception_in_tool_becomes_error_result(
+        self, probe: _ProbeConnector
+    ) -> None:
+        await probe._dispatch_call(
+            {
+                "tool_call_id": "call_b",
+                "session_id": "sess_b",
+                "name": "boom",
+                "arguments": "{}",
+            }
+        )
+        kwargs = probe._client.post_tool_result.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["is_error"] is True
+        body = json.loads(kwargs["content"])
+        assert body["error"] == "kaboom"
+
+    async def test_malformed_arguments_dispatched_as_empty(
+        self, probe: _ProbeConnector
+    ) -> None:
+        """The model occasionally emits invalid JSON for arguments; the
+        runner shouldn't crash — it dispatches with no kwargs and lets
+        the tool method's signature decide whether to accept that."""
+        await probe._dispatch_call(
+            {
+                "tool_call_id": "call_p",
+                "session_id": "sess_p",
+                "name": "shout",
+                "arguments": "not json {",
+            }
+        )
+        # shout(text=...) requires 'text', so it'll raise — surfaces as
+        # an error result, NOT a crash.
+        kwargs = probe._client.post_tool_result.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["is_error"] is True
+
+
+class TestToolCollection:
+    async def test_collects_decorated_methods_only(self) -> None:
+        class Conn(HttpConnector):
+            def __init__(self) -> None:
+                super().__init__(base_url="x", token="t")
+
+            @tool()
+            async def yes(self) -> str:
+                return "y"
+
+            async def no(self) -> str:
+                return "n"
+
+        c = Conn()
+        assert "yes" in c._tools
+        assert "no" not in c._tools
+
+    async def test_explicit_name_override(self) -> None:
+        class Conn(HttpConnector):
+            def __init__(self) -> None:
+                super().__init__(base_url="x", token="t")
+
+            @tool(name="published_name")
+            async def internal_method(self) -> str:
+                return "ok"
+
+        c = Conn()
+        assert "published_name" in c._tools
+        assert "internal_method" not in c._tools
+
+
+class TestAnsweredDedup:
+    async def test_skips_already_answered(self, probe: _ProbeConnector) -> None:
+        """The tool_loop guards against double-execution on SSE replay
+        by checking ``_answered`` before dispatching.  Verify directly."""
+        probe._answered.add("call_1")
+        # Simulate the loop's check inline (since we can't run the SSE).
+        call = {"tool_call_id": "call_1", "session_id": "s", "name": "shout", "arguments": "{}"}
+        if call["tool_call_id"] in probe._answered:
+            pass  # would skip
+        else:
+            await probe._dispatch_call(call)
+        assert probe.calls == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     # discovery → spawn → init pipeline can run. Only needed in dev/test;
     # production uses real connectors (signal, telegram, ...).
     "aios-echo",
+    "aios-echo-http",
 ]
 
 [project.scripts]
@@ -73,9 +74,11 @@ packages = ["src/aios"]
 # ─── uv workspace ────────────────────────────────────────────────────────────
 [tool.uv.workspace]
 members = [
+    "connectors/echo-http",
     "connectors/signal",
     "connectors/telegram",
     "packages/aios-connector",
+    "packages/aios-connector-http",
     "packages/aios-echo",
 ]
 
@@ -85,7 +88,9 @@ members = [
 # so e2e tests that exercise the full discovery pipeline can run.
 [tool.uv.sources]
 aios-connector = { workspace = true }
+aios-connector-http = { workspace = true }
 aios-echo = { workspace = true }
+aios-echo-http = { workspace = true }
 
 # ─── ruff ────────────────────────────────────────────────────────────────────
 [tool.ruff]

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -31,8 +31,10 @@ from sse_starlette import EventSourceResponse
 from aios.api.connector_rpc import connector_rpc
 from aios.api.deps import AuthDep, ConnectorAuthDep, DbUrlDep, PoolDep
 from aios.api.sse import connector_calls_stream
+from aios.db import queries
 from aios.errors import (
     AiosError,
+    ForbiddenError,
     NotFoundError,
     PayloadTooLargeError,
     ValidationError,
@@ -42,7 +44,9 @@ from aios.harness.connector_tasks import (
     defer_connector_status,
     defer_connector_tools,
 )
+from aios.harness.wake import defer_wake
 from aios.services import inbound as inbound_service
+from aios.services import sessions as sessions_service
 
 router = APIRouter(prefix="/v1/connectors", tags=["connectors"])
 
@@ -133,6 +137,59 @@ async def post_inbound(
         session_id=result.session_id,
         deduped=result.deduped,
     )
+
+
+class ConnectorToolResultRequest(BaseModel):
+    """Body for ``POST /v1/connectors/tool-results``.
+
+    Mirrors the operator-facing :class:`ToolResultRequest` but adds
+    ``session_id`` since connector tokens aren't path-scoped to a
+    session.  The handler validates the session is bound to the
+    caller's connection (preventing a connector from posting results
+    for sessions outside its scope).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: str
+    tool_call_id: str
+    content: str | list[dict[str, Any]]
+    is_error: bool = False
+
+
+@router.post(
+    "/tool-results",
+    operation_id="post_connector_tool_result",
+    status_code=status.HTTP_201_CREATED,
+)
+async def post_tool_result(
+    body: ConnectorToolResultRequest,
+    pool: PoolDep,
+    connection_id: ConnectorAuthDep,
+) -> Any:
+    """Submit a custom tool result from a connector container.
+
+    Authorization: the session must be bound to the caller's connection
+    (single_session attach, per_chat origin, or operator-bound chat).
+    Otherwise → 403.
+    """
+    async with pool.acquire() as conn:
+        if not await queries.is_session_bound_to_connection(
+            conn, connection_id=connection_id, session_id=body.session_id
+        ):
+            raise ForbiddenError(
+                "session is not bound to this connection",
+                detail={"session_id": body.session_id, "connection_id": connection_id},
+            )
+        event = await sessions_service.append_tool_result(
+            conn,
+            session_id=body.session_id,
+            tool_call_id=body.tool_call_id,
+            content=body.content,
+            is_error=body.is_error,
+        )
+    await defer_wake(pool, body.session_id, cause="connector_tool_result")
+    return event
 
 
 @router.get("/calls", openapi_extra={"x-codegen": {"targets": []}})

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -25,17 +25,145 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
+from sse_starlette import EventSourceResponse
 
 from aios.api.connector_rpc import connector_rpc
-from aios.api.deps import AuthDep, DbUrlDep
+from aios.api.deps import AuthDep, ConnectorAuthDep, DbUrlDep, PoolDep
+from aios.api.sse import connector_calls_stream
+from aios.errors import (
+    AiosError,
+    NotFoundError,
+    PayloadTooLargeError,
+    ValidationError,
+)
 from aios.harness.connector_tasks import (
     defer_connector_call,
     defer_connector_status,
     defer_connector_tools,
 )
+from aios.services import inbound as inbound_service
 
 router = APIRouter(prefix="/v1/connectors", tags=["connectors"])
+
+
+# ─── connector-facing endpoints (#301) ──────────────────────────────────────
+
+
+class ConnectorInboundRequest(BaseModel):
+    """Body for ``POST /v1/connectors/inbound``.
+
+    Authenticated via ``ConnectorAuthDep`` so the connection_id is
+    server-resolved from the bearer token — clients don't pick which
+    connection their inbound lands on.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str = Field(
+        description="Client-supplied dedup key (ULID).  Replays return the original event id.",
+    )
+    chat_id: str
+    sender: dict[str, Any] = Field(default_factory=dict)
+    content: str
+    attachments: list[dict[str, Any]] | None = None
+    metadata: dict[str, Any] | None = None
+    timestamp: str | None = Field(
+        default=None,
+        description="Optional ISO-8601 platform timestamp; stored in event metadata.",
+    )
+
+
+class ConnectorInboundResponse(BaseModel):
+    """Response for ``POST /v1/connectors/inbound``."""
+
+    appended_event_id: str | None
+    session_id: str | None
+    deduped: bool
+
+
+def _inbound_drop_error(drop_reason: str) -> AiosError:
+    """Pick the right :class:`AiosError` subclass for a drop_reason.
+
+    Each drop maps onto an existing error type — preserving HTTP status
+    contracts without inventing a new error_type for every reason.
+    Detail carries ``drop_reason`` so clients can branch on the
+    machine-readable value.
+    """
+    detail = {"drop_reason": drop_reason}
+    msg = f"inbound dropped ({drop_reason})"
+    if drop_reason == "payload_too_large":
+        return PayloadTooLargeError(msg, detail=detail)
+    if drop_reason in ("detached", "archived_template"):
+        return ValidationError(msg, detail=detail)
+    if drop_reason == "session_missing":
+        return NotFoundError(msg, detail=detail)
+    # attachment_staging_failed (and any unrecognised reason) → 500.
+    return AiosError(msg, detail=detail)
+
+
+@router.post("/inbound", operation_id="post_connector_inbound", status_code=status.HTTP_201_CREATED)
+async def post_inbound(
+    body: ConnectorInboundRequest,
+    pool: PoolDep,
+    connection_id: ConnectorAuthDep,
+) -> ConnectorInboundResponse:
+    """Append an inbound user message to the session bound to the caller's connection.
+
+    Idempotent on ``body.event_id`` — replays return the original
+    event id with ``deduped=True``.  Drops surface as 4xx/5xx with
+    a body explaining the reason (operator-config issue vs server
+    error vs payload).
+    """
+    result = await inbound_service.handle_inbound(
+        pool,
+        connection_id=connection_id,
+        event_id=body.event_id,
+        chat_id=body.chat_id,
+        sender=body.sender,
+        content=body.content,
+        attachments=body.attachments,
+        connector_metadata=body.metadata,
+        platform_timestamp=body.timestamp,
+    )
+    if result.drop_reason is not None:
+        raise _inbound_drop_error(result.drop_reason.value)
+    return ConnectorInboundResponse(
+        appended_event_id=result.appended_event_id,
+        session_id=result.session_id,
+        deduped=result.deduped,
+    )
+
+
+@router.get("/calls", openapi_extra={"x-codegen": {"targets": []}})
+async def get_calls(
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    connection_id: ConnectorAuthDep,
+) -> EventSourceResponse:
+    """SSE stream of pending custom tool calls for the caller's connection.
+
+    Backfills any pending calls at subscribe time (calls already parked
+    in some session's ``stop_reason.custom_tools``), then tails the
+    ``connector_calls_<connection_id>`` NOTIFY channel.  Each emitted
+    event is keyed ``call`` with a JSON body shaped::
+
+        {
+            "session_id": "...",
+            "tool_call_id": "...",
+            "name": "...",
+            "arguments": "...",       // JSON string from the model
+            "focal_channel": "..."
+        }
+
+    Connector containers dedupe by ``tool_call_id`` client-side so SSE
+    reconnects (which replay the backfill) don't double-execute.
+    """
+    return EventSourceResponse(
+        connector_calls_stream(db_url, pool, connection_id),
+        ping=15,
+    )
+
 
 _RESULT_TIMEOUT_S = 60.0
 

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -12,7 +12,7 @@ Postgres ``LISTEN``/``NOTIFY``.
 from __future__ import annotations
 
 import asyncio
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import APIRouter, Query, status
 from sse_starlette import EventSourceResponse
@@ -27,7 +27,7 @@ from aios.api.deps import (
 from aios.api.sse import sse_event_stream
 from aios.db import queries
 from aios.db.listen import SESSION_INTERRUPT_CHANNEL, listen_for_events
-from aios.errors import NotFoundError, ValidationError
+from aios.errors import ValidationError
 from aios.harness.wake import defer_wake
 from aios.ids import GITHUB_REPOSITORY, split_id
 from aios.models.common import ListResponse
@@ -333,18 +333,13 @@ async def submit_tool_result(
     result with no parent is a client bug that would leave an orphan row.
     """
     async with pool.acquire() as conn:
-        name = await queries.lookup_tool_name_by_call_id(conn, session_id, body.tool_call_id)
-        if name is None:
-            raise NotFoundError(f"tool_call_id {body.tool_call_id!r} not found")
-        data: dict[str, Any] = {
-            "role": "tool",
-            "tool_call_id": body.tool_call_id,
-            "content": body.content,
-            "name": name,
-        }
-        if body.is_error:
-            data["is_error"] = True
-        event = await queries.append_event(conn, session_id=session_id, kind="message", data=data)
+        event = await service.append_tool_result(
+            conn,
+            session_id=session_id,
+            tool_call_id=body.tool_call_id,
+            content=body.content,
+            is_error=body.is_error,
+        )
     await defer_wake(pool, session_id, cause="custom_tool_result")
     return event
 

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -28,7 +28,7 @@ import asyncpg
 from sse_starlette import ServerSentEvent
 
 from aios.db import queries
-from aios.db.listen import listen_for_events
+from aios.db.listen import listen_for_connector_calls, listen_for_events
 from aios.logging import get_logger
 
 if TYPE_CHECKING:
@@ -133,6 +133,57 @@ async def sse_event_stream(
             if _is_terminal(event_data):
                 yield ServerSentEvent(data="{}", event="done")
                 return
+
+
+async def connector_calls_stream(
+    db_url: str,
+    pool: asyncpg.Pool[Any],
+    connection_id: str,
+) -> AsyncIterator[ServerSentEvent]:
+    """Yield SSE events for pending custom tool calls owned by ``connection_id``.
+
+    Backfills any pending calls at subscribe time, then tails the
+    ``connector_calls_<connection_id>`` NOTIFY channel.  When NOTIFY
+    fires (with a ``session_id`` payload), looks up that session's
+    pending tool calls and emits one SSE event per call.
+
+    Each emitted event is keyed ``"call"`` with a JSON body shaped::
+
+        {
+            "session_id": "sess_xxx",
+            "tool_call_id": "call_yyy",
+            "name": "telegram_send",
+            "arguments": "{...}",
+            "focal_channel": "telegram/bot1/chat123" | null
+        }
+
+    The connector dedupes by ``tool_call_id`` client-side so SSE
+    reconnects (which replay the backfill) don't double-execute.
+    """
+    import json as _json
+
+    async with listen_for_connector_calls(db_url, connection_id) as queue:
+        emitted: set[str] = set()
+
+        async with pool.acquire() as conn:
+            backfill = await queries.list_pending_calls_for_connection(conn, connection_id)
+        for call in backfill:
+            emitted.add(call["tool_call_id"])
+            yield ServerSentEvent(data=_json.dumps(call), event="call")
+
+        while True:
+            session_id = await queue.get()
+            async with pool.acquire() as conn:
+                pending = await queries.list_pending_calls_for_session_and_connection(
+                    conn,
+                    session_id=session_id,
+                    connection_id=connection_id,
+                )
+            for call in pending:
+                if call["tool_call_id"] in emitted:
+                    continue
+                emitted.add(call["tool_call_id"])
+                yield ServerSentEvent(data=_json.dumps(call), event="call")
 
 
 def _is_terminal(payload: dict[str, Any]) -> bool:

--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -182,6 +182,55 @@ async def listen_for_events(
             await conn.close()
 
 
+@asynccontextmanager
+async def listen_for_connector_calls(
+    db_url: str,
+    connection_id: str,
+    *,
+    queue_max: int = 1000,
+) -> AsyncIterator[asyncio.Queue[str]]:
+    """LISTEN ``connector_calls_<connection_id>``; yield a queue of session_ids.
+
+    Mirrors :func:`listen_for_events` but scoped per-connection (#301).
+    Payload on each notification is the ``session_id`` of the session
+    where an assistant tool-calls event just landed; the SSE consumer
+    fetches that session's pending tool calls and streams them.
+    """
+    conn = await asyncpg.connect(normalize_dsn(db_url))
+    queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
+    channel = f"connector_calls_{connection_id}"
+
+    def _callback(
+        _conn: asyncpg.Connection[object],
+        _pid: int,
+        _channel: str,
+        payload: str,
+    ) -> None:
+        # CRITICAL: invoked on asyncpg's read loop — must stay synchronous.
+        try:
+            queue.put_nowait(payload)
+        except asyncio.QueueFull:
+            log.warning(
+                "listen.connector_calls_queue_full_drop",
+                connection_id=connection_id,
+                queue_max=queue_max,
+            )
+            try:
+                queue.get_nowait()
+                queue.put_nowait(payload)
+            except (asyncio.QueueEmpty, asyncio.QueueFull):
+                pass
+
+    await conn.add_listener(channel, _callback)
+    try:
+        yield queue
+    finally:
+        with contextlib.suppress(Exception):
+            await conn.remove_listener(channel, _callback)
+        with contextlib.suppress(Exception):
+            await conn.close()
+
+
 SESSION_INTERRUPT_CHANNEL = "aios_session_interrupt"
 
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -737,6 +737,21 @@ async def set_session_status(
         session_id,
     )
 
+    # Connector-calls fan-out (#301): when a session parks in
+    # ``requires_action`` with pending custom_tools, every connection
+    # bound to this session needs a NOTIFY so its SSE subscriber can
+    # backfill the new pending calls.  Firing here (after stop_reason
+    # is committed) avoids the race where the SSE consumer's query
+    # checks for ``requires_action`` but stop_reason hasn't been written
+    # yet — the case if NOTIFY fired in :func:`append_event`.
+    if (
+        isinstance(stop_reason, dict)
+        and stop_reason.get("type") == "requires_action"
+        and stop_reason.get("custom_tools")
+    ):
+        for cid in await _list_bound_connection_ids(conn, session_id):
+            await conn.execute("SELECT pg_notify($1, $2)", f"connector_calls_{cid}", session_id)
+
 
 async def increment_session_usage(
     conn: asyncpg.Connection[Any],
@@ -1469,23 +1484,6 @@ async def append_event(
     # preserving case, so the two would never match. pg_notify(text, text)
     # treats the channel as a string literal and preserves it byte-for-byte.
     await conn.execute("SELECT pg_notify($1, $2)", f"events_{session_id}", new_id)
-
-    # Connector-calls fan-out (#301): when an assistant message lands with
-    # tool_calls, every connection bound to this session that declares any
-    # custom tool is potentially affected.  The connector container's SSE
-    # subscriber (``GET /v1/connectors/calls``) listens on
-    # ``connector_calls_{connection_id}`` and filters incoming notifications
-    # against the tool names declared on its connection.
-    if (
-        kind == "message"
-        and isinstance(data, dict)
-        and data.get("role") == "assistant"
-        and data.get("tool_calls")
-    ):
-        bound = await _list_bound_connection_ids(conn, session_id)
-        for cid in bound:
-            await conn.execute("SELECT pg_notify($1, $2)", f"connector_calls_{cid}", session_id)
-
     return _row_to_event(row)
 
 
@@ -1686,6 +1684,39 @@ async def _list_bound_connection_ids(conn: asyncpg.Connection[Any], session_id: 
         session_id,
     )
     return [row["id"] for row in rows]
+
+
+async def is_session_bound_to_connection(
+    conn: asyncpg.Connection[Any], *, connection_id: str, session_id: str
+) -> bool:
+    """True iff ``connection_id`` is bound to ``session_id`` via any of the
+    three lineage paths used everywhere connector-session binding matters:
+
+    * single_session attach (``connections.session_id``)
+    * per_chat origin (``sessions.spawned_from_connection_id``)
+    * operator-curated chat binding (``connection_chat_sessions``)
+
+    Centralised so route handlers don't inline the three-branch WHERE
+    clause every time they need to authorize a connector-driven write.
+    """
+    row = await conn.fetchval(
+        """
+        SELECT 1
+          FROM connections c
+          LEFT JOIN sessions s ON s.id = $2
+         WHERE c.id = $1
+           AND c.archived_at IS NULL
+           AND (c.session_id = $2
+                OR c.id = s.spawned_from_connection_id
+                OR EXISTS (SELECT 1 FROM connection_chat_sessions ccs
+                            WHERE ccs.connection_id = c.id
+                              AND ccs.session_id = $2))
+         LIMIT 1
+        """,
+        connection_id,
+        session_id,
+    )
+    return row is not None
 
 
 async def read_events(

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1469,7 +1469,223 @@ async def append_event(
     # preserving case, so the two would never match. pg_notify(text, text)
     # treats the channel as a string literal and preserves it byte-for-byte.
     await conn.execute("SELECT pg_notify($1, $2)", f"events_{session_id}", new_id)
+
+    # Connector-calls fan-out (#301): when an assistant message lands with
+    # tool_calls, every connection bound to this session that declares any
+    # custom tool is potentially affected.  The connector container's SSE
+    # subscriber (``GET /v1/connectors/calls``) listens on
+    # ``connector_calls_{connection_id}`` and filters incoming notifications
+    # against the tool names declared on its connection.
+    if (
+        kind == "message"
+        and isinstance(data, dict)
+        and data.get("role") == "assistant"
+        and data.get("tool_calls")
+    ):
+        bound = await _list_bound_connection_ids(conn, session_id)
+        for cid in bound:
+            await conn.execute("SELECT pg_notify($1, $2)", f"connector_calls_{cid}", session_id)
+
     return _row_to_event(row)
+
+
+async def list_pending_calls_for_connection(
+    conn: asyncpg.Connection[Any], connection_id: str
+) -> list[dict[str, Any]]:
+    """Pending custom tool calls for ``connection_id`` across bound sessions.
+
+    A "pending" call is one referenced in some session's
+    ``stop_reason.custom_tools`` array — i.e. the model called a custom
+    tool and the session is parked in ``requires_action``.  For each
+    such session, this returns one row per tool_call whose ``name``
+    matches a tool declared on the connection.
+
+    Output dict shape::
+
+        {
+            "session_id": "sess_xxx",
+            "tool_call_id": "call_yyy",
+            "name": "telegram_send",
+            "arguments": "{...}",        # JSON string from the model
+            "focal_channel": "telegram/bot1/chat123" | None,
+        }
+
+    Used by the connector calls SSE endpoint at subscribe-time backfill
+    and on each NOTIFY.
+    """
+    # First read the connection's tools and the bound sessions, then walk
+    # session state.  Two SELECTs because postgres can't efficiently fan
+    # one query across the lineage union with a jsonb tool-name filter.
+    conn_row = await conn.fetchrow(
+        "SELECT tools FROM connections WHERE id = $1 AND archived_at IS NULL",
+        connection_id,
+    )
+    if conn_row is None:
+        return []
+    tools_data = _parse_jsonb(conn_row["tools"])
+    tool_names = {t["name"] for t in tools_data if isinstance(t, dict) and "name" in t}
+    if not tool_names:
+        return []
+
+    rows = await conn.fetch(
+        """
+        SELECT s.id AS session_id, s.stop_reason, s.focal_channel
+          FROM sessions s
+         WHERE s.archived_at IS NULL
+           AND s.status = 'idle'
+           AND s.stop_reason->>'type' = 'requires_action'
+           AND EXISTS (
+               SELECT 1 FROM connections c
+                WHERE c.id = $1 AND c.archived_at IS NULL
+                  AND (c.session_id = s.id
+                       OR c.id = s.spawned_from_connection_id
+                       OR EXISTS (SELECT 1 FROM connection_chat_sessions ccs
+                                   WHERE ccs.connection_id = c.id
+                                     AND ccs.session_id = s.id))
+           )
+        """,
+        connection_id,
+    )
+
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        out.extend(
+            await _pending_calls_for_session(
+                conn,
+                session_id=row["session_id"],
+                stop_reason=_parse_jsonb(row["stop_reason"]),
+                focal_channel=row["focal_channel"],
+                tool_names=tool_names,
+            )
+        )
+    return out
+
+
+async def list_pending_calls_for_session_and_connection(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str,
+    connection_id: str,
+) -> list[dict[str, Any]]:
+    """Same shape as :func:`list_pending_calls_for_connection` but scoped
+    to one session.  Used by the SSE NOTIFY tail to fetch calls only for
+    the session that just emitted, instead of re-scanning all bound
+    sessions.
+    """
+    conn_row = await conn.fetchrow(
+        "SELECT tools FROM connections WHERE id = $1 AND archived_at IS NULL",
+        connection_id,
+    )
+    if conn_row is None:
+        return []
+    tools_data = _parse_jsonb(conn_row["tools"])
+    tool_names = {t["name"] for t in tools_data if isinstance(t, dict) and "name" in t}
+    if not tool_names:
+        return []
+
+    sess_row = await conn.fetchrow(
+        "SELECT stop_reason, status, focal_channel FROM sessions "
+        "WHERE id = $1 AND archived_at IS NULL",
+        session_id,
+    )
+    if sess_row is None:
+        return []
+    if sess_row["status"] != "idle":
+        return []
+    stop_reason = _parse_jsonb(sess_row["stop_reason"])
+    if not isinstance(stop_reason, dict) or stop_reason.get("type") != "requires_action":
+        return []
+
+    return await _pending_calls_for_session(
+        conn,
+        session_id=session_id,
+        stop_reason=stop_reason,
+        focal_channel=sess_row["focal_channel"],
+        tool_names=tool_names,
+    )
+
+
+async def _pending_calls_for_session(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str,
+    stop_reason: Any,
+    focal_channel: str | None,
+    tool_names: set[str],
+) -> list[dict[str, Any]]:
+    """Fetch the pending tool_call rows for one ``requires_action`` session."""
+    if not isinstance(stop_reason, dict):
+        return []
+    pending_ids = stop_reason.get("custom_tools") or []
+    if not pending_ids:
+        return []
+
+    # The pending call_ids are referenced in the most recent assistant
+    # event; walk that event's data->'tool_calls' array.  We could scan
+    # all assistant events but the loop only parks on the latest, so the
+    # latest assistant message owns every id in stop_reason.
+    rows = await conn.fetch(
+        """
+        SELECT data
+          FROM events
+         WHERE session_id = $1
+           AND kind = 'message'
+           AND data->>'role' = 'assistant'
+         ORDER BY seq DESC
+         LIMIT 5
+        """,
+        session_id,
+    )
+
+    pending_set = set(pending_ids)
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        data = _parse_jsonb(row["data"])
+        for tc in data.get("tool_calls") or []:
+            tc_id = tc.get("id")
+            if tc_id not in pending_set:
+                continue
+            fn = tc.get("function") or {}
+            name = fn.get("name")
+            if name not in tool_names:
+                continue
+            out.append(
+                {
+                    "session_id": session_id,
+                    "tool_call_id": tc_id,
+                    "name": name,
+                    "arguments": fn.get("arguments", "{}"),
+                    "focal_channel": focal_channel,
+                }
+            )
+    return out
+
+
+async def _list_bound_connection_ids(conn: asyncpg.Connection[Any], session_id: str) -> list[str]:
+    """IDs of active connections bound to ``session_id``.
+
+    Used by :func:`append_event` to fan an assistant-tool-calls event
+    out to per-connection NOTIFY channels.  Tools-less connections
+    receive notifications and harmlessly no-op them on the consumer
+    side — filtering by ``jsonb_array_length(tools) > 0`` here forces a
+    seq scan (function expressions aren't indexable), so we accept a
+    small amount of cross-connection notification noise instead.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT c.id
+          FROM connections c
+          LEFT JOIN sessions s ON s.id = $1
+         WHERE c.archived_at IS NULL
+           AND (c.session_id = $1
+                OR c.id = s.spawned_from_connection_id
+                OR EXISTS (SELECT 1 FROM connection_chat_sessions ccs
+                            WHERE ccs.connection_id = c.id
+                              AND ccs.session_id = $1))
+        """,
+        session_id,
+    )
+    return [row["id"] for row in rows]
 
 
 async def read_events(

--- a/src/aios/sdk/_generated/api/connectors/get_calls_v1_connectors_calls_get.py
+++ b/src/aios/sdk/_generated/api/connectors/get_calls_v1_connectors_calls_get.py
@@ -1,0 +1,233 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/connectors/calls",
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    r"""Get Calls
+
+     SSE stream of pending custom tool calls for the caller's connection.
+
+    Backfills any pending calls at subscribe time (calls already parked
+    in some session's ``stop_reason.custom_tools``), then tails the
+    ``connector_calls_<connection_id>`` NOTIFY channel.  Each emitted
+    event is keyed ``call`` with a JSON body shaped::
+
+        {
+            \"session_id\": \"...\",
+            \"tool_call_id\": \"...\",
+            \"name\": \"...\",
+            \"arguments\": \"...\",       // JSON string from the model
+            \"focal_channel\": \"...\"
+        }
+
+    Connector containers dedupe by ``tool_call_id`` client-side so SSE
+    reconnects (which replay the backfill) don't double-execute.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    r"""Get Calls
+
+     SSE stream of pending custom tool calls for the caller's connection.
+
+    Backfills any pending calls at subscribe time (calls already parked
+    in some session's ``stop_reason.custom_tools``), then tails the
+    ``connector_calls_<connection_id>`` NOTIFY channel.  Each emitted
+    event is keyed ``call`` with a JSON body shaped::
+
+        {
+            \"session_id\": \"...\",
+            \"tool_call_id\": \"...\",
+            \"name\": \"...\",
+            \"arguments\": \"...\",       // JSON string from the model
+            \"focal_channel\": \"...\"
+        }
+
+    Connector containers dedupe by ``tool_call_id`` client-side so SSE
+    reconnects (which replay the backfill) don't double-execute.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    r"""Get Calls
+
+     SSE stream of pending custom tool calls for the caller's connection.
+
+    Backfills any pending calls at subscribe time (calls already parked
+    in some session's ``stop_reason.custom_tools``), then tails the
+    ``connector_calls_<connection_id>`` NOTIFY channel.  Each emitted
+    event is keyed ``call`` with a JSON body shaped::
+
+        {
+            \"session_id\": \"...\",
+            \"tool_call_id\": \"...\",
+            \"name\": \"...\",
+            \"arguments\": \"...\",       // JSON string from the model
+            \"focal_channel\": \"...\"
+        }
+
+    Connector containers dedupe by ``tool_call_id`` client-side so SSE
+    reconnects (which replay the backfill) don't double-execute.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    r"""Get Calls
+
+     SSE stream of pending custom tool calls for the caller's connection.
+
+    Backfills any pending calls at subscribe time (calls already parked
+    in some session's ``stop_reason.custom_tools``), then tails the
+    ``connector_calls_<connection_id>`` NOTIFY channel.  Each emitted
+    event is keyed ``call`` with a JSON body shaped::
+
+        {
+            \"session_id\": \"...\",
+            \"tool_call_id\": \"...\",
+            \"name\": \"...\",
+            \"arguments\": \"...\",       // JSON string from the model
+            \"focal_channel\": \"...\"
+        }
+
+    Connector containers dedupe by ``tool_call_id`` client-side so SSE
+    reconnects (which replay the backfill) don't double-execute.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connectors/post_connector_inbound.py
+++ b/src/aios/sdk/_generated/api/connectors/post_connector_inbound.py
@@ -1,0 +1,225 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.connector_inbound_request import ConnectorInboundRequest
+from ...models.connector_inbound_response import ConnectorInboundResponse
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: ConnectorInboundRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connectors/inbound",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ConnectorInboundResponse | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = ConnectorInboundResponse.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ConnectorInboundResponse | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectorInboundRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[ConnectorInboundResponse | HTTPValidationError]:
+    """Post Inbound
+
+     Append an inbound user message to the session bound to the caller's connection.
+
+    Idempotent on ``body.event_id`` — replays return the original
+    event id with ``deduped=True``.  Drops surface as 4xx/5xx with
+    a body explaining the reason (operator-config issue vs server
+    error vs payload).
+
+    Args:
+        authorization (None | str | Unset):
+        body (ConnectorInboundRequest): Body for ``POST /v1/connectors/inbound``.
+
+            Authenticated via ``ConnectorAuthDep`` so the connection_id is
+            server-resolved from the bearer token — clients don't pick which
+            connection their inbound lands on.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ConnectorInboundResponse | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectorInboundRequest,
+    authorization: None | str | Unset = UNSET,
+) -> ConnectorInboundResponse | HTTPValidationError | None:
+    """Post Inbound
+
+     Append an inbound user message to the session bound to the caller's connection.
+
+    Idempotent on ``body.event_id`` — replays return the original
+    event id with ``deduped=True``.  Drops surface as 4xx/5xx with
+    a body explaining the reason (operator-config issue vs server
+    error vs payload).
+
+    Args:
+        authorization (None | str | Unset):
+        body (ConnectorInboundRequest): Body for ``POST /v1/connectors/inbound``.
+
+            Authenticated via ``ConnectorAuthDep`` so the connection_id is
+            server-resolved from the bearer token — clients don't pick which
+            connection their inbound lands on.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ConnectorInboundResponse | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectorInboundRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[ConnectorInboundResponse | HTTPValidationError]:
+    """Post Inbound
+
+     Append an inbound user message to the session bound to the caller's connection.
+
+    Idempotent on ``body.event_id`` — replays return the original
+    event id with ``deduped=True``.  Drops surface as 4xx/5xx with
+    a body explaining the reason (operator-config issue vs server
+    error vs payload).
+
+    Args:
+        authorization (None | str | Unset):
+        body (ConnectorInboundRequest): Body for ``POST /v1/connectors/inbound``.
+
+            Authenticated via ``ConnectorAuthDep`` so the connection_id is
+            server-resolved from the bearer token — clients don't pick which
+            connection their inbound lands on.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ConnectorInboundResponse | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectorInboundRequest,
+    authorization: None | str | Unset = UNSET,
+) -> ConnectorInboundResponse | HTTPValidationError | None:
+    """Post Inbound
+
+     Append an inbound user message to the session bound to the caller's connection.
+
+    Idempotent on ``body.event_id`` — replays return the original
+    event id with ``deduped=True``.  Drops surface as 4xx/5xx with
+    a body explaining the reason (operator-config issue vs server
+    error vs payload).
+
+    Args:
+        authorization (None | str | Unset):
+        body (ConnectorInboundRequest): Body for ``POST /v1/connectors/inbound``.
+
+            Authenticated via ``ConnectorAuthDep`` so the connection_id is
+            server-resolved from the bearer token — clients don't pick which
+            connection their inbound lands on.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ConnectorInboundResponse | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/api/connectors/post_connector_tool_result.py
+++ b/src/aios/sdk/_generated/api/connectors/post_connector_tool_result.py
@@ -1,0 +1,227 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.connector_tool_result_request import ConnectorToolResultRequest
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: ConnectorToolResultRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connectors/tool-results",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = response.json()
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectorToolResultRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Post Tool Result
+
+     Submit a custom tool result from a connector container.
+
+    Authorization: the session must be bound to the caller's connection
+    (single_session attach, per_chat origin, or operator-bound chat).
+    Otherwise → 403.
+
+    Args:
+        authorization (None | str | Unset):
+        body (ConnectorToolResultRequest): Body for ``POST /v1/connectors/tool-results``.
+
+            Mirrors the operator-facing :class:`ToolResultRequest` but adds
+            ``session_id`` since connector tokens aren't path-scoped to a
+            session.  The handler validates the session is bound to the
+            caller's connection (preventing a connector from posting results
+            for sessions outside its scope).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectorToolResultRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Post Tool Result
+
+     Submit a custom tool result from a connector container.
+
+    Authorization: the session must be bound to the caller's connection
+    (single_session attach, per_chat origin, or operator-bound chat).
+    Otherwise → 403.
+
+    Args:
+        authorization (None | str | Unset):
+        body (ConnectorToolResultRequest): Body for ``POST /v1/connectors/tool-results``.
+
+            Mirrors the operator-facing :class:`ToolResultRequest` but adds
+            ``session_id`` since connector tokens aren't path-scoped to a
+            session.  The handler validates the session is bound to the
+            caller's connection (preventing a connector from posting results
+            for sessions outside its scope).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectorToolResultRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Post Tool Result
+
+     Submit a custom tool result from a connector container.
+
+    Authorization: the session must be bound to the caller's connection
+    (single_session attach, per_chat origin, or operator-bound chat).
+    Otherwise → 403.
+
+    Args:
+        authorization (None | str | Unset):
+        body (ConnectorToolResultRequest): Body for ``POST /v1/connectors/tool-results``.
+
+            Mirrors the operator-facing :class:`ToolResultRequest` but adds
+            ``session_id`` since connector tokens aren't path-scoped to a
+            session.  The handler validates the session is bound to the
+            caller's connection (preventing a connector from posting results
+            for sessions outside its scope).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ConnectorToolResultRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Post Tool Result
+
+     Submit a custom tool result from a connector container.
+
+    Authorization: the session must be bound to the caller's connection
+    (single_session attach, per_chat origin, or operator-bound chat).
+    Otherwise → 403.
+
+    Args:
+        authorization (None | str | Unset):
+        body (ConnectorToolResultRequest): Body for ``POST /v1/connectors/tool-results``.
+
+            Mirrors the operator-facing :class:`ToolResultRequest` but adds
+            ``session_id`` since connector tokens aren't path-scoped to a
+            session.  The handler validates the session is bound to the
+            caller's connection (preventing a connector from posting results
+            for sessions outside its scope).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/models/__init__.py
+++ b/src/aios/sdk/_generated/models/__init__.py
@@ -29,9 +29,22 @@ from .connection_set_tools import ConnectionSetTools
 from .connector_call_body import ConnectorCallBody
 from .connector_call_body_arguments import ConnectorCallBodyArguments
 from .connector_call_body_meta_type_0 import ConnectorCallBodyMetaType0
+from .connector_inbound_request import ConnectorInboundRequest
+from .connector_inbound_request_attachments_type_0_item import (
+    ConnectorInboundRequestAttachmentsType0Item,
+)
+from .connector_inbound_request_metadata_type_0 import (
+    ConnectorInboundRequestMetadataType0,
+)
+from .connector_inbound_request_sender import ConnectorInboundRequestSender
+from .connector_inbound_response import ConnectorInboundResponse
 from .connector_token import ConnectorToken
 from .connector_token_issue import ConnectorTokenIssue
 from .connector_token_issued import ConnectorTokenIssued
+from .connector_tool_result_request import ConnectorToolResultRequest
+from .connector_tool_result_request_content_type_1_item import (
+    ConnectorToolResultRequestContentType1Item,
+)
 from .context_response import ContextResponse
 from .context_response_messages_item import ContextResponseMessagesItem
 from .context_response_tools_item import ContextResponseToolsItem
@@ -202,9 +215,16 @@ __all__ = (
     "ConnectorCallBody",
     "ConnectorCallBodyArguments",
     "ConnectorCallBodyMetaType0",
+    "ConnectorInboundRequest",
+    "ConnectorInboundRequestAttachmentsType0Item",
+    "ConnectorInboundRequestMetadataType0",
+    "ConnectorInboundRequestSender",
+    "ConnectorInboundResponse",
     "ConnectorToken",
     "ConnectorTokenIssue",
     "ConnectorTokenIssued",
+    "ConnectorToolResultRequest",
+    "ConnectorToolResultRequestContentType1Item",
     "ContextResponse",
     "ContextResponseMessagesItem",
     "ContextResponseToolsItem",

--- a/src/aios/sdk/_generated/models/connector_inbound_request.py
+++ b/src/aios/sdk/_generated/models/connector_inbound_request.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.connector_inbound_request_attachments_type_0_item import (
+        ConnectorInboundRequestAttachmentsType0Item,
+    )
+    from ..models.connector_inbound_request_metadata_type_0 import (
+        ConnectorInboundRequestMetadataType0,
+    )
+    from ..models.connector_inbound_request_sender import ConnectorInboundRequestSender
+
+
+T = TypeVar("T", bound="ConnectorInboundRequest")
+
+
+@_attrs_define
+class ConnectorInboundRequest:
+    """Body for ``POST /v1/connectors/inbound``.
+
+    Authenticated via ``ConnectorAuthDep`` so the connection_id is
+    server-resolved from the bearer token — clients don't pick which
+    connection their inbound lands on.
+
+        Attributes:
+            event_id (str): Client-supplied dedup key (ULID).  Replays return the original event id.
+            chat_id (str):
+            content (str):
+            sender (ConnectorInboundRequestSender | Unset):
+            attachments (list[ConnectorInboundRequestAttachmentsType0Item] | None | Unset):
+            metadata (ConnectorInboundRequestMetadataType0 | None | Unset):
+            timestamp (None | str | Unset): Optional ISO-8601 platform timestamp; stored in event metadata.
+    """
+
+    event_id: str
+    chat_id: str
+    content: str
+    sender: ConnectorInboundRequestSender | Unset = UNSET
+    attachments: list[ConnectorInboundRequestAttachmentsType0Item] | None | Unset = (
+        UNSET
+    )
+    metadata: ConnectorInboundRequestMetadataType0 | None | Unset = UNSET
+    timestamp: None | str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.connector_inbound_request_metadata_type_0 import (
+            ConnectorInboundRequestMetadataType0,
+        )
+
+        event_id = self.event_id
+
+        chat_id = self.chat_id
+
+        content = self.content
+
+        sender: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.sender, Unset):
+            sender = self.sender.to_dict()
+
+        attachments: list[dict[str, Any]] | None | Unset
+        if isinstance(self.attachments, Unset):
+            attachments = UNSET
+        elif isinstance(self.attachments, list):
+            attachments = []
+            for attachments_type_0_item_data in self.attachments:
+                attachments_type_0_item = attachments_type_0_item_data.to_dict()
+                attachments.append(attachments_type_0_item)
+
+        else:
+            attachments = self.attachments
+
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, ConnectorInboundRequestMetadataType0):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
+
+        timestamp: None | str | Unset
+        if isinstance(self.timestamp, Unset):
+            timestamp = UNSET
+        else:
+            timestamp = self.timestamp
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "event_id": event_id,
+                "chat_id": chat_id,
+                "content": content,
+            }
+        )
+        if sender is not UNSET:
+            field_dict["sender"] = sender
+        if attachments is not UNSET:
+            field_dict["attachments"] = attachments
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if timestamp is not UNSET:
+            field_dict["timestamp"] = timestamp
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.connector_inbound_request_attachments_type_0_item import (
+            ConnectorInboundRequestAttachmentsType0Item,
+        )
+        from ..models.connector_inbound_request_metadata_type_0 import (
+            ConnectorInboundRequestMetadataType0,
+        )
+        from ..models.connector_inbound_request_sender import (
+            ConnectorInboundRequestSender,
+        )
+
+        d = dict(src_dict)
+        event_id = d.pop("event_id")
+
+        chat_id = d.pop("chat_id")
+
+        content = d.pop("content")
+
+        _sender = d.pop("sender", UNSET)
+        sender: ConnectorInboundRequestSender | Unset
+        if isinstance(_sender, Unset):
+            sender = UNSET
+        else:
+            sender = ConnectorInboundRequestSender.from_dict(_sender)
+
+        def _parse_attachments(
+            data: object,
+        ) -> list[ConnectorInboundRequestAttachmentsType0Item] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                attachments_type_0 = []
+                _attachments_type_0 = data
+                for attachments_type_0_item_data in _attachments_type_0:
+                    attachments_type_0_item = (
+                        ConnectorInboundRequestAttachmentsType0Item.from_dict(
+                            attachments_type_0_item_data
+                        )
+                    )
+
+                    attachments_type_0.append(attachments_type_0_item)
+
+                return attachments_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                list[ConnectorInboundRequestAttachmentsType0Item] | None | Unset, data
+            )
+
+        attachments = _parse_attachments(d.pop("attachments", UNSET))
+
+        def _parse_metadata(
+            data: object,
+        ) -> ConnectorInboundRequestMetadataType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = ConnectorInboundRequestMetadataType0.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(ConnectorInboundRequestMetadataType0 | None | Unset, data)
+
+        metadata = _parse_metadata(d.pop("metadata", UNSET))
+
+        def _parse_timestamp(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        timestamp = _parse_timestamp(d.pop("timestamp", UNSET))
+
+        connector_inbound_request = cls(
+            event_id=event_id,
+            chat_id=chat_id,
+            content=content,
+            sender=sender,
+            attachments=attachments,
+            metadata=metadata,
+            timestamp=timestamp,
+        )
+
+        return connector_inbound_request

--- a/src/aios/sdk/_generated/models/connector_inbound_request_attachments_type_0_item.py
+++ b/src/aios/sdk/_generated/models/connector_inbound_request_attachments_type_0_item.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ConnectorInboundRequestAttachmentsType0Item")
+
+
+@_attrs_define
+class ConnectorInboundRequestAttachmentsType0Item:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        connector_inbound_request_attachments_type_0_item = cls()
+
+        connector_inbound_request_attachments_type_0_item.additional_properties = d
+        return connector_inbound_request_attachments_type_0_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/connector_inbound_request_metadata_type_0.py
+++ b/src/aios/sdk/_generated/models/connector_inbound_request_metadata_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ConnectorInboundRequestMetadataType0")
+
+
+@_attrs_define
+class ConnectorInboundRequestMetadataType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        connector_inbound_request_metadata_type_0 = cls()
+
+        connector_inbound_request_metadata_type_0.additional_properties = d
+        return connector_inbound_request_metadata_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/connector_inbound_request_sender.py
+++ b/src/aios/sdk/_generated/models/connector_inbound_request_sender.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ConnectorInboundRequestSender")
+
+
+@_attrs_define
+class ConnectorInboundRequestSender:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        connector_inbound_request_sender = cls()
+
+        connector_inbound_request_sender.additional_properties = d
+        return connector_inbound_request_sender
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/connector_inbound_response.py
+++ b/src/aios/sdk/_generated/models/connector_inbound_response.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ConnectorInboundResponse")
+
+
+@_attrs_define
+class ConnectorInboundResponse:
+    """Response for ``POST /v1/connectors/inbound``.
+
+    Attributes:
+        appended_event_id (None | str):
+        session_id (None | str):
+        deduped (bool):
+    """
+
+    appended_event_id: None | str
+    session_id: None | str
+    deduped: bool
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        appended_event_id: None | str
+        appended_event_id = self.appended_event_id
+
+        session_id: None | str
+        session_id = self.session_id
+
+        deduped = self.deduped
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "appended_event_id": appended_event_id,
+                "session_id": session_id,
+                "deduped": deduped,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+
+        def _parse_appended_event_id(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        appended_event_id = _parse_appended_event_id(d.pop("appended_event_id"))
+
+        def _parse_session_id(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        session_id = _parse_session_id(d.pop("session_id"))
+
+        deduped = d.pop("deduped")
+
+        connector_inbound_response = cls(
+            appended_event_id=appended_event_id,
+            session_id=session_id,
+            deduped=deduped,
+        )
+
+        connector_inbound_response.additional_properties = d
+        return connector_inbound_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/connector_tool_result_request.py
+++ b/src/aios/sdk/_generated/models/connector_tool_result_request.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.connector_tool_result_request_content_type_1_item import (
+        ConnectorToolResultRequestContentType1Item,
+    )
+
+
+T = TypeVar("T", bound="ConnectorToolResultRequest")
+
+
+@_attrs_define
+class ConnectorToolResultRequest:
+    """Body for ``POST /v1/connectors/tool-results``.
+
+    Mirrors the operator-facing :class:`ToolResultRequest` but adds
+    ``session_id`` since connector tokens aren't path-scoped to a
+    session.  The handler validates the session is bound to the
+    caller's connection (preventing a connector from posting results
+    for sessions outside its scope).
+
+        Attributes:
+            session_id (str):
+            tool_call_id (str):
+            content (list[ConnectorToolResultRequestContentType1Item] | str):
+            is_error (bool | Unset):  Default: False.
+    """
+
+    session_id: str
+    tool_call_id: str
+    content: list[ConnectorToolResultRequestContentType1Item] | str
+    is_error: bool | Unset = False
+
+    def to_dict(self) -> dict[str, Any]:
+        session_id = self.session_id
+
+        tool_call_id = self.tool_call_id
+
+        content: list[dict[str, Any]] | str
+        if isinstance(self.content, list):
+            content = []
+            for content_type_1_item_data in self.content:
+                content_type_1_item = content_type_1_item_data.to_dict()
+                content.append(content_type_1_item)
+
+        else:
+            content = self.content
+
+        is_error = self.is_error
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "session_id": session_id,
+                "tool_call_id": tool_call_id,
+                "content": content,
+            }
+        )
+        if is_error is not UNSET:
+            field_dict["is_error"] = is_error
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.connector_tool_result_request_content_type_1_item import (
+            ConnectorToolResultRequestContentType1Item,
+        )
+
+        d = dict(src_dict)
+        session_id = d.pop("session_id")
+
+        tool_call_id = d.pop("tool_call_id")
+
+        def _parse_content(
+            data: object,
+        ) -> list[ConnectorToolResultRequestContentType1Item] | str:
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                content_type_1 = []
+                _content_type_1 = data
+                for content_type_1_item_data in _content_type_1:
+                    content_type_1_item = (
+                        ConnectorToolResultRequestContentType1Item.from_dict(
+                            content_type_1_item_data
+                        )
+                    )
+
+                    content_type_1.append(content_type_1_item)
+
+                return content_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[ConnectorToolResultRequestContentType1Item] | str, data)
+
+        content = _parse_content(d.pop("content"))
+
+        is_error = d.pop("is_error", UNSET)
+
+        connector_tool_result_request = cls(
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            content=content,
+            is_error=is_error,
+        )
+
+        return connector_tool_result_request

--- a/src/aios/sdk/_generated/models/connector_tool_result_request_content_type_1_item.py
+++ b/src/aios/sdk/_generated/models/connector_tool_result_request_content_type_1_item.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ConnectorToolResultRequestContentType1Item")
+
+
+@_attrs_define
+class ConnectorToolResultRequestContentType1Item:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        connector_tool_result_request_content_type_1_item = cls()
+
+        connector_tool_result_request_content_type_1_item.additional_properties = d
+        return connector_tool_result_request_content_type_1_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/services/inbound.py
+++ b/src/aios/services/inbound.py
@@ -1,0 +1,241 @@
+"""Inbound message handling for connector containers (#301).
+
+The new ``POST /v1/connectors/inbound`` endpoint calls
+:func:`handle_inbound`, which wraps the dedup / attachment-staging /
+session-resolution logic that today also lives in
+``connector_supervisor._handle_inbound``.  Both paths share the same
+DB primitives (``try_record_inbound_ack``, ``append_event``,
+``stage_inbound_attachments``) so the supervisor and the new HTTP path
+produce indistinguishable event-log state.
+
+In PR 6 the supervisor is deleted and this is the only inbound path.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from enum import StrEnum
+from typing import Any, NamedTuple
+
+import asyncpg
+
+from aios.db import queries
+from aios.errors import NotFoundError
+from aios.harness.attachment_staging import (
+    AttachmentStagingError,
+    stage_inbound_attachments,
+)
+from aios.harness.wake import defer_wake
+from aios.models.connections import Connection
+from aios.models.sessions import MAX_USER_MESSAGE_CHARS
+from aios.services import sessions as sessions_service
+
+
+class _DedupRollback(Exception):
+    """Internal: signals the dedup-ledger conflict path inside the txn."""
+
+
+class InboundDrop(StrEnum):
+    """Why an inbound was not delivered to a session.
+
+    Each maps to an HTTP response in the router: PAYLOAD_TOO_LARGE → 413;
+    DETACHED and ARCHIVED_TEMPLATE → 422 (operator config issue);
+    ATTACHMENT_STAGING_FAILED and SESSION_MISSING → 500.  Replays of an
+    already-processed ``event_id`` are NOT a drop — they return 200
+    with ``deduped=True``.
+    """
+
+    PAYLOAD_TOO_LARGE = "payload_too_large"
+    DETACHED = "detached"
+    ARCHIVED_TEMPLATE = "archived_template"
+    ATTACHMENT_STAGING_FAILED = "attachment_staging_failed"
+    SESSION_MISSING = "session_missing"
+
+
+class InboundResult(NamedTuple):
+    appended_event_id: str | None
+    session_id: str | None
+    drop_reason: InboundDrop | None
+    deduped: bool
+
+
+class _PerChatResolution(NamedTuple):
+    session_id: str | None
+    drop: InboundDrop | None
+
+
+async def handle_inbound(
+    pool: asyncpg.Pool[Any],
+    *,
+    connection_id: str,
+    event_id: str,
+    chat_id: str,
+    sender: dict[str, Any],
+    content: str,
+    attachments: list[Any] | None = None,
+    connector_metadata: dict[str, Any] | None = None,
+    platform_timestamp: str | None = None,
+) -> InboundResult:
+    """Resolve target session, stage attachments, dedup-append, defer wake.
+
+    Idempotent on ``event_id``: a replay returns ``deduped=True`` and
+    re-defers the wake (procrastinate's queueing_lock coalesces).
+    """
+    if len(content) > MAX_USER_MESSAGE_CHARS:
+        return InboundResult(None, None, InboundDrop.PAYLOAD_TOO_LARGE, False)
+
+    async with pool.acquire() as conn:
+        connection = await queries.get_connection(conn, connection_id)
+        existing_session_id = await queries.lookup_chat_session(conn, connection.id, chat_id)
+
+    target_session_id = existing_session_id
+    if target_session_id is None:
+        if connection.session_id is not None:
+            target_session_id = connection.session_id
+        elif connection.session_template_id is not None:
+            resolution = await _resolve_per_chat(pool, connection=connection, chat_id=chat_id)
+            if resolution.drop is not None:
+                return InboundResult(None, None, resolution.drop, False)
+            target_session_id = resolution.session_id
+        else:
+            return InboundResult(None, None, InboundDrop.DETACHED, False)
+
+    assert target_session_id is not None  # both branches above either set it or returned
+
+    try:
+        staged_attachments, newly_staged_paths = stage_inbound_attachments(
+            session_id=target_session_id,
+            connector_name=connection.connector,
+            event_id=event_id,
+            raw_attachments=attachments,
+        )
+    except AttachmentStagingError:
+        return InboundResult(None, target_session_id, InboundDrop.ATTACHMENT_STAGING_FAILED, False)
+
+    try:
+        appended = await _append_with_dedup(
+            pool,
+            connector=connection.connector,
+            account=connection.account,
+            event_id=event_id,
+            session_id=target_session_id,
+            chat_id=chat_id,
+            sender=sender,
+            content=content,
+            attachments=staged_attachments,
+            connector_metadata=connector_metadata,
+            platform_timestamp=platform_timestamp,
+        )
+    except NotFoundError:
+        # Session vanished between resolution and append: clean up freshly
+        # materialized attachment bytes (replay-skipped paths are excluded
+        # by stage_inbound_attachments).
+        for path in newly_staged_paths:
+            with contextlib.suppress(OSError):
+                path.unlink(missing_ok=True)
+        return InboundResult(None, target_session_id, InboundDrop.SESSION_MISSING, False)
+
+    # Defer wake unconditionally — both first-append and dedup paths
+    # heal the case where a prior attempt committed but failed to wake.
+    await defer_wake(pool, target_session_id, cause="inbound")
+
+    return InboundResult(
+        appended_event_id=event_id,
+        session_id=target_session_id,
+        drop_reason=None,
+        deduped=not appended,
+    )
+
+
+async def _resolve_per_chat(
+    pool: asyncpg.Pool[Any], *, connection: Connection, chat_id: str
+) -> _PerChatResolution:
+    """Spawn (or reuse) a session for ``(connection.id, chat_id)`` per-chat mode."""
+    assert connection.session_template_id is not None
+    async with pool.acquire() as conn:
+        template = await queries.get_session_template(conn, connection.session_template_id)
+    if template.archived_at is not None:
+        return _PerChatResolution(session_id=None, drop=InboundDrop.ARCHIVED_TEMPLATE)
+
+    focal_channel = f"{connection.connector}/{connection.account}/{chat_id}"
+    session = await sessions_service.create_session(
+        pool,
+        agent_id=template.agent_id,
+        environment_id=template.environment_id,
+        agent_version=template.agent_version,
+        title=None,
+        metadata={},
+        vault_ids=template.vault_ids or None,
+        focal_channel=focal_channel,
+        spawned_from_connection_id=connection.id,
+    )
+
+    # Race-safe register: insert_chat_session returns the existing
+    # session_id if another writer beat us, and the just-spawned session
+    # is intentionally orphaned (operator can archive later).
+    async with pool.acquire() as conn:
+        registered = await queries.insert_chat_session(
+            conn,
+            connection_id=connection.id,
+            chat_id=chat_id,
+            session_id=session.id,
+        )
+    return _PerChatResolution(session_id=registered, drop=None)
+
+
+async def _append_with_dedup(
+    pool: asyncpg.Pool[Any],
+    *,
+    connector: str,
+    account: str,
+    event_id: str,
+    session_id: str,
+    chat_id: str,
+    sender: dict[str, Any],
+    content: str,
+    attachments: Any,
+    connector_metadata: dict[str, Any] | None,
+    platform_timestamp: str | None,
+) -> bool:
+    """Append the user-message event AND record the dedup ledger row.
+
+    Both writes run in one transaction so a replayed event_id rolls the
+    txn back via :class:`_DedupRollback`.  Returns True on first-append,
+    False on dedup hit.
+    """
+    channel = f"{connector}/{account}/{chat_id}"
+    sender_name = sender.get("display_name")
+    metadata: dict[str, Any] = {}
+    if connector_metadata is not None:
+        metadata.update(connector_metadata)
+    metadata["channel"] = channel
+    if isinstance(sender_name, str):
+        metadata["sender"] = sender_name
+    if isinstance(attachments, list) and attachments:
+        metadata["attachments"] = attachments
+    if platform_timestamp is not None:
+        metadata["platform_timestamp"] = platform_timestamp
+    data: dict[str, Any] = {"role": "user", "content": content, "metadata": metadata}
+
+    try:
+        async with pool.acquire() as conn, conn.transaction():
+            event = await queries.append_event(
+                conn,
+                session_id=session_id,
+                kind="message",
+                data=data,
+                orig_channel=channel,
+            )
+            inserted = await queries.try_record_inbound_ack(
+                conn,
+                connector=connector,
+                account=account,
+                event_id=event_id,
+                appended_seq=event.seq,
+            )
+            if not inserted:
+                raise _DedupRollback()
+            await queries.flip_idle_to_pending(conn, session_id)
+    except _DedupRollback:
+        return False
+    return True

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -203,6 +203,45 @@ async def append_event(
         return await queries.append_event(conn, session_id=session_id, kind=kind, data=data)
 
 
+async def append_tool_result(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str,
+    tool_call_id: str,
+    content: str | list[dict[str, Any]],
+    is_error: bool = False,
+) -> Event:
+    """Append a tool-role event for a custom tool call (#133).
+
+    Stamps the tool's ``name`` from the parent assistant's ``tool_calls``
+    array so the derived ``tool_name`` column on ``events`` stays
+    populated for custom tools.  Raises :class:`NotFoundError` if there's
+    no parent — a result with no matching call would leave an orphan row.
+
+    Takes a connection (not a pool) so the caller can group additional
+    work in the same transaction (e.g. a connection-binding auth check
+    in the connector-facing endpoint).  The caller is responsible for
+    deferring the wake afterwards.
+    """
+    from aios.errors import NotFoundError
+
+    name = await queries.lookup_tool_name_by_call_id(conn, session_id, tool_call_id)
+    if name is None:
+        raise NotFoundError(
+            f"tool_call_id {tool_call_id!r} not found",
+            detail={"session_id": session_id, "tool_call_id": tool_call_id},
+        )
+    data: dict[str, Any] = {
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": content,
+        "name": name,
+    }
+    if is_error:
+        data["is_error"] = True
+    return await queries.append_event(conn, session_id=session_id, kind="message", data=data)
+
+
 async def read_events(
     pool: asyncpg.Pool[Any],
     session_id: str,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -253,9 +253,12 @@ async def http_client(aios_env: dict[str, str]) -> AsyncIterator[Any]:
     app.state.db_url = settings.db_url
     app.state.procrastinate = mock.MagicMock()
     transport = httpx.ASGITransport(app=app)
-    with mock.patch(
-        "aios.api.routers.sessions.defer_wake",
-        new_callable=mock.AsyncMock,
+    # Mock at every call site that imports ``defer_wake`` directly —
+    # patching the source (``aios.harness.wake``) is too late since the
+    # importing modules already captured the unmocked reference.
+    with (
+        mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock),
+        mock.patch("aios.services.inbound.defer_wake", new_callable=mock.AsyncMock),
     ):
         async with httpx.AsyncClient(
             transport=transport,

--- a/tests/e2e/test_connectors_io.py
+++ b/tests/e2e/test_connectors_io.py
@@ -1,0 +1,215 @@
+"""E2E tests for the connector-facing inbound + calls-stream endpoints (#301).
+
+Pins the contract a connector container talks to:
+
+* ``POST /v1/connectors/inbound`` appends a user-message event to the
+  session bound to the caller's connection.  Idempotent on ``event_id``
+  (replays are no-ops with ``deduped=True``).  Drops on detached /
+  oversized / archived-template / attachment-failure surface as 4xx/5xx
+  with a ``drop_reason`` body.
+
+* ``GET /v1/connectors/calls`` (SSE) emits one event per pending custom
+  tool call referencing a tool declared on the caller's connection.
+  Backfills at subscribe time, then tails ``connector_calls_<cid>``.
+
+Both routes use ``ConnectorAuthDep`` — the caller's bearer token
+resolves to a single connection_id, never the global API key.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from aios.ids import EVENT, make_id, split_id
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness
+
+
+def _new_event_id() -> str:
+    """A fresh 26-char ULID — the dedup-key shape connectors emit."""
+    return split_id(make_id(EVENT))[1]
+
+
+async def _create_connection(http_client: httpx.AsyncClient, account: str) -> str:
+    r = await http_client.post(
+        "/v1/connections",
+        json={"connector": "echo", "account": account},
+    )
+    assert r.status_code == 201, r.text
+    return str(r.json()["id"])
+
+
+async def _attach(harness: Harness, connection_id: str, session_id: str) -> None:
+    """Bypass the API attach (which calls into procrastinate for the
+    snapshot drift check, unavailable in tests) — go straight to the service.
+    """
+    from aios.services import connections as connections_service
+
+    await connections_service.attach_connection(harness._pool, connection_id, session_id=session_id)
+
+
+async def _set_tools(
+    http_client: httpx.AsyncClient, connection_id: str, tool_names: list[str]
+) -> None:
+    tools = [
+        {
+            "type": "custom",
+            "name": name,
+            "description": f"send via {name}",
+            "input_schema": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+                "required": ["text"],
+            },
+        }
+        for name in tool_names
+    ]
+    r = await http_client.put(
+        f"/v1/connections/{connection_id}/tools",
+        json={"tools": tools},
+    )
+    assert r.status_code == 200, r.text
+
+
+async def _issue_token(http_client: httpx.AsyncClient, connection_id: str) -> str:
+    r = await http_client.post("/v1/connector-tokens", json={"connection_id": connection_id})
+    assert r.status_code == 201, r.text
+    return str(r.json()["plaintext"])
+
+
+@needs_docker
+class TestPostInbound:
+    async def test_appends_user_event(
+        self, http_client: httpx.AsyncClient, harness: Harness
+    ) -> None:
+        from aios.services import agents as agents_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"inb-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-inb-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        connection_id = await _create_connection(http_client, f"acct-{id(self)}")
+        await _attach(harness, connection_id, session.id)
+        token = await _issue_token(http_client, connection_id)
+
+        r = await http_client.post(
+            "/v1/connectors/inbound",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "event_id": _new_event_id(),
+                "chat_id": "chat-1",
+                "sender": {"display_name": "Alice"},
+                "content": "hello",
+            },
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["session_id"] == session.id
+        assert body["deduped"] is False
+
+        events = await harness.events(session.id)
+        user_events = [e for e in events if e.kind == "message" and e.data.get("role") == "user"]
+        assert len(user_events) == 1
+        assert user_events[0].data["content"] == "hello"
+        assert user_events[0].data["metadata"]["sender"] == "Alice"
+
+    async def test_dedup_returns_same_event(
+        self, http_client: httpx.AsyncClient, harness: Harness
+    ) -> None:
+        from aios.services import agents as agents_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"dedup-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-dedup-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        connection_id = await _create_connection(http_client, f"acct-d-{id(self)}")
+        await _attach(harness, connection_id, session.id)
+        token = await _issue_token(http_client, connection_id)
+
+        event_id = _new_event_id()
+        body = {
+            "event_id": event_id,
+            "chat_id": "chat-1",
+            "sender": {"display_name": "Alice"},
+            "content": "hello",
+        }
+
+        r1 = await http_client.post(
+            "/v1/connectors/inbound",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+        assert r1.status_code == 201
+        assert r1.json()["deduped"] is False
+
+        r2 = await http_client.post(
+            "/v1/connectors/inbound",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+        assert r2.status_code == 201
+        assert r2.json()["deduped"] is True
+        assert r2.json()["session_id"] == session.id
+
+        # No duplicate event in the log.
+        events = await harness.events(session.id)
+        user_events = [e for e in events if e.kind == "message" and e.data.get("role") == "user"]
+        assert len(user_events) == 1
+
+    async def test_detached_connection_drops_with_422(self, http_client: httpx.AsyncClient) -> None:
+        connection_id = await _create_connection(http_client, f"acct-det-{id(self)}")
+        token = await _issue_token(http_client, connection_id)
+
+        r = await http_client.post(
+            "/v1/connectors/inbound",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "event_id": _new_event_id(),
+                "chat_id": "chat-1",
+                "sender": {},
+                "content": "hi",
+            },
+        )
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["detail"]["drop_reason"] == "detached"
+
+    async def test_operator_key_rejected(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        r = await http_client.post(
+            "/v1/connectors/inbound",
+            headers={"Authorization": f"Bearer {aios_env['AIOS_API_KEY']}"},
+            json={
+                "event_id": "01J00000000000000000000000",
+                "chat_id": "chat-1",
+                "sender": {},
+                "content": "hi",
+            },
+        )
+        assert r.status_code == 401, r.text

--- a/tests/e2e/test_echo_http_connector.py
+++ b/tests/e2e/test_echo_http_connector.py
@@ -1,0 +1,450 @@
+"""End-to-end validation gate for the HTTP-client connector path (#301).
+
+PR 4's whole point is to PROVE the new architecture works by spinning
+up the reference echo-http connector against a real aios API instance.
+Tests here:
+
+* Spawn a uvicorn server in-process (a real socket, not ASGITransport)
+  so the connector's SSE streaming actually works.
+* Set up a connection + token + tools.
+* Run an :class:`EchoConnector` as an asyncio task.
+* Drive the model via the harness so it calls a connection-tool.
+* Verify the connector executes the tool and POSTs the result.
+* Verify ``trigger_inbound`` synthesizes a session event.
+
+Once these pass, the architecture is fully validated end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import uvicorn
+from aios_echo_http import EchoConnector
+
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness, assistant, last_assistant_content, tool_call
+
+
+async def _wait_for_health(url: str, *, deadline_s: float = 5.0) -> None:
+    """Poll the health endpoint until it responds."""
+    deadline = asyncio.get_running_loop().time() + deadline_s
+    async with httpx.AsyncClient() as client:
+        while True:
+            with contextlib.suppress(httpx.HTTPError):
+                r = await client.get(f"{url}/v1/health", timeout=0.5)
+                if r.status_code < 500:
+                    return
+            if asyncio.get_running_loop().time() >= deadline:
+                raise TimeoutError(f"server at {url} not ready in {deadline_s}s")
+            await asyncio.sleep(0.05)
+
+
+@pytest.fixture
+async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
+    """Run uvicorn on a free port, serving the aios app.
+
+    Returns the base URL.  Uses defer_wake mocking the same way the
+    in-process http_client fixture does — tests drive the harness
+    directly for any session advancement.
+    """
+    import socket
+    from unittest import mock
+
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    pool = await create_pool(settings.db_url, min_size=1, max_size=4)
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", lifespan="off")
+    server = uvicorn.Server(config)
+    server.config.load()
+    server.lifespan = server.config.lifespan_class(server.config)
+
+    async def _serve() -> None:
+        # Hand uvicorn the prebound socket so we don't race on port pick.
+        sock.setblocking(False)
+        await server.serve(sockets=[sock])
+
+    with (
+        mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock),
+        mock.patch("aios.services.inbound.defer_wake", new_callable=mock.AsyncMock),
+    ):
+        serve_task = asyncio.create_task(_serve())
+        try:
+            url = f"http://127.0.0.1:{port}"
+            await _wait_for_health(url)
+            yield url
+        finally:
+            server.should_exit = True
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(serve_task, timeout=5.0)
+            await pool.close()
+
+
+async def _create_connection(api_key: str, base_url: str, account: str) -> str:
+    async with httpx.AsyncClient(
+        base_url=base_url, headers={"Authorization": f"Bearer {api_key}"}
+    ) as c:
+        r = await c.post("/v1/connections", json={"connector": "echo", "account": account})
+        r.raise_for_status()
+        return str(r.json()["id"])
+
+
+async def _set_tools(api_key: str, base_url: str, connection_id: str) -> None:
+    async with httpx.AsyncClient(
+        base_url=base_url, headers={"Authorization": f"Bearer {api_key}"}
+    ) as c:
+        r = await c.put(
+            f"/v1/connections/{connection_id}/tools",
+            json={
+                "tools": [
+                    {
+                        "type": "custom",
+                        "name": "ping",
+                        "description": "ping",
+                        "input_schema": {"type": "object"},
+                    },
+                    {
+                        "type": "custom",
+                        "name": "echo",
+                        "description": "echo",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {"text": {"type": "string"}},
+                            "required": ["text"],
+                        },
+                    },
+                    {
+                        "type": "custom",
+                        "name": "trigger_inbound",
+                        "description": "synth inbound",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {
+                                "chat_id": {"type": "string"},
+                                "sender_name": {"type": "string"},
+                                "content": {"type": "string"},
+                            },
+                            "required": ["chat_id", "sender_name", "content"],
+                        },
+                    },
+                ]
+            },
+        )
+        r.raise_for_status()
+
+
+async def _issue_token(api_key: str, base_url: str, connection_id: str) -> str:
+    async with httpx.AsyncClient(
+        base_url=base_url, headers={"Authorization": f"Bearer {api_key}"}
+    ) as c:
+        r = await c.post("/v1/connector-tokens", json={"connection_id": connection_id})
+        r.raise_for_status()
+        return str(r.json()["plaintext"])
+
+
+@needs_docker
+class TestSdkAgainstLiveServer:
+    """Smoke test: minimal SDK round-trip against the uvicorn fixture."""
+
+    async def test_whoami_returns_connection_id(
+        self,
+        harness: Harness,
+        live_server: str,
+        aios_env: dict[str, str],
+    ) -> None:
+        from aios_connector_http import AiosClient
+
+        api_key = aios_env["AIOS_API_KEY"]
+        connection_id = await _create_connection(api_key, live_server, f"acct-w-{id(self)}")
+        token = await _issue_token(api_key, live_server, connection_id)
+
+        async with AiosClient(live_server, token) as client:
+            resolved = await client.whoami()
+            assert resolved == connection_id
+
+    async def test_sse_stream_emits_backfill(
+        self,
+        harness: Harness,
+        live_server: str,
+        aios_env: dict[str, str],
+    ) -> None:
+        """Pre-seed a pending call → open SSE → confirm we receive it."""
+        from aios_connector_http import AiosClient
+
+        from aios.services import agents as agents_service
+        from aios.services import connections as connections_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"sse-bf-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-sse-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+
+        api_key = aios_env["AIOS_API_KEY"]
+        connection_id = await _create_connection(api_key, live_server, f"acct-sse-{id(self)}")
+        await connections_service.attach_connection(
+            harness._pool, connection_id, session_id=session.id
+        )
+        await _set_tools(api_key, live_server, connection_id)
+        token = await _issue_token(api_key, live_server, connection_id)
+
+        # Pre-seed a pending call so backfill has something to deliver.
+        await sess_svc.append_event(
+            harness._pool,
+            session.id,
+            "message",
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_sse_bf",
+                        "type": "function",
+                        "function": {"name": "ping", "arguments": "{}"},
+                    }
+                ],
+            },
+        )
+        await sess_svc.set_session_status(
+            harness._pool,
+            session.id,
+            "idle",
+            stop_reason={
+                "type": "requires_action",
+                "event_ids": ["call_sse_bf"],
+                "custom_tools": ["call_sse_bf"],
+            },
+        )
+
+        # Sanity check: query directly to confirm the data is in place.
+        from aios.db import queries
+
+        async with harness._pool.acquire() as db_conn:
+            direct = await queries.list_pending_calls_for_connection(db_conn, connection_id)
+        assert len(direct) == 1, f"backfill query empty in test setup: {direct}"
+
+        # Via the SDK helper — exercises the runner-side parser.
+        async with AiosClient(live_server, token) as client:
+
+            async def _first_call() -> dict[str, str]:
+                async for call in client.stream_calls():
+                    return call
+                raise AssertionError("stream closed before any call")
+
+            first = await asyncio.wait_for(_first_call(), timeout=10.0)
+            assert first["tool_call_id"] == "call_sse_bf"
+            assert first["name"] == "ping"
+
+
+@needs_docker
+class TestEchoHttpConnectorEndToEnd:
+    """Drive the full HTTP-client path: model → SSE → connector → tool-results."""
+
+    async def test_echo_tool_round_trip(
+        self,
+        harness: Harness,
+        live_server: str,
+        aios_env: dict[str, str],
+    ) -> None:
+        from aios.services import agents as agents_service
+        from aios.services import connections as connections_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"e2e-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-e2e-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool,
+            agent_id=agent.id,
+            environment_id=env.id,
+            title=None,
+            metadata={},
+        )
+
+        api_key = aios_env["AIOS_API_KEY"]
+        connection_id = await _create_connection(api_key, live_server, f"acct-{id(self)}")
+        await connections_service.attach_connection(
+            harness._pool, connection_id, session_id=session.id
+        )
+        await _set_tools(api_key, live_server, connection_id)
+        token = await _issue_token(api_key, live_server, connection_id)
+
+        connector = EchoConnector(base_url=live_server, token=token)
+
+        # Run the connector + drive the model in parallel.  The harness's
+        # scripted model calls echo, the connector executes it, posts
+        # the result, the harness's next step sees the result and emits
+        # the wrap-up message.
+        harness.script_model(
+            [
+                assistant(tool_calls=[tool_call("echo", {"text": "hello"}, call_id="call_1")]),
+                assistant("All done."),
+            ]
+        )
+        await sess_svc.append_user_message(harness._pool, session.id, "say hello")
+
+        connector_task = asyncio.create_task(connector.run())
+        try:
+            # Step 1: model calls echo → session parks in requires_action,
+            # which fires connector_calls NOTIFY → connector receives via SSE
+            # → connector posts tool_result.
+            await harness.run_step(session.id)
+
+            # Wait for the connector to post the tool result.
+            async def _result_landed() -> bool:
+                events = await harness.events(session.id)
+                return any(
+                    e.kind == "message"
+                    and e.data.get("role") == "tool"
+                    and e.data.get("tool_call_id") == "call_1"
+                    for e in events
+                )
+
+            deadline = asyncio.get_running_loop().time() + 10.0
+            while not await _result_landed():
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError("connector did not post tool_result in 10s")
+                await asyncio.sleep(0.1)
+
+            # Step 2: model sees the tool_result and emits wrap-up.
+            await harness.run_step(session.id)
+            events = await harness.events(session.id)
+            assert last_assistant_content(events) == "All done."
+
+            # The tool result content carries echo's output.
+            tool_event = next(
+                e
+                for e in events
+                if e.kind == "message"
+                and e.data.get("role") == "tool"
+                and e.data.get("tool_call_id") == "call_1"
+            )
+            import json
+
+            assert json.loads(tool_event.data["content"]) == {"text": "hello"}
+        finally:
+            connector_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, BaseExceptionGroup):
+                await connector_task
+
+    async def test_trigger_inbound_synthesizes_event(
+        self,
+        harness: Harness,
+        live_server: str,
+        aios_env: dict[str, str],
+    ) -> None:
+        """Driver: model calls trigger_inbound → connector POSTs to
+        /v1/connectors/inbound → user-message event lands."""
+        from aios.services import agents as agents_service
+        from aios.services import connections as connections_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"e2e-i-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-e2e-i-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+
+        api_key = aios_env["AIOS_API_KEY"]
+        connection_id = await _create_connection(api_key, live_server, f"acct-i-{id(self)}")
+        await connections_service.attach_connection(
+            harness._pool, connection_id, session_id=session.id
+        )
+        await _set_tools(api_key, live_server, connection_id)
+        token = await _issue_token(api_key, live_server, connection_id)
+
+        connector = EchoConnector(base_url=live_server, token=token)
+
+        harness.script_model(
+            [
+                assistant(
+                    tool_calls=[
+                        tool_call(
+                            "trigger_inbound",
+                            {
+                                "chat_id": "chat-1",
+                                "sender_name": "Alice",
+                                "content": "synthesized hi",
+                            },
+                            call_id="call_t1",
+                        )
+                    ]
+                ),
+                assistant("ack"),
+            ]
+        )
+        await sess_svc.append_user_message(harness._pool, session.id, "fire trigger")
+
+        connector_task = asyncio.create_task(connector.run())
+        try:
+            await harness.run_step(session.id)
+
+            async def _inbound_landed() -> bool:
+                events = await harness.events(session.id)
+                return any(
+                    e.kind == "message"
+                    and e.data.get("role") == "user"
+                    and e.data.get("content") == "synthesized hi"
+                    for e in events
+                )
+
+            deadline = asyncio.get_running_loop().time() + 10.0
+            while not await _inbound_landed():
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError("inbound never landed in 10s")
+                await asyncio.sleep(0.1)
+        finally:
+            connector_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, BaseExceptionGroup):
+                await connector_task

--- a/tests/e2e/test_pending_calls_query.py
+++ b/tests/e2e/test_pending_calls_query.py
@@ -1,0 +1,326 @@
+"""E2E tests for the connector-calls primitives (#301).
+
+The SSE endpoint at ``GET /v1/connectors/calls`` is glue over two
+primitives:
+
+1. ``queries.list_pending_calls_for_connection`` — backfill query
+2. ``listen_for_connector_calls(db_url, connection_id)`` — LISTEN on
+   the per-connection NOTIFY channel, fired by ``append_event`` when an
+   assistant tool-calls event lands on a bound session
+
+This file pins both primitives directly.  End-to-end SSE exercise with
+a real consumer lands in PR 4 with the reference echo-http connector,
+where the consumer's reconnect/dedup logic naturally drives the stream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from aios.config import get_settings
+from aios.db.listen import listen_for_connector_calls
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness
+
+
+@needs_docker
+class TestListPendingCalls:
+    async def test_returns_pending_call_for_attached_session(self, harness: Harness) -> None:
+        from aios.db import queries
+        from aios.models.agents import ToolSpec
+        from aios.services import agents as agents_service
+        from aios.services import connections as connections_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"q-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-q-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        conn = await connections_service.create_connection(
+            harness._pool,
+            connector="echo",
+            account=f"acct-q-{id(self)}",
+            metadata={},
+            tools=[
+                ToolSpec(
+                    type="custom",
+                    name="echo_send",
+                    description="",
+                    input_schema={"type": "object"},
+                ),
+            ],
+        )
+        await connections_service.attach_connection(harness._pool, conn.id, session_id=session.id)
+
+        # Seed an assistant tool_call + park session in requires_action.
+        await sess_svc.append_event(
+            harness._pool,
+            session.id,
+            "message",
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_q1",
+                        "type": "function",
+                        "function": {"name": "echo_send", "arguments": json.dumps({"text": "hi"})},
+                    }
+                ],
+            },
+        )
+        await sess_svc.set_session_status(
+            harness._pool,
+            session.id,
+            "idle",
+            stop_reason={
+                "type": "requires_action",
+                "event_ids": ["call_q1"],
+                "custom_tools": ["call_q1"],
+            },
+        )
+
+        async with harness._pool.acquire() as db_conn:
+            calls = await queries.list_pending_calls_for_connection(db_conn, conn.id)
+
+        assert len(calls) == 1
+        assert calls[0]["tool_call_id"] == "call_q1"
+        assert calls[0]["name"] == "echo_send"
+        assert calls[0]["session_id"] == session.id
+        assert json.loads(calls[0]["arguments"]) == {"text": "hi"}
+
+    async def test_returns_empty_for_unrelated_connection(self, harness: Harness) -> None:
+        from aios.db import queries
+        from aios.models.agents import ToolSpec
+        from aios.services import connections as connections_service
+
+        # A connection with tools but not bound to anything.
+        conn = await connections_service.create_connection(
+            harness._pool,
+            connector="echo",
+            account=f"acct-u-{id(self)}",
+            metadata={},
+            tools=[
+                ToolSpec(
+                    type="custom",
+                    name="echo_send",
+                    description="",
+                    input_schema={"type": "object"},
+                ),
+            ],
+        )
+        async with harness._pool.acquire() as db_conn:
+            calls = await queries.list_pending_calls_for_connection(db_conn, conn.id)
+        assert calls == []
+
+
+@needs_docker
+class TestConnectorCallsNotify:
+    """Verify ``append_event`` fires ``connector_calls_<cid>`` NOTIFY for
+    bound connections that declare any tool — and ONLY for those.
+    """
+
+    async def test_notify_fires_on_bound_assistant_event(self, harness: Harness) -> None:
+        from aios.models.agents import ToolSpec
+        from aios.services import agents as agents_service
+        from aios.services import connections as connections_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"n-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-n-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        conn = await connections_service.create_connection(
+            harness._pool,
+            connector="echo",
+            account=f"acct-n-{id(self)}",
+            metadata={},
+            tools=[
+                ToolSpec(
+                    type="custom",
+                    name="echo_send",
+                    description="",
+                    input_schema={"type": "object"},
+                ),
+            ],
+        )
+        await connections_service.attach_connection(harness._pool, conn.id, session_id=session.id)
+
+        settings = get_settings()
+        async with listen_for_connector_calls(settings.db_url, conn.id) as queue:
+            await sess_svc.append_event(
+                harness._pool,
+                session.id,
+                "message",
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_n1",
+                            "type": "function",
+                            "function": {
+                                "name": "echo_send",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                },
+            )
+            payload = await asyncio.wait_for(queue.get(), timeout=5.0)
+            assert payload == session.id
+
+    async def test_notify_silent_on_role_user_event(self, harness: Harness) -> None:
+        """User-message events MUST NOT trigger the connector-calls fan-out;
+        otherwise inbound POSTs would echo back as 'work' notifications.
+        """
+        from aios.models.agents import ToolSpec
+        from aios.services import agents as agents_service
+        from aios.services import connections as connections_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"nu-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-nu-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        conn = await connections_service.create_connection(
+            harness._pool,
+            connector="echo",
+            account=f"acct-nu-{id(self)}",
+            metadata={},
+            tools=[
+                ToolSpec(
+                    type="custom",
+                    name="echo_send",
+                    description="",
+                    input_schema={"type": "object"},
+                ),
+            ],
+        )
+        await connections_service.attach_connection(harness._pool, conn.id, session_id=session.id)
+
+        settings = get_settings()
+        async with listen_for_connector_calls(settings.db_url, conn.id) as queue:
+            await sess_svc.append_user_message(harness._pool, session.id, "hi")
+            try:
+                payload = await asyncio.wait_for(queue.get(), timeout=0.5)
+            except TimeoutError:
+                payload = None
+            assert payload is None, f"unexpected NOTIFY for user event: {payload}"
+
+    async def test_notify_silent_on_unrelated_connection(self, harness: Harness) -> None:
+        """An assistant tool_calls event on session A must NOT NOTIFY
+        a connection bound to session B.  Scope is the connection's
+        bound sessions, not all sessions.
+        """
+        from aios.models.agents import ToolSpec
+        from aios.services import agents as agents_service
+        from aios.services import connections as connections_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"nu-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-nu-{id(self)}")
+        session_a = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        session_b = await sess_svc.create_session(
+            harness._pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+        )
+        # conn_b is bound only to session_b; conn_a is bound to session_a.
+        conn_a = await connections_service.create_connection(
+            harness._pool,
+            connector="echo",
+            account=f"acct-nu-A-{id(self)}",
+            metadata={},
+            tools=[
+                ToolSpec(type="custom", name="x", description="", input_schema={"type": "object"}),
+            ],
+        )
+        conn_b = await connections_service.create_connection(
+            harness._pool,
+            connector="echo",
+            account=f"acct-nu-B-{id(self)}",
+            metadata={},
+            tools=[
+                ToolSpec(type="custom", name="x", description="", input_schema={"type": "object"}),
+            ],
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_a.id, session_id=session_a.id
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_b.id, session_id=session_b.id
+        )
+
+        settings = get_settings()
+        # Listen as conn_b but emit on session_a — conn_b shouldn't see it.
+        async with listen_for_connector_calls(settings.db_url, conn_b.id) as queue:
+            await sess_svc.append_event(
+                harness._pool,
+                session_a.id,
+                "message",
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_nu1",
+                            "type": "function",
+                            "function": {"name": "x", "arguments": "{}"},
+                        }
+                    ],
+                },
+            )
+            try:
+                payload = await asyncio.wait_for(queue.get(), timeout=0.5)
+            except TimeoutError:
+                payload = None
+            assert payload is None, f"unexpected NOTIFY across connections: {payload}"

--- a/tests/e2e/test_pending_calls_query.py
+++ b/tests/e2e/test_pending_calls_query.py
@@ -129,11 +129,17 @@ class TestListPendingCalls:
 
 @needs_docker
 class TestConnectorCallsNotify:
-    """Verify ``append_event`` fires ``connector_calls_<cid>`` NOTIFY for
-    bound connections that declare any tool — and ONLY for those.
+    """Verify ``set_session_status`` fires ``connector_calls_<cid>`` NOTIFY
+    when a session parks in ``requires_action`` with pending custom_tools,
+    for every connection bound to that session.
+
+    The NOTIFY fires here (not in :func:`append_event`) so the SSE
+    consumer's lookup query can rely on ``stop_reason`` already being
+    committed.  Otherwise there's a race: assistant event lands → NOTIFY
+    fires → SSE consumer queries → stop_reason still null → empty result.
     """
 
-    async def test_notify_fires_on_bound_assistant_event(self, harness: Harness) -> None:
+    async def test_notify_fires_on_requires_action_park(self, harness: Harness) -> None:
         from aios.models.agents import ToolSpec
         from aios.services import agents as agents_service
         from aios.services import connections as connections_service
@@ -173,31 +179,23 @@ class TestConnectorCallsNotify:
 
         settings = get_settings()
         async with listen_for_connector_calls(settings.db_url, conn.id) as queue:
-            await sess_svc.append_event(
+            await sess_svc.set_session_status(
                 harness._pool,
                 session.id,
-                "message",
-                {
-                    "role": "assistant",
-                    "content": None,
-                    "tool_calls": [
-                        {
-                            "id": "call_n1",
-                            "type": "function",
-                            "function": {
-                                "name": "echo_send",
-                                "arguments": "{}",
-                            },
-                        }
-                    ],
+                "idle",
+                stop_reason={
+                    "type": "requires_action",
+                    "event_ids": ["call_n1"],
+                    "custom_tools": ["call_n1"],
                 },
             )
             payload = await asyncio.wait_for(queue.get(), timeout=5.0)
             assert payload == session.id
 
-    async def test_notify_silent_on_role_user_event(self, harness: Harness) -> None:
-        """User-message events MUST NOT trigger the connector-calls fan-out;
-        otherwise inbound POSTs would echo back as 'work' notifications.
+    async def test_notify_silent_on_non_requires_action_park(self, harness: Harness) -> None:
+        """``end_turn`` and other stop reasons MUST NOT trigger the
+        connector-calls fan-out — only ``requires_action`` with pending
+        ``custom_tools`` represents new work for the connector.
         """
         from aios.models.agents import ToolSpec
         from aios.services import agents as agents_service
@@ -238,12 +236,17 @@ class TestConnectorCallsNotify:
 
         settings = get_settings()
         async with listen_for_connector_calls(settings.db_url, conn.id) as queue:
-            await sess_svc.append_user_message(harness._pool, session.id, "hi")
+            await sess_svc.set_session_status(
+                harness._pool,
+                session.id,
+                "idle",
+                stop_reason={"type": "end_turn"},
+            )
             try:
                 payload = await asyncio.wait_for(queue.get(), timeout=0.5)
             except TimeoutError:
                 payload = None
-            assert payload is None, f"unexpected NOTIFY for user event: {payload}"
+            assert payload is None, f"unexpected NOTIFY for end_turn park: {payload}"
 
     async def test_notify_silent_on_unrelated_connection(self, harness: Harness) -> None:
         """An assistant tool_calls event on session A must NOT NOTIFY
@@ -301,22 +304,16 @@ class TestConnectorCallsNotify:
         )
 
         settings = get_settings()
-        # Listen as conn_b but emit on session_a — conn_b shouldn't see it.
+        # Listen as conn_b but park session_a — conn_b shouldn't see it.
         async with listen_for_connector_calls(settings.db_url, conn_b.id) as queue:
-            await sess_svc.append_event(
+            await sess_svc.set_session_status(
                 harness._pool,
                 session_a.id,
-                "message",
-                {
-                    "role": "assistant",
-                    "content": None,
-                    "tool_calls": [
-                        {
-                            "id": "call_nu1",
-                            "type": "function",
-                            "function": {"name": "x", "arguments": "{}"},
-                        }
-                    ],
+                "idle",
+                stop_reason={
+                    "type": "requires_action",
+                    "event_ids": ["call_nu1"],
+                    "custom_tools": ["call_nu1"],
                 },
             )
             try:

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,9 @@ resolution-markers = [
 members = [
     "aios",
     "aios-connector",
+    "aios-connector-http",
     "aios-echo",
+    "aios-echo-http",
     "aios-signal",
     "aios-telegram",
 ]
@@ -134,6 +136,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "aios-echo" },
+    { name = "aios-echo-http" },
     { name = "httpx" },
     { name = "mypy" },
     { name = "openapi-python-client" },
@@ -171,6 +174,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "aios-echo", editable = "packages/aios-echo" },
+    { name = "aios-echo-http", editable = "connectors/echo-http" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", specifier = ">=1.13" },
     { name = "openapi-python-client", specifier = ">=0.21" },
@@ -215,6 +219,37 @@ dev = [
 ]
 
 [[package]]
+name = "aios-connector-http"
+version = "0.1.0"
+source = { editable = "packages/aios-connector-http" }
+dependencies = [
+    { name = "httpx" },
+    { name = "python-ulid" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "python-ulid", specifier = ">=3.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.13" },
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
 name = "aios-echo"
 version = "0.1.0"
 source = { editable = "packages/aios-echo" }
@@ -232,6 +267,33 @@ dev = [
 
 [package.metadata]
 requires-dist = [{ name = "aios-connector", editable = "packages/aios-connector" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.13" },
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "aios-echo-http"
+version = "0.1.0"
+source = { editable = "connectors/echo-http" }
+dependencies = [
+    { name = "aios-connector-http" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "aios-connector-http", editable = "packages/aios-connector-http" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
PR **4 of 6** in the connector rearchitecture stack (#301). The validation gate — after this lands, the new architecture is fully working end-to-end with a real connector against a real HTTP server.

> **DO NOT MERGE** until the full stack lands.

## What changes

- **\`packages/aios-connector-http/\`** — new SDK
  - \`AiosClient\` — httpx wrapper for the three connector endpoints + whoami.
  - \`HttpConnector\` — base class. Subclass + decorate methods with \`@tool()\`. \`run()\` opens the client, runs setup → tool loop + serve → teardown.
  - Tool loop has exponential-backoff reconnect (transient SSE drops don't kill the connector).
  - \`SqliteAnsweredSpool\` — durable answered-id set across container restart.

- **\`connectors/echo-http/\`** — reference connector. Three tools (\`ping\`, \`echo\`, \`trigger_inbound\`) mirror the legacy MCP echo. Thin \`python:slim\` Dockerfile.

- **\`POST /v1/connectors/tool-results\`** — \`ConnectorAuthDep\`. Validates session-binding via the new \`queries.is_session_bound_to_connection\` helper. Shares \`services.sessions.append_tool_result\` with the operator-facing tool-results route (refactored to use the same service).

- **Race fix**: connector-calls NOTIFY moved from \`append_event\` to \`set_session_status\`. The old position fired before \`stop_reason\` was committed, so the SSE consumer's lookup query returned empty. Now fires after \`stop_reason\` commit.

## Tests

- 8 unit tests on the runner.
- 4 e2e tests with a **live uvicorn server** (real socket, not ASGITransport): whoami, SSE backfill, full echo round-trip (model → SSE → connector → result), trigger_inbound synth.

41 PR-stack tests pass.

## Stack

\`\`\`
master
  └── wt/snappy-dreaming-wirth   ← #302 (foundation)
       └── feat/pr1-...           ← #303 (PR 1)
            └── feat/pr2-...      ← #304 (PR 2)
                 └── feat/pr3-... ← #305 (PR 3)
                      └── feat/pr4-... ← THIS PR
                           └── feat/pr5-... (PR 5: migrate Telegram + Signal — coming)
\`\`\`

Refs #301 — supersedes #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)