### PR TITLE
fix: codify post-migration prod fixes (worker git, signal entrypoint, compose+bootstrap perms, e2e)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,7 @@ USER root
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         gnupg \
+        git \
  && install -m 0755 -d /etc/apt/keyrings \
  && curl -fsSL https://download.docker.com/linux/debian/gpg \
         | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \

--- a/compose.yml
+++ b/compose.yml
@@ -79,6 +79,12 @@ services:
       # paths to the host docker daemon when spawning sandboxes, so api +
       # worker + host all see the same string.
       - "${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}:${WORKSPACE_HOST_PATH:?WORKSPACE_HOST_PATH must be an absolute path — run scripts/dev-bootstrap.sh}"
+      # Signal connector writes attachments to its config_dir; api reads
+      # them back via host_path during inbound staging.  The mount needs
+      # to match the signal service's mount path AND be writable: api's
+      # ``os.rename`` falls back to ``shutil.copy2`` + unlink across
+      # filesystems, and the unlink runs on the source side.
+      - signal_state:/var/lib/aios/signal-data
     ports:
       - "${AIOS_API_PORT:-8080}:8080"
     # Healthcheck inherited from Dockerfile (curl http://127.0.0.1:8080/health).

--- a/connectors/signal/Dockerfile
+++ b/connectors/signal/Dockerfile
@@ -52,4 +52,9 @@ RUN uv pip install --system --no-cache \
     /app/packages/aios-connector-http \
     /app/connectors/signal
 
-CMD ["python", "-m", "aios_signal"]
+# Entrypoint chowns the shared state dir so the api (uid 1000) can read
+# signal-cli's attachment writes from the same host bind mount.  Worker
+# and connector containers run as root so the chown succeeds; the actual
+# signal-cli process inside aios_signal still runs as root.
+RUN chmod 0755 /app/connectors/signal/entrypoint.sh
+ENTRYPOINT ["/app/connectors/signal/entrypoint.sh"]

--- a/connectors/signal/entrypoint.sh
+++ b/connectors/signal/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Chown signal-cli's config_dir to uid 1000 so the api can read attachment
+# bytes that signal-cli downloads here.  Both containers share this dir via
+# a bind/named-volume mount; the api runs as USER aios (uid 1000) and would
+# otherwise hit EACCES traversing a root-owned dir tree.  signal-cli itself
+# runs as root inside this container and continues to write new files as
+# root with mode 0644, which the api can read+unlink because the parent
+# dir is uid-1000-owned.
+#
+# The ``|| true`` is so a read-only mount (someone running outside compose
+# with the volume mode wrong) surfaces as a normal startup error from
+# aios_signal rather than a chown failure here.
+
+set -e
+
+config_dir="${AIOS_SIGNAL_CONFIG_DIR:-/var/lib/aios/signal-data}"
+mkdir -p "$config_dir"
+chown -R 1000:1000 "$config_dir" 2>/dev/null || true
+
+exec python -m aios_signal

--- a/scripts/dev-bootstrap.sh
+++ b/scripts/dev-bootstrap.sh
@@ -172,6 +172,12 @@ fi
 WORKSPACE_HOST_PATH="$(env_get WORKSPACE_HOST_PATH)"
 WORKSPACE_HOST_PATH="${WORKSPACE_HOST_PATH:-./.aios/workspaces}"
 mkdir -p "$WORKSPACE_HOST_PATH"
+# 0777 so every container can write inside regardless of in-container uid:
+# api runs as uid 1000 (USER aios), worker + connectors run as root, and
+# host-uid varies across operator machines (501 on macOS, 1000 on most
+# Linux dev boxes).  No security boundary lives at the workspace root —
+# per-session subdirs are isolated by the sandbox containers themselves.
+chmod 0777 "$WORKSPACE_HOST_PATH"
 WORKSPACE_HOST_PATH="$(cd "$WORKSPACE_HOST_PATH" && pwd)"
 env_set WORKSPACE_HOST_PATH "$WORKSPACE_HOST_PATH"
 say "workspace dir at $WORKSPACE_HOST_PATH"

--- a/tests/e2e/test_inbound_attachment.py
+++ b/tests/e2e/test_inbound_attachment.py
@@ -1,0 +1,211 @@
+"""E2E test for inbound attachment staging through ``/v1/connectors/inbound``.
+
+The new post-#318 architecture has connectors POST inbound user messages
+with an ``attachments`` list of ``{host_path, filename, content_type,
+size}`` records.  The api reads those bytes via ``host_path`` (assumed
+reachable from inside the api container via a shared bind mount) and
+stages them into ``<workspace>/_attachments/<session>/<connector>/<...>``.
+
+This test pins the api-side staging contract:
+
+* The api's ``handle_inbound`` service moves the source file via
+  ``os.rename`` (or ``shutil.copy2`` + unlink on EXDEV).
+* The appended event records each attachment with the expected
+  ``in_sandbox_path`` shape so the model sees a stable path.
+* The original ``host_path`` source file is gone after staging (single
+  copy of the bytes lives in the staged location).
+
+It does NOT exercise the docker-level cross-container bind-mount
+plumbing — that's covered by the manual smoke documented in PR 1's
+verification section.  This test catches regressions in the python-level
+staging logic only.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from aios.ids import EVENT, make_id, split_id
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness
+from tests.helpers.connections import bearer
+
+
+def _new_event_id() -> str:
+    return split_id(make_id(EVENT))[1]
+
+
+async def _create_connection(http_client: httpx.AsyncClient, account: str) -> str:
+    r = await http_client.post(
+        "/v1/connections",
+        json={"connector": "echo", "account": account},
+    )
+    assert r.status_code == 201, r.text
+    return str(r.json()["id"])
+
+
+async def _attach(harness: Harness, connection_id: str, session_id: str) -> None:
+    from aios.services import connections as connections_service
+
+    await connections_service.attach_connection(harness._pool, connection_id, session_id=session_id)
+
+
+async def _issue_token(http_client: httpx.AsyncClient, connection_id: str) -> str:
+    r = await http_client.post("/v1/connector-tokens", json={"connection_id": connection_id})
+    assert r.status_code == 201, r.text
+    return str(r.json()["plaintext"])
+
+
+@needs_docker
+class TestInboundAttachmentStaging:
+    async def test_attachment_moved_into_workspace(
+        self, http_client: httpx.AsyncClient, harness: Harness
+    ) -> None:
+        from aios.config import get_settings
+        from aios.sandbox.volumes import session_attachments_dir
+        from aios.services import agents as agents_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"att-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-att-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool,
+            agent_id=agent.id,
+            environment_id=env.id,
+            title=None,
+            metadata={},
+        )
+        connection_id = await _create_connection(http_client, f"att-{id(self)}")
+        await _attach(harness, connection_id, session.id)
+        token = await _issue_token(http_client, connection_id)
+
+        # Pre-stage a fake "downloaded by the connector" file in a sibling
+        # location under workspace_root.  In a real deployment this would
+        # be the connector's own state dir bind-mounted into the api
+        # container at the same path; here we just pick a writable spot.
+        workspace_root = get_settings().workspace_root
+        workspace_root.mkdir(parents=True, exist_ok=True)
+        connector_temp = workspace_root / "_inbound_temp"
+        connector_temp.mkdir(parents=True, exist_ok=True)
+        source = connector_temp / "photo.png"
+        payload = b"\x89PNG\r\n\x1a\nfake-image-bytes"
+        source.write_bytes(payload)
+
+        event_id = _new_event_id()
+        r = await http_client.post(
+            "/v1/connectors/inbound",
+            headers=bearer(token),
+            json={
+                "event_id": event_id,
+                "chat_id": "chat-att",
+                "sender": {"display_name": "Alice"},
+                "content": "here's a photo",
+                "attachments": [
+                    {
+                        "host_path": str(source),
+                        "filename": "photo.png",
+                        "content_type": "image/png",
+                        "size": len(payload),
+                    }
+                ],
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        # Source is gone — bytes moved into staging.
+        assert not source.exists()
+
+        # Staged at the canonical per-session-per-connector path.
+        staged_dir = session_attachments_dir(session.id) / "echo"
+        staged_files = list(staged_dir.iterdir())
+        assert len(staged_files) == 1
+        target = staged_files[0]
+        assert target.name == f"{event_id}-photo.png"
+        assert target.read_bytes() == payload
+
+        # Event log carries the attachment record with the in-sandbox path.
+        events = await harness.events(session.id)
+        user_events = [e for e in events if e.kind == "message" and e.data.get("role") == "user"]
+        assert len(user_events) == 1
+        attachments = user_events[0].data["metadata"]["attachments"]
+        assert len(attachments) == 1
+        assert attachments[0]["filename"] == "photo.png"
+        assert attachments[0]["content_type"] == "image/png"
+        assert attachments[0]["size"] == len(payload)
+        assert attachments[0]["in_sandbox_path"] == f"/mnt/attachments/echo/{event_id}-photo.png"
+
+    async def test_missing_host_path_drops_inbound(
+        self, http_client: httpx.AsyncClient, harness: Harness
+    ) -> None:
+        """A connector that POSTs an unreachable ``host_path`` gets a clean
+        5xx with ``drop_reason='attachment_staging_failed'`` — the api
+        wraps the underlying ``FileNotFoundError`` as
+        ``AttachmentStagingError`` rather than letting it 500 uncaught."""
+        from aios.services import agents as agents_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"attmiss-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-attmiss-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool,
+            agent_id=agent.id,
+            environment_id=env.id,
+            title=None,
+            metadata={},
+        )
+        connection_id = await _create_connection(http_client, f"attmiss-{id(self)}")
+        await _attach(harness, connection_id, session.id)
+        token = await _issue_token(http_client, connection_id)
+
+        r = await http_client.post(
+            "/v1/connectors/inbound",
+            headers=bearer(token),
+            json={
+                "event_id": _new_event_id(),
+                "chat_id": "chat-attmiss",
+                "sender": {"display_name": "Alice"},
+                "content": "broken pointer",
+                "attachments": [
+                    {
+                        "host_path": "/tmp/does-not-exist-" + str(id(self)),
+                        "filename": "missing.png",
+                        "content_type": "image/png",
+                        "size": 0,
+                    }
+                ],
+            },
+        )
+        assert r.status_code >= 400, r.text
+        body = r.json()
+        # The error body must carry a machine-readable drop_reason so the
+        # connector can branch on it (today's prod bug — the connector
+        # crashed on raise_for_status, throwing the body away).
+        assert body["error"]["detail"]["drop_reason"] == "attachment_staging_failed", body
+
+        # No event was appended — staging failure aborts before the
+        # append-with-dedup step.
+        events = await harness.events(session.id)
+        user_events = [e for e in events if e.kind == "message" and e.data.get("role") == "user"]
+        assert user_events == []


### PR DESCRIPTION
Codifies the band-aids applied to production during the 2026-05-11 Ultron
migration so a fresh deploy from master reproduces today's working state.
Companion PR in `eumemic-ops` adds the Coolify recipes for the two new
connector applications.

Scope is intentionally narrow — five small fixes that close the drift between
master and production.  The deeper architectural fix (bytes-over-HTTP for
inbound attachments, eliminating the shared-filesystem contract entirely) is
filed as #322 P1 and explicitly out of scope here.

## Summary

| # | Commit | Closes |
|---|---|---|
| 1 | `fix(worker): install git in worker image` | sandbox tools failed on first use for any session with a `github_repository` resource — `git clone` was attempted in the worker but the binary wasn't installed |
| 2 | `fix(compose): mount signal_state on api so it can read connector attachments` | signal connector writes attachment bytes the api needs to read; only the connector had the mount |
| 3 | `fix(signal): entrypoint chowns config_dir to uid 1000 for api read-access` | signal-cli wrote attachments with `drwx------ root root` parent dir; api runs as uid 1000 and can't traverse |
| 4 | `fix(dev-bootstrap): chmod 0777 workspace dir so api can write attachments` | api uid 1000 can't `mkdir _attachments/` inside a host-owned workspace dir |
| 5 | `test(e2e): pin inbound attachment-staging contract` | regression coverage for the api-level staging path |

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1131 passed
- [x] `uv run pytest tests/e2e/test_inbound_attachment.py -q` — 2 passed
- [ ] Manual smoke locally: `./scripts/dev-bootstrap.sh --reset && docker compose --profile signal --profile telegram up -d`, send a Signal image, verify it lands as an inbound event with the attachment staged on disk
- [ ] Post-merge: prod auto-deploys; verify worker has `git` and an existing failing sandbox tool now succeeds

## Notes

- Commit ordering is per-problem for review readability; each commit is independently revertable.
- The signal entrypoint's `chown -R` succeeds because the connector container runs as root.  Once master is on this branch, the workspace-dir chown done manually on Server B today persists; the per-startup chown of signal-data is now automatic.
- The e2e test exercises api-level staging logic only.  Cross-container bind-mount / UID coordination bugs (today's actual class of failure) would need integration-against-compose tests, which is the larger #322 P4 item.
- Companion PR coming up in `eumemic-ops` to add the aios-signal / aios-telegram Coolify app definitions, the recipes for creating them, and the host-side workspace + signal-state chown that's needed once per fresh server provision.

Refs: #318, #319, #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)