### PR TITLE
build(sandbox): publish aios-sandbox image to GHCR; pull at deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,13 @@ AIOS_VAULT_KEY=replace-me
 # Required: Postgres connection URL.
 AIOS_DB_URL=postgresql://aios:aios@localhost:5432/aios
 
-# Sandbox image used for all v1 sessions. Built from docker/Dockerfile.sandbox.
-AIOS_DOCKER_IMAGE=aios-sandbox:latest
+# Sandbox image used for all v1 sessions.  Built from
+# docker/Dockerfile.sandbox and published to GHCR by the
+# ``Build aios-sandbox image`` workflow on every change to that file.
+# Local-dev builds (``docker build -t aios-sandbox:latest -f docker/Dockerfile.sandbox docker/``)
+# work too — point this at the local tag if you want to test changes
+# without going through CI.
+AIOS_DOCKER_IMAGE=ghcr.io/eumemic/aios-sandbox:latest
 
 # Where per-session workspace directories live on the host.
 # Each session gets a subdir at $AIOS_WORKSPACE_ROOT/<session_id>/, mounted into

--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -1,0 +1,65 @@
+name: Build aios-sandbox image
+
+# Builds and publishes ``ghcr.io/eumemic/aios-sandbox`` whenever the
+# sandbox base image's inputs change.  The worker pulls this image to
+# spawn per-session sandbox containers — see ``docker/Dockerfile.sandbox``
+# for what's in it.
+#
+# Triggers:
+# - Push to master that touches the sandbox Dockerfile (or this workflow)
+# - Manual ``workflow_dispatch`` for force rebuilds
+#
+# Tags published: ``latest`` (always tracks master) + ``sha-<short>`` for
+# traceable rollbacks.
+#
+# Security note: this workflow does not interpolate any untrusted input
+# (issue titles, PR bodies, head_ref, etc.) into ``run:`` commands.  Only
+# trusted contexts (github.actor, secrets.GITHUB_TOKEN, outputs from
+# pinned docker/* actions) are referenced.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - docker/Dockerfile.sandbox
+      - .github/workflows/build-sandbox.yml
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/eumemic/aios-sandbox
+          tags: |
+            type=raw,value=latest
+            type=sha,format=short,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: docker
+          file: docker/Dockerfile.sandbox
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -122,7 +122,7 @@ jobs:
         run: uv run pytest tests/integration -q
 
       - name: Build sandbox image
-        run: docker build -t aios-sandbox:latest -f docker/Dockerfile.sandbox docker/
+        run: docker build -t ghcr.io/eumemic/aios-sandbox:latest -f docker/Dockerfile.sandbox docker/
 
       - name: E2E tests
         run: uv run pytest tests/e2e -q

--- a/README.md
+++ b/README.md
@@ -132,8 +132,11 @@ docker run -d --name aios-pg -p 5433:5432 \
   -e POSTGRES_USER=aios -e POSTGRES_PASSWORD=aios -e POSTGRES_DB=aios \
   postgres:16-alpine
 
-# Build the sandbox image
-docker build -t aios-sandbox:latest -f docker/Dockerfile.sandbox docker/
+# Sandbox image: pulled from GHCR on first session by default.  For local
+# changes to docker/Dockerfile.sandbox, build locally and point
+# AIOS_DOCKER_IMAGE at the local tag:
+#   docker build -t aios-sandbox:latest -f docker/Dockerfile.sandbox docker/
+#   export AIOS_DOCKER_IMAGE=aios-sandbox:latest
 
 # Configure
 cat > .env << 'EOF'
@@ -371,7 +374,7 @@ All aios settings use the `AIOS_` prefix (Pydantic settings):
 | `AIOS_DB_URL` | Postgres connection string (required) |
 | `AIOS_API_HOST` / `AIOS_API_PORT` | API bind address (default `127.0.0.1:8080`) |
 | `AIOS_INSTANCE_ID` | Distinguishes concurrent deployments on a shared host (e.g. dev worktrees) |
-| `AIOS_DOCKER_IMAGE` | Sandbox image (default `aios-sandbox:latest`) |
+| `AIOS_DOCKER_IMAGE` | Sandbox image (default `ghcr.io/eumemic/aios-sandbox:latest`) |
 | `AIOS_WORKSPACE_ROOT` | Host directory bind-mounted as `/workspace` per session |
 | `AIOS_SANDBOX_NETWORK_MODE` | `bridge` / `none` / `host` |
 | `AIOS_WORKER_CONCURRENCY` | Concurrent session steps per worker (default 4) |

--- a/docker/Dockerfile.sandbox
+++ b/docker/Dockerfile.sandbox
@@ -6,10 +6,16 @@
 # grep/glob tools. No languages beyond Python; no package manager state at
 # runtime (apt lists are cleaned).
 #
-# Build with:
+# Published as ``ghcr.io/eumemic/aios-sandbox`` by
+# ``.github/workflows/build-sandbox.yml`` on every change to this file.
+# Deploy targets pull from GHCR via the worker's ``AIOS_DOCKER_IMAGE``
+# env var — no manual on-host build required.
+#
+# Local dev:
 #   docker build -t aios-sandbox:latest -f docker/Dockerfile.sandbox docker/
 # or simply:
 #   uv run python -m aios build-image
+# then point ``AIOS_DOCKER_IMAGE`` at the local tag.
 #
 # The image is labelled `aios.managed=true` at runtime (not build time) via
 # `docker run --label`, so the worker's orphan reaper can find containers

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -75,9 +75,11 @@ class Settings(BaseSettings):
         "extend this enum without changing call sites.",
     )
     docker_image: str = Field(
-        default="aios-sandbox:latest",
-        description="Container image used for all v1 sessions. Build via "
-        "`docker build -t aios-sandbox:latest -f docker/Dockerfile.sandbox docker/`.",
+        default="ghcr.io/eumemic/aios-sandbox:latest",
+        description="Container image used for all v1 sessions. Published from "
+        "`docker/Dockerfile.sandbox` to GHCR by the build-sandbox workflow. "
+        "Override to a local tag for development "
+        "(`docker build -t aios-sandbox:latest -f docker/Dockerfile.sandbox docker/`).",
     )
     workspace_root: Path = Field(
         default=Path("/var/lib/aios/workspaces"),


### PR DESCRIPTION
Closes the long-standing "build the sandbox image on the host" manual setup
step (`eumemic-ops/docs/bootstrap.md` Phase 4).  Today's prod Ultron
sandbox-tool failures (`Unable to find image 'aios-sandbox:latest' locally`)
were the visible symptom — when a fresh Server B was provisioned, that step
was skipped.

## Summary

- New `Build aios-sandbox image` workflow at `.github/workflows/build-sandbox.yml`.  Builds + pushes `ghcr.io/eumemic/aios-sandbox:{latest,sha-<short>}` whenever `docker/Dockerfile.sandbox` changes on master, plus manual `workflow_dispatch`.
- `AIOS_DOCKER_IMAGE` default flips to `ghcr.io/eumemic/aios-sandbox:latest`.  Local-dev overrides documented in `.env.example`, `README.md`, and the Dockerfile header.
- No code changes to the worker's sandbox-spawn logic.  It already accepts any image reference via `AIOS_DOCKER_IMAGE`; just changing the default.

## Sequencing

1. Land this PR.
2. **Manual one-time step** in GitHub Settings → Packages: set `aios-sandbox` package visibility to **public** (no `docker login` required on pull side).
3. Companion PR in `eumemic-ops`: update `AIOS_DOCKER_IMAGE` on the aios-worker Coolify Application; delete `docs/bootstrap.md` Phase 4; sweep audit-script staleness.
4. Redeploy aios-worker.  Next sandbox tool call (e.g. `aios sessions send <ultron> "list /workspace"`) pulls the image on first use, then succeeds.

## Independent from #328

This work is independent from the connector subsystem rework (#328).  The sandbox image is the worker's per-session container — orthogonal to anything #328 touches.  Either can land first.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1152 passed
- [ ] CI: workflow runs on this PR's master-merge (paths-filtered to the Dockerfile + workflow itself).  First publish will appear in the repo's Packages tab.
- [ ] Manual cutover: package set to public, worker env updated, sandbox tool call verified end-to-end on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)