### PR TITLE
feat(#367): PR 1 — accounts + account_keys tables and bootstrap endpoint

### DIFF
--- a/docs/ops/root-recovery.md
+++ b/docs/ops/root-recovery.md
@@ -1,0 +1,115 @@
+# Recovering from lost root credentials
+
+This procedure recovers operator access when the root account's API
+keys have all been lost or revoked, or when the root account has been
+accidentally archived. It requires direct Postgres access — there is
+no in-band recovery path, by design (a re-openable bootstrap endpoint
+would be a permanent re-entry mechanism that defeats the purpose of
+the one-shot model).
+
+## Symptom
+
+Every API call returns `401 unauthorized`. No working root key is
+known. `AIOS_BOOTSTRAP_TOKEN` is set but `POST /v1/accounts/bootstrap`
+returns `404` (a root row exists in the table, just with no usable
+key).
+
+## Procedure
+
+You need shell access to the host running aios and credentials for
+the aios Postgres database.
+
+### 1. Confirm the root account exists
+
+```sql
+SELECT id, display_name, archived_at, created_at
+FROM accounts
+WHERE parent_account_id IS NULL;
+```
+
+You expect exactly one row. If the row is archived (`archived_at IS
+NOT NULL`), continue to step 2. Otherwise skip to step 3.
+
+### 2. Un-archive the root if it was accidentally archived
+
+```sql
+UPDATE accounts
+SET archived_at = NULL
+WHERE id = '<root_account_id>'
+  AND parent_account_id IS NULL;
+```
+
+The `accounts_one_active_root` partial unique index blocks two active
+roots from coexisting — if you somehow ended up with a stale active
+root *and* a real one, you'll see a unique-violation here. In that
+case, archive the stale row first and re-run the un-archive.
+
+### 3. Generate a fresh API key and its sha256 hash
+
+Run this on the host as the aios operator:
+
+```bash
+PLAINTEXT=$(python3 -c '
+import secrets
+print("aios_" + secrets.token_urlsafe(32))
+')
+
+# print the plaintext so you can capture it — this is your new root key
+echo "ROOT_KEY: $PLAINTEXT"
+
+# compute the sha256 hash (raw bytes, hex-encoded for psql)
+HEX_HASH=$(python3 -c "
+import hashlib, sys
+print(hashlib.sha256(sys.argv[1].encode()).hexdigest())
+" "$PLAINTEXT")
+
+echo "HEX_HASH: $HEX_HASH"
+```
+
+Capture `ROOT_KEY` into your secret store *immediately* — you cannot
+recover it from the database after this step.
+
+### 4. Insert the key row
+
+```sql
+INSERT INTO account_keys (key_id, account_id, hash, label)
+VALUES (
+    'key_' || replace(gen_random_uuid()::text, '-', ''),  -- any unique key_id
+    '<root_account_id>',
+    decode('<HEX_HASH from step 3>', 'hex'),
+    'manual-recovery'
+);
+```
+
+The `key_id` value can be any string; the rest of the system only
+identifies keys via their hash. Using a descriptive `label` like
+`manual-recovery` makes the recovery audit-visible in later
+`GET /v1/accounts/{id}/keys` calls.
+
+### 5. Verify and restart
+
+```bash
+# verify the key works against the running api
+curl -sS -H "Authorization: Bearer $PLAINTEXT" \
+  http://localhost:8090/v1/accounts/self
+```
+
+Once the recovery key is verified, restart api + worker so any cached
+auth state is cleared. (Strictly speaking PR 1 doesn't cache anything,
+but later PRs may, and the restart is cheap insurance.)
+
+### 6. Rotate the recovery key
+
+A manually-injected key sidesteps the normal mint flow and isn't
+labeled or scoped like a production key. Once you're back in, use it
+to mint a new key via `POST /v1/accounts/<root_id>/keys` and revoke
+the recovery key with `DELETE /v1/accounts/keys/<key_id>`.
+
+## Why this is deliberately painful
+
+Root represents full operator authority over every account in the
+system. A re-runnable bootstrap path or an "emergency override" env
+var would mean any future compromise of that secret can re-mint root
+indefinitely. The Postgres-side recipe requires database credentials,
+which are themselves a high-trust artifact — the recovery surface is
+exactly as protected as the database itself, and no more.

--- a/docs/ops/root-recovery.md
+++ b/docs/ops/root-recovery.md
@@ -95,8 +95,7 @@ curl -sS -H "Authorization: Bearer $PLAINTEXT" \
 ```
 
 Once the recovery key is verified, restart api + worker so any cached
-auth state is cleared. (Strictly speaking PR 1 doesn't cache anything,
-but later PRs may, and the restart is cheap insurance.)
+auth state is cleared.
 
 ### 6. Rotate the recovery key
 

--- a/migrations/versions/0042_accounts_and_keys.py
+++ b/migrations/versions/0042_accounts_and_keys.py
@@ -1,0 +1,127 @@
+"""Multi-tenancy v1 PR 1: ``accounts`` + ``account_keys`` tables.
+
+First migration of the multi-tenancy stack (issue #367). Adds the two
+tables that everything else hangs off:
+
+* ``accounts`` — the hierarchical tenant. Tree via ``parent_account_id``;
+  one capability flag (``can_mint_children``); soft-archived via
+  ``archived_at``. Three partial-unique indexes enforce: (a) sibling
+  display names are unique within a parent, (b) root display names are
+  unique among roots (because ``NULL != NULL`` in regular UNIQUE), and
+  (c) at most one active root can exist at a time.
+* ``account_keys`` — bearer API keys. Plaintext returned once at mint;
+  stored as ``sha256`` hash. Multiple active keys per account allowed
+  (zero-downtime rotation). ``ON DELETE CASCADE`` so a hard ``purge``
+  of an account sweeps its keys with it.
+
+No resource table gets touched here — PR 4 in the stack will add the
+``account_id`` columns and FKs. PR 2 changes the auth dep to return
+``(account_id, key_id, can_mint_children)``; PR 1 just lays the
+foundation.
+
+Revision ID: 0042
+Revises: 0041
+Create Date: 2026-05-14
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0042"
+down_revision: str = "0041"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE accounts (
+            id                  text PRIMARY KEY,
+            parent_account_id   text REFERENCES accounts(id) ON DELETE RESTRICT,
+            can_mint_children   boolean     NOT NULL DEFAULT FALSE,
+            display_name        text        NOT NULL,
+            metadata            jsonb       NOT NULL DEFAULT '{}'::jsonb,
+            archived_at         timestamptz,
+            created_at          timestamptz NOT NULL DEFAULT now()
+        )
+        """
+    )
+
+    # Sibling-unique display names: two active accounts under the same
+    # parent can't share a name.  Partial on ``archived_at IS NULL`` so a
+    # soft-deleted name is immediately reusable.
+    op.execute(
+        """
+        CREATE UNIQUE INDEX accounts_sibling_name_uniq
+        ON accounts (parent_account_id, display_name)
+        WHERE archived_at IS NULL
+        """
+    )
+
+    # Root display names: regular UNIQUE treats NULLs as distinct, so a
+    # plain ``UNIQUE (parent_account_id, display_name)`` would let two
+    # roots share a name (both rows have ``parent_account_id IS NULL``).
+    # Partial unique on display_name where the parent is NULL fixes it.
+    op.execute(
+        """
+        CREATE UNIQUE INDEX accounts_root_name_uniq
+        ON accounts (display_name)
+        WHERE parent_account_id IS NULL AND archived_at IS NULL
+        """
+    )
+
+    # At most one active root: an expression index on a constant value
+    # makes every matching row share the same key, so a second active
+    # root violates uniqueness.  Cleaner than a CHECK + trigger.
+    op.execute(
+        """
+        CREATE UNIQUE INDEX accounts_one_active_root
+        ON accounts ((TRUE))
+        WHERE parent_account_id IS NULL AND archived_at IS NULL
+        """
+    )
+
+    # Fast lookup of a parent's direct children (the management
+    # endpoint that lists children, the cascade-archive walk).
+    op.execute(
+        """
+        CREATE INDEX accounts_parent_idx
+        ON accounts (parent_account_id)
+        WHERE archived_at IS NULL
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE account_keys (
+            key_id          text PRIMARY KEY,
+            account_id      text NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+            hash            bytea       NOT NULL,
+            label           text        NOT NULL,
+            created_at      timestamptz NOT NULL DEFAULT now(),
+            last_used_at    timestamptz,
+            revoked_at      timestamptz,
+            UNIQUE (hash)
+        )
+        """
+    )
+
+    # The auth dep looks up tokens by hash; the UNIQUE constraint above
+    # already gives a B-tree on hash.  We also need a fast "active keys
+    # for this account" lookup for the list-keys endpoint.
+    op.execute(
+        """
+        CREATE INDEX account_keys_account_active_idx
+        ON account_keys (account_id)
+        WHERE revoked_at IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS account_keys")
+    op.execute("DROP TABLE IF EXISTS accounts")

--- a/migrations/versions/0042_accounts_and_keys.py
+++ b/migrations/versions/0042_accounts_and_keys.py
@@ -1,23 +1,12 @@
-"""Multi-tenancy v1 PR 1: ``accounts`` + ``account_keys`` tables.
+"""Add ``accounts`` + ``account_keys`` tables.
 
-First migration of the multi-tenancy stack (issue #367). Adds the two
-tables that everything else hangs off:
+``accounts`` is the hierarchical tenant. Each row points to its parent
+via ``parent_account_id`` (NULL for the singular root). ``can_mint_children``
+gates the create-child management verbs. Soft-archived via ``archived_at``.
 
-* ``accounts`` — the hierarchical tenant. Tree via ``parent_account_id``;
-  one capability flag (``can_mint_children``); soft-archived via
-  ``archived_at``. Three partial-unique indexes enforce: (a) sibling
-  display names are unique within a parent, (b) root display names are
-  unique among roots (because ``NULL != NULL`` in regular UNIQUE), and
-  (c) at most one active root can exist at a time.
-* ``account_keys`` — bearer API keys. Plaintext returned once at mint;
-  stored as ``sha256`` hash. Multiple active keys per account allowed
-  (zero-downtime rotation). ``ON DELETE CASCADE`` so a hard ``purge``
-  of an account sweeps its keys with it.
-
-No resource table gets touched here — PR 4 in the stack will add the
-``account_id`` columns and FKs. PR 2 changes the auth dep to return
-``(account_id, key_id, can_mint_children)``; PR 1 just lays the
-foundation.
+``account_keys`` holds bearer API keys, hashed at rest. Plaintext is
+returned exactly once at mint time; multiple active keys per account
+are allowed so rotation is mint-new + switch-callers + revoke-old.
 
 Revision ID: 0042
 Revises: 0041
@@ -51,9 +40,6 @@ def upgrade() -> None:
         """
     )
 
-    # Sibling-unique display names: two active accounts under the same
-    # parent can't share a name.  Partial on ``archived_at IS NULL`` so a
-    # soft-deleted name is immediately reusable.
     op.execute(
         """
         CREATE UNIQUE INDEX accounts_sibling_name_uniq
@@ -62,9 +48,9 @@ def upgrade() -> None:
         """
     )
 
-    # Root display names: regular UNIQUE treats NULLs as distinct, so a
-    # plain ``UNIQUE (parent_account_id, display_name)`` would let two
-    # roots share a name (both rows have ``parent_account_id IS NULL``).
+    # Regular UNIQUE treats NULLs as distinct, so a plain
+    # ``UNIQUE (parent_account_id, display_name)`` would let two roots
+    # share a name (both rows have ``parent_account_id IS NULL``).
     # Partial unique on display_name where the parent is NULL fixes it.
     op.execute(
         """
@@ -74,9 +60,9 @@ def upgrade() -> None:
         """
     )
 
-    # At most one active root: an expression index on a constant value
-    # makes every matching row share the same key, so a second active
-    # root violates uniqueness.  Cleaner than a CHECK + trigger.
+    # ``((TRUE))`` makes every matching row share the same index key,
+    # so a second active root violates uniqueness — cleaner than a
+    # CHECK + trigger for "at most one active root."
     op.execute(
         """
         CREATE UNIQUE INDEX accounts_one_active_root
@@ -85,8 +71,6 @@ def upgrade() -> None:
         """
     )
 
-    # Fast lookup of a parent's direct children (the management
-    # endpoint that lists children, the cascade-archive walk).
     op.execute(
         """
         CREATE INDEX accounts_parent_idx
@@ -110,9 +94,6 @@ def upgrade() -> None:
         """
     )
 
-    # The auth dep looks up tokens by hash; the UNIQUE constraint above
-    # already gives a B-tree on hash.  We also need a fast "active keys
-    # for this account" lookup for the list-keys endpoint.
     op.execute(
         """
         CREATE INDEX account_keys_account_active_idx

--- a/openapi.json
+++ b/openapi.json
@@ -29,6 +29,71 @@
         }
       }
     },
+    "/v1/accounts/bootstrap": {
+      "post": {
+        "tags": [
+          "accounts"
+        ],
+        "summary": "Bootstrap",
+        "description": "One-shot endpoint that mints the root account and its first API key.\n\nGated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset\nor empty, the endpoint is 401 regardless of header value \u2014 a fresh\ndeployment must explicitly opt in to bootstrap by setting the env.\n\nOnce a non-archived root account exists, the endpoint is 404\nregardless of token validity. The ``accounts_one_active_root``\npartial unique index in migration 0040 enforces the invariant at\nthe DB layer too \u2014 the 404 here is the friendly upstream answer.\n\nThe ``plaintext_key`` field of the response is the *only* time the\noperator key is returned in plaintext. After this call, every\nsubsequent use of that key authenticates against the stored\n``sha256`` hash.",
+        "operationId": "bootstrap_root_account",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BootstrapRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BootstrapResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen": {
+          "targets": [
+            "sdk"
+          ]
+        }
+      }
+    },
     "/v1/environments": {
       "post": {
         "tags": [
@@ -7002,6 +7067,47 @@
           "file"
         ],
         "title": "Body_upload_session_file"
+      },
+      "BootstrapRequest": {
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Display Name"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "display_name"
+        ],
+        "title": "BootstrapRequest",
+        "description": "Body for ``POST /v1/accounts/bootstrap``.\n\nOnly the human-readable display_name is required at bootstrap time;\nmetadata can be added later via a PATCH endpoint (lands in PR 6)."
+      },
+      "BootstrapResponse": {
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "title": "Account Id"
+          },
+          "key_id": {
+            "type": "string",
+            "title": "Key Id"
+          },
+          "plaintext_key": {
+            "type": "string",
+            "title": "Plaintext Key"
+          }
+        },
+        "type": "object",
+        "required": [
+          "account_id",
+          "key_id",
+          "plaintext_key"
+        ],
+        "title": "BootstrapResponse",
+        "description": "Response from ``POST /v1/accounts/bootstrap``.\n\n``plaintext_key`` is returned exactly once \u2014 it's never recoverable\nafter this response. The operator must capture it (env, secret store,\npassword manager). All subsequent API calls use it as a bearer token."
       },
       "BoundChat": {
         "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -35,7 +35,7 @@
           "accounts"
         ],
         "summary": "Bootstrap",
-        "description": "One-shot endpoint that mints the root account and its first API key.\n\nGated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset\nor empty, the endpoint is 401 regardless of header value \u2014 a fresh\ndeployment must explicitly opt in to bootstrap by setting the env.\n\nOnce a non-archived root account exists, the endpoint is 404\nregardless of token validity. The ``accounts_one_active_root``\npartial unique index in migration 0040 enforces the invariant at\nthe DB layer too \u2014 the 404 here is the friendly upstream answer.\n\nThe ``plaintext_key`` field of the response is the *only* time the\noperator key is returned in plaintext. After this call, every\nsubsequent use of that key authenticates against the stored\n``sha256`` hash.",
+        "description": "Mint the root account and its first API key.\n\nGated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset\nor empty, the endpoint is 401 regardless of header value.\n\nRoot-exists check fires before the token check so a probe with no/\nwrong token can't distinguish \"no bootstrap\" (404) from \"wrong token\nbut bootstrap is still open\" (401). Once a root is in place the\nendpoint behaves like it doesn't exist at all.\n\n``plaintext_key`` in the response is the only time the operator key\nis returned in plaintext.",
         "operationId": "bootstrap_root_account",
         "parameters": [
           {
@@ -7082,8 +7082,7 @@
         "required": [
           "display_name"
         ],
-        "title": "BootstrapRequest",
-        "description": "Body for ``POST /v1/accounts/bootstrap``.\n\nOnly the human-readable display_name is required at bootstrap time;\nmetadata can be added later via a PATCH endpoint (lands in PR 6)."
+        "title": "BootstrapRequest"
       },
       "BootstrapResponse": {
         "properties": {
@@ -7106,8 +7105,7 @@
           "key_id",
           "plaintext_key"
         ],
-        "title": "BootstrapResponse",
-        "description": "Response from ``POST /v1/accounts/bootstrap``.\n\n``plaintext_key`` is returned exactly once \u2014 it's never recoverable\nafter this response. The operator must capture it (env, secret store,\npassword manager). All subsequent API calls use it as a bearer token."
+        "title": "BootstrapResponse"
       },
       "BoundChat": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/accounts/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/accounts/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/packages/aios-sdk/aios_sdk/_generated/api/accounts/bootstrap_root_account.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/accounts/bootstrap_root_account.py
@@ -69,30 +69,24 @@ def sync_detailed(
     body: BootstrapRequest,
     authorization: None | str | Unset = UNSET,
 ) -> Response[BootstrapResponse | HTTPValidationError]:
-    """Bootstrap
+    r"""Bootstrap
 
-     One-shot endpoint that mints the root account and its first API key.
+     Mint the root account and its first API key.
 
     Gated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset
-    or empty, the endpoint is 401 regardless of header value — a fresh
-    deployment must explicitly opt in to bootstrap by setting the env.
+    or empty, the endpoint is 401 regardless of header value.
 
-    Once a non-archived root account exists, the endpoint is 404
-    regardless of token validity. The ``accounts_one_active_root``
-    partial unique index in migration 0040 enforces the invariant at
-    the DB layer too — the 404 here is the friendly upstream answer.
+    Root-exists check fires before the token check so a probe with no/
+    wrong token can't distinguish \"no bootstrap\" (404) from \"wrong token
+    but bootstrap is still open\" (401). Once a root is in place the
+    endpoint behaves like it doesn't exist at all.
 
-    The ``plaintext_key`` field of the response is the *only* time the
-    operator key is returned in plaintext. After this call, every
-    subsequent use of that key authenticates against the stored
-    ``sha256`` hash.
+    ``plaintext_key`` in the response is the only time the operator key
+    is returned in plaintext.
 
     Args:
         authorization (None | str | Unset):
-        body (BootstrapRequest): Body for ``POST /v1/accounts/bootstrap``.
-
-            Only the human-readable display_name is required at bootstrap time;
-            metadata can be added later via a PATCH endpoint (lands in PR 6).
+        body (BootstrapRequest):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -120,30 +114,24 @@ def sync(
     body: BootstrapRequest,
     authorization: None | str | Unset = UNSET,
 ) -> BootstrapResponse | HTTPValidationError | None:
-    """Bootstrap
+    r"""Bootstrap
 
-     One-shot endpoint that mints the root account and its first API key.
+     Mint the root account and its first API key.
 
     Gated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset
-    or empty, the endpoint is 401 regardless of header value — a fresh
-    deployment must explicitly opt in to bootstrap by setting the env.
+    or empty, the endpoint is 401 regardless of header value.
 
-    Once a non-archived root account exists, the endpoint is 404
-    regardless of token validity. The ``accounts_one_active_root``
-    partial unique index in migration 0040 enforces the invariant at
-    the DB layer too — the 404 here is the friendly upstream answer.
+    Root-exists check fires before the token check so a probe with no/
+    wrong token can't distinguish \"no bootstrap\" (404) from \"wrong token
+    but bootstrap is still open\" (401). Once a root is in place the
+    endpoint behaves like it doesn't exist at all.
 
-    The ``plaintext_key`` field of the response is the *only* time the
-    operator key is returned in plaintext. After this call, every
-    subsequent use of that key authenticates against the stored
-    ``sha256`` hash.
+    ``plaintext_key`` in the response is the only time the operator key
+    is returned in plaintext.
 
     Args:
         authorization (None | str | Unset):
-        body (BootstrapRequest): Body for ``POST /v1/accounts/bootstrap``.
-
-            Only the human-readable display_name is required at bootstrap time;
-            metadata can be added later via a PATCH endpoint (lands in PR 6).
+        body (BootstrapRequest):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -166,30 +154,24 @@ async def asyncio_detailed(
     body: BootstrapRequest,
     authorization: None | str | Unset = UNSET,
 ) -> Response[BootstrapResponse | HTTPValidationError]:
-    """Bootstrap
+    r"""Bootstrap
 
-     One-shot endpoint that mints the root account and its first API key.
+     Mint the root account and its first API key.
 
     Gated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset
-    or empty, the endpoint is 401 regardless of header value — a fresh
-    deployment must explicitly opt in to bootstrap by setting the env.
+    or empty, the endpoint is 401 regardless of header value.
 
-    Once a non-archived root account exists, the endpoint is 404
-    regardless of token validity. The ``accounts_one_active_root``
-    partial unique index in migration 0040 enforces the invariant at
-    the DB layer too — the 404 here is the friendly upstream answer.
+    Root-exists check fires before the token check so a probe with no/
+    wrong token can't distinguish \"no bootstrap\" (404) from \"wrong token
+    but bootstrap is still open\" (401). Once a root is in place the
+    endpoint behaves like it doesn't exist at all.
 
-    The ``plaintext_key`` field of the response is the *only* time the
-    operator key is returned in plaintext. After this call, every
-    subsequent use of that key authenticates against the stored
-    ``sha256`` hash.
+    ``plaintext_key`` in the response is the only time the operator key
+    is returned in plaintext.
 
     Args:
         authorization (None | str | Unset):
-        body (BootstrapRequest): Body for ``POST /v1/accounts/bootstrap``.
-
-            Only the human-readable display_name is required at bootstrap time;
-            metadata can be added later via a PATCH endpoint (lands in PR 6).
+        body (BootstrapRequest):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -215,30 +197,24 @@ async def asyncio(
     body: BootstrapRequest,
     authorization: None | str | Unset = UNSET,
 ) -> BootstrapResponse | HTTPValidationError | None:
-    """Bootstrap
+    r"""Bootstrap
 
-     One-shot endpoint that mints the root account and its first API key.
+     Mint the root account and its first API key.
 
     Gated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset
-    or empty, the endpoint is 401 regardless of header value — a fresh
-    deployment must explicitly opt in to bootstrap by setting the env.
+    or empty, the endpoint is 401 regardless of header value.
 
-    Once a non-archived root account exists, the endpoint is 404
-    regardless of token validity. The ``accounts_one_active_root``
-    partial unique index in migration 0040 enforces the invariant at
-    the DB layer too — the 404 here is the friendly upstream answer.
+    Root-exists check fires before the token check so a probe with no/
+    wrong token can't distinguish \"no bootstrap\" (404) from \"wrong token
+    but bootstrap is still open\" (401). Once a root is in place the
+    endpoint behaves like it doesn't exist at all.
 
-    The ``plaintext_key`` field of the response is the *only* time the
-    operator key is returned in plaintext. After this call, every
-    subsequent use of that key authenticates against the stored
-    ``sha256`` hash.
+    ``plaintext_key`` in the response is the only time the operator key
+    is returned in plaintext.
 
     Args:
         authorization (None | str | Unset):
-        body (BootstrapRequest): Body for ``POST /v1/accounts/bootstrap``.
-
-            Only the human-readable display_name is required at bootstrap time;
-            metadata can be added later via a PATCH endpoint (lands in PR 6).
+        body (BootstrapRequest):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/packages/aios-sdk/aios_sdk/_generated/api/accounts/bootstrap_root_account.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/accounts/bootstrap_root_account.py
@@ -1,0 +1,257 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.bootstrap_request import BootstrapRequest
+from ...models.bootstrap_response import BootstrapResponse
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: BootstrapRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/accounts/bootstrap",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> BootstrapResponse | HTTPValidationError | None:
+    if response.status_code == 201:
+        response_201 = BootstrapResponse.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[BootstrapResponse | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: BootstrapRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[BootstrapResponse | HTTPValidationError]:
+    """Bootstrap
+
+     One-shot endpoint that mints the root account and its first API key.
+
+    Gated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset
+    or empty, the endpoint is 401 regardless of header value — a fresh
+    deployment must explicitly opt in to bootstrap by setting the env.
+
+    Once a non-archived root account exists, the endpoint is 404
+    regardless of token validity. The ``accounts_one_active_root``
+    partial unique index in migration 0040 enforces the invariant at
+    the DB layer too — the 404 here is the friendly upstream answer.
+
+    The ``plaintext_key`` field of the response is the *only* time the
+    operator key is returned in plaintext. After this call, every
+    subsequent use of that key authenticates against the stored
+    ``sha256`` hash.
+
+    Args:
+        authorization (None | str | Unset):
+        body (BootstrapRequest): Body for ``POST /v1/accounts/bootstrap``.
+
+            Only the human-readable display_name is required at bootstrap time;
+            metadata can be added later via a PATCH endpoint (lands in PR 6).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[BootstrapResponse | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: BootstrapRequest,
+    authorization: None | str | Unset = UNSET,
+) -> BootstrapResponse | HTTPValidationError | None:
+    """Bootstrap
+
+     One-shot endpoint that mints the root account and its first API key.
+
+    Gated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset
+    or empty, the endpoint is 401 regardless of header value — a fresh
+    deployment must explicitly opt in to bootstrap by setting the env.
+
+    Once a non-archived root account exists, the endpoint is 404
+    regardless of token validity. The ``accounts_one_active_root``
+    partial unique index in migration 0040 enforces the invariant at
+    the DB layer too — the 404 here is the friendly upstream answer.
+
+    The ``plaintext_key`` field of the response is the *only* time the
+    operator key is returned in plaintext. After this call, every
+    subsequent use of that key authenticates against the stored
+    ``sha256`` hash.
+
+    Args:
+        authorization (None | str | Unset):
+        body (BootstrapRequest): Body for ``POST /v1/accounts/bootstrap``.
+
+            Only the human-readable display_name is required at bootstrap time;
+            metadata can be added later via a PATCH endpoint (lands in PR 6).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        BootstrapResponse | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: BootstrapRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[BootstrapResponse | HTTPValidationError]:
+    """Bootstrap
+
+     One-shot endpoint that mints the root account and its first API key.
+
+    Gated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset
+    or empty, the endpoint is 401 regardless of header value — a fresh
+    deployment must explicitly opt in to bootstrap by setting the env.
+
+    Once a non-archived root account exists, the endpoint is 404
+    regardless of token validity. The ``accounts_one_active_root``
+    partial unique index in migration 0040 enforces the invariant at
+    the DB layer too — the 404 here is the friendly upstream answer.
+
+    The ``plaintext_key`` field of the response is the *only* time the
+    operator key is returned in plaintext. After this call, every
+    subsequent use of that key authenticates against the stored
+    ``sha256`` hash.
+
+    Args:
+        authorization (None | str | Unset):
+        body (BootstrapRequest): Body for ``POST /v1/accounts/bootstrap``.
+
+            Only the human-readable display_name is required at bootstrap time;
+            metadata can be added later via a PATCH endpoint (lands in PR 6).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[BootstrapResponse | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: BootstrapRequest,
+    authorization: None | str | Unset = UNSET,
+) -> BootstrapResponse | HTTPValidationError | None:
+    """Bootstrap
+
+     One-shot endpoint that mints the root account and its first API key.
+
+    Gated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset
+    or empty, the endpoint is 401 regardless of header value — a fresh
+    deployment must explicitly opt in to bootstrap by setting the env.
+
+    Once a non-archived root account exists, the endpoint is 404
+    regardless of token validity. The ``accounts_one_active_root``
+    partial unique index in migration 0040 enforces the invariant at
+    the DB layer too — the 404 here is the friendly upstream answer.
+
+    The ``plaintext_key`` field of the response is the *only* time the
+    operator key is returned in plaintext. After this call, every
+    subsequent use of that key authenticates against the stored
+    ``sha256`` hash.
+
+    Args:
+        authorization (None | str | Unset):
+        body (BootstrapRequest): Body for ``POST /v1/accounts/bootstrap``.
+
+            Only the human-readable display_name is required at bootstrap time;
+            metadata can be added later via a PATCH endpoint (lands in PR 6).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        BootstrapResponse | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -17,6 +17,8 @@ from .agent_version_litellm_extra import AgentVersionLitellmExtra
 from .bind_chat_request import BindChatRequest
 from .body_post_connector_runtime_inbound import BodyPostConnectorRuntimeInbound
 from .body_upload_session_file import BodyUploadSessionFile
+from .bootstrap_request import BootstrapRequest
+from .bootstrap_response import BootstrapResponse
 from .bound_chat import BoundChat
 from .connection import Connection
 from .connection_attach import ConnectionAttach
@@ -191,6 +193,8 @@ __all__ = (
     "BindChatRequest",
     "BodyPostConnectorRuntimeInbound",
     "BodyUploadSessionFile",
+    "BootstrapRequest",
+    "BootstrapResponse",
     "BoundChat",
     "Connection",
     "ConnectionAttach",

--- a/packages/aios-sdk/aios_sdk/_generated/models/bootstrap_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/bootstrap_request.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="BootstrapRequest")
+
+
+@_attrs_define
+class BootstrapRequest:
+    """Body for ``POST /v1/accounts/bootstrap``.
+
+    Only the human-readable display_name is required at bootstrap time;
+    metadata can be added later via a PATCH endpoint (lands in PR 6).
+
+        Attributes:
+            display_name (str):
+    """
+
+    display_name: str
+
+    def to_dict(self) -> dict[str, Any]:
+        display_name = self.display_name
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "display_name": display_name,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        display_name = d.pop("display_name")
+
+        bootstrap_request = cls(
+            display_name=display_name,
+        )
+
+        return bootstrap_request

--- a/packages/aios-sdk/aios_sdk/_generated/models/bootstrap_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/bootstrap_request.py
@@ -10,13 +10,9 @@ T = TypeVar("T", bound="BootstrapRequest")
 
 @_attrs_define
 class BootstrapRequest:
-    """Body for ``POST /v1/accounts/bootstrap``.
-
-    Only the human-readable display_name is required at bootstrap time;
-    metadata can be added later via a PATCH endpoint (lands in PR 6).
-
-        Attributes:
-            display_name (str):
+    """
+    Attributes:
+        display_name (str):
     """
 
     display_name: str

--- a/packages/aios-sdk/aios_sdk/_generated/models/bootstrap_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/bootstrap_response.py
@@ -11,16 +11,11 @@ T = TypeVar("T", bound="BootstrapResponse")
 
 @_attrs_define
 class BootstrapResponse:
-    """Response from ``POST /v1/accounts/bootstrap``.
-
-    ``plaintext_key`` is returned exactly once — it's never recoverable
-    after this response. The operator must capture it (env, secret store,
-    password manager). All subsequent API calls use it as a bearer token.
-
-        Attributes:
-            account_id (str):
-            key_id (str):
-            plaintext_key (str):
+    """
+    Attributes:
+        account_id (str):
+        key_id (str):
+        plaintext_key (str):
     """
 
     account_id: str

--- a/packages/aios-sdk/aios_sdk/_generated/models/bootstrap_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/bootstrap_response.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="BootstrapResponse")
+
+
+@_attrs_define
+class BootstrapResponse:
+    """Response from ``POST /v1/accounts/bootstrap``.
+
+    ``plaintext_key`` is returned exactly once — it's never recoverable
+    after this response. The operator must capture it (env, secret store,
+    password manager). All subsequent API calls use it as a bearer token.
+
+        Attributes:
+            account_id (str):
+            key_id (str):
+            plaintext_key (str):
+    """
+
+    account_id: str
+    key_id: str
+    plaintext_key: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        account_id = self.account_id
+
+        key_id = self.key_id
+
+        plaintext_key = self.plaintext_key
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "account_id": account_id,
+                "key_id": key_id,
+                "plaintext_key": plaintext_key,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        account_id = d.pop("account_id")
+
+        key_id = d.pop("key_id")
+
+        plaintext_key = d.pop("plaintext_key")
+
+        bootstrap_response = cls(
+            account_id=account_id,
+            key_id=key_id,
+            plaintext_key=plaintext_key,
+        )
+
+        bootstrap_response.additional_properties = d
+        return bootstrap_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -16,6 +16,7 @@ from fastapi import Depends, FastAPI
 
 from aios.api.deps import require_bearer_auth
 from aios.api.routers import (
+    accounts,
     agents,
     connections,
     connectors,
@@ -89,6 +90,7 @@ def create_app() -> FastAPI:
     )
     install_exception_handlers(app)
     app.include_router(health.router)
+    app.include_router(accounts.router)
     app.include_router(environments.router)
     app.include_router(agents.router)
     app.include_router(sessions.router)

--- a/src/aios/api/deps.py
+++ b/src/aios/api/deps.py
@@ -11,7 +11,7 @@ import secrets
 from typing import Annotated, cast
 
 import asyncpg
-from fastapi import Depends, Header, HTTPException, Request, status
+from fastapi import Depends, Header, Request
 from procrastinate import App as ProcrastinateApp
 
 from aios.config import Settings, get_settings
@@ -26,10 +26,7 @@ def _extract_bearer_token(authorization: str | None) -> str:
         raise UnauthorizedError("missing Authorization header")
     scheme, _, token = authorization.partition(" ")
     if scheme.lower() != "bearer" or not token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="expected `Authorization: Bearer <token>`",
-        )
+        raise UnauthorizedError("expected `Authorization: Bearer <token>`")
     return token
 
 

--- a/src/aios/api/routers/accounts.py
+++ b/src/aios/api/routers/accounts.py
@@ -1,0 +1,101 @@
+"""Account management endpoints.
+
+PR 1 of the multi-tenancy stack (issue #367) ships only the bootstrap
+route. The full ``/v1/accounts/*`` surface (create child, list, mint
+key, archive, by-path lookup, usage) lands in PR 6 once the auth dep
+returns ``(account_id, key_id, can_mint_children)``.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Annotated
+
+from fastapi import APIRouter, Header, status
+
+from aios.api.deps import PoolDep
+from aios.config import Settings, get_settings
+from aios.db import queries
+from aios.errors import NotFoundError, UnauthorizedError
+from aios.logging import get_logger
+from aios.models.accounts import BootstrapRequest, BootstrapResponse
+from aios.services import accounts as service
+
+router = APIRouter(prefix="/v1/accounts", tags=["accounts"])
+
+log = get_logger("aios.api.accounts")
+
+
+def _extract_bootstrap_token(authorization: str | None) -> str:
+    """Pull the bearer token from ``Authorization`` or 401."""
+    if authorization is None:
+        raise UnauthorizedError("missing Authorization header")
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise UnauthorizedError("expected `Authorization: Bearer <token>`")
+    return token
+
+
+@router.post(
+    "/bootstrap",
+    operation_id="bootstrap_root_account",
+    status_code=status.HTTP_201_CREATED,
+    # The bootstrap endpoint is operator-side ceremony, not part of the
+    # agent-facing management plane. Excluding it from the MCP surface
+    # keeps the tool list focused on what a session can actually do.
+    openapi_extra={"x-codegen": {"targets": ["sdk"]}},
+)
+async def bootstrap(
+    body: BootstrapRequest,
+    pool: PoolDep,
+    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+) -> BootstrapResponse:
+    """One-shot endpoint that mints the root account and its first API key.
+
+    Gated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset
+    or empty, the endpoint is 401 regardless of header value — a fresh
+    deployment must explicitly opt in to bootstrap by setting the env.
+
+    Once a non-archived root account exists, the endpoint is 404
+    regardless of token validity. The ``accounts_one_active_root``
+    partial unique index in migration 0040 enforces the invariant at
+    the DB layer too — the 404 here is the friendly upstream answer.
+
+    The ``plaintext_key`` field of the response is the *only* time the
+    operator key is returned in plaintext. After this call, every
+    subsequent use of that key authenticates against the stored
+    ``sha256`` hash.
+    """
+    # Root-exists check fires first so a probe with no/wrong token can't
+    # distinguish "no bootstrap" (404) from "wrong token but bootstrap is
+    # still open" (401). Once a root is in place the endpoint behaves
+    # like it doesn't exist at all, regardless of what the caller sent.
+    async with pool.acquire() as conn:
+        if await queries.has_active_root_account(conn):
+            raise NotFoundError("bootstrap endpoint closed: root account already exists")
+    settings = get_settings()
+    _require_bootstrap_token(settings, authorization)
+    response = await service.bootstrap_root(pool, display_name=body.display_name)
+    log.info(
+        "account.operation",
+        actor_account_id=None,
+        actor_key_id=None,
+        target_account_id=response.account_id,
+        action="account.bootstrap",
+        outcome="success",
+    )
+    return response
+
+
+def _require_bootstrap_token(settings: Settings, authorization: str | None) -> None:
+    """Authenticate a bootstrap request against ``AIOS_BOOTSTRAP_TOKEN``.
+
+    Separated so the unset-env case (401) is indistinguishable from
+    the wrong-token case (401) — the response body is identical and
+    no length-leak via early-return-on-missing-env is possible.
+    """
+    token = _extract_bootstrap_token(authorization)
+    expected_secret = settings.bootstrap_token
+    expected = expected_secret.get_secret_value() if expected_secret is not None else ""
+    if not expected or not secrets.compare_digest(token, expected):
+        raise UnauthorizedError("invalid bootstrap token")

--- a/src/aios/api/routers/accounts.py
+++ b/src/aios/api/routers/accounts.py
@@ -1,10 +1,4 @@
-"""Account management endpoints.
-
-PR 1 of the multi-tenancy stack (issue #367) ships only the bootstrap
-route. The full ``/v1/accounts/*`` surface (create child, list, mint
-key, archive, by-path lookup, usage) lands in PR 6 once the auth dep
-returns ``(account_id, key_id, can_mint_children)``.
-"""
+"""Account management endpoints."""
 
 from __future__ import annotations
 
@@ -13,8 +7,8 @@ from typing import Annotated
 
 from fastapi import APIRouter, Header, status
 
-from aios.api.deps import PoolDep
-from aios.config import Settings, get_settings
+from aios.api.deps import PoolDep, _extract_bearer_token
+from aios.config import get_settings
 from aios.db import queries
 from aios.errors import NotFoundError, UnauthorizedError
 from aios.logging import get_logger
@@ -26,23 +20,11 @@ router = APIRouter(prefix="/v1/accounts", tags=["accounts"])
 log = get_logger("aios.api.accounts")
 
 
-def _extract_bootstrap_token(authorization: str | None) -> str:
-    """Pull the bearer token from ``Authorization`` or 401."""
-    if authorization is None:
-        raise UnauthorizedError("missing Authorization header")
-    scheme, _, token = authorization.partition(" ")
-    if scheme.lower() != "bearer" or not token:
-        raise UnauthorizedError("expected `Authorization: Bearer <token>`")
-    return token
-
-
 @router.post(
     "/bootstrap",
     operation_id="bootstrap_root_account",
     status_code=status.HTTP_201_CREATED,
-    # The bootstrap endpoint is operator-side ceremony, not part of the
-    # agent-facing management plane. Excluding it from the MCP surface
-    # keeps the tool list focused on what a session can actually do.
+    # Operator-side ceremony; not part of the agent-facing management plane.
     openapi_extra={"x-codegen": {"targets": ["sdk"]}},
 )
 async def bootstrap(
@@ -50,31 +32,27 @@ async def bootstrap(
     pool: PoolDep,
     authorization: Annotated[str | None, Header(alias="Authorization")] = None,
 ) -> BootstrapResponse:
-    """One-shot endpoint that mints the root account and its first API key.
+    """Mint the root account and its first API key.
 
     Gated by ``AIOS_BOOTSTRAP_TOKEN`` (env var). When that env is unset
-    or empty, the endpoint is 401 regardless of header value — a fresh
-    deployment must explicitly opt in to bootstrap by setting the env.
+    or empty, the endpoint is 401 regardless of header value.
 
-    Once a non-archived root account exists, the endpoint is 404
-    regardless of token validity. The ``accounts_one_active_root``
-    partial unique index in migration 0040 enforces the invariant at
-    the DB layer too — the 404 here is the friendly upstream answer.
+    Root-exists check fires before the token check so a probe with no/
+    wrong token can't distinguish "no bootstrap" (404) from "wrong token
+    but bootstrap is still open" (401). Once a root is in place the
+    endpoint behaves like it doesn't exist at all.
 
-    The ``plaintext_key`` field of the response is the *only* time the
-    operator key is returned in plaintext. After this call, every
-    subsequent use of that key authenticates against the stored
-    ``sha256`` hash.
+    ``plaintext_key`` in the response is the only time the operator key
+    is returned in plaintext.
     """
-    # Root-exists check fires first so a probe with no/wrong token can't
-    # distinguish "no bootstrap" (404) from "wrong token but bootstrap is
-    # still open" (401). Once a root is in place the endpoint behaves
-    # like it doesn't exist at all, regardless of what the caller sent.
     async with pool.acquire() as conn:
         if await queries.has_active_root_account(conn):
             raise NotFoundError("bootstrap endpoint closed: root account already exists")
-    settings = get_settings()
-    _require_bootstrap_token(settings, authorization)
+    token = _extract_bearer_token(authorization)
+    expected_secret = get_settings().bootstrap_token
+    expected = expected_secret.get_secret_value() if expected_secret is not None else ""
+    if not expected or not secrets.compare_digest(token, expected):
+        raise UnauthorizedError("invalid bootstrap token")
     response = await service.bootstrap_root(pool, display_name=body.display_name)
     log.info(
         "account.operation",
@@ -85,17 +63,3 @@ async def bootstrap(
         outcome="success",
     )
     return response
-
-
-def _require_bootstrap_token(settings: Settings, authorization: str | None) -> None:
-    """Authenticate a bootstrap request against ``AIOS_BOOTSTRAP_TOKEN``.
-
-    Separated so the unset-env case (401) is indistinguishable from
-    the wrong-token case (401) — the response body is identical and
-    no length-leak via early-return-on-missing-env is possible.
-    """
-    token = _extract_bootstrap_token(authorization)
-    expected_secret = settings.bootstrap_token
-    expected = expected_secret.get_secret_value() if expected_secret is not None else ""
-    if not expected or not secrets.compare_digest(token, expected):
-        raise UnauthorizedError("invalid bootstrap token")

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -59,6 +59,15 @@ class Settings(BaseSettings):
         ...,
         description="Base64-encoded 32-byte master key for libsodium secretbox.",
     )
+    bootstrap_token: SecretStr | None = Field(
+        default=None,
+        description="Optional one-shot token that unlocks ``POST /v1/accounts/bootstrap`` "
+        "when the ``accounts`` table has no root row. Once a root exists, the bootstrap "
+        "endpoint is 404 regardless of this value. Operator generates a random token "
+        "(`openssl rand -base64 32`), sets it on a fresh deployment, hits the endpoint, "
+        "captures the returned account_id + plaintext key, then unsets the env. Leaving "
+        "the env set after bootstrap is harmless — the endpoint is already closed.",
+    )
 
     # ── database (required) ────────────────────────────────────────────────
     db_url: str = Field(

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -61,12 +61,9 @@ class Settings(BaseSettings):
     )
     bootstrap_token: SecretStr | None = Field(
         default=None,
-        description="Optional one-shot token that unlocks ``POST /v1/accounts/bootstrap`` "
-        "when the ``accounts`` table has no root row. Once a root exists, the bootstrap "
-        "endpoint is 404 regardless of this value. Operator generates a random token "
-        "(`openssl rand -base64 32`), sets it on a fresh deployment, hits the endpoint, "
-        "captures the returned account_id + plaintext key, then unsets the env. Leaving "
-        "the env set after bootstrap is harmless — the endpoint is already closed.",
+        description="Unlocks ``POST /v1/accounts/bootstrap`` while the ``accounts`` table "
+        "has no root row; the endpoint is 404 once a root exists. Generate with "
+        "``openssl rand -base64 32``.",
     )
 
     # ── database (required) ────────────────────────────────────────────────

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -4815,7 +4815,7 @@ async def insert_file(
     return _row_to_file(row)
 
 
-# ─── accounts + account_keys (#367 PR 1 — multi-tenancy foundation) ──────────
+# ─── accounts + account_keys ─────────────────────────────────────────────────
 
 
 def _row_to_account(row: asyncpg.Record) -> Account:

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -4857,8 +4857,13 @@ async def bootstrap_root_account(
 
     Returns ``(account, key_id)``. The plaintext key isn't stored —
     caller is responsible for returning it to the operator exactly once.
-    Raises :class:`ConflictError` if a root already exists (the partial
-    unique index ``accounts_one_active_root`` fires).
+
+    Raises :class:`NotFoundError` if a root already exists at INSERT
+    time (the ``accounts_one_active_root`` partial unique index fires).
+    Mapping to ``NotFoundError`` rather than ``ConflictError`` preserves
+    the bootstrap endpoint's "404 if root exists" invariant under
+    concurrent bootstrap attempts — the loser of the race sees the same
+    404 as a caller arriving after the winner committed.
     """
     account_id = make_id(ACCOUNT)
     key_id = make_id(ACCOUNT_KEY)
@@ -4874,8 +4879,8 @@ async def bootstrap_root_account(
                 display_name,
             )
         except asyncpg.UniqueViolationError as exc:
-            raise ConflictError(
-                "root account already exists",
+            raise NotFoundError(
+                "bootstrap endpoint closed: root account already exists",
                 detail={"display_name": display_name},
             ) from exc
         assert account_row is not None

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -31,6 +31,8 @@ from aios.errors import (
     NotFoundError,
 )
 from aios.ids import (
+    ACCOUNT,
+    ACCOUNT_KEY,
     AGENT,
     BINDING,
     CONNECTION,
@@ -48,6 +50,7 @@ from aios.ids import (
     VAULT_CREDENTIAL,
     make_id,
 )
+from aios.models.accounts import Account
 from aios.models.agents import Agent, AgentVersion, McpServerSpec, ToolSpec
 from aios.models.connections import BindingMode, Connection, ConnectionMode
 from aios.models.environments import Environment, EnvironmentConfig
@@ -4810,3 +4813,80 @@ async def insert_file(
         ) from exc
     assert row is not None
     return _row_to_file(row)
+
+
+# ─── accounts + account_keys (#367 PR 1 — multi-tenancy foundation) ──────────
+
+
+def _row_to_account(row: asyncpg.Record) -> Account:
+    raw_metadata = row["metadata"]
+    metadata = json.loads(raw_metadata) if isinstance(raw_metadata, str) else raw_metadata
+    return Account(
+        id=row["id"],
+        parent_account_id=row["parent_account_id"],
+        can_mint_children=row["can_mint_children"],
+        display_name=row["display_name"],
+        metadata=metadata,
+        created_at=row["created_at"],
+        archived_at=row["archived_at"],
+    )
+
+
+async def has_active_root_account(conn: asyncpg.Connection[Any]) -> bool:
+    """Whether a non-archived root account exists.
+
+    The bootstrap endpoint gates on this — once a root exists, the
+    endpoint is 404 regardless of the bootstrap token. The
+    ``accounts_one_active_root`` partial unique index enforces the
+    "at most one active root" invariant at the DB level too.
+    """
+    row = await conn.fetchrow(
+        "SELECT 1 FROM accounts WHERE parent_account_id IS NULL AND archived_at IS NULL LIMIT 1"
+    )
+    return row is not None
+
+
+async def bootstrap_root_account(
+    conn: asyncpg.Connection[Any],
+    *,
+    display_name: str,
+    key_hash: bytes,
+    key_label: str,
+) -> tuple[Account, str]:
+    """Atomically create the root account and its first API key.
+
+    Returns ``(account, key_id)``. The plaintext key isn't stored —
+    caller is responsible for returning it to the operator exactly once.
+    Raises :class:`ConflictError` if a root already exists (the partial
+    unique index ``accounts_one_active_root`` fires).
+    """
+    account_id = make_id(ACCOUNT)
+    key_id = make_id(ACCOUNT_KEY)
+    async with conn.transaction():
+        try:
+            account_row = await conn.fetchrow(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ($1, NULL, TRUE, $2)
+                RETURNING *
+                """,
+                account_id,
+                display_name,
+            )
+        except asyncpg.UniqueViolationError as exc:
+            raise ConflictError(
+                "root account already exists",
+                detail={"display_name": display_name},
+            ) from exc
+        assert account_row is not None
+        await conn.execute(
+            """
+            INSERT INTO account_keys (key_id, account_id, hash, label)
+            VALUES ($1, $2, $3, $4)
+            """,
+            key_id,
+            account_id,
+            key_hash,
+            key_label,
+        )
+    return _row_to_account(account_row), key_id

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -48,8 +48,6 @@ MEMORY_VERSION: Final = "memver"
 GITHUB_REPOSITORY: Final = "ghrepo"
 FILE: Final = "file"
 MANAGEMENT_CALL: Final = "mgmt"
-# Multi-tenancy v1 (#367). PR 1 adds the two tables; later PRs in the
-# stack reference account ids on every user-data row.
 ACCOUNT: Final = "acc"
 ACCOUNT_KEY: Final = "key"
 

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -49,7 +49,7 @@ GITHUB_REPOSITORY: Final = "ghrepo"
 FILE: Final = "file"
 MANAGEMENT_CALL: Final = "mgmt"
 ACCOUNT: Final = "acc"
-ACCOUNT_KEY: Final = "key"
+ACCOUNT_KEY: Final = "acckey"
 
 _PREFIXES: Final = frozenset(
     {

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -48,6 +48,10 @@ MEMORY_VERSION: Final = "memver"
 GITHUB_REPOSITORY: Final = "ghrepo"
 FILE: Final = "file"
 MANAGEMENT_CALL: Final = "mgmt"
+# Multi-tenancy v1 (#367). PR 1 adds the two tables; later PRs in the
+# stack reference account ids on every user-data row.
+ACCOUNT: Final = "acc"
+ACCOUNT_KEY: Final = "key"
 
 _PREFIXES: Final = frozenset(
     {
@@ -73,6 +77,8 @@ _PREFIXES: Final = frozenset(
         RUNTIME_TOKEN,
         ROUTING_RULE,
         MANAGEMENT_CALL,
+        ACCOUNT,
+        ACCOUNT_KEY,
     }
 )
 

--- a/src/aios/models/accounts.py
+++ b/src/aios/models/accounts.py
@@ -1,11 +1,4 @@
-"""Account and account-key resource models.
-
-PR 1 of the multi-tenancy stack: only the minimum needed for the
-bootstrap endpoint. Read models for accounts and the bootstrap
-request/response live here; the full CRUD surface (create child,
-list children, mint key, archive, etc.) lands in PR 6 once the auth
-dep is account-aware.
-"""
+"""Account and account-key resource models."""
 
 from __future__ import annotations
 
@@ -16,13 +9,6 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class Account(BaseModel):
-    """Read view of an account.
-
-    ``parent_account_id`` is ``None`` only for the singular root account.
-    ``can_mint_children`` distinguishes accounts that can provision
-    sub-accounts from leaf accounts that cannot.
-    """
-
     id: str
     parent_account_id: str | None
     can_mint_children: bool
@@ -33,25 +19,13 @@ class Account(BaseModel):
 
 
 class BootstrapRequest(BaseModel):
-    """Body for ``POST /v1/accounts/bootstrap``.
-
-    Only the human-readable display_name is required at bootstrap time;
-    metadata can be added later via a PATCH endpoint (lands in PR 6).
-    """
-
     model_config = ConfigDict(extra="forbid")
 
     display_name: str = Field(min_length=1, max_length=128)
 
 
 class BootstrapResponse(BaseModel):
-    """Response from ``POST /v1/accounts/bootstrap``.
-
-    ``plaintext_key`` is returned exactly once — it's never recoverable
-    after this response. The operator must capture it (env, secret store,
-    password manager). All subsequent API calls use it as a bearer token.
-    """
-
     account_id: str
     key_id: str
+    # Returned exactly once at mint; not recoverable after this response.
     plaintext_key: str

--- a/src/aios/models/accounts.py
+++ b/src/aios/models/accounts.py
@@ -1,0 +1,57 @@
+"""Account and account-key resource models.
+
+PR 1 of the multi-tenancy stack: only the minimum needed for the
+bootstrap endpoint. Read models for accounts and the bootstrap
+request/response live here; the full CRUD surface (create child,
+list children, mint key, archive, etc.) lands in PR 6 once the auth
+dep is account-aware.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Account(BaseModel):
+    """Read view of an account.
+
+    ``parent_account_id`` is ``None`` only for the singular root account.
+    ``can_mint_children`` distinguishes accounts that can provision
+    sub-accounts from leaf accounts that cannot.
+    """
+
+    id: str
+    parent_account_id: str | None
+    can_mint_children: bool
+    display_name: str
+    metadata: dict[str, Any]
+    created_at: datetime
+    archived_at: datetime | None = None
+
+
+class BootstrapRequest(BaseModel):
+    """Body for ``POST /v1/accounts/bootstrap``.
+
+    Only the human-readable display_name is required at bootstrap time;
+    metadata can be added later via a PATCH endpoint (lands in PR 6).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: str = Field(min_length=1, max_length=128)
+
+
+class BootstrapResponse(BaseModel):
+    """Response from ``POST /v1/accounts/bootstrap``.
+
+    ``plaintext_key`` is returned exactly once — it's never recoverable
+    after this response. The operator must capture it (env, secret store,
+    password manager). All subsequent API calls use it as a bearer token.
+    """
+
+    account_id: str
+    key_id: str
+    plaintext_key: str

--- a/src/aios/services/accounts.py
+++ b/src/aios/services/accounts.py
@@ -1,0 +1,69 @@
+"""Account lifecycle logic.
+
+PR 1 of the multi-tenancy stack (issue #367) ships only the bootstrap
+path: the operator's one-shot route to mint the root account and its
+first API key on a fresh deployment. Per-account CRUD, child creation,
+key rotation, and the rest of the management surface land in PR 6 once
+the auth dep is account-aware.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from typing import Any
+
+import asyncpg
+
+from aios.db import queries
+from aios.models.accounts import BootstrapResponse
+
+# Generated bearer tokens carry an opaque random body plus a short prefix
+# so they're recognizable in logs without leaking the secret. The body is
+# 32 bytes of cryptographic randomness, base32-encoded so the result is
+# URL/header-safe and easy to copy-paste from a terminal.
+_KEY_PREFIX = "aios_"
+_KEY_BODY_BYTES = 32
+_BOOTSTRAP_KEY_LABEL = "bootstrap"
+
+
+def _generate_plaintext_key() -> str:
+    """Return a fresh ``aios_<base32>`` API key."""
+    body = secrets.token_urlsafe(_KEY_BODY_BYTES)
+    return f"{_KEY_PREFIX}{body}"
+
+
+def hash_key(plaintext: str) -> bytes:
+    """SHA-256 of the plaintext key, in raw bytes for ``bytea`` storage.
+
+    Exposed at module level so the auth dep (later PRs) can hash an
+    inbound bearer token and look it up by ``hash``.
+    """
+    return hashlib.sha256(plaintext.encode("ascii")).digest()
+
+
+async def bootstrap_root(
+    pool: asyncpg.Pool[Any],
+    *,
+    display_name: str,
+) -> BootstrapResponse:
+    """Create the root account and mint its first API key.
+
+    The caller has already authenticated against ``AIOS_BOOTSTRAP_TOKEN``
+    and confirmed no active root exists. Returns the new account id and
+    the plaintext key — the *only* time the key is returned in plaintext.
+    """
+    plaintext = _generate_plaintext_key()
+    key_hash = hash_key(plaintext)
+    async with pool.acquire() as conn:
+        account, key_id = await queries.bootstrap_root_account(
+            conn,
+            display_name=display_name,
+            key_hash=key_hash,
+            key_label=_BOOTSTRAP_KEY_LABEL,
+        )
+    return BootstrapResponse(
+        account_id=account.id,
+        key_id=key_id,
+        plaintext_key=plaintext,
+    )

--- a/src/aios/services/accounts.py
+++ b/src/aios/services/accounts.py
@@ -1,11 +1,4 @@
-"""Account lifecycle logic.
-
-PR 1 of the multi-tenancy stack (issue #367) ships only the bootstrap
-path: the operator's one-shot route to mint the root account and its
-first API key on a fresh deployment. Per-account CRUD, child creation,
-key rotation, and the rest of the management surface land in PR 6 once
-the auth dep is account-aware.
-"""
+"""Account lifecycle logic."""
 
 from __future__ import annotations
 
@@ -18,27 +11,19 @@ import asyncpg
 from aios.db import queries
 from aios.models.accounts import BootstrapResponse
 
-# Generated bearer tokens carry an opaque random body plus a short prefix
-# so they're recognizable in logs without leaking the secret. The body is
-# 32 bytes of cryptographic randomness, base32-encoded so the result is
-# URL/header-safe and easy to copy-paste from a terminal.
 _KEY_PREFIX = "aios_"
 _KEY_BODY_BYTES = 32
 _BOOTSTRAP_KEY_LABEL = "bootstrap"
 
 
 def _generate_plaintext_key() -> str:
-    """Return a fresh ``aios_<base32>`` API key."""
+    """Return a fresh ``aios_<base64url>`` API key with 32 bytes of entropy."""
     body = secrets.token_urlsafe(_KEY_BODY_BYTES)
     return f"{_KEY_PREFIX}{body}"
 
 
 def hash_key(plaintext: str) -> bytes:
-    """SHA-256 of the plaintext key, in raw bytes for ``bytea`` storage.
-
-    Exposed at module level so the auth dep (later PRs) can hash an
-    inbound bearer token and look it up by ``hash``.
-    """
+    """SHA-256 of the plaintext key as raw bytes for ``bytea`` storage."""
     return hashlib.sha256(plaintext.encode("ascii")).digest()
 
 
@@ -47,12 +32,7 @@ async def bootstrap_root(
     *,
     display_name: str,
 ) -> BootstrapResponse:
-    """Create the root account and mint its first API key.
-
-    The caller has already authenticated against ``AIOS_BOOTSTRAP_TOKEN``
-    and confirmed no active root exists. Returns the new account id and
-    the plaintext key — the *only* time the key is returned in plaintext.
-    """
+    """Create the root account and mint its first API key."""
     plaintext = _generate_plaintext_key()
     key_hash = hash_key(plaintext)
     async with pool.acquire() as conn:

--- a/tests/e2e/test_accounts_bootstrap.py
+++ b/tests/e2e/test_accounts_bootstrap.py
@@ -89,7 +89,7 @@ class TestBootstrap:
         assert r.status_code == 201, r.text
         body = r.json()
         assert body["account_id"].startswith("acc_")
-        assert body["key_id"].startswith("key_")
+        assert body["key_id"].startswith("acckey_")
         assert body["plaintext_key"].startswith("aios_")
 
     async def test_persists_hashed_key_not_plaintext(
@@ -208,6 +208,37 @@ class TestBootstrap:
             headers=_bootstrap_headers(token),
         )
         assert r.status_code == 422, r.text
+
+    async def test_concurrent_bootstrap_loser_gets_404(self, pool: Any) -> None:
+        """The race-losing call gets 404, not 409.
+
+        Simulates the TOCTOU window: an existence-check passes for both
+        callers because no root exists yet, and they race to INSERT. The
+        ``accounts_one_active_root`` index lets exactly one win; the
+        loser's ``UniqueViolationError`` must surface as ``NotFoundError``
+        (404), matching the post-bootstrap behavior — otherwise the
+        endpoint's stated invariant breaks under concurrency.
+        """
+        # Pre-seed a root to put the DB in the "already bootstrapped"
+        # state, then call ``bootstrap_root_account`` directly — this is
+        # the same code path the race-loser hits at the INSERT step.
+        from aios.db import queries
+        from aios.errors import NotFoundError
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_existing_root', NULL, TRUE, 'preexisting')
+                """
+            )
+            with pytest.raises(NotFoundError):
+                await queries.bootstrap_root_account(
+                    conn,
+                    display_name="loser",
+                    key_hash=b"\x00" * 32,
+                    key_label="bootstrap",
+                )
 
 
 class TestAccountInvariants:

--- a/tests/e2e/test_accounts_bootstrap.py
+++ b/tests/e2e/test_accounts_bootstrap.py
@@ -1,9 +1,4 @@
-"""E2E tests for ``POST /v1/accounts/bootstrap`` (#367 PR 1).
-
-The bootstrap endpoint is the only ``/v1/accounts/*`` surface in PR 1.
-Tests run against a real testcontainer Postgres so the partial unique
-indexes from migration 0040 are exercised end-to-end.
-"""
+"""E2E tests for ``POST /v1/accounts/bootstrap``."""
 
 from __future__ import annotations
 
@@ -31,11 +26,6 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 def bootstrap_env(aios_env: dict[str, str]) -> Iterator[dict[str, str]]:
-    """Layer ``AIOS_BOOTSTRAP_TOKEN`` on top of the standard aios env.
-
-    ``aios_env`` already mocks the base env; this fixture adds the
-    bootstrap-specific token without disturbing the rest.
-    """
     token = secrets.token_urlsafe(32)
     extra = {"AIOS_BOOTSTRAP_TOKEN": token}
     with mock.patch.dict(os.environ, extra):
@@ -46,17 +36,12 @@ def bootstrap_env(aios_env: dict[str, str]) -> Iterator[dict[str, str]]:
         get_settings.cache_clear()
 
 
-@pytest.fixture
-async def http_client(pool: Any, bootstrap_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    """Bootstrap endpoint is unauthenticated against ``AIOS_API_KEY`` —
-    it carries its own ``AIOS_BOOTSTRAP_TOKEN``. The client returned
-    here sends no default Authorization header; each test adds the
-    right header per call.
-    """
+async def _build_client(pool: Any) -> AsyncIterator[httpx.AsyncClient]:
     from aios.api.app import create_app
     from aios.config import get_settings
     from aios.crypto.vault import CryptoBox
 
+    get_settings.cache_clear()
     settings = get_settings()
     app = create_app()
     app.state.pool = pool
@@ -66,6 +51,12 @@ async def http_client(pool: Any, bootstrap_env: dict[str, str]) -> AsyncIterator
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(base_url="http://testserver", transport=transport) as client:
+        yield client
+
+
+@pytest.fixture
+async def http_client(pool: Any, bootstrap_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    async for client in _build_client(pool):
         yield client
 
 
@@ -73,31 +64,12 @@ async def http_client(pool: Any, bootstrap_env: dict[str, str]) -> AsyncIterator
 async def http_client_no_bootstrap_env(
     pool: Any, aios_env: dict[str, str]
 ) -> AsyncIterator[httpx.AsyncClient]:
-    """Client where ``AIOS_BOOTSTRAP_TOKEN`` is *not* in env.
-
-    Used by the env-unset test; the regular ``http_client`` fixture
-    depends on ``bootstrap_env`` which sets the token, so a separate
-    fixture is needed to exercise the unset case.
+    """Client built without ``AIOS_BOOTSTRAP_TOKEN`` in env — used by the
+    env-unset test, which would otherwise see the token set by
+    ``bootstrap_env`` that the regular ``http_client`` depends on.
     """
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    # Defensive: ensure the env actually doesn't carry the token,
-    # even if a prior test leaked it.
-    assert "AIOS_BOOTSTRAP_TOKEN" not in os.environ
-    get_settings.cache_clear()
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(base_url="http://testserver", transport=transport) as client:
+    async for client in _build_client(pool):
         yield client
-    get_settings.cache_clear()
 
 
 def _bootstrap_headers(token: str) -> dict[str, str]:
@@ -239,7 +211,7 @@ class TestBootstrap:
 
 
 class TestAccountInvariants:
-    """Direct DB tests for the migration 0040 partial-unique indexes.
+    """Direct DB tests for the ``accounts`` partial-unique indexes.
 
     These exercise the DDL itself (not the bootstrap endpoint) so a
     future refactor of the endpoint doesn't accidentally remove the

--- a/tests/e2e/test_accounts_bootstrap.py
+++ b/tests/e2e/test_accounts_bootstrap.py
@@ -1,0 +1,331 @@
+"""E2E tests for ``POST /v1/accounts/bootstrap`` (#367 PR 1).
+
+The bootstrap endpoint is the only ``/v1/accounts/*`` surface in PR 1.
+Tests run against a real testcontainer Postgres so the partial unique
+indexes from migration 0040 are exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest import mock
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+def bootstrap_env(aios_env: dict[str, str]) -> Iterator[dict[str, str]]:
+    """Layer ``AIOS_BOOTSTRAP_TOKEN`` on top of the standard aios env.
+
+    ``aios_env`` already mocks the base env; this fixture adds the
+    bootstrap-specific token without disturbing the rest.
+    """
+    token = secrets.token_urlsafe(32)
+    extra = {"AIOS_BOOTSTRAP_TOKEN": token}
+    with mock.patch.dict(os.environ, extra):
+        from aios.config import get_settings
+
+        get_settings.cache_clear()
+        yield {**aios_env, **extra}
+        get_settings.cache_clear()
+
+
+@pytest.fixture
+async def http_client(pool: Any, bootstrap_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    """Bootstrap endpoint is unauthenticated against ``AIOS_API_KEY`` —
+    it carries its own ``AIOS_BOOTSTRAP_TOKEN``. The client returned
+    here sends no default Authorization header; each test adds the
+    right header per call.
+    """
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    settings = get_settings()
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(base_url="http://testserver", transport=transport) as client:
+        yield client
+
+
+@pytest.fixture
+async def http_client_no_bootstrap_env(
+    pool: Any, aios_env: dict[str, str]
+) -> AsyncIterator[httpx.AsyncClient]:
+    """Client where ``AIOS_BOOTSTRAP_TOKEN`` is *not* in env.
+
+    Used by the env-unset test; the regular ``http_client`` fixture
+    depends on ``bootstrap_env`` which sets the token, so a separate
+    fixture is needed to exercise the unset case.
+    """
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    # Defensive: ensure the env actually doesn't carry the token,
+    # even if a prior test leaked it.
+    assert "AIOS_BOOTSTRAP_TOKEN" not in os.environ
+    get_settings.cache_clear()
+    settings = get_settings()
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(base_url="http://testserver", transport=transport) as client:
+        yield client
+    get_settings.cache_clear()
+
+
+def _bootstrap_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestBootstrap:
+    async def test_success_returns_account_and_plaintext_key(
+        self, http_client: httpx.AsyncClient, bootstrap_env: dict[str, str]
+    ) -> None:
+        token = bootstrap_env["AIOS_BOOTSTRAP_TOKEN"]
+        r = await http_client.post(
+            "/v1/accounts/bootstrap",
+            json={"display_name": "root"},
+            headers=_bootstrap_headers(token),
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["account_id"].startswith("acc_")
+        assert body["key_id"].startswith("key_")
+        assert body["plaintext_key"].startswith("aios_")
+
+    async def test_persists_hashed_key_not_plaintext(
+        self,
+        http_client: httpx.AsyncClient,
+        bootstrap_env: dict[str, str],
+        pool: Any,
+    ) -> None:
+        token = bootstrap_env["AIOS_BOOTSTRAP_TOKEN"]
+        r = await http_client.post(
+            "/v1/accounts/bootstrap",
+            json={"display_name": "root"},
+            headers=_bootstrap_headers(token),
+        )
+        assert r.status_code == 201
+        plaintext = r.json()["plaintext_key"]
+        expected_hash = hashlib.sha256(plaintext.encode()).digest()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT hash, label FROM account_keys")
+        assert row is not None
+        assert bytes(row["hash"]) == expected_hash
+        assert row["label"] == "bootstrap"
+
+    async def test_404_when_root_already_exists(
+        self, http_client: httpx.AsyncClient, bootstrap_env: dict[str, str]
+    ) -> None:
+        token = bootstrap_env["AIOS_BOOTSTRAP_TOKEN"]
+        first = await http_client.post(
+            "/v1/accounts/bootstrap",
+            json={"display_name": "root"},
+            headers=_bootstrap_headers(token),
+        )
+        assert first.status_code == 201
+        second = await http_client.post(
+            "/v1/accounts/bootstrap",
+            json={"display_name": "root"},
+            headers=_bootstrap_headers(token),
+        )
+        assert second.status_code == 404, second.text
+
+    async def test_404_takes_precedence_over_401(
+        self, http_client: httpx.AsyncClient, bootstrap_env: dict[str, str]
+    ) -> None:
+        """Wrong token + existing root = 404, not 401.
+
+        Bootstrapped systems must look identical to outsiders regardless
+        of whether they hold the bootstrap token. Otherwise the response
+        code leaks whether the system has ever been bootstrapped.
+        """
+        token = bootstrap_env["AIOS_BOOTSTRAP_TOKEN"]
+        first = await http_client.post(
+            "/v1/accounts/bootstrap",
+            json={"display_name": "root"},
+            headers=_bootstrap_headers(token),
+        )
+        assert first.status_code == 201
+        wrong = await http_client.post(
+            "/v1/accounts/bootstrap",
+            json={"display_name": "root"},
+            headers=_bootstrap_headers("totally-wrong-token"),
+        )
+        assert wrong.status_code == 404, wrong.text
+
+    async def test_401_on_wrong_token(
+        self, http_client: httpx.AsyncClient, bootstrap_env: dict[str, str]
+    ) -> None:
+        r = await http_client.post(
+            "/v1/accounts/bootstrap",
+            json={"display_name": "root"},
+            headers=_bootstrap_headers("not-the-right-token"),
+        )
+        assert r.status_code == 401, r.text
+
+    async def test_401_on_missing_authorization(self, http_client: httpx.AsyncClient) -> None:
+        r = await http_client.post(
+            "/v1/accounts/bootstrap",
+            json={"display_name": "root"},
+        )
+        assert r.status_code == 401, r.text
+
+    async def test_401_when_bootstrap_token_env_unset(
+        self,
+        http_client_no_bootstrap_env: httpx.AsyncClient,
+    ) -> None:
+        """When ``AIOS_BOOTSTRAP_TOKEN`` is unset, every call to the
+        bootstrap endpoint is 401 — even one carrying a non-empty
+        header. The endpoint requires an explicit opt-in from the
+        operator on every deploy that wants bootstrap available.
+        """
+        r = await http_client_no_bootstrap_env.post(
+            "/v1/accounts/bootstrap",
+            json={"display_name": "root"},
+            headers=_bootstrap_headers("anything-at-all"),
+        )
+        assert r.status_code == 401, r.text
+
+    async def test_400_on_missing_display_name(
+        self, http_client: httpx.AsyncClient, bootstrap_env: dict[str, str]
+    ) -> None:
+        token = bootstrap_env["AIOS_BOOTSTRAP_TOKEN"]
+        r = await http_client.post(
+            "/v1/accounts/bootstrap",
+            json={},
+            headers=_bootstrap_headers(token),
+        )
+        # FastAPI's RequestValidationError handler returns 422
+        assert r.status_code == 422, r.text
+
+    async def test_400_on_empty_display_name(
+        self, http_client: httpx.AsyncClient, bootstrap_env: dict[str, str]
+    ) -> None:
+        token = bootstrap_env["AIOS_BOOTSTRAP_TOKEN"]
+        r = await http_client.post(
+            "/v1/accounts/bootstrap",
+            json={"display_name": ""},
+            headers=_bootstrap_headers(token),
+        )
+        assert r.status_code == 422, r.text
+
+
+class TestAccountInvariants:
+    """Direct DB tests for the migration 0040 partial-unique indexes.
+
+    These exercise the DDL itself (not the bootstrap endpoint) so a
+    future refactor of the endpoint doesn't accidentally remove the
+    safety net at the schema layer.
+    """
+
+    async def test_two_active_roots_violate_uniqueness(self, pool: Any) -> None:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_test_root_a', NULL, TRUE, 'first-root')
+                """
+            )
+            import asyncpg.exceptions
+
+            with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                    VALUES ('acc_test_root_b', NULL, TRUE, 'second-root')
+                    """
+                )
+
+    async def test_archived_root_allows_new_root(self, pool: Any) -> None:
+        """Soft-archived roots free up the active-root slot.
+
+        The recovery doc relies on this: archive the stale root, then
+        bootstrap a fresh one.
+        """
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name, archived_at)
+                VALUES ('acc_archived_root', NULL, TRUE, 'old-root', now())
+                """
+            )
+            # Should now succeed because the only existing root is archived.
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_fresh_root', NULL, TRUE, 'new-root')
+                """
+            )
+
+    async def test_sibling_name_uniqueness(self, pool: Any) -> None:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_parent', NULL, TRUE, 'parent')
+                """
+            )
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_child_a', 'acc_parent', FALSE, 'alice')
+                """
+            )
+            import asyncpg.exceptions
+
+            with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                    VALUES ('acc_child_b', 'acc_parent', FALSE, 'alice')
+                    """
+                )
+
+    async def test_distinct_parents_allow_same_child_name(self, pool: Any) -> None:
+        """``jarvis-prod/alice`` and ``product-x/alice`` are both legal —
+        siblings only need to be unique within their own parent.
+
+        Realistic shape: one root, two products under it, each product has
+        an ``alice`` child. The active-root index allows only one root, so
+        the products live underneath that single root.
+        """
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES
+                    ('acc_root',   NULL,        TRUE,  'root'),
+                    ('acc_jarvis', 'acc_root',  TRUE,  'jarvis-prod'),
+                    ('acc_prodx',  'acc_root',  TRUE,  'product-x'),
+                    ('acc_alice_jarvis', 'acc_jarvis', FALSE, 'alice'),
+                    ('acc_alice_prodx',  'acc_prodx',  FALSE, 'alice')
+                """
+            )


### PR DESCRIPTION
## Summary

First PR of the multi-tenancy stack (#367). Lays the foundational schema and the one-shot bootstrap endpoint; no resource tables get touched yet.

- **Schema** (migration 0042): `accounts` (with three partial-unique indexes — sibling-unique names, root-unique names, at-most-one-active-root) + `account_keys` (multi-active, sha256-hashed, ON DELETE CASCADE).
- **Endpoint**: `POST /v1/accounts/bootstrap` gated by `AIOS_BOOTSTRAP_TOKEN`. 404 takes precedence over 401 once a root exists, so an outside probe can't distinguish "bootstrap not done" from "bootstrap done but wrong token."
- **Recovery doc**: `docs/ops/root-recovery.md` — locked psql recipe for lost-root recovery (root is deliberately unarchivable in the management API).

PR 2 (auth dep returns `account_id`) and PR 3 (query helpers take `account_id`) build on this.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1161 passed
- [x] `DOCKER_HOST=... uv run pytest tests/e2e/test_accounts_bootstrap.py -v` — 13 passed, including the partial-unique-index invariants exercised directly against migrated Postgres
- [x] `pytest tests/integration/test_migrations.py` — migration 0042 applies cleanly

## Design references

- Issue #367 — multi-tenancy v1 design
- The 404-not-403 / 404-precedence-over-401 pattern is locked in the design to prevent bootstrap-state leakage
- ULID prefixes `acc_` and `key_` added to `aios.ids`
- Per-table partial unique indexes are the Postgres idiom for "at most one row matching this predicate"

🤖 Generated with [Claude Code](https://claude.com/claude-code)