### PR TITLE
fix(harness): terminal 'errored' status closes the wake-step retry loop

### DIFF
--- a/migrations/versions/0040_errored_session_status.py
+++ b/migrations/versions/0040_errored_session_status.py
@@ -1,0 +1,47 @@
+"""Add ``errored`` to the session status check constraint.
+
+When the wake-step retry budget is spent (4 consecutive ``rescheduling``
+turn_ends) the harness now parks the session in ``errored`` instead of
+``idle`` so the periodic sweep stops re-firing wakes that just time out
+again.  ``flip_quiescent_to_pending`` is widened in the same change to
+also clear ``errored`` on the next user message, preserving the operator
+recovery contract from #353.
+
+Downgrade rewrites ``errored`` to ``terminated`` rather than ``idle`` —
+the original constraint can't represent the parked-after-budget state,
+and ``terminated`` is the existing terminal vocabulary.  ``idle`` would
+silently reintroduce the #353 loop on any session currently parked.
+
+Revision ID: 0040
+Revises: 0039
+Create Date: 2026-05-14
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0040"
+down_revision: str = "0039"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_status_check;")
+    op.execute(
+        "ALTER TABLE sessions ADD CONSTRAINT sessions_status_check "
+        "CHECK (status IN ('pending', 'running', 'idle', 'rescheduling', "
+        "'errored', 'terminated'));"
+    )
+
+
+def downgrade() -> None:
+    op.execute("UPDATE sessions SET status = 'terminated' WHERE status = 'errored';")
+    op.execute("ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_status_check;")
+    op.execute(
+        "ALTER TABLE sessions ADD CONSTRAINT sessions_status_check "
+        "CHECK (status IN ('pending', 'running', 'idle', 'rescheduling', 'terminated'));"
+    )

--- a/openapi.json
+++ b/openapi.json
@@ -911,6 +911,7 @@
                     "running",
                     "idle",
                     "rescheduling",
+                    "errored",
                     "terminated"
                   ],
                   "type": "string"
@@ -8972,6 +8973,7 @@
               "running",
               "idle",
               "rescheduling",
+              "errored",
               "terminated"
             ],
             "title": "Status"
@@ -10619,6 +10621,7 @@
               "running",
               "idle",
               "rescheduling",
+              "errored",
               "terminated"
             ],
             "title": "Session Status"

--- a/packages/aios-sdk/aios_sdk/_generated/models/list_sessions_status_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/list_sessions_status_type_0.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class ListSessionsStatusType0(str, Enum):
+    ERRORED = "errored"
     IDLE = "idle"
     PENDING = "pending"
     RESCHEDULING = "rescheduling"

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_status.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_status.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class SessionStatus(str, Enum):
+    ERRORED = "errored"
     IDLE = "idle"
     PENDING = "pending"
     RESCHEDULING = "rescheduling"

--- a/packages/aios-sdk/aios_sdk/_generated/models/wait_response_session_status.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wait_response_session_status.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class WaitResponseSessionStatus(str, Enum):
+    ERRORED = "errored"
     IDLE = "idle"
     PENDING = "pending"
     RESCHEDULING = "rescheduling"

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -3334,18 +3334,21 @@ async def list_recent_chat_ids(
 # ─── connector_inbound_acks (dedup ledger) ──────────────────────────────────
 
 
-async def flip_idle_to_pending(conn: asyncpg.Connection[Any], session_id: str) -> None:
-    """Flip ``sessions.status`` from ``idle`` to ``pending`` if currently idle.
+async def flip_quiescent_to_pending(conn: asyncpg.Connection[Any], session_id: str) -> None:
+    """Flip ``sessions.status`` to ``pending`` if currently quiescent.
 
-    Called after appending a user message so polling orchestrators can
-    distinguish queued-but-not-started from turn-finished.  Other states
-    (running / rescheduling / terminated) are left alone — the worker
-    owns the running status, and changing rescheduling would lose the
-    retry-in-progress signal.
+    Quiescent here means either ``idle`` (clean turn end) or ``errored``
+    (retry budget spent — #353).  Called after appending a user message
+    so polling orchestrators can distinguish queued-but-not-started from
+    turn-finished, AND so a fresh user message lifts an ``errored``
+    session out of the sweep's blacklist (errored is opaque to the
+    sweep; ``pending`` is not).  Other states (running / rescheduling /
+    terminated) are left alone — the worker owns the running status, and
+    changing rescheduling would lose the retry-in-progress signal.
     """
     await conn.execute(
         "UPDATE sessions SET status = 'pending', updated_at = now() "
-        "WHERE id = $1 AND status = 'idle'",
+        "WHERE id = $1 AND status IN ('idle', 'errored')",
         session_id,
     )
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -830,10 +830,14 @@ async def _apply_retry_or_failure(pool: Any, session_id: str) -> float | None:
         )
         await _append_lifecycle(pool, session_id, "turn_ended", "rescheduling", "rescheduling")
         return delay
+    # Terminal landing pad (#353): sweep skips ``errored`` (see
+    # ``CANDIDATE_ROWS_SQL`` / ``CONFIRMED_ROWS_SQL``); any in-flight
+    # tool task that completes after this point sits unreaped until a
+    # user message flips status via ``flip_quiescent_to_pending``.
     await sessions_service.set_session_status(
-        pool, session_id, "idle", stop_reason={"type": "error"}
+        pool, session_id, "errored", stop_reason={"type": "error"}
     )
-    await _append_lifecycle(pool, session_id, "turn_ended", "idle", "error")
+    await _append_lifecycle(pool, session_id, "turn_ended", "errored", "error")
     return None
 
 

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -96,6 +96,7 @@ CANDIDATE_ROWS_SQL = """
       JOIN sessions s ON s.id = e.session_id
       LEFT JOIN session_max_reacting smr ON smr.session_id = e.session_id
      WHERE s.archived_at IS NULL
+       AND s.status <> 'errored'
        AND e.kind = 'message'
        AND e.role <> 'assistant'
        AND (smr.max_reacting IS NULL OR e.seq > smr.max_reacting)
@@ -107,6 +108,7 @@ CONFIRMED_ROWS_SQL = """
       FROM events lc
       JOIN sessions s ON s.id = lc.session_id
      WHERE s.archived_at IS NULL
+       AND s.status <> 'errored'
        AND lc.kind = 'lifecycle'
        AND lc.data->>'event' = 'tool_confirmed'
        AND lc.data->>'result' = 'allow'

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -66,7 +66,7 @@ def _validate_session_resources(resources: list[SessionResource]) -> None:
     _validate_github_resources(github)
 
 
-SessionStatus = Literal["pending", "running", "idle", "rescheduling", "terminated"]
+SessionStatus = Literal["pending", "running", "idle", "rescheduling", "errored", "terminated"]
 
 MAX_USER_MESSAGE_CHARS = 1_000_000
 

--- a/src/aios/services/inbound.py
+++ b/src/aios/services/inbound.py
@@ -200,7 +200,7 @@ async def _append_with_dedup(
             )
             if not inserted:
                 raise _DedupRollback()
-            await queries.flip_idle_to_pending(conn, session_id)
+            await queries.flip_quiescent_to_pending(conn, session_id)
     except _DedupRollback:
         return False
     return True

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -188,7 +188,7 @@ async def append_user_message(
         # paths have the same race but are deferred; an orchestrator
         # resolving those still has to combine status polling with
         # event-cursor tracking.  See issue #39.
-        await queries.flip_idle_to_pending(conn, session_id)
+        await queries.flip_quiescent_to_pending(conn, session_id)
         return event
 
 

--- a/tests/e2e/test_errored_session_sweep.py
+++ b/tests/e2e/test_errored_session_sweep.py
@@ -1,0 +1,107 @@
+"""Sweep behavior for sessions parked in ``errored`` status (#353).
+
+Asserts the two halves of the fix:
+
+- ``errored`` is opaque to ``find_sessions_needing_inference`` even when
+  the session has an unreacted user message (the loop trigger #353 hit).
+- A fresh user message lifts ``errored → pending`` via
+  ``flip_quiescent_to_pending``, restoring the operator-recovery contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.harness.sweep import find_sessions_needing_inference
+from aios.harness.task_registry import TaskRegistry
+from aios.models.sessions import SessionStatus
+from aios.services import sessions as sessions_service
+from tests.conftest import needs_docker
+
+
+async def _ensure_agent_and_env(pool: asyncpg.Pool[Any]) -> tuple[str, str]:
+    """Idempotently seed the FK targets ``create_session`` needs."""
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO agents (id, name, model) VALUES ('agt_err', 'err', 'openrouter/x') "
+            "ON CONFLICT (id) DO NOTHING"
+        )
+        await conn.execute(
+            "INSERT INTO environments (id, name) VALUES ('env_err', 'env_err') "
+            "ON CONFLICT (id) DO NOTHING"
+        )
+    return "agt_err", "env_err"
+
+
+async def _seed_session_with_unreacted_message(
+    pool: asyncpg.Pool[Any],
+    *,
+    status: SessionStatus,
+) -> str:
+    """Create a session via the service layer, append a user message, then
+    force ``status`` if it isn't ``pending``.  Returns the new session id.
+    """
+    agent_id, environment_id = await _ensure_agent_and_env(pool)
+    session = await sessions_service.create_session(
+        pool,
+        agent_id=agent_id,
+        environment_id=environment_id,
+        title=None,
+        metadata={},
+    )
+    await sessions_service.append_user_message(pool, session.id, "hi")
+    if status != "pending":
+        await sessions_service.set_session_status(pool, session.id, status)
+    return session.id
+
+
+@pytest.fixture
+async def db_pool(aios_env: dict[str, str]) -> AsyncIterator[asyncpg.Pool[Any]]:
+    pool = await create_pool(aios_env["AIOS_DB_URL"], min_size=1, max_size=2)
+    try:
+        yield pool
+    finally:
+        await pool.close()
+
+
+@needs_docker
+class TestErroredSessionSweepFilter:
+    async def test_errored_session_excluded_from_find_sessions_needing_inference(
+        self, db_pool: asyncpg.Pool[Any]
+    ) -> None:
+        """The exhaustion landing pad: errored + unreacted user msg ⇒ skipped."""
+        sid = await _seed_session_with_unreacted_message(db_pool, status="errored")
+
+        result = await find_sessions_needing_inference(db_pool, TaskRegistry(), session_id=sid)
+
+        assert result == set(), (
+            "Errored sessions must not be re-woken by the sweep — that's the regression #353 fixes."
+        )
+
+    async def test_pending_session_still_picked_up(self, db_pool: asyncpg.Pool[Any]) -> None:
+        """Sanity: a pending session with an unreacted user msg is still found."""
+        sid = await _seed_session_with_unreacted_message(db_pool, status="pending")
+
+        result = await find_sessions_needing_inference(db_pool, TaskRegistry(), session_id=sid)
+
+        assert sid in result
+
+    async def test_user_message_flips_errored_to_pending(self, db_pool: asyncpg.Pool[Any]) -> None:
+        """``append_user_message`` is the operator-recovery escape hatch:
+        it must un-park an ``errored`` session by flipping status to ``pending``.
+        """
+        sid = await _seed_session_with_unreacted_message(db_pool, status="errored")
+
+        await sessions_service.append_user_message(db_pool, sid, "please try again")
+
+        async with db_pool.acquire() as conn:
+            status = await conn.fetchval("SELECT status FROM sessions WHERE id = $1", sid)
+        assert status == "pending", (
+            "A new user message must clear the errored marker so the next "
+            "wake actually runs — otherwise recovery requires manual DB poking."
+        )

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -227,9 +227,17 @@ class TestRunSessionStepOnModelError:
         assert "rescheduling" in status_calls
         assert "idle" not in status_calls
 
-    async def test_exhausted_budget_raises_and_sets_idle_error(
+    async def test_exhausted_budget_raises_and_sets_errored_status(
         self, mock_step_dependencies: Any
     ) -> None:
+        """Budget exhaustion parks the session in ``errored`` status (#353).
+
+        Setting ``idle`` (the prior behavior) left the periodic sweep free
+        to re-fire on any unreacted user message, restarting the budget
+        from zero because the trailing lifecycle is ``stop_reason='error'``
+        (not ``'rescheduling'``). The terminal ``errored`` status is the
+        sweep's stop signal.
+        """
         with (
             patch(
                 "aios.harness.loop._count_consecutive_rescheduling",
@@ -240,9 +248,12 @@ class TestRunSessionStepOnModelError:
             await run_session_step("sess_x")
 
         mock_step_dependencies.defer_wake.assert_not_awaited()
-        idle_call = next(
+        statuses = [call.args[2] for call in mock_step_dependencies.set_status.call_args_list]
+        assert "errored" in statuses
+        assert "idle" not in statuses
+        errored_call = next(
             call
             for call in mock_step_dependencies.set_status.call_args_list
-            if call.args[2] == "idle"
+            if call.args[2] == "errored"
         )
-        assert idle_call.kwargs["stop_reason"] == {"type": "error"}
+        assert errored_call.kwargs["stop_reason"] == {"type": "error"}


### PR DESCRIPTION
## Summary

When a session's wake-step exhausted the 4-attempt exponential-backoff retry budget, `_apply_retry_or_failure` parked it in `idle` with `stop_reason={\"type\": \"error\"}`. But the periodic sweep only filtered on `archived_at IS NULL` — so any unreacted user message re-eligibled the session, and `_count_consecutive_rescheduling` reset to 0 on the trailing non-`rescheduling` lifecycle, restarting the budget. Result: infinite re-fire against a persistent model timeout (observed against a local ollama 27B hitting the 5-min step cap).

Fix is asymmetric on purpose:

- **New terminal `errored` status.** `CANDIDATE_ROWS_SQL` and `CONFIRMED_ROWS_SQL` both filter it out, so neither the periodic sweep nor the tail sweep re-fires.
- **`flip_idle_to_pending` → `flip_quiescent_to_pending`**, widened to lift both `idle` and `errored` back to `pending` on the next user message. The operator-recovery contract from the issue (\"send a fresh user message\") works without manual DB poking.

## Trade-off (deliberate)

An in-flight built-in tool task that completes **after** budget exhaustion appends its result, but its tail-sweep no-ops at the new filter — the model never sees it until a user message un-parks the session. Acceptable because the budget firing implies the model itself is broken; deferring tool reactions until operator recovery beats burning through another 4 attempts. The new comment in `_apply_retry_or_failure` calls this out.

## Migration 0040

Widens `sessions_status_check`. Downgrade rewrites parked `errored` rows to `terminated` (not `idle`) so a constraint shrink can't silently reintroduce #353 for any session currently in the new state.

## Test plan

- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check / format --check\` — clean
- [x] \`uv run pytest tests/unit\` — 1158 passed
- [x] \`DOCKER_HOST=… uv run pytest tests/e2e\` — 274 passed locally
- [x] New e2e tests in \`tests/e2e/test_errored_session_sweep.py\`:
   - errored + unreacted user msg ⇒ sweep skips
   - pending + unreacted user msg ⇒ sweep finds (regression guard)
   - errored + new user message ⇒ status flips to pending
- [x] Updated unit test \`test_exhausted_budget_raises_and_sets_errored_status\`
- [x] OpenAPI snapshot + SDK enums regenerated

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)