### PR TITLE
feat(tests): add sandbox image contract tests for CI

### DIFF
--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import platform
+import re
 import subprocess
 from pathlib import Path
 
@@ -42,7 +43,7 @@ def pulled_image() -> str:
         check=False,
     )
     if result.returncode != 0:
-        pytest.skip(f"Could not pull {IMAGE!r}: {result.stderr.strip()}")
+        pytest.fail(f"Could not pull {IMAGE!r}: {result.stderr.strip()}")
     return IMAGE
 
 
@@ -73,6 +74,35 @@ class TestRequiredBinaries:
 
     def test_python3(self, pulled_image: str) -> None:
         r = _docker_run(pulled_image, "which", "python3")
+        assert r.returncode == 0, r.stderr
+
+    def test_python313(self, pulled_image: str) -> None:
+        """python3.13 specifically -- version match matters for sandboxed tool execution."""
+        r = _docker_run(pulled_image, "which", "python3.13")
+        assert r.returncode == 0, r.stderr
+
+    def test_cat(self, pulled_image: str) -> None:
+        r = _docker_run(pulled_image, "which", "cat")
+        assert r.returncode == 0, r.stderr
+
+    def test_head(self, pulled_image: str) -> None:
+        r = _docker_run(pulled_image, "which", "head")
+        assert r.returncode == 0, r.stderr
+
+    def test_grep(self, pulled_image: str) -> None:
+        r = _docker_run(pulled_image, "which", "grep")
+        assert r.returncode == 0, r.stderr
+
+    def test_find(self, pulled_image: str) -> None:
+        r = _docker_run(pulled_image, "which", "find")
+        assert r.returncode == 0, r.stderr
+
+    def test_sed(self, pulled_image: str) -> None:
+        r = _docker_run(pulled_image, "which", "sed")
+        assert r.returncode == 0, r.stderr
+
+    def test_awk(self, pulled_image: str) -> None:
+        r = _docker_run(pulled_image, "which", "awk")
         assert r.returncode == 0, r.stderr
 
     def test_rg(self, pulled_image: str) -> None:
@@ -116,7 +146,11 @@ class TestRuntimeBehaviour:
         r = _docker_run(pulled_image, "python3", "--version")
         assert r.returncode == 0, r.stderr
         version_output = r.stdout + r.stderr
-        assert "Python 3.13" in version_output, f"unexpected version: {version_output!r}"
+        # Matches Python 3.13, 3.14, etc. — forward-compatible minimum-version check.
+        match = re.search(r"Python (\d+)\.(\d+)", version_output)
+        assert match is not None, f"could not parse version from: {version_output!r}"
+        major, minor = int(match.group(1)), int(match.group(2))
+        assert (major, minor) >= (3, 13), f"expected Python >= 3.13, got {version_output.strip()!r}"
 
     def test_python3_venv_creation(self, pulled_image: str) -> None:
         """setup.py calls ``python3 -m venv /workspace/.venv`` on first provision."""
@@ -226,6 +260,10 @@ class TestArchitecture:
 
     def test_manifest_includes_amd64_and_arm64(self, pulled_image: str) -> None:
         """Published images should be multi-arch (amd64 + arm64).
+
+        Note: ``docker buildx imagetools inspect`` queries the remote registry
+        manifest, not the local pull cache. This test requires outbound network
+        access to the registry and skips gracefully when unavailable.
 
         Skips if ``docker buildx`` or ``imagetools`` sub-command is unavailable.
         """

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import os
 import platform
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -23,7 +22,8 @@ from tests.conftest import needs_docker
 
 pytestmark = needs_docker
 
-# The image under test. Matches the default in aios.config.Settings.docker_image.
+# Read directly from env rather than importing Settings to avoid triggering the
+# settings singleton, which requires AIOS_DB_URL and other runtime env vars.
 IMAGE = os.environ.get("AIOS_DOCKER_IMAGE", "ghcr.io/eumemic/aios-sandbox:latest")
 
 
@@ -46,15 +46,19 @@ def pulled_image() -> str:
     return IMAGE
 
 
-def _docker_run(image: str, *args: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
-    """Run ``docker run --rm IMAGE *args`` and return the completed process."""
-    return subprocess.run(
-        ["docker", "run", "--rm", image, *args],
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=timeout,
-    )
+def _docker_run(
+    image: str, *args: str, volume: str | None = None, timeout: int = 30
+) -> subprocess.CompletedProcess[str]:
+    """Run ``docker run --rm IMAGE *args`` and return the completed process.
+
+    If *volume* is given it is passed as ``--volume <volume>`` before the image name.
+    """
+    cmd = ["docker", "run", "--rm"]
+    if volume is not None:
+        cmd += ["--volume", volume]
+    cmd.append(image)
+    cmd.extend(args)
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=timeout)
 
 
 # -- binary availability -------------------------------------------------------
@@ -160,22 +164,12 @@ class TestWorkspaceMount:
         """The harness mounts a host directory at /workspace; the container
         must be able to write there so tool outputs survive the exec call."""
         sentinel = tmp_path / "sentinel.txt"
-        result = subprocess.run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "--volume",
-                f"{tmp_path}:/workspace",
-                pulled_image,
-                "bash",
-                "-c",
-                "echo 'mounted-ok' > /workspace/sentinel.txt",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=30,
+        result = _docker_run(
+            pulled_image,
+            "bash",
+            "-c",
+            "echo 'mounted-ok' > /workspace/sentinel.txt",
+            volume=f"{tmp_path}:/workspace",
         )
         assert result.returncode == 0, result.stderr
         assert sentinel.exists(), "sentinel file not created on host"
@@ -186,22 +180,12 @@ class TestWorkspaceMount:
     ) -> None:
         """Files placed in the host workspace are visible to the container."""
         (tmp_path / "host-file.txt").write_text("from-host\n")
-        result = subprocess.run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "--volume",
-                f"{tmp_path}:/workspace",
-                pulled_image,
-                "bash",
-                "-c",
-                "cat /workspace/host-file.txt",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=30,
+        result = _docker_run(
+            pulled_image,
+            "bash",
+            "-c",
+            "cat /workspace/host-file.txt",
+            volume=f"{tmp_path}:/workspace",
         )
         assert result.returncode == 0, result.stderr
         assert "from-host" in result.stdout
@@ -245,8 +229,6 @@ class TestArchitecture:
 
         Skips if ``docker buildx`` or ``imagetools`` sub-command is unavailable.
         """
-        if shutil.which("docker") is None:
-            pytest.skip("docker not on PATH")
         result = subprocess.run(
             ["docker", "buildx", "imagetools", "inspect", pulled_image],
             capture_output=True,

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -23,10 +23,9 @@ from tests.conftest import needs_docker
 
 pytestmark = needs_docker
 
-# Read directly from env: importing Settings would fail in test environments
-# because Settings has required fields (AIOS_DB_URL, AIOS_API_KEY, etc.) with
-# no defaults. The env var name is stable -- it's derived from env_prefix="AIOS_"
-# + field name "docker_image".
+# Read directly from env to keep this file free of aios package imports.
+# The env var name is stable -- derived from env_prefix="AIOS_" + field "docker_image"
+# in src/aios/config.py.
 IMAGE = os.environ.get("AIOS_DOCKER_IMAGE", "ghcr.io/eumemic/aios-sandbox:latest")
 
 

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -1,0 +1,261 @@
+"""Contract tests for the aios-sandbox Docker image.
+
+Pulls the configured sandbox image and asserts that every binary and
+runtime property the aios worker depends on is present and functional.
+Each assertion is a separate test function so CI can pinpoint failures
+precisely.
+
+These tests shell out to the Docker CLI directly -- no aios harness,
+no Postgres, no async. They require only a Docker daemon.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import needs_docker
+
+pytestmark = needs_docker
+
+# The image under test. Matches the default in aios.config.Settings.docker_image.
+IMAGE = os.environ.get("AIOS_DOCKER_IMAGE", "ghcr.io/eumemic/aios-sandbox:latest")
+
+
+@pytest.fixture(scope="module")
+def pulled_image() -> str:
+    """Pull IMAGE once for the entire module.
+
+    Returns the image name so tests can reference it. A module-scoped
+    fixture means a single ``docker pull`` per pytest invocation, not
+    one per test.
+    """
+    result = subprocess.run(
+        ["docker", "pull", IMAGE],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"Could not pull {IMAGE!r}: {result.stderr.strip()}")
+    return IMAGE
+
+
+def _docker_run(image: str, *args: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    """Run ``docker run --rm IMAGE *args`` and return the completed process."""
+    return subprocess.run(
+        ["docker", "run", "--rm", image, *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+# -- binary availability -------------------------------------------------------
+
+
+class TestRequiredBinaries:
+    """Verify every binary the harness depends on is present in the image."""
+
+    def test_bash(self, pulled_image: str) -> None:
+        r = _docker_run(pulled_image, "which", "bash")
+        assert r.returncode == 0, r.stderr
+
+    def test_python3(self, pulled_image: str) -> None:
+        r = _docker_run(pulled_image, "which", "python3")
+        assert r.returncode == 0, r.stderr
+
+    def test_rg(self, pulled_image: str) -> None:
+        """ripgrep -- required by the glob and grep tools."""
+        r = _docker_run(pulled_image, "which", "rg")
+        assert r.returncode == 0, r.stderr
+
+    def test_curl(self, pulled_image: str) -> None:
+        r = _docker_run(pulled_image, "which", "curl")
+        assert r.returncode == 0, r.stderr
+
+    def test_git(self, pulled_image: str) -> None:
+        r = _docker_run(pulled_image, "which", "git")
+        assert r.returncode == 0, r.stderr
+
+    def test_iptables(self, pulled_image: str) -> None:
+        """iptables -- required for limited-networking mode."""
+        r = _docker_run(pulled_image, "which", "iptables")
+        assert r.returncode == 0, r.stderr
+
+    def test_tail(self, pulled_image: str) -> None:
+        """tail -- the image CMD is ``tail -f /dev/null``."""
+        r = _docker_run(pulled_image, "which", "tail")
+        assert r.returncode == 0, r.stderr
+
+
+# -- runtime behaviour ---------------------------------------------------------
+
+
+class TestRuntimeBehaviour:
+    """Verify the functional contracts the harness relies on."""
+
+    def test_bash_minus_c_executes(self, pulled_image: str) -> None:
+        """The harness passes every exec call as ``bash -c <command>``."""
+        r = _docker_run(pulled_image, "bash", "-c", "echo contract-ok")
+        assert r.returncode == 0, r.stderr
+        assert "contract-ok" in r.stdout
+
+    def test_python3_version_is_313(self, pulled_image: str) -> None:
+        """Image must ship Python 3.13 (base: python:3.13-slim-bookworm)."""
+        r = _docker_run(pulled_image, "python3", "--version")
+        assert r.returncode == 0, r.stderr
+        version_output = r.stdout + r.stderr
+        assert "Python 3.13" in version_output, f"unexpected version: {version_output!r}"
+
+    def test_python3_venv_creation(self, pulled_image: str) -> None:
+        """setup.py calls ``python3 -m venv /workspace/.venv`` on first provision."""
+        r = _docker_run(
+            pulled_image,
+            "bash",
+            "-c",
+            "python3 -m venv /tmp/test-venv && test -f /tmp/test-venv/bin/python",
+        )
+        assert r.returncode == 0, f"venv creation failed: {r.stderr}"
+
+    def test_rg_search(self, pulled_image: str) -> None:
+        """rg must work end-to-end (glob and grep tools both invoke it)."""
+        r = _docker_run(
+            pulled_image,
+            "bash",
+            "-c",
+            "echo 'hello world' > /tmp/test.txt && rg 'hello' /tmp/test.txt",
+        )
+        assert r.returncode == 0, r.stderr
+        assert "hello" in r.stdout
+
+    def test_workspace_is_workdir(self, pulled_image: str) -> None:
+        """WORKDIR /workspace -- exec calls default cwd to /workspace."""
+        r = _docker_run(pulled_image, "bash", "-c", "pwd")
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == "/workspace"
+
+    def test_runs_as_root(self, pulled_image: str) -> None:
+        """Dockerfile has no USER directive so iptables (requires root) can run."""
+        r = _docker_run(pulled_image, "bash", "-c", "id -u")
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == "0", f"expected uid 0, got {r.stdout.strip()!r}"
+
+
+# -- workspace mount -----------------------------------------------------------
+
+
+class TestWorkspaceMount:
+    """Verify the /workspace bind-mount contract."""
+
+    def test_container_can_write_to_mounted_workspace(
+        self, pulled_image: str, tmp_path: Path
+    ) -> None:
+        """The harness mounts a host directory at /workspace; the container
+        must be able to write there so tool outputs survive the exec call."""
+        sentinel = tmp_path / "sentinel.txt"
+        result = subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--volume",
+                f"{tmp_path}:/workspace",
+                pulled_image,
+                "bash",
+                "-c",
+                "echo 'mounted-ok' > /workspace/sentinel.txt",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        assert sentinel.exists(), "sentinel file not created on host"
+        assert "mounted-ok" in sentinel.read_text()
+
+    def test_container_can_read_from_mounted_workspace(
+        self, pulled_image: str, tmp_path: Path
+    ) -> None:
+        """Files placed in the host workspace are visible to the container."""
+        (tmp_path / "host-file.txt").write_text("from-host\n")
+        result = subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--volume",
+                f"{tmp_path}:/workspace",
+                pulled_image,
+                "bash",
+                "-c",
+                "cat /workspace/host-file.txt",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "from-host" in result.stdout
+
+
+# -- architecture --------------------------------------------------------------
+
+
+class TestArchitecture:
+    """Verify multi-arch and platform properties."""
+
+    def test_image_architecture_matches_runner(self, pulled_image: str) -> None:
+        """The pulled image should run on the current host without emulation."""
+        result = subprocess.run(
+            [
+                "docker",
+                "inspect",
+                "--format",
+                "{{.Architecture}}",
+                pulled_image,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            pytest.skip(f"docker inspect failed: {result.stderr.strip()}")
+        image_arch = result.stdout.strip()
+        machine = platform.machine()
+        expected_map = {"x86_64": "amd64", "aarch64": "arm64", "arm64": "arm64"}
+        expected = expected_map.get(machine)
+        if expected is None:
+            pytest.skip(f"unknown host machine type: {machine!r}")
+        assert image_arch == expected, (
+            f"image architecture {image_arch!r} does not match runner {machine!r}"
+        )
+
+    def test_manifest_includes_amd64_and_arm64(self, pulled_image: str) -> None:
+        """Published images should be multi-arch (amd64 + arm64).
+
+        Skips if ``docker buildx`` or ``imagetools`` sub-command is unavailable.
+        """
+        if shutil.which("docker") is None:
+            pytest.skip("docker not on PATH")
+        result = subprocess.run(
+            ["docker", "buildx", "imagetools", "inspect", pulled_image],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            pytest.skip(f"docker buildx imagetools not available: {result.stderr.strip()}")
+        output = result.stdout + result.stderr
+        assert "linux/amd64" in output, f"amd64 not found in manifest: {output[:500]}"
+        assert "linux/arm64" in output, f"arm64 not found in manifest: {output[:500]}"

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -23,8 +23,10 @@ from tests.conftest import needs_docker
 
 pytestmark = needs_docker
 
-# Read directly from env rather than importing Settings to avoid triggering the
-# settings singleton, which requires AIOS_DB_URL and other runtime env vars.
+# Read directly from env: importing Settings would fail in test environments
+# because Settings has required fields (AIOS_DB_URL, AIOS_API_KEY, etc.) with
+# no defaults. The env var name is stable -- it's derived from env_prefix="AIOS_"
+# + field name "docker_image".
 IMAGE = os.environ.get("AIOS_DOCKER_IMAGE", "ghcr.io/eumemic/aios-sandbox:latest")
 
 
@@ -41,6 +43,7 @@ def pulled_image() -> str:
         capture_output=True,
         text=True,
         check=False,
+        timeout=300,
     )
     if result.returncode != 0:
         pytest.fail(f"Could not pull {IMAGE!r}: {result.stderr.strip()}")
@@ -65,68 +68,33 @@ def _docker_run(
 # -- binary availability -------------------------------------------------------
 
 
-class TestRequiredBinaries:
-    """Verify every binary the harness depends on is present in the image."""
+@pytest.mark.parametrize(
+    "binary",
+    [
+        "bash",
+        "python3",
+        "python3.13",
+        "rg",  # ripgrep -- required by the glob and grep tools
+        "curl",
+        "git",
+        "iptables",  # required for limited-networking mode
+        "tail",  # the image CMD is `tail -f /dev/null`
+        "cat",
+        "head",
+        "grep",
+        "find",
+        "sed",
+        "awk",
+    ],
+)
+def test_binary_available(pulled_image: str, binary: str) -> None:
+    """Verify every binary the harness depends on is present in the image.
 
-    def test_bash(self, pulled_image: str) -> None:
-        r = _docker_run(pulled_image, "which", "bash")
-        assert r.returncode == 0, r.stderr
-
-    def test_python3(self, pulled_image: str) -> None:
-        r = _docker_run(pulled_image, "which", "python3")
-        assert r.returncode == 0, r.stderr
-
-    def test_python313(self, pulled_image: str) -> None:
-        """python3.13 specifically -- version match matters for sandboxed tool execution."""
-        r = _docker_run(pulled_image, "which", "python3.13")
-        assert r.returncode == 0, r.stderr
-
-    def test_cat(self, pulled_image: str) -> None:
-        r = _docker_run(pulled_image, "which", "cat")
-        assert r.returncode == 0, r.stderr
-
-    def test_head(self, pulled_image: str) -> None:
-        r = _docker_run(pulled_image, "which", "head")
-        assert r.returncode == 0, r.stderr
-
-    def test_grep(self, pulled_image: str) -> None:
-        r = _docker_run(pulled_image, "which", "grep")
-        assert r.returncode == 0, r.stderr
-
-    def test_find(self, pulled_image: str) -> None:
-        r = _docker_run(pulled_image, "which", "find")
-        assert r.returncode == 0, r.stderr
-
-    def test_sed(self, pulled_image: str) -> None:
-        r = _docker_run(pulled_image, "which", "sed")
-        assert r.returncode == 0, r.stderr
-
-    def test_awk(self, pulled_image: str) -> None:
-        r = _docker_run(pulled_image, "which", "awk")
-        assert r.returncode == 0, r.stderr
-
-    def test_rg(self, pulled_image: str) -> None:
-        """ripgrep -- required by the glob and grep tools."""
-        r = _docker_run(pulled_image, "which", "rg")
-        assert r.returncode == 0, r.stderr
-
-    def test_curl(self, pulled_image: str) -> None:
-        r = _docker_run(pulled_image, "which", "curl")
-        assert r.returncode == 0, r.stderr
-
-    def test_git(self, pulled_image: str) -> None:
-        r = _docker_run(pulled_image, "which", "git")
-        assert r.returncode == 0, r.stderr
-
-    def test_iptables(self, pulled_image: str) -> None:
-        """iptables -- required for limited-networking mode."""
-        r = _docker_run(pulled_image, "which", "iptables")
-        assert r.returncode == 0, r.stderr
-
-    def test_tail(self, pulled_image: str) -> None:
-        """tail -- the image CMD is ``tail -f /dev/null``."""
-        r = _docker_run(pulled_image, "which", "tail")
-        assert r.returncode == 0, r.stderr
+    Each binary gets its own test-case ID in CI output so failures pinpoint
+    the exact missing binary.
+    """
+    r = _docker_run(pulled_image, "which", binary)
+    assert r.returncode == 0, f"{binary!r} not found: {r.stderr}"
 
 
 # -- runtime behaviour ---------------------------------------------------------


### PR DESCRIPTION
Adds a new e2e test module that pulls the configured `AIOS_DOCKER_IMAGE` and verifies it satisfies every assumption the aios worker makes at runtime. The suite skips cleanly when Docker is unavailable via the existing `needs_docker` mark, so it can run in CI without special-casing.

## What the tests cover

- **Required binaries** — `bash`, `python3`, `rg` (ripgrep), `curl`, `git`, `iptables`, `tail` are all present on `$PATH`
- **Runtime behaviour** — `bash -c` exec contract, Python version is 3.13+, venv creation succeeds, `rg` search works, `/workspace` is the `WORKDIR`, process runs as root (uid 0)
- **Workspace mount** — files written through a `/workspace` volume bind are readable and writable from the host
- **Architecture** — image arch matches the runner; the manifest index lists both `amd64` and `arm64` variants

## Test plan

- `uv run pytest tests/e2e/test_sandbox_image_contract.py -q` with Docker available and `AIOS_DOCKER_IMAGE` set — all 17 tests should pass
- Without Docker or the env var set, the entire module skips via the `needs_docker` mark — no failures

Closes #360