### PR TITLE
fix(connector dockerfiles): pass --no-sources to uv pip install

### DIFF
--- a/connectors/echo-http/Dockerfile
+++ b/connectors/echo-http/Dockerfile
@@ -20,7 +20,13 @@ COPY packages/aios-sdk /app/packages/aios-sdk
 COPY packages/aios-connector-http /app/packages/aios-connector-http
 COPY connectors/echo-http /app/connectors/echo-http
 
-RUN uv pip install --system --no-cache \
+# ``--no-sources`` tells uv to ignore each package's ``[tool.uv.sources]``
+# block — those declare workspace-relative deps (e.g.
+# ``aios-sdk = { workspace = true }``) that only resolve from the
+# repo root.  In this image we install the three packages by path in
+# one invocation; uv satisfies the inter-package deps by name from
+# the install set itself.
+RUN uv pip install --system --no-cache --no-sources \
     /app/packages/aios-sdk \
     /app/packages/aios-connector-http \
     /app/connectors/echo-http

--- a/connectors/signal/Dockerfile
+++ b/connectors/signal/Dockerfile
@@ -50,7 +50,13 @@ COPY packages/aios-sdk /app/packages/aios-sdk
 COPY packages/aios-connector-http /app/packages/aios-connector-http
 COPY connectors/signal /app/connectors/signal
 
-RUN uv pip install --system --no-cache \
+# ``--no-sources`` tells uv to ignore each package's ``[tool.uv.sources]``
+# block — those declare workspace-relative deps (e.g.
+# ``aios-sdk = { workspace = true }``) that only resolve from the
+# repo root.  In this image we install the three packages by path in
+# one invocation; uv satisfies the inter-package deps by name from
+# the install set itself.
+RUN uv pip install --system --no-cache --no-sources \
     /app/packages/aios-sdk \
     /app/packages/aios-connector-http \
     /app/connectors/signal

--- a/connectors/telegram/Dockerfile
+++ b/connectors/telegram/Dockerfile
@@ -21,7 +21,13 @@ COPY packages/aios-sdk /app/packages/aios-sdk
 COPY packages/aios-connector-http /app/packages/aios-connector-http
 COPY connectors/telegram /app/connectors/telegram
 
-RUN uv pip install --system --no-cache \
+# ``--no-sources`` tells uv to ignore each package's ``[tool.uv.sources]``
+# block — those declare workspace-relative deps (e.g.
+# ``aios-sdk = { workspace = true }``) that only resolve from the
+# repo root.  In this image we install the three packages by path in
+# one invocation; uv satisfies the inter-package deps by name from
+# the install set itself.
+RUN uv pip install --system --no-cache --no-sources \
     /app/packages/aios-sdk \
     /app/packages/aios-connector-http \
     /app/connectors/telegram


### PR DESCRIPTION
## Summary

- Connector deploys (signal, telegram) have been failing on every #328-stack merge because uv 0.5.18 refuses to parse `aios-connector-http/pyproject.toml` outside its workspace root once it started declaring `aios-sdk = { workspace = true }` in `[tool.uv.sources]` (added in PR 5).
- Prod was masked by Coolify continuing to run the PR-4-era container (`db7f42c`). PR 7's drop of `/v1/connector-tokens/whoami` then started crashing those stale containers once API/worker rolled forward to `4ce483e`.
- Fix: pass `--no-sources` to the `uv pip install` step in all three connector Dockerfiles. uv ignores `[tool.uv.sources]` and resolves deps by name against PyPI + the install set; since all three packages are installed in the same invocation, `aios-sdk` is found by name from the local path argument.

Verified in a clean `python:3.13-slim-bookworm` container with uv 0.5.18: without the flag the Coolify failure reproduces exactly; with the flag the install completes.

## Test plan
- [x] Reproduce build failure without `--no-sources` (same error string Coolify saw)
- [x] Build succeeds with `--no-sources`
- [ ] Coolify rebuild of `aios-signal` succeeds on this commit
- [ ] Coolify rebuild of `aios-telegram` succeeds on this commit
- [ ] Ultron answers a probe message on Signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)