### PR TITLE
feat(sdk): hoist connector lifecycle hardening onto HttpConnector base

### DIFF
--- a/connectors/echo-http/aios_echo_http/connector.py
+++ b/connectors/echo-http/aios_echo_http/connector.py
@@ -45,12 +45,17 @@ class EchoConnector(HttpConnector):
         """Synthesize an inbound message — used by integration tests, not
         by the model in production (production inbounds arrive via a
         real platform feed in :meth:`serve_connection`)."""
+        # raise_on_4xx so the test tool surfaces validation errors as
+        # exceptions instead of silently dropping them — this method
+        # exists for integration tests, which want loud failures.
         result = await self.emit_inbound(
             connection_id=connection_id,
             chat_id=chat_id,
             sender={"display_name": sender_name},
             content=content,
+            raise_on_4xx=True,
         )
+        assert result is not None  # ``raise_on_4xx=True`` guarantees this
         return {"event_id": result.get("appended_event_id")}
 
 

--- a/connectors/echo-http/aios_echo_http/connector.py
+++ b/connectors/echo-http/aios_echo_http/connector.py
@@ -45,17 +45,19 @@ class EchoConnector(HttpConnector):
         """Synthesize an inbound message — used by integration tests, not
         by the model in production (production inbounds arrive via a
         real platform feed in :meth:`serve_connection`)."""
-        # raise_on_4xx so the test tool surfaces validation errors as
-        # exceptions instead of silently dropping them — this method
-        # exists for integration tests, which want loud failures.
         result = await self.emit_inbound(
             connection_id=connection_id,
             chat_id=chat_id,
             sender={"display_name": sender_name},
             content=content,
-            raise_on_4xx=True,
         )
-        assert result is not None  # ``raise_on_4xx=True`` guarantees this
+        # Integration tests want loud failures.  ``emit_inbound`` returns
+        # ``None`` when the api drops a routine 4xx envelope; surface that
+        # to the test instead of swallowing it.
+        if result is None:
+            raise RuntimeError(
+                f"emit_inbound dropped envelope for connection {connection_id!r}"
+            )
         return {"event_id": result.get("appended_event_id")}
 
 

--- a/connectors/signal/src/aios_signal/__main__.py
+++ b/connectors/signal/src/aios_signal/__main__.py
@@ -5,11 +5,6 @@ this automatically inside ``HttpConnector.__init__``).  Deployment-shape
 fields like ``AIOS_SIGNAL_CONFIG_DIR`` feed pydantic-settings; the
 phone (the account identity) lives on each connection's encrypted
 secrets and is fetched per-connection in ``serve_connection``.
-
-SIGINT / SIGTERM handling, cancel-on-stop, and ``teardown`` dispatch
-all live in :meth:`HttpConnector.run_until_stopped` — without that the
-daemon subprocess would orphan on ``docker stop`` (a SIGTERM the default
-``asyncio.run`` doesn't trap).
 """
 
 from __future__ import annotations

--- a/connectors/signal/src/aios_signal/__main__.py
+++ b/connectors/signal/src/aios_signal/__main__.py
@@ -6,56 +6,22 @@ fields like ``AIOS_SIGNAL_CONFIG_DIR`` feed pydantic-settings; the
 phone (the account identity) lives on each connection's encrypted
 secrets and is fetched per-connection in ``serve_connection``.
 
-SIGINT and SIGTERM are trapped at runtime so ``SignalConnector.teardown``
-gets a chance to fire — ``asyncio.run`` traps SIGINT by default but
-not SIGTERM, and a default SIGTERM would kill Python before the daemon
-subprocess is cleaned up.  The trap converts the signal to a cancel on
-the connector task, the cancellation unwinds the TaskGroup in
-:meth:`SignalConnector.run`, and the surrounding ``try/finally`` runs
-``teardown`` which sends SIGTERM to the daemon subprocess and waits.
+SIGINT / SIGTERM handling, cancel-on-stop, and ``teardown`` dispatch
+all live in :meth:`HttpConnector.run_until_stopped` — without that the
+daemon subprocess would orphan on ``docker stop`` (a SIGTERM the default
+``asyncio.run`` doesn't trap).
 """
 
 from __future__ import annotations
 
 import asyncio
-import contextlib
-import signal
 
 from .config import Settings
 from .connector import SignalConnector
 
 
-async def _serve(connector: SignalConnector, stop: asyncio.Event) -> None:
-    """Run the connector until cancelled or ``stop`` is set.
-
-    Factored out of :func:`main` so a unit test can exercise the
-    cancel-on-stop path without process-level signal handling.
-    """
-    connector_task = asyncio.create_task(connector.run(), name="aios-signal-run")
-    stop_task = asyncio.create_task(stop.wait(), name="aios-signal-stop-wait")
-    try:
-        await asyncio.wait(
-            {connector_task, stop_task},
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-    finally:
-        stop_task.cancel()
-        if not connector_task.done():
-            connector_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await connector_task
-
-
-async def _async_main() -> None:
-    loop = asyncio.get_running_loop()
-    stop = asyncio.Event()
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, stop.set)
-    await _serve(SignalConnector(Settings()), stop)
-
-
 def main() -> None:
-    asyncio.run(_async_main())
+    asyncio.run(SignalConnector(Settings()).run_until_stopped())
 
 
 if __name__ == "__main__":

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -145,11 +145,9 @@ class SignalConnector(HttpConnector):
         """Verify the phone, load roster, drain its inbound queue.
 
         ``secrets["phone"]`` is the account this connection owns.
-        Missing → raise (the operator misconfigured this connection's
-        secrets and the container should refuse to serve it; per
-        ``HttpConnector``'s discovery loop the bad connection's
-        ``serve_connection`` task crashes the TaskGroup, which is
-        the failure mode we want).
+        Missing → raise; :meth:`HttpConnector._isolated_serve_connection`
+        logs the failure under ``connector.connection.serve_failed`` and
+        keeps the container serving its other connections.
         """
         phone = secrets.get("phone")
         if not phone:

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -25,7 +25,7 @@ Tool methods take ``connection_id`` and ``chat_id`` from the call's
 ``focal_channel`` / payload automatically — declare them as kwargs
 and the SDK threads them through.  Each method looks up its
 connection's phone + bot UUID + caches via
-``self._conn_state[connection_id]``.
+``self.state[connection_id]``.
 """
 
 from __future__ import annotations
@@ -37,7 +37,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-import httpx
 import structlog
 from aios_connector_http import (
     Attachment as SDKAttachment,
@@ -86,12 +85,12 @@ class _SignalConnectionState:
 
 class SignalConnector(HttpConnector):
     connector = "signal"
+    state: dict[str, _SignalConnectionState]
 
     def __init__(self, cfg: Settings) -> None:
         super().__init__()
         self._cfg = cfg
         self._daemon: SignalDaemon | None = None
-        self._conn_state: dict[str, _SignalConnectionState] = {}
         # Per-account inbound queues populated by the dispatcher task;
         # created on demand the first time the dispatcher sees that
         # phone OR ``serve_connection`` registers it (whichever comes
@@ -142,9 +141,7 @@ class SignalConnector(HttpConnector):
             await self._daemon.__aexit__(None, None, None)
             self._daemon = None
 
-    async def serve_connection(
-        self, connection_id: str, secrets: dict[str, str]
-    ) -> None:
+    async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
         """Verify the phone, load roster, drain its inbound queue.
 
         ``secrets["phone"]`` is the account this connection owns.
@@ -174,7 +171,7 @@ class SignalConnector(HttpConnector):
             contact_names=contact_names,
             groups=groups,
         )
-        self._conn_state[connection_id] = state
+        self.state[connection_id] = state
         queue = self._queue_for(phone)
         log.info(
             "signal.connection.ready",
@@ -184,12 +181,9 @@ class SignalConnector(HttpConnector):
             contacts=len(contact_names),
             groups=len(groups),
         )
-        try:
-            while True:
-                envelope = await queue.get()
-                await self._handle_envelope(connection_id, state, envelope)
-        finally:
-            self._conn_state.pop(connection_id, None)
+        while True:
+            envelope = await queue.get()
+            await self._handle_envelope(connection_id, state, envelope)
 
     # ── inbound plumbing ──────────────────────────────────────────────
 
@@ -226,7 +220,7 @@ class SignalConnector(HttpConnector):
         async for account, envelope in self._daemon.listener.messages():
             source_uuid = envelope.get("sourceUuid")
             if isinstance(source_uuid, str) and source_uuid:
-                for state in self._conn_state.values():
+                for state in self.state.values():
                     if state.bot_uuid == source_uuid:
                         self._maybe_resolve_self_echo(state, envelope)
                         break
@@ -261,41 +255,26 @@ class SignalConnector(HttpConnector):
             if msg.timestamp_ms
             else None
         )
-        try:
-            await self.emit_inbound(
-                connection_id=connection_id,
-                # Signal's (sender_uuid, timestamp_ms) pair is the platform's
-                # canonical message identity; feeding it as ``event_id`` lets
-                # aios's ``inbound_acks`` dedupe a redelivered envelope after
-                # a runtime restart (the inbound dispatcher's queue can hold
-                # up to ``maxsize`` envelopes that signal-cli would replay).
-                event_id=f"signal-{msg.sender_uuid}-{msg.timestamp_ms}",
-                chat_id=chat_id,
-                sender=sender_payload,
-                content=build_content_text(msg),
-                attachments=attachments,
-                metadata=build_metadata(msg, chat_id, state.bot_uuid),
-                timestamp=timestamp_iso,
-            )
-        except httpx.HTTPStatusError as exc:
-            # Drop-and-continue on routine 4xx so one bad envelope can't
-            # tear down the container and every other connection it
-            # serves.  401/403 (token revoked / runtime misconfigured)
-            # and 5xx (server outage or bug) are container-level problems
-            # that warrant the crash-and-restart loop, so let them
-            # propagate.  Without this guard, a single 422 from the api's
-            # multipart validator collapses the entire TaskGroup.
-            sc = exc.response.status_code
-            if sc in (401, 403) or sc >= 500:
-                raise
-            log.warning(
-                "signal.inbound.dropped",
-                connection_id=connection_id,
-                status_code=sc,
-                sender_uuid=msg.sender_uuid,
-                timestamp_ms=msg.timestamp_ms,
-                body=exc.response.text[:500],
-            )
+        # 4xx drop-and-continue lives in :meth:`HttpConnector.emit_inbound`:
+        # a routine 422 from one malformed envelope can't tear down sibling
+        # connections.  ``None`` return signals the drop; skip the read
+        # receipt since the inbound never landed in the session log.
+        result = await self.emit_inbound(
+            connection_id=connection_id,
+            # Signal's (sender_uuid, timestamp_ms) pair is the platform's
+            # canonical message identity; feeding it as ``event_id`` lets
+            # aios's ``inbound_acks`` dedupe a redelivered envelope after
+            # a runtime restart (the inbound dispatcher's queue can hold
+            # up to ``maxsize`` envelopes that signal-cli would replay).
+            event_id=f"signal-{msg.sender_uuid}-{msg.timestamp_ms}",
+            chat_id=chat_id,
+            sender=sender_payload,
+            content=build_content_text(msg),
+            attachments=attachments,
+            metadata=build_metadata(msg, chat_id, state.bot_uuid),
+            timestamp=timestamp_iso,
+        )
+        if result is None:
             return
         # Send a read receipt now that the message is persisted in the
         # session event log — semantically, "the agent has seen it."
@@ -342,7 +321,7 @@ class SignalConnector(HttpConnector):
                 account to rewrite.  The new ``text`` replaces the old one;
                 Signal clients render an "edited" indicator.
         """
-        state = self._conn_state[connection_id]
+        state = self.state[connection_id]
         host_paths: list[Path] = list(attachments or [])
         member_uuids = await self._group_member_uuids(state, chat_id)
         params = _build_send_params(
@@ -366,9 +345,7 @@ class SignalConnector(HttpConnector):
         echo_future: asyncio.Future[int] | None = None
         if chat_type == "group":
             echo_future = asyncio.get_running_loop().create_future()
-            self._pending_echoes.setdefault((state.phone, chat_id), deque()).append(
-                echo_future
-            )
+            self._pending_echoes.setdefault((state.phone, chat_id), deque()).append(echo_future)
         try:
             result = await self._daemon.rpc.call("send", params)
             ts = _extract_timestamp(result)
@@ -415,7 +392,7 @@ class SignalConnector(HttpConnector):
         Args:
             target_timestamp_ms: The Signal timestamp of the message to delete.
         """
-        state = self._conn_state[connection_id]
+        state = self.state[connection_id]
         assert self._daemon is not None
         params: dict[str, Any] = {
             "account": state.phone,
@@ -444,7 +421,7 @@ class SignalConnector(HttpConnector):
             member_uuids: ACI UUIDs of the members to add (excluding this
                 account, which is added implicitly as the creator).
         """
-        state = self._conn_state[connection_id]
+        state = self.state[connection_id]
         assert self._daemon is not None
         result = await self._daemon.rpc.call(
             "updateGroup",
@@ -470,7 +447,7 @@ class SignalConnector(HttpConnector):
         Args:
             name: The new group name.
         """
-        state = self._conn_state[connection_id]
+        state = self.state[connection_id]
         assert self._daemon is not None
         chat_type, raw_id = decode_chat_id(chat_id)
         if chat_type != "group":
@@ -505,7 +482,7 @@ class SignalConnector(HttpConnector):
             target_timestamp_ms: ``timestamp_ms`` of the target message.
             emoji: The reaction emoji.
         """
-        state = self._conn_state[connection_id]
+        state = self.state[connection_id]
         assert self._daemon is not None
         params = _build_react_params(
             state.phone, chat_id, target_author_uuid, target_timestamp_ms, emoji
@@ -569,9 +546,7 @@ class SignalConnector(HttpConnector):
         if not queue:
             self._pending_echoes.pop(key, None)
 
-    async def _send_read_receipt(
-        self, state: _SignalConnectionState, msg: InboundMessage
-    ) -> None:
+    async def _send_read_receipt(self, state: _SignalConnectionState, msg: InboundMessage) -> None:
         """Send a read receipt for ``msg`` to its original sender.
 
         Best-effort: signal-cli's daemon-mode automatic delivery
@@ -608,9 +583,7 @@ class SignalConnector(HttpConnector):
         assert self._daemon is not None
         state.groups = await self._daemon.list_groups(account=state.phone)
 
-    async def _group_member_uuids(
-        self, state: _SignalConnectionState, chat_id: str
-    ) -> list[str]:
+    async def _group_member_uuids(self, state: _SignalConnectionState, chat_id: str) -> list[str]:
         """Member UUIDs of the focal group, or ``[]`` for a DM.
 
         On cache miss, refreshes the roster once via ``listGroups`` and
@@ -688,9 +661,7 @@ class SignalConnector(HttpConnector):
             return_exceptions=True,
         )
         out: list[tuple[str, bytes, str]] = []
-        for (host_path, filename, content_type), blob in zip(
-            validated, blobs, strict=True
-        ):
+        for (host_path, filename, content_type), blob in zip(validated, blobs, strict=True):
             if isinstance(blob, BaseException):
                 log.warning(
                     "signal.inbound.attachment_read_failed",
@@ -818,9 +789,7 @@ def build_metadata(msg: InboundMessage, chat_id: str, bot_uuid: str) -> dict[str
         if msg.edit_target_timestamp_ms is not None:
             metadata["edit_target_timestamp_ms"] = msg.edit_target_timestamp_ms
     if msg.mentions:
-        metadata["mentions"] = [
-            {"uuid": m.uuid, "name": m.name} for m in msg.mentions
-        ]
+        metadata["mentions"] = [{"uuid": m.uuid, "name": m.name} for m in msg.mentions]
         metadata["self_mentioned"] = any(m.uuid == bot_uuid for m in msg.mentions)
     if msg.reply is not None:
         metadata["reply_to"] = {

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -255,10 +255,6 @@ class SignalConnector(HttpConnector):
             if msg.timestamp_ms
             else None
         )
-        # 4xx drop-and-continue lives in :meth:`HttpConnector.emit_inbound`:
-        # a routine 422 from one malformed envelope can't tear down sibling
-        # connections.  ``None`` return signals the drop; skip the read
-        # receipt since the inbound never landed in the session log.
         result = await self.emit_inbound(
             connection_id=connection_id,
             # Signal's (sender_uuid, timestamp_ms) pair is the platform's

--- a/connectors/signal/tests/conftest.py
+++ b/connectors/signal/tests/conftest.py
@@ -28,6 +28,7 @@ def _fast_echo_wait(monkeypatch: pytest.MonkeyPatch) -> None:
     hit the timeout in ~10ms instead of ~2s."""
     monkeypatch.setattr(_connector_module, "_ECHO_WAIT_S", 0.01)
 
+
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 BOT_UUID = "99999999-8888-7777-6666-555555555555"
@@ -72,7 +73,7 @@ def connector(tmp_path: Path) -> SignalConnector:
             "verify_phone": AsyncMock(return_value="bot-uuid"),
         },
     )()
-    c._conn_state[CONNECTION_ID] = _SignalConnectionState(
+    c.state[CONNECTION_ID] = _SignalConnectionState(
         phone=PHONE,
         bot_uuid="bot-uuid",
         contact_names={},

--- a/connectors/signal/tests/test_handle_envelope.py
+++ b/connectors/signal/tests/test_handle_envelope.py
@@ -1,10 +1,18 @@
-"""Cover ``_handle_envelope``'s drop-and-continue behavior on routine 4xx.
+"""Cover ``_handle_envelope``'s response to ``emit_inbound`` outcomes.
 
-A single bad envelope going to the api must not tear the container down:
-422s and other routine 4xx are logged + dropped so the connector keeps
-serving other connections.  401/403 (token revoked / runtime
-misconfigured) and 5xx (server outage or bug) still propagate so the
-operator sees red on real problems.
+The drop-and-continue policy itself now lives in
+:meth:`HttpConnector.emit_inbound` and is unit-tested in
+``packages/aios-connector-http/tests/test_runner.py``
+(``TestEmitInbound4xxDrop``).  Here we verify that
+``_handle_envelope`` honors the SDK's two return shapes:
+
+* ``None`` → envelope was dropped (routine 4xx); skip the read receipt
+  since the inbound never landed in the session log.
+* ``dict`` → envelope persisted; fire the explicit read receipt.
+
+5xx / 401 / 403 raise out of ``emit_inbound`` and must keep
+propagating so the container crashes + restarts on auth-broken /
+server-outage failures.
 """
 
 from __future__ import annotations
@@ -47,27 +55,12 @@ def _state() -> _SignalConnectionState:
     )
 
 
-async def test_handle_envelope_drops_on_422(
+async def test_handle_envelope_skips_receipt_when_inbound_dropped(
     connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A 422 from the api affects one envelope; the container survives."""
-    monkeypatch.setattr(
-        connector, "emit_inbound", AsyncMock(side_effect=_http_status_error(422, '{"detail":"bad"}'))
-    )
-    receipt = AsyncMock()
-    monkeypatch.setattr(connector, "_send_read_receipt", receipt)
-
-    await connector._handle_envelope(CONNECTION_ID, _state(), _make_envelope())
-
-    receipt.assert_not_awaited()
-
-
-async def test_handle_envelope_drops_on_400(
-    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(
-        connector, "emit_inbound", AsyncMock(side_effect=_http_status_error(400))
-    )
+    """``emit_inbound`` returns ``None`` when the SDK drops a routine 4xx;
+    no read receipt should fire since the inbound never persisted."""
+    monkeypatch.setattr(connector, "emit_inbound", AsyncMock(return_value=None))
     receipt = AsyncMock()
     monkeypatch.setattr(connector, "_send_read_receipt", receipt)
 
@@ -80,9 +73,7 @@ async def test_handle_envelope_raises_on_401(
     connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """401 means the runtime token is busted — fatal for every connection."""
-    monkeypatch.setattr(
-        connector, "emit_inbound", AsyncMock(side_effect=_http_status_error(401))
-    )
+    monkeypatch.setattr(connector, "emit_inbound", AsyncMock(side_effect=_http_status_error(401)))
 
     with pytest.raises(httpx.HTTPStatusError):
         await connector._handle_envelope(CONNECTION_ID, _state(), _make_envelope())
@@ -92,9 +83,7 @@ async def test_handle_envelope_raises_on_500(
     connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """5xx is a server-side outage; let the container crash + restart."""
-    monkeypatch.setattr(
-        connector, "emit_inbound", AsyncMock(side_effect=_http_status_error(503))
-    )
+    monkeypatch.setattr(connector, "emit_inbound", AsyncMock(side_effect=_http_status_error(503)))
 
     with pytest.raises(httpx.HTTPStatusError):
         await connector._handle_envelope(CONNECTION_ID, _state(), _make_envelope())

--- a/connectors/signal/tests/test_handle_envelope.py
+++ b/connectors/signal/tests/test_handle_envelope.py
@@ -1,18 +1,9 @@
 """Cover ``_handle_envelope``'s response to ``emit_inbound`` outcomes.
 
-The drop-and-continue policy itself now lives in
-:meth:`HttpConnector.emit_inbound` and is unit-tested in
-``packages/aios-connector-http/tests/test_runner.py``
-(``TestEmitInbound4xxDrop``).  Here we verify that
-``_handle_envelope`` honors the SDK's two return shapes:
-
-* ``None`` → envelope was dropped (routine 4xx); skip the read receipt
-  since the inbound never landed in the session log.
+* ``None`` → envelope was dropped; skip the read receipt since the
+  inbound never landed in the session log.
 * ``dict`` → envelope persisted; fire the explicit read receipt.
-
-5xx / 401 / 403 raise out of ``emit_inbound`` and must keep
-propagating so the container crashes + restarts on auth-broken /
-server-outage failures.
+* exception → propagates (auth-broken / server-outage failures).
 """
 
 from __future__ import annotations

--- a/connectors/signal/tests/test_setup_health.py
+++ b/connectors/signal/tests/test_setup_health.py
@@ -42,9 +42,7 @@ def connector(tmp_path: Path) -> SignalConnector:
     return SignalConnector(cfg)
 
 
-async def _serve_until_idle(
-    connector: SignalConnector, secrets: dict[str, str]
-) -> None:
+async def _serve_until_idle(connector: SignalConnector, secrets: dict[str, str]) -> None:
     """Run ``serve_connection`` up to the point where it starts draining
     the inbound queue, then cancel.  Lets us assert on the bot_uuid /
     contacts / groups registered in state without leaving a task hanging.
@@ -54,7 +52,7 @@ async def _serve_until_idle(
         # Poll for the state to appear (means verify_phone + list_groups +
         # list_contacts have run and the queue-drain loop has started).
         for _ in range(50):
-            if CONNECTION_ID in connector._conn_state:
+            if CONNECTION_ID in connector.state:
                 break
             await asyncio.sleep(0.01)
     finally:

--- a/connectors/signal/tests/test_signal_delete.py
+++ b/connectors/signal/tests/test_signal_delete.py
@@ -7,7 +7,9 @@ from tests.conftest import ALICE_UUID, CONNECTION_ID, GROUP_CHAT_ID, GROUP_RAW_I
 
 
 async def test_signal_delete_dm_uses_recipient(connector: SignalConnector) -> None:
-    result = await connector.signal_delete(target_timestamp_ms=1700000000000, chat_id=ALICE_UUID, connection_id=CONNECTION_ID)
+    result = await connector.signal_delete(
+        target_timestamp_ms=1700000000000, chat_id=ALICE_UUID, connection_id=CONNECTION_ID
+    )
     assert result == {"status": "ok"}
     method, params = connector._daemon.rpc.call.call_args.args  # type: ignore[union-attr]
     assert method == "remoteDelete"
@@ -19,7 +21,9 @@ async def test_signal_delete_dm_uses_recipient(connector: SignalConnector) -> No
 
 
 async def test_signal_delete_group_uses_groupid(connector: SignalConnector) -> None:
-    await connector.signal_delete(target_timestamp_ms=999, chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID)
+    await connector.signal_delete(
+        target_timestamp_ms=999, chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID
+    )
     method, params = connector._daemon.rpc.call.call_args.args  # type: ignore[union-attr]
     assert method == "remoteDelete"
     assert params == {

--- a/connectors/signal/tests/test_signal_groups.py
+++ b/connectors/signal/tests/test_signal_groups.py
@@ -43,14 +43,18 @@ async def test_create_group_raises_when_no_groupid_in_result(
     # create.  Anything else is a contract break — fail loud rather than
     # silently swallowing.
     with pytest.raises(RuntimeError, match="did not return a groupId"):
-        await connector.signal_create_group(name="x", member_uuids=[], chat_id=ALICE_UUID, connection_id=CONNECTION_ID)
+        await connector.signal_create_group(
+            name="x", member_uuids=[], chat_id=ALICE_UUID, connection_id=CONNECTION_ID
+        )
 
 
 # ── signal_rename_group ──────────────────────────────────────────────
 
 
 async def test_rename_group_with_group_focal(connector: SignalConnector) -> None:
-    result = await connector.signal_rename_group(name="Renamed", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID)
+    result = await connector.signal_rename_group(
+        name="Renamed", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID
+    )
     assert result == {"status": "ok"}
     method, params = connector._daemon.rpc.call.call_args.args  # type: ignore[union-attr]
     assert method == "updateGroup"
@@ -63,7 +67,9 @@ async def test_rename_group_with_group_focal(connector: SignalConnector) -> None
 
 async def test_rename_group_from_dm_focal_raises(connector: SignalConnector) -> None:
     with pytest.raises(ValueError, match="DM, not a group"):
-        await connector.signal_rename_group(name="X", chat_id=ALICE_UUID, connection_id=CONNECTION_ID)
+        await connector.signal_rename_group(
+            name="X", chat_id=ALICE_UUID, connection_id=CONNECTION_ID
+        )
 
 
 # ── _maybe_refresh_roster ──────────────────────────────────────────────
@@ -77,9 +83,9 @@ async def test_maybe_refresh_roster_calls_list_groups_on_update(
     fresh = [GroupInfo(id="abc", name="QA", member_uuids=[ALICE_UUID, BOB_UUID])]
     connector._daemon.list_groups.return_value = fresh  # type: ignore[union-attr]
     envelope = {"dataMessage": {"groupInfo": {"groupId": "abc==", "type": "UPDATE"}}}
-    await connector._maybe_refresh_roster(connector._conn_state[CONNECTION_ID], envelope)
+    await connector._maybe_refresh_roster(connector.state[CONNECTION_ID], envelope)
     connector._daemon.list_groups.assert_awaited_once_with(account=PHONE)  # type: ignore[union-attr]
-    assert connector._conn_state[CONNECTION_ID].groups == fresh
+    assert connector.state[CONNECTION_ID].groups == fresh
 
 
 async def test_maybe_refresh_roster_no_op_for_regular_message(
@@ -91,6 +97,6 @@ async def test_maybe_refresh_roster_no_op_for_regular_message(
             "groupInfo": {"groupId": "abc==", "type": "DELIVER"},
         }
     }
-    await connector._maybe_refresh_roster(connector._conn_state[CONNECTION_ID], envelope)
+    await connector._maybe_refresh_roster(connector.state[CONNECTION_ID], envelope)
     connector._daemon.list_groups.assert_not_awaited()  # type: ignore[union-attr]
-    assert connector._conn_state[CONNECTION_ID].groups == []
+    assert connector.state[CONNECTION_ID].groups == []

--- a/connectors/signal/tests/test_signal_handling.py
+++ b/connectors/signal/tests/test_signal_handling.py
@@ -1,63 +1,24 @@
-"""Cover the SIGINT/SIGTERM shutdown path and the daemon's process-group
-isolation.
+"""Cover the daemon's process-group isolation.
 
-Without these fixes, ``pkill -f aios_signal`` would kill the Python
-connector but leave the signal-cli JVM running with its TCP port and
-SQLite lock still held — a footgun observed during PR 8 smoke (#10).
+Without ``start_new_session=True`` on the signal-cli subprocess, a
+``pkill -f aios_signal`` (or any process-group-targeted signal hitting
+the connector) would also reach the JVM and leave the daemon's TCP port
++ SQLite lock dangling — a footgun observed during PR 8 smoke (#10).
+
+The SIGINT/SIGTERM shutdown path itself now lives in
+:meth:`HttpConnector.run_until_stopped` and is exercised in
+``packages/aios-connector-http/tests/test_runner.py``
+(``TestRunUntilStopped``) rather than per-connector.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable
 from typing import Any
 
 import pytest
 
 from aios_signal import daemon as daemon_module
-from aios_signal.__main__ import _serve
-
-
-class _StubConnector:
-    """Minimal stand-in for :class:`SignalConnector` exposing only ``run``."""
-
-    def __init__(self, behavior: Awaitable[None]) -> None:
-        self._behavior = behavior
-
-    async def run(self) -> None:
-        await self._behavior
-
-
-async def test_serve_stops_when_stop_event_is_set() -> None:
-    """A signal handler flipping ``stop`` cancels the connector task so
-    its ``async with`` blocks unwind and ``teardown`` runs."""
-    teardown_called = asyncio.Event()
-
-    async def _long_running() -> None:
-        try:
-            await asyncio.Event().wait()
-        finally:
-            teardown_called.set()
-
-    connector = _StubConnector(_long_running())
-    stop = asyncio.Event()
-
-    async def _flip_stop() -> None:
-        await asyncio.sleep(0.01)
-        stop.set()
-
-    await asyncio.gather(_serve(connector, stop), _flip_stop())  # type: ignore[arg-type]
-    assert teardown_called.is_set()
-
-
-async def test_serve_returns_if_connector_finishes_first() -> None:
-    """Connector exiting (e.g. fatal error) returns control without
-    requiring the stop signal — the operator sees the original
-    exception in the traceback."""
-    connector = _StubConnector(asyncio.sleep(0))
-    stop = asyncio.Event()
-    await _serve(connector, stop)  # type: ignore[arg-type]
-    # No assertion: the only requirement is that we return.
 
 
 async def test_spawn_starts_new_session(

--- a/connectors/signal/tests/test_signal_send.py
+++ b/connectors/signal/tests/test_signal_send.py
@@ -51,7 +51,9 @@ def test_build_params_with_attachments() -> None:
 
 
 async def test_signal_send_text_only(connector: SignalConnector) -> None:
-    result = await connector.signal_send(text="hello there", chat_id=ALICE_UUID, connection_id=CONNECTION_ID)
+    result = await connector.signal_send(
+        text="hello there", chat_id=ALICE_UUID, connection_id=CONNECTION_ID
+    )
     assert result == {"status": "ok"}
     sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
     assert sent_params["message"] == "hello there"
@@ -103,9 +105,7 @@ async def test_signal_send_dispatch_resolves_sandbox_path(
             "tool_call_id": "c1",
             "session_id": "sess-1",
             "name": "signal_send",
-            "arguments": json.dumps(
-                {"text": "look", "attachments": ["/workspace/cat.jpg"]}
-            ),
+            "arguments": json.dumps({"text": "look", "attachments": ["/workspace/cat.jpg"]}),
             "focal_channel": f"signal/bot-uuid/{ALICE_UUID}",
         }
     )
@@ -128,8 +128,13 @@ async def test_signal_send_dispatch_traversal_returns_error_result(
     captured: list[dict[str, Any]] = []
 
     async def _capture_result(
-        client: Any, *, connection_id: str, session_id: str, tool_call_id: str,
-        content: Any, is_error: bool = False,
+        client: Any,
+        *,
+        connection_id: str,
+        session_id: str,
+        tool_call_id: str,
+        content: Any,
+        is_error: bool = False,
     ) -> None:
         del client
         captured.append(
@@ -150,9 +155,7 @@ async def test_signal_send_dispatch_traversal_returns_error_result(
             "tool_call_id": "c2",
             "session_id": "sess-1",
             "name": "signal_send",
-            "arguments": json.dumps(
-                {"text": "look", "attachments": ["/workspace/../escape.jpg"]}
-            ),
+            "arguments": json.dumps({"text": "look", "attachments": ["/workspace/../escape.jpg"]}),
             "focal_channel": f"signal/bot-uuid/{ALICE_UUID}",
         }
     )
@@ -268,7 +271,7 @@ async def test_signal_send_in_group_encodes_mentions(
 ) -> None:
     # Seed the connector's group cache so signal_send knows the focal
     # group's members at send time.
-    connector._conn_state[CONNECTION_ID].groups = [
+    connector.state[CONNECTION_ID].groups = [
         GroupInfo(id=GROUP_CHAT_ID, name="Tea Party", member_uuids=[ALICE_UUID, BOB_UUID])
     ]
     await connector.signal_send(
@@ -291,11 +294,13 @@ async def test_signal_send_refreshes_group_cache_on_miss(
     # silently degrade.  signal_send must refresh on miss so the second
     # listGroups (now populated) populates the cache and the mention
     # encodes correctly.
-    connector._conn_state[CONNECTION_ID].groups = []
+    connector.state[CONNECTION_ID].groups = []
     connector._daemon.list_groups.return_value = [  # type: ignore[union-attr]
         GroupInfo(id=GROUP_CHAT_ID, name="Tea Party", member_uuids=[ALICE_UUID, BOB_UUID])
     ]
-    await connector.signal_send(text=f"hey @{ALICE_UUID[:8]}", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID)
+    await connector.signal_send(
+        text=f"hey @{ALICE_UUID[:8]}", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID
+    )
     connector._daemon.list_groups.assert_awaited_once_with(account=PHONE)  # type: ignore[union-attr]
     sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
     assert sent_params["mentions"] == [f"4:1:{ALICE_UUID}"]
@@ -304,16 +309,18 @@ async def test_signal_send_refreshes_group_cache_on_miss(
 async def test_signal_send_skips_refresh_on_cache_hit(
     connector: SignalConnector,
 ) -> None:
-    connector._conn_state[CONNECTION_ID].groups = [
+    connector.state[CONNECTION_ID].groups = [
         GroupInfo(id=GROUP_CHAT_ID, name="Tea Party", member_uuids=[ALICE_UUID, BOB_UUID])
     ]
-    await connector.signal_send(text="no mentions", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID)
+    await connector.signal_send(
+        text="no mentions", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID
+    )
     connector._daemon.list_groups.assert_not_awaited()  # type: ignore[union-attr]
 
 
 async def test_signal_send_dm_skips_refresh(connector: SignalConnector) -> None:
     # DMs never need a group roster — refreshing on every DM send would
     # be a wasted RPC.
-    connector._conn_state[CONNECTION_ID].groups = []
+    connector.state[CONNECTION_ID].groups = []
     await connector.signal_send(text="hey", chat_id=ALICE_UUID, connection_id=CONNECTION_ID)
     connector._daemon.list_groups.assert_not_awaited()  # type: ignore[union-attr]

--- a/connectors/signal/tests/test_signal_send_echo.py
+++ b/connectors/signal/tests/test_signal_send_echo.py
@@ -81,9 +81,7 @@ async def test_maybe_resolve_self_echo_pops_first_waiter(connector: SignalConnec
     state = _state()
     fut: asyncio.Future[int] = asyncio.get_running_loop().create_future()
     connector._pending_echoes[(PHONE, GROUP_CHAT_ID)] = deque([fut])
-    connector._maybe_resolve_self_echo(
-        state, _self_echo_envelope(timestamp_ms=12345)
-    )
+    connector._maybe_resolve_self_echo(state, _self_echo_envelope(timestamp_ms=12345))
     assert fut.done()
     assert fut.result() == 12345
     # Empty queue is pruned so we don't leak keys.
@@ -100,9 +98,7 @@ async def test_maybe_resolve_self_echo_skips_stale_futures(
     fresh: asyncio.Future[int] = asyncio.get_running_loop().create_future()
     connector._pending_echoes[(PHONE, GROUP_CHAT_ID)] = deque([stale, fresh])
 
-    connector._maybe_resolve_self_echo(
-        _state(), _self_echo_envelope(timestamp_ms=999)
-    )
+    connector._maybe_resolve_self_echo(_state(), _self_echo_envelope(timestamp_ms=999))
 
     assert fresh.done()
     assert fresh.result() == 999
@@ -190,13 +186,11 @@ async def test_signal_send_group_returns_sent_at_ms_from_echo(
         # _inbound_dispatcher when the envelope lands on any peer's
         # account stream (group self-echoes arrive on RECEIVING peers'
         # streams, not on the sender's own stream).
-        connector._maybe_resolve_self_echo(
-            _state(), _self_echo_envelope(timestamp_ms=sent_ts)
-        )
+        connector._maybe_resolve_self_echo(_state(), _self_echo_envelope(timestamp_ms=sent_ts))
         return None
 
     connector._daemon.rpc.call.side_effect = _fake_send  # type: ignore[union-attr]
-    connector._conn_state[CONNECTION_ID] = _state()
+    connector.state[CONNECTION_ID] = _state()
 
     result = await connector.signal_send(
         text="hello", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID
@@ -212,7 +206,7 @@ async def test_signal_send_group_falls_back_when_echo_times_out(
     signal_send returns ``{"status": "ok"}`` after the deadline rather
     than hanging the tool call forever."""
     connector._daemon.rpc.call.return_value = None  # type: ignore[union-attr]
-    connector._conn_state[CONNECTION_ID] = _state()
+    connector.state[CONNECTION_ID] = _state()
 
     result = await connector.signal_send(
         text="silence", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID
@@ -233,7 +227,7 @@ async def test_inbound_dispatcher_resolves_echo_on_peer_account_stream(
     rather than by per-account routing.
     """
     # Register the bot under its own account.
-    connector._conn_state[CONNECTION_ID] = _state()
+    connector.state[CONNECTION_ID] = _state()
     fut: asyncio.Future[int] = asyncio.get_running_loop().create_future()
     connector._pending_echoes[(PHONE, GROUP_CHAT_ID)] = deque([fut])
 
@@ -271,7 +265,7 @@ async def test_signal_send_cleans_up_echo_future_when_rpc_raises(
     from aios_signal.errors import RpcError
 
     connector._daemon.rpc.call.side_effect = RpcError("send failed")  # type: ignore[union-attr]
-    connector._conn_state[CONNECTION_ID] = _state()
+    connector.state[CONNECTION_ID] = _state()
 
     with pytest.raises(RpcError):
         await connector.signal_send(
@@ -291,11 +285,9 @@ async def test_signal_send_dm_does_not_register_echo_future(
     """DMs skip the echo path entirely — signal-cli returns their
     timestamp inline, so a pending-echoes entry would leak."""
     connector._daemon.rpc.call.return_value = {"timestamp": 999}  # type: ignore[union-attr]
-    connector._conn_state[CONNECTION_ID] = _state()
+    connector.state[CONNECTION_ID] = _state()
 
-    result = await connector.signal_send(
-        text="dm", chat_id=ALICE_UUID, connection_id=CONNECTION_ID
-    )
+    result = await connector.signal_send(text="dm", chat_id=ALICE_UUID, connection_id=CONNECTION_ID)
 
     assert result == {"sent_at_ms": 999}
     assert (PHONE, ALICE_UUID) not in connector._pending_echoes

--- a/connectors/telegram/src/aios_telegram/__main__.py
+++ b/connectors/telegram/src/aios_telegram/__main__.py
@@ -4,12 +4,6 @@ Reads ``AIOS_URL`` and ``AIOS_RUNTIME_TOKEN`` from env (the SDK does
 this automatically inside ``HttpConnector.__init__``).  Each bot token
 lives on its connection record (encrypted at rest server-side); the
 connector fetches secrets per-connection inside ``serve_connection``.
-
-SIGINT / SIGTERM handling, cancel-on-stop, and ``teardown`` dispatch
-live in :meth:`HttpConnector.run_until_stopped` — without that the
-PTB updater's long-poll would orphan its bot-token / ``getUpdates``
-session on ``docker stop`` (a SIGTERM the default ``asyncio.run``
-doesn't trap).
 """
 
 from __future__ import annotations

--- a/connectors/telegram/src/aios_telegram/__main__.py
+++ b/connectors/telegram/src/aios_telegram/__main__.py
@@ -4,6 +4,12 @@ Reads ``AIOS_URL`` and ``AIOS_RUNTIME_TOKEN`` from env (the SDK does
 this automatically inside ``HttpConnector.__init__``).  Each bot token
 lives on its connection record (encrypted at rest server-side); the
 connector fetches secrets per-connection inside ``serve_connection``.
+
+SIGINT / SIGTERM handling, cancel-on-stop, and ``teardown`` dispatch
+live in :meth:`HttpConnector.run_until_stopped` — without that the
+PTB updater's long-poll would orphan its bot-token / ``getUpdates``
+session on ``docker stop`` (a SIGTERM the default ``asyncio.run``
+doesn't trap).
 """
 
 from __future__ import annotations
@@ -14,7 +20,7 @@ from .connector import TelegramConnector
 
 
 def main() -> None:
-    asyncio.run(TelegramConnector().run())
+    asyncio.run(TelegramConnector().run_until_stopped())
 
 
 if __name__ == "__main__":

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -133,8 +133,6 @@ class TelegramConnector(HttpConnector):
                     name=f"telegram-drain-{connection_id}",
                 )
         finally:
-            # State auto-pop lives in :meth:`HttpConnector._isolated_serve_connection`;
-            # PTB shutdown is connector-specific so it stays here.
             await self._shutdown_application(state.application)
 
     async def _build_state(self, bot_token: str) -> _TelegramConnectionState:

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -96,16 +96,11 @@ class _TelegramConnectionState:
 
 class TelegramConnector(HttpConnector):
     connector = "telegram"
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._conn_state: dict[str, _TelegramConnectionState] = {}
+    state: dict[str, _TelegramConnectionState]
 
     # ── lifecycle ─────────────────────────────────────────────────────
 
-    async def serve_connection(
-        self, connection_id: str, secrets: dict[str, str]
-    ) -> None:
+    async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
         """Build a PTB Application for this connection and run its loops.
 
         Each connection has its own bot token (one PTB Application per
@@ -116,11 +111,10 @@ class TelegramConnector(HttpConnector):
         bot_token = secrets.get("bot_token")
         if not bot_token:
             raise RuntimeError(
-                f"telegram connection {connection_id!r} requires a "
-                "'bot_token' entry in its secrets"
+                f"telegram connection {connection_id!r} requires a 'bot_token' entry in its secrets"
             )
         state = await self._build_state(bot_token)
-        self._conn_state[connection_id] = state
+        self.state[connection_id] = state
         log.info(
             "telegram.connection.ready",
             connection_id=connection_id,
@@ -139,7 +133,8 @@ class TelegramConnector(HttpConnector):
                     name=f"telegram-drain-{connection_id}",
                 )
         finally:
-            self._conn_state.pop(connection_id, None)
+            # State auto-pop lives in :meth:`HttpConnector._isolated_serve_connection`;
+            # PTB shutdown is connector-specific so it stays here.
             await self._shutdown_application(state.application)
 
     async def _build_state(self, bot_token: str) -> _TelegramConnectionState:
@@ -177,9 +172,7 @@ class TelegramConnector(HttpConnector):
             await inbound_queue.put(parsed)
 
         async def on_error(_update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
-            log.error(
-                "telegram.handler.error", bot_id=bot_id, error=str(context.error)
-            )
+            log.error("telegram.handler.error", bot_id=bot_id, error=str(context.error))
 
         application.add_handler(MessageHandler(filters.UpdateType.MESSAGES, on_message))
         application.add_handler(MessageReactionHandler(on_reaction))
@@ -214,9 +207,7 @@ class TelegramConnector(HttpConnector):
         await state.application.updater.start_polling(allowed_updates=_ALLOWED_UPDATES)
         await asyncio.Event().wait()
 
-    async def _drain_queue(
-        self, connection_id: str, state: _TelegramConnectionState
-    ) -> None:
+    async def _drain_queue(self, connection_id: str, state: _TelegramConnectionState) -> None:
         while True:
             item = await state.inbound_queue.get()
             if isinstance(item, InboundReaction):
@@ -263,7 +254,7 @@ class TelegramConnector(HttpConnector):
             "display_name": reaction.sender_name or str(reaction.sender_id),
         }
         metadata: dict[str, Any] = {
-            "channel": f"telegram/{state.bot_id}/{reaction.chat_id}",
+            "channel": self.focal_channel(str(state.bot_id), str(reaction.chat_id)),
             "chat_type": reaction.chat_kind,
             "sender_id": reaction.sender_id,
             "timestamp_ms": reaction.timestamp_ms,
@@ -301,9 +292,7 @@ class TelegramConnector(HttpConnector):
         attachments: tuple[Attachment, ...],
     ) -> list[tuple[str, bytes, str]] | None:
         """Download each attachment, validate size + bytes, return runtime tuples."""
-        host_paths = await asyncio.gather(
-            *(self._download_one(state, a) for a in attachments)
-        )
+        host_paths = await asyncio.gather(*(self._download_one(state, a) for a in attachments))
         out: list[tuple[str, bytes, str]] = []
         for att, host_path in zip(attachments, host_paths, strict=True):
             if host_path is None:
@@ -336,9 +325,7 @@ class TelegramConnector(HttpConnector):
             out.append((att.filename, blob, att.content_type))
         return out or None
 
-    async def _download_one(
-        self, state: _TelegramConnectionState, att: Attachment
-    ) -> Path | None:
+    async def _download_one(self, state: _TelegramConnectionState, att: Attachment) -> Path | None:
         try:
             file = await state.application.bot.get_file(att.file_id)
         except TelegramError as err:
@@ -416,7 +403,7 @@ class TelegramConnector(HttpConnector):
                 from an earlier ``telegram_send`` response.  Default
                 ``None`` sends as a top-level message in the chat.
         """
-        state = self._conn_state[connection_id]
+        state = self.state[connection_id]
         chat_id_int = _coerce_chat_id(chat_id)
 
         body, ptb_parse_mode = _prepare_text(text, parse_mode)
@@ -477,11 +464,9 @@ class TelegramConnector(HttpConnector):
                 ``"record_voice"`` / ``"upload_voice"`` /
                 ``"upload_document"`` make sense before sending media.
         """
-        state = self._conn_state[connection_id]
+        state = self.state[connection_id]
         chat_id_int = _coerce_chat_id(chat_id)
-        await state.application.bot.send_chat_action(
-            chat_id=chat_id_int, action=ChatAction(action)
-        )
+        await state.application.bot.send_chat_action(chat_id=chat_id_int, action=ChatAction(action))
         return {"status": "ok"}
 
     @tool()
@@ -510,7 +495,7 @@ class TelegramConnector(HttpConnector):
                 runs the Markdown→Telegram-HTML converter, ``"html"``
                 passes raw HTML through to Telegram.
         """
-        state = self._conn_state[connection_id]
+        state = self.state[connection_id]
         chat_id_int = _coerce_chat_id(chat_id)
         body, ptb_parse_mode = _prepare_text(text, parse_mode)
         edited = await state.application.bot.edit_message_text(
@@ -542,11 +527,9 @@ class TelegramConnector(HttpConnector):
         Args:
             message_id: The id of the message to delete.
         """
-        state = self._conn_state[connection_id]
+        state = self.state[connection_id]
         chat_id_int = _coerce_chat_id(chat_id)
-        await state.application.bot.delete_message(
-            chat_id=chat_id_int, message_id=message_id
-        )
+        await state.application.bot.delete_message(chat_id=chat_id_int, message_id=message_id)
         return {"status": "ok"}
 
     @tool()
@@ -573,7 +556,7 @@ class TelegramConnector(HttpConnector):
                 check there if a glyph you'd expect to work is rejected.
                 Pass ``None`` to clear the bot's existing reaction.
         """
-        state = self._conn_state[connection_id]
+        state = self.state[connection_id]
         chat_id_int = _coerce_chat_id(chat_id)
         reaction = [ReactionTypeEmoji(emoji=emoji)] if emoji is not None else None
         await state.application.bot.set_message_reaction(

--- a/connectors/telegram/tests/conftest.py
+++ b/connectors/telegram/tests/conftest.py
@@ -47,7 +47,7 @@ def connector(bot: Any) -> TelegramConnector:
     c = TelegramConnector()
     application = MagicMock()
     application.bot = bot
-    c._conn_state[CONNECTION_ID] = _TelegramConnectionState(
+    c.state[CONNECTION_ID] = _TelegramConnectionState(
         application=application,
         bot_id=BOT_ID,
         first_name="TestBot",

--- a/connectors/telegram/tests/test_telegram_outbound.py
+++ b/connectors/telegram/tests/test_telegram_outbound.py
@@ -39,30 +39,26 @@ def bot() -> Any:
 # ── telegram_typing ──────────────────────────────────────────────────
 
 
-async def test_telegram_typing_default_action(
-    connector: TelegramConnector, bot: Any
-) -> None:
+async def test_telegram_typing_default_action(connector: TelegramConnector, bot: Any) -> None:
     result = await connector.telegram_typing(chat_id="123", connection_id=CONNECTION_ID)
     assert result == {"status": "ok"}
     bot.send_chat_action.assert_awaited_once_with(chat_id=123, action=ChatAction.TYPING)
 
 
-async def test_telegram_typing_upload_photo_action(
-    connector: TelegramConnector, bot: Any
-) -> None:
-    await connector.telegram_typing(action="upload_photo", chat_id="123", connection_id=CONNECTION_ID)
-    bot.send_chat_action.assert_awaited_once_with(
-        chat_id=123, action=ChatAction.UPLOAD_PHOTO
+async def test_telegram_typing_upload_photo_action(connector: TelegramConnector, bot: Any) -> None:
+    await connector.telegram_typing(
+        action="upload_photo", chat_id="123", connection_id=CONNECTION_ID
     )
+    bot.send_chat_action.assert_awaited_once_with(chat_id=123, action=ChatAction.UPLOAD_PHOTO)
 
 
 # ── telegram_edit_message ────────────────────────────────────────────
 
 
-async def test_telegram_edit_message_plain(
-    connector: TelegramConnector, bot: Any
-) -> None:
-    result = await connector.telegram_edit_message(message_id=99, text="fixed", chat_id="123", connection_id=CONNECTION_ID)
+async def test_telegram_edit_message_plain(connector: TelegramConnector, bot: Any) -> None:
+    result = await connector.telegram_edit_message(
+        message_id=99, text="fixed", chat_id="123", connection_id=CONNECTION_ID
+    )
     assert result == {"message_id": 99}
     bot.edit_message_text.assert_awaited_once_with(
         chat_id=123, message_id=99, text="fixed", parse_mode=None
@@ -107,17 +103,19 @@ async def test_telegram_edit_message_inline_returns_status_ok(
 ) -> None:
     """Editing an inline-bot message returns True from PTB; we surface status only."""
     bot.edit_message_text = AsyncMock(return_value=True)
-    result = await connector.telegram_edit_message(message_id=99, text="hi", chat_id="123", connection_id=CONNECTION_ID)
+    result = await connector.telegram_edit_message(
+        message_id=99, text="hi", chat_id="123", connection_id=CONNECTION_ID
+    )
     assert result == {"status": "ok"}
 
 
 # ── telegram_delete_message ──────────────────────────────────────────
 
 
-async def test_telegram_delete_message(
-    connector: TelegramConnector, bot: Any
-) -> None:
-    result = await connector.telegram_delete_message(message_id=50, chat_id="123", connection_id=CONNECTION_ID)
+async def test_telegram_delete_message(connector: TelegramConnector, bot: Any) -> None:
+    result = await connector.telegram_delete_message(
+        message_id=50, chat_id="123", connection_id=CONNECTION_ID
+    )
     assert result == {"status": "ok"}
     bot.delete_message.assert_awaited_once_with(chat_id=123, message_id=50)
 
@@ -125,10 +123,10 @@ async def test_telegram_delete_message(
 # ── telegram_react ───────────────────────────────────────────────────
 
 
-async def test_telegram_react_with_emoji(
-    connector: TelegramConnector, bot: Any
-) -> None:
-    result = await connector.telegram_react(message_id=50, emoji="👍", chat_id="123", connection_id=CONNECTION_ID)
+async def test_telegram_react_with_emoji(connector: TelegramConnector, bot: Any) -> None:
+    result = await connector.telegram_react(
+        message_id=50, emoji="👍", chat_id="123", connection_id=CONNECTION_ID
+    )
     assert result == {"status": "ok"}
     kwargs = bot.set_message_reaction.call_args.kwargs
     assert kwargs["chat_id"] == 123
@@ -139,10 +137,10 @@ async def test_telegram_react_with_emoji(
     assert kwargs["reaction"][0].emoji == "👍"
 
 
-async def test_telegram_react_clear(
-    connector: TelegramConnector, bot: Any
-) -> None:
-    await connector.telegram_react(message_id=50, emoji=None, chat_id="123", connection_id=CONNECTION_ID)
+async def test_telegram_react_clear(connector: TelegramConnector, bot: Any) -> None:
+    await connector.telegram_react(
+        message_id=50, emoji=None, chat_id="123", connection_id=CONNECTION_ID
+    )
     kwargs = bot.set_message_reaction.call_args.kwargs
     assert kwargs["reaction"] is None
 
@@ -150,14 +148,14 @@ async def test_telegram_react_clear(
 # ── telegram_send parse_mode ─────────────────────────────────────────
 
 
-async def test_telegram_send_markdown_mode_converts(
-    connector: TelegramConnector, bot: Any
-) -> None:
+async def test_telegram_send_markdown_mode_converts(connector: TelegramConnector, bot: Any) -> None:
     """``parse_mode="markdown"`` runs the input through
     :func:`markdown_to_telegram_html`.  This is the renamed form of
     what used to be ``parse_mode="html"`` before the smoke-#17 fix —
     the old name collided with Telegram Bot API semantics."""
-    await connector.telegram_send(text="**hi** _there_", parse_mode="markdown", chat_id="123", connection_id=CONNECTION_ID)
+    await connector.telegram_send(
+        text="**hi** _there_", parse_mode="markdown", chat_id="123", connection_id=CONNECTION_ID
+    )
     kwargs = bot.send_message.call_args.kwargs
     assert kwargs["text"] == "<b>hi</b> <i>there</i>"
     assert kwargs["parse_mode"] == "HTML"
@@ -171,7 +169,9 @@ async def test_telegram_send_html_mode_passes_through(
     verbatim.  Critical for agents that want to use raw ``<a href>``
     tags or other constructs the markdown converter doesn't emit."""
     raw = '<b>bold</b> <a href="https://example.com">link</a>'
-    await connector.telegram_send(text=raw, parse_mode="html", chat_id="123", connection_id=CONNECTION_ID)
+    await connector.telegram_send(
+        text=raw, parse_mode="html", chat_id="123", connection_id=CONNECTION_ID
+    )
     kwargs = bot.send_message.call_args.kwargs
     assert kwargs["text"] == raw  # untouched
     assert kwargs["parse_mode"] == "HTML"

--- a/connectors/telegram/tests/test_telegram_send.py
+++ b/connectors/telegram/tests/test_telegram_send.py
@@ -149,7 +149,9 @@ async def test_telegram_send_single_photo_routes_to_send_photo(
     photo = tmp_path / "cat.jpg"
     photo.write_bytes(b"x")
 
-    result = await connector.telegram_send(text="look", attachments=[photo], chat_id="123", connection_id=CONNECTION_ID)
+    result = await connector.telegram_send(
+        text="look", attachments=[photo], chat_id="123", connection_id=CONNECTION_ID
+    )
 
     assert result == {"message_id": 43}
     bot.send_photo.assert_awaited_once()
@@ -174,7 +176,9 @@ async def test_telegram_send_single_voice_routes_to_send_voice(
 ) -> None:
     voice = tmp_path / "v.ogg"
     voice.write_bytes(b"x")
-    await connector.telegram_send(text="", attachments=[voice], chat_id="123", connection_id=CONNECTION_ID)
+    await connector.telegram_send(
+        text="", attachments=[voice], chat_id="123", connection_id=CONNECTION_ID
+    )
     bot.send_voice.assert_awaited_once()
 
 
@@ -224,7 +228,9 @@ async def test_telegram_send_single_document_routes_to_send_document(
 ) -> None:
     doc = tmp_path / "report.pdf"
     doc.write_bytes(b"x")
-    await connector.telegram_send(text="", attachments=[doc], chat_id="123", connection_id=CONNECTION_ID)
+    await connector.telegram_send(
+        text="", attachments=[doc], chat_id="123", connection_id=CONNECTION_ID
+    )
     bot.send_document.assert_awaited_once()
 
 
@@ -258,7 +264,9 @@ async def test_telegram_send_non_int_chat_id_raises(
     connector: TelegramConnector,
 ) -> None:
     with pytest.raises(ValueError, match="must be an integer"):
-        await connector.telegram_send(text="hi", chat_id="not-a-number", connection_id=CONNECTION_ID)
+        await connector.telegram_send(
+            text="hi", chat_id="not-a-number", connection_id=CONNECTION_ID
+        )
 
 
 # Integration check: feed the SDK dispatch path with a sandbox path
@@ -291,9 +299,7 @@ async def test_telegram_send_dispatch_resolves_sandbox_path(
             "tool_call_id": "c1",
             "session_id": "sess-1",
             "name": "telegram_send",
-            "arguments": json.dumps(
-                {"text": "look", "attachments": ["/workspace/cat.jpg"]}
-            ),
+            "arguments": json.dumps({"text": "look", "attachments": ["/workspace/cat.jpg"]}),
             "focal_channel": "telegram/0/123",
         }
     )

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -89,6 +89,20 @@ log: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
 _TOOL_ATTR = "__aios_http_tool__"
 
 
+def _is_fatal_inbound_status(status_code: int) -> bool:
+    """``emit_inbound`` raises for these; everything else (routine 4xx)
+    drops the envelope and returns ``None``.
+
+    ``401`` / ``403`` mean the runtime token is busted (revoked or
+    misconfigured) — fatal for every connection the container serves.
+    ``5xx`` is a server-side outage / bug — also fatal so the
+    container crash-and-restarts.  Routine 4xx (``400``, ``422``)
+    indicates one specific envelope is malformed; dropping it lets
+    sibling connections keep serving.
+    """
+    return status_code in (401, 403) or status_code >= 500
+
+
 def tool(
     *,
     name: str | None = None,
@@ -235,7 +249,6 @@ class HttpConnector:
         metadata: dict[str, Any] | None = None,
         timestamp: str | None = None,
         event_id: str | None = None,
-        raise_on_4xx: bool = False,
     ) -> dict[str, Any] | None:
         """Forward a platform inbound to aios for ``connection_id``.
 
@@ -249,9 +262,10 @@ class HttpConnector:
         container via the parent TaskGroup.  ``401`` / ``403`` (auth
         broken — runtime token revoked or misconfigured) and ``5xx``
         (server outage / bug) still raise: those are container-level
-        problems that warrant the crash-and-restart loop.  Pass
-        ``raise_on_4xx=True`` if a specific call site needs the old
-        strict behavior.
+        problems that warrant the crash-and-restart loop.  Callers that
+        need the bad-envelope to surface (e.g. integration-test tools
+        that want loud validation failures) check for ``None`` and
+        raise themselves.
         """
         client = self._require_client()
         eid = event_id or str(ULID())
@@ -302,7 +316,7 @@ class HttpConnector:
                 connection_id=connection_id,
                 body=response.text[:2000],
             )
-            if raise_on_4xx or sc in (401, 403) or sc >= 500:
+            if _is_fatal_inbound_status(sc):
                 response.raise_for_status()
             return None
         return dict(response.json())
@@ -323,14 +337,20 @@ class HttpConnector:
         """
         stop = asyncio.Event()
         loop = asyncio.get_running_loop()
-        if install_signal_handlers:
-            for sig in (_signal.SIGINT, _signal.SIGTERM):
-                loop.add_signal_handler(sig, stop.set)
+        signals = (_signal.SIGINT, _signal.SIGTERM) if install_signal_handlers else ()
+        for sig in signals:
+            loop.add_signal_handler(sig, stop.set)
         run_task = asyncio.create_task(self.run(), name=f"aios-{self.connector}-run")
         stop_task = asyncio.create_task(stop.wait(), name=f"aios-{self.connector}-stop-wait")
         try:
             await asyncio.wait({run_task, stop_task}, return_when=asyncio.FIRST_COMPLETED)
         finally:
+            # Removing handlers in the finally lets embedded callers
+            # invoke ``run_until_stopped`` multiple times without the
+            # previous ``stop.set`` target outliving its Event.
+            for sig in signals:
+                with contextlib.suppress(NotImplementedError, ValueError):
+                    loop.remove_signal_handler(sig)
             stop_task.cancel()
             if not run_task.done():
                 run_task.cancel()

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -45,9 +45,11 @@ durability across container restart, override :meth:`load_answered` /
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import json
 import os
+import signal as _signal
 import types
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -157,6 +159,26 @@ class HttpConnector:
         self._tools: dict[str, _ToolMeta] = self._collect_tools()
         self._answered: set[str] = set()
         self._connections: dict[str, _ConnectionState] = {}
+        # User-state slot for subclasses: per-connection objects keyed
+        # by connection_id.  Subclasses populate this inside their
+        # :meth:`serve_connection`; the SDK auto-pops on serve exit so
+        # tool methods always read fresh state.  Narrow the value type
+        # via attribute annotation in the subclass body, e.g.::
+        #
+        #     class SignalConnector(HttpConnector):
+        #         state: dict[str, _SignalConnectionState]
+        self.state: dict[str, Any] = {}
+
+    # ─── helpers (subclasses use these) ──────────────────────────────
+
+    def focal_channel(self, account: str, chat_id: str) -> str:
+        """Return the canonical ``<connector>/<account>/<chat_id>`` string.
+
+        Outbound tool methods write this to messages they edit/react to;
+        the runtime parses it back into ``account`` / ``chat_id`` kwargs
+        on the next call (see :func:`_inject_focal_kwargs`).
+        """
+        return f"{self.connector}/{account}/{chat_id}"
 
     # ─── lifecycle hooks (override as needed) ────────────────────────
 
@@ -175,9 +197,7 @@ class HttpConnector:
         """
         del tg
 
-    async def serve_connection(
-        self, connection_id: str, secrets: dict[str, str]
-    ) -> None:
+    async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
         """Override: per-connection long-running platform task.
 
         Spawned when the discovery SSE emits ``added`` for this
@@ -215,12 +235,23 @@ class HttpConnector:
         metadata: dict[str, Any] | None = None,
         timestamp: str | None = None,
         event_id: str | None = None,
-    ) -> dict[str, Any]:
+        raise_on_4xx: bool = False,
+    ) -> dict[str, Any] | None:
         """Forward a platform inbound to aios for ``connection_id``.
 
         Idempotent on ``event_id``.  ``attachments`` is a list of
         ``(filename, bytes, content_type)`` tuples that ride as
         multipart parts.
+
+        Routine 4xx responses (a 422 from one malformed envelope, a 400
+        from a stale connection_id mid-removal) drop the envelope and
+        return ``None`` so one bad inbound can't tear down the whole
+        container via the parent TaskGroup.  ``401`` / ``403`` (auth
+        broken — runtime token revoked or misconfigured) and ``5xx``
+        (server outage / bug) still raise: those are container-level
+        problems that warrant the crash-and-restart loop.  Pass
+        ``raise_on_4xx=True`` if a specific call site needs the old
+        strict behavior.
         """
         client = self._require_client()
         eid = event_id or str(ULID())
@@ -246,9 +277,7 @@ class HttpConnector:
             ("sender", (None, json.dumps(sender).encode(), "text/plain")),
         ]
         if metadata is not None:
-            files.append(
-                ("metadata", (None, json.dumps(metadata).encode(), "text/plain"))
-            )
+            files.append(("metadata", (None, json.dumps(metadata).encode(), "text/plain")))
         if timestamp is not None:
             files.append(("timestamp", (None, timestamp.encode(), "text/plain")))
         for filename, blob, content_type in attachments or []:
@@ -262,21 +291,51 @@ class HttpConnector:
             # ``response.raise_for_status()`` discards the body, which is
             # exactly where FastAPI's validation diagnostics live for a 422
             # (and where our error envelope lives for everything else).  Log
-            # the body verbatim before raising so the operator has the field
-            # path / message in the container log instead of just the bare
-            # status + URL from ``httpx.HTTPStatusError``.
-            body = response.text
+            # the body verbatim so the operator has the field path /
+            # message in the container log instead of just the bare status
+            # + URL from ``httpx.HTTPStatusError``.
+            sc = response.status_code
             log.warning(
                 "connector.inbound.failed",
-                status_code=response.status_code,
+                status_code=sc,
                 event_id=eid,
                 connection_id=connection_id,
-                body=body[:2000],
+                body=response.text[:2000],
             )
-        response.raise_for_status()
+            if raise_on_4xx or sc in (401, 403) or sc >= 500:
+                response.raise_for_status()
+            return None
         return dict(response.json())
 
     # ─── runner ──────────────────────────────────────────────────────
+
+    async def run_until_stopped(self, *, install_signal_handlers: bool = True) -> None:
+        """Run the connector until SIGINT/SIGTERM (or cancelled).
+
+        Wraps :meth:`run` with a process-level stop signal: a SIGTERM
+        (the Docker stop signal) or SIGINT (Ctrl-C) cancels the run
+        task cleanly so :meth:`teardown` fires.  ``asyncio.run`` traps
+        SIGINT by default but **not** SIGTERM — without this handler,
+        ``docker stop`` would kill Python before subclasses get a
+        chance to clean up subprocesses, sockets, etc.  Pass
+        ``install_signal_handlers=False`` from tests that drive
+        cancellation directly.
+        """
+        stop = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        if install_signal_handlers:
+            for sig in (_signal.SIGINT, _signal.SIGTERM):
+                loop.add_signal_handler(sig, stop.set)
+        run_task = asyncio.create_task(self.run(), name=f"aios-{self.connector}-run")
+        stop_task = asyncio.create_task(stop.wait(), name=f"aios-{self.connector}-stop-wait")
+        try:
+            await asyncio.wait({run_task, stop_task}, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            stop_task.cancel()
+            if not run_task.done():
+                run_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await run_task
 
     async def run(self) -> None:
         """Open the client, publish tools, race discovery + tool loops."""
@@ -307,9 +366,7 @@ class HttpConnector:
         body = ToolsSchemaUpdate(
             tools=[ToolsSchemaUpdateToolsItem.from_dict(spec) for spec in specs]
         )
-        response = await _put_tools_schema(
-            client=client, connector=self.connector, body=body
-        )
+        response = await _put_tools_schema(client=client, connector=self.connector, body=body)
         if response.status_code >= 400:
             raise RuntimeError(
                 f"failed to publish tools schema: {response.status_code} {response.content!r}"
@@ -388,21 +445,15 @@ class HttpConnector:
             )
         body = response.parsed
         if body is None or isinstance(body, HTTPValidationError):
-            raise RuntimeError(
-                f"unparseable secrets response for connection {connection_id!r}"
-            )
+            raise RuntimeError(f"unparseable secrets response for connection {connection_id!r}")
         raw_secrets = body.secrets
         if isinstance(raw_secrets, Unset):
             secrets_map: dict[str, str] = {}
         else:
-            secrets_map = {
-                str(k): str(v) for k, v in raw_secrets.additional_properties.items()
-            }
-        state = _ConnectionState(
-            connection_id=connection_id, account=account, secrets=secrets_map
-        )
+            secrets_map = {str(k): str(v) for k, v in raw_secrets.additional_properties.items()}
+        state = _ConnectionState(connection_id=connection_id, account=account, secrets=secrets_map)
         state.worker = tg.create_task(
-            self.serve_connection(connection_id, secrets_map),
+            self._isolated_serve_connection(connection_id, secrets_map),
             name=f"aios-conn-{connection_id}",
         )
         self._connections[connection_id] = state
@@ -412,6 +463,27 @@ class HttpConnector:
             connection_id=connection_id,
             account=account,
         )
+
+    async def _isolated_serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
+        """Run :meth:`serve_connection` with failure-isolated cleanup.
+
+        Catches any non-``CancelledError`` exception so a single bad
+        connection (typo'd secret, unregistered phone, revoked bot
+        token) can't tear down sibling connections via the parent
+        TaskGroup.  Always pops the user-state slot on exit so
+        connections cycling in/out don't leak stale state.
+        """
+        try:
+            await self.serve_connection(connection_id, secrets)
+        except Exception as exc:
+            log.exception(
+                "connector.connection.serve_failed",
+                connector=self.connector,
+                connection_id=connection_id,
+                error=type(exc).__name__,
+            )
+        finally:
+            self.state.pop(connection_id, None)
 
     async def _on_connection_removed(self, connection_id: str) -> None:
         """Cancel the worker task for a vanished connection."""
@@ -610,7 +682,14 @@ class HttpConnector:
             connection_id=connection_id,
             session_id=session_id,
             tool_call_id=tool_call_id,
-            content=content,
+            # The generated wrapper narrows ``content`` to
+            # ``str | list[RuntimeToolResultRequestContentType1Item]``;
+            # we pass ``list[dict[str, Any]]`` whose items are
+            # structurally compatible with the content-block model.
+            # Re-shaping at this boundary would duplicate the wire
+            # schema in Python without adding any safety the generated
+            # POST doesn't already enforce.
+            content=content,  # type: ignore[arg-type]
             is_error=is_error,
         )
         response = await _post_runtime_tool_result(client=client, body=body)
@@ -738,11 +817,7 @@ def _inject_focal_kwargs(
     pass it explicitly.
     """
     out = dict(args)
-    if (
-        connection_id
-        and "connection_id" in meta.focal_params
-        and "connection_id" not in out
-    ):
+    if connection_id and "connection_id" in meta.focal_params and "connection_id" not in out:
         out["connection_id"] = connection_id
     if focal_channel and meta.focal_params & {"account", "chat_id"}:
         parts = focal_channel.split("/", 2)
@@ -753,5 +828,3 @@ def _inject_focal_kwargs(
             if "chat_id" in meta.focal_params and "chat_id" not in out:
                 out["chat_id"] = chat_id
     return out
-
-

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -173,11 +173,7 @@ class HttpConnector:
         self._tools: dict[str, _ToolMeta] = self._collect_tools()
         self._answered: set[str] = set()
         self._connections: dict[str, _ConnectionState] = {}
-        # User-state slot for subclasses: per-connection objects keyed
-        # by connection_id.  Subclasses populate this inside their
-        # :meth:`serve_connection`; the SDK auto-pops on serve exit so
-        # tool methods always read fresh state.  Narrow the value type
-        # via attribute annotation in the subclass body, e.g.::
+        # Subclasses narrow the value type via a class-body annotation::
         #
         #     class SignalConnector(HttpConnector):
         #         state: dict[str, _SignalConnectionState]
@@ -630,9 +626,9 @@ class HttpConnector:
         except Exception as exc:
             # Tool-call SSE backfill can deliver a call for ``connection_id``
             # before the connection-discovery SSE has finished registering
-            # the connection's state in the connector's ``_conn_state`` dict
+            # the connection's state in the connector's ``state`` dict
             # (the two streams are independent).  The tool method's
-            # ``self._conn_state[connection_id]`` lookup KeyErrors and the
+            # ``self.state[connection_id]`` lookup KeyErrors and the
             # raw ``str(KeyError("'conn_01...'"))`` reaches the model as an
             # opaque quoted ID with no indication that the connection just
             # wasn't ready yet.  Detect that shape and produce an

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -145,9 +145,7 @@ class TestDispatch:
         body = json.loads(r.kwargs["content"])
         assert "unknown tool" in body["error"]
 
-    async def test_exception_in_tool_becomes_error_result(
-        self, probe: _ProbeConnector
-    ) -> None:
+    async def test_exception_in_tool_becomes_error_result(self, probe: _ProbeConnector) -> None:
         await probe.dispatch_call(
             {
                 "connection_id": "conn_1",
@@ -162,9 +160,7 @@ class TestDispatch:
         body = json.loads(r.kwargs["content"])
         assert body["error"] == "kaboom"
 
-    async def test_malformed_arguments_dispatched_as_empty(
-        self, probe: _ProbeConnector
-    ) -> None:
+    async def test_malformed_arguments_dispatched_as_empty(self, probe: _ProbeConnector) -> None:
         await probe.dispatch_call(
             {
                 "connection_id": "conn_1",
@@ -302,9 +298,7 @@ class TestFocalChannelInjection:
                 "focal_channel": "signal/+15551234/group-abc",
             }
         )
-        assert c.focal_calls == [
-            {"account": "+15551234", "chat_id": "group-abc", "text": "hi"}
-        ]
+        assert c.focal_calls == [{"account": "+15551234", "chat_id": "group-abc", "text": "hi"}]
 
     async def test_injects_connection_id_when_signature_accepts(self) -> None:
         c = _FocalConnector()
@@ -376,7 +370,7 @@ class TestLogging:
         # Patch the underlying async httpx client so emit_inbound's POST
         # is a no-op returning a stub response.
         mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
+        mock_response.is_error = False
         mock_response.json = MagicMock(return_value={"appended_event_id": "evt_x"})
         mock_post = AsyncMock(return_value=mock_response)
         probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
@@ -395,12 +389,10 @@ class TestLogging:
         assert rec["sender"] == {"id": 99, "name": "alice"}
         assert rec["connection_id"] == "conn_1"
 
-    async def test_emit_inbound_does_not_log_message_content(
-        self, probe: _ProbeConnector
-    ) -> None:
+    async def test_emit_inbound_does_not_log_message_content(self, probe: _ProbeConnector) -> None:
         """Message bodies are user data — log length, not content."""
         mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
+        mock_response.is_error = False
         mock_response.json = MagicMock(return_value={"appended_event_id": "evt_x"})
         mock_post = AsyncMock(return_value=mock_response)
         probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
@@ -416,18 +408,16 @@ class TestLogging:
             for v in r.values():
                 assert secret_body not in str(v), f"content leaked into log field: {r}"
 
-    async def test_emit_inbound_logs_response_body_on_error(
+    async def test_emit_inbound_logs_response_body_on_4xx_then_drops(
         self, probe: _ProbeConnector
     ) -> None:
         """When the api rejects an inbound (e.g. FastAPI 422 validation),
-        the response body carries the diagnostic — which field, why.
-        ``response.raise_for_status()`` discards it, so the connector must
-        log the body explicitly before raising or the operator only sees a
-        bare ``HTTPStatusError: 422`` in the crash traceback with no clue
-        what triggered the rejection.
+        the response body carries the diagnostic — which field, why.  The
+        body is logged before the envelope drops so the operator has the
+        field path / message in the container log.  ``None`` return
+        signals the drop so callers can skip downstream work (read
+        receipts, side-effects) without inspecting the result shape.
         """
-        import httpx
-
         validation_body = (
             '{"error":{"type":"validation_error","detail":'
             '{"errors":[{"type":"missing","loc":["body","content"],'
@@ -437,24 +427,17 @@ class TestLogging:
         mock_response.is_error = True
         mock_response.status_code = 422
         mock_response.text = validation_body
-        mock_response.raise_for_status = MagicMock(
-            side_effect=httpx.HTTPStatusError(
-                "422 Unprocessable Content", request=MagicMock(), response=mock_response
-            )
-        )
         mock_post = AsyncMock(return_value=mock_response)
         probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
 
-        with (
-            structlog.testing.capture_logs() as records,
-            pytest.raises(httpx.HTTPStatusError),
-        ):
-            await probe.emit_inbound(
+        with structlog.testing.capture_logs() as records:
+            result = await probe.emit_inbound(
                 connection_id="conn_1",
                 chat_id="c",
                 sender={"id": 1},
                 content="",
             )
+        assert result is None
         failed = [r for r in records if r.get("event") == "connector.inbound.failed"]
         assert len(failed) == 1, "expected one connector.inbound.failed record"
         assert failed[0]["status_code"] == 422
@@ -557,9 +540,7 @@ class TestLogging:
         failed = [r for r in records if r["event"] == "connector.tool_call.failed"]
         assert failed[0]["reason"] == "tool_exception"
 
-    async def test_dispatch_call_logs_failed_on_unknown_tool(
-        self, probe: _ProbeConnector
-    ) -> None:
+    async def test_dispatch_call_logs_failed_on_unknown_tool(self, probe: _ProbeConnector) -> None:
         with structlog.testing.capture_logs() as records:
             await probe.dispatch_call(
                 {
@@ -580,9 +561,7 @@ class TestMultiConnectionDispatch:
     """The new shape's headline property: one runner, N connections,
     dispatch routes by ``connection_id`` on the call payload."""
 
-    async def test_two_connections_dispatched_independently(
-        self, probe: _ProbeConnector
-    ) -> None:
+    async def test_two_connections_dispatched_independently(self, probe: _ProbeConnector) -> None:
         await probe.dispatch_call(
             {
                 "connection_id": "conn_A",
@@ -606,3 +585,190 @@ class TestMultiConnectionDispatch:
         assert probe.results[0].kwargs["session_id"] == "sess_A"
         assert probe.results[1].kwargs["connection_id"] == "conn_B"
         assert probe.results[1].kwargs["session_id"] == "sess_B"
+
+
+class TestEmitInbound4xxDrop:
+    """``emit_inbound`` defaults to drop-and-continue on routine 4xx so
+    one bad envelope can't tear down sibling connections via the parent
+    TaskGroup.  Auth-broken (401/403) and 5xx still raise."""
+
+    async def test_drops_422_returns_none(self, probe: _ProbeConnector) -> None:
+        mock_response = MagicMock()
+        mock_response.is_error = True
+        mock_response.status_code = 422
+        mock_response.text = "validation error body"
+        mock_post = AsyncMock(return_value=mock_response)
+        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
+        result = await probe.emit_inbound(
+            connection_id="conn_1",
+            chat_id="c",
+            sender={"id": 1},
+            content="bad",
+        )
+        assert result is None
+
+    async def test_drops_400_returns_none(self, probe: _ProbeConnector) -> None:
+        mock_response = MagicMock()
+        mock_response.is_error = True
+        mock_response.status_code = 400
+        mock_response.text = "bad request"
+        mock_post = AsyncMock(return_value=mock_response)
+        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
+        result = await probe.emit_inbound(
+            connection_id="conn_1", chat_id="c", sender={"id": 1}, content=""
+        )
+        assert result is None
+
+    @pytest.mark.parametrize("status_code", [401, 403, 500, 502, 503])
+    async def test_raises_on_auth_and_5xx(self, probe: _ProbeConnector, status_code: int) -> None:
+        import httpx as _httpx
+
+        mock_response = MagicMock()
+        mock_response.is_error = True
+        mock_response.status_code = status_code
+        mock_response.text = "auth or server error"
+        mock_response.raise_for_status = MagicMock(
+            side_effect=_httpx.HTTPStatusError(
+                f"{status_code}", request=MagicMock(), response=mock_response
+            )
+        )
+        mock_post = AsyncMock(return_value=mock_response)
+        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
+        with pytest.raises(_httpx.HTTPStatusError):
+            await probe.emit_inbound(
+                connection_id="conn_1", chat_id="c", sender={"id": 1}, content=""
+            )
+
+    async def test_raise_on_4xx_escape_hatch(self, probe: _ProbeConnector) -> None:
+        """Callers that need the old strict behavior pass ``raise_on_4xx=True``."""
+        import httpx as _httpx
+
+        mock_response = MagicMock()
+        mock_response.is_error = True
+        mock_response.status_code = 422
+        mock_response.text = "validation"
+        mock_response.raise_for_status = MagicMock(
+            side_effect=_httpx.HTTPStatusError("422", request=MagicMock(), response=mock_response)
+        )
+        mock_post = AsyncMock(return_value=mock_response)
+        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
+        with pytest.raises(_httpx.HTTPStatusError):
+            await probe.emit_inbound(
+                connection_id="conn_1",
+                chat_id="c",
+                sender={"id": 1},
+                content="",
+                raise_on_4xx=True,
+            )
+
+
+class TestFocalChannelHelper:
+    async def test_returns_canonical_string(self, probe: _ProbeConnector) -> None:
+        assert probe.focal_channel("account-x", "chat-42") == "probe/account-x/chat-42"
+
+    async def test_uses_subclass_connector_attr(self) -> None:
+        class Other(HttpConnector):
+            connector = "myplatform"
+
+        c = Other(base_url="http://x", token="aios_runtime_x")
+        assert c.focal_channel("a", "c") == "myplatform/a/c"
+
+
+class TestIsolatedServeConnection:
+    """``_isolated_serve_connection`` wraps ``serve_connection`` so a
+    bad bring-up (typo'd secret, unregistered phone) doesn't tear down
+    sibling connections via the parent TaskGroup.  Always pops the
+    user-state slot on exit."""
+
+    async def test_swallows_non_cancel_exception(self, probe: _ProbeConnector) -> None:
+        class _CrashingConnector(HttpConnector):
+            connector = "crashy"
+
+            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
+                raise RuntimeError("daemon refused this phone")
+
+        c = _CrashingConnector(base_url="http://x", token="aios_runtime_x")
+        with structlog.testing.capture_logs() as records:
+            # Should NOT raise.
+            await c._isolated_serve_connection("conn_1", {"phone": "+1..."})
+        failed = [r for r in records if r["event"] == "connector.connection.serve_failed"]
+        assert len(failed) == 1
+        assert failed[0]["connection_id"] == "conn_1"
+        assert failed[0]["error"] == "RuntimeError"
+
+    async def test_pops_state_on_clean_exit(self, probe: _ProbeConnector) -> None:
+
+        class _Connector(HttpConnector):
+            connector = "withstate"
+
+            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
+                self.state[connection_id] = {"loaded": True}
+                # Return cleanly (simulates _on_connection_removed cancel
+                # path collapsing onto a clean exit).
+                return
+
+        c = _Connector(base_url="http://x", token="aios_runtime_x")
+        await c._isolated_serve_connection("conn_1", {})
+        assert "conn_1" not in c.state
+
+    async def test_pops_state_on_cancel(self) -> None:
+        import asyncio as _asyncio
+        import contextlib as _contextlib
+
+        class _Connector(HttpConnector):
+            connector = "withstate"
+
+            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
+                self.state[connection_id] = {"loaded": True}
+                await _asyncio.Event().wait()
+
+        c = _Connector(base_url="http://x", token="aios_runtime_x")
+        task = _asyncio.create_task(c._isolated_serve_connection("conn_1", {}))
+        await _asyncio.sleep(0)  # let serve_connection populate state
+        assert "conn_1" in c.state
+        task.cancel()
+        with _contextlib.suppress(_asyncio.CancelledError):
+            await task
+        assert "conn_1" not in c.state
+
+
+class TestRunUntilStopped:
+    """``run_until_stopped`` wraps ``run`` with cancel-on-stop so SIGTERM
+    fires ``teardown``.  Tests drive cancellation via the run task; the
+    process-level signal handler is exercised separately by hand or e2e."""
+
+    async def test_cancel_propagates_and_teardown_runs(self) -> None:
+        import asyncio as _asyncio
+        import contextlib as _contextlib
+
+        teardown_called = _asyncio.Event()
+
+        class _Connector(HttpConnector):
+            connector = "stoppable"
+
+            async def run(self) -> None:
+                try:
+                    await _asyncio.Event().wait()
+                finally:
+                    teardown_called.set()
+
+        c = _Connector(base_url="http://x", token="aios_runtime_x")
+        task = _asyncio.create_task(c.run_until_stopped(install_signal_handlers=False))
+        await _asyncio.sleep(0.01)
+        task.cancel()
+        with _contextlib.suppress(_asyncio.CancelledError):
+            await task
+        assert teardown_called.is_set(), "run's finally should have fired"
+
+    async def test_run_returns_naturally(self) -> None:
+        """If ``run`` returns on its own (e.g. SSE closes cleanly),
+        ``run_until_stopped`` returns without raising."""
+
+        class _Connector(HttpConnector):
+            connector = "shortlived"
+
+            async def run(self) -> None:
+                return
+
+        c = _Connector(base_url="http://x", token="aios_runtime_x")
+        await c.run_until_stopped(install_signal_handlers=False)

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -12,10 +12,13 @@ is intercepted by mocking the underlying ``httpx.AsyncClient.post``.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 import structlog
 from aios_connector_http import HttpConnector, tool
@@ -588,30 +591,18 @@ class TestMultiConnectionDispatch:
 
 
 class TestEmitInbound4xxDrop:
-    """``emit_inbound`` defaults to drop-and-continue on routine 4xx so
-    one bad envelope can't tear down sibling connections via the parent
+    """``emit_inbound`` drops-and-continues on routine 4xx so one bad
+    envelope can't tear down sibling connections via the parent
     TaskGroup.  Auth-broken (401/403) and 5xx still raise."""
 
-    async def test_drops_422_returns_none(self, probe: _ProbeConnector) -> None:
+    @pytest.mark.parametrize("status_code", [422, 400])
+    async def test_drops_routine_4xx_returns_none(
+        self, probe: _ProbeConnector, status_code: int
+    ) -> None:
         mock_response = MagicMock()
         mock_response.is_error = True
-        mock_response.status_code = 422
-        mock_response.text = "validation error body"
-        mock_post = AsyncMock(return_value=mock_response)
-        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
-        result = await probe.emit_inbound(
-            connection_id="conn_1",
-            chat_id="c",
-            sender={"id": 1},
-            content="bad",
-        )
-        assert result is None
-
-    async def test_drops_400_returns_none(self, probe: _ProbeConnector) -> None:
-        mock_response = MagicMock()
-        mock_response.is_error = True
-        mock_response.status_code = 400
-        mock_response.text = "bad request"
+        mock_response.status_code = status_code
+        mock_response.text = "diagnostic body"
         mock_post = AsyncMock(return_value=mock_response)
         probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
         result = await probe.emit_inbound(
@@ -619,59 +610,30 @@ class TestEmitInbound4xxDrop:
         )
         assert result is None
 
-    @pytest.mark.parametrize("status_code", [401, 403, 500, 502, 503])
-    async def test_raises_on_auth_and_5xx(self, probe: _ProbeConnector, status_code: int) -> None:
-        import httpx as _httpx
-
+    @pytest.mark.parametrize("status_code", [401, 500])
+    async def test_raises_on_auth_and_5xx(
+        self, probe: _ProbeConnector, status_code: int
+    ) -> None:
         mock_response = MagicMock()
         mock_response.is_error = True
         mock_response.status_code = status_code
         mock_response.text = "auth or server error"
         mock_response.raise_for_status = MagicMock(
-            side_effect=_httpx.HTTPStatusError(
+            side_effect=httpx.HTTPStatusError(
                 f"{status_code}", request=MagicMock(), response=mock_response
             )
         )
         mock_post = AsyncMock(return_value=mock_response)
         probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
-        with pytest.raises(_httpx.HTTPStatusError):
+        with pytest.raises(httpx.HTTPStatusError):
             await probe.emit_inbound(
                 connection_id="conn_1", chat_id="c", sender={"id": 1}, content=""
-            )
-
-    async def test_raise_on_4xx_escape_hatch(self, probe: _ProbeConnector) -> None:
-        """Callers that need the old strict behavior pass ``raise_on_4xx=True``."""
-        import httpx as _httpx
-
-        mock_response = MagicMock()
-        mock_response.is_error = True
-        mock_response.status_code = 422
-        mock_response.text = "validation"
-        mock_response.raise_for_status = MagicMock(
-            side_effect=_httpx.HTTPStatusError("422", request=MagicMock(), response=mock_response)
-        )
-        mock_post = AsyncMock(return_value=mock_response)
-        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
-        with pytest.raises(_httpx.HTTPStatusError):
-            await probe.emit_inbound(
-                connection_id="conn_1",
-                chat_id="c",
-                sender={"id": 1},
-                content="",
-                raise_on_4xx=True,
             )
 
 
 class TestFocalChannelHelper:
     async def test_returns_canonical_string(self, probe: _ProbeConnector) -> None:
         assert probe.focal_channel("account-x", "chat-42") == "probe/account-x/chat-42"
-
-    async def test_uses_subclass_connector_attr(self) -> None:
-        class Other(HttpConnector):
-            connector = "myplatform"
-
-        c = Other(base_url="http://x", token="aios_runtime_x")
-        assert c.focal_channel("a", "c") == "myplatform/a/c"
 
 
 class TestIsolatedServeConnection:
@@ -680,7 +642,7 @@ class TestIsolatedServeConnection:
     sibling connections via the parent TaskGroup.  Always pops the
     user-state slot on exit."""
 
-    async def test_swallows_non_cancel_exception(self, probe: _ProbeConnector) -> None:
+    async def test_swallows_non_cancel_exception(self) -> None:
         class _CrashingConnector(HttpConnector):
             connector = "crashy"
 
@@ -696,67 +658,46 @@ class TestIsolatedServeConnection:
         assert failed[0]["connection_id"] == "conn_1"
         assert failed[0]["error"] == "RuntimeError"
 
-    async def test_pops_state_on_clean_exit(self, probe: _ProbeConnector) -> None:
-
-        class _Connector(HttpConnector):
-            connector = "withstate"
-
-            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
-                self.state[connection_id] = {"loaded": True}
-                # Return cleanly (simulates _on_connection_removed cancel
-                # path collapsing onto a clean exit).
-                return
-
-        c = _Connector(base_url="http://x", token="aios_runtime_x")
-        await c._isolated_serve_connection("conn_1", {})
-        assert "conn_1" not in c.state
-
     async def test_pops_state_on_cancel(self) -> None:
-        import asyncio as _asyncio
-        import contextlib as _contextlib
-
         class _Connector(HttpConnector):
             connector = "withstate"
 
             async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
                 self.state[connection_id] = {"loaded": True}
-                await _asyncio.Event().wait()
+                await asyncio.Event().wait()
 
         c = _Connector(base_url="http://x", token="aios_runtime_x")
-        task = _asyncio.create_task(c._isolated_serve_connection("conn_1", {}))
-        await _asyncio.sleep(0)  # let serve_connection populate state
+        task = asyncio.create_task(c._isolated_serve_connection("conn_1", {}))
+        await asyncio.sleep(0)  # let serve_connection populate state
         assert "conn_1" in c.state
         task.cancel()
-        with _contextlib.suppress(_asyncio.CancelledError):
+        with contextlib.suppress(asyncio.CancelledError):
             await task
         assert "conn_1" not in c.state
 
 
 class TestRunUntilStopped:
     """``run_until_stopped`` wraps ``run`` with cancel-on-stop so SIGTERM
-    fires ``teardown``.  Tests drive cancellation via the run task; the
+    fires ``teardown``.  Tests drive cancellation directly; the
     process-level signal handler is exercised separately by hand or e2e."""
 
     async def test_cancel_propagates_and_teardown_runs(self) -> None:
-        import asyncio as _asyncio
-        import contextlib as _contextlib
-
-        teardown_called = _asyncio.Event()
+        teardown_called = asyncio.Event()
 
         class _Connector(HttpConnector):
             connector = "stoppable"
 
             async def run(self) -> None:
                 try:
-                    await _asyncio.Event().wait()
+                    await asyncio.Event().wait()
                 finally:
                     teardown_called.set()
 
         c = _Connector(base_url="http://x", token="aios_runtime_x")
-        task = _asyncio.create_task(c.run_until_stopped(install_signal_handlers=False))
-        await _asyncio.sleep(0.01)
+        task = asyncio.create_task(c.run_until_stopped(install_signal_handlers=False))
+        await asyncio.sleep(0.01)
         task.cancel()
-        with _contextlib.suppress(_asyncio.CancelledError):
+        with contextlib.suppress(asyncio.CancelledError):
             await task
         assert teardown_called.is_set(), "run's finally should have fired"
 

--- a/packages/aios-connector-http/tests/test_sandbox.py
+++ b/packages/aios-connector-http/tests/test_sandbox.py
@@ -114,7 +114,9 @@ class TestAttachmentParams:
     def test_oversize_rejected(self, tmp_path: Path) -> None:
         path = tmp_path / "big.bin"
         path.write_bytes(b"\0" * (5 * 1024 * 1024 + 1))
-        att = Attachment(host_path=str(path), filename="big.bin", content_type="application/octet-stream")
+        att = Attachment(
+            host_path=str(path), filename="big.bin", content_type="application/octet-stream"
+        )
         with pytest.raises(AttachmentError, match="5242880 bytes"):
             att.as_params()
 
@@ -203,9 +205,7 @@ class TestDispatchSandboxPathResolution:
                 "tool_call_id": "c2",
                 "session_id": "sess_1",
                 "name": "send_many",
-                "arguments": json.dumps(
-                    {"paths": ["/workspace/photo.jpg", "/workspace/doc.pdf"]}
-                ),
+                "arguments": json.dumps({"paths": ["/workspace/photo.jpg", "/workspace/doc.pdf"]}),
             }
         )
         paths = consumer.calls[0]["paths"]

--- a/packages/aios-connector-http/tests/test_schema.py
+++ b/packages/aios-connector-http/tests/test_schema.py
@@ -148,9 +148,7 @@ class TestRequiredAndDefaults:
     def test_required_excludes_defaulted_keeps_undefaulted(self) -> None:
         class C(_DummyForBindings):
             @tool()
-            async def t(
-                self, *, must: str, maybe: int = 7, also: bool = False
-            ) -> str:
+            async def t(self, *, must: str, maybe: int = 7, also: bool = False) -> str:
                 return f"{must} {maybe} {also}"
 
         spec = derive_tool_spec("t", C().t)

--- a/packages/aios-sdk/aios_sdk/streaming.py
+++ b/packages/aios-sdk/aios_sdk/streaming.py
@@ -135,9 +135,7 @@ async def stream_connection_discovery(
         yield msg
 
 
-async def _stream_sse(
-    httpx_client: httpx.AsyncClient, path: str
-) -> AsyncIterator[SseMessage]:
+async def _stream_sse(httpx_client: httpx.AsyncClient, path: str) -> AsyncIterator[SseMessage]:
     """Open an SSE stream against ``path`` and yield parsed messages."""
     async with httpx_client.stream(
         "GET",

--- a/tests/e2e/test_signal_connector.py
+++ b/tests/e2e/test_signal_connector.py
@@ -392,12 +392,12 @@ class TestSignalMultiConnection:
         connector_task = asyncio.create_task(connector.run())
         rpc_call: AsyncMock = mocked_signal_daemon["rpc_call"]
         try:
-            # Let discovery + serve_connection populate ``_conn_state``
-            # before driving the tool call — without this, the calls-SSE
+            # Let discovery + serve_connection populate ``state`` before
+            # driving the tool call — without this, the calls-SSE
             # backfill can dispatch ``signal_send`` before
-            # ``serve_connection`` populates ``_conn_state`` and the
-            # handler ``KeyError``s on the connection_id (CI loses this
-            # race; local dev usually wins it).
+            # ``serve_connection`` populates ``state`` and the handler
+            # ``KeyError``s on the connection_id (CI loses this race;
+            # local dev usually wins it).
             await asyncio.sleep(0.5)
 
             await harness.run_step(session_a.id)

--- a/tests/e2e/test_telegram_connector.py
+++ b/tests/e2e/test_telegram_connector.py
@@ -256,12 +256,12 @@ class TestTelegramMultiConnection:
 
         connector_task = asyncio.create_task(connector.run())
         try:
-            # Let discovery + serve_connection populate ``_conn_state``
-            # before driving the tool call — without this, the calls-SSE
+            # Let discovery + serve_connection populate ``state`` before
+            # driving the tool call — without this, the calls-SSE
             # backfill can dispatch ``telegram_send`` before
-            # ``serve_connection`` populates ``_conn_state`` and the
-            # handler ``KeyError``s on the connection_id (CI loses this
-            # race; local dev usually wins it).
+            # ``serve_connection`` populates ``state`` and the handler
+            # ``KeyError``s on the connection_id (CI loses this race;
+            # local dev usually wins it).
             await asyncio.sleep(0.5)
 
             await harness.run_step(session_a.id)


### PR DESCRIPTION
## Summary

Closes #347; also resolves #346.

Three of the smoke fixes in PR #344 landed in **signal-specific** code paths (SIGTERM trap in `aios_signal/__main__.py`, 4xx drop-and-continue in `_handle_envelope`).  **Telegram inherited none of the hardening** — same footguns, same blast radius.  This PR moves the duplicated lifecycle plumbing onto `HttpConnector` so both connectors get the fix in one place, and bakes in the per-connection bring-up isolation that #346 was tracking.

## SDK additions (`packages/aios-connector-http/aios_connector_http/runner.py`)

| Addition | What it does |
|---|---|
| `state: dict[str, Any]` slot | Per-connection user-state, auto-popped on serve exit.  Subclasses narrow via attribute annotation (`state: dict[str, _SignalConnectionState]`). |
| `focal_channel(account, chat_id)` | Canonical `<connector>/<account>/<chat_id>` formatter. |
| `run_until_stopped(*, install_signal_handlers=True)` | Wraps `run()` with SIGINT/SIGTERM → cancel-on-stop so `teardown` fires on `docker stop`. |
| `_isolated_serve_connection` | Wraps `serve_connection` so one bad bring-up (typo'd phone, revoked bot token, secrets glitch) can't tear down sibling connections.  Closes #346. |
| `emit_inbound` returns `None` on routine 4xx | Drop-and-continue baked into the SDK; 401/403/5xx still raise via `_is_fatal_inbound_status`. |

## Connector deltas

- `aios_signal/__main__.py`: 50 LOC of signal/Event plumbing → one `asyncio.run(SignalConnector(Settings()).run_until_stopped())`.
- `aios_signal/connector.py`: drop the `except httpx.HTTPStatusError` block (SDK owns 4xx now); rename `_conn_state` → `state` + drop the finally-pop.
- `aios_telegram/__main__.py`: `asyncio.run(TelegramConnector().run_until_stopped())` (was a bare `run()` — no SIGTERM trap, the PTB updater's `getUpdates` long-poll would orphan on `docker stop`).
- `aios_telegram/connector.py`: same `_conn_state` → `state` rename + finally-pop drop.
- `aios_echo_http/connector.py`: explicit `if result is None: raise` so the test tool still surfaces validation failures loudly.

## Broken-windows fixes flagged by the pass

- PR #344's removal of `# type: ignore[arg-type]` on `_post_tool_result`'s `content=` was overoptimistic; restored with the reason.
- `ruff format` picked up assorted long-line drift in `aios-sdk/streaming.py` + several test files.  Mechanical wrap-fixes only.

## /simplify findings addressed (commit 2)

- `raise_on_4xx` flag removed — YAGNI; echo-http checks `None` itself.
- `_is_fatal_inbound_status(sc)` helper extracted.
- `loop.remove_signal_handler` pair added so embedded callers don't leak.
- Narrating comments / docstrings trimmed.
- Test bloat consolidated (5 redundant tests → parametrized / merged).

## Test plan
- [x] `uv run mypy src packages/aios-sdk/aios_sdk packages/aios-connector-http/aios_connector_http connectors/{signal,telegram,echo-http}/src/aios_*` — clean
- [x] `uv run ruff check && ruff format --check` — clean
- [x] `uv run pytest tests/unit` — 1154 passed
- [x] `packages/aios-connector-http` tests — 67 passed
- [x] `connectors/signal` tests — 146 passed
- [x] `connectors/telegram` tests — 76 passed
- [ ] CI green on validate
- [ ] Live smoke: signal + telegram connectors restart cleanly on `docker stop`; failed `serve_connection` no longer tears down sibling connections (#346)

🤖 Generated with [Claude Code](https://claude.com/claude-code)