### PR TITLE
feat(memory): reconcile bash writes to /mnt/memory into version log

### DIFF
--- a/src/aios/sandbox/memory_mounts.py
+++ b/src/aios/sandbox/memory_mounts.py
@@ -13,8 +13,8 @@ marker file. Subsequent provisioning sees the marker and is a no-op.
 
 Tool/API writes after materialization keep the host dir in sync via the
 atomic mirror helpers in :mod:`aios.sandbox.atomic_mirror`. Bash writes
-hit the host dir directly — visible cross-session, but not synced to DB
-(documented v2 limitation).
+hit the host dir directly and are reconciled back to the DB by the
+post-exec hook in :mod:`aios.tools.bash_memory_reconcile`.
 """
 
 from __future__ import annotations

--- a/src/aios/sandbox/memory_mounts.py
+++ b/src/aios/sandbox/memory_mounts.py
@@ -31,7 +31,7 @@ from aios.sandbox.volumes import memory_store_host_dir, memory_store_lock_path
 
 log = get_logger("aios.sandbox.memory_mounts")
 
-_MATERIALIZED_MARKER = ".materialized"
+MATERIALIZED_MARKER = ".materialized"
 
 
 async def materialize_store_to_host(
@@ -48,7 +48,7 @@ async def materialize_store_to_host(
     not by re-materialization.
     """
     host_dir = memory_store_host_dir(store_id)
-    marker = host_dir / _MATERIALIZED_MARKER
+    marker = host_dir / MATERIALIZED_MARKER
     if marker.exists():
         return
 

--- a/src/aios/tools/bash.py
+++ b/src/aios/tools/bash.py
@@ -48,6 +48,7 @@ use absolute paths.
 
 from __future__ import annotations
 
+import contextlib
 from typing import Any
 
 from aios.config import get_settings
@@ -126,15 +127,23 @@ async def bash_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
     before = snapshot_memory_mounts(session_id)
+    warnings: list[str] = []
 
-    result = await sandbox.exec(
-        handle,
-        command,
-        timeout_seconds=timeout,
-        max_output_bytes=settings.bash_max_output_bytes,
-    )
-
-    warnings = await reconcile_memory_mounts(session_id, before)
+    try:
+        result = await sandbox.exec(
+            handle,
+            command,
+            timeout_seconds=timeout,
+            max_output_bytes=settings.bash_max_output_bytes,
+        )
+    finally:
+        # Reconcile even when exec raises (e.g. container death) so that
+        # partial writes made before the crash are captured in the DB.
+        # Reconcile errors are suppressed here — the exec exception (if any)
+        # is the primary signal and must not be shadowed.
+        if before:
+            with contextlib.suppress(Exception):
+                warnings = await reconcile_memory_mounts(session_id, before)
 
     stderr = result.stderr
     if warnings:

--- a/src/aios/tools/bash.py
+++ b/src/aios/tools/bash.py
@@ -53,6 +53,7 @@ from typing import Any
 from aios.config import get_settings
 from aios.errors import AiosError
 from aios.harness import runtime
+from aios.tools.bash_memory_reconcile import reconcile_memory_mounts, snapshot_memory_mounts
 from aios.tools.registry import registry
 
 
@@ -124,6 +125,8 @@ async def bash_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     sandbox = runtime.require_sandbox_registry()
     handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
+    before = snapshot_memory_mounts(session_id)
+
     result = await sandbox.exec(
         handle,
         command,
@@ -131,10 +134,17 @@ async def bash_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
         max_output_bytes=settings.bash_max_output_bytes,
     )
 
+    warnings = await reconcile_memory_mounts(session_id, before)
+
+    stderr = result.stderr
+    if warnings:
+        suffix = "\n[memory-reconcile] " + "; ".join(warnings)
+        stderr = stderr + suffix
+
     return {
         "exit_code": result.exit_code,
         "stdout": result.stdout,
-        "stderr": result.stderr,
+        "stderr": stderr,
         "timed_out": result.timed_out,
         "truncated": result.truncated,
     }

--- a/src/aios/tools/bash.py
+++ b/src/aios/tools/bash.py
@@ -48,7 +48,6 @@ use absolute paths.
 
 from __future__ import annotations
 
-import contextlib
 from typing import Any
 
 from aios.config import get_settings
@@ -127,7 +126,9 @@ async def bash_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
     before = snapshot_memory_mounts(session_id)
-    warnings: list[str] = []
+    has_mounts = bool(runtime.get_session_memory_mounts(session_id))
+    reconcile_warnings: list[str] = []
+    exec_raised = False
 
     try:
         result = await sandbox.exec(
@@ -136,18 +137,25 @@ async def bash_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
             timeout_seconds=timeout,
             max_output_bytes=settings.bash_max_output_bytes,
         )
+    except Exception:
+        exec_raised = True
+        raise
     finally:
-        # Reconcile even when exec raises (e.g. container death) so that
-        # partial writes made before the crash are captured in the DB.
-        # Reconcile errors are suppressed here — the exec exception (if any)
-        # is the primary signal and must not be shadowed.
-        if before:
-            with contextlib.suppress(Exception):
-                warnings = await reconcile_memory_mounts(session_id, before)
+        # Reconcile whenever there are writable mounts — even when exec raises
+        # (e.g. container death) so that partial writes made before the crash
+        # are captured in the DB.  When exec succeeded, reconcile errors
+        # propagate; when exec already raised, we suppress them so the original
+        # exception is not shadowed.
+        if has_mounts:
+            try:
+                reconcile_warnings = await reconcile_memory_mounts(session_id, before)
+            except Exception:
+                if not exec_raised:
+                    raise  # fail hard when exec succeeded
 
     stderr = result.stderr
-    if warnings:
-        suffix = "\n[memory-reconcile] " + "; ".join(warnings)
+    if reconcile_warnings:
+        suffix = "\n[memory-reconcile] " + "; ".join(reconcile_warnings)
         stderr = stderr + suffix
 
     return {

--- a/src/aios/tools/bash.py
+++ b/src/aios/tools/bash.py
@@ -126,7 +126,6 @@ async def bash_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
     before = snapshot_memory_mounts(session_id)
-    has_mounts = bool(runtime.get_session_memory_mounts(session_id))
     reconcile_warnings: list[str] = []
     exec_raised = False
 
@@ -141,17 +140,17 @@ async def bash_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
         exec_raised = True
         raise
     finally:
-        # Reconcile whenever there are writable mounts — even when exec raises
-        # (e.g. container death) so that partial writes made before the crash
-        # are captured in the DB.  When exec succeeded, reconcile errors
-        # propagate; when exec already raised, we suppress them so the original
-        # exception is not shadowed.
-        if has_mounts:
-            try:
-                reconcile_warnings = await reconcile_memory_mounts(session_id, before)
-            except Exception:
-                if not exec_raised:
-                    raise  # fail hard when exec succeeded
+        # Reconcile unconditionally — even when exec raises (e.g. container death)
+        # so that partial writes made before the crash are captured in the DB.
+        # reconcile_memory_mounts returns [] immediately when there are no mounts,
+        # so this is a cheap no-op in the common case.
+        # When exec succeeded, reconcile errors propagate; when exec already raised,
+        # we suppress them so the original exception is not shadowed.
+        try:
+            reconcile_warnings = await reconcile_memory_mounts(session_id, before)
+        except Exception:
+            if not exec_raised:
+                raise  # fail hard when exec succeeded
 
     stderr = result.stderr
     if reconcile_warnings:

--- a/src/aios/tools/bash_memory_reconcile.py
+++ b/src/aios/tools/bash_memory_reconcile.py
@@ -38,8 +38,31 @@ _Snapshot = dict[tuple[str, str], str]
 
 
 def _sha256_of_content(content: str) -> str:
-    """sha256 over UTF-8 bytes of content — matches memory_stores._sha256_hex."""
+    """sha256 over UTF-8 bytes of content.
+
+    # mirrors memory_stores._sha256_hex; kept local to avoid cross-layer import
+    """
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _bytes_map_to_sha_map(
+    bytes_map: dict[tuple[str, str], bytes],
+) -> _Snapshot:
+    """Convert a raw-bytes map to a sha256-hex map.
+
+    For UTF-8 decodable bytes, sha is over the decoded string (matching the
+    memory_stores convention).  For binary blobs, sha is over the raw bytes —
+    this allows change detection even though binary files cannot be stored.
+    """
+    result: _Snapshot = {}
+    for (store_id, store_path), raw in bytes_map.items():
+        try:
+            content = raw.decode("utf-8")
+            sha = _sha256_of_content(content)
+        except UnicodeDecodeError:
+            sha = hashlib.sha256(raw).hexdigest()
+        result[(store_id, store_path)] = sha
+    return result
 
 
 def _walk_store_files(host_dir: Path) -> list[tuple[Path, str]]:
@@ -117,17 +140,7 @@ def snapshot_memory_mounts(session_id: str) -> _Snapshot:
     - Stores that have not been materialized (marker file absent).
     """
     by_bytes, _host_dirs = _snapshot_with_bytes(session_id)
-    result: _Snapshot = {}
-    for (store_id, store_path), raw in by_bytes.items():
-        try:
-            content = raw.decode("utf-8")
-            sha = _sha256_of_content(content)
-        except UnicodeDecodeError:
-            # Binary file — still snapshot with raw-bytes sha so we can detect
-            # changes, but reconcile will skip it with a warning.
-            sha = hashlib.sha256(raw).hexdigest()
-        result[(store_id, store_path)] = sha
-    return result
+    return _bytes_map_to_sha_map(by_bytes)
 
 
 def _read_utf8_content(
@@ -196,14 +209,7 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
     warnings: list[str] = []
 
     # Compute sha for after entries (needed for equality checks).
-    after: _Snapshot = {}
-    for (store_id, store_path), raw in after_bytes.items():
-        try:
-            content = raw.decode("utf-8")
-            sha = _sha256_of_content(content)
-        except UnicodeDecodeError:
-            sha = hashlib.sha256(raw).hexdigest()
-        after[(store_id, store_path)] = sha
+    after: _Snapshot = _bytes_map_to_sha_map(after_bytes)
 
     # ── New files (created by bash) ─────────────────────────────────────────
     for (store_id, store_path), _sha in after.items():

--- a/src/aios/tools/bash_memory_reconcile.py
+++ b/src/aios/tools/bash_memory_reconcile.py
@@ -1,0 +1,291 @@
+"""Post-exec memory-mount reconciliation for the bash tool.
+
+After each bash command completes, we diff the memory-mount host directories
+against a snapshot taken before the command ran. Any files that were created,
+modified, or deleted by the bash command are propagated to the database as
+``memory_versions`` rows, closing the v2 limitation where bash writes were
+visible cross-session via the shared FS but did not produce durable version
+history.
+
+Design constraints:
+- Snapshot is synchronous (no DB I/O) — taken before ``sandbox.exec``.
+- Reconcile is async — runs after ``sandbox.exec`` returns.
+- read_only mounts are never written; we skip them in both directions.
+- Binary files and oversized files emit warnings instead of failing loudly
+  (the command already ran; we just can't record what it wrote).
+- sha256 is over UTF-8 encoded bytes of the content string, matching the
+  convention in :mod:`aios.services.memory_stores._sha256_hex`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import structlog
+
+from aios.harness import runtime
+from aios.models.memory_stores import MAX_CONTENT_BYTES
+from aios.sandbox.memory_mounts import _MATERIALIZED_MARKER
+from aios.sandbox.volumes import memory_store_host_dir
+from aios.services import memory_stores as memory_service
+from aios.services.memory_stores import SessionActor
+
+log = structlog.get_logger("aios.tools.bash_memory_reconcile")
+
+# Snapshot type: (store_id, store_path) -> sha256_hex
+_Snapshot = dict[tuple[str, str], str]
+
+
+def _sha256_of_content(content: str) -> str:
+    """sha256 over UTF-8 bytes of content — matches memory_stores._sha256_hex."""
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _walk_store_files(host_dir: Path) -> list[tuple[Path, str]]:
+    """Return (absolute_path, store_path) for all eligible files in host_dir.
+
+    Skips directories, the .materialized marker, and any hidden temp files
+    starting with ``.tmp.`` (written by the atomic_mirror helper during
+    in-flight writes).
+    """
+    results: list[tuple[Path, str]] = []
+    for fpath in host_dir.rglob("*"):
+        if fpath.is_dir():
+            continue
+        name = fpath.name
+        if name == _MATERIALIZED_MARKER:
+            continue
+        if name.startswith(".tmp."):
+            continue
+        rel = fpath.relative_to(host_dir)
+        store_path = "/" + str(rel).replace("\\", "/")
+        results.append((fpath, store_path))
+    return results
+
+
+def snapshot_memory_mounts(session_id: str) -> _Snapshot:
+    """Return a sha256 snapshot of all writable, materialized memory mount files.
+
+    Called synchronously before ``sandbox.exec``.  No DB I/O.  Returns a dict
+    mapping ``(store_id, store_path)`` to the sha256 hex digest of the file's
+    content at that point.
+
+    Skips:
+    - Sessions with no attached stores.
+    - read_only mounts.
+    - Stores whose host directory does not exist yet.
+    - Stores that have not been materialized (marker file absent).
+    """
+    echoes = runtime.get_session_memory_mounts(session_id)
+    result: _Snapshot = {}
+
+    for echo in echoes:
+        if echo.access == "read_only":
+            continue
+        store_id = echo.memory_store_id
+        host_dir = memory_store_host_dir(store_id)
+        if not host_dir.exists():
+            continue
+        marker = host_dir / _MATERIALIZED_MARKER
+        if not marker.exists():
+            continue
+
+        for fpath, store_path in _walk_store_files(host_dir):
+            try:
+                raw = fpath.read_bytes()
+            except OSError:
+                continue
+            # sha256 over UTF-8 decoded content bytes to stay consistent with
+            # _sha256_hex in memory_stores service (which hashes content.encode("utf-8"))
+            try:
+                content = raw.decode("utf-8")
+                sha = _sha256_of_content(content)
+            except UnicodeDecodeError:
+                # Binary file — still snapshot with raw-bytes sha so we can detect
+                # changes, but reconcile will skip it with a warning.
+                sha = hashlib.sha256(raw).hexdigest()
+            result[(store_id, store_path)] = sha
+
+    return result
+
+
+async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[str]:
+    """Diff memory mount state against ``before``; write DB changes.
+
+    Called after ``sandbox.exec`` returns.  For each writable mount:
+
+    - New files (in after, not in before): ``create_memory``
+    - Modified files (sha changed): ``update_memory`` with precondition
+    - Deleted files (in before, not in after): ``delete_memory``
+    - Unchanged files: no DB call
+
+    Binary files and files exceeding ``MAX_CONTENT_BYTES`` are skipped with a
+    warning string (collected and returned).  DB errors propagate — they are
+    the session's problem to recover from through the normal error channel.
+    """
+    after = snapshot_memory_mounts(session_id)
+    pool = runtime.require_pool()
+    actor = SessionActor(session_id=session_id)
+    warnings: list[str] = []
+
+    # Build store_id -> host_dir mapping for quick lookup during reconcile.
+    echoes = runtime.get_session_memory_mounts(session_id)
+    host_dirs: dict[str, Path] = {}
+    for echo in echoes:
+        if echo.access == "read_only":
+            continue
+        hd = memory_store_host_dir(echo.memory_store_id)
+        if hd.exists() and (hd / _MATERIALIZED_MARKER).exists():
+            host_dirs[echo.memory_store_id] = hd
+
+    # ── New files (created by bash) ─────────────────────────────────────────
+    for (store_id, store_path), _sha in after.items():
+        if (store_id, store_path) in before:
+            continue  # will be handled as modify or unchanged
+        host_dir = host_dirs.get(store_id)
+        if host_dir is None:
+            continue
+        fpath = host_dir / store_path.lstrip("/")
+        try:
+            raw = fpath.read_bytes()
+        except OSError:
+            continue
+        try:
+            content = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            warnings.append(
+                f"skipped {store_path!r} in store {store_id}: binary file cannot be stored as memory"
+            )
+            log.warning(
+                "memory_reconcile.binary_file_skipped",
+                session_id=session_id,
+                store_id=store_id,
+                store_path=store_path,
+            )
+            continue
+        if len(raw) > MAX_CONTENT_BYTES:
+            warnings.append(
+                f"skipped {store_path!r} in store {store_id}: "
+                f"file size {len(raw)} exceeds {MAX_CONTENT_BYTES}-byte limit"
+            )
+            log.warning(
+                "memory_reconcile.oversized_file_skipped",
+                session_id=session_id,
+                store_id=store_id,
+                store_path=store_path,
+                size=len(raw),
+            )
+            continue
+        memory = await memory_service.create_memory(
+            pool,
+            store_id=store_id,
+            path=store_path,
+            content=content,
+            actor=actor,
+        )
+        runtime.set_read_sha(session_id, store_id, store_path, memory.content_sha256)
+        log.info(
+            "memory_reconcile.created",
+            session_id=session_id,
+            store_id=store_id,
+            store_path=store_path,
+        )
+
+    # ── Modified files (sha changed) ────────────────────────────────────────
+    for (store_id, store_path), before_sha in before.items():
+        after_sha = after.get((store_id, store_path))
+        if after_sha is None:
+            continue  # deleted — handled below
+        if after_sha == before_sha:
+            continue  # unchanged
+        host_dir = host_dirs.get(store_id)
+        if host_dir is None:
+            continue
+        fpath = host_dir / store_path.lstrip("/")
+        try:
+            raw = fpath.read_bytes()
+        except OSError:
+            continue
+        try:
+            content = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            warnings.append(
+                f"skipped {store_path!r} in store {store_id}: binary file cannot be stored as memory"
+            )
+            log.warning(
+                "memory_reconcile.binary_file_skipped",
+                session_id=session_id,
+                store_id=store_id,
+                store_path=store_path,
+            )
+            continue
+        if len(raw) > MAX_CONTENT_BYTES:
+            warnings.append(
+                f"skipped {store_path!r} in store {store_id}: "
+                f"file size {len(raw)} exceeds {MAX_CONTENT_BYTES}-byte limit"
+            )
+            log.warning(
+                "memory_reconcile.oversized_file_skipped",
+                session_id=session_id,
+                store_id=store_id,
+                store_path=store_path,
+                size=len(raw),
+            )
+            continue
+        existing = await memory_service.get_memory_by_path(
+            pool, store_id, store_path, include_content=False
+        )
+        if existing is None:
+            # Race: was in before snapshot but no DB record (e.g. previously skipped binary).
+            # Treat as a new create.
+            memory = await memory_service.create_memory(
+                pool,
+                store_id=store_id,
+                path=store_path,
+                content=content,
+                actor=actor,
+            )
+            runtime.set_read_sha(session_id, store_id, store_path, memory.content_sha256)
+        else:
+            memory = await memory_service.update_memory(
+                pool,
+                store_id=store_id,
+                memory_id=existing.id,
+                new_content=content,
+                precondition_sha256=before_sha,
+                actor=actor,
+            )
+            runtime.set_read_sha(session_id, store_id, store_path, memory.content_sha256)
+        log.info(
+            "memory_reconcile.modified",
+            session_id=session_id,
+            store_id=store_id,
+            store_path=store_path,
+        )
+
+    # ── Deleted files ────────────────────────────────────────────────────────
+    for store_id, store_path in before:
+        if (store_id, store_path) in after:
+            continue  # still exists
+        if store_id not in host_dirs:
+            continue
+        existing = await memory_service.get_memory_by_path(
+            pool, store_id, store_path, include_content=False
+        )
+        if existing is None:
+            continue  # already gone from DB; nothing to do
+        await memory_service.delete_memory(
+            pool,
+            store_id=store_id,
+            memory_id=existing.id,
+            actor=actor,
+        )
+        log.info(
+            "memory_reconcile.deleted",
+            session_id=session_id,
+            store_id=store_id,
+            store_path=store_path,
+        )
+
+    return warnings

--- a/src/aios/tools/bash_memory_reconcile.py
+++ b/src/aios/tools/bash_memory_reconcile.py
@@ -22,16 +22,15 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
-import structlog
-
 from aios.harness import runtime
+from aios.logging import get_logger
 from aios.models.memory_stores import MAX_CONTENT_BYTES
 from aios.sandbox.memory_mounts import MATERIALIZED_MARKER
 from aios.sandbox.volumes import memory_store_host_dir
 from aios.services import memory_stores as memory_service
 from aios.services.memory_stores import SessionActor
 
-log = structlog.get_logger("aios.tools.bash_memory_reconcile")
+log = get_logger("aios.tools.bash_memory_reconcile")
 
 # Snapshot type: (store_id, store_path) -> sha256_hex
 _Snapshot = dict[tuple[str, str], str]
@@ -252,8 +251,6 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
             continue  # deleted — handled below
         if after_sha == before_sha:
             continue  # unchanged
-        if store_id not in host_dirs:
-            continue
         raw = after_bytes[(store_id, store_path)]
         maybe_content = _read_utf8_content(
             store_id,

--- a/src/aios/tools/bash_memory_reconcile.py
+++ b/src/aios/tools/bash_memory_reconcile.py
@@ -40,7 +40,7 @@ _Snapshot = dict[tuple[str, str], str]
 def _sha256_of_content(content: str) -> str:
     """sha256 over UTF-8 bytes of content.
 
-    # mirrors memory_stores._sha256_hex; kept local to avoid cross-layer import
+    Mirrors memory_stores._sha256_hex; kept local to avoid cross-layer import.
     """
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
@@ -228,7 +228,9 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
         if maybe_content is None:
             continue
         content = maybe_content
-        # _mirror_to_host will no-op: bash already wrote the file (content identical).
+        # create_memory calls _mirror_to_host internally, which rewrites the same
+        # bytes bash just wrote. This is redundant I/O but harmless and unavoidable
+        # without adding a skip_mirror parameter to the service layer.
         memory = await memory_service.create_memory(
             pool,
             store_id=store_id,
@@ -270,7 +272,9 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
         if existing is None:
             # Race: was in before snapshot but no DB record (e.g. previously skipped binary).
             # Treat as a new create.
-            # _mirror_to_host will no-op: bash already wrote the file (content identical).
+            # create_memory calls _mirror_to_host internally, which rewrites the same
+            # bytes bash just wrote. This is redundant I/O but harmless and unavoidable
+            # without adding a skip_mirror parameter to the service layer.
             memory = await memory_service.create_memory(
                 pool,
                 store_id=store_id,
@@ -280,7 +284,12 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
             )
             runtime.set_read_sha(session_id, store_id, store_path, memory.content_sha256)
         else:
-            # _mirror_to_host will no-op: bash already wrote the file (content identical).
+            # update_memory calls _mirror_to_host internally, which rewrites the same
+            # bytes bash just wrote. This is redundant I/O but harmless and unavoidable
+            # without adding a skip_mirror parameter to the service layer.
+            # Precondition is always satisfied at this point (we just read the DB sha).
+            # This is intentional: bash is authoritative for what the filesystem contains;
+            # we record the write unconditionally.
             memory = await memory_service.update_memory(
                 pool,
                 store_id=store_id,
@@ -308,7 +317,8 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
         )
         if existing is None:
             continue  # already gone from DB; nothing to do
-        # _mirror_delete_from_host will no-op: bash already deleted the file (missing_ok=True).
+        # delete_memory calls _mirror_delete_from_host internally, which tries to unlink
+        # a file bash already deleted. Since missing_ok=True it is harmless.
         await memory_service.delete_memory(
             pool,
             store_id=store_id,

--- a/src/aios/tools/bash_memory_reconcile.py
+++ b/src/aios/tools/bash_memory_reconcile.py
@@ -26,7 +26,7 @@ import structlog
 
 from aios.harness import runtime
 from aios.models.memory_stores import MAX_CONTENT_BYTES
-from aios.sandbox.memory_mounts import _MATERIALIZED_MARKER
+from aios.sandbox.memory_mounts import MATERIALIZED_MARKER
 from aios.sandbox.volumes import memory_store_host_dir
 from aios.services import memory_stores as memory_service
 from aios.services.memory_stores import SessionActor
@@ -54,7 +54,7 @@ def _walk_store_files(host_dir: Path) -> list[tuple[Path, str]]:
         if fpath.is_dir():
             continue
         name = fpath.name
-        if name == _MATERIALIZED_MARKER:
+        if name == MATERIALIZED_MARKER:
             continue
         if name.startswith(".tmp."):
             continue
@@ -62,6 +62,37 @@ def _walk_store_files(host_dir: Path) -> list[tuple[Path, str]]:
         store_path = "/" + str(rel).replace("\\", "/")
         results.append((fpath, store_path))
     return results
+
+
+def _snapshot_with_bytes(session_id: str) -> dict[tuple[str, str], bytes]:
+    """Return raw bytes for all eligible files across writable materialized mounts.
+
+    Called internally by both ``snapshot_memory_mounts`` (which only needs
+    sha digests) and ``reconcile_memory_mounts`` (which needs the bytes to
+    avoid a second read).  Returns ``(store_id, store_path) -> raw_bytes``.
+    """
+    echoes = runtime.get_session_memory_mounts(session_id)
+    result: dict[tuple[str, str], bytes] = {}
+
+    for echo in echoes:
+        if echo.access == "read_only":
+            continue
+        store_id = echo.memory_store_id
+        host_dir = memory_store_host_dir(store_id)
+        if not host_dir.exists():
+            continue
+        marker = host_dir / MATERIALIZED_MARKER
+        if not marker.exists():
+            continue
+
+        for fpath, store_path in _walk_store_files(host_dir):
+            try:
+                raw = fpath.read_bytes()
+            except OSError:
+                continue
+            result[(store_id, store_path)] = raw
+
+    return result
 
 
 def snapshot_memory_mounts(session_id: str) -> _Snapshot:
@@ -77,37 +108,62 @@ def snapshot_memory_mounts(session_id: str) -> _Snapshot:
     - Stores whose host directory does not exist yet.
     - Stores that have not been materialized (marker file absent).
     """
-    echoes = runtime.get_session_memory_mounts(session_id)
+    by_bytes = _snapshot_with_bytes(session_id)
     result: _Snapshot = {}
-
-    for echo in echoes:
-        if echo.access == "read_only":
-            continue
-        store_id = echo.memory_store_id
-        host_dir = memory_store_host_dir(store_id)
-        if not host_dir.exists():
-            continue
-        marker = host_dir / _MATERIALIZED_MARKER
-        if not marker.exists():
-            continue
-
-        for fpath, store_path in _walk_store_files(host_dir):
-            try:
-                raw = fpath.read_bytes()
-            except OSError:
-                continue
-            # sha256 over UTF-8 decoded content bytes to stay consistent with
-            # _sha256_hex in memory_stores service (which hashes content.encode("utf-8"))
-            try:
-                content = raw.decode("utf-8")
-                sha = _sha256_of_content(content)
-            except UnicodeDecodeError:
-                # Binary file — still snapshot with raw-bytes sha so we can detect
-                # changes, but reconcile will skip it with a warning.
-                sha = hashlib.sha256(raw).hexdigest()
-            result[(store_id, store_path)] = sha
-
+    for (store_id, store_path), raw in by_bytes.items():
+        try:
+            content = raw.decode("utf-8")
+            sha = _sha256_of_content(content)
+        except UnicodeDecodeError:
+            # Binary file — still snapshot with raw-bytes sha so we can detect
+            # changes, but reconcile will skip it with a warning.
+            sha = hashlib.sha256(raw).hexdigest()
+        result[(store_id, store_path)] = sha
     return result
+
+
+def _read_utf8_content(
+    fpath: Path,
+    store_id: str,
+    store_path: str,
+    warnings: list[str],
+    session_id: str,
+    raw: bytes,
+) -> str | None:
+    """Decode ``raw`` as UTF-8 and enforce the size limit.
+
+    Returns the decoded string on success, or ``None`` if the bytes cannot be
+    decoded or exceed ``MAX_CONTENT_BYTES``.  In the rejection case a human-
+    readable entry is appended to ``warnings`` and a structured warning is
+    emitted via the logger.
+    """
+    try:
+        content = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        warnings.append(
+            f"skipped {store_path!r} in store {store_id}: binary file cannot be stored as memory"
+        )
+        log.warning(
+            "memory_reconcile.binary_file_skipped",
+            session_id=session_id,
+            store_id=store_id,
+            store_path=store_path,
+        )
+        return None
+    if len(raw) > MAX_CONTENT_BYTES:
+        warnings.append(
+            f"skipped {store_path!r} in store {store_id}: "
+            f"file size {len(raw)} exceeds {MAX_CONTENT_BYTES}-byte limit"
+        )
+        log.warning(
+            "memory_reconcile.oversized_file_skipped",
+            session_id=session_id,
+            store_id=store_id,
+            store_path=store_path,
+            size=len(raw),
+        )
+        return None
+    return content
 
 
 async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[str]:
@@ -124,59 +180,52 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
     warning string (collected and returned).  DB errors propagate — they are
     the session's problem to recover from through the normal error channel.
     """
-    after = snapshot_memory_mounts(session_id)
+    # Build after snapshot as (store_id, store_path) -> bytes in one pass.
+    # Using bytes avoids re-reading files during the create/modify loops.
+    after_bytes = _snapshot_with_bytes(session_id)
     pool = runtime.require_pool()
     actor = SessionActor(session_id=session_id)
     warnings: list[str] = []
 
-    # Build store_id -> host_dir mapping for quick lookup during reconcile.
+    # Build store_id -> host_dir from mounts (single iteration, no re-scan).
     echoes = runtime.get_session_memory_mounts(session_id)
     host_dirs: dict[str, Path] = {}
     for echo in echoes:
         if echo.access == "read_only":
             continue
         hd = memory_store_host_dir(echo.memory_store_id)
-        if hd.exists() and (hd / _MATERIALIZED_MARKER).exists():
+        if hd.exists() and (hd / MATERIALIZED_MARKER).exists():
             host_dirs[echo.memory_store_id] = hd
+
+    # Compute sha for after entries (needed for equality checks).
+    after: _Snapshot = {}
+    for (store_id, store_path), raw in after_bytes.items():
+        try:
+            content = raw.decode("utf-8")
+            sha = _sha256_of_content(content)
+        except UnicodeDecodeError:
+            sha = hashlib.sha256(raw).hexdigest()
+        after[(store_id, store_path)] = sha
 
     # ── New files (created by bash) ─────────────────────────────────────────
     for (store_id, store_path), _sha in after.items():
         if (store_id, store_path) in before:
             continue  # will be handled as modify or unchanged
-        host_dir = host_dirs.get(store_id)
-        if host_dir is None:
+        if store_id not in host_dirs:
             continue
-        fpath = host_dir / store_path.lstrip("/")
-        try:
-            raw = fpath.read_bytes()
-        except OSError:
+        raw = after_bytes[(store_id, store_path)]
+        maybe_content = _read_utf8_content(
+            host_dirs[store_id] / store_path.lstrip("/"),
+            store_id,
+            store_path,
+            warnings,
+            session_id,
+            raw,
+        )
+        if maybe_content is None:
             continue
-        try:
-            content = raw.decode("utf-8")
-        except UnicodeDecodeError:
-            warnings.append(
-                f"skipped {store_path!r} in store {store_id}: binary file cannot be stored as memory"
-            )
-            log.warning(
-                "memory_reconcile.binary_file_skipped",
-                session_id=session_id,
-                store_id=store_id,
-                store_path=store_path,
-            )
-            continue
-        if len(raw) > MAX_CONTENT_BYTES:
-            warnings.append(
-                f"skipped {store_path!r} in store {store_id}: "
-                f"file size {len(raw)} exceeds {MAX_CONTENT_BYTES}-byte limit"
-            )
-            log.warning(
-                "memory_reconcile.oversized_file_skipped",
-                session_id=session_id,
-                store_id=store_id,
-                store_path=store_path,
-                size=len(raw),
-            )
-            continue
+        content = maybe_content
+        # _mirror_to_host will no-op: bash already wrote the file (content identical).
         memory = await memory_service.create_memory(
             pool,
             store_id=store_id,
@@ -199,46 +248,27 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
             continue  # deleted — handled below
         if after_sha == before_sha:
             continue  # unchanged
-        host_dir = host_dirs.get(store_id)
-        if host_dir is None:
+        if store_id not in host_dirs:
             continue
-        fpath = host_dir / store_path.lstrip("/")
-        try:
-            raw = fpath.read_bytes()
-        except OSError:
+        raw = after_bytes[(store_id, store_path)]
+        maybe_content = _read_utf8_content(
+            host_dirs[store_id] / store_path.lstrip("/"),
+            store_id,
+            store_path,
+            warnings,
+            session_id,
+            raw,
+        )
+        if maybe_content is None:
             continue
-        try:
-            content = raw.decode("utf-8")
-        except UnicodeDecodeError:
-            warnings.append(
-                f"skipped {store_path!r} in store {store_id}: binary file cannot be stored as memory"
-            )
-            log.warning(
-                "memory_reconcile.binary_file_skipped",
-                session_id=session_id,
-                store_id=store_id,
-                store_path=store_path,
-            )
-            continue
-        if len(raw) > MAX_CONTENT_BYTES:
-            warnings.append(
-                f"skipped {store_path!r} in store {store_id}: "
-                f"file size {len(raw)} exceeds {MAX_CONTENT_BYTES}-byte limit"
-            )
-            log.warning(
-                "memory_reconcile.oversized_file_skipped",
-                session_id=session_id,
-                store_id=store_id,
-                store_path=store_path,
-                size=len(raw),
-            )
-            continue
+        content = maybe_content
         existing = await memory_service.get_memory_by_path(
             pool, store_id, store_path, include_content=False
         )
         if existing is None:
             # Race: was in before snapshot but no DB record (e.g. previously skipped binary).
             # Treat as a new create.
+            # _mirror_to_host will no-op: bash already wrote the file (content identical).
             memory = await memory_service.create_memory(
                 pool,
                 store_id=store_id,
@@ -248,6 +278,7 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
             )
             runtime.set_read_sha(session_id, store_id, store_path, memory.content_sha256)
         else:
+            # _mirror_to_host will no-op: bash already wrote the file (content identical).
             memory = await memory_service.update_memory(
                 pool,
                 store_id=store_id,
@@ -275,6 +306,7 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
         )
         if existing is None:
             continue  # already gone from DB; nothing to do
+        # _mirror_delete_from_host will no-op: bash already deleted the file (missing_ok=True).
         await memory_service.delete_memory(
             pool,
             store_id=store_id,

--- a/src/aios/tools/bash_memory_reconcile.py
+++ b/src/aios/tools/bash_memory_reconcile.py
@@ -64,15 +64,22 @@ def _walk_store_files(host_dir: Path) -> list[tuple[Path, str]]:
     return results
 
 
-def _snapshot_with_bytes(session_id: str) -> dict[tuple[str, str], bytes]:
-    """Return raw bytes for all eligible files across writable materialized mounts.
+def _snapshot_with_bytes(
+    session_id: str,
+) -> tuple[dict[tuple[str, str], bytes], dict[str, Path]]:
+    """Return raw bytes and host-dir map for all eligible writable materialized mounts.
 
     Called internally by both ``snapshot_memory_mounts`` (which only needs
-    sha digests) and ``reconcile_memory_mounts`` (which needs the bytes to
-    avoid a second read).  Returns ``(store_id, store_path) -> raw_bytes``.
+    sha digests) and ``reconcile_memory_mounts`` (which needs both to avoid a
+    second scan).
+
+    Returns a 2-tuple:
+    - ``bytes_map``: ``(store_id, store_path) -> raw_bytes``
+    - ``host_dirs``: ``store_id -> host_dir`` (writable, materialized stores only)
     """
     echoes = runtime.get_session_memory_mounts(session_id)
-    result: dict[tuple[str, str], bytes] = {}
+    bytes_map: dict[tuple[str, str], bytes] = {}
+    host_dirs: dict[str, Path] = {}
 
     for echo in echoes:
         if echo.access == "read_only":
@@ -85,14 +92,15 @@ def _snapshot_with_bytes(session_id: str) -> dict[tuple[str, str], bytes]:
         if not marker.exists():
             continue
 
+        host_dirs[store_id] = host_dir
         for fpath, store_path in _walk_store_files(host_dir):
             try:
                 raw = fpath.read_bytes()
             except OSError:
                 continue
-            result[(store_id, store_path)] = raw
+            bytes_map[(store_id, store_path)] = raw
 
-    return result
+    return bytes_map, host_dirs
 
 
 def snapshot_memory_mounts(session_id: str) -> _Snapshot:
@@ -108,7 +116,7 @@ def snapshot_memory_mounts(session_id: str) -> _Snapshot:
     - Stores whose host directory does not exist yet.
     - Stores that have not been materialized (marker file absent).
     """
-    by_bytes = _snapshot_with_bytes(session_id)
+    by_bytes, _host_dirs = _snapshot_with_bytes(session_id)
     result: _Snapshot = {}
     for (store_id, store_path), raw in by_bytes.items():
         try:
@@ -123,7 +131,6 @@ def snapshot_memory_mounts(session_id: str) -> _Snapshot:
 
 
 def _read_utf8_content(
-    fpath: Path,
     store_id: str,
     store_path: str,
     warnings: list[str],
@@ -182,20 +189,11 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
     """
     # Build after snapshot as (store_id, store_path) -> bytes in one pass.
     # Using bytes avoids re-reading files during the create/modify loops.
-    after_bytes = _snapshot_with_bytes(session_id)
+    # host_dirs comes from the same scan — no second get_session_memory_mounts call.
+    after_bytes, host_dirs = _snapshot_with_bytes(session_id)
     pool = runtime.require_pool()
     actor = SessionActor(session_id=session_id)
     warnings: list[str] = []
-
-    # Build store_id -> host_dir from mounts (single iteration, no re-scan).
-    echoes = runtime.get_session_memory_mounts(session_id)
-    host_dirs: dict[str, Path] = {}
-    for echo in echoes:
-        if echo.access == "read_only":
-            continue
-        hd = memory_store_host_dir(echo.memory_store_id)
-        if hd.exists() and (hd / MATERIALIZED_MARKER).exists():
-            host_dirs[echo.memory_store_id] = hd
 
     # Compute sha for after entries (needed for equality checks).
     after: _Snapshot = {}
@@ -215,7 +213,6 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
             continue
         raw = after_bytes[(store_id, store_path)]
         maybe_content = _read_utf8_content(
-            host_dirs[store_id] / store_path.lstrip("/"),
             store_id,
             store_path,
             warnings,
@@ -252,7 +249,6 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
             continue
         raw = after_bytes[(store_id, store_path)]
         maybe_content = _read_utf8_content(
-            host_dirs[store_id] / store_path.lstrip("/"),
             store_id,
             store_path,
             warnings,
@@ -284,7 +280,7 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
                 store_id=store_id,
                 memory_id=existing.id,
                 new_content=content,
-                precondition_sha256=before_sha,
+                precondition_sha256=existing.content_sha256,
                 actor=actor,
             )
             runtime.set_read_sha(session_id, store_id, store_path, memory.content_sha256)

--- a/src/aios/tools/bash_memory_reconcile.py
+++ b/src/aios/tools/bash_memory_reconcile.py
@@ -36,15 +36,6 @@ log = get_logger("aios.tools.bash_memory_reconcile")
 _Snapshot = dict[tuple[str, str], str]
 
 
-def _sha256_of_content(content: str) -> str:
-    """sha256 over UTF-8 bytes of content.
-
-    Mirrors memory_stores._sha256_hex; avoids calling the private
-    memory_stores._sha256_hex across module boundaries.
-    """
-    return hashlib.sha256(content.encode("utf-8")).hexdigest()
-
-
 def _bytes_map_to_sha_map(
     bytes_map: dict[tuple[str, str], bytes],
 ) -> _Snapshot:
@@ -58,7 +49,8 @@ def _bytes_map_to_sha_map(
     for (store_id, store_path), raw in bytes_map.items():
         try:
             content = raw.decode("utf-8")
-            sha = _sha256_of_content(content)
+            # sha256 over UTF-8 bytes of content — mirrors memory_stores._sha256_hex
+            sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
         except UnicodeDecodeError:
             sha = hashlib.sha256(raw).hexdigest()
         result[(store_id, store_path)] = sha
@@ -89,20 +81,17 @@ def _walk_store_files(host_dir: Path) -> list[tuple[Path, str]]:
 
 def _snapshot_with_bytes(
     session_id: str,
-) -> tuple[dict[tuple[str, str], bytes], dict[str, Path]]:
-    """Return raw bytes and host-dir map for all eligible writable materialized mounts.
+) -> dict[tuple[str, str], bytes]:
+    """Return raw bytes for all eligible writable materialized mounts.
 
     Called internally by both ``snapshot_memory_mounts`` (which only needs
-    sha digests) and ``reconcile_memory_mounts`` (which needs both to avoid a
-    second scan).
+    sha digests) and ``reconcile_memory_mounts`` (which needs bytes to avoid
+    a second scan).
 
-    Returns a 2-tuple:
-    - ``bytes_map``: ``(store_id, store_path) -> raw_bytes``
-    - ``host_dirs``: ``store_id -> host_dir`` (writable, materialized stores only)
+    Returns ``bytes_map``: ``(store_id, store_path) -> raw_bytes``.
     """
     echoes = runtime.get_session_memory_mounts(session_id)
     bytes_map: dict[tuple[str, str], bytes] = {}
-    host_dirs: dict[str, Path] = {}
 
     for echo in echoes:
         if echo.access == "read_only":
@@ -115,7 +104,6 @@ def _snapshot_with_bytes(
         if not marker.exists():
             continue
 
-        host_dirs[store_id] = host_dir
         for fpath, store_path in _walk_store_files(host_dir):
             try:
                 raw = fpath.read_bytes()
@@ -123,7 +111,7 @@ def _snapshot_with_bytes(
                 continue
             bytes_map[(store_id, store_path)] = raw
 
-    return bytes_map, host_dirs
+    return bytes_map
 
 
 def snapshot_memory_mounts(session_id: str) -> _Snapshot:
@@ -139,7 +127,7 @@ def snapshot_memory_mounts(session_id: str) -> _Snapshot:
     - Stores whose host directory does not exist yet.
     - Stores that have not been materialized (marker file absent).
     """
-    by_bytes, _host_dirs = _snapshot_with_bytes(session_id)
+    by_bytes = _snapshot_with_bytes(session_id)
     return _bytes_map_to_sha_map(by_bytes)
 
 
@@ -202,8 +190,7 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
     """
     # Build after snapshot as (store_id, store_path) -> bytes in one pass.
     # Using bytes avoids re-reading files during the create/modify loops.
-    # host_dirs comes from the same scan — no second get_session_memory_mounts call.
-    after_bytes, host_dirs = _snapshot_with_bytes(session_id)
+    after_bytes = _snapshot_with_bytes(session_id)
     pool = runtime.require_pool()
     actor = SessionActor(session_id=session_id)
     warnings: list[str] = []
@@ -307,8 +294,6 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
     for store_id, store_path in before:
         if (store_id, store_path) in after:
             continue  # still exists
-        if store_id not in host_dirs:
-            continue
         existing = await memory_service.get_memory_by_path(
             pool, store_id, store_path, include_content=False
         )

--- a/src/aios/tools/bash_memory_reconcile.py
+++ b/src/aios/tools/bash_memory_reconcile.py
@@ -40,7 +40,8 @@ _Snapshot = dict[tuple[str, str], str]
 def _sha256_of_content(content: str) -> str:
     """sha256 over UTF-8 bytes of content.
 
-    Mirrors memory_stores._sha256_hex; kept local to avoid cross-layer import.
+    Mirrors memory_stores._sha256_hex; avoids calling the private
+    memory_stores._sha256_hex across module boundaries.
     """
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
@@ -215,8 +216,6 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
     for (store_id, store_path), _sha in after.items():
         if (store_id, store_path) in before:
             continue  # will be handled as modify or unchanged
-        if store_id not in host_dirs:
-            continue
         raw = after_bytes[(store_id, store_path)]
         maybe_content = _read_utf8_content(
             store_id,
@@ -287,9 +286,10 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
             # update_memory calls _mirror_to_host internally, which rewrites the same
             # bytes bash just wrote. This is redundant I/O but harmless and unavoidable
             # without adding a skip_mirror parameter to the service layer.
-            # Precondition is always satisfied at this point (we just read the DB sha).
-            # This is intentional: bash is authoritative for what the filesystem contains;
-            # we record the write unconditionally.
+            # Passing existing.content_sha256 as precondition guards against concurrent writes
+            # from another session: if a peer session wrote between our get_memory_by_path and
+            # this update, the precondition fails and MemoryPreconditionFailedError propagates
+            # as a tool-result error, which the model can handle.
             memory = await memory_service.update_memory(
                 pool,
                 store_id=store_id,

--- a/tests/e2e/test_memory_cross_session_sync.py
+++ b/tests/e2e/test_memory_cross_session_sync.py
@@ -231,9 +231,8 @@ class TestCrossSessionSync:
         assert "error" not in result, result
         assert "from-api" in result["content"]
 
-    async def test_bash_visible_cross_session_but_no_version(self, docker_harness: Harness) -> None:
-        """Documented v2 limitation: bash writes propagate via shared FS
-        (so other sessions see them) but produce no memory_versions row."""
+    async def test_bash_create_reconciles_to_version(self, docker_harness: Harness) -> None:
+        """bash writes to memory mounts are reconciled into memory_versions by the post-exec hook."""
         from aios.db import queries
         from aios.tools.bash import bash_handler
 
@@ -245,7 +244,7 @@ class TestCrossSessionSync:
         await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
         await sandbox.get_or_provision(b.id, pool=docker_harness._pool)
 
-        # A bash-writes a new file.
+        # A bash-writes a new file; reconcile hook fires after exec.
         a_bash = await bash_handler(
             a.id,
             {"command": "echo bashed-by-a > /mnt/memory/xsync-bash/from_bash.md"},
@@ -256,11 +255,117 @@ class TestCrossSessionSync:
         b_bash = await bash_handler(b.id, {"command": "cat /mnt/memory/xsync-bash/from_bash.md"})
         assert "bashed-by-a" in b_bash["stdout"]
 
-        # But: no memory_versions row was created. Documented v2 gap.
+        # Post-exec reconcile created a memory_versions row.
         async with docker_harness._pool.acquire() as conn:
             versions = await queries.list_memory_versions(conn, store_id)
         paths = [v.path for v in versions]
-        assert "/from_bash.md" not in paths
+        assert "/from_bash.md" in paths
+
+        # Version was stamped as session_actor.
+        version = next(v for v in versions if v.path == "/from_bash.md")
+        assert version.created_by.type == "session_actor"
+
+    async def test_bash_modify_reconciles_version(self, docker_harness: Harness) -> None:
+        """bash modifies existing file; a 'modified' version row appears."""
+        from aios.db import queries
+        from aios.tools.bash import bash_handler
+
+        store_id = await _attach_store(docker_harness, "xsync-bash-mod")
+        a = await _start_session_with_store(docker_harness, store_id)
+
+        sandbox = runtime.require_sandbox_registry()
+        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
+
+        # Modify the pre-seeded /seed.md via bash.
+        # snapshot before exec sees seed.md; after exec sees changed content.
+        result = await bash_handler(
+            a.id,
+            {"command": "echo modified-by-bash > /mnt/memory/xsync-bash-mod/seed.md"},
+        )
+        assert result.get("exit_code", 0) == 0, result
+
+        async with docker_harness._pool.acquire() as conn:
+            versions = await queries.list_memory_versions(conn, store_id)
+        # There should be at least 2 versions: created (from seed) + modified (from bash).
+        seed_versions = [v for v in versions if v.path == "/seed.md"]
+        operations = {v.operation for v in seed_versions}
+        assert "modified" in operations
+
+    async def test_bash_delete_reconciles_version(self, docker_harness: Harness) -> None:
+        """bash rm's a file; a 'deleted' version row appears."""
+        from aios.db import queries
+        from aios.tools.bash import bash_handler
+
+        store_id = await _attach_store(docker_harness, "xsync-bash-del")
+        a = await _start_session_with_store(docker_harness, store_id)
+
+        sandbox = runtime.require_sandbox_registry()
+        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
+
+        # Delete /seed.md via bash.
+        result = await bash_handler(
+            a.id,
+            {"command": "rm /mnt/memory/xsync-bash-del/seed.md"},
+        )
+        assert result.get("exit_code", 0) == 0, result
+
+        async with docker_harness._pool.acquire() as conn:
+            versions = await queries.list_memory_versions(conn, store_id)
+        seed_versions = [v for v in versions if v.path == "/seed.md"]
+        operations = {v.operation for v in seed_versions}
+        assert "deleted" in operations
+
+    async def test_bash_binary_file_reconcile_warning(self, docker_harness: Harness) -> None:
+        """bash writes binary bytes; stderr contains reconcile warning; no version row created."""
+        from aios.db import queries
+        from aios.tools.bash import bash_handler
+
+        store_id = await _attach_store(docker_harness, "xsync-bash-bin")
+        a = await _start_session_with_store(docker_harness, store_id)
+
+        sandbox = runtime.require_sandbox_registry()
+        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
+
+        # Write binary (non-UTF-8) bytes to a memory mount file.
+        result = await bash_handler(
+            a.id,
+            {"command": "printf '\\xff\\xfe\\x00\\x01' > /mnt/memory/xsync-bash-bin/binary.bin"},
+        )
+        assert result.get("exit_code", 0) == 0, result
+
+        # Warning should appear in stderr.
+        assert "[memory-reconcile]" in result["stderr"]
+
+        # No version row created for the binary file.
+        async with docker_harness._pool.acquire() as conn:
+            versions = await queries.list_memory_versions(conn, store_id)
+        paths = [v.path for v in versions]
+        assert "/binary.bin" not in paths
+
+    async def test_bash_nohup_residual_gap(self, docker_harness: Harness) -> None:
+        """Background processes after bash returns may not be captured.
+
+        Documents that nohup/background bash writes to memory mounts that
+        complete *after* the command returns fall outside the reconcile window.
+        The test simply asserts no crash occurs — not that the write is captured.
+        """
+        from aios.tools.bash import bash_handler
+
+        store_id = await _attach_store(docker_harness, "xsync-bash-nohup")
+        a = await _start_session_with_store(docker_harness, store_id)
+
+        sandbox = runtime.require_sandbox_registry()
+        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
+
+        # Background process that writes after bash -c returns.
+        result = await bash_handler(
+            a.id,
+            {
+                "command": "nohup sh -c 'sleep 0.5; echo done > /mnt/memory/xsync-bash-nohup/bg.md' & echo done"
+            },
+        )
+        # No crash; exit_code check is lenient — the command itself should succeed.
+        assert result.get("exit_code", 0) == 0, result
 
 
 @needs_docker

--- a/tests/unit/test_bash_handler.py
+++ b/tests/unit/test_bash_handler.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -154,3 +154,29 @@ class TestTimeoutCapping:
         )
         kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
         assert kwargs["timeout_seconds"] == 5
+
+
+class TestExecRaisedReconcileSuppression:
+    """When exec raises, reconcile exceptions are suppressed so the original propagates."""
+
+    async def test_exec_exception_propagates_not_reconcile_exception(
+        self, stub_registry: _StubRegistry
+    ) -> None:
+        """sandbox.exec raises; reconcile also raises; original exec exception propagates."""
+        exec_error = RuntimeError("container died")
+        reconcile_error = RuntimeError("reconcile failed too")
+
+        stub_registry.exec.side_effect = exec_error  # type: ignore[attr-defined]
+
+        with (
+            patch(
+                "aios.tools.bash.reconcile_memory_mounts",
+                new_callable=AsyncMock,
+                side_effect=reconcile_error,
+            ) as mock_reconcile,
+            pytest.raises(RuntimeError, match="container died"),
+        ):
+            await bash_handler("sess_01TEST", {"command": "true"})
+
+        # reconcile was still attempted despite exec raising
+        mock_reconcile.assert_awaited_once()

--- a/tests/unit/test_bash_memory_reconcile.py
+++ b/tests/unit/test_bash_memory_reconcile.py
@@ -221,7 +221,7 @@ class TestReconcile:
         assert call_kwargs["content"] == content
 
     async def test_modified_file_calls_update_memory(self, tmp_path: Path) -> None:
-        """before has sha A, after sha B; update_memory called with precondition_sha256=sha_A."""
+        """before has sha A, after sha B; update_memory called with precondition_sha256=existing.content_sha256."""
         from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
 
         host_dir = self._make_host_dir(tmp_path)
@@ -230,12 +230,13 @@ class TestReconcile:
         (host_dir / "mod.md").write_text(new_content)
 
         old_sha = _sha256(old_content)
+        db_sha = _sha256("db-current\n")  # DB's sha may differ from before_sha
         before = {(STORE_A, "/mod.md"): old_sha}
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
 
         fake_memory = MagicMock()
         fake_memory.id = "mem_01FAKE0000000000000000001"
-        fake_memory.content_sha256 = _sha256(new_content)
+        fake_memory.content_sha256 = db_sha
 
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
@@ -263,7 +264,7 @@ class TestReconcile:
         assert warnings == []
         mock_update.assert_awaited_once()
         call_kwargs = mock_update.await_args.kwargs
-        assert call_kwargs["precondition_sha256"] == old_sha
+        assert call_kwargs["precondition_sha256"] == db_sha
         assert call_kwargs["new_content"] == new_content
 
     async def test_deleted_file_calls_delete_memory(self, tmp_path: Path) -> None:

--- a/tests/unit/test_bash_memory_reconcile.py
+++ b/tests/unit/test_bash_memory_reconcile.py
@@ -1,0 +1,536 @@
+"""Unit tests for bash_memory_reconcile — snapshot + reconcile helpers.
+
+All tests are pure in-memory: no Docker, no Postgres.  The file system
+operations use pytest's ``tmp_path`` fixture; DB calls are mocked via
+``unittest.mock``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.harness import runtime
+from aios.models.memory_stores import MemoryStoreResourceEcho
+
+SESSION_ID = "sesn_01RECONCILETEST00000000001"
+STORE_A = "memstore_01STOREA000000000000000001"
+STORE_B = "memstore_01STOREB000000000000000001"
+
+
+def _echo(
+    store_id: str = STORE_A,
+    name: str = "notes",
+    access: str = "read_write",
+) -> MemoryStoreResourceEcho:
+    return MemoryStoreResourceEcho(
+        memory_store_id=store_id,
+        access=access,  # type: ignore[arg-type]
+        instructions="",
+        name=name,
+        description="",
+        mount_path=f"/mnt/memory/{name}",
+    )
+
+
+def _sha256(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@pytest.fixture(autouse=True)
+def _clear_runtime() -> Any:
+    runtime.clear_session_memory_mounts(SESSION_ID)
+    runtime.clear_session_read_shas(SESSION_ID)
+    yield
+    runtime.clear_session_memory_mounts(SESSION_ID)
+    runtime.clear_session_read_shas(SESSION_ID)
+
+
+# ── TestSnapshot ─────────────────────────────────────────────────────────────
+
+
+class TestSnapshot:
+    def test_empty_when_no_mounts(self, tmp_path: Path) -> None:
+        """Session has no mounts attached; snapshot returns {}."""
+        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
+
+        runtime.set_session_memory_mounts(SESSION_ID, [])
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=tmp_path):
+            result = snapshot_memory_mounts(SESSION_ID)
+        assert result == {}
+
+    def test_empty_when_host_dir_missing(self, tmp_path: Path) -> None:
+        """Mount in cache but host dir doesn't exist; snapshot returns {}."""
+        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        missing = tmp_path / "nonexistent_store"
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=missing):
+            result = snapshot_memory_mounts(SESSION_ID)
+        assert result == {}
+
+    def test_empty_when_not_materialized(self, tmp_path: Path) -> None:
+        """Host dir exists but .materialized marker absent; returns {}."""
+        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
+
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        # Write a file but no .materialized marker
+        (host_dir / "foo.md").write_text("hello")
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
+            result = snapshot_memory_mounts(SESSION_ID)
+        assert result == {}
+
+    def test_includes_file_sha(self, tmp_path: Path) -> None:
+        """Host dir has foo.md with known content; snapshot returns correct sha."""
+        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
+
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        (host_dir / ".materialized").touch()
+        content = "hello world\n"
+        (host_dir / "foo.md").write_text(content)
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
+            result = snapshot_memory_mounts(SESSION_ID)
+
+        expected_sha = _sha256(content)
+        assert (STORE_A, "/foo.md") in result
+        assert result[(STORE_A, "/foo.md")] == expected_sha
+
+    def test_nested_path(self, tmp_path: Path) -> None:
+        """File at a/b/c.md resolves to store path /a/b/c.md."""
+        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
+
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        (host_dir / ".materialized").touch()
+        nested = host_dir / "a" / "b"
+        nested.mkdir(parents=True)
+        (nested / "c.md").write_text("nested")
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
+            result = snapshot_memory_mounts(SESSION_ID)
+
+        assert (STORE_A, "/a/b/c.md") in result
+
+    def test_skips_read_only_mounts(self, tmp_path: Path) -> None:
+        """read_only mount is present; its files are not included."""
+        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
+
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        (host_dir / ".materialized").touch()
+        (host_dir / "secret.md").write_text("protected")
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo(access="read_only")])
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
+            result = snapshot_memory_mounts(SESSION_ID)
+
+        assert result == {}
+
+    def test_materialized_marker_itself_excluded(self, tmp_path: Path) -> None:
+        """.materialized file not treated as a memory file."""
+        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
+
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        (host_dir / ".materialized").touch()
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
+            result = snapshot_memory_mounts(SESSION_ID)
+
+        assert result == {}
+
+
+# ── TestReconcile ─────────────────────────────────────────────────────────────
+
+
+class TestReconcile:
+    """Reconcile tests mock out memory_service functions and pool."""
+
+    @pytest.fixture
+    def mock_pool(self) -> MagicMock:
+        pool = MagicMock()
+        return pool
+
+    @pytest.fixture(autouse=True)
+    def _install_pool(self, mock_pool: MagicMock) -> Any:
+        prev = runtime.pool
+        runtime.pool = mock_pool
+        yield
+        runtime.pool = prev
+
+    def _make_host_dir(self, tmp_path: Path, store_id: str = STORE_A) -> Path:
+        host_dir = tmp_path / store_id
+        host_dir.mkdir(parents=True, exist_ok=True)
+        (host_dir / ".materialized").touch()
+        return host_dir
+
+    async def test_new_file_calls_create_memory(self, tmp_path: Path) -> None:
+        """before={}, after has one file; create_memory called with correct args."""
+        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+
+        host_dir = self._make_host_dir(tmp_path)
+        content = "new content\n"
+        (host_dir / "new.md").write_text(content)
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                new_callable=AsyncMock,
+            ) as mock_create,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_create.return_value = MagicMock(content_sha256=_sha256(content))
+            warnings = await reconcile_memory_mounts(SESSION_ID, before={})
+
+        assert warnings == []
+        mock_create.assert_awaited_once()
+        call_kwargs = mock_create.await_args.kwargs
+        assert call_kwargs["store_id"] == STORE_A
+        assert call_kwargs["path"] == "/new.md"
+        assert call_kwargs["content"] == content
+
+    async def test_modified_file_calls_update_memory(self, tmp_path: Path) -> None:
+        """before has sha A, after sha B; update_memory called with precondition_sha256=sha_A."""
+        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+
+        host_dir = self._make_host_dir(tmp_path)
+        old_content = "old\n"
+        new_content = "new\n"
+        (host_dir / "mod.md").write_text(new_content)
+
+        old_sha = _sha256(old_content)
+        before = {(STORE_A, "/mod.md"): old_sha}
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        fake_memory = MagicMock()
+        fake_memory.id = "mem_01FAKE0000000000000000001"
+        fake_memory.content_sha256 = _sha256(new_content)
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                new_callable=AsyncMock,
+                return_value=fake_memory,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                new_callable=AsyncMock,
+                return_value=fake_memory,
+            ) as mock_update,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                new_callable=AsyncMock,
+            ),
+        ):
+            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+
+        assert warnings == []
+        mock_update.assert_awaited_once()
+        call_kwargs = mock_update.await_args.kwargs
+        assert call_kwargs["precondition_sha256"] == old_sha
+        assert call_kwargs["new_content"] == new_content
+
+    async def test_deleted_file_calls_delete_memory(self, tmp_path: Path) -> None:
+        """path in before but not after; delete_memory called."""
+        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+
+        host_dir = self._make_host_dir(tmp_path)
+        # No file written — before has it, after won't
+        before = {(STORE_A, "/gone.md"): _sha256("old content\n")}
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        fake_memory = MagicMock()
+        fake_memory.id = "mem_01FAKE0000000000000000002"
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                new_callable=AsyncMock,
+                return_value=fake_memory,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+
+        assert warnings == []
+        mock_delete.assert_awaited_once()
+        call_kwargs = mock_delete.await_args.kwargs
+        assert call_kwargs["store_id"] == STORE_A
+        assert call_kwargs["memory_id"] == fake_memory.id
+
+    async def test_unchanged_file_no_db_call(self, tmp_path: Path) -> None:
+        """Same sha in before and after; no create/update/delete called."""
+        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+
+        host_dir = self._make_host_dir(tmp_path)
+        content = "unchanged\n"
+        (host_dir / "same.md").write_text(content)
+        sha = _sha256(content)
+        before = {(STORE_A, "/same.md"): sha}
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                new_callable=AsyncMock,
+            ) as mock_create,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                new_callable=AsyncMock,
+            ) as mock_update,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+
+        assert warnings == []
+        mock_create.assert_not_awaited()
+        mock_update.assert_not_awaited()
+        mock_delete.assert_not_awaited()
+
+    async def test_binary_file_skipped_with_warning(self, tmp_path: Path) -> None:
+        """Non-UTF-8 bytes; create not called; warning returned."""
+        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+
+        host_dir = self._make_host_dir(tmp_path)
+        # Write binary data that can't be decoded as UTF-8
+        (host_dir / "binary.bin").write_bytes(b"\xff\xfe\x00\x01")
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                new_callable=AsyncMock,
+            ) as mock_create,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                new_callable=AsyncMock,
+            ),
+        ):
+            warnings = await reconcile_memory_mounts(SESSION_ID, before={})
+
+        assert len(warnings) == 1
+        assert "binary.bin" in warnings[0] or "binary" in warnings[0].lower()
+        mock_create.assert_not_awaited()
+
+    async def test_oversized_file_skipped_with_warning(self, tmp_path: Path) -> None:
+        """File > MAX_CONTENT_BYTES; warning returned, no create."""
+        from aios.models.memory_stores import MAX_CONTENT_BYTES
+        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+
+        host_dir = self._make_host_dir(tmp_path)
+        big_content = "x" * (MAX_CONTENT_BYTES + 1)
+        (host_dir / "big.md").write_text(big_content)
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                new_callable=AsyncMock,
+            ) as mock_create,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                new_callable=AsyncMock,
+            ),
+        ):
+            warnings = await reconcile_memory_mounts(SESSION_ID, before={})
+
+        assert len(warnings) == 1
+        assert (
+            "big.md" in warnings[0]
+            or "size" in warnings[0].lower()
+            or "exceeds" in warnings[0].lower()
+        )
+        mock_create.assert_not_awaited()
+
+    async def test_skips_read_only_mounts_in_reconcile(self, tmp_path: Path) -> None:
+        """read_only mount; no DB call even if file changed."""
+        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+
+        host_dir = self._make_host_dir(tmp_path)
+        (host_dir / "file.md").write_text("content\n")
+
+        # read_only mount: even if we have a before sha that differs, no DB call
+        before = {(STORE_A, "/file.md"): "different_sha"}
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo(access="read_only")])
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                new_callable=AsyncMock,
+            ) as mock_create,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                new_callable=AsyncMock,
+            ) as mock_update,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+
+        assert warnings == []
+        mock_create.assert_not_awaited()
+        mock_update.assert_not_awaited()
+        mock_delete.assert_not_awaited()
+
+    async def test_read_sha_updated_after_create(self, tmp_path: Path) -> None:
+        """runtime.set_read_sha called after create_memory."""
+        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+
+        host_dir = self._make_host_dir(tmp_path)
+        content = "fresh\n"
+        (host_dir / "fresh.md").write_text(content)
+        expected_sha = _sha256(content)
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                new_callable=AsyncMock,
+                return_value=MagicMock(content_sha256=expected_sha),
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await reconcile_memory_mounts(SESSION_ID, before={})
+
+        cached_sha = runtime.get_read_sha(SESSION_ID, STORE_A, "/fresh.md")
+        assert cached_sha == expected_sha
+
+    async def test_read_sha_updated_after_update(self, tmp_path: Path) -> None:
+        """runtime.set_read_sha called after update_memory."""
+        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+
+        host_dir = self._make_host_dir(tmp_path)
+        new_content = "updated\n"
+        (host_dir / "upd.md").write_text(new_content)
+        old_sha = _sha256("old\n")
+        new_sha = _sha256(new_content)
+        before = {(STORE_A, "/upd.md"): old_sha}
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        fake_memory = MagicMock()
+        fake_memory.id = "mem_01FAKEUPDATETEST0000000001"
+        fake_memory.content_sha256 = new_sha
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                new_callable=AsyncMock,
+                return_value=fake_memory,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                new_callable=AsyncMock,
+                return_value=fake_memory,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await reconcile_memory_mounts(SESSION_ID, before=before)
+
+        cached_sha = runtime.get_read_sha(SESSION_ID, STORE_A, "/upd.md")
+        assert cached_sha == new_sha

--- a/tests/unit/test_bash_memory_reconcile.py
+++ b/tests/unit/test_bash_memory_reconcile.py
@@ -493,6 +493,50 @@ class TestReconcile:
         cached_sha = runtime.get_read_sha(SESSION_ID, STORE_A, "/fresh.md")
         assert cached_sha == expected_sha
 
+    async def test_modified_file_no_db_record_skips(self, tmp_path: Path) -> None:
+        """before has sha A, after sha B, but get_memory_by_path returns None (race); update_memory NOT called."""
+        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+
+        host_dir = self._make_host_dir(tmp_path)
+        new_content = "new content after race\n"
+        (host_dir / "race.md").write_text(new_content)
+
+        old_sha = _sha256("old content\n")
+        before = {(STORE_A, "/race.md"): old_sha}
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        fake_created = MagicMock()
+        fake_created.content_sha256 = _sha256(new_content)
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                new_callable=AsyncMock,
+                return_value=fake_created,
+            ) as mock_create,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                new_callable=AsyncMock,
+            ) as mock_update,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                new_callable=AsyncMock,
+            ),
+        ):
+            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+
+        # No crash; update_memory is not called (create_memory is used instead)
+        mock_update.assert_not_awaited()
+        mock_create.assert_awaited_once()
+        # No warning for this path — it is handled gracefully as a create
+        assert warnings == []
+
     async def test_read_sha_updated_after_update(self, tmp_path: Path) -> None:
         """runtime.set_read_sha called after update_memory."""
         from aios.tools.bash_memory_reconcile import reconcile_memory_mounts

--- a/tests/unit/test_bash_memory_reconcile.py
+++ b/tests/unit/test_bash_memory_reconcile.py
@@ -19,7 +19,6 @@ from aios.models.memory_stores import MemoryStoreResourceEcho
 
 SESSION_ID = "sesn_01RECONCILETEST00000000001"
 STORE_A = "memstore_01STOREA000000000000000001"
-STORE_B = "memstore_01STOREB000000000000000001"
 
 
 def _echo(
@@ -420,14 +419,15 @@ class TestReconcile:
         mock_create.assert_not_awaited()
 
     async def test_skips_read_only_mounts_in_reconcile(self, tmp_path: Path) -> None:
-        """read_only mount; no DB call even if file changed."""
+        """read_only mount; no DB call — files from read_only mounts never appear in before or after."""
         from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
 
         host_dir = self._make_host_dir(tmp_path)
         (host_dir / "file.md").write_text("content\n")
 
-        # read_only mount: even if we have a before sha that differs, no DB call
-        before = {(STORE_A, "/file.md"): "different_sha"}
+        # read_only mount: snapshot_memory_mounts also skips read_only mounts, so
+        # before is empty; after will also be empty (read_only skipped in scan).
+        before: dict[tuple[str, str], str] = {}
         runtime.set_session_memory_mounts(SESSION_ID, [_echo(access="read_only")])
 
         with (
@@ -493,8 +493,8 @@ class TestReconcile:
         cached_sha = runtime.get_read_sha(SESSION_ID, STORE_A, "/fresh.md")
         assert cached_sha == expected_sha
 
-    async def test_modified_file_no_db_record_skips(self, tmp_path: Path) -> None:
-        """before has sha A, after sha B, but get_memory_by_path returns None (race); update_memory NOT called."""
+    async def test_modified_file_no_db_record_falls_back_to_create(self, tmp_path: Path) -> None:
+        """before has sha A, after sha B, but get_memory_by_path returns None (race); falls back to create_memory."""
         from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
 
         host_dir = self._make_host_dir(tmp_path)


### PR DESCRIPTION
Closes #332

## Problem

Bash writes to `/mnt/memory/` paths bypassed the `memory_versions` audit log entirely. The shared bind-mount made bytes visible to peer sessions, but no version row was created, the `memories` table stayed stale, and redaction was unenforceable for bash-written content.

## Solution

- New module `src/aios/tools/bash_memory_reconcile.py`:
  - `snapshot_memory_mounts(session_id)`: walks read-write-mounted store host dirs (only materialized), sha256-hashes each file, returns `{(store_id, store_path) -> sha_hex}`. Pure filesystem, no DB.
  - `reconcile_memory_mounts(session_id, before)`: diffs before/after snapshots, routes changes through the existing memory service — `create_memory` for new files, `update_memory` for modifications, `delete_memory` for removals — all with `SessionActor` attribution. Non-UTF-8 and oversized (`>MAX_CONTENT_BYTES`) files emit tool-result warnings.
- `bash.py` wrapped: snapshot before `sandbox.exec`, reconcile after (even on nonzero exit or timeout).

## Residual gap

Background processes (`nohup`/`&`) that write after the handler returns are not captured. This is a strictly smaller hole, consistent with bash's one-shot contract, and is documented in tests.

## Tests

- 16 new unit tests covering snapshot and reconcile logic.
- Flipped e2e test `test_bash_visible_cross_session_but_no_version` — now asserts a version row **exists**.
- 4 new e2e tests: modify reconcile, delete reconcile, binary file warning, nohup gap documentation.