### PR TITLE
feat(#361): tag-promotion workflow for aios-sandbox (Track R v1)

### DIFF
--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -28,6 +28,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       packages: write
@@ -77,3 +78,37 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  smoke:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install test deps
+        run: |
+          pip install uv
+          uv sync --frozen
+      - name: Pull just-built image
+        run: docker pull ghcr.io/eumemic/aios-sandbox:latest
+      - name: Run sandbox contract test
+        run: uv run pytest tests/e2e/test_sandbox_image_contract.py -v
+        env:
+          AIOS_DOCKER_IMAGE: ghcr.io/eumemic/aios-sandbox:latest
+      - name: Retag :latest → :smoked
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/eumemic/aios-sandbox:smoked \
+            ghcr.io/eumemic/aios-sandbox:latest

--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -25,6 +25,12 @@ on:
       - .github/workflows/build-sandbox.yml
   workflow_dispatch:
 
+# One build+smoke pipeline at a time per ref.  A second push while smoke
+# is running cancels the in-flight run rather than racing to update :smoked.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install test deps
-        run: uv sync --frozen
+        run: uv sync --dev --frozen
       - name: Pull just-built image
         # Pull by immutable sha tag (set by build job) to avoid a race
         # where a concurrent master push advances :latest before we smoke.

--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -28,6 +28,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      # Immutable sha-tagged reference for the smoke job so it always tests
+      # the exact image produced by this build step, regardless of concurrent
+      # master pushes that may advance :latest between build and smoke.
+      sha_tag: ${{ steps.sha_tag.outputs.tag }}
 
     permissions:
       contents: read
@@ -79,6 +84,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Expose sha tag for smoke job
+        id: sha_tag
+        run: echo "tag=ghcr.io/eumemic/aios-sandbox:sha-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+
   smoke:
     needs: build
     runs-on: ubuntu-latest
@@ -101,14 +110,17 @@ jobs:
         run: |
           pip install uv
           uv sync --frozen
+      - uses: docker/setup-buildx-action@v3
       - name: Pull just-built image
-        run: docker pull ghcr.io/eumemic/aios-sandbox:latest
+        # Pull by immutable sha tag (set by build job) to avoid a race
+        # where a concurrent master push advances :latest before we smoke.
+        run: docker pull ${{ needs.build.outputs.sha_tag }}
       - name: Run sandbox contract test
         run: uv run pytest tests/e2e/test_sandbox_image_contract.py -v
         env:
-          AIOS_DOCKER_IMAGE: ghcr.io/eumemic/aios-sandbox:latest
-      - name: Retag :latest → :smoked
+          AIOS_DOCKER_IMAGE: ${{ needs.build.outputs.sha_tag }}
+      - name: Retag sha → :smoked
         run: |
           docker buildx imagetools create \
             -t ghcr.io/eumemic/aios-sandbox:smoked \
-            ghcr.io/eumemic/aios-sandbox:latest
+            ${{ needs.build.outputs.sha_tag }}

--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -91,6 +91,7 @@ jobs:
   smoke:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write
@@ -120,6 +121,7 @@ jobs:
         env:
           AIOS_DOCKER_IMAGE: ${{ needs.build.outputs.sha_tag }}
       - name: Retag sha → :smoked
+        if: success()
         run: |
           docker buildx imagetools create \
             -t ghcr.io/eumemic/aios-sandbox:smoked \

--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -103,26 +103,22 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: docker/setup-buildx-action@v3
+      - uses: astral-sh/setup-uv@v4
         with:
           python-version: '3.13'
       - name: Install test deps
-        run: |
-          pip install uv
-          uv sync --frozen
-      - uses: docker/setup-buildx-action@v3
+        run: uv sync --frozen
       - name: Pull just-built image
         # Pull by immutable sha tag (set by build job) to avoid a race
         # where a concurrent master push advances :latest before we smoke.
-        run: docker pull ${{ needs.build.outputs.sha_tag }}
+        run: docker pull "${{ needs.build.outputs.sha_tag }}"
       - name: Run sandbox contract test
         run: uv run pytest tests/e2e/test_sandbox_image_contract.py -v
         env:
           AIOS_DOCKER_IMAGE: ${{ needs.build.outputs.sha_tag }}
       - name: Retag sha → :smoked
-        if: success()
         run: |
           docker buildx imagetools create \
             -t ghcr.io/eumemic/aios-sandbox:smoked \
-            ${{ needs.build.outputs.sha_tag }}
+            "${{ needs.build.outputs.sha_tag }}"

--- a/.github/workflows/promote-sandbox.yml
+++ b/.github/workflows/promote-sandbox.yml
@@ -36,12 +36,17 @@ jobs:
           DIGEST=$(docker buildx imagetools inspect \
             ghcr.io/eumemic/aios-sandbox:smoked \
             --format '{{.Manifest.Digest}}')
+          # Fail loudly if :smoked doesn't exist or inspect returned empty.
+          [ -n "$DIGEST" ] || { echo "ERROR: could not resolve :smoked digest — has the smoke job run?"; exit 1; }
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
       - name: Retag :smoked → :stable
+        # Use the pinned digest (not the mutable :smoked tag) so that even
+        # if a concurrent smoke run updates :smoked between the resolve and
+        # retag steps, :stable points to exactly the image we inspected.
         run: |
           docker buildx imagetools create \
             -t ghcr.io/eumemic/aios-sandbox:stable \
-            ghcr.io/eumemic/aios-sandbox:smoked
+            ghcr.io/eumemic/aios-sandbox@${{ steps.digest.outputs.digest }}
       - name: Trigger ledger append
         uses: peter-evans/repository-dispatch@v3
         with:

--- a/.github/workflows/promote-sandbox.yml
+++ b/.github/workflows/promote-sandbox.yml
@@ -1,0 +1,57 @@
+name: Promote aios-sandbox :smoked → :stable
+
+# Manifest-level retag: promotes the already-smoked image to :stable.
+# Requires explicit reviewer approval via the ``stable`` GitHub environment
+# before the retag executes, so no untested image can reach :stable
+# without a human sign-off.
+#
+# After promoting, fires a repository-dispatch event to eumemic-ops so the
+# deploy ledger can record the new :stable digest.
+#
+# Security note: this workflow does not interpolate any untrusted input
+# into ``run:`` commands.  Only trusted contexts (github.actor,
+# secrets.GITHUB_TOKEN, secrets.EUMEMIC_OPS_DISPATCH_TOKEN, and outputs
+# from pinned actions) are referenced.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment: stable  # requires reviewer approval
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve :smoked digest
+        id: digest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect \
+            ghcr.io/eumemic/aios-sandbox:smoked \
+            --format '{{.Manifest.Digest}}')
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+      - name: Retag :smoked → :stable
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/eumemic/aios-sandbox:stable \
+            ghcr.io/eumemic/aios-sandbox:smoked
+      - name: Trigger ledger append
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.EUMEMIC_OPS_DISPATCH_TOKEN }}
+          repository: eumemic/eumemic-ops
+          event-type: deploy-ledger-append
+          client-payload: |
+            {
+              "app": "aios-sandbox",
+              "track": "R",
+              "digest": "${{ steps.digest.outputs.digest }}",
+              "promoted_by": "${{ github.actor }}"
+            }

--- a/.github/workflows/promote-sandbox.yml
+++ b/.github/workflows/promote-sandbox.yml
@@ -48,6 +48,7 @@ jobs:
             -t ghcr.io/eumemic/aios-sandbox:stable \
             ghcr.io/eumemic/aios-sandbox@${{ steps.digest.outputs.digest }}
       - name: Trigger ledger append
+        if: success()
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.EUMEMIC_OPS_DISPATCH_TOKEN }}

--- a/.github/workflows/promote-sandbox.yml
+++ b/.github/workflows/promote-sandbox.yml
@@ -58,6 +58,5 @@ jobs:
               "app": "aios-sandbox",
               "track": "R",
               "digest": "${{ steps.digest.outputs.digest }}",
-              "sha": "${{ github.sha }}",
               "promoted_by": "${{ github.actor }}"
             }

--- a/.github/workflows/promote-sandbox.yml
+++ b/.github/workflows/promote-sandbox.yml
@@ -58,5 +58,6 @@ jobs:
               "app": "aios-sandbox",
               "track": "R",
               "digest": "${{ steps.digest.outputs.digest }}",
+              "sha": "${{ github.sha }}",
               "promoted_by": "${{ github.actor }}"
             }


### PR DESCRIPTION
Implements Track R v1 of the deploy gate stack for `aios-sandbox`.

## What

**`build-sandbox.yml`** — new `smoke` job (runs after `build`):
- Pulls the just-published `:latest` from GHCR
- Runs `tests/e2e/test_sandbox_image_contract.py` against it via `AIOS_DOCKER_IMAGE`
- On green, retags `:latest` → `:smoked` using `docker buildx imagetools create` (manifest-level retag, no rebuild, multi-arch manifest list preserved)

**`.github/workflows/promote-sandbox.yml`** — new `workflow_dispatch` workflow:
- Blocks at the `stable` GitHub environment gate (requires explicit reviewer approval)
- Resolves the current `:smoked` digest
- Retags `:smoked` → `:stable` (manifest-level)
- Fires `deploy-ledger-append` repository-dispatch to `eumemic/eumemic-ops` with app, track, digest, and actor

## Manual steps required after merge

- Create `stable` environment in aios repo settings with required reviewers (`tom`) and master-only deployment branch policy
- Add `EUMEMIC_OPS_DISPATCH_TOKEN` secret (fine-grained PAT scoped to `repository_dispatch` on `eumemic/eumemic-ops`)

## Tag semantics

| Tag | Meaning |
|-----|---------|
| `:latest` | Most recent build from master — may be unsmoked |
| `:smoked` | Last `:latest` that passed the contract test |
| `:stable` | Last `:smoked` that received explicit reviewer approval |

## Depends on

- #360 (sandbox image contract test — the smoke job calls it)

Closes #361