### PR TITLE
feat(compose): full-stack docker compose for local dev (#310)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,9 +26,8 @@ build
 venv
 .uv-cache
 
-# Local secrets / env (.env.example is needed by docs but harmless either way;
-# .env.example is whitelisted because it's referenced from CLAUDE.md and may be
-# read by future bootstrap tooling).
+# Local secrets / env.  .env.example is whitelisted because
+# scripts/dev-bootstrap.sh copies it as the seed for new .env files.
 .env
 .env.*
 !.env.example

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,62 @@
+# Files excluded from the build context for every image (api, worker,
+# echo-http, telegram, signal — all use the repo root as context).
+#
+# Without this file, `docker compose build` ships hundreds of MB of
+# `.git`, `.venv`, caches, and runtime artifacts on every build.
+
+# Version control
+.git
+.github
+
+# Python build / cache artifacts
+__pycache__
+*.py[cod]
+*.egg-info
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.tox
+.coverage
+htmlcov
+dist
+build
+
+# Virtualenvs / uv
+.venv
+venv
+.uv-cache
+
+# Local secrets / env (.env.example is needed by docs but harmless either way;
+# .env.example is whitelisted because it's referenced from CLAUDE.md and may be
+# read by future bootstrap tooling).
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+
+# Editors
+.idea
+.vscode
+*.swp
+*.swo
+
+# aios runtime state (host-side compose volumes / lean-mode artifacts)
+.aios
+.logs
+spool.sqlite*
+/var/lib/aios
+
+# Claude Code session state — not part of aios source.
+.claude
+
+# Tests don't ship in production images.
+tests
+
+# Generated SDK source — not consumed at runtime; FastAPI builds OpenAPI
+# in-memory.
+openapi.json
+
+# Documentation (Dockerfile copies README.md; everything else is excluded).
+*.md
+!README.md

--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,35 @@ AIOS_API_PORT=8080
 
 # Logging level.
 AIOS_LOG_LEVEL=INFO
+
+# ── Docker Compose / dev-bootstrap (issue #310) ───────────────────────
+
+# Host directory bind-mounted into worker, api, and every connector at
+# the SAME path on each side.  The worker hands these path strings to
+# the host docker daemon when spawning sandbox containers, so they MUST
+# resolve identically on the host and inside containers — a Docker
+# named volume cannot satisfy this.
+#
+# Default is repo-relative for friction-free dev; operators with a
+# stable runtime layout typically point this at /var/lib/aios/workspaces
+# (the AIOS_WORKSPACE_ROOT default) and align both vars.
+WORKSPACE_HOST_PATH=./.aios/workspaces
+
+# Per-connection bearer tokens issued by ``scripts/dev-bootstrap.sh``.
+# Each is the plaintext returned ONCE from POST /v1/connector-tokens;
+# loss requires re-issue + .env rewrite (use ``--reset``).
+ECHO_HTTP_CONNECTOR_TOKEN=
+TELEGRAM_CONNECTOR_TOKEN=
+SIGNAL_CONNECTOR_TOKEN=
+
+# Model provider keys.  At least one is required for any real session;
+# LiteLLM picks based on the agent's mind URL.
+ANTHROPIC_API_KEY=
+# Optional Anthropic-API-compatible proxy (e.g. ant-proxy).  Both compose
+# and lean modes pass this through to the api + worker.
+ANTHROPIC_API_BASE=
+OPENROUTER_API_KEY=
+OPENAI_API_KEY=
+
+# Optional: Tavily key for web_fetch / web_search built-in tools.
+AIOS_TAVILY_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ venv/
 # aios runtime state
 /var/lib/aios/
 workspaces/
+/.aios/
 
 # smoke-test runtime artifacts
 .logs/

--- a/README.md
+++ b/README.md
@@ -172,6 +172,39 @@ uv run aios chat --agent <agent_id> --environment-id <env_id> \
 
 Model API keys are configured via standard LiteLLM environment variables: `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc. For web tools: `AIOS_TAVILY_API_KEY`. For connectors, see each connector's README.
 
+## Run the full stack with Docker Compose
+
+The Quickstart above runs **lean mode**: postgres in a container, api + worker on the host. That's the fastest hot-reload path while iterating on aios itself.
+
+When you need the production-shape topology — every connector in its own container, isolated network namespace, encrypted-at-rest credentials on the connection record — use `compose.yml`:
+
+```bash
+# One-time bootstrap (generates keys, brings up postgres + api,
+# creates the default echo-http connection + token, writes .env).
+./scripts/dev-bootstrap.sh
+
+# Bring up postgres + migrate + api + worker + echo-http.
+docker compose up
+
+# With platform connectors:
+./scripts/dev-bootstrap.sh --connector telegram --bot-token <BOT_TOKEN>
+docker compose --profile telegram up
+
+./scripts/dev-bootstrap.sh --connector signal --phone +15551234567
+docker compose --profile signal up
+```
+
+The bootstrap script is idempotent — re-runs are a no-op once a connector's token is in `.env`. Use `./scripts/dev-bootstrap.sh --reset` to wipe generated keys + tokens and start fresh (useful after rotating credentials or when handing the worktree to another developer).
+
+**Connector tokens are returned ONCE** by `POST /v1/connector-tokens` and never readable thereafter. The bootstrap script captures them into `.env`. If `.env` is lost, run `--reset` to issue new ones.
+
+### Operator notes
+
+- **Workspace path bind-mount.** The worker spawns sibling sandbox containers via the host docker daemon. The host paths it computes (`<workspace_root>/<session_id>`, `<workspace_root>/_attachments/...`) must resolve identically on the host and inside the worker container. `compose.yml` bind-mounts `${WORKSPACE_HOST_PATH}:${WORKSPACE_HOST_PATH}` — the same string on both sides. Default is repo-relative (`./.aios/workspaces`); for prod-shape testing, set `WORKSPACE_HOST_PATH=/var/lib/aios/workspaces` in `.env`. A Docker named volume cannot satisfy this — its host path lives under `/var/lib/docker/volumes/...` which the worker has no way to know.
+- **Apple Silicon.** signal-cli's upstream native build is amd64-only, so the `signal` service declares `platform: linux/amd64` and runs under emulation. Acceptable for local dev.
+- **Lean + full coexist.** Lean mode is the same Quickstart above — preserved unchanged. You can flip between modes (e.g., `docker compose stop api worker; uv run aios api &; uv run aios worker &`) as long as `.env` is consistent.
+- **signal-cli registration.** Bootstrap creates the connection and issues the token, but signal-cli's `register` / `verify` flow against Signal's servers is a separate manual step inside the running container — see `connectors/signal/README.md`.
+
 ### Per-worktree dev instances
 
 Working on aios itself? `aios dev bootstrap` creates an isolated dev instance per git worktree — separate database, free port, scoped Docker labels — so multiple branches can run concurrently without stepping on each other:

--- a/compose.yml
+++ b/compose.yml
@@ -74,8 +74,8 @@ services:
       AIOS_API_PORT: "8080"
       AIOS_WORKSPACE_ROOT: ${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}
     volumes:
-      # Same path on both sides: services/inbound.py:stage_inbound_attachments
-      # writes to <workspace_root>/_attachments/...; the worker hands those
+      # Same path on both sides: the api process stages inbound attachment
+      # bytes to <workspace_root>/_attachments/...; the worker hands those
       # paths to the host docker daemon when spawning sandboxes, so api +
       # worker + host all see the same string.
       - "${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}:${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}"

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,164 @@
+# Local-dev topology for aios.  Two valid runtime modes:
+#
+#   Lean: ``docker compose up -d postgres`` only; api + worker run on the
+#         host via ``uv run python -m aios api/worker``.  Fastest hot-reload
+#         while iterating on aios itself.
+#
+#   Full: ``./scripts/dev-bootstrap.sh && docker compose up`` brings up
+#         postgres + migrate + api + worker + echo-http.  Profile flags add
+#         platform connectors:
+#           docker compose --profile telegram up
+#           docker compose --profile signal up
+#
+# The worker spawns sibling sandbox containers via /var/run/docker.sock,
+# so the workspace dir is bind-mounted at the SAME host path inside both
+# api and worker.  See README → "Run the full stack with Docker Compose"
+# for why a Docker named volume cannot satisfy this.
+
+services:
+  postgres:
+    # 16-alpine matches the README quickstart and existing dev conventions;
+    # postgres:18 changed the in-image data layout from /var/lib/postgresql/data
+    # to /var/lib/postgresql/<major>, which would break existing volumes.
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: aios
+      POSTGRES_PASSWORD: aios
+      POSTGRES_DB: aios
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U aios -d aios"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    # Host-side 5433 (default) leaves 5432 free for an OS-installed
+    # postgres; lean mode dials this port via .env's AIOS_DB_URL.
+    # Override POSTGRES_HOST_PORT for parallel smoke stacks.
+    ports:
+      - "${POSTGRES_HOST_PORT:-5433}:5432"
+
+  migrate:
+    build:
+      context: .
+      target: api
+    # Direct ``aios`` (not ``uv run aios``) because the image's venv is
+    # baked at build time + PATH-injected; ``uv run`` would attempt a
+    # re-sync that fails as the non-root ``aios`` user.
+    command: ["aios", "migrate"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      AIOS_API_KEY: ${AIOS_API_KEY:?AIOS_API_KEY required — run scripts/dev-bootstrap.sh}
+      AIOS_VAULT_KEY: ${AIOS_VAULT_KEY:?AIOS_VAULT_KEY required — run scripts/dev-bootstrap.sh}
+      AIOS_DB_URL: postgresql://aios:aios@postgres:5432/aios
+
+  api:
+    build:
+      context: .
+      target: api
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    # env_file pulls everything from .env so model-provider keys, LiteLLM
+    # tunables (LITELLM_LOG, *_API_BASE, AZURE_API_VERSION, AWS_*, …),
+    # and any future tooling vars flow through without compose edits.
+    # ``environment:`` below overrides the few values that differ between
+    # lean mode (.env's localhost-bound defaults) and in-container values.
+    env_file:
+      - .env
+    environment:
+      AIOS_DB_URL: postgresql://aios:aios@postgres:5432/aios
+      AIOS_API_HOST: 0.0.0.0
+      AIOS_API_PORT: "8080"
+      AIOS_WORKSPACE_ROOT: ${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}
+    volumes:
+      # Same path on both sides: services/inbound.py:stage_inbound_attachments
+      # writes to <workspace_root>/_attachments/...; the worker hands those
+      # paths to the host docker daemon when spawning sandboxes, so api +
+      # worker + host all see the same string.
+      - "${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}:${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}"
+    ports:
+      - "${AIOS_API_PORT:-8080}:8080"
+    # Healthcheck inherited from Dockerfile (curl http://127.0.0.1:8080/health).
+
+  worker:
+    build:
+      context: .
+      target: worker
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    # See note on the api service for why we use env_file.
+    env_file:
+      - .env
+    environment:
+      AIOS_DB_URL: postgresql://aios:aios@postgres:5432/aios
+      AIOS_WORKSPACE_ROOT: ${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}
+    volumes:
+      - "${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}:${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}"
+      # Worker uses the host's docker daemon to spawn sandbox containers.
+      - /var/run/docker.sock:/var/run/docker.sock
+    # Healthcheck inherited from Dockerfile (mtime of /var/run/aios-worker-alive).
+
+  echo-http:
+    build:
+      context: .
+      dockerfile: connectors/echo-http/Dockerfile
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      AIOS_URL: http://api:8080
+      # Empty default — populated by ``scripts/dev-bootstrap.sh``.  All
+      # connector services use ``:-`` (not ``:?``) because compose
+      # interpolates every service at config time, and bootstrap brings
+      # up postgres + api BEFORE the connector token exists.  Empty
+      # token surfaces as a 401 from the api at first request.
+      AIOS_CONNECTOR_TOKEN: ${ECHO_HTTP_CONNECTOR_TOKEN:-}
+      AIOS_WORKSPACE_ROOT: ${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}
+    volumes:
+      # :ro because the SDK resolves SandboxPath args against
+      # AIOS_WORKSPACE_ROOT and reads the host file; the connector never
+      # writes back through this mount.
+      - "${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}:${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}:ro"
+
+  telegram:
+    profiles: [telegram]
+    build:
+      context: .
+      dockerfile: connectors/telegram/Dockerfile
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      AIOS_URL: http://api:8080
+      AIOS_CONNECTOR_TOKEN: ${TELEGRAM_CONNECTOR_TOKEN:-}
+      AIOS_WORKSPACE_ROOT: ${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}
+    volumes:
+      - "${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}:${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}:ro"
+
+  signal:
+    profiles: [signal]
+    # signal-cli upstream native build is amd64-only; on Apple Silicon
+    # this runs under emulation.  Acceptable for local dev.
+    platform: linux/amd64
+    build:
+      context: .
+      dockerfile: connectors/signal/Dockerfile
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      AIOS_URL: http://api:8080
+      AIOS_CONNECTOR_TOKEN: ${SIGNAL_CONNECTOR_TOKEN:-}
+      AIOS_WORKSPACE_ROOT: ${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}
+      AIOS_SIGNAL_CONFIG_DIR: /var/lib/aios/signal-data
+    volumes:
+      - "${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}:${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}:ro"
+      - signal_state:/var/lib/aios/signal-data
+
+volumes:
+  pgdata:
+  signal_state:

--- a/packages/aios-connector-http/pyproject.toml
+++ b/packages/aios-connector-http/pyproject.toml
@@ -11,6 +11,10 @@ dependencies = [
     "httpx>=0.27",
     "python-ulid>=3.0",
     "structlog>=24.1",
+    # python-ulid 3.x imports ``typing_extensions`` at module load but
+    # doesn't declare it; works in the root image (transitive of pydantic
+    # / fastapi) but breaks in bare connector images.
+    "typing-extensions>=4.0",
 ]
 
 [dependency-groups]

--- a/scripts/dev-bootstrap.sh
+++ b/scripts/dev-bootstrap.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# Bootstrap the aios compose stack for local dev.
+#
+# Idempotent: re-running with no flags is a no-op once keys + the default
+# echo-http connection are populated.  ``--reset`` wipes generated values
+# and starts over.  Connection-creation flags need a fresh slot in .env;
+# ``--reset`` is the only way to re-bootstrap a connector that already has
+# a token in .env.
+#
+# Usage:
+#   ./scripts/dev-bootstrap.sh
+#       Generate keys (if absent), bring up postgres + migrate + api,
+#       create the echo-http connection + token.
+#
+#   ./scripts/dev-bootstrap.sh --connector telegram --bot-token <TOKEN>
+#   ./scripts/dev-bootstrap.sh --connector signal --phone +15551234567
+#       Also create the corresponding connection + token.  Repeat
+#       --connector to bootstrap multiple at once.
+#
+#   ./scripts/dev-bootstrap.sh --reset
+#       Wipe AIOS_API_KEY, AIOS_VAULT_KEY, all *_CONNECTOR_TOKEN values
+#       in .env, then run a fresh bootstrap.
+
+set -euo pipefail
+
+# ── repo root ─────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ── pretty output ─────────────────────────────────────────────────────
+say() { printf '\033[36m·\033[0m %s\n' "$*"; }
+ok()  { printf '\033[32m✓\033[0m %s\n' "$*"; }
+fail() { printf '\033[31m✗\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ── parse flags ───────────────────────────────────────────────────────
+# macOS dev hosts ship bash 3.x without associative-array support, so we
+# stick to scalar vars + space-separated lists.
+RESET=false
+CONNECTORS="echo-http"
+TELEGRAM_BOT_TOKEN_FLAG=""
+SIGNAL_PHONE_FLAG=""
+
+while (( $# )); do
+  case "$1" in
+    --connector)
+      shift
+      [[ $# -gt 0 ]] || fail "--connector requires a value"
+      case "$1" in
+        echo-http|telegram|signal) ;;
+        *) fail "--connector must be one of echo-http, telegram, signal" ;;
+      esac
+      # Append, dedup later.  echo-http always comes first via the seed.
+      CONNECTORS="$CONNECTORS $1"
+      ;;
+    --bot-token)
+      shift
+      [[ $# -gt 0 ]] || fail "--bot-token requires a value"
+      TELEGRAM_BOT_TOKEN_FLAG="$1"
+      ;;
+    --phone)
+      shift
+      [[ $# -gt 0 ]] || fail "--phone requires a value"
+      SIGNAL_PHONE_FLAG="$1"
+      ;;
+    --reset)
+      RESET=true
+      ;;
+    -h|--help)
+      # Print the leading comment block (everything from line 2 up to the
+      # first non-comment, non-blank line).  Skip line 1 (the shebang).
+      awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
+      exit 0
+      ;;
+    *)
+      fail "unknown flag: $1"
+      ;;
+  esac
+  shift
+done
+
+# Dedup CONNECTORS while preserving first-seen order.
+DEDUPED=""
+for c in $CONNECTORS; do
+  case " $DEDUPED " in
+    *" $c "*) ;;
+    *) DEDUPED="$DEDUPED $c" ;;
+  esac
+done
+CONNECTORS="$(echo "$DEDUPED" | tr -s ' ' | sed 's/^ //')"
+
+# ── .env management ───────────────────────────────────────────────────
+ENV_FILE="$REPO_ROOT/.env"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  say "no .env — copying from .env.example"
+  cp "$REPO_ROOT/.env.example" "$ENV_FILE"
+fi
+
+# Set or replace a single KEY=VALUE pair in .env (creates the line if
+# absent).  Idempotent: a re-run with the same value is a no-op diff.
+env_set() {
+  local key="$1" value="$2"
+  python3 - "$ENV_FILE" "$key" "$value" <<'PY'
+import sys, pathlib
+path, key, value = sys.argv[1:]
+text = pathlib.Path(path).read_text().splitlines()
+seen = False
+out = []
+for line in text:
+    if "=" in line and not line.lstrip().startswith("#"):
+        k = line.split("=", 1)[0]
+        if k == key:
+            out.append(f"{key}={value}")
+            seen = True
+            continue
+    out.append(line)
+if not seen:
+    out.append(f"{key}={value}")
+pathlib.Path(path).write_text("\n".join(out) + "\n")
+PY
+}
+
+# Read a single KEY's value from .env (empty string if absent / unset).
+env_get() {
+  local key="$1"
+  python3 - "$ENV_FILE" "$key" <<'PY'
+import sys, pathlib
+path, key = sys.argv[1:]
+for line in pathlib.Path(path).read_text().splitlines():
+    if line.lstrip().startswith("#") or "=" not in line:
+        continue
+    k, _, v = line.partition("=")
+    if k == key:
+        print(v); break
+PY
+}
+
+if $RESET; then
+  say "--reset: clearing keys + tokens in .env"
+  env_set AIOS_API_KEY ""
+  env_set AIOS_VAULT_KEY ""
+  env_set ECHO_HTTP_CONNECTOR_TOKEN ""
+  env_set TELEGRAM_CONNECTOR_TOKEN ""
+  env_set SIGNAL_CONNECTOR_TOKEN ""
+  ok ".env reset"
+fi
+
+# Generate keys lazily — only when their slot is empty or still the
+# .env.example placeholder.  openssl is on every macOS / Debian dev
+# host; refusing to fall back avoids surprising operators with Python's
+# secrets module producing a different format.
+needs_gen() {
+  local v="$1"
+  [[ -z "$v" || "$v" == "replace-me" ]]
+}
+if needs_gen "$(env_get AIOS_API_KEY)"; then
+  say "generating AIOS_API_KEY (openssl rand -hex 32)"
+  env_set AIOS_API_KEY "$(openssl rand -hex 32)"
+fi
+if needs_gen "$(env_get AIOS_VAULT_KEY)"; then
+  say "generating AIOS_VAULT_KEY (openssl rand -base64 32)"
+  env_set AIOS_VAULT_KEY "$(openssl rand -base64 32)"
+fi
+
+# Workspace dir must exist before docker bind-mount sees it (Docker would
+# otherwise auto-create it as root-owned, which then breaks rm in dev).
+# Resolve to absolute and persist back to .env: compose bind-mounts use
+# the same string on host AND container side, and Docker rejects relative
+# container paths — so a literal ``./.aios/workspaces`` from .env.example
+# cannot be passed straight through.
+WORKSPACE_HOST_PATH="$(env_get WORKSPACE_HOST_PATH)"
+WORKSPACE_HOST_PATH="${WORKSPACE_HOST_PATH:-./.aios/workspaces}"
+mkdir -p "$WORKSPACE_HOST_PATH"
+WORKSPACE_HOST_PATH="$(cd "$WORKSPACE_HOST_PATH" && pwd)"
+env_set WORKSPACE_HOST_PATH "$WORKSPACE_HOST_PATH"
+say "workspace dir at $WORKSPACE_HOST_PATH"
+
+# ── source .env so subsequent docker compose + aios calls see vars ────
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+# Override AIOS_DB_URL for host-side aios CLI calls — postgres is exposed
+# at 5433 in compose.yml, but inside-network services use 5432.  Lean
+# mode's .env default is 5432 (matches host postgres conventions); the
+# override here is host-CLI-only and doesn't get persisted.
+export AIOS_URL="http://localhost:${AIOS_API_PORT:-8080}"
+
+# ── compose: postgres → migrate → api ─────────────────────────────────
+say "starting postgres"
+docker compose up -d postgres >/dev/null
+
+say "waiting for postgres healthy"
+deadline=$((SECONDS + 60))
+while (( SECONDS < deadline )); do
+  status="$(docker compose ps --format '{{.Health}}' postgres 2>/dev/null || true)"
+  [[ "$status" == "healthy" ]] && break
+  sleep 1
+done
+[[ "$status" == "healthy" ]] || fail "postgres didn't reach healthy in 60s"
+ok "postgres healthy"
+
+say "running migrations"
+docker compose run --rm migrate >/dev/null
+ok "migrations applied"
+
+say "starting api"
+docker compose up -d api >/dev/null
+
+say "waiting for api /health"
+api_url_local="http://localhost:${AIOS_API_PORT:-8080}/health"
+deadline=$((SECONDS + 60))
+while (( SECONDS < deadline )); do
+  if curl -fsS "$api_url_local" >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+curl -fsS "$api_url_local" >/dev/null 2>&1 || fail "api didn't reach /health in 60s"
+ok "api healthy"
+
+# ── helpers for connection creation ───────────────────────────────────
+# Find the connection id for (connector, account) if one already exists,
+# else echo nothing.  Preserves idempotency on re-runs.
+find_connection_id() {
+  local connector="$1" account="$2"
+  uv run aios -f json connections list --connector "$connector" 2>/dev/null \
+    | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for c in data.get('data', []):
+    if c.get('connector') == '$connector' and c.get('account') == '$account':
+        print(c.get('id', '')); break
+"
+}
+
+# Resolve telegram bot account from its bot token (Telegram's getMe).
+resolve_telegram_account() {
+  local token="$1"
+  curl -fsS "https://api.telegram.org/bot${token}/getMe" \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['result']['id'])"
+}
+
+create_or_get_connection() {
+  local connector="$1" account="$2"
+  shift 2
+  local existing
+  existing="$(find_connection_id "$connector" "$account" || true)"
+  if [[ -n "$existing" ]]; then
+    echo "$existing"; return 0
+  fi
+  local args=(connections create --connector "$connector" --account "$account")
+  while (( $# )); do
+    args+=(--secret "$1"); shift
+  done
+  uv run aios -f json "${args[@]}" \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])"
+}
+
+issue_token() {
+  local connection_id="$1" label="$2"
+  uv run aios -f json connector-tokens issue \
+      --connection-id "$connection_id" --label "$label" \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)['plaintext'])"
+}
+
+# Returns 0 if .env already has a non-empty value for $slot, printing a
+# skip message.  Caller pattern: ``already_bootstrapped X conn && continue``.
+already_bootstrapped() {
+  local slot="$1" connector="$2"
+  if [[ -n "$(env_get "$slot")" ]]; then
+    ok "$connector already bootstrapped (set $slot to '' to re-issue)"
+    return 0
+  fi
+  return 1
+}
+
+# Common tail for every connector arm: create (or reuse) the connection,
+# issue a token, persist it.  Args after the third are forwarded as
+# ``--secret KEY=VALUE`` pairs to ``aios connections create``.
+bootstrap_connector() {
+  local connector="$1" account="$2" slot="$3"
+  shift 3
+  say "creating $connector connection (account=$account)"
+  local conn_id token
+  conn_id="$(create_or_get_connection "$connector" "$account" "$@")"
+  token="$(issue_token "$conn_id" "dev-bootstrap")"
+  env_set "$slot" "$token"
+  ok "$connector connection=$conn_id"
+}
+
+# ── per-connector bootstrap ───────────────────────────────────────────
+for connector in $CONNECTORS; do
+  case "$connector" in
+    echo-http)
+      already_bootstrapped ECHO_HTTP_CONNECTOR_TOKEN echo-http && continue
+      bootstrap_connector echo-http echo ECHO_HTTP_CONNECTOR_TOKEN
+      ;;
+
+    telegram)
+      already_bootstrapped TELEGRAM_CONNECTOR_TOKEN telegram && continue
+      [[ -n "$TELEGRAM_BOT_TOKEN_FLAG" ]] \
+        || fail "telegram bootstrap requires --bot-token <token>"
+      say "resolving telegram bot identity (getMe)"
+      account="$(resolve_telegram_account "$TELEGRAM_BOT_TOKEN_FLAG")" \
+        || fail "telegram getMe failed — bad token?"
+      bootstrap_connector telegram "$account" TELEGRAM_CONNECTOR_TOKEN \
+        "bot_token=$TELEGRAM_BOT_TOKEN_FLAG"
+      ;;
+
+    signal)
+      already_bootstrapped SIGNAL_CONNECTOR_TOKEN signal && continue
+      [[ -n "$SIGNAL_PHONE_FLAG" ]] || fail "signal bootstrap requires --phone <e164>"
+      [[ "$SIGNAL_PHONE_FLAG" == +* ]] || fail "--phone must be E.164 (start with +)"
+      bootstrap_connector signal "$SIGNAL_PHONE_FLAG" SIGNAL_CONNECTOR_TOKEN \
+        "phone=$SIGNAL_PHONE_FLAG"
+      printf '\n  \033[33mNote\033[0m: signal-cli registration (signal-cli register / verify) is\n        a separate manual step — see connectors/signal/README.md.\n\n'
+      ;;
+  esac
+done
+
+# ── summary ───────────────────────────────────────────────────────────
+profile_args=""
+for connector in $CONNECTORS; do
+  case "$connector" in
+    telegram|signal) profile_args="$profile_args --profile $connector" ;;
+  esac
+done
+profile_args="${profile_args# }"
+
+printf '\n\033[32m✓\033[0m bootstrap complete\n\n'
+printf '  next:\n'
+if [[ -n "$profile_args" ]]; then
+  printf '    docker compose %s up\n' "$profile_args"
+else
+  printf '    docker compose up\n'
+fi
+printf '\n  api:        http://localhost:%s\n' "${AIOS_API_PORT:-8080}"
+printf '  workspace:  %s\n' "$WORKSPACE_HOST_PATH"
+printf '  connectors: %s\n' "$CONNECTORS"

--- a/scripts/dev-bootstrap.sh
+++ b/scripts/dev-bootstrap.sh
@@ -182,10 +182,6 @@ set -a
 source "$ENV_FILE"
 set +a
 
-# Override AIOS_DB_URL for host-side aios CLI calls — postgres is exposed
-# at 5433 in compose.yml, but inside-network services use 5432.  Lean
-# mode's .env default is 5432 (matches host postgres conventions); the
-# override here is host-CLI-only and doesn't get persisted.
 export AIOS_URL="http://localhost:${AIOS_API_PORT:-8080}"
 
 # ── compose: postgres → migrate → api ─────────────────────────────────
@@ -221,31 +217,33 @@ ok "api healthy"
 
 # ── helpers for connection creation ───────────────────────────────────
 # Find the connection id for (connector, account) if one already exists,
-# else echo nothing.  Preserves idempotency on re-runs.
+# else echo nothing.  --connector filters server-side, so the python only
+# matches on account.  Single-quoted -c so account flows via argv (no
+# shell interpolation into the script).
 find_connection_id() {
   local connector="$1" account="$2"
-  uv run aios -f json connections list --connector "$connector" 2>/dev/null \
-    | python3 -c "
+  uv run aios -f json connections list --connector "$connector" \
+    | python3 -c '
 import json, sys
-data = json.load(sys.stdin)
-for c in data.get('data', []):
-    if c.get('connector') == '$connector' and c.get('account') == '$account':
-        print(c.get('id', '')); break
-"
+account = sys.argv[1]
+for c in json.load(sys.stdin).get("data", []):
+    if c.get("account") == account:
+        print(c.get("id", "")); break
+' "$account"
 }
 
 # Resolve telegram bot account from its bot token (Telegram's getMe).
 resolve_telegram_account() {
   local token="$1"
   curl -fsS "https://api.telegram.org/bot${token}/getMe" \
-    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['result']['id'])"
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["result"]["id"])'
 }
 
 create_or_get_connection() {
   local connector="$1" account="$2"
   shift 2
   local existing
-  existing="$(find_connection_id "$connector" "$account" || true)"
+  existing="$(find_connection_id "$connector" "$account")"
   if [[ -n "$existing" ]]; then
     echo "$existing"; return 0
   fi

--- a/uv.lock
+++ b/uv.lock
@@ -187,6 +187,7 @@ dependencies = [
     { name = "httpx" },
     { name = "python-ulid" },
     { name = "structlog" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -202,6 +203,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "python-ulid", specifier = ">=3.0" },
     { name = "structlog", specifier = ">=24.1" },
+    { name = "typing-extensions", specifier = ">=4.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Closes #310.

Re-opened after #318 was merged (the prior PR #319 auto-closed when its base branch `feat/connectors-and-secrets` was deleted by the squash-merge). Content is unchanged from #319; rebases cleanly onto master since #318 absorbed the prior 13-commit stack.

See #319 for the full description, design decisions, and test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)