### PR TITLE
refactor: pre-work for connector subsystem rework (PR 1/8 of #328)

### DIFF
--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -28,11 +28,11 @@ from aios.errors import (
     PayloadTooLargeError,
     ValidationError,
 )
-from aios.harness.wake import defer_wake
 from aios.models.connections import Connection, ConnectionSetTools, ConnectorSecrets
 from aios.services import connections as connections_service
 from aios.services import inbound as inbound_service
 from aios.services import sessions as sessions_service
+from aios.services.wake import defer_wake
 
 router = APIRouter(prefix="/v1/connectors", tags=["connectors"])
 

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -29,7 +29,6 @@ from aios.api.sse import sse_event_stream
 from aios.db import queries
 from aios.db.listen import SESSION_INTERRUPT_CHANNEL, listen_for_events
 from aios.errors import ForbiddenError, ValidationError
-from aios.harness.wake import defer_wake
 from aios.ids import GITHUB_REPOSITORY, split_id
 from aios.models.common import ListResponse
 from aios.models.events import Event, EventKind
@@ -55,6 +54,7 @@ from aios.models.sessions import (
 from aios.services import files as files_service
 from aios.services import github_repositories as github_repo_service
 from aios.services import sessions as service
+from aios.services.wake import defer_wake
 
 router = APIRouter(prefix="/v1/sessions", tags=["sessions"])
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2691,50 +2691,6 @@ async def get_connection(conn: asyncpg.Connection[Any], connection_id: str) -> C
     return _row_to_connection(row)
 
 
-async def session_authorizes_connector_account(
-    conn: asyncpg.Connection[Any],
-    session_id: str,
-    connector: str,
-    account: str,
-) -> bool:
-    """Permission check for outbound connector tool calls.
-
-    True iff there's an active connection whose ``(connector, account)``
-    matches AND any of:
-
-    * ``c.session_id`` is this session (single_session attach), OR
-    * ``c.id`` is this session's ``spawned_from_connection_id``
-      (per_chat origin grant), OR
-    * a row in ``connection_chat_sessions`` ties this connection to
-      this session (operator-curated chat binding, #215).
-
-    Used by the outbound MCP dispatch to gate tool calls that take an
-    explicit ``account`` argument — the supervisor will happily forward
-    to the connector regardless, but the model shouldn't be able to
-    reach accounts the operator hasn't bound to this session.
-    """
-    row = await conn.fetchrow(
-        """
-        SELECT 1
-          FROM connections c
-          LEFT JOIN sessions s ON s.id = $1
-         WHERE c.connector = $2
-           AND c.account = $3
-           AND c.archived_at IS NULL
-           AND (c.session_id = $1
-                OR c.id = s.spawned_from_connection_id
-                OR EXISTS (SELECT 1 FROM connection_chat_sessions ccs
-                            WHERE ccs.connection_id = c.id
-                              AND ccs.session_id = $1))
-         LIMIT 1
-        """,
-        session_id,
-        connector,
-        account,
-    )
-    return row is not None
-
-
 async def set_connection_tools(
     conn: asyncpg.Connection[Any],
     connection_id: str,
@@ -2838,15 +2794,11 @@ async def list_connection_tools_for_session(
 ) -> list[dict[str, Any]]:
     """Custom tool specs from every active connection bound to ``session_id``.
 
-    Mirrors the three lineage paths in
-    :func:`session_authorizes_connector_account`:
-
-    * ``c.session_id = $1`` — single_session attach
-    * ``c.id = s.spawned_from_connection_id`` — per_chat origin
-    * ``connection_chat_sessions`` — operator-curated chat binding
-
-    Returns the flattened list of ToolSpec dicts (jsonb) ready to feed
-    through :func:`tools.registry.to_openai_tools_custom`.
+    Walks the three lineage paths enumerated in
+    :func:`is_session_bound_to_connection` (single_session attach,
+    per_chat origin, operator-curated chat binding) and returns the
+    flattened list of ToolSpec dicts (jsonb) ready to feed through
+    :func:`tools.registry.to_openai_tools_custom`.
     """
     rows = await conn.fetch(
         """

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -32,11 +32,11 @@ from aios.harness.step_context import compose_step_context, compute_step_prelude
 from aios.harness.sweep import find_sessions_needing_inference
 from aios.harness.tokens import approx_tokens
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
-from aios.harness.wake import defer_wake
 from aios.logging import get_logger
 from aios.models.agents import ToolSpec
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
+from aios.services.wake import defer_wake
 
 if TYPE_CHECKING:
     import asyncpg
@@ -617,13 +617,9 @@ def _is_mcp_tool(name: str) -> bool:
 def _is_known_mcp_server(server_name: str, mcp_server_map: dict[str, str]) -> bool:
     """Return True if ``server_name`` resolves to a registered MCP server.
 
-    A server is "known" if either:
-
-    * It's a connector instance currently registered with the
-      :class:`~aios.harness.connector_supervisor.ConnectorSubprocessRegistry`,
-      or
-    * It appears in ``mcp_server_map`` (the agent-declared HTTP MCP
-      servers, keyed by ``McpServerSpec.name``).
+    ``mcp_server_map`` is the agent-derived map of MCP server names →
+    URLs (built upstream from both agent-declared HTTP MCP servers and
+    connection-provided MCP servers — all HTTP transport since #318).
 
     Used by :func:`_classify_tool_call` to short-circuit hallucinated
     tool names before the permission gate, so the model gets a tool

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -28,9 +28,9 @@ if TYPE_CHECKING:
     from aios.models.agents import ToolSpec
 
 from aios.harness.task_registry import TaskRegistry
-from aios.harness.wake import defer_wake
 from aios.logging import get_logger
 from aios.services import sessions as sessions_service
+from aios.services.wake import defer_wake
 
 log = get_logger("aios.harness.sweep")
 

--- a/src/aios/harness/tasks.py
+++ b/src/aios/harness/tasks.py
@@ -6,14 +6,14 @@
     the job and runs a single inference step.
 
     The lock and queueing_lock are NOT set on the decorator — they are
-    passed per call from :mod:`aios.harness.wake` (``defer_wake``).
+    passed per call from :mod:`aios.services.wake` (``defer_wake``).
     Procrastinate stores the decorator's lock arguments verbatim with
     no kwarg-template substitution, so a decorator-level
     ``lock="{session_id}"`` would assign every job the same literal
     lock value and serialize all sessions through one job slot — the
     bug behind issue #192.
 
-    Per-call values used by :mod:`aios.harness.wake`:
+    Per-call values used by :mod:`aios.services.wake`:
 
     * ``lock=session_id``: procrastinate enforces mutual exclusion via
       a partial unique index ``WHERE status='doing'``. With distinct

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -3,22 +3,20 @@
 ``aios serve worker`` runs :func:`worker_main` in an asyncio event loop. It:
 
 1. Configures structlog
-2. Opens the asyncpg pool
-3. Acquires a Postgres advisory lock to refuse a duplicate worker
+2. Acquires a Postgres advisory lock to refuse a duplicate worker
+3. Opens the asyncpg pool
 4. Constructs the libsodium CryptoBox
 5. Creates the SandboxRegistry, TaskRegistry, and McpSessionPool
-6. Resolves and starts the connector subprocess supervisor
-7. Stashes globals on :mod:`aios.harness.runtime`
-8. Opens the procrastinate connector
-9. Recovers orphaned sessions (re-enqueue stuck ones)
-10. Reaps orphaned sandbox containers
-11. Starts the container idle-TTL reaper
-12. Starts ``app.run_worker_async`` which blocks until SIGTERM/SIGINT
+6. Stashes globals on :mod:`aios.harness.runtime`
+7. Opens the procrastinate connector
+8. Sweeps orphan attachments, reaps stalled jobs, wakes sessions needing inference
+9. Reaps orphaned sandbox containers
+10. Starts the container idle-TTL reaper, periodic sweep, interrupt listener, and liveness heartbeat
+11. Starts ``app.run_worker_async`` which blocks until SIGTERM/SIGINT
 
 Shutdown: procrastinate's signal handlers stop accepting new jobs and wait
 for in-flight jobs. The ``finally`` block then cancels in-flight tool tasks,
-releases all containers, closes MCP sessions, stops the connector
-supervisor, and closes connections.
+releases all containers, closes MCP sessions, and closes connections.
 """
 
 from __future__ import annotations
@@ -55,11 +53,11 @@ from aios.mcp.pool import McpSessionPool
 from aios.sandbox.backends import make_backend
 from aios.sandbox.registry import SandboxRegistry
 
-# 64-bit hash of the lock identifier; stable across processes / restarts.
-# Generated once via Postgres ``hashtextextended('aios_worker_connector_supervisor', 0)``
-# and inlined so we don't burn a query just to compute it.  The text key
-# stays in code as documentation of *what* this number means.
-_WORKER_LOCK_KEY_TEXT = "aios_worker_connector_supervisor"
+# Hashed (via Postgres ``hashtextextended($1, 0)``) into the 64-bit
+# advisory-lock key enforcing the worker-process singleton. The string
+# is a historical magic value, preserved verbatim so a rolling deploy
+# computes the same lock number across old and new workers.
+_WORKER_SINGLETON_LOCK_KEY_TEXT = "aios_worker_connector_supervisor"
 
 # Path the worker touches periodically to signal liveness; the Dockerfile
 # HEALTHCHECK reads its mtime. tmpfs in containers, so touch/unlink are
@@ -83,11 +81,13 @@ async def worker_main() -> None:
     install_exit_diagnostics(log)
 
     # Single-instance guard.  Two `aios worker` processes against the same
-    # database would race for connector subprocess ownership (signal-cli's
-    # local socket, telegram's bot session, etc.) so we refuse to boot a
-    # second worker by holding a session-scoped advisory lock on a
-    # dedicated connection.  Pool-borrowed connections release the lock
-    # on return, so the lock conn is intentionally NOT in the pool.
+    # database would compete over per-worker state that procrastinate's
+    # session-scoped job lock doesn't cover — in-memory sandbox container
+    # stewardship, attachment-staging atomicity, the startup orphan sweep.
+    # So we refuse to boot a second worker by holding a session-scoped
+    # advisory lock on a dedicated connection.  Pool-borrowed connections
+    # release the lock on return, so the lock conn is intentionally NOT
+    # in the pool.
     lock_conn = await _acquire_worker_lock(settings.db_url, log)
     if lock_conn is None:
         sys.exit(1)
@@ -263,14 +263,14 @@ async def _acquire_worker_lock(
         while True:
             held: bool = await conn.fetchval(
                 "SELECT pg_try_advisory_lock(hashtextextended($1, 0))",
-                _WORKER_LOCK_KEY_TEXT,
+                _WORKER_SINGLETON_LOCK_KEY_TEXT,
             )
             if held:
                 return conn
             if time.monotonic() >= deadline:
                 log.error(
                     "worker.duplicate_instance_refused",
-                    lock_key=_WORKER_LOCK_KEY_TEXT,
+                    lock_key=_WORKER_SINGLETON_LOCK_KEY_TEXT,
                     waited_seconds=timeout_seconds,
                 )
                 await conn.close()
@@ -278,7 +278,7 @@ async def _acquire_worker_lock(
             if not waiting_logged:
                 log.info(
                     "worker.lock_busy.waiting",
-                    lock_key=_WORKER_LOCK_KEY_TEXT,
+                    lock_key=_WORKER_SINGLETON_LOCK_KEY_TEXT,
                     timeout_seconds=timeout_seconds,
                 )
                 waiting_logged = True

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -189,10 +189,6 @@ async def discover_mcp_tools(
 def shape_call_result(result: Any) -> dict[str, Any]:
     """Project an MCP ``CallToolResult`` onto aios's ``{"content"|"error": str}`` envelope.
 
-    Shared by the HTTP-transport path here and the stdio-transport path
-    in :class:`~aios.harness.connector_supervisor.ConnectorSubprocessRegistry`
-    so both surfaces stay byte-identical.
-
     Tool-level errors carry ``code="tool_error"`` so the API router can
     distinguish them from transport / not-ready / circuit-open
     failures (mapped to different HTTP statuses) without substring

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -177,7 +177,8 @@ def attachments_root() -> Path:
     Each session subdir is bind-mounted read-only into its container at
     ``/mnt/attachments`` (see :mod:`aios.sandbox.provisioner`). Inbound
     binary blobs (Signal photos, Telegram voice notes, etc.) are staged
-    here by :mod:`aios.harness.connector_supervisor` before the inbound
+    here by :mod:`aios.services.attachment_staging` from
+    :func:`aios.services.inbound.handle_inbound` before the inbound
     event is appended; the model sees them at stable in-sandbox paths
     of the form ``/mnt/attachments/<connector>/<event-ulid>-<filename>``.
     """

--- a/src/aios/services/attachment_staging.py
+++ b/src/aios/services/attachment_staging.py
@@ -77,8 +77,9 @@ def stage_inbound_attachments(
     other attachment's bytes corrupts ``metadata.attachments``. The
     realistic trigger (e.g. Telegram album with two ``image.jpg``
     files) is the platform's responsibility to disambiguate via the
-    SDK; the supervisor drops the inbound and the operator sees the
-    canonical ``attachment_staging_failed`` reason.
+    SDK; on collision this function raises :class:`AttachmentStagingError`,
+    the inbound is dropped, and the operator sees the canonical
+    ``attachment_staging_failed`` reason.
     """
     if not isinstance(raw_attachments, list) or not raw_attachments:
         return [], []

--- a/src/aios/services/attachment_staging.py
+++ b/src/aios/services/attachment_staging.py
@@ -1,8 +1,9 @@
 """Inbound attachment staging.
 
-The connector hands the SDK a host path it owns; bytes never
-traverse stdio. The supervisor renames each attachment into a
-stable per-session location before appending the inbound event::
+Connector containers POST inbound messages with attachment host
+paths to ``POST /v1/connectors/inbound``; this module renames each
+attachment into a stable per-session location before the inbound
+event is appended::
 
     <workspace_root>/_attachments/<session_id>/<connector>/<event-ulid>-<filename>
 

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -180,29 +180,6 @@ async def unconfigure_connection(pool: asyncpg.Pool[Any], connection_id: str) ->
         return await queries.unconfigure_connection(conn, connection_id)
 
 
-async def validate_account_for_session(
-    pool: asyncpg.Pool[Any],
-    session_id: str,
-    *,
-    connector: str,
-    account: str,
-) -> bool:
-    """Return True iff ``session_id`` is allowed to act on ``(connector, account)``.
-
-    Authorization model: a session may invoke connector tools targeted
-    at accounts that are either bound to it via ``connections.session_id``
-    (single_session attach), spawned it via
-    ``sessions.spawned_from_connection_id`` (per_chat origin), or
-    operator-curated to it via a row in ``connection_chat_sessions``
-    (#215).  Used by the outbound MCP dispatch — see
-    :mod:`aios.harness.tool_dispatch`.
-    """
-    async with pool.acquire() as conn:
-        return await queries.session_authorizes_connector_account(
-            conn, session_id, connector, account
-        )
-
-
 async def bind_chat_to_session(
     pool: asyncpg.Pool[Any],
     connection_id: str,

--- a/src/aios/services/inbound.py
+++ b/src/aios/services/inbound.py
@@ -1,14 +1,12 @@
-"""Inbound message handling for connector containers (#301).
+"""Inbound message handling for connector containers (#301, #318).
 
-The new ``POST /v1/connectors/inbound`` endpoint calls
+The ``POST /v1/connectors/inbound`` endpoint calls
 :func:`handle_inbound`, which wraps the dedup / attachment-staging /
-session-resolution logic that today also lives in
-``connector_supervisor._handle_inbound``.  Both paths share the same
-DB primitives (``try_record_inbound_ack``, ``append_event``,
-``stage_inbound_attachments``) so the supervisor and the new HTTP path
-produce indistinguishable event-log state.
-
-In PR 6 the supervisor is deleted and this is the only inbound path.
+session-resolution logic shared with the peer HTTP-client connector
+architecture introduced in #318. Built on
+:func:`aios.db.queries.try_record_inbound_ack`,
+:func:`aios.services.sessions.append_event`, and
+:func:`aios.services.attachment_staging.stage_inbound_attachments`.
 """
 
 from __future__ import annotations
@@ -21,14 +19,14 @@ import asyncpg
 
 from aios.db import queries
 from aios.errors import NotFoundError
-from aios.harness.attachment_staging import (
-    AttachmentStagingError,
-    stage_inbound_attachments,
-)
-from aios.harness.wake import defer_wake
 from aios.models.connections import Connection
 from aios.models.sessions import MAX_USER_MESSAGE_CHARS
 from aios.services import sessions as sessions_service
+from aios.services.attachment_staging import (
+    AttachmentStagingError,
+    stage_inbound_attachments,
+)
+from aios.services.wake import defer_wake
 
 
 class _DedupRollback(Exception):

--- a/src/aios/services/wake.py
+++ b/src/aios/services/wake.py
@@ -18,7 +18,7 @@ from aios.services import sessions as sessions_service
 if TYPE_CHECKING:
     import asyncpg
 
-log = get_logger("aios.harness.wake")
+log = get_logger("aios.services.wake")
 
 
 async def defer_wake(

--- a/src/aios/tools/schedule_wake.py
+++ b/src/aios/tools/schedule_wake.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from aios.errors import AiosError
 from aios.harness import runtime
-from aios.harness.wake import defer_wake
+from aios.services.wake import defer_wake
 from aios.tools.registry import registry
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -141,7 +141,7 @@ async def harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     with (
         mock.patch("aios.harness.completion.litellm.acompletion", _fake_acompletion),
         mock.patch("aios.harness.completion.litellm.stream_chunk_builder", _fake_chunk_builder),
-        mock.patch("aios.harness.wake.defer_wake", _noop_defer_wake),
+        mock.patch("aios.services.wake.defer_wake", _noop_defer_wake),
     ):
         yield h
 
@@ -204,7 +204,7 @@ async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     with (
         mock.patch("aios.harness.completion.litellm.acompletion", _fake_acompletion),
         mock.patch("aios.harness.completion.litellm.stream_chunk_builder", _fake_chunk_builder),
-        mock.patch("aios.harness.wake.defer_wake", _noop_defer_wake),
+        mock.patch("aios.services.wake.defer_wake", _noop_defer_wake),
     ):
         yield h
 
@@ -245,7 +245,7 @@ async def http_client(aios_env: dict[str, str]) -> AsyncIterator[Any]:
     app.state.procrastinate = mock.MagicMock()
     transport = httpx.ASGITransport(app=app)
     # Mock at every call site that imports ``defer_wake`` directly —
-    # patching the source (``aios.harness.wake``) is too late since the
+    # patching the source (``aios.services.wake``) is too late since the
     # importing modules already captured the unmocked reference.
     with (
         mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock),

--- a/tests/e2e/test_litellm_502_recovery.py
+++ b/tests/e2e/test_litellm_502_recovery.py
@@ -41,7 +41,7 @@ class TestLiteLLMBadGatewayRecovery:
             return harness._pop_response(**kwargs)
 
         # ``loop.py`` binds ``defer_wake`` via ``from … import …``, so the
-        # conftest's patch on ``aios.harness.wake.defer_wake`` doesn't reach
+        # conftest's patch on ``aios.services.wake.defer_wake`` doesn't reach
         # the loop-level call site.  Patch the loop binding directly.
         async def _noop_defer_wake(*args: Any, **kwargs: Any) -> None:
             return None

--- a/tests/e2e/test_wake_lock_release_latency.py
+++ b/tests/e2e/test_wake_lock_release_latency.py
@@ -27,7 +27,7 @@ class TestWakeLockReleaseLatencyE2E:
         """When a lock-blocked wake becomes eligible, the worker must pick
         it up within a single LISTEN/NOTIFY round-trip (<200ms)."""
         from aios.harness.procrastinate_app import app as procrastinate_app
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = real_wake_setup
 

--- a/tests/e2e/test_worker_concurrency.py
+++ b/tests/e2e/test_worker_concurrency.py
@@ -46,7 +46,7 @@ class TestWorkerConcurrencyE2E:
         self, real_wake_setup: asyncpg.Pool[Any], aios_env: dict[str, str]
     ) -> None:
         from aios.harness.procrastinate_app import app as procrastinate_app
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = real_wake_setup
         n_sessions = 8

--- a/tests/unit/test_attachment_staging.py
+++ b/tests/unit/test_attachment_staging.py
@@ -1,4 +1,4 @@
-"""Unit coverage for :mod:`aios.harness.attachment_staging`.
+"""Unit coverage for :mod:`aios.services.attachment_staging`.
 
 Exercises the rename/copy/cleanup state machine with a temp
 ``workspace_root`` so we never touch the production attachments
@@ -16,11 +16,11 @@ from typing import Any
 import pytest
 
 from aios.config import get_settings
-from aios.harness.attachment_staging import (
+from aios.sandbox.volumes import safe_filename
+from aios.services.attachment_staging import (
     AttachmentStagingError,
     stage_inbound_attachments,
 )
-from aios.sandbox.volumes import safe_filename
 
 
 @pytest.fixture

--- a/tests/unit/test_scheduled_wake_marker.py
+++ b/tests/unit/test_scheduled_wake_marker.py
@@ -112,9 +112,9 @@ class TestDeferWakeExtension:
         from procrastinate.testing import InMemoryConnector
 
         from aios.harness.procrastinate_app import app
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
-        monkeypatch.setattr("aios.harness.wake.sessions_service.append_event", AsyncMock())
+        monkeypatch.setattr("aios.services.wake.sessions_service.append_event", AsyncMock())
 
         patched: App
         with app.replace_connector(InMemoryConnector()) as patched:
@@ -145,9 +145,9 @@ class TestDeferWakeExtension:
         from procrastinate.testing import InMemoryConnector
 
         from aios.harness.procrastinate_app import app
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
-        monkeypatch.setattr("aios.harness.wake.sessions_service.append_event", AsyncMock())
+        monkeypatch.setattr("aios.services.wake.sessions_service.append_event", AsyncMock())
 
         with app.replace_connector(InMemoryConnector()) as patched:
             await defer_wake(MagicMock(), "sess_x", cause="message")

--- a/tests/unit/test_wake.py
+++ b/tests/unit/test_wake.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from procrastinate import App
 
-from aios.harness.wake import defer_wake
+from aios.services.wake import defer_wake
 
 
 @pytest.fixture(autouse=True)
@@ -17,7 +17,7 @@ def mock_append_event() -> AsyncIterator[AsyncMock]:
     """Patch ``sessions_service.append_event`` so ``wake_deferred`` span
     emission doesn't require a real DB connection (issue #131)."""
     mock = AsyncMock()
-    with patch("aios.harness.wake.sessions_service.append_event", mock):
+    with patch("aios.services.wake.sessions_service.append_event", mock):
         yield mock
 
 

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -29,7 +29,7 @@ class TestE2EConftestMockSignatures:
     def test_noop_defer_wake_matches_real_defer_wake(self) -> None:
         import inspect
 
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
         from tests.e2e.conftest import _noop_defer_wake
 
         real_params = list(inspect.signature(defer_wake).parameters.keys())
@@ -39,11 +39,11 @@ class TestE2EConftestMockSignatures:
 
 class TestWakeDeferredEvent:
     async def test_defer_wake_emits_span_with_cause(self, in_memory_app: App) -> None:
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         mock_append = AsyncMock()
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", mock_append):
+        with patch("aios.services.wake.sessions_service.append_event", mock_append):
             await defer_wake(pool, "sess_x", cause="message")
 
         mock_append.assert_awaited_once_with(
@@ -54,11 +54,11 @@ class TestWakeDeferredEvent:
         )
 
     async def test_defer_wake_span_carries_delay_when_scheduled(self, in_memory_app: App) -> None:
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         mock_append = AsyncMock()
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", mock_append):
+        with patch("aios.services.wake.sessions_service.append_event", mock_append):
             await defer_wake(pool, "sess_x", cause="scheduled", delay_seconds=30, wake_reason="r")
 
         mock_append.assert_awaited_once_with(
@@ -71,11 +71,11 @@ class TestWakeDeferredEvent:
     async def test_defer_wake_emits_span_even_when_coalesced(self, in_memory_app: App) -> None:
         """N deferrals must all emit ``wake_deferred``, even if procrastinate
         coalesces them — the profiler observes coalescing as N deferred → 1 step."""
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         mock_append = AsyncMock()
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", mock_append):
+        with patch("aios.services.wake.sessions_service.append_event", mock_append):
             await defer_wake(pool, "sess_x", cause="message")
             await defer_wake(pool, "sess_x", cause="sweep")
             await defer_wake(pool, "sess_x", cause="tool_confirmation")
@@ -89,11 +89,11 @@ class TestWakeDeferredEvent:
     async def test_defer_wake_with_reschedule_cause_emits_reschedule_span(
         self, in_memory_app: App
     ) -> None:
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         mock_append = AsyncMock()
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", mock_append):
+        with patch("aios.services.wake.sessions_service.append_event", mock_append):
             await defer_wake(pool, "sess_x", cause="reschedule", delay_seconds=2)
 
         mock_append.assert_awaited_once_with(

--- a/tests/unit/test_wake_locks.py
+++ b/tests/unit/test_wake_locks.py
@@ -25,10 +25,10 @@ def _job_rows(app: App) -> list[dict]:
 
 class TestDeferWakeLockValues:
     async def test_lock_is_session_id(self, in_memory_app: App) -> None:
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+        with patch("aios.services.wake.sessions_service.append_event", AsyncMock()):
             await defer_wake(pool, "sess_alpha", cause="message")
 
         rows = _job_rows(in_memory_app)
@@ -36,10 +36,10 @@ class TestDeferWakeLockValues:
         assert rows[0]["lock"] == "sess_alpha"
 
     async def test_queueing_lock_is_session_id(self, in_memory_app: App) -> None:
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+        with patch("aios.services.wake.sessions_service.append_event", AsyncMock()):
             await defer_wake(pool, "sess_beta", cause="message")
 
         rows = _job_rows(in_memory_app)
@@ -47,10 +47,10 @@ class TestDeferWakeLockValues:
         assert rows[0]["queueing_lock"] == "sess_beta"
 
     async def test_reschedule_defer_wake_uses_session_id_lock(self, in_memory_app: App) -> None:
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+        with patch("aios.services.wake.sessions_service.append_event", AsyncMock()):
             await defer_wake(pool, "sess_gamma", cause="reschedule", delay_seconds=2)
 
         rows = _job_rows(in_memory_app)
@@ -67,12 +67,12 @@ class TestDeferWakeCrossSessionIsolation:
         the original bug wouldn't raise — it would surface as fewer
         queued jobs than sessions.
         """
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = MagicMock()
         n = 5
 
-        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+        with patch("aios.services.wake.sessions_service.append_event", AsyncMock()):
             for i in range(n):
                 await defer_wake(pool, f"sess_{i}", cause="message")
 
@@ -87,11 +87,11 @@ class TestDeferWakeCrossSessionIsolation:
         completion + sweep) collapse into a single wake; the queued
         wake handles all events that arrived since it was deferred.
         """
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = MagicMock()
 
-        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+        with patch("aios.services.wake.sessions_service.append_event", AsyncMock()):
             await defer_wake(pool, "sess_x", cause="message")
             await defer_wake(pool, "sess_x", cause="sweep")
             await defer_wake(pool, "sess_x", cause="tool_confirmation")


### PR DESCRIPTION
## Summary

PR 1 of the 8-PR stack for #328. **Pre-work foundation**: relocates two modules into `aios.services.*`, deletes connector-area dead code, sweeps stale `connector_supervisor` documentation. No new functionality, no schema changes, no behavior changes.

## What it does

- **Bucket A — Module relocations** (`git mv`, blame preserved):
  - `aios.harness.attachment_staging` → `aios.services.attachment_staging`
  - `aios.harness.wake` → `aios.services.wake`
  - All 17 importers updated (src + tests, including `mock.patch(...)` strings).
  - The new `aios_connectors` subsystem layer (lands in PR 2+) needs these in services so it can import them without crossing the harness boundary.

- **Bucket B — Dead-code deletion**:
  - `services.connections.validate_account_for_session`
  - `db.queries.session_authorizes_connector_account`
  - Both unreferenced post-#318. Docstring back-reference in `list_connection_tools_for_session` redirects to `is_session_bound_to_connection`, which already documents the three lineage paths.

- **Bucket C — Stale `connector_supervisor` documentation sweep** (the supervisor class was removed in #307):
  - 5 docstrings/comments updated in `mcp/client.py`, `sandbox/volumes.py`, `harness/loop.py`, `services/inbound.py`, `harness/worker.py` (module docstring + lock guard comment), `services/attachment_staging.py` (post-move).
  - `_WORKER_LOCK_KEY_TEXT` constant renamed to `_WORKER_SINGLETON_LOCK_KEY_TEXT`. The string literal `"aios_worker_connector_supervisor"` is kept verbatim — it's the input to `hashtextextended()` for an advisory lock, and rolling deploys must compute the same lock number.

Net **-79 lines** (92 insertions, 171 deletions).

## Test plan

- [x] `uv run mypy src` — 0 errors
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — **1152 passed**
- [x] `uv run pytest tests/e2e -q` — 275 passed, 12 environmental failures (missing arm64 manifest for `ghcr.io/eumemic/aios-sandbox:latest` from #329; unrelated to this PR)
- [x] Exhaustive grep gates clean:
  ```
  rg 'aios\.harness\.wake|aios\.harness\.attachment_staging' src tests  →  0
  rg 'connector_supervisor' src tests                                   →  string literal only (intentional)
  rg 'validate_account_for_session|session_authorizes_connector_account' src tests  →  0
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)