### PR TITLE
refactor: PR 8 of #328 — cleanup, drop legacy connection columns + table

### DIFF
--- a/connectors/signal/README.md
+++ b/connectors/signal/README.md
@@ -62,7 +62,7 @@ docker run \
 ```
 
 The container reads ``AIOS_URL`` and ``AIOS_RUNTIME_TOKEN`` from
-env, fetches its phone via ``GET /v1/connectors/secrets``, spawns
+env, fetches its phone via ``GET /v1/connectors/runtime/secrets``, spawns
 ``signal-cli daemon`` against the bind-mounted config dir, and
 starts the inbound pump.  The workspace bind-mount is required for
 outbound attachments — paths under ``/workspace/...`` resolve to host

--- a/migrations/versions/0039_drop_legacy_connection_columns.py
+++ b/migrations/versions/0039_drop_legacy_connection_columns.py
@@ -1,34 +1,18 @@
 """Drop the legacy ``connections.{session_id,session_template_id,tools}``
-columns and the legacy ``connection_chat_sessions`` table (#328 PR 8).
+columns and the legacy ``connection_chat_sessions`` table.
 
-PR 7 cut every reader and writer over to the new subsystem:
+Replacements:
 
-* ``connections.session_id`` / ``session_template_id`` → now projected
-  from the active row of the ``bindings`` table via LEFT JOIN.
-* ``connections.tools`` → was zombie data; the per-connector-type
-  catalog in ``connectors.tools_schema`` is the live source consulted
-  by ``list_connection_tools_for_session``.
-* ``connection_chat_sessions`` → superseded by ``chat_sessions``
-  (migration 0033) which is read by the resolver's Tier 1.
+* ``connections.session_id`` / ``session_template_id`` — projected from
+  the active row of the ``bindings`` table via LEFT JOIN.
+* ``connections.tools`` — superseded by ``connectors.tools_schema``
+  (per connector type).
+* ``connection_chat_sessions`` — superseded by ``chat_sessions``.
 
-The columns and table sat dormant across PR 7 so operators could watch
-for accidental writes during the soak window.  Soak is clean — this
-migration finishes the cutover by removing them from the schema.
-
-``DROP COLUMN ... CASCADE`` removes the column along with any
-constraints / indexes that reference it:
-
-* ``connections.session_id`` cascades the ``connections_session_id_idx``
-  partial index (0029) and the FK to ``sessions(id)`` (0027).
-* ``connections.session_template_id`` cascades the FK to
-  ``session_templates(id)`` (0027).
-* Either column drop cascades ``connections_one_mode_ck`` (0027) — the
-  CHECK constraint that enforced "at most one populated" is no longer
-  meaningful once the mode lives on ``bindings``.
-
-The downgrade path reconstitutes the schema shape but not the data;
-recovery from a pre-0039 state requires a database snapshot, since the
-catch-up migration (0035) is one-way.
+``CASCADE`` on the column drops sweeps along the partial index on
+``session_id``, the FKs to ``sessions(id)`` / ``session_templates(id)``,
+and the ``connections_one_mode_ck`` CHECK that gated mode-uniqueness on
+the legacy shape.
 
 Revision ID: 0039
 Revises: 0038
@@ -48,9 +32,15 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.execute("ALTER TABLE connections DROP COLUMN IF EXISTS session_id CASCADE")
-    op.execute("ALTER TABLE connections DROP COLUMN IF EXISTS session_template_id CASCADE")
-    op.execute("ALTER TABLE connections DROP COLUMN IF EXISTS tools")
+    # One ALTER per relation: a single ACCESS EXCLUSIVE lock cycle on
+    # ``connections`` for all three drops, instead of three serialized
+    # waits during deploy.
+    op.execute(
+        "ALTER TABLE connections "
+        "DROP COLUMN IF EXISTS session_id CASCADE, "
+        "DROP COLUMN IF EXISTS session_template_id CASCADE, "
+        "DROP COLUMN IF EXISTS tools"
+    )
     op.execute("DROP TABLE IF EXISTS connection_chat_sessions")
 
 

--- a/migrations/versions/0039_drop_legacy_connection_columns.py
+++ b/migrations/versions/0039_drop_legacy_connection_columns.py
@@ -1,0 +1,96 @@
+"""Drop the legacy ``connections.{session_id,session_template_id,tools}``
+columns and the legacy ``connection_chat_sessions`` table (#328 PR 8).
+
+PR 7 cut every reader and writer over to the new subsystem:
+
+* ``connections.session_id`` / ``session_template_id`` → now projected
+  from the active row of the ``bindings`` table via LEFT JOIN.
+* ``connections.tools`` → was zombie data; the per-connector-type
+  catalog in ``connectors.tools_schema`` is the live source consulted
+  by ``list_connection_tools_for_session``.
+* ``connection_chat_sessions`` → superseded by ``chat_sessions``
+  (migration 0033) which is read by the resolver's Tier 1.
+
+The columns and table sat dormant across PR 7 so operators could watch
+for accidental writes during the soak window.  Soak is clean — this
+migration finishes the cutover by removing them from the schema.
+
+``DROP COLUMN ... CASCADE`` removes the column along with any
+constraints / indexes that reference it:
+
+* ``connections.session_id`` cascades the ``connections_session_id_idx``
+  partial index (0029) and the FK to ``sessions(id)`` (0027).
+* ``connections.session_template_id`` cascades the FK to
+  ``session_templates(id)`` (0027).
+* Either column drop cascades ``connections_one_mode_ck`` (0027) — the
+  CHECK constraint that enforced "at most one populated" is no longer
+  meaningful once the mode lives on ``bindings``.
+
+The downgrade path reconstitutes the schema shape but not the data;
+recovery from a pre-0039 state requires a database snapshot, since the
+catch-up migration (0035) is one-way.
+
+Revision ID: 0039
+Revises: 0038
+Create Date: 2026-05-12
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0039"
+down_revision: str = "0038"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE connections DROP COLUMN IF EXISTS session_id CASCADE")
+    op.execute("ALTER TABLE connections DROP COLUMN IF EXISTS session_template_id CASCADE")
+    op.execute("ALTER TABLE connections DROP COLUMN IF EXISTS tools")
+    op.execute("DROP TABLE IF EXISTS connection_chat_sessions")
+
+
+def downgrade() -> None:
+    # Reconstitutes the legacy shape but not the data.  Operators downgrading
+    # past 0039 should restore from a snapshot rather than rely on this path.
+    op.execute(
+        """
+        ALTER TABLE connections
+            ADD COLUMN IF NOT EXISTS session_id          text REFERENCES sessions(id),
+            ADD COLUMN IF NOT EXISTS session_template_id text REFERENCES session_templates(id),
+            ADD COLUMN IF NOT EXISTS tools               jsonb NOT NULL DEFAULT '[]'::jsonb
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE connections
+            ADD CONSTRAINT connections_one_mode_ck CHECK (
+                (session_id IS NULL AND session_template_id IS NULL)
+                OR (session_id IS NOT NULL AND session_template_id IS NULL)
+                OR (session_id IS NULL AND session_template_id IS NOT NULL)
+            )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS connections_session_id_idx "
+        "ON connections (session_id) WHERE archived_at IS NULL AND session_id IS NOT NULL"
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS connection_chat_sessions (
+            connection_id  text NOT NULL REFERENCES connections(id) ON DELETE CASCADE,
+            chat_id        text NOT NULL,
+            session_id     text NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            created_at     timestamptz NOT NULL DEFAULT now(),
+            PRIMARY KEY (connection_id, chat_id)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS connection_chat_sessions_session_idx "
+        "ON connection_chat_sessions (session_id)"
+    )

--- a/openapi.json
+++ b/openapi.json
@@ -4577,7 +4577,7 @@
           "connections"
         ],
         "summary": "Set Secrets",
-        "description": "Replace the connection's encrypted secrets dict, wholesale.\n\nMirrors ``set_tools`` \u2014 the request body fully replaces the stored\nblob.  Pass ``{\"secrets\": {}}`` to clear secrets entirely.\nOperator-facing reads only ever expose ``secrets_set: bool``; the\ndecrypted values are exclusively available to the connector\ncontainer that holds a connector token resolving to this connection.",
+        "description": "Replace the connection's encrypted secrets dict, wholesale.\n\nThe request body fully replaces the stored blob.  Pass\n``{\"secrets\": {}}`` to clear secrets entirely.  Operator-facing reads\nonly ever expose ``secrets_set: bool``; the decrypted values are\nexclusively available via the runtime-scoped\n``GET /v1/connectors/runtime/secrets`` route to a connector container\nholding a runtime token for this connector type.",
         "operationId": "set_connection_secrets",
         "parameters": [
           {
@@ -6787,13 +6787,6 @@
             "type": "object",
             "title": "Metadata"
           },
-          "tools": {
-            "items": {
-              "$ref": "#/components/schemas/ToolSpec"
-            },
-            "type": "array",
-            "title": "Tools"
-          },
           "secrets_set": {
             "type": "boolean",
             "title": "Secrets Set",
@@ -6895,13 +6888,6 @@
             "type": "object",
             "title": "Metadata"
           },
-          "tools": {
-            "items": {
-              "$ref": "#/components/schemas/ToolSpec"
-            },
-            "type": "array",
-            "title": "Tools"
-          },
           "secrets": {
             "anyOf": [
               {
@@ -6925,7 +6911,7 @@
           "account"
         ],
         "title": "ConnectionCreate",
-        "description": "Request body for ``POST /v1/connections``.\n\nCreated in detached mode \u2014 neither ``session_id`` nor\n``session_template_id`` is set.  Use ``POST .../attach`` or\n``POST .../configure-per-chat`` afterward to bind a routing mode.\n\n``connector`` and ``account`` may not contain ``/`` \u2014 they're used\nin the focal-channel address scheme ``{connector}/{account}/{chat_id}``\nand a ``/`` would create ambiguous segment boundaries.\n\n``tools`` declares the model-facing custom tools this connection\ncontributes to any session it's attached to (see #301)."
+        "description": "Request body for ``POST /v1/connections``.\n\nCreated in detached mode \u2014 neither ``session_id`` nor\n``session_template_id`` is set.  Use ``POST .../attach`` or\n``POST .../configure-per-chat`` afterward to bind a routing mode.\n\n``connector`` and ``account`` may not contain ``/`` \u2014 they're used\nin the focal-channel address scheme ``{connector}/{account}/{chat_id}``\nand a ``/`` would create ambiguous segment boundaries."
       },
       "ConnectionSetSecrets": {
         "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -4390,7 +4390,7 @@
           "connections"
         ],
         "summary": "Create",
-        "description": "Create a detached connection, **idempotent on ``(connector, account)``**.\n\nPer plan decision #5, this endpoint and the supervisor's\nauto-create-on-first-inbound path race-safely converge on a single row:\nposting twice with the same ``(connector, account)`` returns 201 with the\nexisting row rather than 409.  The ``id`` may differ from a freshly-allocated\none if a concurrent writer landed first; the response always reflects the\ncanonical active row.\n\nOptional ``secrets`` carry platform credentials (e.g. Telegram\n``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``\nand only ever read back through the connector-scoped\n``GET /v1/connectors/secrets`` route \u2014 operator-facing reads return\n``secrets_set: bool`` instead of values.",
+        "description": "Create a detached connection, **idempotent on ``(connector, account)``**.\n\nPer plan decision #5, this endpoint and the supervisor's\nauto-create-on-first-inbound path race-safely converge on a single row:\nposting twice with the same ``(connector, account)`` returns 201 with the\nexisting row rather than 409.  The ``id`` may differ from a freshly-allocated\none if a concurrent writer landed first; the response always reflects the\ncanonical active row.\n\nOptional ``secrets`` carry platform credentials (e.g. Telegram\n``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``\nand only ever read back through the runtime-scoped\n``GET /v1/connectors/runtime/secrets`` route \u2014 operator-facing\nreads return ``secrets_set: bool`` instead of values.",
         "operationId": "create_connection",
         "parameters": [
           {
@@ -6901,7 +6901,7 @@
               }
             ],
             "title": "Secrets",
-            "description": "Platform credentials (e.g. ``bot_token``).  Encrypted at rest via the server's ``AIOS_VAULT_KEY``; only ever read back via the connector-scoped ``GET /v1/connectors/secrets``.  Operator-facing reads return ``secrets_set: bool`` instead of values."
+            "description": "Platform credentials (e.g. ``bot_token``).  Encrypted at rest via the server's ``AIOS_VAULT_KEY``; only ever read back via the runtime-scoped ``GET /v1/connectors/runtime/secrets``.  Operator-facing reads return ``secrets_set: bool`` instead of values."
           }
         },
         "additionalProperties": false,
@@ -6978,7 +6978,7 @@
         },
         "type": "object",
         "title": "ConnectorSecrets",
-        "description": "Response shape for ``GET /v1/connectors/secrets``.\n\nOnly the connector container's bearer token (which scopes to one\n``connection_id``) can hit this route.  Returns the decrypted dict\nthe operator stored at create / set-secrets time.  Empty dict when\nthe connection has no secrets configured."
+        "description": "Response shape for ``GET /v1/connectors/runtime/secrets``.\n\nOnly a connector container holding a runtime token for the\nconnection's connector type can hit this route.  Returns the\ndecrypted dict the operator stored at create / set-secrets time,\nor an empty dict when the connection has no secrets configured."
       },
       "ContextResponse": {
         "properties": {

--- a/packages/aios-connector-http/aios_connector_http/schema.py
+++ b/packages/aios-connector-http/aios_connector_http/schema.py
@@ -4,9 +4,11 @@ The connector author writes Python; the SDK derives the schema the
 model sees.  Operators no longer hand-write a ``tools.json`` that
 drifts from the source.
 
-The output shape is one entry of a ``ConnectionSetTools`` body — a
-dict the runner POSTs at startup so the connection's tools list
-matches whatever the connector container is actually serving::
+The output is one entry of the per-connector-type ``tools_schema``
+list — a dict the runner publishes at startup via
+``PUT /v1/connectors/{connector}/tools_schema`` (runtime-authed) so
+the catalog matches whatever the connector container is actually
+serving::
 
     {
       "type": "custom",

--- a/packages/aios-connector-http/tests/test_schema.py
+++ b/packages/aios-connector-http/tests/test_schema.py
@@ -270,7 +270,7 @@ class TestDocstringParsing:
 
 class TestSpecShape:
     """The output is a ``type=custom`` ToolSpec dict ready to ship as
-    one entry of a ``ConnectionSetTools`` body.
+    one entry of the per-connector-type ``tools_schema`` list.
     """
 
     def test_top_level_shape(self) -> None:

--- a/packages/aios-sdk/aios_sdk/_generated/api/connections/create_connection.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connections/create_connection.py
@@ -98,9 +98,6 @@ def sync_detailed(
             in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
             and a ``/`` would create ambiguous segment boundaries.
 
-            ``tools`` declares the model-facing custom tools this connection
-            contributes to any session it's attached to (see #301).
-
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
@@ -156,9 +153,6 @@ def sync(
             in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
             and a ``/`` would create ambiguous segment boundaries.
 
-            ``tools`` declares the model-facing custom tools this connection
-            contributes to any session it's attached to (see #301).
-
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
@@ -208,9 +202,6 @@ async def asyncio_detailed(
             ``connector`` and ``account`` may not contain ``/`` — they're used
             in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
             and a ``/`` would create ambiguous segment boundaries.
-
-            ``tools`` declares the model-facing custom tools this connection
-            contributes to any session it's attached to (see #301).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -264,9 +255,6 @@ async def asyncio(
             ``connector`` and ``account`` may not contain ``/`` — they're used
             in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
             and a ``/`` would create ambiguous segment boundaries.
-
-            ``tools`` declares the model-facing custom tools this connection
-            contributes to any session it's attached to (see #301).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/packages/aios-sdk/aios_sdk/_generated/api/connections/create_connection.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connections/create_connection.py
@@ -82,9 +82,9 @@ def sync_detailed(
 
     Optional ``secrets`` carry platform credentials (e.g. Telegram
     ``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``
-    and only ever read back through the connector-scoped
-    ``GET /v1/connectors/secrets`` route — operator-facing reads return
-    ``secrets_set: bool`` instead of values.
+    and only ever read back through the runtime-scoped
+    ``GET /v1/connectors/runtime/secrets`` route — operator-facing
+    reads return ``secrets_set: bool`` instead of values.
 
     Args:
         authorization (None | str | Unset):
@@ -137,9 +137,9 @@ def sync(
 
     Optional ``secrets`` carry platform credentials (e.g. Telegram
     ``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``
-    and only ever read back through the connector-scoped
-    ``GET /v1/connectors/secrets`` route — operator-facing reads return
-    ``secrets_set: bool`` instead of values.
+    and only ever read back through the runtime-scoped
+    ``GET /v1/connectors/runtime/secrets`` route — operator-facing
+    reads return ``secrets_set: bool`` instead of values.
 
     Args:
         authorization (None | str | Unset):
@@ -187,9 +187,9 @@ async def asyncio_detailed(
 
     Optional ``secrets`` carry platform credentials (e.g. Telegram
     ``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``
-    and only ever read back through the connector-scoped
-    ``GET /v1/connectors/secrets`` route — operator-facing reads return
-    ``secrets_set: bool`` instead of values.
+    and only ever read back through the runtime-scoped
+    ``GET /v1/connectors/runtime/secrets`` route — operator-facing
+    reads return ``secrets_set: bool`` instead of values.
 
     Args:
         authorization (None | str | Unset):
@@ -240,9 +240,9 @@ async def asyncio(
 
     Optional ``secrets`` carry platform credentials (e.g. Telegram
     ``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``
-    and only ever read back through the connector-scoped
-    ``GET /v1/connectors/secrets`` route — operator-facing reads return
-    ``secrets_set: bool`` instead of values.
+    and only ever read back through the runtime-scoped
+    ``GET /v1/connectors/runtime/secrets`` route — operator-facing
+    reads return ``secrets_set: bool`` instead of values.
 
     Args:
         authorization (None | str | Unset):

--- a/packages/aios-sdk/aios_sdk/_generated/api/connections/set_connection_secrets.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connections/set_connection_secrets.py
@@ -78,11 +78,12 @@ def sync_detailed(
 
      Replace the connection's encrypted secrets dict, wholesale.
 
-    Mirrors ``set_tools`` — the request body fully replaces the stored
-    blob.  Pass ``{\"secrets\": {}}`` to clear secrets entirely.
-    Operator-facing reads only ever expose ``secrets_set: bool``; the
-    decrypted values are exclusively available to the connector
-    container that holds a connector token resolving to this connection.
+    The request body fully replaces the stored blob.  Pass
+    ``{\"secrets\": {}}`` to clear secrets entirely.  Operator-facing reads
+    only ever expose ``secrets_set: bool``; the decrypted values are
+    exclusively available via the runtime-scoped
+    ``GET /v1/connectors/runtime/secrets`` route to a connector container
+    holding a runtime token for this connector type.
 
     Args:
         connection_id (str):
@@ -127,11 +128,12 @@ def sync(
 
      Replace the connection's encrypted secrets dict, wholesale.
 
-    Mirrors ``set_tools`` — the request body fully replaces the stored
-    blob.  Pass ``{\"secrets\": {}}`` to clear secrets entirely.
-    Operator-facing reads only ever expose ``secrets_set: bool``; the
-    decrypted values are exclusively available to the connector
-    container that holds a connector token resolving to this connection.
+    The request body fully replaces the stored blob.  Pass
+    ``{\"secrets\": {}}`` to clear secrets entirely.  Operator-facing reads
+    only ever expose ``secrets_set: bool``; the decrypted values are
+    exclusively available via the runtime-scoped
+    ``GET /v1/connectors/runtime/secrets`` route to a connector container
+    holding a runtime token for this connector type.
 
     Args:
         connection_id (str):
@@ -171,11 +173,12 @@ async def asyncio_detailed(
 
      Replace the connection's encrypted secrets dict, wholesale.
 
-    Mirrors ``set_tools`` — the request body fully replaces the stored
-    blob.  Pass ``{\"secrets\": {}}`` to clear secrets entirely.
-    Operator-facing reads only ever expose ``secrets_set: bool``; the
-    decrypted values are exclusively available to the connector
-    container that holds a connector token resolving to this connection.
+    The request body fully replaces the stored blob.  Pass
+    ``{\"secrets\": {}}`` to clear secrets entirely.  Operator-facing reads
+    only ever expose ``secrets_set: bool``; the decrypted values are
+    exclusively available via the runtime-scoped
+    ``GET /v1/connectors/runtime/secrets`` route to a connector container
+    holding a runtime token for this connector type.
 
     Args:
         connection_id (str):
@@ -218,11 +221,12 @@ async def asyncio(
 
      Replace the connection's encrypted secrets dict, wholesale.
 
-    Mirrors ``set_tools`` — the request body fully replaces the stored
-    blob.  Pass ``{\"secrets\": {}}`` to clear secrets entirely.
-    Operator-facing reads only ever expose ``secrets_set: bool``; the
-    decrypted values are exclusively available to the connector
-    container that holds a connector token resolving to this connection.
+    The request body fully replaces the stored blob.  Pass
+    ``{\"secrets\": {}}`` to clear secrets entirely.  Operator-facing reads
+    only ever expose ``secrets_set: bool``; the decrypted values are
+    exclusively available via the runtime-scoped
+    ``GET /v1/connectors/runtime/secrets`` route to a connector container
+    holding a runtime token for this connector type.
 
     Args:
         connection_id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/models/connection.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/connection.py
@@ -12,7 +12,6 @@ from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
     from ..models.connection_metadata import ConnectionMetadata
-    from ..models.tool_spec import ToolSpec
 
 
 T = TypeVar("T", bound="Connection")
@@ -50,7 +49,6 @@ class Connection:
             updated_at (datetime.datetime):
             session_id (None | str | Unset):
             session_template_id (None | str | Unset):
-            tools (list[ToolSpec] | Unset):
             secrets_set (bool | Unset):  Default: False.
             attached_at (datetime.datetime | None | Unset):
             archived_at (datetime.datetime | None | Unset):
@@ -64,7 +62,6 @@ class Connection:
     updated_at: datetime.datetime
     session_id: None | str | Unset = UNSET
     session_template_id: None | str | Unset = UNSET
-    tools: list[ToolSpec] | Unset = UNSET
     secrets_set: bool | Unset = False
     attached_at: datetime.datetime | None | Unset = UNSET
     archived_at: datetime.datetime | None | Unset = UNSET
@@ -94,13 +91,6 @@ class Connection:
             session_template_id = UNSET
         else:
             session_template_id = self.session_template_id
-
-        tools: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.tools, Unset):
-            tools = []
-            for tools_item_data in self.tools:
-                tools_item = tools_item_data.to_dict()
-                tools.append(tools_item)
 
         secrets_set = self.secrets_set
 
@@ -136,8 +126,6 @@ class Connection:
             field_dict["session_id"] = session_id
         if session_template_id is not UNSET:
             field_dict["session_template_id"] = session_template_id
-        if tools is not UNSET:
-            field_dict["tools"] = tools
         if secrets_set is not UNSET:
             field_dict["secrets_set"] = secrets_set
         if attached_at is not UNSET:
@@ -150,7 +138,6 @@ class Connection:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.connection_metadata import ConnectionMetadata
-        from ..models.tool_spec import ToolSpec
 
         d = dict(src_dict)
         id = d.pop("id")
@@ -184,15 +171,6 @@ class Connection:
         session_template_id = _parse_session_template_id(
             d.pop("session_template_id", UNSET)
         )
-
-        _tools = d.pop("tools", UNSET)
-        tools: list[ToolSpec] | Unset = UNSET
-        if _tools is not UNSET:
-            tools = []
-            for tools_item_data in _tools:
-                tools_item = ToolSpec.from_dict(tools_item_data)
-
-                tools.append(tools_item)
 
         secrets_set = d.pop("secrets_set", UNSET)
 
@@ -239,7 +217,6 @@ class Connection:
             updated_at=updated_at,
             session_id=session_id,
             session_template_id=session_template_id,
-            tools=tools,
             secrets_set=secrets_set,
             attached_at=attached_at,
             archived_at=archived_at,

--- a/packages/aios-sdk/aios_sdk/_generated/models/connection_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/connection_create.py
@@ -10,7 +10,6 @@ from ..types import UNSET, Unset
 if TYPE_CHECKING:
     from ..models.connection_create_metadata import ConnectionCreateMetadata
     from ..models.connection_create_secrets_type_0 import ConnectionCreateSecretsType0
-    from ..models.tool_spec import ToolSpec
 
 
 T = TypeVar("T", bound="ConnectionCreate")
@@ -28,14 +27,10 @@ class ConnectionCreate:
     in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
     and a ``/`` would create ambiguous segment boundaries.
 
-    ``tools`` declares the model-facing custom tools this connection
-    contributes to any session it's attached to (see #301).
-
         Attributes:
             connector (str):
             account (str):
             metadata (ConnectionCreateMetadata | Unset):
-            tools (list[ToolSpec] | Unset):
             secrets (ConnectionCreateSecretsType0 | None | Unset): Platform credentials (e.g. ``bot_token``).  Encrypted at
                 rest via the server's ``AIOS_VAULT_KEY``; only ever read back via the connector-scoped ``GET
                 /v1/connectors/secrets``.  Operator-facing reads return ``secrets_set: bool`` instead of values.
@@ -44,7 +39,6 @@ class ConnectionCreate:
     connector: str
     account: str
     metadata: ConnectionCreateMetadata | Unset = UNSET
-    tools: list[ToolSpec] | Unset = UNSET
     secrets: ConnectionCreateSecretsType0 | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
@@ -59,13 +53,6 @@ class ConnectionCreate:
         metadata: dict[str, Any] | Unset = UNSET
         if not isinstance(self.metadata, Unset):
             metadata = self.metadata.to_dict()
-
-        tools: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.tools, Unset):
-            tools = []
-            for tools_item_data in self.tools:
-                tools_item = tools_item_data.to_dict()
-                tools.append(tools_item)
 
         secrets: dict[str, Any] | None | Unset
         if isinstance(self.secrets, Unset):
@@ -85,8 +72,6 @@ class ConnectionCreate:
         )
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
-        if tools is not UNSET:
-            field_dict["tools"] = tools
         if secrets is not UNSET:
             field_dict["secrets"] = secrets
 
@@ -98,7 +83,6 @@ class ConnectionCreate:
         from ..models.connection_create_secrets_type_0 import (
             ConnectionCreateSecretsType0,
         )
-        from ..models.tool_spec import ToolSpec
 
         d = dict(src_dict)
         connector = d.pop("connector")
@@ -111,15 +95,6 @@ class ConnectionCreate:
             metadata = UNSET
         else:
             metadata = ConnectionCreateMetadata.from_dict(_metadata)
-
-        _tools = d.pop("tools", UNSET)
-        tools: list[ToolSpec] | Unset = UNSET
-        if _tools is not UNSET:
-            tools = []
-            for tools_item_data in _tools:
-                tools_item = ToolSpec.from_dict(tools_item_data)
-
-                tools.append(tools_item)
 
         def _parse_secrets(data: object) -> ConnectionCreateSecretsType0 | None | Unset:
             if data is None:
@@ -142,7 +117,6 @@ class ConnectionCreate:
             connector=connector,
             account=account,
             metadata=metadata,
-            tools=tools,
             secrets=secrets,
         )
 

--- a/packages/aios-sdk/aios_sdk/_generated/models/connection_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/connection_create.py
@@ -32,8 +32,8 @@ class ConnectionCreate:
             account (str):
             metadata (ConnectionCreateMetadata | Unset):
             secrets (ConnectionCreateSecretsType0 | None | Unset): Platform credentials (e.g. ``bot_token``).  Encrypted at
-                rest via the server's ``AIOS_VAULT_KEY``; only ever read back via the connector-scoped ``GET
-                /v1/connectors/secrets``.  Operator-facing reads return ``secrets_set: bool`` instead of values.
+                rest via the server's ``AIOS_VAULT_KEY``; only ever read back via the runtime-scoped ``GET
+                /v1/connectors/runtime/secrets``.  Operator-facing reads return ``secrets_set: bool`` instead of values.
     """
 
     connector: str

--- a/packages/aios-sdk/aios_sdk/_generated/models/connector_secrets.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/connector_secrets.py
@@ -17,12 +17,12 @@ T = TypeVar("T", bound="ConnectorSecrets")
 
 @_attrs_define
 class ConnectorSecrets:
-    """Response shape for ``GET /v1/connectors/secrets``.
+    """Response shape for ``GET /v1/connectors/runtime/secrets``.
 
-    Only the connector container's bearer token (which scopes to one
-    ``connection_id``) can hit this route.  Returns the decrypted dict
-    the operator stored at create / set-secrets time.  Empty dict when
-    the connection has no secrets configured.
+    Only a connector container holding a runtime token for the
+    connection's connector type can hit this route.  Returns the
+    decrypted dict the operator stored at create / set-secrets time,
+    or an empty dict when the connection has no secrets configured.
 
         Attributes:
             secrets (ConnectorSecretsSecrets | Unset):

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -48,9 +48,9 @@ async def create(
 
     Optional ``secrets`` carry platform credentials (e.g. Telegram
     ``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``
-    and only ever read back through the connector-scoped
-    ``GET /v1/connectors/secrets`` route — operator-facing reads return
-    ``secrets_set: bool`` instead of values.
+    and only ever read back through the runtime-scoped
+    ``GET /v1/connectors/runtime/secrets`` route — operator-facing
+    reads return ``secrets_set: bool`` instead of values.
     """
     return await service.create_connection(
         pool,

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -57,7 +57,6 @@ async def create(
         connector=body.connector,
         account=body.account,
         metadata=body.metadata,
-        tools=body.tools,
         secrets=body.secrets,
         crypto_box=crypto_box,
     )
@@ -73,11 +72,12 @@ async def set_secrets(
 ) -> Connection:
     """Replace the connection's encrypted secrets dict, wholesale.
 
-    Mirrors ``set_tools`` — the request body fully replaces the stored
-    blob.  Pass ``{"secrets": {}}`` to clear secrets entirely.
-    Operator-facing reads only ever expose ``secrets_set: bool``; the
-    decrypted values are exclusively available to the connector
-    container that holds a connector token resolving to this connection.
+    The request body fully replaces the stored blob.  Pass
+    ``{"secrets": {}}`` to clear secrets entirely.  Operator-facing reads
+    only ever expose ``secrets_set: bool``; the decrypted values are
+    exclusively available via the runtime-scoped
+    ``GET /v1/connectors/runtime/secrets`` route to a connector container
+    holding a runtime token for this connector type.
     """
     return await service.set_connection_secrets(
         pool, connection_id, secrets=body.secrets, crypto_box=crypto_box

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2804,10 +2804,9 @@ async def _raise_for_failed_binding_insert(
 #   single_session — active binding row with mode='single_session'
 #   per_chat       — active binding row with mode='per_chat'
 #
-# The legacy in-place ``connections.session_id`` / ``session_template_id``
-# columns are retained in the schema for PR 8 soak but are neither read
-# nor written by this layer. ``Connection.session_id`` / ``session_template_id``
-# wire fields are populated from the active binding via a LEFT JOIN.
+# ``Connection.session_id`` / ``session_template_id`` / ``attached_at``
+# wire fields are populated from the active binding row via a LEFT JOIN
+# on ``bindings`` — there is no per-connection session column to read.
 
 _CONNECTION_COLUMNS = """
     c.*,
@@ -2838,22 +2837,17 @@ _CONNECTION_UPDATE_CTE_TAIL = """
 
 
 def _row_to_connection(row: asyncpg.Record) -> Connection:
-    metadata = _parse_jsonb(row["metadata"])
-    tools_data = _parse_jsonb(row["tools"])
     return Connection(
         id=row["id"],
         connector=row["connector"],
         account=row["account"],
         session_id=row["binding_session_id"],
         session_template_id=row["binding_session_template_id"],
-        metadata=metadata,
-        tools=tools_data,
+        metadata=_parse_jsonb(row["metadata"]),
         secrets_set=row["secrets_ciphertext"] is not None,
         created_at=row["created_at"],
-        # ``attached_at`` is "when did the active binding land" — derive
-        # from the binding row's ``created_at`` rather than the legacy
-        # ``connections.attached_at`` column (which is no longer written
-        # by the new attach/configure service paths).
+        # ``attached_at`` is "when did the active binding land," derived
+        # from the binding row's ``created_at``.
         attached_at=row["binding_created_at"],
         updated_at=row["updated_at"],
         archived_at=row["archived_at"],
@@ -2866,7 +2860,6 @@ async def insert_connection(
     connector: str,
     account: str,
     metadata: dict[str, Any],
-    tools: list[dict[str, Any]] | None = None,
     secrets_blob: EncryptedBlob | None = None,
 ) -> Connection:
     """Insert a detached connection, idempotent on the active uniqueness key.
@@ -2893,7 +2886,6 @@ async def insert_connection(
     # any realistic contention pattern.  The bound is defensive — three
     # iterations is enough that exhaustion would mean the system is wedged
     # in a hot insert/archive cycle that no retry strategy can resolve.
-    tools_json = json.dumps(tools or [])
     ciphertext = secrets_blob.ciphertext if secrets_blob is not None else None
     nonce = secrets_blob.nonce if secrets_blob is not None else None
     # Upsert into the connectors catalog so the runtime_tokens /
@@ -2910,10 +2902,10 @@ async def insert_connection(
             """
             WITH inserted AS (
                 INSERT INTO connections (
-                    id, connector, account, metadata, tools,
+                    id, connector, account, metadata,
                     secrets_ciphertext, secrets_nonce
                 )
-                VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6, $7)
+                VALUES ($1, $2, $3, $4::jsonb, $5, $6)
                 ON CONFLICT (connector, account) WHERE archived_at IS NULL DO NOTHING
                 RETURNING *
             )
@@ -2927,7 +2919,6 @@ async def insert_connection(
             connector,
             account,
             json.dumps(metadata),
-            tools_json,
             ciphertext,
             nonce,
         )

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2804,9 +2804,9 @@ async def _raise_for_failed_binding_insert(
 #   single_session — active binding row with mode='single_session'
 #   per_chat       — active binding row with mode='per_chat'
 #
-# ``Connection.session_id`` / ``session_template_id`` / ``attached_at``
-# wire fields are populated from the active binding row via a LEFT JOIN
-# on ``bindings`` — there is no per-connection session column to read.
+# ``Connection.session_id`` / ``session_template_id`` / ``attached_at`` are
+# projected from the binding via a LEFT JOIN — there is no per-connection
+# session column.
 
 _CONNECTION_COLUMNS = """
     c.*,
@@ -2846,8 +2846,6 @@ def _row_to_connection(row: asyncpg.Record) -> Connection:
         metadata=_parse_jsonb(row["metadata"]),
         secrets_set=row["secrets_ciphertext"] is not None,
         created_at=row["created_at"],
-        # ``attached_at`` is "when did the active binding land," derived
-        # from the binding row's ``created_at``.
         attached_at=row["binding_created_at"],
         updated_at=row["updated_at"],
         archived_at=row["archived_at"],

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -59,7 +59,7 @@ class ConnectionCreate(BaseModel):
         default=None,
         description="Platform credentials (e.g. ``bot_token``).  Encrypted "
         "at rest via the server's ``AIOS_VAULT_KEY``; only ever read back "
-        "via the connector-scoped ``GET /v1/connectors/secrets``.  "
+        "via the runtime-scoped ``GET /v1/connectors/runtime/secrets``.  "
         "Operator-facing reads return ``secrets_set: bool`` instead of values.",
     )
 
@@ -139,12 +139,12 @@ class ConnectionSetSecrets(BaseModel):
 
 
 class ConnectorSecrets(BaseModel):
-    """Response shape for ``GET /v1/connectors/secrets``.
+    """Response shape for ``GET /v1/connectors/runtime/secrets``.
 
-    Only the connector container's bearer token (which scopes to one
-    ``connection_id``) can hit this route.  Returns the decrypted dict
-    the operator stored at create / set-secrets time.  Empty dict when
-    the connection has no secrets configured.
+    Only a connector container holding a runtime token for the
+    connection's connector type can hit this route.  Returns the
+    decrypted dict the operator stored at create / set-secrets time,
+    or an empty dict when the connection has no secrets configured.
     """
 
     secrets: dict[str, str] = Field(default_factory=dict)

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -29,8 +29,6 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from aios.models.agents import ToolSpec
-
 ConnectionMode = Literal["detached", "single_session", "per_chat"]
 
 # A connection's *binding* exists only when curated — ``detached`` is "no
@@ -38,21 +36,6 @@ ConnectionMode = Literal["detached", "single_session", "per_chat"]
 # ``bindings`` table's ``mode`` column carries (enforced by the
 # ``bindings_mode_ck`` CHECK constraint).
 BindingMode = Literal["single_session", "per_chat"]
-
-
-def _validate_connection_tools(tools: list[ToolSpec]) -> list[ToolSpec]:
-    """Connection-declared tools must be ``type="custom"`` (#301).
-
-    Connections expose model-facing tools that the connector executes
-    externally via the ``requires_action`` flow.  Built-in tools live on
-    the agent; ``mcp_toolset`` is for HTTP MCP servers, not connectors.
-    """
-    for t in tools:
-        if t.type != "custom":
-            raise ValueError(
-                f"connection tools must be type='custom', got type={t.type!r}",
-            )
-    return tools
 
 
 class ConnectionCreate(BaseModel):
@@ -65,9 +48,6 @@ class ConnectionCreate(BaseModel):
     ``connector`` and ``account`` may not contain ``/`` — they're used
     in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
     and a ``/`` would create ambiguous segment boundaries.
-
-    ``tools`` declares the model-facing custom tools this connection
-    contributes to any session it's attached to (see #301).
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -75,7 +55,6 @@ class ConnectionCreate(BaseModel):
     connector: str = Field(min_length=1, max_length=64)
     account: str = Field(min_length=1, max_length=256)
     metadata: dict[str, Any] = Field(default_factory=dict)
-    tools: list[ToolSpec] = Field(default_factory=list)
     secrets: dict[str, str] | None = Field(
         default=None,
         description="Platform credentials (e.g. ``bot_token``).  Encrypted "
@@ -90,11 +69,6 @@ class ConnectionCreate(BaseModel):
         if "/" in v:
             raise ValueError("must not contain '/'")
         return v
-
-    @field_validator("tools")
-    @classmethod
-    def _custom_only(cls, v: list[ToolSpec]) -> list[ToolSpec]:
-        return _validate_connection_tools(v)
 
 
 class ConnectionAttach(BaseModel):
@@ -142,7 +116,6 @@ class Connection(BaseModel):
     session_id: str | None = None
     session_template_id: str | None = None
     metadata: dict[str, Any]
-    tools: list[ToolSpec] = Field(default_factory=list)
     secrets_set: bool = False
     created_at: datetime
     attached_at: datetime | None = None

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -22,7 +22,6 @@ import asyncpg
 from aios.crypto.vault import CryptoBox, EncryptedBlob
 from aios.db import queries
 from aios.errors import ConflictError, NotFoundError
-from aios.models.agents import ToolSpec
 from aios.models.connections import (
     BindingMode,
     BoundChat,
@@ -50,18 +49,15 @@ async def create_connection(
     connector: str,
     account: str,
     metadata: dict[str, Any],
-    tools: list[ToolSpec] | None = None,
     secrets: dict[str, str] | None = None,
     crypto_box: CryptoBox,
 ) -> Connection:
-    tools_payload = [t.model_dump(exclude_none=True) for t in (tools or [])]
     async with pool.acquire() as conn:
         return await queries.insert_connection(
             conn,
             connector=connector,
             account=account,
             metadata=metadata,
-            tools=tools_payload,
             secrets_blob=_encrypt_secrets(secrets, crypto_box),
         )
 

--- a/tests/unit/test_connection_models.py
+++ b/tests/unit/test_connection_models.py
@@ -1,10 +1,10 @@
-"""Unit tests for the new connection + session-template models (#200).
+"""Unit tests for the connection + session-template wire models.
 
-The connector redesign collapses ``connections`` + ``channel_bindings`` +
-``connection_routing_rules`` into one ``connections`` table with three
-valid shapes (detached / single_session / per_chat) enforced by the
-``connections_one_mode_ck`` CHECK constraint.  Wire-level model
-validation covers the request shapes.
+Three valid connection shapes (detached / single_session / per_chat) are
+encoded by which of ``session_id`` / ``session_template_id`` is populated
+on the ``Connection`` read view; both are projected from the active
+``bindings`` row at read time.  These tests cover wire-level validation
+of the request bodies and response shapes.
 """
 
 from __future__ import annotations
@@ -13,7 +13,6 @@ from datetime import datetime
 
 import pytest
 
-from aios.models.agents import ToolSpec
 from aios.models.connections import (
     Connection,
     ConnectionAttach,
@@ -56,44 +55,18 @@ class TestConnectionCreate:
                 }
             )
 
-    def test_accepts_tools(self) -> None:
-        """Connections can declare model-facing custom tools (#301)."""
-        body = ConnectionCreate(
-            connector="signal",
-            account="+1",
-            tools=[
-                ToolSpec(
-                    type="custom",
-                    name="signal_send",
-                    description="Send a Signal message",
-                    input_schema={
-                        "type": "object",
-                        "properties": {
-                            "chat_id": {"type": "string"},
-                            "text": {"type": "string"},
-                        },
-                        "required": ["chat_id", "text"],
-                    },
-                ),
-            ],
-        )
-        assert len(body.tools) == 1
-        assert body.tools[0].name == "signal_send"
-
-    def test_tools_default_empty(self) -> None:
-        body = ConnectionCreate(connector="signal", account="+1")
-        assert body.tools == []
-
-    def test_rejects_non_custom_tool_types(self) -> None:
-        """Per #301: connection-declared tools are always client-executed.
-        Built-in (e.g. ``bash``) and ``mcp_toolset`` types belong on the
-        agent, not the connection.
+    def test_rejects_tools_field(self) -> None:
+        """``tools`` is no longer accepted on create — per-connector-type
+        catalogs live on the ``connectors`` table now, not per connection.
+        ``extra="forbid"`` 422s any caller still passing it.
         """
-        with pytest.raises(ValueError, match="custom"):
-            ConnectionCreate(
-                connector="signal",
-                account="+1",
-                tools=[ToolSpec(type="bash")],
+        with pytest.raises(ValueError):
+            ConnectionCreate.model_validate(
+                {
+                    "connector": "signal",
+                    "account": "+1",
+                    "tools": [{"type": "custom", "name": "x", "input_schema": {}}],
+                }
             )
 
 
@@ -158,37 +131,6 @@ class TestConnectionReadView:
         )
         assert c.session_id is None
         assert c.session_template_id == "stpl_1"
-
-    def test_tools_default_empty(self) -> None:
-        c = Connection(
-            id="conn_1",
-            connector="signal",
-            account="+1",
-            metadata={},
-            created_at=self._now(),
-            updated_at=self._now(),
-        )
-        assert c.tools == []
-
-    def test_round_trips_tools(self) -> None:
-        c = Connection(
-            id="conn_1",
-            connector="signal",
-            account="+1",
-            metadata={},
-            tools=[
-                ToolSpec(
-                    type="custom",
-                    name="signal_send",
-                    description="Send",
-                    input_schema={"type": "object"},
-                ),
-            ],
-            created_at=self._now(),
-            updated_at=self._now(),
-        )
-        assert len(c.tools) == 1
-        assert c.tools[0].name == "signal_send"
 
 
 class TestSessionTemplateCreate:


### PR DESCRIPTION
## Summary

Final PR in the #328 connector subsystem rework.  PR 7 cut every
reader and writer over to the new subsystem schema (``bindings``,
``chat_sessions``, ``connectors.tools_schema``).  PR 8 retires the
dormant artifacts that PR 7 left in place for a soak window.

* **App layer.** Drop the dead ``Connection.tools`` wire field —
  ``ConnectionCreate`` now rejects ``tools`` via ``extra="forbid"``,
  ``Connection`` no longer exposes it, and the projection/INSERT
  plumbing in ``services/connections.py`` + ``db/queries.py`` is
  gone.  Per-connector-type custom-tool catalogs live in
  ``connectors.tools_schema`` (PR 5's runtime route) and remain the
  only path; ``list_connection_tools_for_session`` is unchanged.
* **Schema.** Migration 0039 drops ``connections.session_id``,
  ``connections.session_template_id``, ``connections.tools``, and
  the legacy ``connection_chat_sessions`` table.  The three column
  drops collapse into one ``ALTER TABLE`` so deploy takes a single
  ACCESS EXCLUSIVE lock cycle on ``connections``.  ``CASCADE``
  sweeps the partial index on ``session_id``, the FKs to
  ``sessions(id)`` / ``session_templates(id)``, and the
  ``connections_one_mode_ck`` CHECK constraint.
* **Auto-regenerated.** ``openapi.json`` and the SDK regenerate to
  drop ``tools`` from both ``Connection`` and ``ConnectionCreate``.

Wire shape otherwise preserved: ``session_id`` /
``session_template_id`` / ``attached_at`` still appear on
``Connection``, projected from the active ``bindings`` row via the
LEFT JOIN established in PR 7.

The ``binding: {mode, ...}`` richer shape that #328 sketches as a
future possibility is deferred — no consumer needs it yet.

Commit chain:

* ``1c537ae`` — drop ``Connection.tools`` from the wire + app layer
* ``90bf40e`` — migration 0039
* ``c196745`` — ``/simplify`` pass (collapse ALTERs, trim docstrings)

## Test plan

- [x] ``uv run mypy src`` clean
- [x] ``uv run ruff check src tests && uv run ruff format --check src tests`` clean
- [x] ``uv run pytest tests/unit -q`` — 1133 passed
- [x] Migration 0039 applies cleanly on a PR-7 DB (manually verified: ``alembic upgrade head`` + ``downgrade -1`` + ``upgrade head`` round-trip OK; columns + table verified absent)
- [x] aios-connector-http unit tests pass (54 passed)
- [x] signal / telegram / echo-http connector unit tests pass (125 / 73 / 0 — echo-http has only e2e tests)
- [x] e2e — connection-CRUD-adjacent suite (``test_connection_tools``, ``test_connection_discovery_sse``, ``test_connector_secrets``, ``test_focal_channel``): 24/24 passed
- [x] e2e — full suite: 248 passed, 20 failed; failures match the PR 7 baseline (ARM64 sandbox image manifest + pre-existing fixture pollution); no PR-8 regressions
- [x] SDK regen produces only the expected diff (``tools`` field removed from Connection / ConnectionCreate, generated operation files re-rendered, docstrings refreshed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)