### PR TITLE
fix(vision): byte-sniff image mime at SDK boundary and renderer

### DIFF
--- a/packages/aios-connector-http/aios_connector_http/mime.py
+++ b/packages/aios-connector-http/aios_connector_http/mime.py
@@ -1,0 +1,24 @@
+"""Magic-byte image-mime detector.
+
+Anthropic's ``/v1/messages`` validates declared mime against actual
+bytes and 400s on mismatch; inbound platform metadata occasionally
+disagrees with the bytes, so callers re-detect rather than trust the
+declaration.
+"""
+
+from __future__ import annotations
+
+_IMAGE_MAGIC: tuple[tuple[bytes, str], ...] = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+)
+
+
+def sniff_image_mime(data: bytes) -> str | None:
+    """Return the detected mime, or ``None`` for short or unrecognised bytes."""
+    for sig, mime in _IMAGE_MAGIC:
+        if data.startswith(sig):
+            return mime
+    return None

--- a/packages/aios-connector-http/aios_connector_http/sandbox.py
+++ b/packages/aios-connector-http/aios_connector_http/sandbox.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Any
 
+from aios_connector_http.mime import sniff_image_mime
+
 # Trailing slash on _WORKSPACE_PREFIX is load-bearing — prevents
 # ``/workspaces/foo`` matching ``/workspace``.
 _WORKSPACE_PREFIX = "/workspace/"
@@ -132,6 +134,10 @@ class Attachment:
         exceeds the 5 MiB cap.  Stat'ing here rather than at construction
         lets callers build :class:`Attachment` instances before their
         backing files are fully written.
+
+        For image attachments, the declared ``content_type`` is
+        reconciled against the actual magic bytes — Anthropic rejects
+        mime-vs-magic mismatches, so the truth must reach the event log.
         """
         try:
             st = os.stat(self.host_path)
@@ -146,9 +152,15 @@ class Attachment:
                 f"attachment {self.filename!r} is {st.st_size} bytes; "
                 f"SDK cap is {_MAX_ATTACHMENT_BYTES} bytes (5 MiB)."
             )
+        content_type = self.content_type
+        if content_type.startswith("image/"):
+            with open(self.host_path, "rb") as f:
+                sniffed = sniff_image_mime(f.read(16))
+            if sniffed is not None:
+                content_type = sniffed
         return {
             "host_path": self.host_path,
             "filename": self.filename,
-            "content_type": self.content_type,
+            "content_type": content_type,
             "size": st.st_size,
         }

--- a/packages/aios-connector-http/tests/test_mime.py
+++ b/packages/aios-connector-http/tests/test_mime.py
@@ -1,0 +1,40 @@
+"""Magic-byte image-mime sniffer (#342).
+
+Inbound platform metadata (Signal, Telegram) and extension-based
+guesses both occasionally lie about an image's true mime type;
+Anthropic's ``/v1/messages`` validates declared mime against actual
+bytes and 400s on mismatch.  Sniff at the SDK boundary so every
+inbound :class:`Attachment` carries a correct ``content_type`` before
+the event is persisted.
+"""
+
+from __future__ import annotations
+
+from aios_connector_http.mime import sniff_image_mime
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+JPEG_MAGIC = b"\xff\xd8\xff\xe0"
+GIF87_MAGIC = b"GIF87a"
+GIF89_MAGIC = b"GIF89a"
+
+
+class TestSniffImageMime:
+    def test_png(self) -> None:
+        assert sniff_image_mime(PNG_MAGIC + b"trailing-bytes") == "image/png"
+
+    def test_jpeg(self) -> None:
+        assert sniff_image_mime(JPEG_MAGIC + b"trailing-bytes") == "image/jpeg"
+
+    def test_gif87a(self) -> None:
+        assert sniff_image_mime(GIF87_MAGIC + b"trailing-bytes") == "image/gif"
+
+    def test_gif89a(self) -> None:
+        assert sniff_image_mime(GIF89_MAGIC + b"trailing-bytes") == "image/gif"
+
+    def test_short_bytes_returns_none(self) -> None:
+        assert sniff_image_mime(b"") is None
+        assert sniff_image_mime(b"\x89P") is None
+
+    def test_unknown_magic_returns_none(self) -> None:
+        assert sniff_image_mime(b"%PDF-1.4\n%...") is None
+        assert sniff_image_mime(b"\x00\x00\x00\x00garbage") is None

--- a/packages/aios-connector-http/tests/test_sandbox.py
+++ b/packages/aios-connector-http/tests/test_sandbox.py
@@ -114,9 +114,35 @@ class TestAttachmentParams:
     def test_oversize_rejected(self, tmp_path: Path) -> None:
         path = tmp_path / "big.bin"
         path.write_bytes(b"\0" * (5 * 1024 * 1024 + 1))
-        att = Attachment(host_path=str(path), filename="big.bin", content_type="application/octet-stream")
+        att = Attachment(
+            host_path=str(path), filename="big.bin", content_type="application/octet-stream"
+        )
         with pytest.raises(AttachmentError, match="5242880 bytes"):
             att.as_params()
+
+    def test_mime_corrected_when_magic_disagrees(self, tmp_path: Path) -> None:
+        """#342: inbound platforms occasionally label a JPEG as image/png.
+        as_params re-detects from magic bytes and rewrites content_type
+        so the persisted event carries the truth.
+        """
+        path = tmp_path / "lies.png"
+        path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 32)  # JPEG magic
+        att = Attachment(host_path=str(path), filename="photo.png", content_type="image/png")
+        assert att.as_params()["content_type"] == "image/jpeg"
+
+    def test_mime_unchanged_when_magic_agrees(self, tmp_path: Path) -> None:
+        path = tmp_path / "real.png"
+        path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+        att = Attachment(host_path=str(path), filename="real.png", content_type="image/png")
+        assert att.as_params()["content_type"] == "image/png"
+
+    def test_mime_unchanged_for_unsniffable_bytes(self, tmp_path: Path) -> None:
+        """Sniffer recognises PNG/JPEG/GIF only; non-image attachments
+        (PDFs, audio, etc.) keep their declared content_type."""
+        path = tmp_path / "doc.pdf"
+        path.write_bytes(b"%PDF-1.4\n%trailer")
+        att = Attachment(host_path=str(path), filename="doc.pdf", content_type="application/pdf")
+        assert att.as_params()["content_type"] == "application/pdf"
 
 
 class _PathConsumer(HttpConnector):
@@ -203,9 +229,7 @@ class TestDispatchSandboxPathResolution:
                 "tool_call_id": "c2",
                 "session_id": "sess_1",
                 "name": "send_many",
-                "arguments": json.dumps(
-                    {"paths": ["/workspace/photo.jpg", "/workspace/doc.pdf"]}
-                ),
+                "arguments": json.dumps({"paths": ["/workspace/photo.jpg", "/workspace/doc.pdf"]}),
             }
         )
         paths = consumer.calls[0]["paths"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ dependencies = [
     # Split into its own package so connector containers can depend on the
     # SDK without dragging in fastapi/asyncpg/procrastinate/etc.
     "aios-sdk",
+    # Shared HTTP-client SDK: the runtime imports ``sniff_image_mime``
+    # for renderer-side mime correction so the same magic-byte detector
+    # runs at the connector boundary and at replay time.
+    "aios-connector-http",
 ]
 
 [dependency-groups]

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -33,6 +33,7 @@ import litellm
 
 from aios.harness.vision import (
     can_inline_image,
+    correct_image_mime,
     make_image_url_part,
     text_marker,
 )
@@ -316,9 +317,12 @@ def _apply_attachments(
                 )
                 marker_lines.append(text_marker(record))
                 continue
+            # Re-sniff here so historical events with a wrong declared
+            # mime (predating SDK-boundary correction) still render with
+            # the actual bytes' mime — Anthropic rejects mismatches.
             image_parts.append(
                 make_image_url_part(
-                    content_type=content_type,
+                    content_type=correct_image_mime(content_type, payload),
                     data_b64=base64.b64encode(payload).decode("ascii"),
                 )
             )

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -33,7 +33,7 @@ import litellm
 
 from aios.harness.vision import (
     can_inline_image,
-    correct_image_mime,
+    correct_image_mime_b64,
     make_image_url_part,
     text_marker,
 )
@@ -317,12 +317,9 @@ def _apply_attachments(
                 )
                 marker_lines.append(text_marker(record))
                 continue
-            # Re-sniff here so historical events with a wrong declared
-            # mime (predating SDK-boundary correction) still render with
-            # the actual bytes' mime — Anthropic rejects mismatches.
             image_parts.append(
                 make_image_url_part(
-                    content_type=correct_image_mime(content_type, payload),
+                    content_type=content_type,
                     data_b64=base64.b64encode(payload).decode("ascii"),
                 )
             )
@@ -384,6 +381,37 @@ def _sanitize_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any
             }
         )
     return sanitized
+
+
+def _correct_image_data_url_mimes(messages: list[dict[str, Any]]) -> None:
+    """Rewrite mismatched mime declarations on ``data:<mime>;base64,...``
+    image URLs already in the assembled message list.  Mutates in place.
+
+    The renderer cannot prevent persisted events from carrying a wrong
+    mime — tool_result content arrives pre-formed and is appended
+    verbatim, so historical events from before centralised sniffing
+    will replay forever unless we re-check them every build.
+    """
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict) or part.get("type") != "image_url":
+                continue
+            image_url = part.get("image_url")
+            if not isinstance(image_url, dict):
+                continue
+            url = image_url.get("url")
+            if not isinstance(url, str) or not url.startswith("data:"):
+                continue
+            head, sep, data_b64 = url.partition(",")
+            if not sep or ";base64" not in head:
+                continue
+            declared = head.removeprefix("data:").split(";", 1)[0]
+            corrected = correct_image_mime_b64(declared, data_b64)
+            if corrected != declared:
+                image_url["url"] = f"data:{corrected};base64,{data_b64}"
 
 
 def _strip_to_spec(
@@ -589,6 +617,8 @@ def build_messages(
 
     if system_prompt:
         messages.insert(0, {"role": "system", "content": system_prompt})
+
+    _correct_image_data_url_mimes(messages)
 
     target_supports_thinking = bool(model) and litellm.supports_reasoning(model)
     return ContextResult(

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -8,6 +8,8 @@ recoverable.
 
 from __future__ import annotations
 
+import base64
+import binascii
 from typing import Any
 
 import litellm
@@ -18,12 +20,19 @@ from aios_connector_http.mime import sniff_image_mime
 log = get_logger("aios.harness.vision")
 
 
-def correct_image_mime(declared: str, data: bytes) -> str:
-    """Return the magic-byte-detected mime, or ``declared`` when sniffing
-    yields nothing.  Warns on substitution so operators see when a
-    persisted event's declared mime disagreed with its bytes.
+def correct_image_mime_b64(declared: str, data_b64: str) -> str:
+    """Return the magic-byte-detected mime for a base64-encoded image,
+    or ``declared`` unchanged when sniffing yields nothing.  Warns on
+    substitution so operators see when a persisted event's declared
+    mime disagreed with its bytes.
     """
-    sniffed = sniff_image_mime(data)
+    head_b64 = data_b64[:24]
+    pad = (-len(head_b64)) % 4
+    try:
+        head = base64.b64decode(head_b64 + "=" * pad)
+    except binascii.Error:
+        return declared
+    sniffed = sniff_image_mime(head)
     if sniffed is None or sniffed == declared:
         return declared
     log.warning("vision.image_mime_corrected", declared=declared, actual=sniffed)
@@ -75,7 +84,15 @@ def can_inline_image(*, model: str, content_type: str, size_bytes: int) -> bool:
 
 
 def make_image_url_part(*, content_type: str, data_b64: str) -> dict[str, Any]:
-    """Build a chat-completions ``image_url`` content part."""
+    """Build a chat-completions ``image_url`` content part.
+
+    Reconciles the declared ``content_type`` against the magic bytes —
+    inbound platform metadata and extension-based guesses both
+    occasionally lie, and Anthropic rejects mime-vs-magic mismatches.
+    Centralising the sniff here means every caller is covered without
+    having to remember to wire correction at the call site.
+    """
+    content_type = correct_image_mime_b64(content_type, data_b64)
     return {
         "type": "image_url",
         "image_url": {"url": f"data:{content_type};base64,{data_b64}"},

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -13,8 +13,22 @@ from typing import Any
 import litellm
 
 from aios.logging import get_logger
+from aios_connector_http.mime import sniff_image_mime
 
 log = get_logger("aios.harness.vision")
+
+
+def correct_image_mime(declared: str, data: bytes) -> str:
+    """Return the magic-byte-detected mime, or ``declared`` when sniffing
+    yields nothing.  Warns on substitution so operators see when a
+    persisted event's declared mime disagreed with its bytes.
+    """
+    sniffed = sniff_image_mime(data)
+    if sniffed is None or sniffed == declared:
+        return declared
+    log.warning("vision.image_mime_corrected", declared=declared, actual=sniffed)
+    return sniffed
+
 
 INLINE_SIZE_CAP_BYTES = 2 * 1024 * 1024
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -256,6 +256,47 @@ class TestBuildMessages:
         roles = [m["role"] for m in msgs]
         assert roles == ["user", "assistant", "tool", "assistant", "tool", "assistant"]
 
+    def test_tool_result_image_url_mime_corrected_at_replay(self) -> None:
+        """Historical tool_result events (e.g. from the ``read`` tool) may
+        carry an ``image_url`` data URL whose declared mime disagrees with
+        the base64 bytes.  build_messages walks the assembled message list
+        and substitutes the magic-byte-detected mime so Anthropic doesn't
+        400 on replay — the original wedge incident was a tool_result
+        image part.
+        """
+        import base64 as _b64
+
+        jpeg_b64 = _b64.b64encode(b"\xff\xd8\xff\xe0" + b"\x00" * 32).decode("ascii")
+        bad_url = f"data:image/png;base64,{jpeg_b64}"
+        events = [
+            _evt(1, "user", content="show photo"),
+            _evt(2, "assistant", tool_calls=[_tc("a", name="read")]),
+            Event(
+                id="evt_3",
+                session_id="sess_01TEST",
+                seq=3,
+                kind="message",
+                data={
+                    "role": "tool",
+                    "tool_call_id": "a",
+                    "content": [
+                        {"type": "text", "text": "Image: photo.png"},
+                        {"type": "image_url", "image_url": {"url": bad_url}},
+                    ],
+                },
+                created_at=datetime.now(tz=UTC),
+                orig_channel=None,
+                focal_channel_at_arrival=None,
+            ),
+        ]
+        msgs = build_messages(events, system_prompt=None).messages
+        tool_msg = msgs[2]
+        assert tool_msg["role"] == "tool"
+        url = tool_msg["content"][1]["image_url"]["url"]
+        assert url.startswith("data:image/jpeg;base64,"), (
+            f"walker should have corrected image/png → image/jpeg, got {url[:40]}"
+        )
+
     def test_prune_orphan_tool_results_at_start(self) -> None:
         """If DB windowing drops an assistant but keeps its tool results,
         those orphan tool results should be pruned from the start."""

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -274,6 +274,46 @@ class TestVisionAwareRendering:
         # And the image_url part is preserved.
         assert any(p.get("type") == "image_url" for p in content)
 
+    def test_mime_corrected_when_event_declares_wrong_type(self, temp_workspace_root: Path) -> None:
+        """#342: a persisted event may carry a wrong content_type (Signal /
+        Telegram occasionally label JPEG as image/png).  Without correction
+        the rendered data URL declares image/png and Anthropic 400s on
+        magic-vs-declared mismatch.  Renderer must sniff and substitute.
+
+        This is the historical-event path — the SDK-boundary correction
+        only protects new events; long-running sessions still carry bad
+        declarations from before the fix, so the renderer is the layer
+        that unwedges them at replay time.
+        """
+        jpeg_bytes = b"\xff\xd8\xff\xe0" + b"\x00" * 32
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-lies.png", jpeg_bytes
+        )
+        event = _user_event(
+            content="historical",
+            attachments=[
+                {
+                    "filename": "lies.png",
+                    "content_type": "image/png",  # the lie
+                    "size": len(jpeg_bytes),
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="model/vision",
+            session_id="sess-1",
+        )
+        content = msg["content"]
+        assert isinstance(content, list)
+        url = content[1]["image_url"]["url"]
+        assert url.startswith("data:image/jpeg;base64,"), (
+            f"renderer should have corrected image/png → image/jpeg, got {url[:50]}"
+        )
+
     def test_multiple_attachments_mixed(self, temp_workspace_root: Path) -> None:
         a = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-a.jpg", b"AAA")
         b = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-b.pdf", b"PDF")

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -124,6 +124,22 @@ class TestMakeImageUrlPart:
             "image_url": {"url": "data:image/png;base64,ZmFrZQ=="},
         }
 
+    def test_self_corrects_mismatched_mime(self) -> None:
+        """Single construction point reconciles declared mime against the
+        bytes' magic.  Covers every caller (renderer, read tool, future)
+        without each having to remember to wire correction.
+        """
+        import base64 as _b64
+
+        jpeg_b64 = _b64.b64encode(b"\xff\xd8\xff\xe0" + b"\x00" * 32).decode("ascii")
+        part = vision.make_image_url_part(content_type="image/png", data_b64=jpeg_b64)
+        assert part["image_url"]["url"] == f"data:image/jpeg;base64,{jpeg_b64}"
+
+    def test_keeps_declared_mime_when_unrecognized(self) -> None:
+        """Sniff returns None on random/unknown bytes — declared mime wins."""
+        part = vision.make_image_url_part(content_type="image/png", data_b64="ZmFrZQ==")
+        assert part["image_url"]["url"].startswith("data:image/png;base64,")
+
 
 class TestTextMarker:
     def test_image_with_path(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -111,6 +111,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodocker" },
+    { name = "aios-connector-http" },
     { name = "aios-sdk" },
     { name = "alembic" },
     { name = "asyncpg" },
@@ -150,6 +151,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiodocker", specifier = ">=0.23" },
+    { name = "aios-connector-http", editable = "packages/aios-connector-http" },
     { name = "aios-sdk", editable = "packages/aios-sdk" },
     { name = "alembic", specifier = ">=1.13" },
     { name = "asyncpg", specifier = ">=0.30" },


### PR DESCRIPTION
## Summary

Restores byte-sniffing of image MIME types after PR #318 silently deleted PR #294's protection during the connector rework. The deletion looked like dead code at the time, but the new attachment pipeline (#216 / #229) never had equivalent sniffing, and long-running sessions still carry events whose declared MIME disagrees with their bytes. Anthropic 400s on every replay until the bad declaration is corrected.

Two protection layers:

- **SDK boundary** — `Attachment.as_params()` re-detects `content_type` from the first 16 bytes when the declaration is an `image/*` type, so the bad MIME never reaches the event log.
- **Renderer** — `_apply_attachments()` re-sniffs at render time, so historical events with a wrong declared MIME still produce a valid data URL.

The pure sniffer lives in `aios_connector_http.mime` so both layers share it without inverting the deliberate aios-server -> SDK dependency direction. Recognises PNG, JPEG, GIF — the formats Anthropic accepts as image inputs.

Closes #342.

## Test plan

- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests packages/aios-connector-http\` — clean
- [x] \`uv run pytest tests/unit\` — 1155 passed
- [x] \`uv run pytest packages/aios-connector-http/tests\` — 67 passed
- [x] New SDK-boundary tests: `test_mime_corrected_when_magic_disagrees`, `test_mime_unchanged_when_magic_agrees`, `test_mime_unchanged_for_unsniffable_bytes`
- [x] New renderer test: `test_mime_corrected_when_event_declares_wrong_type` (asserts the historical-event path the issue describes)
- [x] New pure-sniffer tests in `test_mime.py` for PNG / JPEG / GIF87 / GIF89 / short / unknown

🤖 Generated with [Claude Code](https://claude.com/claude-code)