### PR TITLE
refactor(runtime_tokens): drop stale connector_tokens cross-references

### DIFF
--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -162,8 +162,6 @@ async def _do_inbound(
 #
 # All routes accept a ``runtime`` bearer token (``RuntimeAuthDep``) that
 # scopes the caller to one ``connector`` type and N of its connections.
-# Per-connection variants from PR 4/PR 5's parallel-live window were
-# removed in PR 7 alongside their ``connector_tokens`` auth surface.
 
 
 class ToolsSchemaUpdate(BaseModel):

--- a/src/aios/api/routers/runtime_tokens.py
+++ b/src/aios/api/routers/runtime_tokens.py
@@ -1,10 +1,8 @@
 """Runtime token endpoints — operator-scoped issue / list / revoke (#328 PR 5).
 
-Successor to :mod:`aios.api.routers.connector_tokens`: bearer tokens
-scope per ``connector`` type rather than per ``connection_id``.  One
-runtime container hosts N connections of one type and authenticates
-with one token; per-connection auth lives on for the legacy paths only
-until PR 7 cuts them.
+Bearer tokens scope per ``connector`` type rather than per
+``connection_id``.  One runtime container hosts N connections of one
+type and authenticates with one token.
 
 Plaintext is returned ONCE on issue.  All subsequent reads expose only
 the :class:`RuntimeToken` view.

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -4480,11 +4480,9 @@ async def update_connector_tools_schema(
 
 # ─── runtime_tokens ──────────────────────────────────────────────────────────
 #
-# Per-connector-type bearer tokens (#328 PR 5). Successor to
-# ``connector_tokens`` (which is per-connection); one bearer authenticates
+# Per-connector-type bearer tokens (#328 PR 5). One bearer authenticates
 # a runtime container that hosts N connections of one ``connector`` type.
-# Shape mirrors ``connector_tokens`` queries — SHA-256 hash, soft-revoke,
-# single ``UPDATE … RETURNING`` resolve.
+# Storage: SHA-256 hash, soft-revoke, single ``UPDATE … RETURNING`` resolve.
 
 
 def _row_to_runtime_token(row: asyncpg.Record) -> RuntimeToken:

--- a/src/aios/services/runtime_tokens.py
+++ b/src/aios/services/runtime_tokens.py
@@ -8,10 +8,6 @@ token; resolution returns ``(token_id, connector)``, never a single
 Plaintext format: ``aios_runtime_<32-byte-base64url>``.  The DB stores
 only ``sha256(plaintext).hexdigest()``; plaintext is returned exactly
 once, in the issue response.
-
-Mirrors :mod:`aios.services.connector_tokens` shape — see that module
-for the broader design rationale on hashing, soft revocation, and the
-prefix pre-filter.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Pure documentation cleanup — first iteration of the kaizen audit loop.

- PR #340 (PR 7 of #328) deleted the `connector_tokens` module and table; five stale docstring/comment references to it lingered in 4 source files.
- Rewrote each reference to stand on its own without the dead cross-ref, preserving the surrounding WHAT-info (per-connector-type bearer tokens, runtime-bearer auth scope, SHA-256 hash + soft-revoke).
- Migrations under `migrations/versions/` that reference the `connector_tokens` table at their respective revisions are intentionally left untouched — they are append-only schema history.

Zero behavior change. Net `-15 / +5` LOC.

## Files touched

- `src/aios/api/routers/runtime_tokens.py` — module docstring "Successor to ..."
- `src/aios/services/runtime_tokens.py` — closing "Mirrors ... see that module" paragraph
- `src/aios/api/routers/connectors.py` — transitional "Per-connection variants ... removed in PR 7" comment
- `src/aios/db/queries.py` — section banner "Successor to ..." + "Shape mirrors ..."

## Test plan

- [x] `uv run mypy src` — clean (145 files)
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean (294 files)
- [x] `uv run pytest tests/unit -q` — 1158 passed
- [ ] CI runs e2e on push

## Audit context

Found by the kaizen smell-word audit (one of five parallel auditors). Cross-checked: zero live `from aios...connector_tokens` imports in `src/` or `tests/`; the module is fully deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)