### PR TITLE
perf(tests): session-scope DB testcontainer + in-process alembic

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -6,6 +6,7 @@
 [alembic]
 script_location = migrations
 prepend_sys_path = .
+path_separator = os
 version_path_separator = os
 sqlalchemy.url = driver://placeholder/replaced/by/env.py
 

--- a/src/aios/cli/commands/ops.py
+++ b/src/aios/cli/commands/ops.py
@@ -8,8 +8,6 @@ migrations — they do NOT talk to the HTTP API.
 from __future__ import annotations
 
 import asyncio
-import subprocess
-import sys
 
 import typer
 
@@ -45,44 +43,13 @@ def _run_worker() -> int:
     return 0
 
 
-async def _apply_procrastinate_schema_if_missing() -> None:
-    """Apply procrastinate's schema if missing, then idempotently install
-    aios's lock-release trigger.
-
-    ``apply_schema_async`` isn't idempotent, hence the ``to_regclass``
-    guard; the trigger DDL is.
-    """
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-    from aios.db.procrastinate_extensions import LOCK_RELEASE_TRIGGER_DDL
-    from aios.harness.procrastinate_app import app as procrastinate_app
-
-    settings = get_settings()
-    pool = await create_pool(settings.db_url, max_size=2)
-    try:
-        async with pool.acquire() as conn:
-            present = await conn.fetchval("SELECT to_regclass('procrastinate_jobs')")
-            if present is None:
-                print("applying procrastinate schema...", file=sys.stderr)
-                await procrastinate_app.open_async()
-                try:
-                    await procrastinate_app.schema_manager.apply_schema_async()
-                finally:
-                    await procrastinate_app.close_async()
-                print("procrastinate schema applied", file=sys.stderr)
-            else:
-                print("procrastinate schema already present, skipping", file=sys.stderr)
-            await conn.execute(LOCK_RELEASE_TRIGGER_DDL)
-            print("aios lock-release trigger ensured", file=sys.stderr)
-    finally:
-        await pool.close()
-
-
 def _run_migrate() -> int:
-    rc = subprocess.call(["alembic", "upgrade", "head"])
-    if rc != 0:
-        return rc
-    asyncio.run(_apply_procrastinate_schema_if_missing())
+    from aios.config import get_settings
+    from aios.db.migrations import apply_procrastinate_schema, upgrade_to_head
+
+    db_url = get_settings().db_url
+    upgrade_to_head(db_url)
+    asyncio.run(apply_procrastinate_schema(db_url, verbose=True))
     return 0
 
 

--- a/src/aios/db/migrations.py
+++ b/src/aios/db/migrations.py
@@ -1,0 +1,65 @@
+"""In-process migration helpers.
+
+Replaces ``subprocess.call(["alembic", "upgrade", ...])`` so callers (the
+``aios migrate`` CLI command and the e2e test fixtures) skip the
+``uv run`` cold-start tax. ``migrations/env.py`` reads ``AIOS_DB_URL``
+from the environment, so we temporarily set it for the duration of the
+upgrade.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def upgrade_to_head(db_url: str, target: str = "head") -> None:
+    """In-process equivalent of ``alembic upgrade <target>`` against ``db_url``."""
+    from alembic import command
+    from alembic.config import Config
+
+    cfg = Config(str(_REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(_REPO_ROOT / "migrations"))
+    with mock.patch.dict(os.environ, {"AIOS_DB_URL": db_url}):
+        command.upgrade(cfg, target)
+
+
+async def apply_procrastinate_schema(db_url: str, *, verbose: bool = False) -> None:
+    """Apply procrastinate's schema (if missing) and the aios lock-release
+    trigger against ``db_url``. Idempotent — safe on an already-migrated DB.
+
+    ``apply_schema_async`` isn't idempotent (no ``IF NOT EXISTS``), hence the
+    ``to_regclass`` guard; the trigger DDL is.
+
+    Pass ``verbose=True`` from CLI contexts to surface user-facing status.
+    """
+    import asyncpg
+    from procrastinate import App, PsycopgConnector
+
+    from aios.db.procrastinate_extensions import LOCK_RELEASE_TRIGGER_DDL
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        present = await conn.fetchval("SELECT to_regclass('procrastinate_jobs')")
+        if present is None:
+            if verbose:
+                print("applying procrastinate schema...", file=sys.stderr)
+            tmp_app = App(connector=PsycopgConnector(conninfo=db_url))
+            await tmp_app.open_async()
+            try:
+                await tmp_app.schema_manager.apply_schema_async()
+            finally:
+                await tmp_app.close_async()
+            if verbose:
+                print("procrastinate schema applied", file=sys.stderr)
+        elif verbose:
+            print("procrastinate schema already present, skipping", file=sys.stderr)
+        await conn.execute(LOCK_RELEASE_TRIGGER_DDL)
+        if verbose:
+            print("aios lock-release trigger ensured", file=sys.stderr)
+    finally:
+        await conn.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 """Shared pytest fixtures for aios tests.
 
-* ``postgres_container`` — module-scoped testcontainer running Postgres 16
-* ``migrated_db_url`` — runs alembic upgrade head against the testcontainer
-* ``app_env`` — sets the env vars the FastAPI app needs (api key, vault key, db url)
-* ``test_client`` — a FastAPI test client wired against a fresh app + the migrated DB
+* ``postgres_container`` — session-scoped testcontainer running Postgres 16
+* ``migrated_db_url`` — runs alembic upgrade head + applies the procrastinate
+  schema and aios lock-release trigger against the testcontainer
+* ``_reset_db_state`` — function-scoped: TRUNCATEs all public-schema tables
+  before each test so the session-scoped DB stays isolated between tests
+* ``aios_env`` — sets the env vars the FastAPI app needs (api key, vault key,
+  db url) and depends on ``_reset_db_state``
 
 Tests that need Docker are marked ``integration``; pytest -m "not integration"
 runs only the unit tests, which is what most local dev iterations use.
@@ -83,7 +86,7 @@ needs_docker = pytest.mark.skipif(
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def postgres_container() -> Iterator[Any]:
     if not _docker_available():
         pytest.skip("Docker not available")
@@ -93,7 +96,7 @@ def postgres_container() -> Iterator[Any]:
         yield pg
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def db_url(postgres_container: Any) -> str:
     host = postgres_container.get_container_host_ip()
     port = postgres_container.get_exposed_port(5432)
@@ -103,32 +106,43 @@ def db_url(postgres_container: Any) -> str:
     return f"postgresql://{user}:{password}@{host}:{port}/{db}"
 
 
-def run_alembic_upgrade(db_url: str, target: str = "head") -> None:
-    """Run ``alembic upgrade <target>`` against ``db_url`` via subprocess."""
-    env = {**os.environ, "AIOS_DB_URL": db_url}
-    result = subprocess.run(
-        ["uv", "run", "alembic", "upgrade", target],
-        cwd=PROJECT_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"alembic upgrade {target} failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
-        )
-
-
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def migrated_db_url(db_url: str) -> str:
-    """Run alembic upgrade head against the testcontainer DB and return its URL."""
-    run_alembic_upgrade(db_url, "head")
+    """Run alembic upgrade head against the testcontainer, then apply the
+    procrastinate schema and the aios lock-release trigger. Returns the URL."""
+    import asyncio
+
+    from aios.db.migrations import apply_procrastinate_schema, upgrade_to_head
+
+    upgrade_to_head(db_url)
+    asyncio.run(apply_procrastinate_schema(db_url))
     return db_url
 
 
 @pytest.fixture
-def aios_env(migrated_db_url: str, tmp_path: Path) -> Iterator[dict[str, str]]:
+async def _reset_db_state(migrated_db_url: str) -> None:
+    """TRUNCATE every public-schema table before each test.
+
+    Restores the cross-test isolation that module-scoped Postgres used to
+    provide.  ``TRUNCATE`` is metadata-only in Postgres, so this is O(tables)
+    regardless of row count.
+    """
+    import asyncpg
+
+    conn = await asyncpg.connect(migrated_db_url)
+    try:
+        rows = await conn.fetch("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
+        if rows:
+            quoted = ", ".join(f'"{r["tablename"]}"' for r in rows)
+            await conn.execute(f"TRUNCATE {quoted} RESTART IDENTITY CASCADE")
+    finally:
+        await conn.close()
+
+
+@pytest.fixture
+def aios_env(
+    migrated_db_url: str, _reset_db_state: None, tmp_path: Path
+) -> Iterator[dict[str, str]]:
     """Set the env vars the FastAPI app needs."""
     env_vars = {
         "AIOS_API_KEY": secrets.token_urlsafe(32),

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -57,44 +57,19 @@ async def _noop_defer_wake(
     pass
 
 
-async def ensure_procrastinate_schema(aios_db_url: str) -> None:
-    """Apply procrastinate's schema if missing, then install the aios
-    lock-release trigger. Mirrors ``aios migrate`` for tests."""
-    import asyncpg
-    from procrastinate import App, PsycopgConnector
-
-    from aios.config import get_settings
-    from aios.db.procrastinate_extensions import LOCK_RELEASE_TRIGGER_DDL
-
-    settings = get_settings()
-    conn = await asyncpg.connect(settings.db_url)
-    try:
-        present = await conn.fetchval("SELECT to_regclass('procrastinate_jobs')")
-        if present is None:
-            conninfo = aios_db_url.replace("postgresql+psycopg://", "postgresql://")
-            tmp_app = App(connector=PsycopgConnector(conninfo=conninfo))
-            await tmp_app.open_async()
-            try:
-                await tmp_app.schema_manager.apply_schema_async()
-            finally:
-                await tmp_app.close_async()
-        await conn.execute(LOCK_RELEASE_TRIGGER_DDL)
-    finally:
-        await conn.close()
-
-
 @pytest.fixture
 async def real_wake_setup(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    """Real pool + procrastinate schema (with the aios lock-release trigger).
+    """Real pool against the session-migrated DB.
 
     Used by tests that exercise the real ``defer_wake`` and a real
     procrastinate worker — the ``harness`` fixture's ``defer_wake`` is
-    a no-op and so unsuitable here.
+    a no-op and so unsuitable here. The procrastinate schema + aios
+    lock-release trigger are applied once at session start by
+    ``migrated_db_url``; this fixture only needs a fresh pool.
     """
     from aios.config import get_settings
     from aios.db.pool import create_pool
 
-    await ensure_procrastinate_schema(aios_env["AIOS_DB_URL"])
     pool = await create_pool(get_settings().db_url, min_size=1, max_size=8)
     try:
         yield pool

--- a/tests/e2e/test_reap_stalled_jobs.py
+++ b/tests/e2e/test_reap_stalled_jobs.py
@@ -28,9 +28,7 @@ from tests.conftest import needs_docker
 async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
     from aios.config import get_settings
     from aios.db.pool import create_pool
-    from tests.e2e.conftest import ensure_procrastinate_schema
 
-    await ensure_procrastinate_schema(aios_env["AIOS_DB_URL"])
     p = await create_pool(get_settings().db_url, min_size=1, max_size=4)
     yield p
     await p.close()


### PR DESCRIPTION
## Summary
- E2E suite: **223s → 166s** (−25%, −57s) on 287 tests.
- Move `postgres_container`, `db_url`, `migrated_db_url` from `scope="module"` to `scope="session"`. With 37 e2e modules, this eliminates 36 redundant testcontainer + alembic-subprocess cycles.
- New `src/aios/db/migrations.py` exposes `upgrade_to_head(db_url)` and `apply_procrastinate_schema(db_url, verbose=...)`. Drops the `uv run alembic` subprocess from both the `aios migrate` CLI and the test fixtures — production migrate also speeds up (no `uv run` cold start).
- New function-scoped `_reset_db_state` fixture: `TRUNCATE` every public-schema table before each test, restoring the cross-test isolation that module-scoped Postgres used to give us. `TRUNCATE` is metadata-only in Postgres, so this is O(tables) regardless of row count.
- Deduped procrastinate-schema setup between CLI and tests: both paths now call `apply_procrastinate_schema(db_url)`. Removed `ensure_procrastinate_schema` from `tests/e2e/conftest.py` — applied once at session start via `migrated_db_url` instead of lazily per-fixture.
- `alembic.ini`: added `path_separator = os` to silence the deprecation warning that surfaces now that alembic runs in-process.

Net diff: **+116 / −96 lines** (deduplication wins over the new helper module).

## Why only 57s, not the ~150s I originally projected
My earlier "visible duration" measurement was clipped by `tail -500` truncating the head of the durations output where the slowest tests actually live. Many e2e tests legitimately take 2–8s (Docker sandbox boot, network-policy tests, cross-session memory). Those costs were always there; module-scope just buried them under fixture overhead. The new `--durations=20` shows them clearly: `test_limited_blocks_unlisted_host` (8.0s), `test_concurrent_writes_use_precondition` (5.6s), `test_bash_real_container` (3.0s). Session setup itself is **3.5s, paid once**.

## Why this is safe
- No e2e test relies on pristine DB at module start — IDs are either fresh UUIDs or `ON CONFLICT DO NOTHING` (verified across `test_sweep_perf`, `test_orphan_stuck`, `test_search_events`, `test_session_files_api`, etc.).
- Procrastinate's tables land in the public schema, so the `pg_tables`-driven TRUNCATE catches them too. The three real-procrastinate tests (`test_wake_lock_release_latency`, `test_worker_concurrency`, `test_reap_stalled_jobs`) get a clean queue per test, which is what they already assume.
- The lock-release trigger DDL already uses `CREATE OR REPLACE FUNCTION` + `DROP TRIGGER IF EXISTS`, so it's idempotent — safe whether applied per-test (old) or once at session start (new).

## Out of scope (next levers)
The remaining e2e time is dominated by real test work in Docker-using tests. A shared sandbox container pool across tests would be the next ~30–50s lever, but it's a bigger change with different blast radius — keeping this PR focused.

## Test plan
- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1152 pass in 10s
- [x] `DOCKER_HOST=… uv run pytest tests/integration -q` — 4 pass in 8s
- [x] `DOCKER_HOST=… uv run pytest tests/e2e -q` — 287 pass in 166s (was 223s)
- [x] Spot-check real-procrastinate tests pass — `test_wake_lock_release_latency`, `test_worker_concurrency`, `test_reap_stalled_jobs` all green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)