### PR TITLE
fix: smoke fixup on PR 8 capstone (connector + sandbox)

### DIFF
--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -35,6 +35,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # QEMU enables cross-arch emulation so we can build linux/arm64
+      # layers on the linux/amd64 GitHub runner without separate runners.
+      # The sandbox Dockerfile only uses apt + the multi-arch
+      # ``python:3.13-slim-bookworm`` base, so cross-build under QEMU is
+      # well within the "trivial enough to emulate" envelope.
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
@@ -58,6 +67,11 @@ jobs:
         with:
           context: docker
           file: docker/Dockerfile.sandbox
+          # Multi-arch so developer machines on Apple Silicon (linux/arm64
+          # under Docker Desktop) pull a native image without ``no matching
+          # manifest`` errors.  Cross-build is QEMU-emulated; layers are
+          # cached so subsequent builds with unchanged apt set are fast.
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/SMOKE_PR8.md
+++ b/SMOKE_PR8.md
@@ -1,0 +1,141 @@
+# PR 8 capstone smoke — findings
+
+Live smoke of the `refactor/328-pr8-cleanup` branch plus the `refactor/328-fixup-smoke` follow-up branch.  Telegram + Signal exercised against real bot accounts, with the smoke session bound to two connectors at once (telegram + signal).  Two-bot QA group brought online to verify bidirectional capability rendering against an independent peer bot.
+
+## Environment
+
+- **First (botched) run**: api/worker against the shared local dev DB at `localhost:5433/aios` — sourced from `/Users/tom/code/aios/.env` directly.  Persisted real connection records (EumemicBot 8622121495, Ultron signal 909) and produced ~380 events of live Telegram traffic in an existing prod-shadow session before being torn down.  Cleanup: archived the stray smoke connection in the local DB, archived Tom's binding modifications, revoked smoke runtime tokens, kept the model-switch + session events as-is.
+- **Second (correct) run**: per-worktree dev instance via `aios dev bootstrap`, separate DB (`aios_dev_worktree_effervescent_tickling_cook_9myls3_995bf272`) on the same postgres host, fresh agent + session + connections.  Initial agent was Haiku 4.5; switched to Sonnet 4.6 for the bidirectional matrix run (Sonnet produces cleaner one-shot tool calls and less monologue drift).
+- Connectors run locally, not in Docker.  `signal-cli` daemon spawned from `~/.local/share/signal-cli` (shared with other local instances by design).
+
+## Capability matrix — bidirectional
+
+Verified end-to-end with an independent peer bot ("Jarvis") on a 3-party Signal group ("QA"):
+
+| Capability | Send (bot → human/peer) | Receive (human/peer → bot) |
+|---|---|---|
+| Text message | ✅ | ✅ |
+| Emoji reaction | ✅ | ✅ |
+| Quote-reply / threading | ✅ | ✅ |
+| @mention | ✅ (pings recipient) | ⚠ delivered, but mention metadata flattened to `@<name>` text (see #5) |
+| Attachment | ❌ blocked upstream (#7: ARM64 sandbox) | ✅ metadata + path delivered; ❌ content access (sandbox) |
+| Voice note (audio) | ❌ blocked upstream (sandbox) | ✅ metadata + path delivered; ❌ playback / transcription (sandbox) |
+| Sound effect (audio) | ❌ blocked upstream (sandbox) | ✅ metadata + path delivered; ❌ playback (sandbox) |
+| Audio transcription | n/a — not in connector tool spec | n/a |
+| Read receipts (sender side) | ✅ promptly via #2 fix | n/a (we don't act on signal-cli receipts) |
+
+Send-side ❌s and the receive-side "❌ content access" entries all trace to **#7** (the ARM64 sandbox image gap), not connector code.
+
+Telegram-side: text inbound + text outbound on `@EumemicBot`, plus switch_channel between signal-DM + signal-group + telegram-DM focal channels in a single session.  Three bindings on one session record (signal connection × 1 + telegram connection × 1), all routing to the same model context.
+
+## Bugs found
+
+### Fixed in `refactor/328-fixup-smoke`
+
+**1. `connection_id` exposed as a required arg in model-facing tool schemas** — `cc92e35`
+
+`packages/aios-connector-http/aios_connector_http/schema.py` stripped `account` and `chat_id` from the JSON schema but **not** `connection_id`.  Model sees `connection_id` as a required keyword-only param it must supply; runner injects it correctly from the SSE payload but only when not already passed, so the model's guess overrides reality and the per-conn-state lookup `KeyError`s with the bad value.  Symptom on smoke: `telegram_send({"connection_id": "", "text": "..."})` and `telegram_send({"connection_id": "8622121495/1595907265", "text": "..."})` both returned `{"error": "''"}` / `{"error": "'8622121495/1595907265'"}` until the model gave up and tried without `connection_id`.
+
+Fix: add `connection_id` to the strip set alongside `account` + `chat_id`, rename `_FOCAL_INJECTABLE` → `_INJECTED_PARAMS` to reflect that `connection_id` comes from the SSE payload (not the focal channel), refresh module docstring, lock with a `test_connection_id_is_excluded_from_schema` test.
+
+**2. Signal delivery receipts batch unpredictably; sender sees inconsistent checkmarks** — `6dfc978`
+
+signal-cli's daemon-mode automatic delivery receipts (the 2nd grey checkmark) batch on internal flush triggers we don't control (new inbound traffic, reconnects, timers).  Some sender-side messages got 2 checks immediately; some got 1 then promoted to 2 minutes later; some sat at 1 for the duration of the smoke.  Not a delivery failure (every message reached the bot) — purely sender UX.
+
+Fix: after `emit_inbound` returns 201 ("the agent has seen it" in the session log), fire an explicit `sendReceipt --type read` via the daemon RPC targeting the original sender.  Best-effort: a receipt failure is logged + swallowed since the inbound is already persisted.  Semantics: ✅ on the sender side now means "the agent's session log has the message", not "signal-cli's flush scheduler got around to it".  Locked with an e2e assertion that `sendReceipt` fires per inbound with the right account/recipient/targetTimestamp.
+
+**3. Empty-content inbound 422s and crashes the connector container** — `326b612`
+
+Reaction-only, attachment-only, and group-update envelopes have no text body.  `build_content_text(msg)` correctly produces `""`; the connector POSTs `content=""` as a multipart form part; **the api 422s it as a missing required field** because FastAPI's multipart `Form` parser treats empty values as `input=null` (missing).  The 422 propagates through `serve_connection` → TaskGroup, taking down the entire container along with every other connection it serves.  Both crashes in this smoke had `content_len=0` as the last `connector.inbound` log line before exit.
+
+Root cause analysis was painful for a second reason: `emit_inbound` called `response.raise_for_status()` and let the `HTTPStatusError` propagate verbatim, discarding the response body — which is exactly where the FastAPI validation diagnostic lives.  Operator saw `HTTPStatusError: 422 ...` with no hint at the offending field.
+
+Two-part fix:
+
+- **api**: `src/aios/api/routers/connectors.py` — `content: Annotated[str, Form()] = ""` (default empty so attachment-only / reaction-passthrough envelopes are a first-class shape).  Locked with `test_empty_content_inbound_accepted`.
+- **connector**: `packages/aios-connector-http/aios_connector_http/runner.py:emit_inbound` — log `connector.inbound.failed` with `status_code` + `body` (capped at 2000 chars) before raising.  Locked with `test_emit_inbound_logs_response_body_on_error`.
+
+Verified by replaying the previously-crashing payload via curl (now returns 201) AND by Jarvis exercising the full bidirectional matrix above — reaction inbounds, attachment inbounds, voice notes, sound effects all flow through cleanly.  Container stayed up across the entire smoke after the fix.
+
+### Open — observed but not yet fixed
+
+**4. `emit_inbound` propagating raise still tears down the container on non-2xx**
+
+Even with #3, the connector still treats any `emit_inbound` failure as fatal: 4xx propagates → `serve_connection` raises → TaskGroup tears down → process exit.  That's correct for genuine server outages and for unrecoverable contract violations (5xx, 401/403), but for routine 4xx ("the api rejected one specific payload"), drop-and-continue makes more sense.  One bad envelope shouldn't kill every other connection the container is serving.
+
+Recommended: in `_handle_envelope`, catch `httpx.HTTPStatusError` for 4xx specifically, log + `return`; let 5xx and connection errors propagate.
+
+**5. Inbound `@mention` metadata is collapsed into plain text**
+
+`connectors/signal/src/aios_signal/parse.py:_substitute_mentions` replaces the Unicode placeholder (`￼`) with `@<display_name>` inline in the message body.  The model sees a string indistinguishable from "the sender typed my name as text" — there's no signal that the sender's client encoded a structured mention targeting the bot's own UUID.
+
+Recommended: extend `build_metadata` to carry a `mentions: list[{"uuid", "name"}]` entry on the inbound event, plus a derived `self_mentioned: bool` when one of the entries matches the bot's UUID.  The model can then choose to react/respond differently when actually pinged vs. just named.
+
+**6. Group `signal_send` returns `{"status": "ok"}`; DM returns `{"sent_at_ms": ...}`**
+
+Inconsistent result shape between group and DM outbound.  `_extract_timestamp(result)` in `connectors/signal/src/aios_signal/connector.py` returns `None` for group sends, so the tool result falls back to `{"status": "ok"}`.  Minor — the model can edit/react/delete a previous message by `target_timestamp_ms`, but only knows the timestamp for DM sends.  Group outbound editing/reacting/deleting from the bot's own messages is therefore harder.
+
+Recommended: check what signal-cli returns for group `send` calls and surface that timestamp (signal-cli's `sendMessage` should return a per-recipient envelope with a timestamp even for group sends).
+
+### Pre-existing, not stack-related
+
+**7. ARM64 sandbox image missing** (`ghcr.io/eumemic/aios-sandbox:latest` has no `linux/arm64/v8` manifest)
+
+Blocks every sandbox-dependent capability on Apple Silicon developer machines.  `bash`, `read`, `write`, `edit`, `grep`, `glob` tools fail with `SandboxBackendError`.  Cascades through the smoke: SmokeBot couldn't create attachment files, generate audio, read inbound attachment contents, transcribe voice notes, or play back sound effects.  Every ❌ in the matrix above traces back here.
+
+Fix scope: rebuild `docker/Dockerfile.sandbox` as multi-arch via `docker buildx build --platform linux/amd64,linux/arm64 --push`.
+
+**8. Stale `mcp_toolset` config on existing pre-PR-5 agents**
+
+Agents like `eumemic-bot` still carry an `mcp_toolset` tools-list entry with `mcp_server_name='telegram'`.  Inert at runtime (skipped by `to_openai_tools`, not in `agent.mcp_servers`), but presents as "the agent has 7 tools" in operator-facing reads.  Not a bug — orphaned data from before PR 5's MCP-out, no data migration was written to scrub.
+
+**9. Polluted session history → tool-name hallucination**
+
+The pre-PR-5 `eumemic-bot` session at `sess_01KQXTMDFR8NPCE24ZBEQE9W81` had ~1200 events of `mcp__telegram__telegram_send(...)` calls in its history.  Post-PR-5 the actual exposed tool is plain `telegram_send`, but the model pattern-matched off history and called `mcp__telegram__telegram_send(...)`, which routed to the MCP dispatcher and errored `"MCP server 'telegram' not found"`.  Real architectural cost of the monotonic-context invariant.
+
+**10. `signal-cli` daemon child not in connector's process group**
+
+Encountered mid-smoke: `pkill -f aios_signal` killed the Python connector but left the spawned `signal-cli daemon` JVM running with the TCP port + SQLite lock on `~/.local/share/signal-cli/data` still held.  Multiple restarts accumulated three orphaned daemons fighting for the lock.  Symptom: new connector's daemon couldn't fully claim the receive websocket — the oldest live daemon kept consuming inbounds.
+
+Recommended: connector should put `signal-cli daemon` in its own process group (start_new_session=True on subprocess) so a single SIGTERM to the connector cleans up the daemon tree, OR explicitly terminate the subprocess on `SignalConnector.teardown()` and confirm via wait_for / timeout.
+
+### Verification
+
+After the three fixes in `refactor/328-fixup-smoke`, the previously-crashing scenarios were re-exercised end-to-end:
+
+- Reaction-only inbound (empty content + reaction metadata) — ✅ no crash, model sees the reaction context
+- Attachment-only inbound with text caption present — ✅ delivered, metadata + path visible to model
+- Voice note inbound (audio attachment, empty caption) — ✅ delivered
+- Sound effect inbound (small audio attachment) — ✅ delivered
+- All four scenarios run in sequence against the same connector container without restart — container stays alive
+
+## Architecture observations / footguns
+
+### Smoke isolation gaps
+
+- **Same-host shared DB by default**: sourcing `/Users/tom/code/aios/.env` from a worktree picks up the shared dev DB.  Easy to pollute with smoke traffic.  `aios dev bootstrap` provisions a per-worktree DB on the same postgres host + writes a worktree-local `.env` — needs to be run *before* the first source of any `.env`.
+- **`~/.local/share/signal-cli` is shared globally**: only one process at a time can hold a registered phone's device key.  Worktree-DB isolation doesn't isolate the signal-cli device.  Smoke against signal requires either a number with no other live aios instance claiming it, OR a separate config dir.
+- **Telegram bot tokens in shared `.env`**: `getUpdates` is exclusive per token.  Any worktree's telegram connector polling the same token competes with prod / other worktrees.
+
+### Runtime container can't scope discovery
+
+`aios_signal` (and `aios_telegram`) discover connections via `/v1/connectors/connections` filtered only by connector *type*.  No way to subset by label, tag, or explicit allowlist.  Means: smoking ONE signal connection requires either (a) archiving every other active signal connection in the DB, or (b) running in an isolated DB.
+
+### Verbose internal monologue from smaller models
+
+Both qwen3.6-flash and Haiku 4.5 frequently emitted `INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER` content instead of either calling a connector send tool or returning silently (the latter being the "right" choice per the focal paradigm).  Sonnet 4.6 was noticeably cleaner — fewer wakes ended in monologue-only output, more wakes responded directly with `signal_send` when a reply was actually warranted.  Not a bug per se — bare assistant text is correctly never delivered — but a measurable model-capability gradient.
+
+## Recommendations / follow-ups
+
+| # | Action | Scope | Where |
+|---|---|---|---|
+| 4 | Container resilience: drop-and-continue on 4xx in `_handle_envelope` | one commit | runner.py |
+| 5 | Expose mention metadata + `self_mentioned: bool` to the model | small feature | signal connector `build_metadata` + parse |
+| 6 | Surface group-send timestamp | small fix | signal `signal_send` result shape |
+| 7 | Build multi-arch sandbox image (linux/amd64 + linux/arm64) | infra | `docker/Dockerfile.sandbox` + buildx |
+| 8 | Scrub orphaned `mcp_toolset` entries on agents missing matching `mcp_servers` | data migration or CLI | one-off |
+| 10 | Process-group ownership of `signal-cli daemon` | small fix | signal `daemon.py:SignalDaemon.__aenter__` |
+| (env) | `aios dev bootstrap` discoverability / harder-to-source-wrong-.env | DX | dev CLI doc |
+| (env) | Runtime token connection-subset scope | feature | runtime tokens + discovery filter |
+
+Items 4, 5, 6, 7, 10 are stack-level and could fold into the fixup PR.  Item 7 (sandbox image) is highest priority given how many ❌s in the matrix collapse to it.

--- a/SMOKE_PR8.md
+++ b/SMOKE_PR8.md
@@ -95,6 +95,25 @@ Recommended scope:
 
 The same wrap applies to `telegram_connector.serve_connection` — a bad bot token currently has the same blast radius.
 
+**13. SDK lifecycle hardening: duplication between signal + telegram that should live on `HttpConnector`**
+
+Surfaced when reading the post-fixup connectors side-by-side.  Three of the smoke fixes (#4 4xx drop-and-continue, #10 SIGTERM trap, the recommended #12 per-connection failure isolation) landed in signal-specific code paths, which means **telegram inherits none of the hardening**.  Same footguns, same blast radius — `pkill -f aios_telegram` leaves the PTB updater's `getUpdates` long-poll holding the bot token against Telegram's API until the dead poll times out, and a 422 on any single inbound envelope still tears down the whole telegram container.
+
+Per-connector duplication that should be hoisted to the SDK base:
+
+| Item | Currently | Should be |
+|---|---|---|
+| SIGINT / SIGTERM trap + cancel-on-stop helper | `aios_signal/__main__.py` (telegram is unhardened) | `HttpConnector.run_until_stopped()` or a `runner.serve(connector)` wrapper; both `__main__.py` files collapse to one line |
+| 4xx drop-and-continue on `emit_inbound` | `aios_signal/connector.py:_handle_envelope` (telegram is unhardened) | `HttpConnector.emit_inbound` directly, with a `raise_on_4xx=True` escape hatch for callers that genuinely want fatal-on-4xx |
+| Per-connection `serve_connection` failure isolation (#12) | nowhere yet — both connectors crash the container on a bad bring-up | `HttpConnector._on_connection_added`'s task wrapper catches non-`CancelledError`, logs structured failure, optionally POSTs a `connector_error` back to aios |
+| `_conn_state` dict + finally-pop boilerplate; focal channel `f"{connector}/{account}/{chat_id}"` string | reimplemented inline in every connector | generic state slot via `set_connection_state` / `get_connection_state`; `self.focal_channel(account, chat_id)` helper |
+
+Correctly per-connector (do NOT hoist): `event_id` construction (platform-specific identity tuples), `build_metadata` content (signal has mentions / quote / reaction; telegram has message_id / old_emojis / new_emojis), inbound parsing, long-lived per-platform plumbing (signal-cli daemon vs PTB Application), tool method implementations.
+
+After the refactor: telegram inherits #4 / #10 / #12 hardening for free; the next connector author gets the safety rails by default; each connector shrinks by ~30-50 LOC.
+
+Note: changing `emit_inbound`'s default to swallow 4xx is a behavior change.  Either (a) signal removes its wrap when the SDK gets one, or (b) the SDK adds the wrap as opt-in (`raise_on_4xx=False` default, but with a strict mode for callers that depend on the raise).  Sign-off needed on the default before landing.
+
 ### Pre-existing, not stack-related
 
 **7. ARM64 sandbox image missing** (`ghcr.io/eumemic/aios-sandbox:latest` has no `linux/arm64/v8` manifest)
@@ -165,7 +184,8 @@ Both qwen3.6-flash and Haiku 4.5 frequently emitted `INTERNAL_MONOLOGUE_NOT_SEEN
 | 10 | Daemon process-group ownership + SIGTERM trap | small fix | ✅ `5f6a0e5` |
 | 11 | Telegram attachment Path → bytes for PTB upload | small fix | ✅ `02b4ac5` |
 | 12 | Per-connection `serve_connection` failure isolation (same shape as #4 but for bring-up) | small fix | open (separate PR) |
+| 13 | SDK lifecycle hardening — hoist #4 / #10 / #12 + state/focal-channel boilerplate onto `HttpConnector` so telegram inherits the safety rails | medium refactor | open (separate PR) |
 | (env) | `aios dev bootstrap` discoverability / harder-to-source-wrong-.env | DX | open |
 | (env) | Runtime token connection-subset scope | feature | open |
 
-All numbered code-path findings (4, 5, 6, 10, 11) landed in the `refactor/328-fixup-smoke` follow-up branch.  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene unrelated to PR 8's scope.  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.  #12 is a follow-up surfaced when reasoning about the post-fixup architecture and deserves its own targeted PR.
+All numbered code-path findings (4, 5, 6, 10, 11) landed in the `refactor/328-fixup-smoke` follow-up branch.  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene unrelated to PR 8's scope.  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.  #12 + #13 are architectural follow-ups surfaced when reasoning about the post-fixup connector boundary and deserve their own targeted PRs.

--- a/SMOKE_PR8.md
+++ b/SMOKE_PR8.md
@@ -57,25 +57,25 @@ Two-part fix:
 
 Verified by replaying the previously-crashing payload via curl (now returns 201) AND by Jarvis exercising the full bidirectional matrix above — reaction inbounds, attachment inbounds, voice notes, sound effects all flow through cleanly.  Container stayed up across the entire smoke after the fix.
 
-### Open — observed but not yet fixed
+**4. `emit_inbound` propagating raise tore down the container on non-2xx** — `315c969`
 
-**4. `emit_inbound` propagating raise still tears down the container on non-2xx**
+Even with #3, the connector previously treated any `emit_inbound` failure as fatal: 4xx propagated → `serve_connection` raised → TaskGroup tore down → process exit.  That's correct for genuine server outages and unrecoverable contract violations (5xx, 401/403), but for routine 4xx ("the api rejected one specific payload"), drop-and-continue is the right posture — one bad envelope shouldn't kill every other connection the container is serving.
 
-Even with #3, the connector still treats any `emit_inbound` failure as fatal: 4xx propagates → `serve_connection` raises → TaskGroup tears down → process exit.  That's correct for genuine server outages and for unrecoverable contract violations (5xx, 401/403), but for routine 4xx ("the api rejected one specific payload"), drop-and-continue makes more sense.  One bad envelope shouldn't kill every other connection the container is serving.
+Fix: in `_handle_envelope`, catch `httpx.HTTPStatusError` and classify by status.  4xx except 401/403 → log + drop the envelope, keep serving.  401/403 (token revoked / runtime misconfigured) and 5xx (server outage or bug) still propagate so the operator sees red on real problems.  Locked with five tests covering 400/422/401/503 + the happy path (read receipt fires on 2xx).
 
-Recommended: in `_handle_envelope`, catch `httpx.HTTPStatusError` for 4xx specifically, log + `return`; let 5xx and connection errors propagate.
+**5. Inbound `@mention` metadata was collapsed into plain text** — `67a14e0`
 
-**5. Inbound `@mention` metadata is collapsed into plain text**
+`connectors/signal/src/aios_signal/parse.py:_substitute_mentions` replaces the Unicode placeholder (`￼`) with `@<display_name>` inline in the message body.  The model saw a string indistinguishable from "the sender typed my name as text" — no signal that the sender's client encoded a structured mention targeting the bot's own UUID.  Group chats in particular use mentions to summon a response; that signal was getting lost in the substring.
 
-`connectors/signal/src/aios_signal/parse.py:_substitute_mentions` replaces the Unicode placeholder (`￼`) with `@<display_name>` inline in the message body.  The model sees a string indistinguishable from "the sender typed my name as text" — there's no signal that the sender's client encoded a structured mention targeting the bot's own UUID.
+Fix: structured `Mention(uuid, name)` dataclass on `InboundMessage`, populated from the raw envelope alongside the placeholder substitution.  `build_metadata` emits a `mentions: [{uuid, name}]` list and a derived `self_mentioned: bool` (True when one of the entries matches `bot_uuid`).  Agents that want different behavior for "tagged" vs "named-in-passing" inbounds read `metadata.self_mentioned` instead of grepping content.  Locked with four `build_metadata` tests + a parse test that asserts the raw envelope mention array survives intact through `parse_envelope`.
 
-Recommended: extend `build_metadata` to carry a `mentions: list[{"uuid", "name"}]` entry on the inbound event, plus a derived `self_mentioned: bool` when one of the entries matches the bot's UUID.  The model can then choose to react/respond differently when actually pinged vs. just named.
+**6. Group `signal_send` returned `{"status": "ok"}`; DM returned `{"sent_at_ms": ...}`** — `a5db125`
 
-**6. Group `signal_send` returns `{"status": "ok"}`; DM returns `{"sent_at_ms": ...}`**
+Investigation against the live daemon (signal-cli 0.14.2) revealed that `send` RPC for groups returns literal `null` regardless of params — no nested timestamp to fish out.  The smoke doc's original recommendation ("check what signal-cli returns for group send calls and surface that timestamp") rested on a premise that turned out to be false.
 
-Inconsistent result shape between group and DM outbound.  `_extract_timestamp(result)` in `connectors/signal/src/aios_signal/connector.py` returns `None` for group sends, so the tool result falls back to `{"status": "ok"}`.  Minor — the model can edit/react/delete a previous message by `target_timestamp_ms`, but only knows the timestamp for DM sends.  Group outbound editing/reacting/deleting from the bot's own messages is therefore harder.
+However, the timestamp *does* arrive on the receive stream as a self-echo envelope (`sourceUuid == bot_uuid` + `dataMessage.groupInfo` + `dataMessage.timestamp`).  Direct probe confirmed the shape; parse_envelope already drops self-messages to `None`, which is the existing hook we extend.
 
-Recommended: check what signal-cli returns for group `send` calls and surface that timestamp (signal-cli's `sendMessage` should return a per-recipient envelope with a timestamp even for group sends).
+Fix: `signal_send` for groups pre-registers an `asyncio.Future` in a per-`(phone, chat_id)` FIFO before issuing the RPC, then waits up to 2s for the matching echo.  `_maybe_resolve_self_echo` runs in `_handle_envelope`'s `msg is None` branch, pops the head future, sets the timestamp.  On timeout we degrade to `{"status": "ok"}` so a slow network doesn't hang the tool call.  DMs untouched — signal-cli already returns the timestamp inline.  Locked with seven tests covering match / prune / non-bot-sender / DM-skip + signal_send end-to-end (echo → sent_at_ms, timeout → status:ok, DM skips registration entirely).
 
 ### Pre-existing, not stack-related
 
@@ -93,11 +93,21 @@ Agents like `eumemic-bot` still carry an `mcp_toolset` tools-list entry with `mc
 
 The pre-PR-5 `eumemic-bot` session at `sess_01KQXTMDFR8NPCE24ZBEQE9W81` had ~1200 events of `mcp__telegram__telegram_send(...)` calls in its history.  Post-PR-5 the actual exposed tool is plain `telegram_send`, but the model pattern-matched off history and called `mcp__telegram__telegram_send(...)`, which routed to the MCP dispatcher and errored `"MCP server 'telegram' not found"`.  Real architectural cost of the monotonic-context invariant.
 
-**10. `signal-cli` daemon child not in connector's process group**
+**10. `signal-cli` daemon child orphaned on connector kill** — `5f6a0e5`
 
-Encountered mid-smoke: `pkill -f aios_signal` killed the Python connector but left the spawned `signal-cli daemon` JVM running with the TCP port + SQLite lock on `~/.local/share/signal-cli/data` still held.  Multiple restarts accumulated three orphaned daemons fighting for the lock.  Symptom: new connector's daemon couldn't fully claim the receive websocket — the oldest live daemon kept consuming inbounds.
+`pkill -f aios_signal` killed the Python connector but left the spawned `signal-cli daemon` JVM running with the TCP port + SQLite lock on `~/.local/share/signal-cli/data` still held.  Multiple restarts accumulated three orphaned daemons fighting for the lock; the oldest live daemon kept consuming inbounds.
 
-Recommended: connector should put `signal-cli daemon` in its own process group (start_new_session=True on subprocess) so a single SIGTERM to the connector cleans up the daemon tree, OR explicitly terminate the subprocess on `SignalConnector.teardown()` and confirm via wait_for / timeout.
+Two correlated causes:
+1. `asyncio.run` installs a SIGINT handler by default but not SIGTERM, so the default SIGTERM action (kill the runtime) ran before `teardown` could fire.
+2. `pkill -f aios_signal` matches only the Python cmdline, never the JVM cmdline; the JVM survived as an orphan.
+
+Fix: `__main__.py` now traps both SIGINT and SIGTERM via `loop.add_signal_handler`, flipping a stop event that cancels the connector task — the `try/finally` in `HttpConnector.run` then calls `teardown` which SIGTERMs the daemon subprocess and waits with a grace period.  `daemon.py` spawns signal-cli with `start_new_session=True` so a foreground-terminal Ctrl-C no longer reaches the daemon via the controlling terminal.  Locked with three tests: `_serve` cancels the connector on stop, `_serve` returns cleanly if the connector exits first, `_spawn_subprocess` passes `start_new_session=True` to the loop.
+
+**11. Telegram outbound attachments crashed on `pathlib.Path` JSON serialization** — `02b4ac5`
+
+python-telegram-bot's HTTPX request layer JSON-serializes the request body; passing a raw `pathlib.Path` as a `photo` / `document` / etc. kwarg falls into the "unknown object" branch and raises `TypeError: Object of type PosixPath is not JSON serializable`.  Surfaced live in PR 8 smoke when SmokeBot tried to send an outbound image attachment.
+
+Fix: `_read_for_upload(host_path)` reads bytes up-front; `_send_single_media` and `_build_media_group` pass the bytes (not Path) to PTB so the upload path is multipart, not JSON-encoded.  Locked with a regression test asserting every media kwarg handed to PTB is bytes, never a `Path`.
 
 ### Verification
 
@@ -127,15 +137,16 @@ Both qwen3.6-flash and Haiku 4.5 frequently emitted `INTERNAL_MONOLOGUE_NOT_SEEN
 
 ## Recommendations / follow-ups
 
-| # | Action | Scope | Where |
+| # | Action | Scope | Status |
 |---|---|---|---|
-| 4 | Container resilience: drop-and-continue on 4xx in `_handle_envelope` | one commit | runner.py |
-| 5 | Expose mention metadata + `self_mentioned: bool` to the model | small feature | signal connector `build_metadata` + parse |
-| 6 | Surface group-send timestamp | small fix | signal `signal_send` result shape |
-| 7 | Build multi-arch sandbox image (linux/amd64 + linux/arm64) | infra | `docker/Dockerfile.sandbox` + buildx |
-| 8 | Scrub orphaned `mcp_toolset` entries on agents missing matching `mcp_servers` | data migration or CLI | one-off |
-| 10 | Process-group ownership of `signal-cli daemon` | small fix | signal `daemon.py:SignalDaemon.__aenter__` |
-| (env) | `aios dev bootstrap` discoverability / harder-to-source-wrong-.env | DX | dev CLI doc |
-| (env) | Runtime token connection-subset scope | feature | runtime tokens + discovery filter |
+| 4 | Container resilience: drop-and-continue on 4xx | one commit | ✅ `315c969` |
+| 5 | Expose mention metadata + `self_mentioned: bool` | small feature | ✅ `67a14e0` |
+| 6 | Surface group-send timestamp via self-echo correlation | small feature | ✅ `a5db125` |
+| 7 | Build multi-arch sandbox image (linux/amd64 + linux/arm64) | infra | ✅ workflow `456cf58` (image republishes on next master merge) |
+| 8 | Scrub orphaned `mcp_toolset` entries on pre-PR-5 agents | data migration or CLI | open (separate one-off) |
+| 10 | Daemon process-group ownership + SIGTERM trap | small fix | ✅ `5f6a0e5` |
+| 11 | Telegram attachment Path → bytes for PTB upload | small fix | ✅ `02b4ac5` |
+| (env) | `aios dev bootstrap` discoverability / harder-to-source-wrong-.env | DX | open |
+| (env) | Runtime token connection-subset scope | feature | open |
 
-Items 4, 5, 6, 7, 10 are stack-level and could fold into the fixup PR.  Item 7 (sandbox image) is highest priority given how many ❌s in the matrix collapse to it.
+All numbered code-path findings (4, 5, 6, 10, 11) landed in the `refactor/328-fixup-smoke` follow-up branch.  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene unrelated to PR 8's scope.  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.

--- a/SMOKE_PR8.md
+++ b/SMOKE_PR8.md
@@ -69,6 +69,8 @@ Fix: in `_handle_envelope`, catch `httpx.HTTPStatusError` and classify by status
 
 Fix: structured `Mention(uuid, name)` dataclass on `InboundMessage`, populated from the raw envelope alongside the placeholder substitution.  `build_metadata` emits a `mentions: [{uuid, name}]` list and a derived `self_mentioned: bool` (True when one of the entries matches `bot_uuid`).  Agents that want different behavior for "tagged" vs "named-in-passing" inbounds read `metadata.self_mentioned` instead of grepping content.  Locked with four `build_metadata` tests + a parse test that asserts the raw envelope mention array survives intact through `parse_envelope`.
 
+**Follow-on caught in live smoke** — `cfc464e`: extracting mention metadata to the inbound event was only half the job.  The harness's `_format_channel_header` rendered a whitelist of metadata fields into the visible `content` (channel, sender, timestamp, edited, reaction, reply_to, sticker_emoji) but **didn't include `mentions` or `self_mentioned`**.  So even with the connector fix the model never saw the structured signal — it only saw the placeholder-substituted `@<name>` text in the body, exactly the pre-fix shape.  Direct harness invocation against the persisted event confirmed: the metadata was there, the renderer was dropping it.  Fix: extend `_format_channel_header` to emit `self_mentioned=true` on the main header line and one `[mention: name=... · uuid=...]` line per entry so the model has both the boolean signal and the uuids for outbound mention encoding.  Locked with three new context tests.
+
 **6. Group `signal_send` returned `{"status": "ok"}`; DM returned `{"sent_at_ms": ...}`** — `a5db125`
 
 Investigation against the live daemon (signal-cli 0.14.2) revealed that `send` RPC for groups returns literal `null` regardless of params — no nested timestamp to fish out.  The smoke doc's original recommendation ("check what signal-cli returns for group send calls and surface that timestamp") rested on a premise that turned out to be false.
@@ -76,6 +78,12 @@ Investigation against the live daemon (signal-cli 0.14.2) revealed that `send` R
 However, the timestamp *does* arrive on the receive stream as a self-echo envelope (`sourceUuid == bot_uuid` + `dataMessage.groupInfo` + `dataMessage.timestamp`).  Direct probe confirmed the shape; parse_envelope already drops self-messages to `None`, which is the existing hook we extend.
 
 Fix: `signal_send` for groups pre-registers an `asyncio.Future` in a per-`(phone, chat_id)` FIFO before issuing the RPC, then waits up to 2s for the matching echo.  `_maybe_resolve_self_echo` runs in `_handle_envelope`'s `msg is None` branch, pops the head future, sets the timestamp.  On timeout we degrade to `{"status": "ok"}` so a slow network doesn't hang the tool call.  DMs untouched — signal-cli already returns the timestamp inline.  Locked with seven tests covering match / prune / non-bot-sender / DM-skip + signal_send end-to-end (echo → sent_at_ms, timeout → status:ok, DM skips registration entirely).
+
+**Three follow-on bugs caught in live smoke after the first deploy:**
+
+- **`9620a74`** — Self-echo for group sends actually lands on the **receiving peers' account streams**, not the bot's own account stream.  When signal-cli serves multiple registered phones (e.g. a co-located bot like Ultron in the QA group), the dataMessage echo for SmokeBot's send appears on Ultron's `+19092871349` stream — never on SmokeBot's `+16575274288` stream.  The original fix's `_handle_envelope` only watched the bot's own queue, so the echo never resolved, every group send hit the 2s timeout, and the result fell back to `{"status": "ok"}` 100% of the time.  Moved the resolver to `_inbound_dispatcher` and key match by `sourceUuid` against any known `bot_uuid` rather than per-account routing.  Live-verified: `signal_send` → `{"sent_at_ms": 1778711928198}` on the very next group send.
+- **`c7d824c`** — Edit echoes use a DIFFERENT envelope shape: `envelope.editMessage.dataMessage` (nested one level deeper) with the new edit's timestamp at the envelope root.  The matcher only checked `envelope.dataMessage`; chained-edit timestamps (model edits its own message and wants the new timestamp for further edits) silently fell back to `{"status": "ok"}`.  Accept both shapes.
+- **`4fe0ef5`** — When `daemon.rpc.call("send", ...)` raises (e.g. signal-cli's `InvalidSessionException` if a group member has no protocol session yet), the pre-registered echo future was orphaned at the head of the deque.  Drain-stale only pops `done()` futures; an orphan sits indefinitely and the NEXT successful send's echo resolves the orphan with the wrong message's timestamp.  Wrap in `try/finally` cancelling the future on the way out so drain-stale prunes it before the next send.
 
 ### Open — surfaced post-fixup
 
@@ -159,6 +167,44 @@ Risks worth flagging:
 - **Phone-number reclamation** — registering a phone already in use elsewhere boots the other device.  Worth a confirmation flag.
 - **Secrets shape** — `secrets={phone}` is just an addressing label; the real cryptographic material (libsignal protocol keys) lives in signal-cli's `accounts.json`, not in aios.
 
+**15. Peer inbound edits silently dropped** — `cfc464e`
+
+When a chat partner (not the bot) edits a prior message, signal-cli emits an envelope with `envelope.editMessage.dataMessage` rather than the top-level `envelope.dataMessage` shape `parse_envelope` was matching.  Edits returned `None` from parse → the inbound dispatcher dropped them → **the bot never saw a peer's edit**, so the bot's view of the conversation silently diverged from the chat client's view.
+
+Caught live when Tom edited "@+16575274288 still?" to "@+16575274288 still? - EDIT can you see this?" and asked SmokeBot.  Before the fix the bot would have been answering off the pre-edit content.
+
+Fix: `parse_envelope` falls back to `envelope.editMessage.dataMessage` and sets `edited=True` + `edit_target_timestamp_ms` on the resulting `InboundMessage`.  `build_metadata` propagates these to event metadata; the harness's existing `edited=true` rendering picks it up and now also surfaces `edit_target_timestamp_ms`.  Locked with a parse test against the captured envelope shape.
+
+**16. Telegram outbound `.gif` rendered as a static first frame** — `4f409bd`
+
+Telegram's Bot API treats a `.gif` passed to `sendPhoto` as a static image and only renders the first frame.  `sendAnimation` is the first-class animated-image surface.
+
+`_classify` had `.gif` in `_PHOTO_EXTS` → routed to `bot.send_photo` → Tom saw a static image where a 30-frame Mandelbrot zoom was supposed to be.  The bot worked around it client-side by converting to MP4 via moviepy (installed on demand via `pip install`), which worked but lost the obvious-thing-should-just-work property.
+
+Fix: extract `.gif` from `_PHOTO_EXTS` into a new `_ANIMATION_EXTS`; `_classify` returns `"animation"`; dispatch table maps `"animation"` to `bot.send_animation`.  Multi-attachment media-group path leaves `.gif` falling back to `InputMediaDocument` since Telegram media groups don't have an `InputMediaAnimation` type (platform constraint, not a fixable connector issue).  Locked with a new `_classify` assertion.
+
+**Note**: #16 + the `9617c84` follow-on to #11 together close the full attachment-rendering chain: `.gif` now routes via `send_animation` AND has `Content-Type: image/gif`, so animated GIFs play inline in Telegram.
+
+### Open — observed but not yet fixed
+
+**17. Telegram `parse_mode="html"` runs Markdown→HTML converter; name collides with Bot API semantics** → [#351](https://github.com/eumemic/aios/issues/351)
+
+The connector's `parse_mode: Literal["plain", "html"]` parameter does NOT mean "I'm writing HTML" (Telegram Bot API semantics) — it means "I'm writing markdown, you run it through `markdown_to_telegram_html` before sending".  The docstring describes the actual behavior, but the parameter NAME is the load-bearing signal; smart-enough models infer the standard semantics, write `<a href="...">`, and get literal-text fallout in chat.
+
+Surfaced live when another agent (Ultron) tried `parse_mode="html"` with raw `<a href>` tags and saw the text render as literal characters.  Recommended rename: `parse_mode: Literal["plain", "markdown", "html"]` where `"markdown"` is the current converter behavior and `"html"` becomes true HTML pass-through.
+
+**18. Tool-call dispatched before `serve_connection` registers state → stringified KeyError** → [#352](https://github.com/eumemic/aios/issues/352)
+
+The dispatch SSE and the connection-discovery SSE are independent streams.  Backfill on the tool-call stream can fire while `_on_connection_added` is still running.  When the tool method does `self._conn_state[connection_id]`, it raises `KeyError(connection_id)` and the SDK base stringifies it to `{"error": "'conn_01...'"}` — incomprehensible from the model's POV.
+
+Observed during a telegram restart: connector came up at `17:48:40`, tool-call dispatched at `17:48:43`, got the bare-ID KeyError; retry 1s later succeeded.  Same root cause family as #346 (per-connection state race), different symptom path.
+
+**19. Harness sweep re-wakes session forever on persistent model timeouts** → [#353](https://github.com/eumemic/aios/issues/353)
+
+When wake-step consistently exceeds the 5-min `step_timeout` (e.g. agent on a slow local model with too-large a context window), the sweep keeps re-firing the same wake on every cycle with no backoff or budget.  Each retry pegs the local GPU for 5 minutes and produces nothing.
+
+Observed during the ollama-27B experiment: wake_session[331, 332, 362, 375, 379, 402, 423, ...] all on the same session, alternating between 41s/142s/300s.  Tom's laptop got pegged before we caught it; archive on the session was the only way to break the loop.  Recommended fix: retry budget on consecutive timeouts + promote to `errored` status after N to make the sweep skip the session.
+
 ### Pre-existing, not stack-related
 
 **7. ARM64 sandbox image missing** (`ghcr.io/eumemic/aios-sandbox:latest` has no `linux/arm64/v8` manifest)
@@ -191,6 +237,8 @@ python-telegram-bot's HTTPX request layer JSON-serializes the request body; pass
 
 Fix: `_read_for_upload(host_path)` reads bytes up-front; `_send_single_media` and `_build_media_group` pass the bytes (not Path) to PTB so the upload path is multipart, not JSON-encoded.  Locked with a regression test asserting every media kwarg handed to PTB is bytes, never a `Path`.
 
+**Follow-on caught in live smoke** — `9617c84`: bytes survived the JSON-serialize layer, but PTB then wraps raw bytes in an `InputFile` with a default filename of `"application.octet-stream"`.  Telegram derives `Content-Type` from the InputFile filename's extension; with the default, every attachment landed as `Content-Type: application/octet-stream` — Tom saw a 713 KB "application.octet-stream" download icon even for animated GIFs that had been correctly routed (post-#16) to `send_animation`.  Wrap the bytes in `InputFile(bytes, filename=host_path.name)` so PTB's multipart writer attaches the source filename, Telegram reads the extension, and the attachment renders in its native player (image preview / inline animation / audio scrubber / etc.).
+
 ### Verification
 
 After the three fixes in `refactor/328-fixup-smoke`, the previously-crashing scenarios were re-exercised end-to-end:
@@ -217,6 +265,22 @@ After the three fixes in `refactor/328-fixup-smoke`, the previously-crashing sce
 
 Both qwen3.6-flash and Haiku 4.5 frequently emitted `INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER` content instead of either calling a connector send tool or returning silently (the latter being the "right" choice per the focal paradigm).  Sonnet 4.6 was noticeably cleaner — fewer wakes ended in monologue-only output, more wakes responded directly with `signal_send` when a reply was actually warranted.  Not a bug per se — bare assistant text is correctly never delivered — but a measurable model-capability gradient.
 
+### Bot ↔ bot invisibility in Telegram groups
+
+Observed when SmokeBot and another bot (MetalsAndAIBot / Ultron) were both members of the "Metals and AI" Telegram group: SmokeBot received messages from human members (Tom, David) but NOT from MetalsAndAIBot, and vice versa.  Confirmed via direct test — SmokeBot saw 4 `@mention` strings in a message that tagged 4 entities (`@MetalsAndAIBot @eumemic @EumemicBot @daviduser`) but no inbound stream from MetalsAndAIBot's posts.
+
+Telegram-platform-level constraint: bots can't read other bots' messages in groups, even with privacy mode disabled.  Nothing aios can route around.  Worth noting because the smoke matrix's "bot-to-bot in group" cell is permanently ❌ on Telegram (whereas on Signal it works fine — Signal has no bot-vs-user concept).
+
+### Ollama 27B local model: latency profile vs harness step_timeout
+
+Observed during a brief experiment switching the agent's `model` to `ollama_chat/huihui_ai/qwen3.5-abliterated:27b-Claude` (locally hosted Qwen 3.5 27B Q4_K_M) on an M4 Pro / 48GB Mac:
+
+- **Throughput**: ~18.7 tok/s prompt eval, ~8.6 tok/s generation eval (vs typical M4 Pro range of 15-20 tok/s for 27B Q4_K_M — somewhat below ceiling but functional).
+- **Thinking-mode**: Default ON for this Qwen variant.  With thinking enabled, all output budget gets spent in `<thinking>` tokens and the visible `response` field stays empty — directly observed: 10-token probe returned `response=''` with all 10 tokens in `thinking=`.  Disabled via `/no_think` system-prompt prefix + ollama `think: false` option (latter passes through LiteLLM via the agent's `litellm_extra`).
+- **Step budget**: The harness's 5-minute `step_timeout` is too short for this combination of (27B model + 30k context window + un-disabled thinking).  Hit reliably during smoke; the sweep then re-fires the timed-out wake forever (see #19).
+
+Not a bug — agent-level configuration choice.  Documented here as a capacity / compat note for anyone wiring a similar local model.
+
 ## Recommendations / follow-ups
 
 | # | Action | Scope | Status |
@@ -227,11 +291,16 @@ Both qwen3.6-flash and Haiku 4.5 frequently emitted `INTERNAL_MONOLOGUE_NOT_SEEN
 | 7 | Build multi-arch sandbox image (linux/amd64 + linux/arm64) | infra | ✅ workflow `456cf58` (image republishes on next master merge) |
 | 8 | Scrub orphaned `mcp_toolset` entries on pre-PR-5 agents | data migration or CLI | open (separate one-off) |
 | 10 | Daemon process-group ownership + SIGTERM trap | small fix | ✅ `5f6a0e5` |
-| 11 | Telegram attachment Path → bytes for PTB upload | small fix | ✅ `02b4ac5` |
+| 11 | Telegram attachment shape (Path → bytes → InputFile + filename for Content-Type) | small fix | ✅ `02b4ac5` + `9617c84` |
 | 12 | Per-connection `serve_connection` failure isolation (same shape as #4 but for bring-up) | small fix | open → [#346](https://github.com/eumemic/aios/issues/346) |
 | 13 | SDK lifecycle hardening — hoist #4 / #10 / #12 + state/focal-channel boilerplate onto `HttpConnector` so telegram inherits the safety rails | medium refactor | open → [#347](https://github.com/eumemic/aios/issues/347) |
 | 14 | Signal account registration via the aios API — three routes + management-call SSE so new phones can be onboarded without SSH or restart | medium feature | open → [#348](https://github.com/eumemic/aios/issues/348) |
+| 15 | Peer inbound edits silently dropped — accept `envelope.editMessage.dataMessage` shape | small fix | ✅ `cfc464e` |
+| 16 | Telegram outbound `.gif` → `send_animation` (not `send_photo`) | small fix | ✅ `4f409bd` |
+| 17 | Telegram `parse_mode="html"` parameter name collides with Bot API semantics | small fix | open → [#351](https://github.com/eumemic/aios/issues/351) |
+| 18 | Tool-call dispatched before `serve_connection` registers state → stringified KeyError | small fix | open → [#352](https://github.com/eumemic/aios/issues/352) |
+| 19 | Harness sweep retries persistent-timeout sessions forever; no backoff or cap | medium fix | open → [#353](https://github.com/eumemic/aios/issues/353) |
 | (env) | `aios dev bootstrap` discoverability / harder-to-source-wrong-.env | DX | open → [#349](https://github.com/eumemic/aios/issues/349) |
 | (env) | Runtime token connection-subset scope | feature | open → [#350](https://github.com/eumemic/aios/issues/350) |
 
-All numbered code-path findings (4, 5, 6, 10, 11) landed in the `refactor/328-fixup-smoke` follow-up branch.  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene → [#345](https://github.com/eumemic/aios/issues/345).  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.  #12 → [#346](https://github.com/eumemic/aios/issues/346) and #13 + #14 are architectural follow-ups surfaced when reasoning about the post-fixup connector boundary and operator UX, all filed as separate issues for their own targeted PRs.
+All ✅ items landed in the `refactor/328-fixup-smoke` follow-up branch (PR #344).  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene → [#345](https://github.com/eumemic/aios/issues/345).  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.  #12 → [#346](https://github.com/eumemic/aios/issues/346), #13 → [#347](https://github.com/eumemic/aios/issues/347), #14 → [#348](https://github.com/eumemic/aios/issues/348), #17 → [#351](https://github.com/eumemic/aios/issues/351), #18 → [#352](https://github.com/eumemic/aios/issues/352), and #19 → [#353](https://github.com/eumemic/aios/issues/353) are all open follow-ups with their own targeted PRs.

--- a/SMOKE_PR8.md
+++ b/SMOKE_PR8.md
@@ -185,19 +185,23 @@ Fix: extract `.gif` from `_PHOTO_EXTS` into a new `_ANIMATION_EXTS`; `_classify`
 
 **Note**: #16 + the `9617c84` follow-on to #11 together close the full attachment-rendering chain: `.gif` now routes via `send_animation` AND has `Content-Type: image/gif`, so animated GIFs play inline in Telegram.
 
-### Open — observed but not yet fixed
+**17. Telegram `parse_mode="html"` ran Markdown→HTML converter; name collided with Bot API semantics**
 
-**17. Telegram `parse_mode="html"` runs Markdown→HTML converter; name collides with Bot API semantics** → [#351](https://github.com/eumemic/aios/issues/351)
+The connector's `parse_mode: Literal["plain", "html"]` parameter did NOT mean "I'm writing HTML" (Telegram Bot API semantics) — it meant "I'm writing markdown, you run it through `markdown_to_telegram_html` before sending".  The docstring described the actual behavior, but the parameter NAME was the load-bearing signal; smart-enough models inferred the standard semantics, wrote `<a href="...">`, and got literal-text fallout in chat.
 
-The connector's `parse_mode: Literal["plain", "html"]` parameter does NOT mean "I'm writing HTML" (Telegram Bot API semantics) — it means "I'm writing markdown, you run it through `markdown_to_telegram_html` before sending".  The docstring describes the actual behavior, but the parameter NAME is the load-bearing signal; smart-enough models infer the standard semantics, write `<a href="...">`, and get literal-text fallout in chat.
+Surfaced live when another agent (Ultron) tried `parse_mode="html"` with raw `<a href>` tags and saw the text render as literal characters.
 
-Surfaced live when another agent (Ultron) tried `parse_mode="html"` with raw `<a href>` tags and saw the text render as literal characters.  Recommended rename: `parse_mode: Literal["plain", "markdown", "html"]` where `"markdown"` is the current converter behavior and `"html"` becomes true HTML pass-through.
+Fix: renamed the literal values to match what each actually does.  `parse_mode: Literal["plain", "markdown", "html"]` where `"plain"` is unchanged literal-text, `"markdown"` is the renamed form of the old `"html"` (runs the converter), and the new `"html"` is true Bot-API-semantics raw HTML pass-through (`<b>`, `<i>`, `<a href>`, etc. forwarded verbatim).  Old `parse_mode="html"` callers now hit the new pass-through path; the misnamed-converter behavior is reachable only via `"markdown"`.  Locked with separate tests for each branch.
 
-**18. Tool-call dispatched before `serve_connection` registers state → stringified KeyError** → [#352](https://github.com/eumemic/aios/issues/352)
+**18. Tool-call dispatched before `serve_connection` registers state → stringified KeyError**
 
-The dispatch SSE and the connection-discovery SSE are independent streams.  Backfill on the tool-call stream can fire while `_on_connection_added` is still running.  When the tool method does `self._conn_state[connection_id]`, it raises `KeyError(connection_id)` and the SDK base stringifies it to `{"error": "'conn_01...'"}` — incomprehensible from the model's POV.
+The dispatch SSE and the connection-discovery SSE are independent streams.  Backfill on the tool-call stream could fire while `_on_connection_added` was still running.  When the tool method did `self._conn_state[connection_id]`, it raised `KeyError(connection_id)` and the SDK base stringified it to `{"error": "'conn_01...'"}` — incomprehensible from the model's POV.
 
 Observed during a telegram restart: connector came up at `17:48:40`, tool-call dispatched at `17:48:43`, got the bare-ID KeyError; retry 1s later succeeded.  Same root cause family as #346 (per-connection state race), different symptom path.
+
+Fix: in `HttpConnector.dispatch_call`, special-case the shape — when the tool method raises `KeyError(connection_id)`, produce a structured `{"error": "connection not yet active; retry shortly", "connection_id": ...}` result and log with `reason="connection_state_race"` instead of the opaque quoted ID.  Locked with two tests: one asserting the race shape produces the new payload + reason, one asserting an unrelated `KeyError` (different key) still surfaces as the generic `tool_exception` so the special-case doesn't disguise real bugs.
+
+### Open — observed but not yet fixed
 
 **19. Harness sweep re-wakes session forever on persistent model timeouts** → [#353](https://github.com/eumemic/aios/issues/353)
 
@@ -297,10 +301,10 @@ Not a bug — agent-level configuration choice.  Documented here as a capacity /
 | 14 | Signal account registration via the aios API — three routes + management-call SSE so new phones can be onboarded without SSH or restart | medium feature | open → [#348](https://github.com/eumemic/aios/issues/348) |
 | 15 | Peer inbound edits silently dropped — accept `envelope.editMessage.dataMessage` shape | small fix | ✅ `cfc464e` |
 | 16 | Telegram outbound `.gif` → `send_animation` (not `send_photo`) | small fix | ✅ `4f409bd` |
-| 17 | Telegram `parse_mode="html"` parameter name collides with Bot API semantics | small fix | open → [#351](https://github.com/eumemic/aios/issues/351) |
-| 18 | Tool-call dispatched before `serve_connection` registers state → stringified KeyError | small fix | open → [#352](https://github.com/eumemic/aios/issues/352) |
+| 17 | Telegram `parse_mode="html"` parameter name (rename + add real HTML pass-through) | small fix | ✅ (this PR) |
+| 18 | Tool-call dispatched before `serve_connection` registers state → stringified KeyError | small fix | ✅ (this PR) |
 | 19 | Harness sweep retries persistent-timeout sessions forever; no backoff or cap | medium fix | open → [#353](https://github.com/eumemic/aios/issues/353) |
 | (env) | `aios dev bootstrap` discoverability / harder-to-source-wrong-.env | DX | open → [#349](https://github.com/eumemic/aios/issues/349) |
 | (env) | Runtime token connection-subset scope | feature | open → [#350](https://github.com/eumemic/aios/issues/350) |
 
-All ✅ items landed in the `refactor/328-fixup-smoke` follow-up branch (PR #344).  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene → [#345](https://github.com/eumemic/aios/issues/345).  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.  #12 → [#346](https://github.com/eumemic/aios/issues/346), #13 → [#347](https://github.com/eumemic/aios/issues/347), #14 → [#348](https://github.com/eumemic/aios/issues/348), #17 → [#351](https://github.com/eumemic/aios/issues/351), #18 → [#352](https://github.com/eumemic/aios/issues/352), and #19 → [#353](https://github.com/eumemic/aios/issues/353) are all open follow-ups with their own targeted PRs.
+All ✅ items landed in the `refactor/328-fixup-smoke` follow-up branch (PR #344).  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene → [#345](https://github.com/eumemic/aios/issues/345).  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.  #12 → [#346](https://github.com/eumemic/aios/issues/346), #13 → [#347](https://github.com/eumemic/aios/issues/347), #14 → [#348](https://github.com/eumemic/aios/issues/348), and #19 → [#353](https://github.com/eumemic/aios/issues/353) are all open follow-ups with their own targeted PRs.  [#351](https://github.com/eumemic/aios/issues/351) and [#352](https://github.com/eumemic/aios/issues/352) were closed by this PR — their fixes landed in the same fixup so the open-issue queue stays focused on the items that genuinely need separate PRs.

--- a/SMOKE_PR8.md
+++ b/SMOKE_PR8.md
@@ -77,6 +77,24 @@ However, the timestamp *does* arrive on the receive stream as a self-echo envelo
 
 Fix: `signal_send` for groups pre-registers an `asyncio.Future` in a per-`(phone, chat_id)` FIFO before issuing the RPC, then waits up to 2s for the matching echo.  `_maybe_resolve_self_echo` runs in `_handle_envelope`'s `msg is None` branch, pops the head future, sets the timestamp.  On timeout we degrade to `{"status": "ok"}` so a slow network doesn't hang the tool call.  DMs untouched — signal-cli already returns the timestamp inline.  Locked with seven tests covering match / prune / non-bot-sender / DM-skip + signal_send end-to-end (echo → sent_at_ms, timeout → status:ok, DM skips registration entirely).
 
+### Open — surfaced post-fixup
+
+**12. Per-connection `serve_connection` failure crashes the entire connector container**
+
+Adjacent to #4's failure-isolation theme but on the bring-up path rather than the inbound path.  When the discovery SSE emits `added` for a connection whose `serve_connection` raises — most commonly when signal-cli has no `accounts.json` entry for the phone, so `daemon.verify_phone` raises `BotAccountNotFoundError` — the exception propagates out of the spawned task into the runner's `TaskGroup`, which cancels every sibling worker (every healthy connection of this connector type) and exits the container.
+
+Concretely: an operator types a typo in a new signal connection's `phone` secret, or attaches a connection for a phone they haven't yet `signal-cli register`-ed.  The discovery loop sees the new row, spawns `serve_connection(connection_id, secrets)`, the task raises before it ever drains its inbound queue, and the TaskGroup tears down the whole process.  Every other connection in that container loses its in-flight inbound queue.
+
+This was theoretical during PR 8 smoke (we registered both phones before attaching) but surfaced in the post-fix architecture pass: it's the same "one bad envelope shouldn't kill every other connection" principle as #4, applied to connection lifecycle instead of inbound dispatch.
+
+Recommended scope:
+
+- Wrap each per-connection task body in a `try/except` that catches non-`CancelledError` exceptions, logs `signal.connection.bringup_failed` with the connection_id + error class + traceback, and ends the task cleanly.
+- Optionally: POST a `connector_error` event back to aios so the api can mark the connection's binding as errored, surfacing the bad connection to operators via the existing connection-status reads instead of via container restart logs.
+- Keep `CancelledError` propagating so `_on_connection_removed` continues to work (the runner cancels the task on `removed` events).
+
+The same wrap applies to `telegram_connector.serve_connection` — a bad bot token currently has the same blast radius.
+
 ### Pre-existing, not stack-related
 
 **7. ARM64 sandbox image missing** (`ghcr.io/eumemic/aios-sandbox:latest` has no `linux/arm64/v8` manifest)
@@ -146,7 +164,8 @@ Both qwen3.6-flash and Haiku 4.5 frequently emitted `INTERNAL_MONOLOGUE_NOT_SEEN
 | 8 | Scrub orphaned `mcp_toolset` entries on pre-PR-5 agents | data migration or CLI | open (separate one-off) |
 | 10 | Daemon process-group ownership + SIGTERM trap | small fix | ✅ `5f6a0e5` |
 | 11 | Telegram attachment Path → bytes for PTB upload | small fix | ✅ `02b4ac5` |
+| 12 | Per-connection `serve_connection` failure isolation (same shape as #4 but for bring-up) | small fix | open (separate PR) |
 | (env) | `aios dev bootstrap` discoverability / harder-to-source-wrong-.env | DX | open |
 | (env) | Runtime token connection-subset scope | feature | open |
 
-All numbered code-path findings (4, 5, 6, 10, 11) landed in the `refactor/328-fixup-smoke` follow-up branch.  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene unrelated to PR 8's scope.  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.
+All numbered code-path findings (4, 5, 6, 10, 11) landed in the `refactor/328-fixup-smoke` follow-up branch.  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene unrelated to PR 8's scope.  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.  #12 is a follow-up surfaced when reasoning about the post-fixup architecture and deserves its own targeted PR.

--- a/SMOKE_PR8.md
+++ b/SMOKE_PR8.md
@@ -228,10 +228,10 @@ Both qwen3.6-flash and Haiku 4.5 frequently emitted `INTERNAL_MONOLOGUE_NOT_SEEN
 | 8 | Scrub orphaned `mcp_toolset` entries on pre-PR-5 agents | data migration or CLI | open (separate one-off) |
 | 10 | Daemon process-group ownership + SIGTERM trap | small fix | ✅ `5f6a0e5` |
 | 11 | Telegram attachment Path → bytes for PTB upload | small fix | ✅ `02b4ac5` |
-| 12 | Per-connection `serve_connection` failure isolation (same shape as #4 but for bring-up) | small fix | open (separate PR) |
-| 13 | SDK lifecycle hardening — hoist #4 / #10 / #12 + state/focal-channel boilerplate onto `HttpConnector` so telegram inherits the safety rails | medium refactor | open (separate PR) |
-| 14 | Signal account registration via the aios API — three routes + management-call SSE so new phones can be onboarded without SSH or restart | medium feature | open (separate PR) |
-| (env) | `aios dev bootstrap` discoverability / harder-to-source-wrong-.env | DX | open |
-| (env) | Runtime token connection-subset scope | feature | open |
+| 12 | Per-connection `serve_connection` failure isolation (same shape as #4 but for bring-up) | small fix | open → [#346](https://github.com/eumemic/aios/issues/346) |
+| 13 | SDK lifecycle hardening — hoist #4 / #10 / #12 + state/focal-channel boilerplate onto `HttpConnector` so telegram inherits the safety rails | medium refactor | open → [#347](https://github.com/eumemic/aios/issues/347) |
+| 14 | Signal account registration via the aios API — three routes + management-call SSE so new phones can be onboarded without SSH or restart | medium feature | open → [#348](https://github.com/eumemic/aios/issues/348) |
+| (env) | `aios dev bootstrap` discoverability / harder-to-source-wrong-.env | DX | open → [#349](https://github.com/eumemic/aios/issues/349) |
+| (env) | Runtime token connection-subset scope | feature | open → [#350](https://github.com/eumemic/aios/issues/350) |
 
-All numbered code-path findings (4, 5, 6, 10, 11) landed in the `refactor/328-fixup-smoke` follow-up branch.  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene unrelated to PR 8's scope.  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.  #12 + #13 + #14 are architectural follow-ups surfaced when reasoning about the post-fixup connector boundary and operator UX, and deserve their own targeted PRs.
+All numbered code-path findings (4, 5, 6, 10, 11) landed in the `refactor/328-fixup-smoke` follow-up branch.  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene → [#345](https://github.com/eumemic/aios/issues/345).  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.  #12 → [#346](https://github.com/eumemic/aios/issues/346) and #13 + #14 are architectural follow-ups surfaced when reasoning about the post-fixup connector boundary and operator UX, all filed as separate issues for their own targeted PRs.

--- a/SMOKE_PR8.md
+++ b/SMOKE_PR8.md
@@ -114,6 +114,51 @@ After the refactor: telegram inherits #4 / #10 / #12 hardening for free; the nex
 
 Note: changing `emit_inbound`'s default to swallow 4xx is a behavior change.  Either (a) signal removes its wrap when the SDK gets one, or (b) the SDK adds the wrap as opt-in (`raise_on_4xx=False` default, but with a strict mode for callers that depend on the raise).  Sign-off needed on the default before landing.
 
+**14. Signal account registration via the aios API (close the SSH-required gap)**
+
+Surfaced when reasoning about operator UX for adding new signal/telegram accounts.  Today's aios api is the bookkeeping side: `POST /v1/connections`, `PUT .../secrets`, `attach`, `configure-per-chat`, `bind-chat` — all dynamic, all no-restart for adding connections of an **already-registered** platform account.  The connector runtime's discovery SSE picks up new connection rows without a container bounce.
+
+What's gated behind SSH today: signal-cli's `register` / `verify` / `submitRateLimitChallenge` / `updateProfile` JSON-RPC methods.  signal-cli exposes them on the running daemon, but the connector doesn't route them through; operators have to SSH into the host and shell into `signal-cli` directly to register a new phone.  Once registration completes, `accounts.json` updates and `verify_phone` re-reads it fresh per call — so the running daemon picks up the new account without restart.  The api gap is the missing piece, not the runtime.
+
+Telegram has a different shape: bot creation via @BotFather is upstream-manual (Telegram doesn't expose programmatic bot creation), but token-in-hand → connection-attached is already a single `POST /v1/connections` away.  So telegram's part of this finding is "already done modulo the irreducible BotFather step".
+
+Recommended scope for signal:
+
+| Piece | Size |
+|---|---|
+| Three api routes (`/v1/connectors/signal/register`, `/verify`, optional `/profile`) | ~120 LOC + tests |
+| Management-call SSE event kind (sibling of `tool_call` on the existing per-type call stream) | ~80 LOC + tests |
+| SDK base: management-call dispatcher routing the new event to per-connector handlers | ~40 LOC + tests |
+| Captcha-handoff response shape (api returns signalcaptchas.org URL; operator solves; reposts token) | ~30 LOC + tests |
+| CLI convenience (`aios signal register +<phone>` / `aios signal verify <code>`) | ~60 LOC |
+
+Architecture choice: reuse the existing tool-call SSE pattern (api emits `management_call` events on the connector-type stream; connector handles via a sibling of `_tool_loop`; result POSTs back through the existing tool-result route, keyed by `call_id` and unblocked via the same one-shot future pattern requires-action custom tools already use).  Fits the current architecture without adding a new connector-side HTTP listener.
+
+End-to-end signal flow then becomes:
+
+```
+POST /v1/connectors/signal/register   { phone, captcha_token? }
+→ if captcha needed: 200 { captcha_url }; operator solves + reposts with token
+→ 200 { verification_required: true }
+
+POST /v1/connectors/signal/verify     { phone, code }
+→ 200 { account: { phone, uuid } }    // accounts.json now has the entry
+
+POST /v1/connections                  { connector: "signal", account: <phone>, secrets: { phone } }
+→ 201                                   // discovery SSE fires "added"
+
+POST /v1/connections/{id}/attach      { session_id }
+→ 201                                   // binding row inserted, connector serves
+```
+
+No SSH, no restart, no shelling into the host.
+
+Risks worth flagging:
+
+- **Captcha rate-limiting** — Signal aggressively requires captcha on programmatic registration; the route shape needs to surface the captcha URL cleanly rather than returning opaque "Captcha required" errors.
+- **Phone-number reclamation** — registering a phone already in use elsewhere boots the other device.  Worth a confirmation flag.
+- **Secrets shape** — `secrets={phone}` is just an addressing label; the real cryptographic material (libsignal protocol keys) lives in signal-cli's `accounts.json`, not in aios.
+
 ### Pre-existing, not stack-related
 
 **7. ARM64 sandbox image missing** (`ghcr.io/eumemic/aios-sandbox:latest` has no `linux/arm64/v8` manifest)
@@ -185,7 +230,8 @@ Both qwen3.6-flash and Haiku 4.5 frequently emitted `INTERNAL_MONOLOGUE_NOT_SEEN
 | 11 | Telegram attachment Path → bytes for PTB upload | small fix | ✅ `02b4ac5` |
 | 12 | Per-connection `serve_connection` failure isolation (same shape as #4 but for bring-up) | small fix | open (separate PR) |
 | 13 | SDK lifecycle hardening — hoist #4 / #10 / #12 + state/focal-channel boilerplate onto `HttpConnector` so telegram inherits the safety rails | medium refactor | open (separate PR) |
+| 14 | Signal account registration via the aios API — three routes + management-call SSE so new phones can be onboarded without SSH or restart | medium feature | open (separate PR) |
 | (env) | `aios dev bootstrap` discoverability / harder-to-source-wrong-.env | DX | open |
 | (env) | Runtime token connection-subset scope | feature | open |
 
-All numbered code-path findings (4, 5, 6, 10, 11) landed in the `refactor/328-fixup-smoke` follow-up branch.  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene unrelated to PR 8's scope.  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.  #12 + #13 are architectural follow-ups surfaced when reasoning about the post-fixup connector boundary and deserve their own targeted PRs.
+All numbered code-path findings (4, 5, 6, 10, 11) landed in the `refactor/328-fixup-smoke` follow-up branch.  #7's workflow change publishes the multi-arch image on the next push to master.  #8 is pre-existing data hygiene unrelated to PR 8's scope.  #9 is the architectural cost of the monotonic-context invariant and not a fixable bug.  #12 + #13 + #14 are architectural follow-ups surfaced when reasoning about the post-fixup connector boundary and operator UX, and deserve their own targeted PRs.

--- a/connectors/signal/src/aios_signal/__main__.py
+++ b/connectors/signal/src/aios_signal/__main__.py
@@ -5,18 +5,57 @@ this automatically inside ``HttpConnector.__init__``).  Deployment-shape
 fields like ``AIOS_SIGNAL_CONFIG_DIR`` feed pydantic-settings; the
 phone (the account identity) lives on each connection's encrypted
 secrets and is fetched per-connection in ``serve_connection``.
+
+SIGINT and SIGTERM are trapped at runtime so ``SignalConnector.teardown``
+gets a chance to fire — ``asyncio.run`` traps SIGINT by default but
+not SIGTERM, and a default SIGTERM would kill Python before the daemon
+subprocess is cleaned up.  The trap converts the signal to a cancel on
+the connector task, the cancellation unwinds the TaskGroup in
+:meth:`SignalConnector.run`, and the surrounding ``try/finally`` runs
+``teardown`` which sends SIGTERM to the daemon subprocess and waits.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import signal
 
 from .config import Settings
 from .connector import SignalConnector
 
 
+async def _serve(connector: SignalConnector, stop: asyncio.Event) -> None:
+    """Run the connector until cancelled or ``stop`` is set.
+
+    Factored out of :func:`main` so a unit test can exercise the
+    cancel-on-stop path without process-level signal handling.
+    """
+    connector_task = asyncio.create_task(connector.run(), name="aios-signal-run")
+    stop_task = asyncio.create_task(stop.wait(), name="aios-signal-stop-wait")
+    try:
+        await asyncio.wait(
+            {connector_task, stop_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+    finally:
+        stop_task.cancel()
+        if not connector_task.done():
+            connector_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await connector_task
+
+
+async def _async_main() -> None:
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop.set)
+    await _serve(SignalConnector(Settings()), stop)
+
+
 def main() -> None:
-    asyncio.run(SignalConnector(Settings()).run())
+    asyncio.run(_async_main())
 
 
 if __name__ == "__main__":

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -208,9 +208,28 @@ class SignalConnector(HttpConnector):
         return self._inbound_queues[phone]
 
     async def _inbound_dispatcher(self) -> None:
-        """Fan ``daemon.listener.messages()`` out to per-account queues."""
+        """Fan ``daemon.listener.messages()`` out to per-account queues.
+
+        Self-echo resolution rides at this layer rather than inside the
+        per-account queue drain because signal-cli's group self-echoes
+        (the ``dataMessage`` with ``groupInfo`` carrying the send
+        timestamp) emit on the RECEIVING peers' account streams, not on
+        the sender's own account stream.  When the bot sends to a group
+        that includes other peers whose accounts signal-cli also serves
+        (e.g. a co-located bot like Ultron in the QA group), the echo
+        arrives on *their* stream and never reaches the bot's queue.
+        Checking each envelope's ``sourceUuid`` against every known
+        bot before routing lets us correlate regardless of which
+        account stream the envelope landed on.
+        """
         assert self._daemon is not None
         async for account, envelope in self._daemon.listener.messages():
+            source_uuid = envelope.get("sourceUuid")
+            if isinstance(source_uuid, str) and source_uuid:
+                for state in self._conn_state.values():
+                    if state.bot_uuid == source_uuid:
+                        self._maybe_resolve_self_echo(state, envelope)
+                        break
             queue = self._queue_for(account.strip())
             await queue.put(envelope)
 
@@ -223,12 +242,6 @@ class SignalConnector(HttpConnector):
         await self._maybe_refresh_roster(state, envelope)
         msg = parse_envelope(envelope, bot_account_uuid=state.bot_uuid)
         if msg is None:
-            # Could still be a self-echo of one of our own group sends
-            # whose timestamp ``signal_send`` is waiting for.  Inbounds
-            # from other peers get a structured ``InboundMessage``; bot
-            # self-traffic falls into this None branch (parse_envelope
-            # drops same-uuid envelopes).
-            self._maybe_resolve_self_echo(state, envelope)
             return
         if msg.sender_name is None:
             resolved = state.contact_names.get(msg.sender_uuid)

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -658,6 +658,13 @@ def build_metadata(msg: InboundMessage, chat_id: str, bot_uuid: str) -> dict[str
     (e.g. ``aios sessions events`` JSON output).  Reply / reaction
     payloads are nested so the model sees them as structured siblings
     of ``content`` rather than embedded prose.
+
+    Mentions ride as a structured list plus a derived ``self_mentioned``
+    bool, so the agent can distinguish "sender typed @<name> as text"
+    from "sender's client encoded a mention targeting my UUID" without
+    substring-searching ``content``.  Group sends in particular often
+    @-tag the bot to summon a response, and the placeholder-substituted
+    text alone hides that signal.
     """
     metadata: dict[str, Any] = {
         "channel": f"signal/{bot_uuid}/{chat_id}",
@@ -669,6 +676,11 @@ def build_metadata(msg: InboundMessage, chat_id: str, bot_uuid: str) -> dict[str
         metadata["sender_name"] = msg.sender_name
     if msg.chat_name is not None:
         metadata["chat_name"] = msg.chat_name
+    if msg.mentions:
+        metadata["mentions"] = [
+            {"uuid": m.uuid, "name": m.name} for m in msg.mentions
+        ]
+        metadata["self_mentioned"] = any(m.uuid == bot_uuid for m in msg.mentions)
     if msg.reply is not None:
         metadata["reply_to"] = {
             "author_uuid": msg.reply.author_uuid,

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -50,6 +50,7 @@ from aios_connector_http import (
 from .addressing import decode_chat_id, encode_chat_id
 from .config import Settings
 from .daemon import GroupInfo, SignalDaemon
+from .errors import RpcError
 from .markdown import convert_markdown_to_signal_styles
 from .mentions import build_mention_strings, encode_mentions
 from .parse import InboundMessage, build_content_text, is_group_update_envelope, parse_envelope
@@ -235,6 +236,17 @@ class SignalConnector(HttpConnector):
             metadata=build_metadata(msg, chat_id, state.bot_uuid),
             timestamp=timestamp_iso,
         )
+        # Send a read receipt now that the message is persisted in the
+        # session event log — semantically, "the agent has seen it."
+        # signal-cli's automatic delivery receipts in daemon mode batch
+        # unpredictably (some receipts land seconds after the envelope,
+        # some get skipped until a later flush trigger), so the sender's
+        # UI checkmark state lags reality.  An explicit read receipt
+        # forces the 2nd checkmark immediately and gives the sender
+        # confirmation tied to actual consumption rather than to
+        # signal-cli's internal flush timing.  Best-effort: a failure
+        # here is cosmetic only — the inbound is already in the log.
+        await self._send_read_receipt(state, msg)
 
     # ── model-facing tools ────────────────────────────────────────────
 
@@ -401,6 +413,35 @@ class SignalConnector(HttpConnector):
         return {"status": "ok"}
 
     # ── helpers ───────────────────────────────────────────────────────
+
+    async def _send_read_receipt(
+        self, state: _SignalConnectionState, msg: InboundMessage
+    ) -> None:
+        """Send a read receipt for ``msg`` to its original sender.
+
+        Best-effort: signal-cli's daemon-mode automatic delivery
+        receipts batch unpredictably, so we fire an explicit read
+        receipt synchronously after ``emit_inbound`` succeeds.  A
+        failure here is logged and swallowed — the inbound is already
+        in the session log, so retrying or crashing would just churn.
+        """
+        assert self._daemon is not None
+        params = {
+            "account": state.phone,
+            "recipient": msg.sender_uuid,
+            "targetTimestamp": [msg.timestamp_ms],
+            "type": "read",
+        }
+        try:
+            await self._daemon.rpc.call("sendReceipt", params)
+        except RpcError as exc:
+            log.warning(
+                "signal.read_receipt.send_failed",
+                phone=state.phone,
+                sender_uuid=msg.sender_uuid,
+                target_timestamp_ms=msg.timestamp_ms,
+                error=str(exc),
+            )
 
     async def _maybe_refresh_roster(
         self, state: _SignalConnectionState, envelope: dict[str, Any]

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -369,22 +369,36 @@ class SignalConnector(HttpConnector):
             self._pending_echoes.setdefault((state.phone, chat_id), deque()).append(
                 echo_future
             )
-        result = await self._daemon.rpc.call("send", params)
-        ts = _extract_timestamp(result)
-        if ts is None and echo_future is not None:
-            try:
-                ts = await asyncio.wait_for(echo_future, timeout=_ECHO_WAIT_S)
-            except (TimeoutError, asyncio.CancelledError):
-                # Echo never arrived in the deadline window — degrade
-                # to the no-timestamp shape.  The cancelled future
-                # gets pruned at next ``_maybe_resolve_self_echo``
-                # pop-from-front.
-                log.warning(
-                    "signal.send.echo_timeout",
-                    phone=state.phone,
-                    chat_id=chat_id,
-                )
-        return {"sent_at_ms": ts} if ts is not None else {"status": "ok"}
+        try:
+            result = await self._daemon.rpc.call("send", params)
+            ts = _extract_timestamp(result)
+            if ts is None and echo_future is not None:
+                try:
+                    ts = await asyncio.wait_for(echo_future, timeout=_ECHO_WAIT_S)
+                except (TimeoutError, asyncio.CancelledError):
+                    # Echo never arrived in the deadline window — degrade
+                    # to the no-timestamp shape.  The cancelled future
+                    # gets pruned at next ``_maybe_resolve_self_echo``
+                    # pop-from-front.
+                    log.warning(
+                        "signal.send.echo_timeout",
+                        phone=state.phone,
+                        chat_id=chat_id,
+                    )
+            return {"sent_at_ms": ts} if ts is not None else {"status": "ok"}
+        finally:
+            # Cancel any unresolved future so the drain-stale logic in
+            # ``_maybe_resolve_self_echo`` prunes it before the NEXT
+            # successful send's echo can match it.  Without this guard,
+            # a failing rpc.call (e.g. signal-cli's libsignal
+            # ``InvalidSessionException`` when a group member has no
+            # established protocol session yet) would leak an orphan
+            # future at the head of the deque, and the next echo would
+            # resolve to the WRONG send's timestamp.  cancel() on
+            # already-done futures (resolved by the echo dispatcher or
+            # cancelled by wait_for's timeout path) is a no-op.
+            if echo_future is not None and not echo_future.done():
+                echo_future.cancel()
 
     @tool()
     async def signal_delete(

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -514,6 +514,11 @@ class SignalConnector(HttpConnector):
         signal-cli's send blocks until the network round-trip
         completes, so echoes to the same chat arrive in send order.
 
+        Edits use a different envelope shape — ``editMessage.dataMessage``
+        nested one level deeper, with the new edit's timestamp at the
+        envelope root.  We accept both so an edit-send-then-edit-again
+        flow (model wants the new timestamp for chained edits) works.
+
         DM echoes are silently dropped — signal-cli's DM send returns
         the timestamp inline, so the future-registration path in
         ``signal_send`` is groups-only.
@@ -522,7 +527,11 @@ class SignalConnector(HttpConnector):
             return
         data = envelope.get("dataMessage")
         if not isinstance(data, dict):
-            return
+            edit = envelope.get("editMessage")
+            if isinstance(edit, dict):
+                data = edit.get("dataMessage")
+            if not isinstance(data, dict):
+                return
         group_info = data.get("groupInfo")
         if not isinstance(group_info, dict):
             return

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -31,6 +31,7 @@ connection's phone + bot UUID + caches via
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -57,6 +58,14 @@ from .mentions import build_mention_strings, encode_mentions
 from .parse import InboundMessage, build_content_text, is_group_update_envelope, parse_envelope
 
 log = structlog.get_logger(__name__)
+
+# How long ``signal_send`` waits for the self-echo of a group send
+# to arrive on the inbound stream before degrading to the
+# no-timestamp result shape.  Signal-cli's ``send`` blocks until the
+# network round-trip completes, so the echo typically arrives within
+# tens of ms; 2.0s gives generous headroom for a slow network and
+# still keeps the model's tool-call latency reasonable on failure.
+_ECHO_WAIT_S: float = 2.0
 
 
 @dataclass
@@ -89,6 +98,17 @@ class SignalConnector(HttpConnector):
         # first — there's a natural race between an inbound arriving
         # and the connection's serve loop coming online).
         self._inbound_queues: dict[str, asyncio.Queue[dict[str, Any]]] = {}
+        # Self-echo correlation for group sends: signal-cli 0.14.x's
+        # ``send`` JSON-RPC returns a top-level ``timestamp`` for DM
+        # sends but a bare ``null`` for groups.  The send timestamp
+        # *does* arrive on the receive stream as a self-echo envelope
+        # (source_uuid == bot_uuid + groupInfo + dataMessage.timestamp);
+        # we register a future before issuing ``send`` and resolve it
+        # from ``_handle_envelope`` when the matching echo arrives.
+        # Keyed by ``(account_phone, chat_id)``, FIFO since signal-cli's
+        # send blocks until the network round-trip completes so echoes
+        # to the same chat arrive in send order.
+        self._pending_echoes: dict[tuple[str, str], deque[asyncio.Future[int]]] = {}
 
     # ── lifecycle ─────────────────────────────────────────────────────
 
@@ -203,6 +223,12 @@ class SignalConnector(HttpConnector):
         await self._maybe_refresh_roster(state, envelope)
         msg = parse_envelope(envelope, bot_account_uuid=state.bot_uuid)
         if msg is None:
+            # Could still be a self-echo of one of our own group sends
+            # whose timestamp ``signal_send`` is waiting for.  Inbounds
+            # from other peers get a structured ``InboundMessage``; bot
+            # self-traffic falls into this None branch (parse_envelope
+            # drops same-uuid envelopes).
+            self._maybe_resolve_self_echo(state, envelope)
             return
         if msg.sender_name is None:
             resolved = state.contact_names.get(msg.sender_uuid)
@@ -317,8 +343,34 @@ class SignalConnector(HttpConnector):
             edit_timestamp_ms=edit_timestamp_ms,
         )
         assert self._daemon is not None
+        # Pre-register an echo future for group sends.  DMs get a
+        # timestamp inline from signal-cli's send result; groups
+        # return null there and we fish the timestamp out of the
+        # self-echo on the inbound stream instead.  Registering
+        # *before* issuing the RPC closes the race where the echo
+        # could arrive before we're listening.
+        chat_type, _ = decode_chat_id(chat_id)
+        echo_future: asyncio.Future[int] | None = None
+        if chat_type == "group":
+            echo_future = asyncio.get_running_loop().create_future()
+            self._pending_echoes.setdefault((state.phone, chat_id), deque()).append(
+                echo_future
+            )
         result = await self._daemon.rpc.call("send", params)
         ts = _extract_timestamp(result)
+        if ts is None and echo_future is not None:
+            try:
+                ts = await asyncio.wait_for(echo_future, timeout=_ECHO_WAIT_S)
+            except (TimeoutError, asyncio.CancelledError):
+                # Echo never arrived in the deadline window — degrade
+                # to the no-timestamp shape.  The cancelled future
+                # gets pruned at next ``_maybe_resolve_self_echo``
+                # pop-from-front.
+                log.warning(
+                    "signal.send.echo_timeout",
+                    phone=state.phone,
+                    chat_id=chat_id,
+                )
         return {"sent_at_ms": ts} if ts is not None else {"status": "ok"}
 
     @tool()
@@ -435,6 +487,51 @@ class SignalConnector(HttpConnector):
         return {"status": "ok"}
 
     # ── helpers ───────────────────────────────────────────────────────
+
+    def _maybe_resolve_self_echo(
+        self, state: _SignalConnectionState, envelope: dict[str, Any]
+    ) -> None:
+        """Resolve a pending ``signal_send`` echo future from a self-envelope.
+
+        signal-cli emits the bot's own outbound group messages back on
+        the receive stream as ``sourceUuid == bot_uuid`` envelopes with
+        ``dataMessage.groupInfo``.  The envelope's ``timestamp`` is the
+        send timestamp the model needs to edit / delete / react to the
+        message later.  We match by ``(phone, chat_id)`` FIFO since
+        signal-cli's send blocks until the network round-trip
+        completes, so echoes to the same chat arrive in send order.
+
+        DM echoes are silently dropped — signal-cli's DM send returns
+        the timestamp inline, so the future-registration path in
+        ``signal_send`` is groups-only.
+        """
+        if envelope.get("sourceUuid") != state.bot_uuid:
+            return
+        data = envelope.get("dataMessage")
+        if not isinstance(data, dict):
+            return
+        group_info = data.get("groupInfo")
+        if not isinstance(group_info, dict):
+            return
+        raw_id = group_info.get("groupId")
+        if not isinstance(raw_id, str) or not raw_id:
+            return
+        ts = envelope.get("timestamp")
+        if not isinstance(ts, int):
+            return
+        chat_id = encode_chat_id(raw_id, "group")
+        key = (state.phone, chat_id)
+        queue = self._pending_echoes.get(key)
+        if queue is None:
+            return
+        # Drain stale (timed-out / cancelled) waiters at the front so
+        # the FIFO discipline reflects live ``signal_send`` callers.
+        while queue and queue[0].done():
+            queue.popleft()
+        if queue:
+            queue.popleft().set_result(ts)
+        if not queue:
+            self._pending_echoes.pop(key, None)
 
     async def _send_read_receipt(
         self, state: _SignalConnectionState, msg: InboundMessage

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -36,6 +36,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+import httpx
 import structlog
 from aios_connector_http import (
     Attachment as SDKAttachment,
@@ -221,21 +222,42 @@ class SignalConnector(HttpConnector):
             if msg.timestamp_ms
             else None
         )
-        await self.emit_inbound(
-            connection_id=connection_id,
-            # Signal's (sender_uuid, timestamp_ms) pair is the platform's
-            # canonical message identity; feeding it as ``event_id`` lets
-            # aios's ``inbound_acks`` dedupe a redelivered envelope after
-            # a runtime restart (the inbound dispatcher's queue can hold
-            # up to ``maxsize`` envelopes that signal-cli would replay).
-            event_id=f"signal-{msg.sender_uuid}-{msg.timestamp_ms}",
-            chat_id=chat_id,
-            sender=sender_payload,
-            content=build_content_text(msg),
-            attachments=attachments,
-            metadata=build_metadata(msg, chat_id, state.bot_uuid),
-            timestamp=timestamp_iso,
-        )
+        try:
+            await self.emit_inbound(
+                connection_id=connection_id,
+                # Signal's (sender_uuid, timestamp_ms) pair is the platform's
+                # canonical message identity; feeding it as ``event_id`` lets
+                # aios's ``inbound_acks`` dedupe a redelivered envelope after
+                # a runtime restart (the inbound dispatcher's queue can hold
+                # up to ``maxsize`` envelopes that signal-cli would replay).
+                event_id=f"signal-{msg.sender_uuid}-{msg.timestamp_ms}",
+                chat_id=chat_id,
+                sender=sender_payload,
+                content=build_content_text(msg),
+                attachments=attachments,
+                metadata=build_metadata(msg, chat_id, state.bot_uuid),
+                timestamp=timestamp_iso,
+            )
+        except httpx.HTTPStatusError as exc:
+            # Drop-and-continue on routine 4xx so one bad envelope can't
+            # tear down the container and every other connection it
+            # serves.  401/403 (token revoked / runtime misconfigured)
+            # and 5xx (server outage or bug) are container-level problems
+            # that warrant the crash-and-restart loop, so let them
+            # propagate.  Without this guard, a single 422 from the api's
+            # multipart validator collapses the entire TaskGroup.
+            sc = exc.response.status_code
+            if sc in (401, 403) or sc >= 500:
+                raise
+            log.warning(
+                "signal.inbound.dropped",
+                connection_id=connection_id,
+                status_code=sc,
+                sender_uuid=msg.sender_uuid,
+                timestamp_ms=msg.timestamp_ms,
+                body=exc.response.text[:500],
+            )
+            return
         # Send a read receipt now that the message is persisted in the
         # session event log — semantically, "the agent has seen it."
         # signal-cli's automatic delivery receipts in daemon mode batch

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -809,6 +809,14 @@ def build_metadata(msg: InboundMessage, chat_id: str, bot_uuid: str) -> dict[str
         metadata["sender_name"] = msg.sender_name
     if msg.chat_name is not None:
         metadata["chat_name"] = msg.chat_name
+    if msg.edited:
+        # The harness's ``_format_channel_header`` already renders
+        # ``edited=true`` when this flag is set; pairing it with
+        # ``edit_target_timestamp_ms`` lets the model correlate the
+        # edited message back to the original it's replacing.
+        metadata["edited"] = True
+        if msg.edit_target_timestamp_ms is not None:
+            metadata["edit_target_timestamp_ms"] = msg.edit_target_timestamp_ms
     if msg.mentions:
         metadata["mentions"] = [
             {"uuid": m.uuid, "name": m.name} for m in msg.mentions

--- a/connectors/signal/src/aios_signal/daemon.py
+++ b/connectors/signal/src/aios_signal/daemon.py
@@ -362,12 +362,33 @@ class SignalDaemon:
 
 
 async def _spawn_subprocess(args: list[str]) -> asyncio.subprocess.Process:
-    """Thin wrapper for test-time monkeypatching."""
+    """Spawn signal-cli detached into its own session + process group.
+
+    ``start_new_session=True`` (POSIX ``setsid()``) makes the child a
+    session and process group leader.  Two payoffs:
+
+    1. A foreground-terminal SIGINT (Ctrl-C) does not get forwarded to
+       the daemon via the controlling terminal — the connector's own
+       SIGINT handler runs ``__aexit__``, which terminates the daemon
+       cleanly.  Without the new session, both the connector and the
+       daemon get SIGINT simultaneously and the cleanup race is
+       observable as half-shutdown state on the daemon's SQLite lock.
+    2. Hard kills targeting the connector's pgroup (e.g. an operator
+       running ``kill -TERM -<pgid>`` against the connector's group)
+       no longer cascade to the daemon, so the daemon's controlled
+       shutdown through ``__aexit__`` is not pre-empted.
+
+    The corresponding shutdown asymmetry — that ``pkill -f aios_signal``
+    only matches the Python process and not the daemon's JVM cmdline —
+    is fixed by trapping SIGTERM in :func:`aios_signal.__main__.main`
+    so ``__aexit__`` actually runs.
+    """
     spawn = asyncio.create_subprocess_exec
     return await spawn(
         *args,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
     )
 
 

--- a/connectors/signal/src/aios_signal/parse.py
+++ b/connectors/signal/src/aios_signal/parse.py
@@ -83,6 +83,8 @@ class InboundMessage:
     mentions: tuple[Mention, ...]
     reply: Reply | None
     reaction: Reaction | None
+    edited: bool = False
+    edit_target_timestamp_ms: int | None = None
 
 
 def _substitute_mentions(text: str, mentions: list[dict[str, Any]]) -> str:
@@ -118,9 +120,30 @@ def parse_envelope(
     if envelope.get("receiptMessage") or envelope.get("typingMessage"):
         return None
 
+    # signal-cli emits two top-level shapes for inbound payloads:
+    # ``dataMessage`` for plain sends and ``editMessage.dataMessage``
+    # for edits.  An edit envelope carries the EDITED content's
+    # ``timestamp`` at the envelope root and ``targetSentTimestamp``
+    # inside ``editMessage`` pointing at the original.  Both shapes
+    # feed the same downstream parsing — only the ``edited`` /
+    # ``edit_target_timestamp_ms`` fields on the result differ.
+    edited = False
+    edit_target_ts: int | None = None
     data_message = envelope.get("dataMessage")
     if not isinstance(data_message, dict):
-        return None
+        edit_envelope = envelope.get("editMessage")
+        if isinstance(edit_envelope, dict):
+            nested = edit_envelope.get("dataMessage")
+            if isinstance(nested, dict):
+                data_message = nested
+                edited = True
+                target_raw = edit_envelope.get("targetSentTimestamp")
+                if isinstance(target_raw, int):
+                    edit_target_ts = target_raw
+            else:
+                return None
+        else:
+            return None
 
     timestamp_ms = int(envelope.get("timestamp", 0))
     sender_name = envelope.get("sourceName") or None
@@ -225,6 +248,8 @@ def parse_envelope(
         mentions=parsed_mentions,
         reply=reply,
         reaction=reaction,
+        edited=edited,
+        edit_target_timestamp_ms=edit_target_ts,
     )
 
 

--- a/connectors/signal/src/aios_signal/parse.py
+++ b/connectors/signal/src/aios_signal/parse.py
@@ -55,6 +55,22 @@ class Reply:
 
 
 @dataclass(slots=True, frozen=True)
+class Mention:
+    """One structured @-mention from a Signal inbound.
+
+    The placeholder-substituted text in ``InboundMessage.text`` is what
+    the sender's UI rendered; the structured ``Mention`` list is what
+    the platform actually encoded.  Agents that need to distinguish "the
+    sender typed my name as text" from "the sender's client emitted a
+    mention targeting my UUID" read ``mentions`` (and ``self_mentioned``
+    on the metadata) rather than substring-searching ``text``.
+    """
+
+    uuid: str
+    name: str | None
+
+
+@dataclass(slots=True, frozen=True)
 class InboundMessage:
     chat_type: ChatType
     raw_chat_id: str
@@ -64,6 +80,7 @@ class InboundMessage:
     timestamp_ms: int
     text: str
     attachments: tuple[Attachment, ...]
+    mentions: tuple[Mention, ...]
     reply: Reply | None
     reaction: Reaction | None
 
@@ -172,11 +189,26 @@ def parse_envelope(
     )
 
     raw_text = data_message.get("message")
-    mentions = data_message.get("mentions")
+    mentions_raw = data_message.get("mentions")
     if isinstance(raw_text, str):
-        text = _substitute_mentions(raw_text, mentions) if isinstance(mentions, list) else raw_text
+        text = (
+            _substitute_mentions(raw_text, mentions_raw)
+            if isinstance(mentions_raw, list)
+            else raw_text
+        )
     else:
         text = ""
+
+    parsed_mentions: tuple[Mention, ...] = ()
+    if isinstance(mentions_raw, list):
+        parsed_mentions = tuple(
+            Mention(
+                uuid=m["uuid"],
+                name=m.get("name") if isinstance(m.get("name"), str) else None,
+            )
+            for m in mentions_raw
+            if isinstance(m, dict) and isinstance(m.get("uuid"), str) and m.get("uuid")
+        )
 
     if not text and not attachments and reaction is None:
         return None
@@ -190,6 +222,7 @@ def parse_envelope(
         timestamp_ms=timestamp_ms,
         text=text,
         attachments=attachments,
+        mentions=parsed_mentions,
         reply=reply,
         reaction=reaction,
     )

--- a/connectors/signal/tests/conftest.py
+++ b/connectors/signal/tests/conftest.py
@@ -14,8 +14,19 @@ import pytest
 os.environ.setdefault("AIOS_URL", "http://test")
 os.environ.setdefault("AIOS_RUNTIME_TOKEN", "aios_runtime_test")
 
+from aios_signal import connector as _connector_module
 from aios_signal.config import Settings
 from aios_signal.connector import SignalConnector, _SignalConnectionState
+
+
+@pytest.fixture(autouse=True)
+def _fast_echo_wait(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Collapse the group-send self-echo deadline so tests don't pay 2s
+    per group ``signal_send`` while waiting for an echo that the mocked
+    daemon never emits.  Tests that exercise the echo path explicitly
+    set the future themselves; everyone else relies on this autouse to
+    hit the timeout in ~10ms instead of ~2s."""
+    monkeypatch.setattr(_connector_module, "_ECHO_WAIT_S", 0.01)
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 

--- a/connectors/signal/tests/test_build_metadata.py
+++ b/connectors/signal/tests/test_build_metadata.py
@@ -1,0 +1,77 @@
+"""Cover ``build_metadata`` — the connector-side helper that turns an
+:class:`InboundMessage` into the structured metadata dict aios stamps
+on every inbound event.
+
+Most of the function is mechanical field mirroring; the interesting
+bits are the optional fields (mentions / reply / reaction) and the
+``self_mentioned`` derivation, all of which are reflective of platform
+quirks the model needs explicit signal for.
+"""
+
+from __future__ import annotations
+
+from aios_signal.connector import build_metadata
+from aios_signal.parse import InboundMessage, Mention
+
+
+def _msg(**overrides: object) -> InboundMessage:
+    defaults: dict[str, object] = dict(
+        chat_type="dm",
+        raw_chat_id="alice-uuid",
+        sender_uuid="alice-uuid",
+        sender_name="Alice",
+        chat_name=None,
+        timestamp_ms=1700000000000,
+        text="hi",
+        attachments=(),
+        mentions=(),
+        reply=None,
+        reaction=None,
+    )
+    defaults.update(overrides)
+    return InboundMessage(**defaults)  # type: ignore[arg-type]
+
+
+BOT_UUID = "99999999-8888-7777-6666-555555555555"
+ALICE_UUID = "11111111-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+
+def test_no_mentions_omitted() -> None:
+    """Empty mentions → no ``mentions`` / ``self_mentioned`` keys at all."""
+    meta = build_metadata(_msg(), chat_id="alice-uuid", bot_uuid=BOT_UUID)
+    assert "mentions" not in meta
+    assert "self_mentioned" not in meta
+
+
+def test_mentions_surfaced_with_self_mentioned_true() -> None:
+    """When the bot's UUID is mentioned, ``self_mentioned`` is True so the
+    agent can react/respond differently from incidental name usage."""
+    msg = _msg(mentions=(Mention(uuid=BOT_UUID, name="SmokeBot"),))
+    meta = build_metadata(msg, chat_id="group-id", bot_uuid=BOT_UUID)
+    assert meta["mentions"] == [{"uuid": BOT_UUID, "name": "SmokeBot"}]
+    assert meta["self_mentioned"] is True
+
+
+def test_mentions_surfaced_with_self_mentioned_false() -> None:
+    """Mentions of someone other than the bot still ride along, but
+    ``self_mentioned`` is False — useful context without summoning."""
+    msg = _msg(mentions=(Mention(uuid=ALICE_UUID, name="Alice"),))
+    meta = build_metadata(msg, chat_id="group-id", bot_uuid=BOT_UUID)
+    assert meta["mentions"] == [{"uuid": ALICE_UUID, "name": "Alice"}]
+    assert meta["self_mentioned"] is False
+
+
+def test_multiple_mentions_preserved_in_order() -> None:
+    """Order is preserved so callers can match offsets back to the text."""
+    msg = _msg(
+        mentions=(
+            Mention(uuid=ALICE_UUID, name="Alice"),
+            Mention(uuid=BOT_UUID, name=None),
+        )
+    )
+    meta = build_metadata(msg, chat_id="group-id", bot_uuid=BOT_UUID)
+    assert meta["mentions"] == [
+        {"uuid": ALICE_UUID, "name": "Alice"},
+        {"uuid": BOT_UUID, "name": None},
+    ]
+    assert meta["self_mentioned"] is True

--- a/connectors/signal/tests/test_handle_envelope.py
+++ b/connectors/signal/tests/test_handle_envelope.py
@@ -1,0 +1,113 @@
+"""Cover ``_handle_envelope``'s drop-and-continue behavior on routine 4xx.
+
+A single bad envelope going to the api must not tear the container down:
+422s and other routine 4xx are logged + dropped so the connector keeps
+serving other connections.  401/403 (token revoked / runtime
+misconfigured) and 5xx (server outage or bug) still propagate so the
+operator sees red on real problems.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from aios_signal.connector import SignalConnector, _SignalConnectionState
+from tests.conftest import ALICE_UUID, BOT_UUID, CONNECTION_ID, PHONE
+
+
+def _make_envelope(sender_uuid: str = ALICE_UUID) -> dict[str, Any]:
+    """Minimal valid DM envelope that ``parse_envelope`` accepts."""
+    return {
+        "sourceUuid": sender_uuid,
+        "sourceName": "Alice",
+        "timestamp": 1700000000000,
+        "dataMessage": {
+            "timestamp": 1700000000000,
+            "message": "hello",
+        },
+    }
+
+
+def _http_status_error(status_code: int, body: str = "") -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "/v1/connectors/runtime/inbound")
+    response = httpx.Response(status_code, content=body.encode(), request=request)
+    return httpx.HTTPStatusError(f"{status_code}", request=request, response=response)
+
+
+def _state() -> _SignalConnectionState:
+    return _SignalConnectionState(
+        phone=PHONE,
+        bot_uuid=BOT_UUID,
+        contact_names={},
+        groups=[],
+    )
+
+
+async def test_handle_envelope_drops_on_422(
+    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 422 from the api affects one envelope; the container survives."""
+    monkeypatch.setattr(
+        connector, "emit_inbound", AsyncMock(side_effect=_http_status_error(422, '{"detail":"bad"}'))
+    )
+    receipt = AsyncMock()
+    monkeypatch.setattr(connector, "_send_read_receipt", receipt)
+
+    await connector._handle_envelope(CONNECTION_ID, _state(), _make_envelope())
+
+    receipt.assert_not_awaited()
+
+
+async def test_handle_envelope_drops_on_400(
+    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        connector, "emit_inbound", AsyncMock(side_effect=_http_status_error(400))
+    )
+    receipt = AsyncMock()
+    monkeypatch.setattr(connector, "_send_read_receipt", receipt)
+
+    await connector._handle_envelope(CONNECTION_ID, _state(), _make_envelope())
+
+    receipt.assert_not_awaited()
+
+
+async def test_handle_envelope_raises_on_401(
+    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """401 means the runtime token is busted — fatal for every connection."""
+    monkeypatch.setattr(
+        connector, "emit_inbound", AsyncMock(side_effect=_http_status_error(401))
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await connector._handle_envelope(CONNECTION_ID, _state(), _make_envelope())
+
+
+async def test_handle_envelope_raises_on_500(
+    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """5xx is a server-side outage; let the container crash + restart."""
+    monkeypatch.setattr(
+        connector, "emit_inbound", AsyncMock(side_effect=_http_status_error(503))
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await connector._handle_envelope(CONNECTION_ID, _state(), _make_envelope())
+
+
+async def test_handle_envelope_sends_receipt_on_success(
+    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: ``_send_read_receipt`` fires after a successful inbound."""
+    monkeypatch.setattr(connector, "emit_inbound", AsyncMock(return_value={"ok": True}))
+    receipt = AsyncMock()
+    monkeypatch.setattr(connector, "_send_read_receipt", receipt)
+
+    await connector._handle_envelope(CONNECTION_ID, _state(), _make_envelope())
+
+    receipt.assert_awaited_once()

--- a/connectors/signal/tests/test_inbound_attachment_fallback.py
+++ b/connectors/signal/tests/test_inbound_attachment_fallback.py
@@ -31,6 +31,7 @@ def _make_msg(attachments: tuple[Attachment, ...]) -> InboundMessage:
         timestamp_ms=1700000000000,
         text="",
         attachments=attachments,
+        mentions=(),
         reply=None,
         reaction=None,
     )

--- a/connectors/signal/tests/test_parse.py
+++ b/connectors/signal/tests/test_parse.py
@@ -44,6 +44,39 @@ def test_no_mentions_yields_empty_tuple(envelope_text_dm: dict[str, Any], bot_uu
     assert msg.mentions == ()
 
 
+def test_edit_envelope_surfaces_as_inbound(bot_uuid: str) -> None:
+    """signal-cli wraps inbound peer edits as ``envelope.editMessage.dataMessage``
+    rather than a top-level ``dataMessage``.  Without parsing both shapes the
+    bot never sees that a peer rewrote a prior message; the envelope drops to
+    None and the conversation thread silently diverges from the chat client's view.
+    """
+    envelope: dict[str, Any] = {
+        "sourceUuid": "11111111-2222-3333-4444-555555555555",
+        "sourceName": "Alice",
+        "timestamp": 1700000010000,
+        "editMessage": {
+            "targetSentTimestamp": 1700000005000,
+            "dataMessage": {
+                "timestamp": 1700000010000,
+                "message": "Actually, I meant Tuesday",
+                "groupInfo": {
+                    "groupId": "abc+def/xyz==",
+                    "groupName": "Friends",
+                    "type": "DELIVER",
+                },
+            },
+        },
+    }
+    msg = parse_envelope(envelope, bot_account_uuid=bot_uuid)
+    assert msg is not None
+    assert msg.text == "Actually, I meant Tuesday"
+    assert msg.edited is True
+    assert msg.edit_target_timestamp_ms == 1700000005000
+    # New edit timestamp at the envelope root becomes the event's
+    # ``timestamp_ms`` — uniquely identifies the edit relative to the original.
+    assert msg.timestamp_ms == 1700000010000
+
+
 def test_reaction(envelope_reaction: dict[str, Any], bot_uuid: str) -> None:
     msg = parse_envelope(envelope_reaction, bot_account_uuid=bot_uuid)
     assert msg is not None

--- a/connectors/signal/tests/test_parse.py
+++ b/connectors/signal/tests/test_parse.py
@@ -31,6 +31,17 @@ def test_text_group_with_mentions(envelope_text_group: dict[str, Any], bot_uuid:
     assert msg.chat_name == "Friends"
     # Mention placeholder substituted with @Name.
     assert msg.text == "hey @Bob thanks!"
+    # Structured mention list preserved alongside the substituted text so
+    # callers can distinguish a structured @-mention from a literal "@Bob".
+    assert len(msg.mentions) == 1
+    assert msg.mentions[0].uuid == "66666666-7777-8888-9999-aaaaaaaaaaaa"
+    assert msg.mentions[0].name == "Bob"
+
+
+def test_no_mentions_yields_empty_tuple(envelope_text_dm: dict[str, Any], bot_uuid: str) -> None:
+    msg = parse_envelope(envelope_text_dm, bot_account_uuid=bot_uuid)
+    assert msg is not None
+    assert msg.mentions == ()
 
 
 def test_reaction(envelope_reaction: dict[str, Any], bot_uuid: str) -> None:
@@ -109,6 +120,7 @@ def test_build_content_text_with_text_and_attachment(bot_uuid: str) -> None:
                 id="abc",
             ),
         ),
+        mentions=(),
         reply=None,
         reaction=None,
     )

--- a/connectors/signal/tests/test_signal_handling.py
+++ b/connectors/signal/tests/test_signal_handling.py
@@ -1,0 +1,86 @@
+"""Cover the SIGINT/SIGTERM shutdown path and the daemon's process-group
+isolation.
+
+Without these fixes, ``pkill -f aios_signal`` would kill the Python
+connector but leave the signal-cli JVM running with its TCP port and
+SQLite lock still held — a footgun observed during PR 8 smoke (#10).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+from typing import Any
+
+import pytest
+
+from aios_signal import daemon as daemon_module
+from aios_signal.__main__ import _serve
+
+
+class _StubConnector:
+    """Minimal stand-in for :class:`SignalConnector` exposing only ``run``."""
+
+    def __init__(self, behavior: Awaitable[None]) -> None:
+        self._behavior = behavior
+
+    async def run(self) -> None:
+        await self._behavior
+
+
+async def test_serve_stops_when_stop_event_is_set() -> None:
+    """A signal handler flipping ``stop`` cancels the connector task so
+    its ``async with`` blocks unwind and ``teardown`` runs."""
+    teardown_called = asyncio.Event()
+
+    async def _long_running() -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            teardown_called.set()
+
+    connector = _StubConnector(_long_running())
+    stop = asyncio.Event()
+
+    async def _flip_stop() -> None:
+        await asyncio.sleep(0.01)
+        stop.set()
+
+    await asyncio.gather(_serve(connector, stop), _flip_stop())  # type: ignore[arg-type]
+    assert teardown_called.is_set()
+
+
+async def test_serve_returns_if_connector_finishes_first() -> None:
+    """Connector exiting (e.g. fatal error) returns control without
+    requiring the stop signal — the operator sees the original
+    exception in the traceback."""
+    connector = _StubConnector(asyncio.sleep(0))
+    stop = asyncio.Event()
+    await _serve(connector, stop)  # type: ignore[arg-type]
+    # No assertion: the only requirement is that we return.
+
+
+async def test_spawn_starts_new_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``start_new_session=True`` detaches the daemon from the parent's
+    session + process group so a SIGTERM targeting the connector's
+    pgroup does not pre-empt the daemon's controlled shutdown."""
+    captured: dict[str, Any] = {}
+
+    class _FakeProc:
+        pid = 1234
+        returncode: int | None = None
+
+    async def _fake_spawn(*args: Any, **kwargs: Any) -> _FakeProc:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return _FakeProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+
+    proc = await daemon_module._spawn_subprocess(["signal-cli", "daemon"])
+
+    assert proc.pid == 1234
+    assert captured["kwargs"].get("start_new_session") is True
+    assert captured["args"] == ("signal-cli", "daemon")

--- a/connectors/signal/tests/test_signal_send_echo.py
+++ b/connectors/signal/tests/test_signal_send_echo.py
@@ -121,6 +121,41 @@ async def test_maybe_resolve_self_echo_ignores_non_bot_sender(
     assert not fut.done()
 
 
+async def test_maybe_resolve_self_echo_handles_edit_envelope(
+    connector: SignalConnector,
+) -> None:
+    """Edits arrive on the receive stream wrapped as
+    ``envelope.editMessage.dataMessage`` (nested one level deeper than
+    a normal send), with the new edit timestamp at the envelope root.
+    Match should still fire so chained edits get their new sent_at_ms
+    back from the tool result."""
+    fut: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+    connector._pending_echoes[(PHONE, GROUP_CHAT_ID)] = deque([fut])
+
+    # Build a synthetic edit envelope matching the shape captured from
+    # signal-cli 0.14.2 during PR 8 smoke: top-level ``editMessage``
+    # with the original message's ``targetSentTimestamp`` and a nested
+    # ``dataMessage`` carrying the new content + groupInfo.
+    edit_envelope: dict[str, Any] = {
+        "source": BOT_UUID,
+        "sourceUuid": BOT_UUID,
+        "timestamp": 555,
+        "editMessage": {
+            "targetSentTimestamp": 111,
+            "dataMessage": {
+                "timestamp": 555,
+                "message": "✅ Edited",
+                "groupInfo": {"groupId": GROUP_RAW_ID, "groupName": "QA"},
+            },
+        },
+    }
+
+    connector._maybe_resolve_self_echo(_state(), edit_envelope)
+
+    assert fut.done()
+    assert fut.result() == 555
+
+
 async def test_maybe_resolve_self_echo_ignores_dm_echo(connector: SignalConnector) -> None:
     """DM self-echoes carry no ``groupInfo``; the DM send path is
     already getting its timestamp from the RPC return, so we skip."""

--- a/connectors/signal/tests/test_signal_send_echo.py
+++ b/connectors/signal/tests/test_signal_send_echo.py
@@ -1,0 +1,197 @@
+"""Group-send self-echo correlation.
+
+signal-cli 0.14.x's JSON-RPC ``send`` returns a top-level ``timestamp``
+for DM sends but a bare ``null`` for groups.  The timestamp does arrive
+on the receive stream as a self-echo envelope (``sourceUuid == bot_uuid``
++ ``dataMessage.groupInfo`` + ``dataMessage.timestamp``).  ``signal_send``
+registers a future before issuing the RPC and waits briefly for the
+echo dispatcher to resolve it; on timeout we degrade to the
+no-timestamp result shape.
+
+These tests cover the correlation in both directions:
+
+- ``_maybe_resolve_self_echo`` matches by ``(phone, chat_id)`` FIFO and
+  prunes stale (cancelled / timed-out) waiters at the front.
+- ``signal_send`` registers + awaits + degrades cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import Any
+
+from aios_signal.connector import SignalConnector, _SignalConnectionState
+from aios_signal.daemon import GroupInfo
+from tests.conftest import (
+    ALICE_UUID,
+    BOB_UUID,
+    BOT_UUID,
+    CONNECTION_ID,
+    GROUP_CHAT_ID,
+    GROUP_RAW_ID,
+    PHONE,
+)
+
+
+def _state() -> _SignalConnectionState:
+    return _SignalConnectionState(
+        phone=PHONE,
+        bot_uuid=BOT_UUID,
+        contact_names={},
+        groups=[
+            GroupInfo(
+                id=GROUP_CHAT_ID,
+                name="Tea Party",
+                member_uuids=[ALICE_UUID, BOB_UUID],
+            )
+        ],
+    )
+
+
+def _self_echo_envelope(
+    *,
+    bot_uuid: str = BOT_UUID,
+    group_raw_id: str = GROUP_RAW_ID,
+    timestamp_ms: int = 1700000000000,
+    message: str = "hello",
+) -> dict[str, Any]:
+    """Shape mirrors signal-cli 0.14.2 group self-echo envelopes
+    captured via direct daemon probe during PR 8 smoke."""
+    return {
+        "source": bot_uuid,
+        "sourceUuid": bot_uuid,
+        "sourceName": "SmokeBot",
+        "timestamp": timestamp_ms,
+        "dataMessage": {
+            "timestamp": timestamp_ms,
+            "message": message,
+            "groupInfo": {"groupId": group_raw_id, "groupName": "Tea Party"},
+        },
+    }
+
+
+# ── _maybe_resolve_self_echo ────────────────────────────────────────
+
+
+async def test_maybe_resolve_self_echo_pops_first_waiter(connector: SignalConnector) -> None:
+    """A queued waiter resolves with the envelope's timestamp."""
+    state = _state()
+    fut: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+    connector._pending_echoes[(PHONE, GROUP_CHAT_ID)] = deque([fut])
+    connector._maybe_resolve_self_echo(
+        state, _self_echo_envelope(timestamp_ms=12345)
+    )
+    assert fut.done()
+    assert fut.result() == 12345
+    # Empty queue is pruned so we don't leak keys.
+    assert (PHONE, GROUP_CHAT_ID) not in connector._pending_echoes
+
+
+async def test_maybe_resolve_self_echo_skips_stale_futures(
+    connector: SignalConnector,
+) -> None:
+    """A cancelled waiter at the head of the queue is drained so the next
+    live waiter receives the echo."""
+    stale: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+    stale.cancel()
+    fresh: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+    connector._pending_echoes[(PHONE, GROUP_CHAT_ID)] = deque([stale, fresh])
+
+    connector._maybe_resolve_self_echo(
+        _state(), _self_echo_envelope(timestamp_ms=999)
+    )
+
+    assert fresh.done()
+    assert fresh.result() == 999
+
+
+async def test_maybe_resolve_self_echo_ignores_non_bot_sender(
+    connector: SignalConnector,
+) -> None:
+    """Echoes from other senders are not bot self-echoes; futures stay
+    unresolved so we don't latch onto unrelated inbounds."""
+    fut: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+    connector._pending_echoes[(PHONE, GROUP_CHAT_ID)] = deque([fut])
+    env = _self_echo_envelope()
+    env["sourceUuid"] = ALICE_UUID  # not the bot
+
+    connector._maybe_resolve_self_echo(_state(), env)
+
+    assert not fut.done()
+
+
+async def test_maybe_resolve_self_echo_ignores_dm_echo(connector: SignalConnector) -> None:
+    """DM self-echoes carry no ``groupInfo``; the DM send path is
+    already getting its timestamp from the RPC return, so we skip."""
+    fut: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+    connector._pending_echoes[(PHONE, GROUP_CHAT_ID)] = deque([fut])
+    env = _self_echo_envelope()
+    del env["dataMessage"]["groupInfo"]
+
+    connector._maybe_resolve_self_echo(_state(), env)
+
+    assert not fut.done()
+
+
+# ── signal_send end-to-end ──────────────────────────────────────────
+
+
+async def test_signal_send_group_returns_sent_at_ms_from_echo(
+    connector: SignalConnector,
+) -> None:
+    """The end-to-end path: signal_send for a group registers a future,
+    the daemon emits a self-echo via _handle_envelope's None branch,
+    signal_send picks up the timestamp, returns ``sent_at_ms``."""
+    sent_ts = 1700000054321
+
+    async def _fake_send(_method: str, _params: dict[str, Any]) -> Any:
+        # signal-cli 0.14.x: group send returns null at the RPC layer.
+        # The echo arrives via the receive stream concurrently — simulate
+        # by routing a synthetic envelope through _handle_envelope from
+        # inside the mocked RPC call.
+        await connector._handle_envelope(
+            CONNECTION_ID, _state(), _self_echo_envelope(timestamp_ms=sent_ts)
+        )
+        return None
+
+    connector._daemon.rpc.call.side_effect = _fake_send  # type: ignore[union-attr]
+    connector._conn_state[CONNECTION_ID] = _state()
+
+    result = await connector.signal_send(
+        text="hello", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID
+    )
+
+    assert result == {"sent_at_ms": sent_ts}
+
+
+async def test_signal_send_group_falls_back_when_echo_times_out(
+    connector: SignalConnector,
+) -> None:
+    """When the self-echo never arrives (slow network, daemon stall),
+    signal_send returns ``{"status": "ok"}`` after the deadline rather
+    than hanging the tool call forever."""
+    connector._daemon.rpc.call.return_value = None  # type: ignore[union-attr]
+    connector._conn_state[CONNECTION_ID] = _state()
+
+    result = await connector.signal_send(
+        text="silence", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID
+    )
+
+    assert result == {"status": "ok"}
+
+
+async def test_signal_send_dm_does_not_register_echo_future(
+    connector: SignalConnector,
+) -> None:
+    """DMs skip the echo path entirely — signal-cli returns their
+    timestamp inline, so a pending-echoes entry would leak."""
+    connector._daemon.rpc.call.return_value = {"timestamp": 999}  # type: ignore[union-attr]
+    connector._conn_state[CONNECTION_ID] = _state()
+
+    result = await connector.signal_send(
+        text="dm", chat_id=ALICE_UUID, connection_id=CONNECTION_ID
+    )
+
+    assert result == {"sent_at_ms": 999}
+    assert (PHONE, ALICE_UUID) not in connector._pending_echoes

--- a/connectors/signal/tests/test_signal_send_echo.py
+++ b/connectors/signal/tests/test_signal_send_echo.py
@@ -148,10 +148,13 @@ async def test_signal_send_group_returns_sent_at_ms_from_echo(
     async def _fake_send(_method: str, _params: dict[str, Any]) -> Any:
         # signal-cli 0.14.x: group send returns null at the RPC layer.
         # The echo arrives via the receive stream concurrently — simulate
-        # by routing a synthetic envelope through _handle_envelope from
-        # inside the mocked RPC call.
-        await connector._handle_envelope(
-            CONNECTION_ID, _state(), _self_echo_envelope(timestamp_ms=sent_ts)
+        # by routing a synthetic envelope through _maybe_resolve_self_echo
+        # directly.  In production the dispatcher invokes this from
+        # _inbound_dispatcher when the envelope lands on any peer's
+        # account stream (group self-echoes arrive on RECEIVING peers'
+        # streams, not on the sender's own stream).
+        connector._maybe_resolve_self_echo(
+            _state(), _self_echo_envelope(timestamp_ms=sent_ts)
         )
         return None
 
@@ -179,6 +182,42 @@ async def test_signal_send_group_falls_back_when_echo_times_out(
     )
 
     assert result == {"status": "ok"}
+
+
+async def test_inbound_dispatcher_resolves_echo_on_peer_account_stream(
+    connector: SignalConnector,
+) -> None:
+    """Regression for the post-#6 smoke gap: signal-cli emits group
+    self-echoes on the receiving peers' account streams (because
+    those are the streams the message actually flows through),
+    *not* on the sender's own account stream.  The dispatcher must
+    resolve the echo regardless of which ``account`` arrived with
+    the envelope — keyed by ``sourceUuid`` matching any known bot
+    rather than by per-account routing.
+    """
+    # Register the bot under its own account.
+    connector._conn_state[CONNECTION_ID] = _state()
+    fut: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+    connector._pending_echoes[(PHONE, GROUP_CHAT_ID)] = deque([fut])
+
+    # Mock listener.messages() to emit a single self-echo envelope
+    # arriving on a DIFFERENT account stream (e.g. a peer bot like
+    # Ultron whose account signal-cli also serves).
+    peer_account = "+19092871349"
+
+    class _StubListener:
+        async def messages(self) -> Any:
+            yield peer_account, _self_echo_envelope(timestamp_ms=777)
+
+    assert connector._daemon is not None
+    connector._daemon.listener = _StubListener()  # type: ignore[assignment]
+
+    # Dispatcher runs until listener.messages exhausts; our generator
+    # yields once then completes.
+    await connector._inbound_dispatcher()
+
+    assert fut.done()
+    assert fut.result() == 777
 
 
 async def test_signal_send_dm_does_not_register_echo_future(

--- a/connectors/signal/tests/test_signal_send_echo.py
+++ b/connectors/signal/tests/test_signal_send_echo.py
@@ -21,6 +21,8 @@ import asyncio
 from collections import deque
 from typing import Any
 
+import pytest
+
 from aios_signal.connector import SignalConnector, _SignalConnectionState
 from aios_signal.daemon import GroupInfo
 from tests.conftest import (
@@ -253,6 +255,34 @@ async def test_inbound_dispatcher_resolves_echo_on_peer_account_stream(
 
     assert fut.done()
     assert fut.result() == 777
+
+
+async def test_signal_send_cleans_up_echo_future_when_rpc_raises(
+    connector: SignalConnector,
+) -> None:
+    """If ``rpc.call`` raises (e.g. signal-cli's libsignal
+    ``InvalidSessionException`` when a group member has no
+    established protocol session yet), the pre-registered echo
+    future must be cancelled rather than left orphan at the head of
+    the deque.  Without the cleanup, a subsequent successful send's
+    echo would resolve the orphan with the WRONG message's
+    timestamp.
+    """
+    from aios_signal.errors import RpcError
+
+    connector._daemon.rpc.call.side_effect = RpcError("send failed")  # type: ignore[union-attr]
+    connector._conn_state[CONNECTION_ID] = _state()
+
+    with pytest.raises(RpcError):
+        await connector.signal_send(
+            text="explodes", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID
+        )
+
+    # Any future registered before the raise must be done (cancelled
+    # by the finally block) so the drain-stale logic in
+    # _maybe_resolve_self_echo prunes it before the next send.
+    queue = connector._pending_echoes.get((PHONE, GROUP_CHAT_ID), deque())
+    assert all(fut.done() for fut in queue)
 
 
 async def test_signal_send_dm_does_not_register_echo_future(

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -388,13 +388,15 @@ class TelegramConnector(HttpConnector):
             text: Message body.  Becomes the caption when attachments are
                 present.  See ``parse_mode``.
             attachments: Optional in-sandbox file paths.  Type is inferred
-                from extension (``.jpg``/``.png``/``.gif``/``.webp`` →
-                photo, ``.mp4``/``.mov`` → video, ``.ogg`` → voice,
-                ``.mp3``/``.m4a``/``.wav`` → audio, anything else →
-                document).  Single attachment uses ``send_photo`` /
-                ``send_voice`` / etc.; multiple attachments use
-                ``send_media_group`` with caption attached to the first
-                item only (per Telegram API).
+                from extension (``.jpg``/``.png``/``.webp`` → photo,
+                ``.gif`` → animation (plays inline; ``send_photo``
+                would render only the first frame), ``.mp4``/``.mov``
+                → video, ``.ogg`` → voice, ``.mp3``/``.m4a``/``.wav``
+                → audio, anything else → document).  Single attachment
+                uses ``send_photo`` / ``send_animation`` / ``send_voice``
+                / etc.; multiple attachments use ``send_media_group``
+                with caption attached to the first item only (per
+                Telegram API).
             parse_mode: ``"plain"`` (default) sends the text as-is —
                 literal characters, no formatting.  ``"html"`` runs
                 ``text`` through a Markdown→Telegram-HTML converter so
@@ -576,16 +578,27 @@ class TelegramConnector(HttpConnector):
         return {"status": "ok"}
 
 
-_PHOTO_EXTS = frozenset({".jpg", ".jpeg", ".png", ".gif", ".webp"})
+_PHOTO_EXTS = frozenset({".jpg", ".jpeg", ".png", ".webp"})
+_ANIMATION_EXTS = frozenset({".gif"})
 _VIDEO_EXTS = frozenset({".mp4", ".mov", ".webm"})
 _VOICE_EXTS = frozenset({".ogg", ".oga"})
 _AUDIO_EXTS = frozenset({".mp3", ".m4a", ".wav", ".flac"})
 
 
 def _classify(host_path: Path) -> str:
+    """Route an outbound attachment to the right PTB send method.
+
+    ``.gif`` rides on ``send_animation`` (not ``send_photo``) — Telegram's
+    Bot API treats a GIF passed to ``sendPhoto`` as a static image and
+    only renders the first frame, defeating the point of an animated GIF.
+    ``sendAnimation`` is Telegram's first-class animated-image surface;
+    clients render it as an inline playing animation just like a video.
+    """
     ext = host_path.suffix.lower()
     if ext in _PHOTO_EXTS:
         return "photo"
+    if ext in _ANIMATION_EXTS:
+        return "animation"
     if ext in _VIDEO_EXTS:
         return "video"
     if ext in _VOICE_EXTS:
@@ -639,6 +652,7 @@ async def _send_single_media(
     kind = _classify(host_path)
     sender = {
         "photo": bot.send_photo,
+        "animation": bot.send_animation,
         "video": bot.send_video,
         "voice": bot.send_voice,
         "audio": bot.send_audio,

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -614,6 +614,19 @@ def _iso(ts_ms: int) -> str:
     return datetime.fromtimestamp(ts_ms / 1000, tz=UTC).isoformat()
 
 
+def _read_for_upload(host_path: Path) -> bytes:
+    """Read attachment bytes for upload to Telegram's Bot API.
+
+    python-telegram-bot serializes the request body via JSON; passing a
+    raw ``pathlib.Path`` falls into the "unknown object" branch and
+    raises ``TypeError('Object of type PosixPath is not JSON
+    serializable')`` from the HTTPX layer.  Bytes (or a file-like) are
+    treated as multipart uploads.  See PTB's
+    ``telegram.request.HTTPXRequest`` for the serialization rule.
+    """
+    return host_path.read_bytes()
+
+
 async def _send_single_media(
     bot: Any,
     *,
@@ -631,7 +644,7 @@ async def _send_single_media(
         "audio": bot.send_audio,
         "document": bot.send_document,
     }[kind]
-    kwargs: dict[str, Any] = {"chat_id": chat_id, kind: host_path}
+    kwargs: dict[str, Any] = {"chat_id": chat_id, kind: _read_for_upload(host_path)}
     if caption is not None:
         kwargs["caption"] = caption
         if parse_mode is not None:
@@ -649,7 +662,7 @@ def _build_media_group(
     items: list[Any] = []
     for idx, path in enumerate(host_paths):
         kind = _classify(path)
-        kwargs: dict[str, Any] = {"media": path}
+        kwargs: dict[str, Any] = {"media": _read_for_upload(path)}
         if idx == 0 and caption is not None:
             kwargs["caption"] = caption
             if parse_mode is not None:

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -373,7 +373,7 @@ class TelegramConnector(HttpConnector):
         self,
         text: str,
         attachments: list[SandboxPath] | None = None,
-        parse_mode: Literal["plain", "html"] = "plain",
+        parse_mode: Literal["plain", "markdown", "html"] = "plain",
         reply_to_message_id: int | None = None,
         *,
         connection_id: str,
@@ -398,12 +398,16 @@ class TelegramConnector(HttpConnector):
                 / etc.; multiple attachments use ``send_media_group``
                 with caption attached to the first item only (per
                 Telegram API).
-            parse_mode: ``"plain"`` (default) sends the text as-is —
-                literal characters, no formatting.  ``"html"`` runs
-                ``text`` through a Markdown→Telegram-HTML converter so
+            parse_mode: How to interpret ``text``.
+                ``"plain"`` (default) — literal characters, no
+                formatting.  ``"markdown"`` — input is markdown;
                 ``**bold**``, ``*italic*``, ``[label](url)``, fenced
-                code, ``> quotes``, and ``||spoilers||`` render with
-                Telegram's native styling.
+                code, ``> quotes``, and ``||spoilers||`` are converted
+                to Telegram's native styling.  ``"html"`` — input is
+                raw HTML (``<b>``, ``<i>``, ``<a href="...">``,
+                ``<code>``, ``<blockquote>``, ``<tg-spoiler>``); passed
+                through verbatim to Telegram per its Bot API
+                ``parse_mode=HTML`` semantics.
             reply_to_message_id: When set, the message is rendered as a
                 native Telegram reply quoting that message (the client
                 UI shows the parent inline above your text).  Pass the
@@ -485,7 +489,7 @@ class TelegramConnector(HttpConnector):
         self,
         message_id: int,
         text: str,
-        parse_mode: Literal["plain", "html"] = "plain",
+        parse_mode: Literal["plain", "markdown", "html"] = "plain",
         *,
         connection_id: str,
         chat_id: str,
@@ -501,9 +505,10 @@ class TelegramConnector(HttpConnector):
             message_id: The id of the message to edit.  Returned by
                 ``telegram_send`` as ``message_id``.
             text: The new body.  See ``parse_mode``.
-            parse_mode: ``"plain"`` sends literal text; ``"html"`` runs
-                ``text`` through the same Markdown→Telegram-HTML
-                converter as ``telegram_send``.
+            parse_mode: How to interpret ``text``.  Same semantics as
+                ``telegram_send``: ``"plain"`` literal text, ``"markdown"``
+                runs the Markdown→Telegram-HTML converter, ``"html"``
+                passes raw HTML through to Telegram.
         """
         state = self._conn_state[connection_id]
         chat_id_int = _coerce_chat_id(chat_id)
@@ -617,9 +622,26 @@ def _coerce_chat_id(chat_id: str) -> int:
 
 
 def _prepare_text(text: str, parse_mode: str) -> tuple[str, str | None]:
-    """Map a model-facing parse_mode to (body, ptb_parse_mode)."""
-    if parse_mode == "html":
+    """Map a model-facing ``parse_mode`` to (body, ptb_parse_mode).
+
+    Three modes, named so each matches the actual *input* convention
+    being declared:
+
+    - ``"plain"`` — literal text, no formatting.  Empty PTB parse_mode.
+    - ``"markdown"`` — input is markdown; run through
+      :func:`markdown_to_telegram_html` and tell PTB to render the
+      result as HTML.  This is the new name for what used to be called
+      ``"html"`` (which collided with Telegram Bot API semantics — see
+      smoke finding #17).
+    - ``"html"`` — input IS HTML; pass through verbatim and tell PTB
+      to render as HTML.  Matches Telegram's own ``parse_mode=HTML``
+      semantics, so an agent that writes ``<a href="...">link</a>``
+      gets the expected rendering instead of literal text.
+    """
+    if parse_mode == "markdown":
         return markdown_to_telegram_html(text), "HTML"
+    if parse_mode == "html":
+        return text, "HTML"
     return text, None
 
 

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -46,6 +46,7 @@ from aios_connector_http import (
     tool,
 )
 from telegram import (
+    InputFile,
     InputMediaAudio,
     InputMediaDocument,
     InputMediaPhoto,
@@ -627,17 +628,31 @@ def _iso(ts_ms: int) -> str:
     return datetime.fromtimestamp(ts_ms / 1000, tz=UTC).isoformat()
 
 
-def _read_for_upload(host_path: Path) -> bytes:
-    """Read attachment bytes for upload to Telegram's Bot API.
+def _read_for_upload(host_path: Path) -> InputFile:
+    """Wrap attachment bytes in a PTB :class:`InputFile` for upload.
 
-    python-telegram-bot serializes the request body via JSON; passing a
-    raw ``pathlib.Path`` falls into the "unknown object" branch and
-    raises ``TypeError('Object of type PosixPath is not JSON
-    serializable')`` from the HTTPX layer.  Bytes (or a file-like) are
-    treated as multipart uploads.  See PTB's
-    ``telegram.request.HTTPXRequest`` for the serialization rule.
+    Two problems we have to thread:
+
+    1. python-telegram-bot's HTTPX request layer JSON-serializes the
+       request body; passing a raw ``pathlib.Path`` falls into the
+       "unknown object" branch and raises ``TypeError('Object of type
+       PosixPath is not JSON serializable')``.
+    2. Passing raw ``bytes`` *does* survive the JSON path (PTB wraps
+       them in InputFile internally), but with no filename hint the
+       default falls to literal ``"application.octet-stream"`` and
+       Telegram interprets the attachment as
+       ``application/octet-stream`` — animated GIFs render as a
+       static download instead of an inline animation, photos lose
+       their image affordance, etc.  Surfaced live during PR 8 smoke
+       when a ``.gif`` attachment rendered as a downloadable blob
+       even after routing through ``send_animation``.
+
+    Wrapping in ``InputFile(bytes, filename=host_path.name)`` lets
+    PTB's multipart writer set the correct ``Content-Type`` from the
+    extension, which Telegram then uses to render the attachment in
+    its native player.
     """
-    return host_path.read_bytes()
+    return InputFile(host_path.read_bytes(), filename=host_path.name)
 
 
 async def _send_single_media(

--- a/connectors/telegram/tests/test_telegram_outbound.py
+++ b/connectors/telegram/tests/test_telegram_outbound.py
@@ -69,18 +69,36 @@ async def test_telegram_edit_message_plain(
     )
 
 
-async def test_telegram_edit_message_html_mode_converts_markdown(
+async def test_telegram_edit_message_markdown_mode_converts(
     connector: TelegramConnector, bot: Any
 ) -> None:
     await connector.telegram_edit_message(
         message_id=99,
         text="**bold**",
-        parse_mode="html",
+        parse_mode="markdown",
         chat_id="123",
         connection_id=CONNECTION_ID,
     )
     kwargs = bot.edit_message_text.call_args.kwargs
     assert kwargs["text"] == "<b>bold</b>"
+    assert kwargs["parse_mode"] == "HTML"
+
+
+async def test_telegram_edit_message_html_mode_passes_through(
+    connector: TelegramConnector, bot: Any
+) -> None:
+    """``parse_mode="html"`` ships raw HTML to Telegram (matching the
+    Bot API's own ``parse_mode=HTML`` semantics).  No markdown
+    conversion — what the agent wrote is what gets sent."""
+    await connector.telegram_edit_message(
+        message_id=99,
+        text='<a href="https://example.com">link</a>',
+        parse_mode="html",
+        chat_id="123",
+        connection_id=CONNECTION_ID,
+    )
+    kwargs = bot.edit_message_text.call_args.kwargs
+    assert kwargs["text"] == '<a href="https://example.com">link</a>'
     assert kwargs["parse_mode"] == "HTML"
 
 
@@ -132,12 +150,30 @@ async def test_telegram_react_clear(
 # ── telegram_send parse_mode ─────────────────────────────────────────
 
 
-async def test_telegram_send_html_mode_converts_markdown(
+async def test_telegram_send_markdown_mode_converts(
     connector: TelegramConnector, bot: Any
 ) -> None:
-    await connector.telegram_send(text="**hi** _there_", parse_mode="html", chat_id="123", connection_id=CONNECTION_ID)
+    """``parse_mode="markdown"`` runs the input through
+    :func:`markdown_to_telegram_html`.  This is the renamed form of
+    what used to be ``parse_mode="html"`` before the smoke-#17 fix —
+    the old name collided with Telegram Bot API semantics."""
+    await connector.telegram_send(text="**hi** _there_", parse_mode="markdown", chat_id="123", connection_id=CONNECTION_ID)
     kwargs = bot.send_message.call_args.kwargs
     assert kwargs["text"] == "<b>hi</b> <i>there</i>"
+    assert kwargs["parse_mode"] == "HTML"
+
+
+async def test_telegram_send_html_mode_passes_through(
+    connector: TelegramConnector, bot: Any
+) -> None:
+    """``parse_mode="html"`` matches Telegram's own ``parse_mode=HTML``
+    semantics: the agent writes HTML directly, the connector forwards
+    verbatim.  Critical for agents that want to use raw ``<a href>``
+    tags or other constructs the markdown converter doesn't emit."""
+    raw = '<b>bold</b> <a href="https://example.com">link</a>'
+    await connector.telegram_send(text=raw, parse_mode="html", chat_id="123", connection_id=CONNECTION_ID)
+    kwargs = bot.send_message.call_args.kwargs
+    assert kwargs["text"] == raw  # untouched
     assert kwargs["parse_mode"] == "HTML"
 
 

--- a/connectors/telegram/tests/test_telegram_send.py
+++ b/connectors/telegram/tests/test_telegram_send.py
@@ -39,26 +39,31 @@ def test_classify_extensions() -> None:
     assert _classify(Path("/x/no-ext")) == "document"
 
 
-def test_build_media_group_caption_on_first_only() -> None:
-    items = _build_media_group(
-        [Path("/host/a.jpg"), Path("/host/b.jpg"), Path("/host/c.jpg")],
-        caption="three pics",
-    )
+def test_build_media_group_caption_on_first_only(tmp_path: Path) -> None:
+    paths = [tmp_path / f"{name}.jpg" for name in ("a", "b", "c")]
+    for p in paths:
+        p.write_bytes(b"x")
+    items = _build_media_group(paths, caption="three pics")
     assert items[0].caption == "three pics"
     assert items[1].caption is None
     assert items[2].caption is None
 
 
-def test_build_media_group_no_caption() -> None:
-    items = _build_media_group([Path("/host/a.jpg"), Path("/host/b.jpg")], caption=None)
+def test_build_media_group_no_caption(tmp_path: Path) -> None:
+    paths = [tmp_path / "a.jpg", tmp_path / "b.jpg"]
+    for p in paths:
+        p.write_bytes(b"x")
+    items = _build_media_group(paths, caption=None)
     assert all(item.caption is None for item in items)
 
 
-def test_build_media_group_voice_demoted_to_document() -> None:
+def test_build_media_group_voice_demoted_to_document(tmp_path: Path) -> None:
     """Voice can't ride in a media group; falls back to document."""
     from telegram import InputMediaDocument
 
-    items = _build_media_group([Path("/host/v.ogg")], caption=None)
+    voice = tmp_path / "v.ogg"
+    voice.write_bytes(b"x")
+    items = _build_media_group([voice], caption=None)
     assert isinstance(items[0], InputMediaDocument)
 
 
@@ -144,7 +149,11 @@ async def test_telegram_send_single_photo_routes_to_send_photo(
     bot.send_photo.assert_awaited_once()
     kwargs = bot.send_photo.call_args.kwargs
     assert kwargs["chat_id"] == 123
-    assert kwargs["photo"] == photo
+    # Bytes, not Path: python-telegram-bot serializes the request body as
+    # JSON and rejects ``pathlib.Path`` (``TypeError: Object of type
+    # PosixPath is not JSON serializable``).  Read-bytes-up-front pins
+    # the upload path to multipart.
+    assert kwargs["photo"] == photo.read_bytes()
     assert kwargs["caption"] == "look"
 
 
@@ -157,6 +166,32 @@ async def test_telegram_send_single_voice_routes_to_send_voice(
     voice.write_bytes(b"x")
     await connector.telegram_send(text="", attachments=[voice], chat_id="123", connection_id=CONNECTION_ID)
     bot.send_voice.assert_awaited_once()
+
+
+async def test_telegram_send_passes_bytes_not_path(
+    connector: TelegramConnector,
+    bot: Any,
+    tmp_path: Path,
+) -> None:
+    """python-telegram-bot's HTTPX request layer JSON-serializes the
+    body; passing a raw ``pathlib.Path`` falls into the "unknown object"
+    branch and raises
+    ``TypeError('Object of type PosixPath is not JSON serializable')``.
+
+    Surfaced live in PR 8 smoke when SmokeBot tried to send an outbound
+    image attachment.  Pin the upload-shape contract: every media kwarg
+    handed to PTB is bytes (or another non-Path), never a ``Path``.
+    """
+    photo = tmp_path / "img.png"
+    photo.write_bytes(b"\x89PNG\r\n\x1a\nbytes-canary")
+    await connector.telegram_send(
+        text="", attachments=[photo], chat_id="123", connection_id=CONNECTION_ID
+    )
+    photo_arg = bot.send_photo.call_args.kwargs["photo"]
+    assert not isinstance(photo_arg, Path), (
+        f"PTB media kwarg leaked a Path object: {photo_arg!r}"
+    )
+    assert photo_arg == b"\x89PNG\r\n\x1a\nbytes-canary"
 
 
 async def test_telegram_send_single_document_routes_to_send_document(
@@ -240,6 +275,8 @@ async def test_telegram_send_dispatch_resolves_sandbox_path(
         }
     )
 
+    # The SDK resolves the ``SandboxPath`` to a real ``Path`` for the
+    # tool method; we then read it up-front (see ``_read_for_upload``)
+    # so PTB gets bytes rather than a ``PosixPath`` it can't JSON-encode.
     photo_arg: Any = bot.send_photo.call_args.kwargs["photo"]
-    assert isinstance(photo_arg, Path)
-    assert photo_arg == ws / "cat.jpg"
+    assert photo_arg == (ws / "cat.jpg").read_bytes()

--- a/connectors/telegram/tests/test_telegram_send.py
+++ b/connectors/telegram/tests/test_telegram_send.py
@@ -37,6 +37,11 @@ def test_classify_extensions() -> None:
     assert _classify(Path("/x/song.mp3")) == "audio"
     assert _classify(Path("/x/report.pdf")) == "document"
     assert _classify(Path("/x/no-ext")) == "document"
+    # .gif routes to send_animation, not send_photo: Telegram's Bot API
+    # treats a GIF passed to sendPhoto as a static image and only
+    # renders the first frame.  sendAnimation is the first-class
+    # animated-image surface — clients play it inline.
+    assert _classify(Path("/x/zoom.gif")) == "animation"
 
 
 def test_build_media_group_caption_on_first_only(tmp_path: Path) -> None:

--- a/connectors/telegram/tests/test_telegram_send.py
+++ b/connectors/telegram/tests/test_telegram_send.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aios_connector_http import HttpConnector
+from telegram import InputFile
 
 from aios_telegram.connector import (
     TelegramConnector,
@@ -154,11 +155,15 @@ async def test_telegram_send_single_photo_routes_to_send_photo(
     bot.send_photo.assert_awaited_once()
     kwargs = bot.send_photo.call_args.kwargs
     assert kwargs["chat_id"] == 123
-    # Bytes, not Path: python-telegram-bot serializes the request body as
-    # JSON and rejects ``pathlib.Path`` (``TypeError: Object of type
-    # PosixPath is not JSON serializable``).  Read-bytes-up-front pins
-    # the upload path to multipart.
-    assert kwargs["photo"] == photo.read_bytes()
+    # Wrapped in ``InputFile`` with the source filename so PTB's
+    # multipart writer sets the right Content-Type from the
+    # extension.  Raw bytes would land as application/octet-stream
+    # and Telegram would render the attachment as a downloadable
+    # blob instead of an inline image / animation / etc.
+    photo_arg = kwargs["photo"]
+    assert isinstance(photo_arg, InputFile)
+    assert photo_arg.input_file_content == photo.read_bytes()
+    assert photo_arg.filename == "cat.jpg"
     assert kwargs["caption"] == "look"
 
 
@@ -173,19 +178,30 @@ async def test_telegram_send_single_voice_routes_to_send_voice(
     bot.send_voice.assert_awaited_once()
 
 
-async def test_telegram_send_passes_bytes_not_path(
+async def test_telegram_send_wraps_bytes_in_input_file_with_filename(
     connector: TelegramConnector,
     bot: Any,
     tmp_path: Path,
 ) -> None:
-    """python-telegram-bot's HTTPX request layer JSON-serializes the
-    body; passing a raw ``pathlib.Path`` falls into the "unknown object"
-    branch and raises
-    ``TypeError('Object of type PosixPath is not JSON serializable')``.
+    """Pin the full upload-shape contract:
 
-    Surfaced live in PR 8 smoke when SmokeBot tried to send an outbound
-    image attachment.  Pin the upload-shape contract: every media kwarg
-    handed to PTB is bytes (or another non-Path), never a ``Path``.
+    1. **Never a Path** — python-telegram-bot's HTTPX layer JSON-
+       serializes the body; ``pathlib.Path`` raises
+       ``TypeError('Object of type PosixPath is not JSON
+       serializable')``.  Surfaced live in PR 8 smoke as an outbound
+       image crash.
+    2. **Never raw bytes** — bytes survive JSON, but PTB defaults the
+       ``InputFile`` filename to ``"application.octet-stream"`` and
+       Telegram renders the attachment as a downloadable blob
+       (``Content-Type: application/octet-stream``) instead of an
+       inline image / animation / audio.  Caught live on the
+       follow-on smoke (Tom: "don't send an octet-stream") after the
+       ``.gif`` extension already routed correctly to
+       ``send_animation`` — without the filename hint, Telegram
+       still couldn't determine the type.
+
+    Right shape: ``InputFile(bytes, filename=host_path.name)`` so
+    PTB's multipart writer sets ``Content-Type`` from the extension.
     """
     photo = tmp_path / "img.png"
     photo.write_bytes(b"\x89PNG\r\n\x1a\nbytes-canary")
@@ -193,10 +209,12 @@ async def test_telegram_send_passes_bytes_not_path(
         text="", attachments=[photo], chat_id="123", connection_id=CONNECTION_ID
     )
     photo_arg = bot.send_photo.call_args.kwargs["photo"]
-    assert not isinstance(photo_arg, Path), (
-        f"PTB media kwarg leaked a Path object: {photo_arg!r}"
+    assert isinstance(photo_arg, InputFile), (
+        f"PTB media kwarg should be InputFile so the filename drives "
+        f"Content-Type, got {type(photo_arg).__name__}: {photo_arg!r}"
     )
-    assert photo_arg == b"\x89PNG\r\n\x1a\nbytes-canary"
+    assert photo_arg.input_file_content == b"\x89PNG\r\n\x1a\nbytes-canary"
+    assert photo_arg.filename == "img.png"
 
 
 async def test_telegram_send_single_document_routes_to_send_document(
@@ -284,4 +302,5 @@ async def test_telegram_send_dispatch_resolves_sandbox_path(
     # tool method; we then read it up-front (see ``_read_for_upload``)
     # so PTB gets bytes rather than a ``PosixPath`` it can't JSON-encode.
     photo_arg: Any = bot.send_photo.call_args.kwargs["photo"]
-    assert photo_arg == (ws / "cat.jpg").read_bytes()
+    assert isinstance(photo_arg, InputFile)
+    assert photo_arg.input_file_content == (ws / "cat.jpg").read_bytes()

--- a/openapi.json
+++ b/openapi.json
@@ -6642,7 +6642,8 @@
           },
           "content": {
             "type": "string",
-            "title": "Content"
+            "title": "Content",
+            "default": ""
           },
           "sender": {
             "anyOf": [
@@ -6701,8 +6702,7 @@
         "required": [
           "connection_id",
           "event_id",
-          "chat_id",
-          "content"
+          "chat_id"
         ],
         "title": "Body_post_connector_runtime_inbound"
       },

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -536,12 +536,37 @@ class HttpConnector:
         try:
             result = await meta.fn(**args)
         except Exception as exc:
+            # Tool-call SSE backfill can deliver a call for ``connection_id``
+            # before the connection-discovery SSE has finished registering
+            # the connection's state in the connector's ``_conn_state`` dict
+            # (the two streams are independent).  The tool method's
+            # ``self._conn_state[connection_id]`` lookup KeyErrors and the
+            # raw ``str(KeyError("'conn_01...'"))`` reaches the model as an
+            # opaque quoted ID with no indication that the connection just
+            # wasn't ready yet.  Detect that shape and produce an
+            # interpretable error so the model retries sensibly instead of
+            # guessing at "is `'conn_01...'` an arg I should pass?".
+            error_payload: dict[str, Any]
+            if (
+                isinstance(exc, KeyError)
+                and len(exc.args) == 1
+                and isinstance(exc.args[0], str)
+                and exc.args[0] == connection_id
+            ):
+                error_payload = {
+                    "error": "connection not yet active; retry shortly",
+                    "connection_id": connection_id,
+                }
+                reason = "connection_state_race"
+            else:
+                error_payload = {"error": str(exc)}
+                reason = "tool_exception"
             log.warning(
                 "connector.tool_call.failed",
                 name=name,
                 tool_call_id=tool_call_id,
                 session_id=session_id,
-                reason="tool_exception",
+                reason=reason,
                 error=str(exc),
             )
             await self._post_tool_result(
@@ -549,7 +574,7 @@ class HttpConnector:
                 connection_id=connection_id,
                 session_id=session_id,
                 tool_call_id=tool_call_id,
-                content=json.dumps({"error": str(exc)}),
+                content=json.dumps(error_payload),
                 is_error=True,
             )
             return
@@ -585,7 +610,7 @@ class HttpConnector:
             connection_id=connection_id,
             session_id=session_id,
             tool_call_id=tool_call_id,
-            content=content,  # type: ignore[arg-type]
+            content=content,
             is_error=is_error,
         )
         response = await _post_runtime_tool_result(client=client, body=body)

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -258,6 +258,21 @@ class HttpConnector:
             "/v1/connectors/runtime/inbound",
             files=files,
         )
+        if response.is_error:
+            # ``response.raise_for_status()`` discards the body, which is
+            # exactly where FastAPI's validation diagnostics live for a 422
+            # (and where our error envelope lives for everything else).  Log
+            # the body verbatim before raising so the operator has the field
+            # path / message in the container log instead of just the bare
+            # status + URL from ``httpx.HTTPStatusError``.
+            body = response.text
+            log.warning(
+                "connector.inbound.failed",
+                status_code=response.status_code,
+                event_id=eid,
+                connection_id=connection_id,
+                body=body[:2000],
+            )
         response.raise_for_status()
         return dict(response.json())
 

--- a/packages/aios-connector-http/aios_connector_http/schema.py
+++ b/packages/aios-connector-http/aios_connector_http/schema.py
@@ -38,8 +38,13 @@ shape):
   ``Path``s before dispatching.
 * Anything else → ``SchemaError``.
 
-Focal-channel-injected params (``account``, ``chat_id``) are
-excluded from the schema entirely — the model never supplies them.
+Runtime-injected params (``connection_id``, ``account``, ``chat_id``)
+are excluded from the schema entirely — the model never supplies
+them.  ``connection_id`` rides on every calls-SSE event and is
+authoritative; ``account`` / ``chat_id`` are parsed from the focal
+channel.  Stripping them from the model-facing schema means the
+runner is the sole source of truth and the model can't guess them
+wrong.
 
 Docstrings parse Google-style: the description is everything before
 ``Args:``; the per-param descriptions come from the indented entries
@@ -58,7 +63,7 @@ from typing import Any, Literal, Union, get_args, get_origin, get_type_hints
 
 from .sandbox import _SandboxPathMarker
 
-_FOCAL_INJECTABLE: frozenset[str] = frozenset({"account", "chat_id"})
+_INJECTED_PARAMS: frozenset[str] = frozenset({"connection_id", "account", "chat_id"})
 
 
 class SchemaError(ValueError):
@@ -81,7 +86,7 @@ def derive_tool_spec(name: str, fn: Callable[..., Any]) -> dict[str, Any]:
     properties: dict[str, dict[str, Any]] = {}
     required: list[str] = []
     for param_name, param in sig.parameters.items():
-        if param_name == "self" or param_name in _FOCAL_INJECTABLE:
+        if param_name == "self" or param_name in _INJECTED_PARAMS:
             continue
         if param.kind in (
             inspect.Parameter.VAR_POSITIONAL,

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -57,6 +57,14 @@ class _ProbeConnector(HttpConnector):
         self.calls.append(("boom", {}))
         raise RuntimeError("kaboom")
 
+    @tool()
+    async def race(self, *, connection_id: str) -> str:
+        """Simulate the SDK's most common KeyError shape — a tool method
+        looking up its per-connection state right after a connector
+        restart, before ``serve_connection`` has registered it."""
+        self.calls.append(("race", {"connection_id": connection_id}))
+        raise KeyError(connection_id)
+
     @tool(name="say_struct")
     async def returns_dict(self, *, n: int) -> dict[str, int]:
         self.calls.append(("say_struct", {"n": n}))
@@ -476,6 +484,78 @@ class TestLogging:
         assert completed["name"] == "shout"
         assert completed["tool_call_id"] == "call_1"
         assert completed["is_error"] is False
+
+    async def test_dispatch_call_reshapes_connection_state_race(
+        self, probe: _ProbeConnector
+    ) -> None:
+        """When a tool method KeyErrors on its connection_id (the SSE
+        dispatch backfill raced ahead of ``serve_connection``'s state
+        registration), the SDK base shouldn't surface the bare quoted
+        id as the result — it should produce a structured error the
+        model can interpret and retry.
+
+        Without this special-case the model sees
+        ``{"error": "'conn_01...'"}`` and has to guess at the meaning;
+        with it the model sees
+        ``{"error": "connection not yet active; retry shortly",
+        "connection_id": "conn_X"}`` and retries sensibly.
+        """
+        with structlog.testing.capture_logs() as records:
+            await probe.dispatch_call(
+                {
+                    "connection_id": "conn_X",
+                    "tool_call_id": "call_race",
+                    "session_id": "sess_race",
+                    "name": "race",
+                    "arguments": "{}",
+                }
+            )
+        r = probe.results[0]
+        assert r.kwargs["is_error"] is True
+        payload = json.loads(r.kwargs["content"])
+        assert payload == {
+            "error": "connection not yet active; retry shortly",
+            "connection_id": "conn_X",
+        }
+        failed = [r for r in records if r["event"] == "connector.tool_call.failed"]
+        assert len(failed) == 1
+        assert failed[0]["reason"] == "connection_state_race"
+
+    async def test_dispatch_call_keyerror_unrelated_to_connection_id_passes_through(
+        self, probe: _ProbeConnector
+    ) -> None:
+        """A KeyError whose key isn't the connection_id is just a
+        regular bug — surface as the generic ``tool_exception`` error
+        rather than disguising it as a race.  Without this gate the
+        special-case would swallow real bugs."""
+
+        @tool(name="bad_dict_access")
+        async def _bad_dict(self_: _ProbeConnector) -> str:
+            raise KeyError("some_other_key")
+
+        # Inject the tool into the probe's registry.
+        from aios_connector_http.runner import _build_tool_meta
+
+        probe._tools["bad_dict_access"] = _build_tool_meta(_bad_dict.__get__(probe))  # type: ignore[attr-defined]
+
+        with structlog.testing.capture_logs() as records:
+            await probe.dispatch_call(
+                {
+                    "connection_id": "conn_X",
+                    "tool_call_id": "call_bd",
+                    "session_id": "sess_bd",
+                    "name": "bad_dict_access",
+                    "arguments": "{}",
+                }
+            )
+        r = probe.results[0]
+        assert r.kwargs["is_error"] is True
+        payload = json.loads(r.kwargs["content"])
+        # Generic shape, not the race-specific one.
+        assert "connection_id" not in payload
+        assert payload["error"] == "'some_other_key'"
+        failed = [r for r in records if r["event"] == "connector.tool_call.failed"]
+        assert failed[0]["reason"] == "tool_exception"
 
     async def test_dispatch_call_logs_failed_on_unknown_tool(
         self, probe: _ProbeConnector

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -408,6 +408,54 @@ class TestLogging:
             for v in r.values():
                 assert secret_body not in str(v), f"content leaked into log field: {r}"
 
+    async def test_emit_inbound_logs_response_body_on_error(
+        self, probe: _ProbeConnector
+    ) -> None:
+        """When the api rejects an inbound (e.g. FastAPI 422 validation),
+        the response body carries the diagnostic — which field, why.
+        ``response.raise_for_status()`` discards it, so the connector must
+        log the body explicitly before raising or the operator only sees a
+        bare ``HTTPStatusError: 422`` in the crash traceback with no clue
+        what triggered the rejection.
+        """
+        import httpx
+
+        validation_body = (
+            '{"error":{"type":"validation_error","detail":'
+            '{"errors":[{"type":"missing","loc":["body","content"],'
+            '"msg":"Field required","input":null}]}}}'
+        )
+        mock_response = MagicMock()
+        mock_response.is_error = True
+        mock_response.status_code = 422
+        mock_response.text = validation_body
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "422 Unprocessable Content", request=MagicMock(), response=mock_response
+            )
+        )
+        mock_post = AsyncMock(return_value=mock_response)
+        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
+
+        with (
+            structlog.testing.capture_logs() as records,
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await probe.emit_inbound(
+                connection_id="conn_1",
+                chat_id="c",
+                sender={"id": 1},
+                content="",
+            )
+        failed = [r for r in records if r.get("event") == "connector.inbound.failed"]
+        assert len(failed) == 1, "expected one connector.inbound.failed record"
+        assert failed[0]["status_code"] == 422
+        assert failed[0]["connection_id"] == "conn_1"
+        # The full validation body is logged so the operator can see the
+        # offending field path without replaying the request.
+        assert "content" in failed[0]["body"]
+        assert "Field required" in failed[0]["body"]
+
     async def test_dispatch_call_logs_dispatched_then_completed(
         self, probe: _ProbeConnector
     ) -> None:

--- a/packages/aios-connector-http/tests/test_schema.py
+++ b/packages/aios-connector-http/tests/test_schema.py
@@ -160,9 +160,11 @@ class TestRequiredAndDefaults:
 
 
 class TestSkipsInjectedParams:
-    """Focal-channel kwargs (``chat_id``, ``account``) are injected by
-    the SDK at dispatch time — the model never supplies them, so they
-    must be absent from the input_schema.
+    """Runtime-injected kwargs (``connection_id``, ``chat_id``,
+    ``account``) are filled in by the SDK at dispatch time from the
+    calls-SSE payload + focal channel — the model never supplies them,
+    so they must be absent from the input_schema.  Leaving any of them
+    in the schema invites the model to guess and pass an invalid value.
     """
 
     def test_chat_id_is_excluded_from_schema(self) -> None:
@@ -186,6 +188,18 @@ class TestSkipsInjectedParams:
         spec = derive_tool_spec("t", C().t)
         assert spec["input_schema"]["properties"] == {}
         assert spec["input_schema"].get("required", []) == []
+
+    def test_connection_id_is_excluded_from_schema(self) -> None:
+        class C(_DummyForBindings):
+            @tool()
+            async def t(self, *, text: str, connection_id: str) -> str:
+                return f"{connection_id}: {text}"
+
+        spec = derive_tool_spec("t", C().t)
+        props = spec["input_schema"]["properties"]
+        assert "text" in props
+        assert "connection_id" not in props
+        assert "connection_id" not in spec["input_schema"]["required"]
 
 
 class TestDocstringParsing:

--- a/packages/aios-sdk/aios_sdk/_generated/models/body_post_connector_runtime_inbound.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/body_post_connector_runtime_inbound.py
@@ -19,7 +19,7 @@ class BodyPostConnectorRuntimeInbound:
         connection_id (str): The connection this inbound belongs to.
         event_id (str): Client-supplied dedup key (ULID).
         chat_id (str):
-        content (str):
+        content (str | Unset):  Default: ''.
         sender (None | str | Unset): JSON-encoded sender dict (e.g. {"display_name": "Alice"}).
         metadata (None | str | Unset): JSON-encoded connector metadata dict.
         timestamp (None | str | Unset): Optional ISO-8601 platform timestamp; stored in event metadata.
@@ -29,7 +29,7 @@ class BodyPostConnectorRuntimeInbound:
     connection_id: str
     event_id: str
     chat_id: str
-    content: str
+    content: str | Unset = ""
     sender: None | str | Unset = UNSET
     metadata: None | str | Unset = UNSET
     timestamp: None | str | Unset = UNSET
@@ -79,9 +79,10 @@ class BodyPostConnectorRuntimeInbound:
                 "connection_id": connection_id,
                 "event_id": event_id,
                 "chat_id": chat_id,
-                "content": content,
             }
         )
+        if content is not UNSET:
+            field_dict["content"] = content
         if sender is not UNSET:
             field_dict["sender"] = sender
         if metadata is not UNSET:
@@ -104,7 +105,8 @@ class BodyPostConnectorRuntimeInbound:
 
         files.append(("chat_id", (None, str(self.chat_id).encode(), "text/plain")))
 
-        files.append(("content", (None, str(self.content).encode(), "text/plain")))
+        if not isinstance(self.content, Unset):
+            files.append(("content", (None, str(self.content).encode(), "text/plain")))
 
         if not isinstance(self.sender, Unset):
             if isinstance(self.sender, str):
@@ -171,7 +173,7 @@ class BodyPostConnectorRuntimeInbound:
 
         chat_id = d.pop("chat_id")
 
-        content = d.pop("content")
+        content = d.pop("content", UNSET)
 
         def _parse_sender(data: object) -> None | str | Unset:
             if data is None:

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -272,7 +272,12 @@ async def post_runtime_inbound(
     connection_id: Annotated[str, Form(description="The connection this inbound belongs to.")],
     event_id: Annotated[str, Form(description="Client-supplied dedup key (ULID).")],
     chat_id: Annotated[str, Form()],
-    content: Annotated[str, Form()],
+    # Default empty so attachment-only / reaction-passthrough / group-update
+    # envelopes can flow through.  FastAPI's multipart Form parser treats an
+    # empty field value as ``input=null`` (missing), which 422s a required
+    # ``content: str``; the explicit ``= ""`` default makes empty bodies a
+    # valid first-class shape rather than a server-side validation failure.
+    content: Annotated[str, Form()] = "",
     sender: Annotated[
         str | None,
         Form(description='JSON-encoded sender dict (e.g. {"display_name": "Alice"}).'),

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -100,10 +100,37 @@ def _format_channel_header(metadata: dict[str, Any]) -> str:
         parts.append(f"message_id={message_id}")
     if metadata.get("edited") is True:
         parts.append("edited=true")
+    edit_target = metadata.get("edit_target_timestamp_ms")
+    if isinstance(edit_target, int):
+        parts.append(f"edit_target_timestamp_ms={edit_target}")
+    if metadata.get("self_mentioned") is True:
+        # Hoist ahead of the structured ``mentions`` list — for
+        # group chats the model often only needs to know "was I
+        # tagged?" and substring-matching ``content`` is the
+        # alternative that #5 set out to eliminate.
+        parts.append("self_mentioned=true")
     sticker_emoji = metadata.get("sticker_emoji")
     if isinstance(sticker_emoji, str) and sticker_emoji:
         parts.append(f"sticker_emoji={sticker_emoji!r}")
     header = "[" + " · ".join(parts) + "]"
+    mentions = metadata.get("mentions")
+    if isinstance(mentions, list) and mentions:
+        # One entry per line; uuid is the platform-stable identity the
+        # model needs for outbound mention encoding via signal_send.
+        mention_lines: list[str] = []
+        for m in mentions:
+            if not isinstance(m, dict):
+                continue
+            uuid = m.get("uuid")
+            if not isinstance(uuid, str) or not uuid:
+                continue
+            name = m.get("name")
+            if isinstance(name, str) and name:
+                mention_lines.append(f"[mention: name={name!r} · uuid={uuid}]")
+            else:
+                mention_lines.append(f"[mention: uuid={uuid}]")
+        if mention_lines:
+            header += "\n" + "\n".join(mention_lines)
     reaction = metadata.get("reaction")
     if isinstance(reaction, dict):
         emoji = reaction.get("emoji") or "?"

--- a/tests/e2e/test_inbound_attachment.py
+++ b/tests/e2e/test_inbound_attachment.py
@@ -119,3 +119,60 @@ class TestInboundAttachmentStaging:
         assert attachments[0]["content_type"] == "image/png"
         assert attachments[0]["size"] == len(payload)
         assert attachments[0]["in_sandbox_path"] == f"/mnt/attachments/echo/{event_id}-photo.png"
+
+    async def test_empty_content_inbound_accepted(
+        self, http_client: httpx.AsyncClient, harness: Harness, aios_env: dict[str, str]
+    ) -> None:
+        """Reaction-only / attachment-only / group-update envelopes have no
+        text body and POST ``content=""`` to the runtime inbound route.
+        FastAPI's multipart ``Form`` parser treats empty values as
+        ``input=null`` (missing), so without an explicit default this would
+        422 and crash the connector container.  Pin that the route accepts
+        empty content as a first-class shape.
+        """
+        from aios.services import agents as agents_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"att-empty-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await env_svc.create_environment(harness._pool, name=f"env-att-empty-{id(self)}")
+        session = await sess_svc.create_session(
+            harness._pool,
+            agent_id=agent.id,
+            environment_id=env.id,
+            title=None,
+            metadata={},
+        )
+        connection_id = await _create_connection(http_client, f"att-empty-{id(self)}")
+        await _attach(harness, connection_id, session.id)
+        r = await http_client.post("/v1/runtime-tokens", json={"connector": "echo"})
+        r.raise_for_status()
+        token = str(r.json()["plaintext"])
+
+        event_id = _new_event_id()
+        r = await http_client.post(
+            "/v1/connectors/runtime/inbound",
+            headers=bearer(token),
+            data={
+                "connection_id": connection_id,
+                "event_id": event_id,
+                "chat_id": "chat-empty",
+                "content": "",
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        events = await harness.events(session.id)
+        user_events = [e for e in events if e.kind == "message" and e.data.get("role") == "user"]
+        assert len(user_events) == 1
+        assert user_events[0].data["content"] == ""

--- a/tests/e2e/test_signal_connector.py
+++ b/tests/e2e/test_signal_connector.py
@@ -292,6 +292,27 @@ class TestSignalMultiConnection:
             events_b = await harness.events(session_b.id)
             assert not any("hello-B" in (e.data.get("content") or "") for e in events_a)
             assert not any("hello-A" in (e.data.get("content") or "") for e in events_b)
+
+            # The connector sends an explicit ``sendReceipt --type read``
+            # to the original sender after every inbound is persisted to
+            # the session log — "the agent has seen it."  signal-cli's
+            # automatic delivery receipts in daemon mode batch
+            # unpredictably; the explicit read receipt forces the
+            # sender's 2nd checkmark immediately on consumption.
+            rpc_call = mocked_signal_daemon["rpc_call"]
+            receipt_calls = [
+                c for c in rpc_call.call_args_list if c.args and c.args[0] == "sendReceipt"
+            ]
+            assert len(receipt_calls) == 2, (
+                f"expected 2 read receipts (one per inbound), got {len(receipt_calls)}"
+            )
+            receipt_accounts = {c.args[1]["account"] for c in receipt_calls}
+            assert receipt_accounts == {PHONE_A, PHONE_B}
+            for c in receipt_calls:
+                params = c.args[1]
+                assert params["type"] == "read"
+                assert params["recipient"] == ALICE_UUID
+                assert params["targetTimestamp"] == [1700000000000]
         finally:
             connector_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1035,6 +1035,79 @@ class TestFocalRendering:
         content = build_messages(events, system_prompt=None).messages[0]["content"]
         assert "edited" not in content
 
+    def test_focal_match_edit_target_timestamp(self) -> None:
+        """When ``metadata.edited=True``, ``edit_target_timestamp_ms`` is
+        emitted alongside so the model can correlate the edit back to the
+        original (and react/delete/re-edit if needed).  Signal carries it
+        natively via ``editMessage.targetSentTimestamp``; telegram doesn't
+        but the field name stays platform-agnostic on the metadata.
+        """
+        md = {
+            "channel": self._CHAN_A,
+            "edited": True,
+            "edit_target_timestamp_ms": 1776400000000,
+        }
+        events = [
+            _evt(
+                1, "user", content="oops, fixed", metadata=md, focal_channel_at_arrival=self._CHAN_A
+            )
+        ]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "edited=true" in content
+        assert "edit_target_timestamp_ms=1776400000000" in content
+
+    def test_focal_match_self_mentioned_surfaced(self) -> None:
+        """Group chats use mentions to summon a response; ``self_mentioned``
+        gives the model an unambiguous "the sender's client encoded a
+        mention targeting my account" signal rather than substring-matching
+        the (placeholder-substituted) text content.
+        """
+        md = {
+            "channel": self._CHAN_A,
+            "self_mentioned": True,
+            "mentions": [
+                {"uuid": "bot-uuid", "name": "SmokeBot"},
+            ],
+        }
+        events = [
+            _evt(
+                1,
+                "user",
+                content="@SmokeBot hi",
+                metadata=md,
+                focal_channel_at_arrival=self._CHAN_A,
+            )
+        ]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "self_mentioned=true" in content
+        # Structured mention entries render on their own line so the
+        # uuid is available to the model for outbound mention encoding.
+        assert "mention: name='SmokeBot' · uuid=bot-uuid" in content
+
+    def test_focal_match_mentions_without_self_mention(self) -> None:
+        """Mentions of someone other than the bot still render so the
+        model has context (e.g. "Alice tagged Bob"), but
+        ``self_mentioned=true`` doesn't appear when the bot wasn't
+        the target.
+        """
+        md = {
+            "channel": self._CHAN_A,
+            "self_mentioned": False,
+            "mentions": [{"uuid": "alice-uuid", "name": "Alice"}],
+        }
+        events = [
+            _evt(
+                1,
+                "user",
+                content="@Alice did it",
+                metadata=md,
+                focal_channel_at_arrival=self._CHAN_A,
+            )
+        ]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "self_mentioned" not in content
+        assert "mention: name='Alice' · uuid=alice-uuid" in content
+
     def test_focal_match_sticker_emoji(self) -> None:
         """Stickers arrive with an empty body and a ``sticker_emoji`` in
         metadata — the model otherwise has no textual cue that something


### PR DESCRIPTION
## Summary

Fixup PR stacked on top of PR 8 (`refactor/328-pr8-cleanup`) addressing every code-path anomaly observed during the live smoke session against telegram + signal connectors.  Each finding is numbered in [`SMOKE_PR8.md`](./SMOKE_PR8.md) with evidence trail + concrete fix.

### Findings landed

- **#1 / `cc92e35`** — `connection_id` was leaking into the model-facing tool schema as a required arg; model would supply garbage values that overrode the SDK's correct injection.  Added to the strip set alongside `account` / `chat_id`.
- **#2 / `6dfc978`** — signal-cli's daemon-mode automatic delivery receipts batch unpredictably (some sender-side checkmarks lagged 30+ seconds, some never came).  Explicit `sendReceipt --type read` fires after `emit_inbound` returns 201, tying the 2nd checkmark to actual session-log persistence.
- **#3 / `326b612`** — empty-content inbound (reactions, attachment-only, group updates) 422'd at the api's multipart validator because FastAPI's `Form(...)` treats empty as missing.  Default to `""`.  Also: `emit_inbound` now logs the response body on non-2xx so 422 diagnostics surface in operator logs instead of being swallowed by `raise_for_status`.
- **#4 / `315c969`** — `emit_inbound`'s `HTTPStatusError` was tearing down the entire connector container on any non-2xx, taking every other connection along with it.  Now classifies: 4xx except 401/403 → log + drop the envelope, keep serving.  401/403 + 5xx + transport errors still propagate.
- **#5 / `67a14e0`** — `@mention` metadata was getting collapsed into plain text (`@<display_name>` substitution), so the model couldn't distinguish "sender typed my name as letters" from "sender's client encoded a mention targeting my UUID".  Structured `Mention` list + derived `self_mentioned: bool` ride on the inbound metadata.
- **#6 / `a5db125`** — signal-cli 0.14.x's `send` returns literal `null` for groups (confirmed via direct daemon probe), so `signal_send` was returning `{"status": "ok"}` for every group send and the model couldn't edit/delete/react to its own group messages.  The timestamp *does* arrive on the receive stream as a self-echo envelope with `groupInfo`; pre-register a future before issuing the RPC, await up to 2s, resolve from `_handle_envelope`.
- **#7 / `456cf58`** — `ghcr.io/eumemic/aios-sandbox:latest` had no linux/arm64 manifest, blocking every sandbox-dependent capability on Apple Silicon developer machines.  Workflow now builds linux/amd64 + linux/arm64 via buildx + QEMU; image republishes on next master merge.
- **#10 / `5f6a0e5`** — `pkill -f aios_signal` killed Python but left the signal-cli JVM as an orphan holding the TCP port + SQLite lock.  Two causes: `asyncio.run` doesn't trap SIGTERM by default, and the JVM cmdline doesn't match the pkill filter.  Trap SIGINT + SIGTERM in `__main__`, factor the serve loop into a testable `_serve(connector, stop)`, spawn signal-cli with `start_new_session=True` for clean session isolation.
- **#11 / `02b4ac5`** — telegram outbound attachments crashed with `TypeError: Object of type PosixPath is not JSON serializable` because python-telegram-bot's HTTPX layer JSON-encodes the body.  Read bytes up-front and pass bytes (not Path) so the upload path is multipart.

### Not in scope

- **#8** — orphan `mcp_toolset` entries on pre-PR-5 agents.  Pre-existing data hygiene, deferred to a separate one-off scrub.
- **#9** — tool-name hallucination from pre-PR-5 session history.  Architectural cost of the monotonic-context invariant, not a fixable bug.
- Env footguns (`aios dev bootstrap` discoverability, runtime-token connection-subset scope) — separate DX/feature work.

## Test plan

- [x] `uv run pytest tests/unit -q` — 1133 green
- [x] `cd connectors/signal && uv run pytest -q` — 145 green (16 new tests for #4 / #5 / #6 / #10)
- [x] `cd connectors/telegram && uv run pytest -q` — green incl. new bytes-upload regression
- [x] `uv run mypy src packages/aios-sdk/aios_sdk packages/aios-connector-http/aios_connector_http connectors/signal/src/aios_signal connectors/telegram/src/aios_telegram` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] Direct probe against live signal-cli 0.14.2 daemon confirmed group-send returns `null` and the self-echo envelope shape matches test fixtures
- [ ] Live re-smoke under the fixup branch (post-merge) to verify the four fixed regressions stay fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)