### PR TITLE
feat: core schema additions + ToolProvider Protocol (PR 3/8 of #328)

### DIFF
--- a/migrations/versions/0033_subsystem_tables.py
+++ b/migrations/versions/0033_subsystem_tables.py
@@ -101,9 +101,11 @@ def upgrade() -> None:
         "ON bindings (session_template_id) WHERE archived_at IS NULL"
     )
 
-    # ``gen_random_uuid()`` is built into PG 13+; the prefix matches
-    # ``aios.ids.BINDING`` so backfilled rows interop with future
-    # ``make_id(BINDING)``-generated rows as plain text PKs.
+    # ``gen_random_uuid()`` is built into PG 13+; the ``bnd_`` prefix
+    # matches ``aios.ids.BINDING`` for log readability. The body is hex
+    # rather than a Crockford-ULID — pure-SQL ULID generation isn't
+    # worth the complexity here, and no current code path runs
+    # ``split_id`` on a binding id. See note on ``BINDING`` in ids.py.
     op.execute(
         """
         INSERT INTO bindings (id, connection_id, mode, session_id,

--- a/migrations/versions/0033_subsystem_tables.py
+++ b/migrations/versions/0033_subsystem_tables.py
@@ -1,0 +1,245 @@
+"""Connector subsystem tables alongside old, with backfill (#328 PR 2/8).
+
+Lands the seven ``aios_connectors`` subsystem tables (``connectors``,
+``bindings``, ``chat_sessions``, ``routing_rules``, ``runtimes``,
+``runtime_tokens``, ``inbound_acks``) alongside today's connector tables.
+Old tables stay authoritative this PR; PR 4 is the code switch. Backfill
+seeds the new tables from existing data where the mapping is mechanical
+(curation, chat ledger, dedup). Runtime liveness and bearer tokens stay
+empty — PR 5/6 populate them.
+
+Every new table reserves ``user_id text`` for the future multi-tenant
+migration (no enforcement here; PR 3 adds it to existing core tables).
+
+Revision ID: 0033
+Revises: 0032
+Create Date: 2026-05-12
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0033"
+down_revision: str = "0032"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ---- connectors: connector-type catalog -------------------------------
+    # Natural-key PK: the connector type IS the identity (a small fixed set
+    # — "signal", "telegram", "echo-http", …). Future sharding across
+    # multiple runtimes of the same type still keys on the type, so a
+    # surrogate id would just add indirection.
+    op.execute(
+        """
+        CREATE TABLE connectors (
+            connector     text PRIMARY KEY,
+            tools_schema  jsonb NOT NULL DEFAULT '[]'::jsonb,
+            user_id       text,
+            created_at    timestamptz NOT NULL DEFAULT now(),
+            updated_at    timestamptz NOT NULL DEFAULT now()
+        )
+        """
+    )
+
+    # Most recently updated active connection's tools jsonb wins per
+    # connector type; operator reconciliation post-PR 5 supersedes.
+    op.execute(
+        """
+        INSERT INTO connectors (connector, tools_schema, created_at, updated_at)
+        SELECT DISTINCT ON (connector)
+               connector,
+               COALESCE(tools, '[]'::jsonb),
+               now(),
+               now()
+          FROM connections
+         WHERE archived_at IS NULL
+         ORDER BY connector, updated_at DESC
+        """
+    )
+
+    # ---- bindings: unit of curation ---------------------------------------
+    op.execute(
+        """
+        CREATE TABLE bindings (
+            id                   text PRIMARY KEY,
+            connection_id        text NOT NULL REFERENCES connections(id),
+            mode                 text NOT NULL,
+            session_id           text REFERENCES sessions(id),
+            session_template_id  text REFERENCES session_templates(id),
+            user_id              text,
+            created_at           timestamptz NOT NULL DEFAULT now(),
+            archived_at          timestamptz,
+            CONSTRAINT bindings_mode_ck CHECK (mode IN ('single_session', 'per_chat')),
+            CONSTRAINT bindings_target_matches_mode_ck CHECK (
+                (mode = 'single_session'
+                    AND session_id IS NOT NULL
+                    AND session_template_id IS NULL)
+             OR (mode = 'per_chat'
+                    AND session_template_id IS NOT NULL
+                    AND session_id IS NULL)
+            )
+        )
+        """
+    )
+    # At most one active binding per connection (matches today's invariant
+    # that a connection has at most one curation target).
+    op.execute(
+        "CREATE UNIQUE INDEX bindings_connection_active_uniq "
+        "ON bindings (connection_id) WHERE archived_at IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX bindings_session_id_idx "
+        "ON bindings (session_id) WHERE archived_at IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX bindings_session_template_id_idx "
+        "ON bindings (session_template_id) WHERE archived_at IS NULL"
+    )
+
+    # ``gen_random_uuid()`` is built into PG 13+; the prefix matches
+    # ``aios.ids.BINDING`` so backfilled rows interop with future
+    # ``make_id(BINDING)``-generated rows as plain text PKs.
+    op.execute(
+        """
+        INSERT INTO bindings (id, connection_id, mode, session_id,
+                              session_template_id, created_at)
+        SELECT 'bnd_' || REPLACE(gen_random_uuid()::text, '-', ''),
+               id,
+               CASE WHEN session_id IS NOT NULL THEN 'single_session'
+                    ELSE 'per_chat' END,
+               session_id,
+               session_template_id,
+               COALESCE(attached_at, created_at)
+          FROM connections
+         WHERE archived_at IS NULL
+           AND (session_id IS NOT NULL OR session_template_id IS NOT NULL)
+        """
+    )
+
+    # ---- chat_sessions: per_chat ledger ----------------------------------
+    op.execute(
+        """
+        CREATE TABLE chat_sessions (
+            connection_id  text NOT NULL REFERENCES connections(id),
+            chat_id        text NOT NULL,
+            session_id     text NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            user_id        text,
+            created_at     timestamptz NOT NULL DEFAULT now(),
+            PRIMARY KEY (connection_id, chat_id)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX chat_sessions_session_idx ON chat_sessions (session_id)"
+    )
+    op.execute(
+        """
+        INSERT INTO chat_sessions (connection_id, chat_id, session_id, created_at)
+        SELECT connection_id, chat_id, session_id, created_at
+          FROM connection_chat_sessions
+        """
+    )
+
+    # ---- routing_rules: per-binding prefix demux (DDL only this PR) ------
+    # ``target_id`` is plain text rather than a polymorphic FK — SQL can't
+    # FK to a union of (sessions, session_templates) and the application
+    # layer resolves it by ``target_type``. Resolver lands in PR 4.
+    op.execute(
+        """
+        CREATE TABLE routing_rules (
+            id           text PRIMARY KEY,
+            binding_id   text NOT NULL REFERENCES bindings(id) ON DELETE CASCADE,
+            prefix       text NOT NULL,
+            target_type  text NOT NULL,
+            target_id    text NOT NULL,
+            user_id      text,
+            created_at   timestamptz NOT NULL DEFAULT now(),
+            CONSTRAINT routing_rules_target_type_ck
+                CHECK (target_type IN ('session', 'session_template'))
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX routing_rules_binding_id_idx ON routing_rules (binding_id)"
+    )
+
+    # ---- runtimes: container liveness ------------------------------------
+    op.execute(
+        """
+        CREATE TABLE runtimes (
+            id                 text PRIMARY KEY,
+            connector          text NOT NULL REFERENCES connectors(connector),
+            user_id            text,
+            created_at         timestamptz NOT NULL DEFAULT now(),
+            last_heartbeat_at  timestamptz
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX runtimes_connector_idx ON runtimes (connector)"
+    )
+
+    # ---- runtime_tokens: per-connector-type bearer auth ------------------
+    # No ``connection_id`` FK: one bearer scopes N connections of one type,
+    # discovered at runtime via SSE add/remove (PR 5). SHA-256 hash with
+    # soft-revocation, same shape as ``connector_tokens`` (which it replaces).
+    op.execute(
+        """
+        CREATE TABLE runtime_tokens (
+            id            text PRIMARY KEY,
+            connector     text NOT NULL REFERENCES connectors(connector),
+            token_hash    text NOT NULL UNIQUE,
+            label         text,
+            user_id       text,
+            created_at    timestamptz NOT NULL DEFAULT now(),
+            last_used_at  timestamptz,
+            revoked_at    timestamptz
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX runtime_tokens_connector_idx "
+        "ON runtime_tokens (connector) WHERE revoked_at IS NULL"
+    )
+
+    # ---- inbound_acks: dedup ledger (rename target) ----------------------
+    op.execute(
+        """
+        CREATE TABLE inbound_acks (
+            connector      text NOT NULL,
+            account        text NOT NULL,
+            event_id       text NOT NULL,
+            appended_seq   bigint NOT NULL,
+            user_id        text,
+            appended_at    timestamptz NOT NULL DEFAULT now(),
+            PRIMARY KEY (connector, account, event_id)
+        )
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO inbound_acks (connector, account, event_id,
+                                  appended_seq, appended_at)
+        SELECT connector, account, event_id, appended_seq, appended_at
+          FROM connector_inbound_acks
+        """
+    )
+
+
+def downgrade() -> None:
+    # Data-lossy: dropping the new tables doesn't reconstitute prior state
+    # if the new tables were ever written to as authoritative. Provided so
+    # ``alembic downgrade`` doesn't error, not as a real rollback path —
+    # see migrations/versions/0027_connector_redesign.py for the same posture.
+    op.execute("DROP TABLE IF EXISTS inbound_acks")
+    op.execute("DROP TABLE IF EXISTS runtime_tokens")
+    op.execute("DROP TABLE IF EXISTS runtimes")
+    op.execute("DROP TABLE IF EXISTS routing_rules")
+    op.execute("DROP TABLE IF EXISTS chat_sessions")
+    op.execute("DROP TABLE IF EXISTS bindings")
+    op.execute("DROP TABLE IF EXISTS connectors")

--- a/migrations/versions/0034_core_schema_additions.py
+++ b/migrations/versions/0034_core_schema_additions.py
@@ -1,0 +1,102 @@
+"""Core schema additions: sessions.owner_id, focal_locked, user_id reservations (#328 PR 3/8).
+
+Adds the core-side columns the connector subsystem rework relies on:
+
+* ``sessions.owner_id text NULL`` — opaque to core. The subsystem
+  chooses the value; today it's a constant string (no principals table
+  per #328's PR 2 design sign-off), in the future it carries
+  multi-tenant ownership semantics.
+* ``sessions.focal_locked boolean NOT NULL DEFAULT FALSE`` — the
+  ``switch_channel`` tool's gate. Replaces the
+  ``spawned_from_connection_id IS NOT NULL`` check that lived in the
+  tool body. Backfilled here so the invariant survives the migration
+  without any code-side coordination.
+* ``user_id text NULL`` on every existing core user-data table.
+  Reserved for the future multi-tenant migration — no enforcement,
+  no filtering, no query changes. PR 2 already reserved this on the
+  new subsystem tables; this migration completes the coverage.
+
+``spawned_from_connection_id`` stays for now — drops in PR 7 alongside
+its dependent queries.
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-05-12
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0034"
+down_revision: str = "0033"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Existing user-data tables that should reserve a nullable ``user_id``.
+# Excludes tables already covered by PR 2 (bindings/connectors/etc) and
+# tables on the chopping block (connector_tokens, connector_inbound_acks,
+# connection_chat_sessions all drop in PR 7/8).
+_USER_ID_TABLES: Sequence[str] = (
+    "agent_versions",
+    "agents",
+    "connections",
+    "credentials",
+    "environments",
+    "events",
+    "files",
+    "memories",
+    "memory_stores",
+    "memory_versions",
+    "session_github_repositories",
+    "session_memory_stores",
+    "session_templates",
+    "session_vaults",
+    "skill_versions",
+    "skills",
+    "vault_credentials",
+    "vaults",
+)
+
+
+def upgrade() -> None:
+    # ---- sessions: owner_id, focal_locked, user_id -----------------------
+    op.execute(
+        """
+        ALTER TABLE sessions
+          ADD COLUMN owner_id     text,
+          ADD COLUMN focal_locked boolean NOT NULL DEFAULT FALSE,
+          ADD COLUMN user_id      text
+        """
+    )
+
+    # focal_locked backfill: preserve today's "per_chat-spawned sessions
+    # can't switch focal" invariant after the switch_channel tool starts
+    # reading focal_locked instead of spawned_from_connection_id.
+    op.execute(
+        """
+        UPDATE sessions
+           SET focal_locked = TRUE
+         WHERE spawned_from_connection_id IS NOT NULL
+        """
+    )
+
+    # ---- user_id reservation on every other user-data table --------------
+    for table in _USER_ID_TABLES:
+        op.execute(f"ALTER TABLE {table} ADD COLUMN user_id text")
+
+
+def downgrade() -> None:
+    for table in reversed(_USER_ID_TABLES):
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS user_id")
+    op.execute(
+        """
+        ALTER TABLE sessions
+          DROP COLUMN IF EXISTS user_id,
+          DROP COLUMN IF EXISTS focal_locked,
+          DROP COLUMN IF EXISTS owner_id
+        """
+    )

--- a/openapi.json
+++ b/openapi.json
@@ -9119,6 +9119,22 @@
               }
             ],
             "title": "Focal Channel"
+          },
+          "focal_locked": {
+            "type": "boolean",
+            "title": "Focal Locked",
+            "default": false
+          },
+          "owner_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Id"
           }
         },
         "type": "object",

--- a/packages/aios-sdk/aios_sdk/_generated/models/session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session.py
@@ -43,6 +43,8 @@ class Session:
         resources (list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho] | Unset):
         archived_at (datetime.datetime | None | Unset):
         focal_channel (None | str | Unset):
+        focal_locked (bool | Unset):  Default: False.
+        owner_id (None | str | Unset):
     """
 
     id: str
@@ -63,6 +65,8 @@ class Session:
     )
     archived_at: datetime.datetime | None | Unset = UNSET
     focal_channel: None | str | Unset = UNSET
+    focal_locked: bool | Unset = False
+    owner_id: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -131,6 +135,14 @@ class Session:
         else:
             focal_channel = self.focal_channel
 
+        focal_locked = self.focal_locked
+
+        owner_id: None | str | Unset
+        if isinstance(self.owner_id, Unset):
+            owner_id = UNSET
+        else:
+            owner_id = self.owner_id
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -158,6 +170,10 @@ class Session:
             field_dict["archived_at"] = archived_at
         if focal_channel is not UNSET:
             field_dict["focal_channel"] = focal_channel
+        if focal_locked is not UNSET:
+            field_dict["focal_locked"] = focal_locked
+        if owner_id is not UNSET:
+            field_dict["owner_id"] = owner_id
 
         return field_dict
 
@@ -281,6 +297,17 @@ class Session:
 
         focal_channel = _parse_focal_channel(d.pop("focal_channel", UNSET))
 
+        focal_locked = d.pop("focal_locked", UNSET)
+
+        def _parse_owner_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        owner_id = _parse_owner_id(d.pop("owner_id", UNSET))
+
         session = cls(
             id=id,
             agent_id=agent_id,
@@ -298,6 +325,8 @@ class Session:
             resources=resources,
             archived_at=archived_at,
             focal_channel=focal_channel,
+            focal_locked=focal_locked,
+            owner_id=owner_id,
         )
 
         session.additional_properties = d

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -28,11 +28,11 @@ from aios.errors import (
     PayloadTooLargeError,
     ValidationError,
 )
-from aios.harness.wake import defer_wake
 from aios.models.connections import Connection, ConnectionSetTools, ConnectorSecrets
 from aios.services import connections as connections_service
 from aios.services import inbound as inbound_service
 from aios.services import sessions as sessions_service
+from aios.services.wake import defer_wake
 
 router = APIRouter(prefix="/v1/connectors", tags=["connectors"])
 

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -29,7 +29,6 @@ from aios.api.sse import sse_event_stream
 from aios.db import queries
 from aios.db.listen import SESSION_INTERRUPT_CHANNEL, listen_for_events
 from aios.errors import ForbiddenError, ValidationError
-from aios.harness.wake import defer_wake
 from aios.ids import GITHUB_REPOSITORY, split_id
 from aios.models.common import ListResponse
 from aios.models.events import Event, EventKind
@@ -55,6 +54,7 @@ from aios.models.sessions import (
 from aios.services import files as files_service
 from aios.services import github_repositories as github_repo_service
 from aios.services import sessions as service
+from aios.services.wake import defer_wake
 
 router = APIRouter(prefix="/v1/sessions", tags=["sessions"])
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -657,20 +657,6 @@ async def get_session_focal_channel(conn: asyncpg.Connection[Any], session_id: s
     return focal
 
 
-async def get_session_spawn_origin(conn: asyncpg.Connection[Any], session_id: str) -> str | None:
-    """Return the session's ``spawned_from_connection_id`` (or NULL).
-
-    Retained as the source of truth for per_chat lineage queries until
-    PR 7 (#328) reshapes the connector tables. The ``switch_channel``
-    gate has moved to :func:`is_session_focal_locked`.
-    """
-    val: str | None = await conn.fetchval(
-        "SELECT spawned_from_connection_id FROM sessions WHERE id = $1",
-        session_id,
-    )
-    return val
-
-
 async def is_session_focal_locked(conn: asyncpg.Connection[Any], session_id: str) -> bool:
     """Return whether the session's focal channel is locked.
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -561,6 +561,8 @@ def _row_to_session(row: asyncpg.Record) -> Session:
         updated_at=row["updated_at"],
         archived_at=row["archived_at"],
         focal_channel=row["focal_channel"],
+        focal_locked=row["focal_locked"],
+        owner_id=row["owner_id"],
     )
 
 
@@ -658,15 +660,35 @@ async def get_session_focal_channel(conn: asyncpg.Connection[Any], session_id: s
 async def get_session_spawn_origin(conn: asyncpg.Connection[Any], session_id: str) -> str | None:
     """Return the session's ``spawned_from_connection_id`` (or NULL).
 
-    A non-null value indicates a per_chat-spawned session whose focal
-    channel is locked at creation; ``switch_channel`` rejects mutations
-    on those sessions.
+    Retained as the source of truth for per_chat lineage queries until
+    PR 7 (#328) reshapes the connector tables. The ``switch_channel``
+    gate has moved to :func:`is_session_focal_locked`.
     """
     val: str | None = await conn.fetchval(
         "SELECT spawned_from_connection_id FROM sessions WHERE id = $1",
         session_id,
     )
     return val
+
+
+async def is_session_focal_locked(conn: asyncpg.Connection[Any], session_id: str) -> bool:
+    """Return whether the session's focal channel is locked.
+
+    The flag is set at session creation by per_chat-mode spawns (and any
+    future spawner that wants to pin a session to a single channel).
+    ``switch_channel`` rejects any mutation when this returns ``True``.
+
+    Raises :class:`NotFoundError` if the session row doesn't exist —
+    callers in the harness should never reach this with an invalid
+    session id, so a missing row is a real bug, not a permission state.
+    """
+    locked: bool | None = await conn.fetchval(
+        "SELECT focal_locked FROM sessions WHERE id = $1",
+        session_id,
+    )
+    if locked is None:
+        raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
+    return locked
 
 
 async def set_session_focal_channel(

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -589,22 +589,25 @@ async def insert_session(
     ``spawned_from_connection_id`` + ``focal_channel`` are written
     atomically with the row insert so the focal-locked invariant (see
     ``switch_channel``'s rejection of mutations on per_chat sessions)
-    holds from creation.
+    holds from creation. ``focal_locked`` is derived in the same
+    statement: any session that was spawned for a single chat starts
+    its life locked.
     """
     from aios.config import get_settings
 
     new_id = make_id(SESSION)
     if workspace_path is None:
         workspace_path = str(get_settings().workspace_root / new_id)
+    focal_locked = spawned_from_connection_id is not None
     try:
         row = await conn.fetchrow(
             """
             INSERT INTO sessions (
                 id, agent_id, environment_id, agent_version, title, metadata,
                 status, workspace_volume_path, env,
-                spawned_from_connection_id, focal_channel
+                spawned_from_connection_id, focal_channel, focal_locked
             )
-            VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'idle', $7, $8::jsonb, $9, $10)
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'idle', $7, $8::jsonb, $9, $10, $11)
             RETURNING *
             """,
             new_id,
@@ -617,6 +620,7 @@ async def insert_session(
             json.dumps(env or {}),
             spawned_from_connection_id,
             focal_channel,
+            focal_locked,
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2691,50 +2691,6 @@ async def get_connection(conn: asyncpg.Connection[Any], connection_id: str) -> C
     return _row_to_connection(row)
 
 
-async def session_authorizes_connector_account(
-    conn: asyncpg.Connection[Any],
-    session_id: str,
-    connector: str,
-    account: str,
-) -> bool:
-    """Permission check for outbound connector tool calls.
-
-    True iff there's an active connection whose ``(connector, account)``
-    matches AND any of:
-
-    * ``c.session_id`` is this session (single_session attach), OR
-    * ``c.id`` is this session's ``spawned_from_connection_id``
-      (per_chat origin grant), OR
-    * a row in ``connection_chat_sessions`` ties this connection to
-      this session (operator-curated chat binding, #215).
-
-    Used by the outbound MCP dispatch to gate tool calls that take an
-    explicit ``account`` argument — the supervisor will happily forward
-    to the connector regardless, but the model shouldn't be able to
-    reach accounts the operator hasn't bound to this session.
-    """
-    row = await conn.fetchrow(
-        """
-        SELECT 1
-          FROM connections c
-          LEFT JOIN sessions s ON s.id = $1
-         WHERE c.connector = $2
-           AND c.account = $3
-           AND c.archived_at IS NULL
-           AND (c.session_id = $1
-                OR c.id = s.spawned_from_connection_id
-                OR EXISTS (SELECT 1 FROM connection_chat_sessions ccs
-                            WHERE ccs.connection_id = c.id
-                              AND ccs.session_id = $1))
-         LIMIT 1
-        """,
-        session_id,
-        connector,
-        account,
-    )
-    return row is not None
-
-
 async def set_connection_tools(
     conn: asyncpg.Connection[Any],
     connection_id: str,
@@ -2838,15 +2794,11 @@ async def list_connection_tools_for_session(
 ) -> list[dict[str, Any]]:
     """Custom tool specs from every active connection bound to ``session_id``.
 
-    Mirrors the three lineage paths in
-    :func:`session_authorizes_connector_account`:
-
-    * ``c.session_id = $1`` — single_session attach
-    * ``c.id = s.spawned_from_connection_id`` — per_chat origin
-    * ``connection_chat_sessions`` — operator-curated chat binding
-
-    Returns the flattened list of ToolSpec dicts (jsonb) ready to feed
-    through :func:`tools.registry.to_openai_tools_custom`.
+    Walks the three lineage paths enumerated in
+    :func:`is_session_bound_to_connection` (single_session attach,
+    per_chat origin, operator-curated chat binding) and returns the
+    flattened list of ToolSpec dicts (jsonb) ready to feed through
+    :func:`tools.registry.to_openai_tools_custom`.
     """
     rows = await conn.fetch(
         """

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -32,11 +32,11 @@ from aios.harness.step_context import compose_step_context, compute_step_prelude
 from aios.harness.sweep import find_sessions_needing_inference
 from aios.harness.tokens import approx_tokens
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
-from aios.harness.wake import defer_wake
 from aios.logging import get_logger
 from aios.models.agents import ToolSpec
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
+from aios.services.wake import defer_wake
 
 if TYPE_CHECKING:
     import asyncpg
@@ -617,13 +617,9 @@ def _is_mcp_tool(name: str) -> bool:
 def _is_known_mcp_server(server_name: str, mcp_server_map: dict[str, str]) -> bool:
     """Return True if ``server_name`` resolves to a registered MCP server.
 
-    A server is "known" if either:
-
-    * It's a connector instance currently registered with the
-      :class:`~aios.harness.connector_supervisor.ConnectorSubprocessRegistry`,
-      or
-    * It appears in ``mcp_server_map`` (the agent-declared HTTP MCP
-      servers, keyed by ``McpServerSpec.name``).
+    ``mcp_server_map`` is the agent-derived map of MCP server names →
+    URLs (built upstream from both agent-declared HTTP MCP servers and
+    connection-provided MCP servers — all HTTP transport since #318).
 
     Used by :func:`_classify_tool_call` to short-circuit hallucinated
     tool names before the permission gate, so the model gets a tool

--- a/src/aios/harness/runtime.py
+++ b/src/aios/harness/runtime.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from aios.mcp.pool import McpSessionPool
     from aios.models.memory_stores import MemoryStoreResourceEcho
     from aios.sandbox.registry import SandboxRegistry
+    from aios.tools.providers import ToolProvider
 
 
 pool: asyncpg.Pool[Any] | None = None
@@ -35,6 +36,7 @@ worker_id: str | None = None
 sandbox_registry: SandboxRegistry | None = None
 task_registry: TaskRegistry | None = None
 mcp_session_pool: McpSessionPool | None = None
+tool_provider: ToolProvider | None = None
 
 # Per-session memory-mount cache. Populated at the top of every step (in
 # ``loop._run_session_step_body``) and consumed by ``tools.memory_intercept``
@@ -142,3 +144,12 @@ def require_mcp_session_pool() -> McpSessionPool:
             "this code is running outside a worker_main context"
         )
     return mcp_session_pool
+
+
+def require_tool_provider() -> ToolProvider:
+    if tool_provider is None:
+        raise RuntimeError(
+            "aios.harness.runtime.tool_provider is not initialized; "
+            "this code is running outside a worker_main context"
+        )
+    return tool_provider

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -28,9 +28,9 @@ if TYPE_CHECKING:
     from aios.models.agents import ToolSpec
 
 from aios.harness.task_registry import TaskRegistry
-from aios.harness.wake import defer_wake
 from aios.logging import get_logger
 from aios.services import sessions as sessions_service
+from aios.services.wake import defer_wake
 
 log = get_logger("aios.harness.sweep")
 

--- a/src/aios/harness/tasks.py
+++ b/src/aios/harness/tasks.py
@@ -6,14 +6,14 @@
     the job and runs a single inference step.
 
     The lock and queueing_lock are NOT set on the decorator — they are
-    passed per call from :mod:`aios.harness.wake` (``defer_wake``).
+    passed per call from :mod:`aios.services.wake` (``defer_wake``).
     Procrastinate stores the decorator's lock arguments verbatim with
     no kwarg-template substitution, so a decorator-level
     ``lock="{session_id}"`` would assign every job the same literal
     lock value and serialize all sessions through one job slot — the
     bug behind issue #192.
 
-    Per-call values used by :mod:`aios.harness.wake`:
+    Per-call values used by :mod:`aios.services.wake`:
 
     * ``lock=session_id``: procrastinate enforces mutual exclusion via
       a partial unique index ``WHERE status='doing'``. With distinct

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -3,22 +3,20 @@
 ``aios serve worker`` runs :func:`worker_main` in an asyncio event loop. It:
 
 1. Configures structlog
-2. Opens the asyncpg pool
-3. Acquires a Postgres advisory lock to refuse a duplicate worker
+2. Acquires a Postgres advisory lock to refuse a duplicate worker
+3. Opens the asyncpg pool
 4. Constructs the libsodium CryptoBox
 5. Creates the SandboxRegistry, TaskRegistry, and McpSessionPool
-6. Resolves and starts the connector subprocess supervisor
-7. Stashes globals on :mod:`aios.harness.runtime`
-8. Opens the procrastinate connector
-9. Recovers orphaned sessions (re-enqueue stuck ones)
-10. Reaps orphaned sandbox containers
-11. Starts the container idle-TTL reaper
-12. Starts ``app.run_worker_async`` which blocks until SIGTERM/SIGINT
+6. Stashes globals on :mod:`aios.harness.runtime`
+7. Opens the procrastinate connector
+8. Sweeps orphan attachments, reaps stalled jobs, wakes sessions needing inference
+9. Reaps orphaned sandbox containers
+10. Starts the container idle-TTL reaper, periodic sweep, interrupt listener, and liveness heartbeat
+11. Starts ``app.run_worker_async`` which blocks until SIGTERM/SIGINT
 
 Shutdown: procrastinate's signal handlers stop accepting new jobs and wait
 for in-flight jobs. The ``finally`` block then cancels in-flight tool tasks,
-releases all containers, closes MCP sessions, stops the connector
-supervisor, and closes connections.
+releases all containers, closes MCP sessions, and closes connections.
 """
 
 from __future__ import annotations
@@ -55,11 +53,11 @@ from aios.mcp.pool import McpSessionPool
 from aios.sandbox.backends import make_backend
 from aios.sandbox.registry import SandboxRegistry
 
-# 64-bit hash of the lock identifier; stable across processes / restarts.
-# Generated once via Postgres ``hashtextextended('aios_worker_connector_supervisor', 0)``
-# and inlined so we don't burn a query just to compute it.  The text key
-# stays in code as documentation of *what* this number means.
-_WORKER_LOCK_KEY_TEXT = "aios_worker_connector_supervisor"
+# Hashed (via Postgres ``hashtextextended($1, 0)``) into the 64-bit
+# advisory-lock key enforcing the worker-process singleton. The string
+# is a historical magic value, preserved verbatim so a rolling deploy
+# computes the same lock number across old and new workers.
+_WORKER_SINGLETON_LOCK_KEY_TEXT = "aios_worker_connector_supervisor"
 
 # Path the worker touches periodically to signal liveness; the Dockerfile
 # HEALTHCHECK reads its mtime. tmpfs in containers, so touch/unlink are
@@ -83,11 +81,13 @@ async def worker_main() -> None:
     install_exit_diagnostics(log)
 
     # Single-instance guard.  Two `aios worker` processes against the same
-    # database would race for connector subprocess ownership (signal-cli's
-    # local socket, telegram's bot session, etc.) so we refuse to boot a
-    # second worker by holding a session-scoped advisory lock on a
-    # dedicated connection.  Pool-borrowed connections release the lock
-    # on return, so the lock conn is intentionally NOT in the pool.
+    # database would compete over per-worker state that procrastinate's
+    # session-scoped job lock doesn't cover — in-memory sandbox container
+    # stewardship, attachment-staging atomicity, the startup orphan sweep.
+    # So we refuse to boot a second worker by holding a session-scoped
+    # advisory lock on a dedicated connection.  Pool-borrowed connections
+    # release the lock on return, so the lock conn is intentionally NOT
+    # in the pool.
     lock_conn = await _acquire_worker_lock(settings.db_url, log)
     if lock_conn is None:
         sys.exit(1)
@@ -263,14 +263,14 @@ async def _acquire_worker_lock(
         while True:
             held: bool = await conn.fetchval(
                 "SELECT pg_try_advisory_lock(hashtextextended($1, 0))",
-                _WORKER_LOCK_KEY_TEXT,
+                _WORKER_SINGLETON_LOCK_KEY_TEXT,
             )
             if held:
                 return conn
             if time.monotonic() >= deadline:
                 log.error(
                     "worker.duplicate_instance_refused",
-                    lock_key=_WORKER_LOCK_KEY_TEXT,
+                    lock_key=_WORKER_SINGLETON_LOCK_KEY_TEXT,
                     waited_seconds=timeout_seconds,
                 )
                 await conn.close()
@@ -278,7 +278,7 @@ async def _acquire_worker_lock(
             if not waiting_logged:
                 log.info(
                     "worker.lock_busy.waiting",
-                    lock_key=_WORKER_LOCK_KEY_TEXT,
+                    lock_key=_WORKER_SINGLETON_LOCK_KEY_TEXT,
                     timeout_seconds=timeout_seconds,
                 )
                 waiting_logged = True

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -31,6 +31,13 @@ SKILL: Final = "skl"
 CONNECTION: Final = "conn"
 CONNECTOR_TOKEN: Final = "ctok"
 SESSION_TEMPLATE: Final = "stpl"
+# Connector subsystem (#328 PR 2+). The aios_connectors module reads
+# these to mint ids; the PR 2 migration backfills bindings with the
+# same ``bnd_`` prefix verbatim so the two id sources stay coherent.
+BINDING: Final = "bnd"
+RUNTIME: Final = "rt"
+RUNTIME_TOKEN: Final = "rtk"
+ROUTING_RULE: Final = "rule"
 MEMORY_STORE: Final = "memstore"
 MEMORY: Final = "mem"
 MEMORY_VERSION: Final = "memver"
@@ -56,6 +63,10 @@ _PREFIXES: Final = frozenset(
         MEMORY_VERSION,
         GITHUB_REPOSITORY,
         FILE,
+        BINDING,
+        RUNTIME,
+        RUNTIME_TOKEN,
+        ROUTING_RULE,
     }
 )
 

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -31,9 +31,13 @@ SKILL: Final = "skl"
 CONNECTION: Final = "conn"
 CONNECTOR_TOKEN: Final = "ctok"
 SESSION_TEMPLATE: Final = "stpl"
-# Connector subsystem (#328 PR 2+). The aios_connectors module reads
-# these to mint ids; the PR 2 migration backfills bindings with the
-# same ``bnd_`` prefix verbatim so the two id sources stay coherent.
+# Connector subsystem (#328 PR 2+). The aios_connectors module uses
+# these prefixes to mint ids via ``make_id``; the PR 2 migration
+# also backfills binding ids prefixed with ``bnd_`` (but with a
+# random-hex body, not a ULID) — backfilled rows are valid ``text``
+# PKs that won't survive ``split_id`` parsing.  No current call site
+# does that on a binding id; if one is added later, generate ULIDs
+# in the migration or relax ``split_id``.
 BINDING: Final = "bnd"
 RUNTIME: Final = "rt"
 RUNTIME_TOKEN: Final = "rtk"

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -189,10 +189,6 @@ async def discover_mcp_tools(
 def shape_call_result(result: Any) -> dict[str, Any]:
     """Project an MCP ``CallToolResult`` onto aios's ``{"content"|"error": str}`` envelope.
 
-    Shared by the HTTP-transport path here and the stdio-transport path
-    in :class:`~aios.harness.connector_supervisor.ConnectorSubprocessRegistry`
-    so both surfaces stay byte-identical.
-
     Tool-level errors carry ``code="tool_error"`` so the API router can
     distinguish them from transport / not-ready / circuit-open
     failures (mapped to different HTTP statuses) without substring

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -194,6 +194,8 @@ class Session(BaseModel):
     updated_at: datetime
     archived_at: datetime | None = None
     focal_channel: str | None = None
+    focal_locked: bool = False
+    owner_id: str | None = None
 
 
 class SessionCloneRequest(BaseModel):

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -177,7 +177,8 @@ def attachments_root() -> Path:
     Each session subdir is bind-mounted read-only into its container at
     ``/mnt/attachments`` (see :mod:`aios.sandbox.provisioner`). Inbound
     binary blobs (Signal photos, Telegram voice notes, etc.) are staged
-    here by :mod:`aios.harness.connector_supervisor` before the inbound
+    here by :mod:`aios.services.attachment_staging` from
+    :func:`aios.services.inbound.handle_inbound` before the inbound
     event is appended; the model sees them at stable in-sandbox paths
     of the form ``/mnt/attachments/<connector>/<event-ulid>-<filename>``.
     """

--- a/src/aios/services/attachment_staging.py
+++ b/src/aios/services/attachment_staging.py
@@ -77,8 +77,9 @@ def stage_inbound_attachments(
     other attachment's bytes corrupts ``metadata.attachments``. The
     realistic trigger (e.g. Telegram album with two ``image.jpg``
     files) is the platform's responsibility to disambiguate via the
-    SDK; the supervisor drops the inbound and the operator sees the
-    canonical ``attachment_staging_failed`` reason.
+    SDK; on collision this function raises :class:`AttachmentStagingError`,
+    the inbound is dropped, and the operator sees the canonical
+    ``attachment_staging_failed`` reason.
     """
     if not isinstance(raw_attachments, list) or not raw_attachments:
         return [], []

--- a/src/aios/services/attachment_staging.py
+++ b/src/aios/services/attachment_staging.py
@@ -1,8 +1,9 @@
 """Inbound attachment staging.
 
-The connector hands the SDK a host path it owns; bytes never
-traverse stdio. The supervisor renames each attachment into a
-stable per-session location before appending the inbound event::
+Connector containers POST inbound messages with attachment host
+paths to ``POST /v1/connectors/inbound``; this module renames each
+attachment into a stable per-session location before the inbound
+event is appended::
 
     <workspace_root>/_attachments/<session_id>/<connector>/<event-ulid>-<filename>
 

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -180,29 +180,6 @@ async def unconfigure_connection(pool: asyncpg.Pool[Any], connection_id: str) ->
         return await queries.unconfigure_connection(conn, connection_id)
 
 
-async def validate_account_for_session(
-    pool: asyncpg.Pool[Any],
-    session_id: str,
-    *,
-    connector: str,
-    account: str,
-) -> bool:
-    """Return True iff ``session_id`` is allowed to act on ``(connector, account)``.
-
-    Authorization model: a session may invoke connector tools targeted
-    at accounts that are either bound to it via ``connections.session_id``
-    (single_session attach), spawned it via
-    ``sessions.spawned_from_connection_id`` (per_chat origin), or
-    operator-curated to it via a row in ``connection_chat_sessions``
-    (#215).  Used by the outbound MCP dispatch — see
-    :mod:`aios.harness.tool_dispatch`.
-    """
-    async with pool.acquire() as conn:
-        return await queries.session_authorizes_connector_account(
-            conn, session_id, connector, account
-        )
-
-
 async def bind_chat_to_session(
     pool: asyncpg.Pool[Any],
     connection_id: str,

--- a/src/aios/services/inbound.py
+++ b/src/aios/services/inbound.py
@@ -1,14 +1,12 @@
-"""Inbound message handling for connector containers (#301).
+"""Inbound message handling for connector containers (#301, #318).
 
-The new ``POST /v1/connectors/inbound`` endpoint calls
+The ``POST /v1/connectors/inbound`` endpoint calls
 :func:`handle_inbound`, which wraps the dedup / attachment-staging /
-session-resolution logic that today also lives in
-``connector_supervisor._handle_inbound``.  Both paths share the same
-DB primitives (``try_record_inbound_ack``, ``append_event``,
-``stage_inbound_attachments``) so the supervisor and the new HTTP path
-produce indistinguishable event-log state.
-
-In PR 6 the supervisor is deleted and this is the only inbound path.
+session-resolution logic shared with the peer HTTP-client connector
+architecture introduced in #318. Built on
+:func:`aios.db.queries.try_record_inbound_ack`,
+:func:`aios.services.sessions.append_event`, and
+:func:`aios.services.attachment_staging.stage_inbound_attachments`.
 """
 
 from __future__ import annotations
@@ -21,14 +19,14 @@ import asyncpg
 
 from aios.db import queries
 from aios.errors import NotFoundError
-from aios.harness.attachment_staging import (
-    AttachmentStagingError,
-    stage_inbound_attachments,
-)
-from aios.harness.wake import defer_wake
 from aios.models.connections import Connection
 from aios.models.sessions import MAX_USER_MESSAGE_CHARS
 from aios.services import sessions as sessions_service
+from aios.services.attachment_staging import (
+    AttachmentStagingError,
+    stage_inbound_attachments,
+)
+from aios.services.wake import defer_wake
 
 
 class _DedupRollback(Exception):

--- a/src/aios/services/wake.py
+++ b/src/aios/services/wake.py
@@ -18,7 +18,7 @@ from aios.services import sessions as sessions_service
 if TYPE_CHECKING:
     import asyncpg
 
-log = get_logger("aios.harness.wake")
+log = get_logger("aios.services.wake")
 
 
 async def defer_wake(

--- a/src/aios/tools/providers.py
+++ b/src/aios/tools/providers.py
@@ -1,0 +1,41 @@
+"""Pluggable per-session tool source for the harness prelude.
+
+The per-step prelude (``aios.harness.step_context.compute_step_prelude``)
+needs to merge session-scoped custom tools into the model's tool list
+every turn. Today those tools come from the connector-area
+``services.connections.list_tools_for_session`` query directly. After
+#328 PR 4 they'll come from the new ``aios_connectors`` subsystem
+instead.
+
+The point of this Protocol is to keep core code from importing
+subsystem code: core calls against ``ToolProvider``; the subsystem
+registers an implementation at worker startup via
+``aios.harness.runtime.tool_provider``. The arrow only ever points
+core → interface ← subsystem.
+
+PR 3 just lands the contract. The slot in ``runtime`` is reserved but
+nothing registers against it yet; the rewire of ``step_context.py`` is
+PR 4's job, atomically with the subsystem impl.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+import asyncpg
+
+
+@runtime_checkable
+class ToolProvider(Protocol):
+    """Source of session-scoped custom tools for the per-step prelude."""
+
+    async def list_tools_for_session(
+        self, pool: asyncpg.Pool[Any], session_id: str
+    ) -> list[dict[str, Any]]:
+        """Return the JSON-schema tool dicts available to ``session_id``.
+
+        Each dict is a ToolSpec ready for ``ToolSpec.model_validate`` —
+        the same shape ``services.connections.list_tools_for_session``
+        returns today.
+        """
+        ...

--- a/src/aios/tools/providers.py
+++ b/src/aios/tools/providers.py
@@ -1,21 +1,12 @@
 """Pluggable per-session tool source for the harness prelude.
 
-The per-step prelude (``aios.harness.step_context.compute_step_prelude``)
-needs to merge session-scoped custom tools into the model's tool list
-every turn. Today those tools come from the connector-area
-``services.connections.list_tools_for_session`` query directly. After
-#328 PR 4 they'll come from the new ``aios_connectors`` subsystem
-instead.
-
-The point of this Protocol is to keep core code from importing
-subsystem code: core calls against ``ToolProvider``; the subsystem
-registers an implementation at worker startup via
-``aios.harness.runtime.tool_provider``. The arrow only ever points
-core → interface ← subsystem.
-
-PR 3 just lands the contract. The slot in ``runtime`` is reserved but
-nothing registers against it yet; the rewire of ``step_context.py`` is
-PR 4's job, atomically with the subsystem impl.
+The per-step prelude in ``aios.harness.step_context`` needs to merge
+session-scoped custom tools into the model's tool list every turn.
+Defining the source as a Protocol keeps core code from importing the
+subsystem that provides those tools: core calls against
+``ToolProvider``, the subsystem registers an implementation at worker
+startup via ``aios.harness.runtime.tool_provider``. The dependency
+arrow only ever points core → interface ← subsystem.
 """
 
 from __future__ import annotations

--- a/src/aios/tools/schedule_wake.py
+++ b/src/aios/tools/schedule_wake.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from aios.errors import AiosError
 from aios.harness import runtime
-from aios.harness.wake import defer_wake
+from aios.services.wake import defer_wake
 from aios.tools.registry import registry
 
 

--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -111,14 +111,15 @@ async def switch_channel_handler(session_id: str, arguments: dict[str, Any]) -> 
     # was misleading weak models into treating the quoted past as new
     # stimulus.
     async with pool.acquire() as conn, conn.transaction():
-        # Per_chat sessions are bound to a single chat by construction —
-        # focal is set at session-spawn time and switching it would
-        # contradict the "one session per chat partner" invariant.
-        if await queries.get_session_spawn_origin(conn, session_id) is not None:
+        # Focal-locked sessions are bound to a single chat by construction
+        # — focal is set at session-spawn time and switching it would
+        # contradict the "one session per chat partner" invariant. Today
+        # the connector subsystem sets ``focal_locked`` on per_chat-mode
+        # spawns (#328).
+        if await queries.is_session_focal_locked(conn, session_id):
             return ToolResult(
                 content=(
-                    "switch_channel is unavailable on this session: it was "
-                    "spawned for a single chat by a per_chat connection."
+                    "switch_channel is unavailable on this session: its focal channel is locked."
                 ),
                 metadata={
                     SWITCH_CHANNEL_METADATA_KEY: {"target": target, "success": False},

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -141,7 +141,7 @@ async def harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     with (
         mock.patch("aios.harness.completion.litellm.acompletion", _fake_acompletion),
         mock.patch("aios.harness.completion.litellm.stream_chunk_builder", _fake_chunk_builder),
-        mock.patch("aios.harness.wake.defer_wake", _noop_defer_wake),
+        mock.patch("aios.services.wake.defer_wake", _noop_defer_wake),
     ):
         yield h
 
@@ -204,7 +204,7 @@ async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     with (
         mock.patch("aios.harness.completion.litellm.acompletion", _fake_acompletion),
         mock.patch("aios.harness.completion.litellm.stream_chunk_builder", _fake_chunk_builder),
-        mock.patch("aios.harness.wake.defer_wake", _noop_defer_wake),
+        mock.patch("aios.services.wake.defer_wake", _noop_defer_wake),
     ):
         yield h
 
@@ -245,7 +245,7 @@ async def http_client(aios_env: dict[str, str]) -> AsyncIterator[Any]:
     app.state.procrastinate = mock.MagicMock()
     transport = httpx.ASGITransport(app=app)
     # Mock at every call site that imports ``defer_wake`` directly —
-    # patching the source (``aios.harness.wake``) is too late since the
+    # patching the source (``aios.services.wake``) is too late since the
     # importing modules already captured the unmocked reference.
     with (
         mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock),

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -189,7 +189,7 @@ class TestFocalChannelE2E:
         events = await harness.events(session.id)
         result = next(e for e in events if e.data.get("role") == "tool")
         assert result.data.get("is_error") is True
-        assert "per_chat" in result.data["content"]
+        assert "focal channel is locked" in result.data["content"]
 
     async def test_paradigm_block_renders_when_session_has_channels(self, harness: Harness) -> None:
         """The cache-stable focal-channel paradigm block appears in the

--- a/tests/e2e/test_litellm_502_recovery.py
+++ b/tests/e2e/test_litellm_502_recovery.py
@@ -41,7 +41,7 @@ class TestLiteLLMBadGatewayRecovery:
             return harness._pop_response(**kwargs)
 
         # ``loop.py`` binds ``defer_wake`` via ``from … import …``, so the
-        # conftest's patch on ``aios.harness.wake.defer_wake`` doesn't reach
+        # conftest's patch on ``aios.services.wake.defer_wake`` doesn't reach
         # the loop-level call site.  Patch the loop binding directly.
         async def _noop_defer_wake(*args: Any, **kwargs: Any) -> None:
             return None

--- a/tests/e2e/test_wake_lock_release_latency.py
+++ b/tests/e2e/test_wake_lock_release_latency.py
@@ -27,7 +27,7 @@ class TestWakeLockReleaseLatencyE2E:
         """When a lock-blocked wake becomes eligible, the worker must pick
         it up within a single LISTEN/NOTIFY round-trip (<200ms)."""
         from aios.harness.procrastinate_app import app as procrastinate_app
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = real_wake_setup
 

--- a/tests/e2e/test_worker_concurrency.py
+++ b/tests/e2e/test_worker_concurrency.py
@@ -46,7 +46,7 @@ class TestWorkerConcurrencyE2E:
         self, real_wake_setup: asyncpg.Pool[Any], aios_env: dict[str, str]
     ) -> None:
         from aios.harness.procrastinate_app import app as procrastinate_app
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = real_wake_setup
         n_sessions = 8

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -78,6 +78,15 @@ def test_migration_creates_all_tables(postgres: object) -> None:
                 "sessions",
                 "events",
                 "alembic_version",
+                # Subsystem tables (0033, #328 PR 2/8) live alongside today's
+                # connector tables until the code switch in PR 4.
+                "connectors",
+                "bindings",
+                "chat_sessions",
+                "routing_rules",
+                "runtimes",
+                "runtime_tokens",
+                "inbound_acks",
             } <= names, f"missing tables: {names}"
 
             # Spot-check a few critical indexes
@@ -91,6 +100,8 @@ def test_migration_creates_all_tables(postgres: object) -> None:
                 "events_session_seq_idx",
                 "events_session_message_seq_idx",
                 "events_model_request_end_calibration_idx",
+                "bindings_connection_active_uniq",
+                "runtime_tokens_connector_idx",
             ):
                 assert required in index_names, f"missing index {required}"
         finally:

--- a/tests/unit/test_attachment_staging.py
+++ b/tests/unit/test_attachment_staging.py
@@ -1,4 +1,4 @@
-"""Unit coverage for :mod:`aios.harness.attachment_staging`.
+"""Unit coverage for :mod:`aios.services.attachment_staging`.
 
 Exercises the rename/copy/cleanup state machine with a temp
 ``workspace_root`` so we never touch the production attachments
@@ -16,11 +16,11 @@ from typing import Any
 import pytest
 
 from aios.config import get_settings
-from aios.harness.attachment_staging import (
+from aios.sandbox.volumes import safe_filename
+from aios.services.attachment_staging import (
     AttachmentStagingError,
     stage_inbound_attachments,
 )
-from aios.sandbox.volumes import safe_filename
 
 
 @pytest.fixture

--- a/tests/unit/test_scheduled_wake_marker.py
+++ b/tests/unit/test_scheduled_wake_marker.py
@@ -112,9 +112,9 @@ class TestDeferWakeExtension:
         from procrastinate.testing import InMemoryConnector
 
         from aios.harness.procrastinate_app import app
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
-        monkeypatch.setattr("aios.harness.wake.sessions_service.append_event", AsyncMock())
+        monkeypatch.setattr("aios.services.wake.sessions_service.append_event", AsyncMock())
 
         patched: App
         with app.replace_connector(InMemoryConnector()) as patched:
@@ -145,9 +145,9 @@ class TestDeferWakeExtension:
         from procrastinate.testing import InMemoryConnector
 
         from aios.harness.procrastinate_app import app
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
-        monkeypatch.setattr("aios.harness.wake.sessions_service.append_event", AsyncMock())
+        monkeypatch.setattr("aios.services.wake.sessions_service.append_event", AsyncMock())
 
         with app.replace_connector(InMemoryConnector()) as patched:
             await defer_wake(MagicMock(), "sess_x", cause="message")

--- a/tests/unit/test_switch_channel_handler.py
+++ b/tests/unit/test_switch_channel_handler.py
@@ -33,9 +33,9 @@ def _patched_conn() -> Any:
 
 
 class TestPerChatLock:
-    """Sessions with ``spawned_from_connection_id`` set are bound to a
-    single chat by construction; ``switch_channel`` must reject any
-    attempt to mutate focal on them.
+    """Sessions with ``focal_locked = TRUE`` are bound to a single chat
+    by construction (today set at per_chat-mode spawn time);
+    ``switch_channel`` must reject any attempt to mutate focal on them.
     """
 
     async def test_rejects_when_session_was_per_chat_spawned(self) -> None:
@@ -44,9 +44,9 @@ class TestPerChatLock:
         with (
             _patch_pool(pool),
             patch(
-                "aios.tools.switch_channel.queries.get_session_spawn_origin",
+                "aios.tools.switch_channel.queries.is_session_focal_locked",
                 new_callable=AsyncMock,
-            ) as origin,
+            ) as locked,
             patch(
                 "aios.tools.switch_channel.queries.get_session_focal_channel",
                 new_callable=AsyncMock,
@@ -60,14 +60,14 @@ class TestPerChatLock:
                 new_callable=AsyncMock,
             ) as list_channels,
         ):
-            origin.return_value = "conn_per_chat"
+            locked.return_value = True
             result = await switch_channel_handler(
                 "sess_per_chat", {"channel_id": "signal/+1/chat-2"}
             )
 
         assert isinstance(result, ToolResult)
         assert result.is_error is True
-        assert "per_chat" in result.content
+        assert "focal channel is locked" in result.content
         marker = result.metadata[SWITCH_CHANNEL_METADATA_KEY]
         assert marker == {"target": "signal/+1/chat-2", "success": False}
         # Focal-lock short-circuits before any other DB read or write.
@@ -84,15 +84,15 @@ class TestPerChatLock:
         with (
             _patch_pool(pool),
             patch(
-                "aios.tools.switch_channel.queries.get_session_spawn_origin",
+                "aios.tools.switch_channel.queries.is_session_focal_locked",
                 new_callable=AsyncMock,
-            ) as origin,
+            ) as locked,
             patch(
                 "aios.tools.switch_channel.queries.set_session_focal_channel",
                 new_callable=AsyncMock,
             ) as set_focal,
         ):
-            origin.return_value = "conn_per_chat"
+            locked.return_value = True
             result = await switch_channel_handler("sess_per_chat", {"channel_id": None})
 
         assert result.is_error is True
@@ -104,9 +104,9 @@ class TestPerChatLock:
 
 
 class TestNonPerChatPathStillWorks:
-    """Sanity check that ordinary (non-per_chat) sessions reach the
+    """Sanity check that ordinary (non-locked) sessions reach the
     rest of the handler — the focal-lock guard short-circuits *only*
-    when ``spawned_from_connection_id`` is set.
+    when ``focal_locked`` is TRUE.
     """
 
     async def test_no_op_when_target_already_focal(self) -> None:
@@ -115,9 +115,9 @@ class TestNonPerChatPathStillWorks:
         with (
             _patch_pool(pool),
             patch(
-                "aios.tools.switch_channel.queries.get_session_spawn_origin",
+                "aios.tools.switch_channel.queries.is_session_focal_locked",
                 new_callable=AsyncMock,
-            ) as origin,
+            ) as locked,
             patch(
                 "aios.tools.switch_channel.queries.get_session_focal_channel",
                 new_callable=AsyncMock,
@@ -127,7 +127,7 @@ class TestNonPerChatPathStillWorks:
                 new_callable=AsyncMock,
             ) as set_focal,
         ):
-            origin.return_value = None
+            locked.return_value = False
             focal.return_value = "signal/+1/chat-1"
             result = await switch_channel_handler("sess_normal", {"channel_id": "signal/+1/chat-1"})
 
@@ -142,9 +142,9 @@ class TestNonPerChatPathStillWorks:
         with (
             _patch_pool(pool),
             patch(
-                "aios.tools.switch_channel.queries.get_session_spawn_origin",
+                "aios.tools.switch_channel.queries.is_session_focal_locked",
                 new_callable=AsyncMock,
-            ) as origin,
+            ) as locked,
             patch(
                 "aios.tools.switch_channel.queries.get_session_focal_channel",
                 new_callable=AsyncMock,
@@ -154,7 +154,7 @@ class TestNonPerChatPathStillWorks:
                 new_callable=AsyncMock,
             ) as set_focal,
         ):
-            origin.return_value = None
+            locked.return_value = False
             focal.return_value = "signal/+1/chat-1"
             result = await switch_channel_handler("sess_normal", {"channel_id": None})
 

--- a/tests/unit/test_wake.py
+++ b/tests/unit/test_wake.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from procrastinate import App
 
-from aios.harness.wake import defer_wake
+from aios.services.wake import defer_wake
 
 
 @pytest.fixture(autouse=True)
@@ -17,7 +17,7 @@ def mock_append_event() -> AsyncIterator[AsyncMock]:
     """Patch ``sessions_service.append_event`` so ``wake_deferred`` span
     emission doesn't require a real DB connection (issue #131)."""
     mock = AsyncMock()
-    with patch("aios.harness.wake.sessions_service.append_event", mock):
+    with patch("aios.services.wake.sessions_service.append_event", mock):
         yield mock
 
 

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -29,7 +29,7 @@ class TestE2EConftestMockSignatures:
     def test_noop_defer_wake_matches_real_defer_wake(self) -> None:
         import inspect
 
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
         from tests.e2e.conftest import _noop_defer_wake
 
         real_params = list(inspect.signature(defer_wake).parameters.keys())
@@ -39,11 +39,11 @@ class TestE2EConftestMockSignatures:
 
 class TestWakeDeferredEvent:
     async def test_defer_wake_emits_span_with_cause(self, in_memory_app: App) -> None:
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         mock_append = AsyncMock()
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", mock_append):
+        with patch("aios.services.wake.sessions_service.append_event", mock_append):
             await defer_wake(pool, "sess_x", cause="message")
 
         mock_append.assert_awaited_once_with(
@@ -54,11 +54,11 @@ class TestWakeDeferredEvent:
         )
 
     async def test_defer_wake_span_carries_delay_when_scheduled(self, in_memory_app: App) -> None:
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         mock_append = AsyncMock()
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", mock_append):
+        with patch("aios.services.wake.sessions_service.append_event", mock_append):
             await defer_wake(pool, "sess_x", cause="scheduled", delay_seconds=30, wake_reason="r")
 
         mock_append.assert_awaited_once_with(
@@ -71,11 +71,11 @@ class TestWakeDeferredEvent:
     async def test_defer_wake_emits_span_even_when_coalesced(self, in_memory_app: App) -> None:
         """N deferrals must all emit ``wake_deferred``, even if procrastinate
         coalesces them — the profiler observes coalescing as N deferred → 1 step."""
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         mock_append = AsyncMock()
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", mock_append):
+        with patch("aios.services.wake.sessions_service.append_event", mock_append):
             await defer_wake(pool, "sess_x", cause="message")
             await defer_wake(pool, "sess_x", cause="sweep")
             await defer_wake(pool, "sess_x", cause="tool_confirmation")
@@ -89,11 +89,11 @@ class TestWakeDeferredEvent:
     async def test_defer_wake_with_reschedule_cause_emits_reschedule_span(
         self, in_memory_app: App
     ) -> None:
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         mock_append = AsyncMock()
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", mock_append):
+        with patch("aios.services.wake.sessions_service.append_event", mock_append):
             await defer_wake(pool, "sess_x", cause="reschedule", delay_seconds=2)
 
         mock_append.assert_awaited_once_with(

--- a/tests/unit/test_wake_locks.py
+++ b/tests/unit/test_wake_locks.py
@@ -25,10 +25,10 @@ def _job_rows(app: App) -> list[dict]:
 
 class TestDeferWakeLockValues:
     async def test_lock_is_session_id(self, in_memory_app: App) -> None:
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+        with patch("aios.services.wake.sessions_service.append_event", AsyncMock()):
             await defer_wake(pool, "sess_alpha", cause="message")
 
         rows = _job_rows(in_memory_app)
@@ -36,10 +36,10 @@ class TestDeferWakeLockValues:
         assert rows[0]["lock"] == "sess_alpha"
 
     async def test_queueing_lock_is_session_id(self, in_memory_app: App) -> None:
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+        with patch("aios.services.wake.sessions_service.append_event", AsyncMock()):
             await defer_wake(pool, "sess_beta", cause="message")
 
         rows = _job_rows(in_memory_app)
@@ -47,10 +47,10 @@ class TestDeferWakeLockValues:
         assert rows[0]["queueing_lock"] == "sess_beta"
 
     async def test_reschedule_defer_wake_uses_session_id_lock(self, in_memory_app: App) -> None:
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = MagicMock()
-        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+        with patch("aios.services.wake.sessions_service.append_event", AsyncMock()):
             await defer_wake(pool, "sess_gamma", cause="reschedule", delay_seconds=2)
 
         rows = _job_rows(in_memory_app)
@@ -67,12 +67,12 @@ class TestDeferWakeCrossSessionIsolation:
         the original bug wouldn't raise — it would surface as fewer
         queued jobs than sessions.
         """
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = MagicMock()
         n = 5
 
-        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+        with patch("aios.services.wake.sessions_service.append_event", AsyncMock()):
             for i in range(n):
                 await defer_wake(pool, f"sess_{i}", cause="message")
 
@@ -87,11 +87,11 @@ class TestDeferWakeCrossSessionIsolation:
         completion + sweep) collapse into a single wake; the queued
         wake handles all events that arrived since it was deferred.
         """
-        from aios.harness.wake import defer_wake
+        from aios.services.wake import defer_wake
 
         pool = MagicMock()
 
-        with patch("aios.harness.wake.sessions_service.append_event", AsyncMock()):
+        with patch("aios.services.wake.sessions_service.append_event", AsyncMock()):
             await defer_wake(pool, "sess_x", cause="message")
             await defer_wake(pool, "sess_x", cause="sweep")
             await defer_wake(pool, "sess_x", cause="tool_confirmation")


### PR DESCRIPTION
## Summary

PR 3 of the 8-PR stack for #328. **Core-side schema work + the architectural seam that decouples connector-tool merging from core code.** Stacked on #331 (PR 2) — merge into that branch, not master.

## Three buckets

### 1. Migration `0034_core_schema_additions`

- **`sessions.owner_id text NULL`** — opaque to core. Subsystem chooses the value. Per #328's PR 2 sign-off, v1 sets it to a constant subsystem string.
- **`sessions.focal_locked boolean NOT NULL DEFAULT FALSE`** — the `switch_channel` tool's gate. Backfilled from `spawned_from_connection_id IS NOT NULL` so the existing invariant survives the migration without code-side coordination.
- **`user_id text NULL` on 18 existing user-data tables** — reserves the column so the eventual multi-tenant migration is "ADD INDEX + populate + flip NOT NULL" rather than "ADD COLUMN + backfill + rewrite all queries". No enforcement; no filtering; no query changes. Skipped tables that will be dropped in PR 7/8 (`connection_chat_sessions`, `connector_tokens`, `connector_inbound_acks`).

`spawned_from_connection_id` stays this PR. PR 7 drops it.

### 2. ToolProvider Protocol (`src/aios/tools/providers.py`)

The harness's per-step prelude needs a session-scoped custom-tool source. Today it calls `services.connections.list_tools_for_session` directly; after PR 4 the connector subsystem provides them. The Protocol is the contract that lets core call against an interface the subsystem registers against — core → interface ← subsystem.

PR 3 only lands the contract:
- `ToolProvider` Protocol in `src/aios/tools/providers.py`
- `runtime.tool_provider: ToolProvider | None` slot + `require_tool_provider()` helper, mirroring the existing `require_pool`/`require_crypto_box`/etc pattern.

**Nothing calls `require_tool_provider()` yet.** PR 4 registers the subsystem impl and rewires `step_context.py`.

### 3. `switch_channel` tool: swap the gate

- Today: `if await queries.get_session_spawn_origin(conn, session_id) is not None:` → error
- Now: `if await queries.is_session_focal_locked(conn, session_id):` → error

Error message rewords from "spawned for a single chat by a per_chat connection" to "its focal channel is locked" so the message survives PR 7's column drop. New query raises `NotFoundError` on missing session to avoid lying about the `-> bool` return type.

## Out-of-scope (deferred per the issue)

- `pg_notify('session_calls_<owner_id>')` fanout — PR 7
- `OperatorOrOwnerAuthDep` resolution — PR 5/7
- `step_context.py` rewire to call against `ToolProvider` — PR 4
- subsystem Python module — PR 4
- dropping `spawned_from_connection_id` — PR 7

## Test plan

- [x] `uv run mypy src` — clean (418 files)
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — **1152 passed**
- [x] `uv run pytest tests/integration/test_migrations.py -xvs` — alembic upgrade head succeeds with new sessions columns + user_id reservations applied
- [x] `openapi.json` + `src/aios/sdk/_generated/` regen'd (`scripts/regen-client.sh`) — only the two new `Session` fields surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)