### PR TITLE
feat(api): POST /v1/sessions/<id>/files — first-class workspace upload (#324)

### DIFF
--- a/migrations/versions/0032_files.py
+++ b/migrations/versions/0032_files.py
@@ -1,19 +1,5 @@
 """Session-scoped file uploads (#324).
 
-Records bytes uploaded via ``POST /v1/sessions/<id>/files``.  The file row
-holds enough metadata to (a) locate the bytes on the api's filesystem
-(``host_path``), (b) tell the model where to find them inside the sandbox
-(``in_sandbox_path``), and (c) verify integrity (``sha256``).
-
-``ON DELETE CASCADE`` ties row lifetime to the session — when a session is
-hard-deleted, its uploads disappear too.  Cleanup of the host directory is
-handled out-of-band (same policy as ``_attachments``: workspace cleanup is
-a separate sweep).
-
-The ``(session_id, created_at DESC)`` index supports a future
-``GET /v1/sessions/<id>/files`` listing endpoint without a full scan; it's
-cheap to maintain on the write path since uploads are not high-frequency.
-
 Revision ID: 0032
 Revises: 0031
 Create Date: 2026-05-11

--- a/migrations/versions/0032_files.py
+++ b/migrations/versions/0032_files.py
@@ -1,0 +1,60 @@
+"""Session-scoped file uploads (#324).
+
+Records bytes uploaded via ``POST /v1/sessions/<id>/files``.  The file row
+holds enough metadata to (a) locate the bytes on the api's filesystem
+(``host_path``), (b) tell the model where to find them inside the sandbox
+(``in_sandbox_path``), and (c) verify integrity (``sha256``).
+
+``ON DELETE CASCADE`` ties row lifetime to the session — when a session is
+hard-deleted, its uploads disappear too.  Cleanup of the host directory is
+handled out-of-band (same policy as ``_attachments``: workspace cleanup is
+a separate sweep).
+
+The ``(session_id, created_at DESC)`` index supports a future
+``GET /v1/sessions/<id>/files`` listing endpoint without a full scan; it's
+cheap to maintain on the write path since uploads are not high-frequency.
+
+Revision ID: 0032
+Revises: 0031
+Create Date: 2026-05-11
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0032"
+down_revision: str = "0031"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE files (
+            id              text PRIMARY KEY,
+            session_id      text NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            filename        text NOT NULL,
+            host_path       text NOT NULL,
+            in_sandbox_path text NOT NULL,
+            size            bigint NOT NULL,
+            content_type    text NOT NULL,
+            sha256          text NOT NULL,
+            created_at      timestamptz NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX files_session_id_created_at_idx
+            ON files (session_id, created_at DESC)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS files_session_id_created_at_idx")
+    op.execute("DROP TABLE IF EXISTS files")

--- a/openapi.json
+++ b/openapi.json
@@ -7504,13 +7504,11 @@
         "properties": {
           "file_id": {
             "type": "string",
-            "title": "File Id",
-            "description": "Stable id of the uploaded file."
+            "title": "File Id"
           },
           "in_sandbox_path": {
             "type": "string",
-            "title": "In Sandbox Path",
-            "description": "Path inside the sandbox container where the model sees the file."
+            "title": "In Sandbox Path"
           },
           "filename": {
             "type": "string",
@@ -7539,7 +7537,7 @@
           "sha256"
         ],
         "title": "FileUploadResponse",
-        "description": "Wire shape returned from ``POST /v1/sessions/<id>/files``.\n\nThe ``file_id`` name (rather than the internal ``id``) matches the\ncontract in #324 so callers can reference the file in future inbound\nattachment payloads without rebinding."
+        "description": "Wire shape returned from ``POST /v1/sessions/<id>/files``.\n\n``file_id`` rather than ``id`` matches the #324 contract so callers can\nreference the file in future inbound attachment payloads without rebinding."
       },
       "GithubRepositoryResource": {
         "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -1703,6 +1703,75 @@
         }
       }
     },
+    "/v1/sessions/{session_id}/files": {
+      "post": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Upload File",
+        "description": "Upload a single file into the session's workspace (#324).\n\nAccepts either the operator API key or a connector token bound to\nthis session.  Files land at a stable host path; the model sees\nthem inside the sandbox at ``/mnt/uploads/<file_id>/<filename>``.",
+        "operationId": "upload_session_file",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_session_file"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileUploadResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/sessions/{session_id}/tool-confirmations": {
       "post": {
         "tags": [
@@ -6607,6 +6676,21 @@
         "title": "BindChatRequest",
         "description": "Request body for ``POST /v1/connections/{id}/bind-chat``.\n\nPre-populates a ``connection_chat_sessions`` row so inbound on\n``chat_id`` routes to ``session_id`` regardless of the connection's\nmode-default fallback (#215).  Operators use this to point\ndifferent chats on a single account at different operator-curated\nexisting sessions."
       },
+      "Body_upload_session_file": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "contentMediaType": "application/octet-stream",
+            "title": "File",
+            "description": "Bytes to upload into the session workspace."
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_upload_session_file"
+      },
       "BoundChat": {
         "properties": {
           "chat_id": {
@@ -7415,6 +7499,47 @@
         ],
         "title": "Event",
         "description": "Read view of a single event from the session log."
+      },
+      "FileUploadResponse": {
+        "properties": {
+          "file_id": {
+            "type": "string",
+            "title": "File Id",
+            "description": "Stable id of the uploaded file."
+          },
+          "in_sandbox_path": {
+            "type": "string",
+            "title": "In Sandbox Path",
+            "description": "Path inside the sandbox container where the model sees the file."
+          },
+          "filename": {
+            "type": "string",
+            "title": "Filename"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "content_type": {
+            "type": "string",
+            "title": "Content Type"
+          },
+          "sha256": {
+            "type": "string",
+            "title": "Sha256"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file_id",
+          "in_sandbox_path",
+          "filename",
+          "size",
+          "content_type",
+          "sha256"
+        ],
+        "title": "FileUploadResponse",
+        "description": "Wire shape returned from ``POST /v1/sessions/<id>/files``.\n\nThe ``file_id`` name (rather than the internal ``id``) matches the\ncontract in #324 so callers can reference the file in future inbound\nattachment payloads without rebinding."
       },
       "GithubRepositoryResource": {
         "properties": {

--- a/src/aios/api/deps.py
+++ b/src/aios/api/deps.py
@@ -8,7 +8,7 @@ exposed here as typed accessors.
 from __future__ import annotations
 
 import secrets
-from typing import Annotated, cast
+from typing import Annotated, Literal, cast
 
 import asyncpg
 from fastapi import Depends, Header, HTTPException, Request, status
@@ -89,6 +89,33 @@ async def require_connector_auth(
     return resolved.connection_id
 
 
+async def require_operator_or_connector_auth(
+    settings: Annotated[Settings, Depends(get_settings_dep)],
+    pool: Annotated[asyncpg.Pool, Depends(get_pool)],
+    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+) -> tuple[Literal["operator", "connector"], str | None]:
+    """Accept either the operator API key or a connector token.
+
+    Returns ``("operator", None)`` for the operator key and
+    ``("connector", connection_id)`` for a valid connector token.
+    Raises :class:`UnauthorizedError` (401) when the header is missing,
+    malformed, or doesn't match either credential.
+
+    The operator-key path is checked first via constant-time compare so
+    requests carrying the operator key never hit the DB.  Routes that
+    take ``OperatorOrConnectorAuthDep`` are responsible for any
+    session-level scope check on the ``connector`` branch (typically
+    ``queries.is_session_bound_to_connection``).
+    """
+    token = _extract_bearer_token(authorization)
+    if secrets.compare_digest(token, settings.api_key.get_secret_value()):
+        return ("operator", None)
+    resolved = await connector_tokens_service.resolve(pool, token)
+    if resolved is None:
+        raise UnauthorizedError("invalid api key or connector token")
+    return ("connector", resolved.connection_id)
+
+
 # Type aliases for clarity at the route definitions.
 # Note: asyncpg.Pool isn't subscriptable at runtime, so we annotate with the
 # bare class. FastAPI's dependency injection ignores generic parameters.
@@ -98,3 +125,7 @@ ProcrastinateDep = Annotated[ProcrastinateApp, Depends(get_procrastinate)]
 DbUrlDep = Annotated[str, Depends(get_db_url)]
 AuthDep = Annotated[None, Depends(require_bearer_auth)]
 ConnectorAuthDep = Annotated[str, Depends(require_connector_auth)]
+OperatorOrConnectorAuthDep = Annotated[
+    tuple[Literal["operator", "connector"], str | None],
+    Depends(require_operator_or_connector_auth),
+]

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -14,24 +14,26 @@ from __future__ import annotations
 import asyncio
 from typing import Annotated
 
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, File, Query, UploadFile, status
 from sse_starlette import EventSourceResponse
 
 from aios.api.deps import (
     AuthDep,
     CryptoBoxDep,
     DbUrlDep,
+    OperatorOrConnectorAuthDep,
     PoolDep,
     ProcrastinateDep,
 )
 from aios.api.sse import sse_event_stream
 from aios.db import queries
 from aios.db.listen import SESSION_INTERRUPT_CHANNEL, listen_for_events
-from aios.errors import ValidationError
+from aios.errors import ForbiddenError, ValidationError
 from aios.harness.wake import defer_wake
 from aios.ids import GITHUB_REPOSITORY, split_id
 from aios.models.common import ListResponse
 from aios.models.events import Event, EventKind
+from aios.models.files import FileUploadResponse
 from aios.models.github_repositories import (
     GithubRepositoryResourceEcho,
     GithubRepositoryUpdate,
@@ -50,6 +52,7 @@ from aios.models.sessions import (
     ToolResultRequest,
     WaitResponse,
 )
+from aios.services import files as files_service
 from aios.services import github_repositories as github_repo_service
 from aios.services import sessions as service
 
@@ -342,6 +345,47 @@ async def submit_tool_result(
         )
     await defer_wake(pool, session_id, cause="custom_tool_result")
     return event
+
+
+@router.post(
+    "/{session_id}/files",
+    operation_id="upload_session_file",
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_file(
+    session_id: str,
+    pool: PoolDep,
+    auth: OperatorOrConnectorAuthDep,
+    file: Annotated[UploadFile, File(description="Bytes to upload into the session workspace.")],
+) -> FileUploadResponse:
+    """Upload a single file into the session's workspace (#324).
+
+    Accepts either the operator API key or a connector token bound to
+    this session.  Files land at a stable host path; the model sees
+    them inside the sandbox at ``/mnt/uploads/<file_id>/<filename>``.
+    """
+    mode, connection_id = auth
+    if mode == "connector":
+        # connection_id is non-None on the connector branch (see deps.py).
+        assert connection_id is not None
+        async with pool.acquire() as conn:
+            bound = await queries.is_session_bound_to_connection(
+                conn, connection_id=connection_id, session_id=session_id
+            )
+        if not bound:
+            raise ForbiddenError(
+                "session is not bound to this connection",
+                detail={"session_id": session_id, "connection_id": connection_id},
+            )
+    record = await files_service.stage_upload(pool, session_id=session_id, upload=file)
+    return FileUploadResponse(
+        file_id=record.id,
+        in_sandbox_path=record.in_sandbox_path,
+        filename=record.filename,
+        size=record.size,
+        content_type=record.content_type,
+        sha256=record.sha256,
+    )
 
 
 @router.post(

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -366,7 +366,6 @@ async def upload_file(
     """
     mode, connection_id = auth
     if mode == "connector":
-        # connection_id is non-None on the connector branch (see deps.py).
         assert connection_id is not None
         async with pool.acquire() as conn:
             bound = await queries.is_session_bound_to_connection(

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -103,6 +103,14 @@ class Settings(BaseSettings):
         description="Maximum bytes of stdout+stderr returned from a bash tool call. "
         "Output beyond this is truncated with a [truncated] marker.",
     )
+    upload_max_size_bytes: int = Field(
+        default=50 * 1024 * 1024,
+        ge=1,
+        description="Maximum size of a single file uploaded via "
+        "``POST /v1/sessions/<id>/files``. Overflow is rejected with 413 "
+        "after the multipart body is drained so the client sees a clean "
+        "response rather than a transport reset.",
+    )
 
     # ── worker ─────────────────────────────────────────────────────────────
     worker_concurrency: int = Field(

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -4552,27 +4552,3 @@ async def insert_file(
         ) from exc
     assert row is not None
     return _row_to_file(row)
-
-
-async def get_file(conn: asyncpg.Connection[Any], file_id: str) -> File:
-    row = await conn.fetchrow("SELECT * FROM files WHERE id = $1", file_id)
-    if row is None:
-        raise NotFoundError(f"file {file_id} not found", detail={"id": file_id})
-    return _row_to_file(row)
-
-
-async def list_session_files(conn: asyncpg.Connection[Any], session_id: str) -> list[File]:
-    """Return all files for ``session_id`` newest-first.
-
-    Used by tests today; the eventual ``GET /v1/sessions/<id>/files``
-    listing endpoint will share this query.
-    """
-    rows = await conn.fetch(
-        """
-        SELECT * FROM files
-         WHERE session_id = $1
-         ORDER BY created_at DESC
-        """,
-        session_id,
-    )
-    return [_row_to_file(r) for r in rows]

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -52,6 +52,7 @@ from aios.models.connections import Connection
 from aios.models.connector_tokens import ConnectorToken
 from aios.models.environments import Environment, EnvironmentConfig
 from aios.models.events import Event, EventKind
+from aios.models.files import File
 from aios.models.github_repositories import GithubRepositoryResourceEcho
 from aios.models.memory_stores import (
     Actor,
@@ -4488,3 +4489,90 @@ async def resolve_connector_token(
     if row is None:
         return None
     return (row["id"], row["connection_id"])
+
+
+# ─── files ───────────────────────────────────────────────────────────────────
+
+
+def _row_to_file(row: asyncpg.Record) -> File:
+    return File(
+        id=row["id"],
+        session_id=row["session_id"],
+        filename=row["filename"],
+        host_path=row["host_path"],
+        in_sandbox_path=row["in_sandbox_path"],
+        size=row["size"],
+        content_type=row["content_type"],
+        sha256=row["sha256"],
+        created_at=row["created_at"],
+    )
+
+
+async def insert_file(
+    conn: asyncpg.Connection[Any],
+    *,
+    file_id: str,
+    session_id: str,
+    filename: str,
+    host_path: str,
+    in_sandbox_path: str,
+    size: int,
+    content_type: str,
+    sha256: str,
+) -> File:
+    """Insert a row for an already-staged upload.
+
+    Caller has already written the bytes to ``host_path`` and computed
+    ``sha256`` + ``size`` during streaming. Raises :class:`NotFoundError`
+    if ``session_id`` doesn't exist (FK violation).
+    """
+    try:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO files (
+                id, session_id, filename, host_path, in_sandbox_path,
+                size, content_type, sha256
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING *
+            """,
+            file_id,
+            session_id,
+            filename,
+            host_path,
+            in_sandbox_path,
+            size,
+            content_type,
+            sha256,
+        )
+    except asyncpg.ForeignKeyViolationError as exc:
+        raise NotFoundError(
+            f"session {session_id} not found",
+            detail={"session_id": session_id},
+        ) from exc
+    assert row is not None
+    return _row_to_file(row)
+
+
+async def get_file(conn: asyncpg.Connection[Any], file_id: str) -> File:
+    row = await conn.fetchrow("SELECT * FROM files WHERE id = $1", file_id)
+    if row is None:
+        raise NotFoundError(f"file {file_id} not found", detail={"id": file_id})
+    return _row_to_file(row)
+
+
+async def list_session_files(conn: asyncpg.Connection[Any], session_id: str) -> list[File]:
+    """Return all files for ``session_id`` newest-first.
+
+    Used by tests today; the eventual ``GET /v1/sessions/<id>/files``
+    listing endpoint will share this query.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT * FROM files
+         WHERE session_id = $1
+         ORDER BY created_at DESC
+        """,
+        session_id,
+    )
+    return [_row_to_file(r) for r in rows]

--- a/src/aios/harness/attachment_staging.py
+++ b/src/aios/harness/attachment_staging.py
@@ -21,42 +21,16 @@ from __future__ import annotations
 import contextlib
 import errno
 import os
-import re
 import shutil
 from pathlib import Path
 from typing import Any
 
-from aios.sandbox.volumes import ensure_session_attachments_dir
+from aios.sandbox.volumes import ensure_session_attachments_dir, safe_filename
 
 
 class AttachmentStagingError(Exception):
     """Per-attachment staging failure.  Caller drops the inbound with
     the canonical ``attachment_staging_failed`` reason."""
-
-
-_UNSAFE_FILENAME_CHARS = re.compile(r"[^\w.\-]")
-_MAX_FILENAME_LEN = 200
-
-
-def _safe_filename(name: str) -> str:
-    """Sanitize ``name`` for use as a path leaf.
-
-    Strips directory separators (defeats ``../`` traversal), maps
-    unsupported characters to ``_``, falls back to ``"unnamed"`` for
-    empty or all-dot inputs, and caps length so a pathological
-    filename combined with the ULID prefix can't exhaust the host
-    FS's per-component limit.
-
-    Unicode-aware: Python's ``\\w`` matches the full Unicode word class
-    by default, so non-ASCII letters are preserved (e.g.
-    ``café.jpg`` → ``café.jpg``). Only structurally unsafe punctuation
-    and whitespace get rewritten.
-    """
-    base = os.path.basename(name)
-    cleaned = _UNSAFE_FILENAME_CHARS.sub("_", base)
-    if not cleaned or cleaned.replace(".", "") == "":
-        return "unnamed"
-    return cleaned[:_MAX_FILENAME_LEN]
 
 
 def stage_inbound_attachments(
@@ -134,7 +108,7 @@ def stage_inbound_attachments(
                     f"{{host_path, filename, content_type, size}}: {raw!r}"
                 )
 
-            target_name = f"{event_id}-{_safe_filename(filename)}"
+            target_name = f"{event_id}-{safe_filename(filename)}"
             if target_name in target_names_seen:
                 raise AttachmentStagingError(
                     f"two attachments in inbound {event_id!r} sanitize to the "

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -35,6 +35,7 @@ MEMORY_STORE: Final = "memstore"
 MEMORY: Final = "mem"
 MEMORY_VERSION: Final = "memver"
 GITHUB_REPOSITORY: Final = "ghrepo"
+FILE: Final = "file"
 
 _PREFIXES: Final = frozenset(
     {
@@ -54,6 +55,7 @@ _PREFIXES: Final = frozenset(
         MEMORY,
         MEMORY_VERSION,
         GITHUB_REPOSITORY,
+        FILE,
     }
 )
 

--- a/src/aios/models/files.py
+++ b/src/aios/models/files.py
@@ -1,28 +1,17 @@
-"""Files uploaded into a session's workspace via ``POST /v1/sessions/<id>/files``.
-
-A file is a session-scoped, immutable-from-the-model's-POV blob staged into
-the api's filesystem and exposed read-only to the sandbox at
-``/mnt/uploads/<file_id>/<filename>``.  Connectors upload bytes through the
-api instead of placing them on a shared mount; the model accesses uploads
-through the same standard tools (``read``, ``bash``, …) it uses for any
-other path under a known bind.
-
-``host_path`` is the internal location on the api's filesystem and is NOT
-exposed in API responses — see :class:`FileUploadResponse` for the wire shape.
-"""
+"""Files uploaded into a session's workspace via ``POST /v1/sessions/<id>/files``."""
 
 from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class File(BaseModel):
     """Internal view of a row in the ``files`` table.
 
-    Includes ``host_path`` so service-layer code can locate the bytes; the
-    public response shape strips it.
+    ``host_path`` is service-layer-only and is stripped from the public
+    response shape :class:`FileUploadResponse`.
     """
 
     id: str
@@ -39,15 +28,12 @@ class File(BaseModel):
 class FileUploadResponse(BaseModel):
     """Wire shape returned from ``POST /v1/sessions/<id>/files``.
 
-    The ``file_id`` name (rather than the internal ``id``) matches the
-    contract in #324 so callers can reference the file in future inbound
-    attachment payloads without rebinding.
+    ``file_id`` rather than ``id`` matches the #324 contract so callers can
+    reference the file in future inbound attachment payloads without rebinding.
     """
 
-    file_id: str = Field(description="Stable id of the uploaded file.")
-    in_sandbox_path: str = Field(
-        description="Path inside the sandbox container where the model sees the file."
-    )
+    file_id: str
+    in_sandbox_path: str
     filename: str
     size: int
     content_type: str

--- a/src/aios/models/files.py
+++ b/src/aios/models/files.py
@@ -1,0 +1,54 @@
+"""Files uploaded into a session's workspace via ``POST /v1/sessions/<id>/files``.
+
+A file is a session-scoped, immutable-from-the-model's-POV blob staged into
+the api's filesystem and exposed read-only to the sandbox at
+``/mnt/uploads/<file_id>/<filename>``.  Connectors upload bytes through the
+api instead of placing them on a shared mount; the model accesses uploads
+through the same standard tools (``read``, ``bash``, …) it uses for any
+other path under a known bind.
+
+``host_path`` is the internal location on the api's filesystem and is NOT
+exposed in API responses — see :class:`FileUploadResponse` for the wire shape.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class File(BaseModel):
+    """Internal view of a row in the ``files`` table.
+
+    Includes ``host_path`` so service-layer code can locate the bytes; the
+    public response shape strips it.
+    """
+
+    id: str
+    session_id: str
+    filename: str
+    host_path: str
+    in_sandbox_path: str
+    size: int
+    content_type: str
+    sha256: str
+    created_at: datetime
+
+
+class FileUploadResponse(BaseModel):
+    """Wire shape returned from ``POST /v1/sessions/<id>/files``.
+
+    The ``file_id`` name (rather than the internal ``id``) matches the
+    contract in #324 so callers can reference the file in future inbound
+    attachment payloads without rebinding.
+    """
+
+    file_id: str = Field(description="Stable id of the uploaded file.")
+    in_sandbox_path: str = Field(
+        description="Path inside the sandbox container where the model sees the file."
+    )
+    filename: str
+    size: int
+    content_type: str
+    sha256: str

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -309,6 +309,7 @@ def _assemble_plan(
     """Pure assembly of the plan from already-materialized inputs."""
     from aios.sandbox.volumes import (
         ensure_session_attachments_dir,
+        ensure_session_uploads_dir,
         memory_store_host_dir,
         session_repo_working_tree_dir,
     )
@@ -319,16 +320,18 @@ def _assemble_plan(
         **session_env,
     }
 
-    # Bind the per-session attachments dir at every provision so an
-    # inbound landing during a running step is visible to the live
-    # sandbox.  Docker doesn't update binds in place; this works
-    # because the bind exposes the *directory* (not a file snapshot),
-    # and any new file the supervisor stages into it appears through
-    # the existing kernel namespace bind without re-mounting.
+    # Bind the per-session attachments and uploads dirs at every provision
+    # so an inbound landing — or a ``POST /v1/sessions/<id>/files`` arriving
+    # — during a running step is visible to the live sandbox.  Docker doesn't
+    # update binds in place; this works because the bind exposes the
+    # *directory* (not a file snapshot), and any new file staged into it
+    # appears through the existing kernel namespace bind without re-mounting.
     attachments_path = ensure_session_attachments_dir(session_id)
+    uploads_path = ensure_session_uploads_dir(session_id)
 
     extra_mounts: list[Mount] = [
         Mount(host_path=attachments_path, sandbox_path="/mnt/attachments", read_only=True),
+        Mount(host_path=uploads_path, sandbox_path="/mnt/uploads", read_only=True),
     ]
 
     # Bind-mount each attached memory store. Read-only attaches make the

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -176,6 +176,43 @@ def ensure_session_attachments_dir(session_id: str) -> Path:
     return path
 
 
+_UPLOADS_ROOT = "_uploads"
+
+
+def uploads_root() -> Path:
+    """Return ``<workspace_root>/_uploads`` — the parent of all per-session
+    upload directories.
+
+    Each session subdir is bind-mounted read-only into its container at
+    ``/mnt/uploads`` (see :mod:`aios.sandbox.spec`). Bytes uploaded via
+    ``POST /v1/sessions/<id>/files`` land here under
+    ``<workspace_root>/_uploads/<session_id>/<file_id>/<filename>``; the
+    model sees them at ``/mnt/uploads/<file_id>/<filename>``.
+    """
+    return (get_settings().workspace_root / _UPLOADS_ROOT).resolve()
+
+
+def session_uploads_dir(session_id: str) -> Path:
+    """Per-session host directory backing ``/mnt/uploads``.
+
+    Pure — does not create the directory. Use
+    :func:`ensure_session_uploads_dir` to create.
+    """
+    return uploads_root() / session_id
+
+
+def ensure_session_uploads_dir(session_id: str) -> Path:
+    """Return the per-session uploads directory, creating it if needed.
+
+    Called eagerly from the provisioner at every container start so the
+    bind-mount source always exists before Docker tries to mount it,
+    even for sessions that have never received an upload.
+    """
+    path = session_uploads_dir(session_id)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 def resolve_to_host_path(session_id: str, sandbox_path: str) -> Path | None:
     """Map an in-sandbox path to its host-side equivalent for known bind mounts.
 
@@ -221,4 +258,8 @@ def _bind_mount_base(session_id: str, sandbox_path: str) -> tuple[Path | None, s
         return session_attachments_dir(session_id), None
     if sandbox_path.startswith("/mnt/attachments/"):
         return session_attachments_dir(session_id), sandbox_path[len("/mnt/attachments/") :]
+    if sandbox_path == "/mnt/uploads":
+        return session_uploads_dir(session_id), None
+    if sandbox_path.startswith("/mnt/uploads/"):
+        return session_uploads_dir(session_id), sandbox_path[len("/mnt/uploads/") :]
     return None, None

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -14,9 +14,38 @@ dirs is a Phase 6 polish item.
 
 from __future__ import annotations
 
+import os
+import re
 from pathlib import Path
 
 from aios.config import get_settings
+
+_UNSAFE_FILENAME_CHARS = re.compile(r"[^\w.\-]")
+_MAX_FILENAME_LEN = 200
+_FILENAME_FALLBACK = "unnamed"
+
+
+def safe_filename(name: str | None) -> str:
+    """Sanitize ``name`` for use as a path leaf.
+
+    Strips directory separators (defeats ``../`` traversal), maps
+    unsupported characters to ``_``, falls back to ``"unnamed"`` for
+    None / empty / all-dot inputs, and caps length so a pathological
+    filename combined with a per-file id prefix can't exhaust the
+    host FS's per-component limit.
+
+    Unicode-aware: Python's ``\\w`` matches the full Unicode word class
+    by default, so non-ASCII letters are preserved (e.g.
+    ``café.jpg``, ``图片.png``). Only structurally unsafe punctuation
+    and whitespace get rewritten.
+    """
+    if not name:
+        return _FILENAME_FALLBACK
+    base = os.path.basename(name)
+    cleaned = _UNSAFE_FILENAME_CHARS.sub("_", base)
+    if not cleaned or cleaned.replace(".", "") == "":
+        return _FILENAME_FALLBACK
+    return cleaned[:_MAX_FILENAME_LEN]
 
 
 def workspace_dir_for(session_id: str) -> Path:

--- a/src/aios/sdk/_generated/api/sessions/upload_session_file.py
+++ b/src/aios/sdk/_generated/api/sessions/upload_session_file.py
@@ -1,0 +1,219 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.body_upload_session_file import BodyUploadSessionFile
+from ...models.file_upload_response import FileUploadResponse
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    body: BodyUploadSessionFile,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/sessions/{session_id}/files".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+    }
+
+    _kwargs["files"] = body.to_multipart()
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> FileUploadResponse | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = FileUploadResponse.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[FileUploadResponse | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: BodyUploadSessionFile,
+    authorization: None | str | Unset = UNSET,
+) -> Response[FileUploadResponse | HTTPValidationError]:
+    """Upload File
+
+     Upload a single file into the session's workspace (#324).
+
+    Accepts either the operator API key or a connector token bound to
+    this session.  Files land at a stable host path; the model sees
+    them inside the sandbox at ``/mnt/uploads/<file_id>/<filename>``.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (BodyUploadSessionFile):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[FileUploadResponse | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: BodyUploadSessionFile,
+    authorization: None | str | Unset = UNSET,
+) -> FileUploadResponse | HTTPValidationError | None:
+    """Upload File
+
+     Upload a single file into the session's workspace (#324).
+
+    Accepts either the operator API key or a connector token bound to
+    this session.  Files land at a stable host path; the model sees
+    them inside the sandbox at ``/mnt/uploads/<file_id>/<filename>``.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (BodyUploadSessionFile):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        FileUploadResponse | HTTPValidationError
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: BodyUploadSessionFile,
+    authorization: None | str | Unset = UNSET,
+) -> Response[FileUploadResponse | HTTPValidationError]:
+    """Upload File
+
+     Upload a single file into the session's workspace (#324).
+
+    Accepts either the operator API key or a connector token bound to
+    this session.  Files land at a stable host path; the model sees
+    them inside the sandbox at ``/mnt/uploads/<file_id>/<filename>``.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (BodyUploadSessionFile):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[FileUploadResponse | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: BodyUploadSessionFile,
+    authorization: None | str | Unset = UNSET,
+) -> FileUploadResponse | HTTPValidationError | None:
+    """Upload File
+
+     Upload a single file into the session's workspace (#324).
+
+    Accepts either the operator API key or a connector token bound to
+    this session.  Files land at a stable host path; the model sees
+    them inside the sandbox at ``/mnt/uploads/<file_id>/<filename>``.
+
+    Args:
+        session_id (str):
+        authorization (None | str | Unset):
+        body (BodyUploadSessionFile):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        FileUploadResponse | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/sdk/_generated/models/__init__.py
+++ b/src/aios/sdk/_generated/models/__init__.py
@@ -15,6 +15,7 @@ from .agent_update_metadata_type_0 import AgentUpdateMetadataType0
 from .agent_version import AgentVersion
 from .agent_version_litellm_extra import AgentVersionLitellmExtra
 from .bind_chat_request import BindChatRequest
+from .body_upload_session_file import BodyUploadSessionFile
 from .bound_chat import BoundChat
 from .connection import Connection
 from .connection_attach import ConnectionAttach
@@ -56,6 +57,7 @@ from .environment_update import EnvironmentUpdate
 from .event import Event
 from .event_data import EventData
 from .event_kind import EventKind
+from .file_upload_response import FileUploadResponse
 from .get_health_response_get_health import GetHealthResponseGetHealth
 from .github_repository_resource import GithubRepositoryResource
 from .github_repository_resource_echo import GithubRepositoryResourceEcho
@@ -187,6 +189,7 @@ __all__ = (
     "AgentVersion",
     "AgentVersionLitellmExtra",
     "BindChatRequest",
+    "BodyUploadSessionFile",
     "BoundChat",
     "Connection",
     "ConnectionAttach",
@@ -222,6 +225,7 @@ __all__ = (
     "Event",
     "EventData",
     "EventKind",
+    "FileUploadResponse",
     "GetHealthResponseGetHealth",
     "GithubRepositoryResource",
     "GithubRepositoryResourceEcho",

--- a/src/aios/sdk/_generated/models/body_upload_session_file.py
+++ b/src/aios/sdk/_generated/models/body_upload_session_file.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from .. import types
+
+T = TypeVar("T", bound="BodyUploadSessionFile")
+
+
+@_attrs_define
+class BodyUploadSessionFile:
+    """
+    Attributes:
+        file (str): Bytes to upload into the session workspace.
+    """
+
+    file: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        file = self.file
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "file": file,
+            }
+        )
+
+        return field_dict
+
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
+
+        files.append(("file", (None, str(self.file).encode(), "text/plain")))
+
+        for prop_name, prop in self.additional_properties.items():
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
+
+        return files
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        file = d.pop("file")
+
+        body_upload_session_file = cls(
+            file=file,
+        )
+
+        body_upload_session_file.additional_properties = d
+        return body_upload_session_file
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/file_upload_response.py
+++ b/src/aios/sdk/_generated/models/file_upload_response.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="FileUploadResponse")
+
+
+@_attrs_define
+class FileUploadResponse:
+    """Wire shape returned from ``POST /v1/sessions/<id>/files``.
+
+    The ``file_id`` name (rather than the internal ``id``) matches the
+    contract in #324 so callers can reference the file in future inbound
+    attachment payloads without rebinding.
+
+        Attributes:
+            file_id (str): Stable id of the uploaded file.
+            in_sandbox_path (str): Path inside the sandbox container where the model sees the file.
+            filename (str):
+            size (int):
+            content_type (str):
+            sha256 (str):
+    """
+
+    file_id: str
+    in_sandbox_path: str
+    filename: str
+    size: int
+    content_type: str
+    sha256: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        file_id = self.file_id
+
+        in_sandbox_path = self.in_sandbox_path
+
+        filename = self.filename
+
+        size = self.size
+
+        content_type = self.content_type
+
+        sha256 = self.sha256
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "file_id": file_id,
+                "in_sandbox_path": in_sandbox_path,
+                "filename": filename,
+                "size": size,
+                "content_type": content_type,
+                "sha256": sha256,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        file_id = d.pop("file_id")
+
+        in_sandbox_path = d.pop("in_sandbox_path")
+
+        filename = d.pop("filename")
+
+        size = d.pop("size")
+
+        content_type = d.pop("content_type")
+
+        sha256 = d.pop("sha256")
+
+        file_upload_response = cls(
+            file_id=file_id,
+            in_sandbox_path=in_sandbox_path,
+            filename=filename,
+            size=size,
+            content_type=content_type,
+            sha256=sha256,
+        )
+
+        file_upload_response.additional_properties = d
+        return file_upload_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/sdk/_generated/models/file_upload_response.py
+++ b/src/aios/sdk/_generated/models/file_upload_response.py
@@ -13,13 +13,12 @@ T = TypeVar("T", bound="FileUploadResponse")
 class FileUploadResponse:
     """Wire shape returned from ``POST /v1/sessions/<id>/files``.
 
-    The ``file_id`` name (rather than the internal ``id``) matches the
-    contract in #324 so callers can reference the file in future inbound
-    attachment payloads without rebinding.
+    ``file_id`` rather than ``id`` matches the #324 contract so callers can
+    reference the file in future inbound attachment payloads without rebinding.
 
         Attributes:
-            file_id (str): Stable id of the uploaded file.
-            in_sandbox_path (str): Path inside the sandbox container where the model sees the file.
+            file_id (str):
+            in_sandbox_path (str):
             filename (str):
             size (int):
             content_type (str):

--- a/src/aios/services/files.py
+++ b/src/aios/services/files.py
@@ -1,14 +1,14 @@
 """Multipart upload staging for ``POST /v1/sessions/<id>/files`` (#324).
 
-Streams the request body to disk in chunks, computing sha256 as it goes
-and enforcing :attr:`Settings.upload_max_size_bytes`.  On overflow the
-remainder of the body is drained so the client sees a clean 413 rather
-than a transport reset (a parser-level reset surfaces as a generic 500
-on the client and is hostile to debug).
+Two non-obvious choices worth recording here:
 
-Ordering is file-then-DB on purpose: a half-written ``.part`` file is a
-harmless orphan that a future sweeper can reap, whereas a DB row that
-points at missing bytes is observable corruption.
+* **Drain-before-413.** On overflow the rest of the multipart body is
+  read and discarded before raising ``PayloadTooLargeError``. Without
+  the drain the parser bails out and the client sees a transport reset,
+  which is much harder to diagnose than a clean 413.
+* **File-then-DB ordering.** Bytes hit disk and rename atomically into
+  place before the row insert. A half-written ``.part`` is a harmless
+  orphan; a DB row pointing at missing bytes is observable corruption.
 """
 
 from __future__ import annotations
@@ -16,8 +16,6 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import os
-import re
-from pathlib import Path
 from typing import Any, Protocol
 
 import asyncpg
@@ -27,11 +25,10 @@ from aios.db import queries
 from aios.errors import PayloadTooLargeError
 from aios.ids import FILE, make_id
 from aios.models.files import File
-from aios.sandbox.volumes import ensure_session_uploads_dir
+from aios.sandbox.volumes import ensure_session_uploads_dir, safe_filename
 
 _CHUNK_SIZE = 1 << 20  # 1 MiB
 _DEFAULT_CONTENT_TYPE = "application/octet-stream"
-_DEFAULT_FILENAME = "upload.bin"
 
 
 class UploadStream(Protocol):
@@ -45,27 +42,6 @@ class UploadStream(Protocol):
     content_type: str | None
 
     async def read(self, size: int = -1) -> bytes: ...
-
-
-def sanitize_filename(name: str | None) -> str:
-    """Strip path components and replace unsafe characters.
-
-    Python's ``\\w`` matches unicode word characters by default, so
-    Chinese / Cyrillic / accented filenames survive intact; only true
-    path-unsafe characters (separators, null bytes, control chars,
-    spaces, shell metacharacters) get replaced.  Empty result falls
-    back to :data:`_DEFAULT_FILENAME`.
-    """
-    if not name:
-        return _DEFAULT_FILENAME
-    base = Path(name).name
-    # ``Path('..').name == '..'`` (not empty) — pathlib doesn't treat
-    # parent-refs specially in the .name accessor. Reject them
-    # explicitly so we don't end up writing to ``<file_dir>/..``.
-    if base in (".", ".."):
-        return _DEFAULT_FILENAME
-    cleaned = re.sub(r"[^\w.-]", "_", base)
-    return cleaned or _DEFAULT_FILENAME
 
 
 async def stage_upload(
@@ -86,7 +62,7 @@ async def stage_upload(
         await queries.get_session(conn, session_id)  # 404 if missing
 
     file_id = make_id(FILE)
-    filename = sanitize_filename(upload.filename)
+    filename = safe_filename(upload.filename)
     content_type = upload.content_type or _DEFAULT_CONTENT_TYPE
 
     file_dir = ensure_session_uploads_dir(session_id) / file_id
@@ -99,11 +75,7 @@ async def stage_upload(
     size = 0
     overflow = False
     try:
-        # ASYNC230: open() on a local-disk path is fast (one syscall) and
-        # the file stays open across awaits only as long as the upstream
-        # multipart body keeps feeding chunks — exactly the lifetime we
-        # want. Wrapping every chunk write in asyncio.to_thread() would
-        # add executor overhead per MiB without measurable benefit.
+        # ASYNC230: local-disk write, executor wrap isn't worth the per-chunk cost.
         with open(temp_path, "wb") as f:  # noqa: ASYNC230
             while True:
                 chunk = await upload.read(_CHUNK_SIZE)
@@ -111,8 +83,6 @@ async def stage_upload(
                     break
                 size += len(chunk)
                 if size > settings.upload_max_size_bytes:
-                    # Drain the rest so the client sees a clean 413 instead of
-                    # a transport reset from the multipart parser bailing out.
                     while await upload.read(_CHUNK_SIZE):
                         pass
                     overflow = True
@@ -129,10 +99,11 @@ async def stage_upload(
             )
         os.rename(temp_path, final_path)
     except BaseException:
-        if temp_path.exists():
-            temp_path.unlink(missing_ok=True)
-        if final_path.exists():
-            final_path.unlink(missing_ok=True)
+        # BaseException (not Exception) so partial state still gets cleaned up
+        # under task cancellation — CancelledError doesn't inherit from
+        # Exception in 3.11+.
+        temp_path.unlink(missing_ok=True)
+        final_path.unlink(missing_ok=True)
         with contextlib.suppress(OSError):
             file_dir.rmdir()
         raise

--- a/src/aios/services/files.py
+++ b/src/aios/services/files.py
@@ -1,0 +1,151 @@
+"""Multipart upload staging for ``POST /v1/sessions/<id>/files`` (#324).
+
+Streams the request body to disk in chunks, computing sha256 as it goes
+and enforcing :attr:`Settings.upload_max_size_bytes`.  On overflow the
+remainder of the body is drained so the client sees a clean 413 rather
+than a transport reset (a parser-level reset surfaces as a generic 500
+on the client and is hostile to debug).
+
+Ordering is file-then-DB on purpose: a half-written ``.part`` file is a
+harmless orphan that a future sweeper can reap, whereas a DB row that
+points at missing bytes is observable corruption.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import os
+import re
+from pathlib import Path
+from typing import Any, Protocol
+
+import asyncpg
+
+from aios.config import get_settings
+from aios.db import queries
+from aios.errors import PayloadTooLargeError
+from aios.ids import FILE, make_id
+from aios.models.files import File
+from aios.sandbox.volumes import ensure_session_uploads_dir
+
+_CHUNK_SIZE = 1 << 20  # 1 MiB
+_DEFAULT_CONTENT_TYPE = "application/octet-stream"
+_DEFAULT_FILENAME = "upload.bin"
+
+
+class UploadStream(Protocol):
+    """Subset of ``fastapi.UploadFile`` we depend on.
+
+    Declared as a :class:`Protocol` so unit tests can pass a lightweight
+    in-memory shim without dragging starlette into the test path.
+    """
+
+    filename: str | None
+    content_type: str | None
+
+    async def read(self, size: int = -1) -> bytes: ...
+
+
+def sanitize_filename(name: str | None) -> str:
+    """Strip path components and replace unsafe characters.
+
+    Python's ``\\w`` matches unicode word characters by default, so
+    Chinese / Cyrillic / accented filenames survive intact; only true
+    path-unsafe characters (separators, null bytes, control chars,
+    spaces, shell metacharacters) get replaced.  Empty result falls
+    back to :data:`_DEFAULT_FILENAME`.
+    """
+    if not name:
+        return _DEFAULT_FILENAME
+    base = Path(name).name
+    # ``Path('..').name == '..'`` (not empty) — pathlib doesn't treat
+    # parent-refs specially in the .name accessor. Reject them
+    # explicitly so we don't end up writing to ``<file_dir>/..``.
+    if base in (".", ".."):
+        return _DEFAULT_FILENAME
+    cleaned = re.sub(r"[^\w.-]", "_", base)
+    return cleaned or _DEFAULT_FILENAME
+
+
+async def stage_upload(
+    pool: asyncpg.Pool[Any],
+    *,
+    session_id: str,
+    upload: UploadStream,
+) -> File:
+    """Stream the upload to disk and persist a row in ``files``.
+
+    Raises :class:`NotFoundError` if ``session_id`` doesn't exist and
+    :class:`PayloadTooLargeError` (413) if the body exceeds the
+    configured size limit.  Returns the inserted :class:`File`.
+    """
+    settings = get_settings()
+
+    async with pool.acquire() as conn:
+        await queries.get_session(conn, session_id)  # 404 if missing
+
+    file_id = make_id(FILE)
+    filename = sanitize_filename(upload.filename)
+    content_type = upload.content_type or _DEFAULT_CONTENT_TYPE
+
+    file_dir = ensure_session_uploads_dir(session_id) / file_id
+    file_dir.mkdir(parents=True, exist_ok=False)
+    final_path = file_dir / filename
+    temp_path = file_dir / f"{filename}.part"
+    in_sandbox_path = f"/mnt/uploads/{file_id}/{filename}"
+
+    hasher = hashlib.sha256()
+    size = 0
+    overflow = False
+    try:
+        # ASYNC230: open() on a local-disk path is fast (one syscall) and
+        # the file stays open across awaits only as long as the upstream
+        # multipart body keeps feeding chunks — exactly the lifetime we
+        # want. Wrapping every chunk write in asyncio.to_thread() would
+        # add executor overhead per MiB without measurable benefit.
+        with open(temp_path, "wb") as f:  # noqa: ASYNC230
+            while True:
+                chunk = await upload.read(_CHUNK_SIZE)
+                if not chunk:
+                    break
+                size += len(chunk)
+                if size > settings.upload_max_size_bytes:
+                    # Drain the rest so the client sees a clean 413 instead of
+                    # a transport reset from the multipart parser bailing out.
+                    while await upload.read(_CHUNK_SIZE):
+                        pass
+                    overflow = True
+                    break
+                hasher.update(chunk)
+                f.write(chunk)
+            if not overflow:
+                f.flush()
+                os.fsync(f.fileno())
+        if overflow:
+            raise PayloadTooLargeError(
+                f"upload exceeds {settings.upload_max_size_bytes:,} bytes",
+                detail={"max_size_bytes": settings.upload_max_size_bytes},
+            )
+        os.rename(temp_path, final_path)
+    except BaseException:
+        if temp_path.exists():
+            temp_path.unlink(missing_ok=True)
+        if final_path.exists():
+            final_path.unlink(missing_ok=True)
+        with contextlib.suppress(OSError):
+            file_dir.rmdir()
+        raise
+
+    async with pool.acquire() as conn:
+        return await queries.insert_file(
+            conn,
+            file_id=file_id,
+            session_id=session_id,
+            filename=filename,
+            host_path=str(final_path),
+            in_sandbox_path=in_sandbox_path,
+            size=size,
+            content_type=content_type,
+            sha256=hasher.hexdigest(),
+        )

--- a/tests/e2e/test_session_files_api.py
+++ b/tests/e2e/test_session_files_api.py
@@ -1,0 +1,172 @@
+"""E2E coverage for ``POST /v1/sessions/<id>/files`` (#324).
+
+Exercises the multipart upload endpoint against the in-process API
+(no Docker required for the api-side contract).  The model-side
+visibility at ``/mnt/uploads/<file_id>/<filename>`` is exercised
+manually per the plan's Verification section — this test pins the
+HTTP-level shape, auth scoping, size enforcement, and durable
+landing of bytes on the api filesystem.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+
+import httpx
+import pytest
+
+from aios.config import get_settings
+from aios.sandbox.volumes import session_uploads_dir
+from tests.e2e.harness import Harness
+from tests.helpers.connections import bearer
+
+
+async def _make_session(harness: Harness) -> str:
+    from aios.services import agents as agents_service
+    from aios.services import environments as env_svc
+    from aios.services import sessions as sess_svc
+
+    # Fresh suffix per call — multiple sessions in one test can't collide on
+    # agent/env names.
+    suffix = secrets.token_hex(4)
+    agent = await agents_service.create_agent(
+        harness._pool,
+        name=f"files-{suffix}",
+        model="fake/test",
+        system="",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    env = await env_svc.create_environment(harness._pool, name=f"env-files-{suffix}")
+    session = await sess_svc.create_session(
+        harness._pool,
+        agent_id=agent.id,
+        environment_id=env.id,
+        title=None,
+        metadata={},
+    )
+    return session.id
+
+
+async def _create_connection_with_session(
+    harness: Harness, http_client: httpx.AsyncClient, session_id: str, account_suffix: str
+) -> tuple[str, str]:
+    """Returns ``(connection_id, token_plaintext)`` attached to ``session_id``."""
+    from aios.services import connections as connections_service
+
+    r = await http_client.post(
+        "/v1/connections",
+        json={"connector": "echo", "account": f"files-{account_suffix}"},
+    )
+    assert r.status_code == 201, r.text
+    connection_id = str(r.json()["id"])
+    await connections_service.attach_connection(harness._pool, connection_id, session_id=session_id)
+    t = await http_client.post("/v1/connector-tokens", json={"connection_id": connection_id})
+    assert t.status_code == 201, t.text
+    return connection_id, str(t.json()["plaintext"])
+
+
+class TestSessionFilesUpload:
+    async def test_operator_upload_happy_path(
+        self, http_client: httpx.AsyncClient, harness: Harness
+    ) -> None:
+        session_id = await _make_session(harness)
+        payload = b"\x89PNG\r\n\x1a\nfake-image-bytes"
+
+        r = await http_client.post(
+            f"/v1/sessions/{session_id}/files",
+            files={"file": ("photo.png", payload, "image/png")},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+
+        assert body["filename"] == "photo.png"
+        assert body["content_type"] == "image/png"
+        assert body["size"] == len(payload)
+        assert body["sha256"] == hashlib.sha256(payload).hexdigest()
+        assert body["in_sandbox_path"] == f"/mnt/uploads/{body['file_id']}/photo.png"
+        assert body["file_id"].startswith("file_")
+
+        # Bytes durable on the api filesystem at the expected per-file dir.
+        host_path = session_uploads_dir(session_id) / body["file_id"] / "photo.png"
+        assert host_path.exists()
+        assert host_path.read_bytes() == payload
+
+    async def test_connector_token_can_upload_to_attached_session(
+        self, http_client: httpx.AsyncClient, harness: Harness
+    ) -> None:
+        session_id = await _make_session(harness)
+        _, token = await _create_connection_with_session(harness, http_client, session_id, "ok")
+
+        r = await http_client.post(
+            f"/v1/sessions/{session_id}/files",
+            headers=bearer(token),
+            files={"file": ("doc.txt", b"hello", "text/plain")},
+        )
+        assert r.status_code == 201, r.text
+        assert r.json()["filename"] == "doc.txt"
+
+    async def test_connector_token_rejected_for_other_session(
+        self, http_client: httpx.AsyncClient, harness: Harness
+    ) -> None:
+        attached_session = await _make_session(harness)
+        other_session = await _make_session(harness)
+        _, token = await _create_connection_with_session(
+            harness, http_client, attached_session, "mismatch"
+        )
+
+        r = await http_client.post(
+            f"/v1/sessions/{other_session}/files",
+            headers=bearer(token),
+            files={"file": ("nope.bin", b"x", "application/octet-stream")},
+        )
+        assert r.status_code == 403, r.text
+        body = r.json()
+        # Error envelope is {"error": {"type", "message", "detail": {...}}}.
+        assert body["error"]["type"] == "forbidden"
+        assert body["error"]["detail"]["session_id"] == other_session
+
+    async def test_unknown_session_returns_404(
+        self, http_client: httpx.AsyncClient, harness: Harness
+    ) -> None:
+        r = await http_client.post(
+            "/v1/sessions/sess_does_not_exist/files",
+            files={"file": ("x.bin", b"x", "application/octet-stream")},
+        )
+        assert r.status_code == 404, r.text
+
+    async def test_oversized_returns_413(
+        self,
+        http_client: httpx.AsyncClient,
+        harness: Harness,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        session_id = await _make_session(harness)
+        settings = get_settings()
+        monkeypatch.setattr(settings, "upload_max_size_bytes", 64)
+
+        r = await http_client.post(
+            f"/v1/sessions/{session_id}/files",
+            files={"file": ("big.bin", b"a" * 256, "application/octet-stream")},
+        )
+        assert r.status_code == 413, r.text
+        # Per-file dir was cleaned up.
+        assert list(session_uploads_dir(session_id).iterdir()) == []
+
+    async def test_missing_bearer_returns_401(
+        self, http_client: httpx.AsyncClient, harness: Harness
+    ) -> None:
+        session_id = await _make_session(harness)
+        # Force the request through with no Authorization header — strip
+        # the one the fixture installs by passing an empty headers dict
+        # that overrides per-call.
+        r = await http_client.post(
+            f"/v1/sessions/{session_id}/files",
+            headers={"Authorization": ""},
+            files={"file": ("x.bin", b"x", "application/octet-stream")},
+        )
+        assert r.status_code == 401, r.text

--- a/tests/unit/test_attachment_staging.py
+++ b/tests/unit/test_attachment_staging.py
@@ -18,9 +18,9 @@ import pytest
 from aios.config import get_settings
 from aios.harness.attachment_staging import (
     AttachmentStagingError,
-    _safe_filename,
     stage_inbound_attachments,
 )
+from aios.sandbox.volumes import safe_filename
 
 
 @pytest.fixture
@@ -52,22 +52,22 @@ def _make_temp_attachment(tmp_path: Path, name: str, payload: bytes) -> dict[str
 class TestSafeFilename:
     def test_strips_path_separators(self) -> None:
         # Defeats ``../../etc/passwd`` style traversal attempts.
-        assert _safe_filename("../../etc/passwd") == "passwd"
+        assert safe_filename("../../etc/passwd") == "passwd"
 
     def test_replaces_unsafe_chars(self) -> None:
-        assert _safe_filename("hello world!.jpg") == "hello_world_.jpg"
+        assert safe_filename("hello world!.jpg") == "hello_world_.jpg"
 
     def test_preserves_dots_and_dashes(self) -> None:
-        assert _safe_filename("photo-2026.05.04.jpg") == "photo-2026.05.04.jpg"
+        assert safe_filename("photo-2026.05.04.jpg") == "photo-2026.05.04.jpg"
 
     def test_empty_falls_back_to_unnamed(self) -> None:
-        assert _safe_filename("") == "unnamed"
+        assert safe_filename("") == "unnamed"
 
     def test_all_dots_falls_back_to_unnamed(self) -> None:
-        assert _safe_filename("...") == "unnamed"
+        assert safe_filename("...") == "unnamed"
 
     def test_caps_length(self) -> None:
-        result = _safe_filename("a" * 500)
+        result = safe_filename("a" * 500)
         assert len(result) <= 200
 
 

--- a/tests/unit/test_deps_auth.py
+++ b/tests/unit/test_deps_auth.py
@@ -1,0 +1,95 @@
+"""Unit coverage for ``require_operator_or_connector_auth``.
+
+The dual-auth dep is what guards ``POST /v1/sessions/<id>/files`` (#324),
+so the dispatch table — operator → ``("operator", None)``, connector →
+``("connector", connection_id)``, neither → 401 — has to be precise.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncpg
+import pytest
+
+from aios.api.deps import require_operator_or_connector_auth
+from aios.config import get_settings
+from aios.errors import UnauthorizedError
+from aios.services.connector_tokens import ResolvedToken
+
+
+@pytest.fixture
+def _settings(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Force a known operator key so the constant-time compare is exact."""
+    s = get_settings()
+    monkeypatch.setattr(s, "api_key", type(s.api_key)("operator-key-for-test"))
+    return s
+
+
+def _pool() -> Any:
+    return cast("asyncpg.Pool[Any]", MagicMock())
+
+
+class TestRequireOperatorOrConnectorAuth:
+    async def test_operator_key_returns_operator_mode(self, _settings: Any) -> None:
+        result = await require_operator_or_connector_auth(
+            _settings,
+            _pool(),
+            authorization="Bearer operator-key-for-test",
+        )
+        assert result == ("operator", None)
+
+    async def test_operator_key_short_circuits_before_db(self, _settings: Any) -> None:
+        """Operator path must never hit the DB — otherwise every operator
+        request pays a connector_tokens lookup."""
+        with patch(
+            "aios.api.deps.connector_tokens_service.resolve",
+            AsyncMock(side_effect=RuntimeError("should not be called")),
+        ):
+            result = await require_operator_or_connector_auth(
+                _settings,
+                _pool(),
+                authorization="Bearer operator-key-for-test",
+            )
+        assert result == ("operator", None)
+
+    async def test_valid_connector_token_returns_connector_mode(self, _settings: Any) -> None:
+        with patch(
+            "aios.api.deps.connector_tokens_service.resolve",
+            AsyncMock(return_value=ResolvedToken(token_id="ctok_x", connection_id="conn_abc")),
+        ):
+            result = await require_operator_or_connector_auth(
+                _settings,
+                _pool(),
+                authorization="Bearer aios_conn_somecredential",
+            )
+        assert result == ("connector", "conn_abc")
+
+    async def test_unknown_token_raises_401(self, _settings: Any) -> None:
+        with (
+            patch(
+                "aios.api.deps.connector_tokens_service.resolve",
+                AsyncMock(return_value=None),
+            ),
+            pytest.raises(UnauthorizedError) as excinfo,
+        ):
+            await require_operator_or_connector_auth(
+                _settings,
+                _pool(),
+                authorization="Bearer aios_conn_bogus",
+            )
+        assert excinfo.value.status_code == 401
+
+    async def test_missing_header_raises_401(self, _settings: Any) -> None:
+        with pytest.raises(UnauthorizedError):
+            await require_operator_or_connector_auth(_settings, _pool(), authorization=None)
+
+    async def test_non_bearer_scheme_raises_401(self, _settings: Any) -> None:
+        # ``_extract_bearer_token`` rejects anything that isn't ``Bearer …``.
+        from fastapi import HTTPException
+
+        with pytest.raises((UnauthorizedError, HTTPException)):
+            await require_operator_or_connector_auth(
+                _settings, _pool(), authorization="Basic dXNlcjpwYXNz"
+            )

--- a/tests/unit/test_files_service.py
+++ b/tests/unit/test_files_service.py
@@ -1,0 +1,246 @@
+"""Unit coverage for the multipart upload service."""
+
+from __future__ import annotations
+
+import hashlib
+from io import BytesIO
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncpg
+import pytest
+
+from aios.config import get_settings
+from aios.errors import NotFoundError, PayloadTooLargeError
+from aios.models.files import File
+from aios.services.files import sanitize_filename, stage_upload
+
+
+class TestSanitizeFilename:
+    """``sanitize_filename`` strips path components and unsafe characters
+    while preserving unicode word characters (issue #324 v1 stance)."""
+
+    def test_basic_name_preserved(self) -> None:
+        assert sanitize_filename("photo.png") == "photo.png"
+
+    def test_unicode_word_chars_preserved(self) -> None:
+        # Chinese / Cyrillic / accented filenames survive — \w matches
+        # the full unicode word category in Python 3.
+        assert sanitize_filename("图片.png") == "图片.png"
+        assert sanitize_filename("файл.txt") == "файл.txt"
+        assert sanitize_filename("naïve.md") == "naïve.md"
+
+    def test_path_components_stripped(self) -> None:
+        assert sanitize_filename("/etc/passwd") == "passwd"
+        assert sanitize_filename("../../escape.sh") == "escape.sh"
+
+    def test_unsafe_chars_replaced(self) -> None:
+        assert sanitize_filename("file with spaces.txt") == "file_with_spaces.txt"
+        assert sanitize_filename("weird?<>|.png") == "weird____.png"
+        assert sanitize_filename("a/b/c.txt") == "c.txt"  # path-strip happens first
+
+    def test_none_falls_back(self) -> None:
+        assert sanitize_filename(None) == "upload.bin"
+
+    def test_empty_falls_back(self) -> None:
+        assert sanitize_filename("") == "upload.bin"
+
+    def test_path_only_falls_back(self) -> None:
+        # ``.`` and ``..`` survive ``Path(...).name``; we reject them
+        # explicitly so we can't end up writing to a parent dir.
+        assert sanitize_filename(".") == "upload.bin"
+        assert sanitize_filename("..") == "upload.bin"
+        # ``Path('/').name`` is the empty string, which falls back via
+        # the ``cleaned or _DEFAULT_FILENAME`` guard.
+        assert sanitize_filename("/") == "upload.bin"
+
+
+class _FakeAcquireCM:
+    def __init__(self, conn: object) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> object:
+        return self._conn
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+
+def _fake_pool() -> Any:
+    pool = MagicMock()
+    pool.acquire = MagicMock(side_effect=lambda: _FakeAcquireCM(MagicMock()))
+    return pool
+
+
+class _FakeUpload:
+    """Minimal ``UploadStream`` Protocol implementation backed by BytesIO."""
+
+    def __init__(
+        self, data: bytes, *, filename: str | None = "test.bin", content_type: str | None = None
+    ) -> None:
+        self._buf = BytesIO(data)
+        self.filename = filename
+        self.content_type = content_type
+
+    async def read(self, size: int = -1) -> bytes:
+        return self._buf.read(size if size > 0 else -1)
+
+
+def _patch_session_get(session_id: str = "sess_x") -> Any:
+    """Patch ``queries.get_session`` to return a stub session row."""
+    stub = MagicMock()
+    stub.id = session_id
+    return patch(
+        "aios.services.files.queries.get_session",
+        AsyncMock(return_value=stub),
+    )
+
+
+def _patch_session_not_found() -> Any:
+    return patch(
+        "aios.services.files.queries.get_session",
+        AsyncMock(side_effect=NotFoundError("session sess_x not found", detail={"id": "sess_x"})),
+    )
+
+
+def _patch_insert_file(captured: dict[str, Any]) -> Any:
+    """Patch ``queries.insert_file`` so the test can inspect the args."""
+
+    async def _record(_conn: object, **kwargs: Any) -> File:
+        captured.update(kwargs)
+        return File(
+            id=kwargs["file_id"],
+            session_id=kwargs["session_id"],
+            filename=kwargs["filename"],
+            host_path=kwargs["host_path"],
+            in_sandbox_path=kwargs["in_sandbox_path"],
+            size=kwargs["size"],
+            content_type=kwargs["content_type"],
+            sha256=kwargs["sha256"],
+            created_at=__import__("datetime").datetime.now(),
+        )
+
+    return patch("aios.services.files.queries.insert_file", new=_record)
+
+
+@pytest.fixture
+def _workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    return tmp_path
+
+
+class TestStageUploadHappyPath:
+    async def test_writes_bytes_and_computes_sha256(self, _workspace: Path) -> None:
+        data = b"hello world\nthis is a test upload"
+        upload = _FakeUpload(data, filename="hello.txt", content_type="text/plain")
+        captured: dict[str, Any] = {}
+        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+
+        with _patch_session_get(), _patch_insert_file(captured):
+            result = await stage_upload(pool, session_id="sess_x", upload=upload)
+
+        assert result.size == len(data)
+        assert result.sha256 == hashlib.sha256(data).hexdigest()
+        assert result.filename == "hello.txt"
+        assert result.content_type == "text/plain"
+        assert result.in_sandbox_path == f"/mnt/uploads/{result.id}/hello.txt"
+        # Bytes durable on disk at the host path.
+        assert Path(result.host_path).read_bytes() == data  # noqa: ASYNC240
+        # File-then-DB: insert called after the bytes are present.
+        assert captured["file_id"] == result.id
+        assert captured["host_path"] == result.host_path
+
+    async def test_empty_file_accepted(self, _workspace: Path) -> None:
+        upload = _FakeUpload(b"", filename="empty.bin")
+        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        with _patch_session_get(), _patch_insert_file({}):
+            result = await stage_upload(pool, session_id="sess_x", upload=upload)
+        assert result.size == 0
+        assert result.sha256 == hashlib.sha256(b"").hexdigest()
+        assert Path(result.host_path).read_bytes() == b""  # noqa: ASYNC240
+
+    async def test_content_type_defaults_to_octet_stream(self, _workspace: Path) -> None:
+        upload = _FakeUpload(b"x", filename="anon", content_type=None)
+        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        with _patch_session_get(), _patch_insert_file({}):
+            result = await stage_upload(pool, session_id="sess_x", upload=upload)
+        assert result.content_type == "application/octet-stream"
+
+    async def test_unicode_filename_preserved_on_disk(self, _workspace: Path) -> None:
+        upload = _FakeUpload(b"hi", filename="图片.png", content_type="image/png")
+        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        with _patch_session_get(), _patch_insert_file({}):
+            result = await stage_upload(pool, session_id="sess_x", upload=upload)
+        assert result.filename == "图片.png"
+        assert Path(result.host_path).name == "图片.png"
+
+
+class TestStageUploadOversize:
+    async def test_oversize_raises_413(
+        self, _workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "upload_max_size_bytes", 64)
+        upload = _FakeUpload(b"a" * 256, filename="big.bin")
+        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        with (
+            _patch_session_get(),
+            _patch_insert_file({}),
+            pytest.raises(PayloadTooLargeError) as excinfo,
+        ):
+            await stage_upload(pool, session_id="sess_x", upload=upload)
+        assert excinfo.value.status_code == 413
+        assert excinfo.value.detail["max_size_bytes"] == 64
+
+    async def test_oversize_drains_remainder(
+        self, _workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Drain is what lets the client see a clean 413 instead of a
+        transport reset. Verifying the upstream is empty after the call
+        is the easiest end-state check."""
+        settings = get_settings()
+        monkeypatch.setattr(settings, "upload_max_size_bytes", 64)
+        upload = _FakeUpload(b"a" * 4096, filename="big.bin")
+        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        with (
+            _patch_session_get(),
+            _patch_insert_file({}),
+            pytest.raises(PayloadTooLargeError),
+        ):
+            await stage_upload(pool, session_id="sess_x", upload=upload)
+        assert await upload.read() == b""
+
+    async def test_oversize_leaves_no_artifacts(
+        self, _workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed upload must not leave a half-written .part or an
+        empty file_id directory under _uploads/<session>/. Otherwise a
+        sweeper has to reason about state instead of just deleting."""
+        settings = get_settings()
+        monkeypatch.setattr(settings, "upload_max_size_bytes", 64)
+        upload = _FakeUpload(b"a" * 256, filename="big.bin")
+        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        with (
+            _patch_session_get(),
+            _patch_insert_file({}),
+            pytest.raises(PayloadTooLargeError),
+        ):
+            await stage_upload(pool, session_id="sess_x", upload=upload)
+        uploads_dir = _workspace / "_uploads" / "sess_x"
+        # The session-level dir exists (ensure_session_uploads_dir) but it
+        # holds no per-file subdirectories.
+        assert uploads_dir.exists()
+        assert list(uploads_dir.iterdir()) == []
+
+
+class TestStageUploadSessionNotFound:
+    async def test_nonexistent_session_propagates_404(self, _workspace: Path) -> None:
+        upload = _FakeUpload(b"x", filename="ok.bin")
+        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        with _patch_session_not_found(), pytest.raises(NotFoundError):
+            await stage_upload(pool, session_id="sess_x", upload=upload)
+        # Short-circuited before any disk activity.
+        uploads_dir = _workspace / "_uploads" / "sess_x"
+        assert not uploads_dir.exists()

--- a/tests/unit/test_files_service.py
+++ b/tests/unit/test_files_service.py
@@ -1,4 +1,8 @@
-"""Unit coverage for the multipart upload service."""
+"""Unit coverage for the multipart upload service.
+
+Filename sanitisation lives in ``volumes.safe_filename`` and is covered by
+``test_attachment_staging.TestSafeFilename`` — not duplicated here.
+"""
 
 from __future__ import annotations
 
@@ -14,63 +18,8 @@ import pytest
 from aios.config import get_settings
 from aios.errors import NotFoundError, PayloadTooLargeError
 from aios.models.files import File
-from aios.services.files import sanitize_filename, stage_upload
-
-
-class TestSanitizeFilename:
-    """``sanitize_filename`` strips path components and unsafe characters
-    while preserving unicode word characters (issue #324 v1 stance)."""
-
-    def test_basic_name_preserved(self) -> None:
-        assert sanitize_filename("photo.png") == "photo.png"
-
-    def test_unicode_word_chars_preserved(self) -> None:
-        # Chinese / Cyrillic / accented filenames survive — \w matches
-        # the full unicode word category in Python 3.
-        assert sanitize_filename("图片.png") == "图片.png"
-        assert sanitize_filename("файл.txt") == "файл.txt"
-        assert sanitize_filename("naïve.md") == "naïve.md"
-
-    def test_path_components_stripped(self) -> None:
-        assert sanitize_filename("/etc/passwd") == "passwd"
-        assert sanitize_filename("../../escape.sh") == "escape.sh"
-
-    def test_unsafe_chars_replaced(self) -> None:
-        assert sanitize_filename("file with spaces.txt") == "file_with_spaces.txt"
-        assert sanitize_filename("weird?<>|.png") == "weird____.png"
-        assert sanitize_filename("a/b/c.txt") == "c.txt"  # path-strip happens first
-
-    def test_none_falls_back(self) -> None:
-        assert sanitize_filename(None) == "upload.bin"
-
-    def test_empty_falls_back(self) -> None:
-        assert sanitize_filename("") == "upload.bin"
-
-    def test_path_only_falls_back(self) -> None:
-        # ``.`` and ``..`` survive ``Path(...).name``; we reject them
-        # explicitly so we can't end up writing to a parent dir.
-        assert sanitize_filename(".") == "upload.bin"
-        assert sanitize_filename("..") == "upload.bin"
-        # ``Path('/').name`` is the empty string, which falls back via
-        # the ``cleaned or _DEFAULT_FILENAME`` guard.
-        assert sanitize_filename("/") == "upload.bin"
-
-
-class _FakeAcquireCM:
-    def __init__(self, conn: object) -> None:
-        self._conn = conn
-
-    async def __aenter__(self) -> object:
-        return self._conn
-
-    async def __aexit__(self, *_args: object) -> None:
-        return None
-
-
-def _fake_pool() -> Any:
-    pool = MagicMock()
-    pool.acquire = MagicMock(side_effect=lambda: _FakeAcquireCM(MagicMock()))
-    return pool
+from aios.services.files import stage_upload
+from tests.unit.conftest import fake_pool_yielding_conn
 
 
 class _FakeUpload:
@@ -136,7 +85,7 @@ class TestStageUploadHappyPath:
         data = b"hello world\nthis is a test upload"
         upload = _FakeUpload(data, filename="hello.txt", content_type="text/plain")
         captured: dict[str, Any] = {}
-        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        pool = cast("asyncpg.Pool[Any]", fake_pool_yielding_conn(MagicMock()))
 
         with _patch_session_get(), _patch_insert_file(captured):
             result = await stage_upload(pool, session_id="sess_x", upload=upload)
@@ -154,7 +103,7 @@ class TestStageUploadHappyPath:
 
     async def test_empty_file_accepted(self, _workspace: Path) -> None:
         upload = _FakeUpload(b"", filename="empty.bin")
-        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        pool = cast("asyncpg.Pool[Any]", fake_pool_yielding_conn(MagicMock()))
         with _patch_session_get(), _patch_insert_file({}):
             result = await stage_upload(pool, session_id="sess_x", upload=upload)
         assert result.size == 0
@@ -163,14 +112,14 @@ class TestStageUploadHappyPath:
 
     async def test_content_type_defaults_to_octet_stream(self, _workspace: Path) -> None:
         upload = _FakeUpload(b"x", filename="anon", content_type=None)
-        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        pool = cast("asyncpg.Pool[Any]", fake_pool_yielding_conn(MagicMock()))
         with _patch_session_get(), _patch_insert_file({}):
             result = await stage_upload(pool, session_id="sess_x", upload=upload)
         assert result.content_type == "application/octet-stream"
 
     async def test_unicode_filename_preserved_on_disk(self, _workspace: Path) -> None:
         upload = _FakeUpload(b"hi", filename="图片.png", content_type="image/png")
-        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        pool = cast("asyncpg.Pool[Any]", fake_pool_yielding_conn(MagicMock()))
         with _patch_session_get(), _patch_insert_file({}):
             result = await stage_upload(pool, session_id="sess_x", upload=upload)
         assert result.filename == "图片.png"
@@ -184,7 +133,7 @@ class TestStageUploadOversize:
         settings = get_settings()
         monkeypatch.setattr(settings, "upload_max_size_bytes", 64)
         upload = _FakeUpload(b"a" * 256, filename="big.bin")
-        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        pool = cast("asyncpg.Pool[Any]", fake_pool_yielding_conn(MagicMock()))
         with (
             _patch_session_get(),
             _patch_insert_file({}),
@@ -203,7 +152,7 @@ class TestStageUploadOversize:
         settings = get_settings()
         monkeypatch.setattr(settings, "upload_max_size_bytes", 64)
         upload = _FakeUpload(b"a" * 4096, filename="big.bin")
-        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        pool = cast("asyncpg.Pool[Any]", fake_pool_yielding_conn(MagicMock()))
         with (
             _patch_session_get(),
             _patch_insert_file({}),
@@ -221,7 +170,7 @@ class TestStageUploadOversize:
         settings = get_settings()
         monkeypatch.setattr(settings, "upload_max_size_bytes", 64)
         upload = _FakeUpload(b"a" * 256, filename="big.bin")
-        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        pool = cast("asyncpg.Pool[Any]", fake_pool_yielding_conn(MagicMock()))
         with (
             _patch_session_get(),
             _patch_insert_file({}),
@@ -238,7 +187,7 @@ class TestStageUploadOversize:
 class TestStageUploadSessionNotFound:
     async def test_nonexistent_session_propagates_404(self, _workspace: Path) -> None:
         upload = _FakeUpload(b"x", filename="ok.bin")
-        pool = cast("asyncpg.Pool[Any]", _fake_pool())
+        pool = cast("asyncpg.Pool[Any]", fake_pool_yielding_conn(MagicMock()))
         with _patch_session_not_found(), pytest.raises(NotFoundError):
             await stage_upload(pool, session_id="sess_x", upload=upload)
         # Short-circuited before any disk activity.

--- a/tests/unit/test_volumes_attachments.py
+++ b/tests/unit/test_volumes_attachments.py
@@ -10,8 +10,11 @@ from aios.config import get_settings
 from aios.sandbox.volumes import (
     attachments_root,
     ensure_session_attachments_dir,
+    ensure_session_uploads_dir,
     resolve_to_host_path,
     session_attachments_dir,
+    session_uploads_dir,
+    uploads_root,
 )
 
 
@@ -53,6 +56,42 @@ def test_ensure_session_attachments_dir_creates(
     assert p == p2
 
 
+def test_uploads_root_under_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    assert uploads_root() == (tmp_path / "_uploads").resolve()
+
+
+def test_session_uploads_dir_keyed_by_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    a = session_uploads_dir("sess-a")
+    b = session_uploads_dir("sess-b")
+    assert a != b
+    assert a.parent == b.parent == (tmp_path / "_uploads").resolve()
+
+
+def test_session_uploads_dir_pure_function(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    p = session_uploads_dir("sess-new")
+    assert not p.exists()
+
+
+def test_ensure_session_uploads_dir_creates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    p = ensure_session_uploads_dir("sess-1")
+    assert p.exists() and p.is_dir()
+    # Idempotent.
+    p2 = ensure_session_uploads_dir("sess-1")
+    assert p == p2
+
+
 class TestResolveToHostPath:
     """Mapping must be exact and only fire for known mount roots."""
 
@@ -84,6 +123,28 @@ class TestResolveToHostPath:
         assert result == (
             (tmp_path / "_attachments" / "sess-1").resolve() / "echo" / "evt-photo.jpg"
         )
+
+    def test_uploads_root_maps_to_session_uploads(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        result = resolve_to_host_path("sess-1", "/mnt/uploads")
+        assert result == (tmp_path / "_uploads" / "sess-1").resolve()
+
+    def test_uploads_subpath(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        result = resolve_to_host_path("sess-1", "/mnt/uploads/file_01XYZ/photo.png")
+        assert result == ((tmp_path / "_uploads" / "sess-1").resolve() / "file_01XYZ" / "photo.png")
+
+    def test_uploads_dotdot_escape_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        # Same containment guarantee as workspace/attachments — symmetric protection.
+        assert resolve_to_host_path("sess-1", "/mnt/uploads/../foo") is None
 
     def test_unknown_paths_return_none(self) -> None:
         # Paths outside the bind-mount roots fall back to docker-exec.


### PR DESCRIPTION
## Summary

- New `POST /v1/sessions/<session_id>/files` multipart endpoint accepts either the operator API key or a connector token scoped to the session; bytes stream to `<workspace_root>/_uploads/<session>/<file_id>/<filename>` and are exposed read-only to the sandbox at `/mnt/uploads/<file_id>/<filename>` (a new bind mount paralleling `/mnt/attachments`).
- Endpoint-only scope per #324: the inbound contract change, connector SDK helper, signal/telegram migration, and per-chat-aware `/v1/connectors/files` resolver remain as explicit follow-ups. The existing `host_path`-based inbound flow is unchanged.
- Lift `safe_filename` (formerly `harness.attachment_staging._safe_filename`) into `sandbox.volumes` so the new upload path and the existing attachment-staging path share one implementation, one length cap, and one test suite.

Closes #324.

## What's in this branch

Two commits:

1. **`feat(api): POST /v1/sessions/<id>/files`** — the endpoint + service + DB table + sandbox mount + auth dep + tests.
2. **`refactor(api/files): lift shared filename sanitizer, drop unused queries, trim narration`** — review-pass cleanup (net −133 lines). Shared sanitiser, dropped TOCTOU pre-checks, deleted speculative `get_file`/`list_session_files`, trimmed WHAT-narration, swapped to shared `fake_pool_yielding_conn` test helper.

## Design notes worth flagging at review time

- **Auth.** New `require_operator_or_connector_auth` dependency: operator key (constant-time compare, no DB) first, falls back to `connector_tokens_service.resolve`. Connector callers must satisfy `queries.is_session_bound_to_connection` — the same primitive `POST /v1/connectors/tool-results` uses, so the endpoint inherits all three lineage paths (single_session, per_chat origin, operator-curated `connection_chat_sessions`) for free.
- **Streaming.** 1 MiB chunks, incremental sha256, size enforcement mid-stream against `settings.upload_max_size_bytes` (default 50 MiB). On overflow the remainder of the multipart body is drained before raising `PayloadTooLargeError` — without the drain, the client sees a transport reset from the parser bailing out, which is harder to diagnose than a clean 413.
- **File-then-DB ordering.** Bytes hit disk and rename atomically into place before the row insert. A half-written `.part` is a harmless orphan a future sweeper can reap; a DB row pointing at missing bytes is observable corruption.
- **`except BaseException` in cleanup.** Deliberate — `asyncio.CancelledError` doesn't inherit from `Exception` in 3.11+, so narrowing to `Exception` would leak partial state on task cancellation.
- **`_bind_mount_base` extension.** Two new branches before the catch-all `return None, None`. Purely additive (no existing prefix overlaps `/mnt/uploads`), so the model's `read` tool resolves uploaded paths via the existing containment + symlink-escape machinery.
- **Per-chat connections still need work.** A connector in `per_chat` mode whose session hasn't been spawned yet has no `<session_id>` to address. That's the intentional v1 limitation; the follow-up `/v1/connectors/files` resolver issue addresses it.

## Test plan

- [x] `uv run mypy src` — 416 files, no issues
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1152 passed (+21 new: 9 sandbox/auth, 12 service)
- [x] `DOCKER_HOST=… uv run pytest tests/e2e/test_session_files_api.py tests/e2e/test_inbound_attachment.py -q` — 8 passed (6 new + 2 existing inbound regression check)
- [x] `scripts/regen-openapi.sh` + `scripts/regen-client.sh` — generated spec + SDK committed
- [ ] Manual smoke per plan's Verification section: `curl -F file=@/tmp/photo.png` into a session, confirm `in_sandbox_path` is `/mnt/uploads/file_…/photo.png`, send a message asking the model to `ls /mnt/uploads/` inside the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)