### PR TITLE
feat(#367): PR 2 — auth dep resolves bearer to account tuple

### DIFF
--- a/src/aios/api/deps.py
+++ b/src/aios/api/deps.py
@@ -7,17 +7,22 @@ exposed here as typed accessors.
 
 from __future__ import annotations
 
-import secrets
 from typing import Annotated, cast
 
 import asyncpg
 from fastapi import Depends, Header, Request
 from procrastinate import App as ProcrastinateApp
 
-from aios.config import Settings, get_settings
 from aios.crypto.vault import CryptoBox
+from aios.db import queries
 from aios.errors import UnauthorizedError
+from aios.services import accounts as accounts_service
 from aios.services import runtime_tokens as runtime_tokens_service
+
+# ``(account_id, key_id, can_mint_children)`` resolved from the bearer
+# token. Named so routes that destructure it don't have to consult the
+# auth dep's docstring to know the positions.
+AccountAuthResult = tuple[str, str, bool]
 
 
 def _extract_bearer_token(authorization: str | None) -> str:
@@ -49,23 +54,27 @@ def get_db_url(request: Request) -> str:
     return db_url
 
 
-def get_settings_dep() -> Settings:
-    return get_settings()
-
-
-def require_bearer_auth(
-    settings: Annotated[Settings, Depends(get_settings_dep)],
+async def require_bearer_auth(
+    pool: Annotated[asyncpg.Pool, Depends(get_pool)],
     authorization: Annotated[str | None, Header(alias="Authorization")] = None,
-) -> None:
-    """Verify the request carries the operator API key.
+) -> AccountAuthResult:
+    """Resolve the bearer token to ``(account_id, key_id, can_mint_children)``.
 
-    Constant-time compare so the comparison itself doesn't leak timing
-    information about the key.
+    The token is hashed (sha256) and looked up against ``account_keys``;
+    a match must reference an active key on a non-archived account. Any
+    mismatch raises 401 with the same message regardless of cause so
+    timing or wording can't distinguish "unknown key" from "revoked key"
+    from "archived account."
     """
     token = _extract_bearer_token(authorization)
-    expected = settings.api_key.get_secret_value()
-    if not secrets.compare_digest(token, expected):
+    async with pool.acquire() as conn:
+        result = await queries.lookup_account_by_key_hash(
+            conn, key_hash=accounts_service.hash_key(token)
+        )
+    if result is None:
         raise UnauthorizedError("invalid api key")
+    account, key_id = result
+    return (account.id, key_id, account.can_mint_children)
 
 
 async def require_runtime_auth(
@@ -74,8 +83,8 @@ async def require_runtime_auth(
 ) -> tuple[str, str]:
     """Resolve a bearer runtime token to ``(runtime_token_id, connector)``.
 
-    Accepts only tokens issued via ``POST /v1/runtime-tokens`` (#328 PR 5).
-    Routes that take ``RuntimeAuthDep`` receive the resolved tuple — the
+    Accepts only tokens issued via ``POST /v1/runtime-tokens``. Routes
+    that take ``RuntimeAuthDep`` receive the resolved tuple — the
     ``connector`` half is used to scope the runtime-facing routes
     (``/connectors/runtime/...`` family) to one connector type.
     """
@@ -93,5 +102,5 @@ PoolDep = Annotated[asyncpg.Pool, Depends(get_pool)]
 CryptoBoxDep = Annotated[CryptoBox, Depends(get_crypto_box)]
 ProcrastinateDep = Annotated[ProcrastinateApp, Depends(get_procrastinate)]
 DbUrlDep = Annotated[str, Depends(get_db_url)]
-AuthDep = Annotated[None, Depends(require_bearer_auth)]
+AuthDep = Annotated[AccountAuthResult, Depends(require_bearer_auth)]
 RuntimeAuthDep = Annotated[tuple[str, str], Depends(require_runtime_auth)]

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -50,11 +50,7 @@ class Settings(BaseSettings):
         "labels.",
     )
 
-    # ── auth + crypto (required) ───────────────────────────────────────────
-    api_key: SecretStr = Field(
-        ...,
-        description="Shared API key clients send as `Authorization: Bearer <key>`.",
-    )
+    # ── crypto (required) ──────────────────────────────────────────────────
     vault_key: SecretStr = Field(
         ...,
         description="Base64-encoded 32-byte master key for libsodium secretbox.",

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -4895,3 +4895,32 @@ async def bootstrap_root_account(
             key_label,
         )
     return _row_to_account(account_row), key_id
+
+
+async def lookup_account_by_key_hash(
+    conn: asyncpg.Connection[Any],
+    *,
+    key_hash: bytes,
+) -> tuple[Account, str] | None:
+    """Resolve a bearer-key sha256 hash to its account and key_id.
+
+    Returns ``(account, key_id)`` if the hash matches an active key
+    on an active account; ``None`` otherwise. Filters out revoked
+    keys and archived accounts so the auth path never accepts them.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT
+            accounts.*,
+            account_keys.key_id AS _key_id
+        FROM account_keys
+        JOIN accounts ON accounts.id = account_keys.account_id
+        WHERE account_keys.hash = $1
+          AND account_keys.revoked_at IS NULL
+          AND accounts.archived_at IS NULL
+        """,
+        key_hash,
+    )
+    if row is None:
+        return None
+    return _row_to_account(row), row["_key_id"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,18 +172,17 @@ def aios_env_minimal(
 
 
 @pytest.fixture
-def aios_env(aios_env_minimal: dict[str, str]) -> dict[str, str]:
+async def aios_env(aios_env_minimal: dict[str, str]) -> dict[str, str]:
     """Env vars + a bootstrapped root whose key is ``AIOS_API_KEY``.
 
     Auth looks the bearer token up against ``account_keys``, so any
     test that hits an authenticated route needs a matching DB row.
     This fixture seeds that row using ``AIOS_API_KEY``'s sha256 hash.
-    """
-    # ``aios_env_minimal`` is a sync Iterator (uses ``mock.patch.dict``
-    # as a context manager), so the seed step can't be ``async def``.
-    # ``asyncio.run`` is the right bridge here, not an oversight.
-    import asyncio
 
+    Async so the seed step runs on the same event loop pytest-asyncio
+    drives the test on — avoids the spurious ``asyncio.run`` event-loop
+    isolation that caused ASGI-callable teardown flakiness in CI.
+    """
     import asyncpg
 
     from aios.db import queries
@@ -192,17 +191,14 @@ def aios_env(aios_env_minimal: dict[str, str]) -> dict[str, str]:
     plaintext = aios_env_minimal["AIOS_API_KEY"]
     db_url = aios_env_minimal["AIOS_DB_URL"]
 
-    async def _seed_root() -> None:
-        conn = await asyncpg.connect(db_url)
-        try:
-            await queries.bootstrap_root_account(
-                conn,
-                display_name="root",
-                key_hash=hash_key(plaintext),
-                key_label="test-root",
-            )
-        finally:
-            await conn.close()
-
-    asyncio.run(_seed_root())
+    conn = await asyncpg.connect(db_url)
+    try:
+        await queries.bootstrap_root_account(
+            conn,
+            display_name="root",
+            key_hash=hash_key(plaintext),
+            key_label="test-root",
+        )
+    finally:
+        await conn.close()
     return aios_env_minimal

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,11 @@
   schema and aios lock-release trigger against the testcontainer
 * ``_reset_db_state`` — function-scoped: TRUNCATEs all public-schema tables
   before each test so the session-scoped DB stays isolated between tests
-* ``aios_env`` — sets the env vars the FastAPI app needs (api key, vault key,
-  db url) and depends on ``_reset_db_state``
+* ``aios_env_minimal`` — env vars only, no DB seeding. For tests that
+  exercise pre-bootstrap state (bootstrap endpoint tests, etc.)
+* ``aios_env`` — ``aios_env_minimal`` plus a bootstrapped root account
+  whose key is ``AIOS_API_KEY``. The default for tests that need an
+  authenticated route to work without manual setup
 
 Tests that need Docker are marked ``integration``; pytest -m "not integration"
 runs only the unit tests, which is what most local dev iterations use.
@@ -140,18 +143,24 @@ async def _reset_db_state(migrated_db_url: str) -> None:
 
 
 @pytest.fixture
-def aios_env(
+def aios_env_minimal(
     migrated_db_url: str, _reset_db_state: None, tmp_path: Path
 ) -> Iterator[dict[str, str]]:
-    """Set the env vars the FastAPI app needs."""
+    """Set the env vars the FastAPI app needs, without seeding any data.
+
+    Use this when the test specifically needs a fresh-install state —
+    e.g. the bootstrap-endpoint tests, which expect no root account
+    to exist yet. Most tests want :func:`aios_env`, which layers a
+    bootstrapped root on top so the auth dep accepts ``AIOS_API_KEY``
+    as a bearer token without further setup.
+    """
     env_vars = {
-        "AIOS_API_KEY": secrets.token_urlsafe(32),
+        "AIOS_API_KEY": "aios_" + secrets.token_urlsafe(32),
         "AIOS_VAULT_KEY": base64.b64encode(secrets.token_bytes(32)).decode("ascii"),
         "AIOS_DB_URL": migrated_db_url,
         "AIOS_WORKSPACE_ROOT": str(tmp_path / "workspaces"),
     }
     with mock.patch.dict(os.environ, env_vars):
-        # Reset the cached settings singleton
         from aios.config import get_settings
         from aios.db import pool
 
@@ -160,3 +169,40 @@ def aios_env(
         yield env_vars
         get_settings.cache_clear()
         pool._pool = None
+
+
+@pytest.fixture
+def aios_env(aios_env_minimal: dict[str, str]) -> dict[str, str]:
+    """Env vars + a bootstrapped root whose key is ``AIOS_API_KEY``.
+
+    Auth looks the bearer token up against ``account_keys``, so any
+    test that hits an authenticated route needs a matching DB row.
+    This fixture seeds that row using ``AIOS_API_KEY``'s sha256 hash.
+    """
+    # ``aios_env_minimal`` is a sync Iterator (uses ``mock.patch.dict``
+    # as a context manager), so the seed step can't be ``async def``.
+    # ``asyncio.run`` is the right bridge here, not an oversight.
+    import asyncio
+
+    import asyncpg
+
+    from aios.db import queries
+    from aios.services.accounts import hash_key
+
+    plaintext = aios_env_minimal["AIOS_API_KEY"]
+    db_url = aios_env_minimal["AIOS_DB_URL"]
+
+    async def _seed_root() -> None:
+        conn = await asyncpg.connect(db_url)
+        try:
+            await queries.bootstrap_root_account(
+                conn,
+                display_name="root",
+                key_hash=hash_key(plaintext),
+                key_label="test-root",
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(_seed_root())
+    return aios_env_minimal

--- a/tests/e2e/test_account_auth.py
+++ b/tests/e2e/test_account_auth.py
@@ -1,0 +1,107 @@
+"""E2E tests for the account-aware bearer auth dep."""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.helpers.connections import asgi_client
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    async with asgi_client(pool) as client:
+        yield client
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestAccountAuth:
+    async def test_bootstrapped_key_authenticates(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        """The plaintext key seeded into ``account_keys`` by ``aios_env``
+        successfully authenticates an arbitrary protected route.
+        """
+        r = await http_client.get("/v1/agents", headers=_bearer(aios_env["AIOS_API_KEY"]))
+        assert r.status_code == 200, r.text
+
+    @pytest.mark.parametrize(
+        "headers",
+        [
+            pytest.param({}, id="missing"),
+            pytest.param(
+                {"Authorization": f"Bearer aios_{secrets.token_urlsafe(32)}"},
+                id="unknown-token",
+            ),
+            pytest.param({"Authorization": "Basic some-creds"}, id="wrong-scheme"),
+        ],
+    )
+    async def test_header_shape_variants_401(
+        self, http_client: httpx.AsyncClient, headers: dict[str, str]
+    ) -> None:
+        r = await http_client.get("/v1/agents", headers=headers)
+        assert r.status_code == 401, r.text
+
+    async def test_revoked_key_401(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str], pool: Any
+    ) -> None:
+        """Setting ``revoked_at`` on the matching key kicks the holder out."""
+        from aios.services.accounts import hash_key
+
+        plaintext = aios_env["AIOS_API_KEY"]
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE account_keys SET revoked_at = now() WHERE hash = $1",
+                hash_key(plaintext),
+            )
+        r = await http_client.get("/v1/agents", headers=_bearer(plaintext))
+        assert r.status_code == 401, r.text
+
+    async def test_archived_account_401(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str], pool: Any
+    ) -> None:
+        """Archiving the owning account locks all its keys out, even
+        without an explicit revoke on the key row.
+        """
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE accounts SET archived_at = now() WHERE parent_account_id IS NULL"
+            )
+        r = await http_client.get("/v1/agents", headers=_bearer(aios_env["AIOS_API_KEY"]))
+        assert r.status_code == 401, r.text
+
+    async def test_aios_api_key_env_no_longer_consulted(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str], pool: Any
+    ) -> None:
+        """``AIOS_API_KEY`` env var alone doesn't unlock auth — the key
+        must have a matching row in ``account_keys``. Delete the seeded
+        row and confirm even the env-var value is rejected.
+        """
+        from aios.services.accounts import hash_key
+
+        plaintext = aios_env["AIOS_API_KEY"]
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM account_keys WHERE hash = $1",
+                hash_key(plaintext),
+            )
+        r = await http_client.get("/v1/agents", headers=_bearer(plaintext))
+        assert r.status_code == 401, r.text

--- a/tests/e2e/test_accounts_bootstrap.py
+++ b/tests/e2e/test_accounts_bootstrap.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import os
 import secrets
 from collections.abc import AsyncIterator, Iterator
@@ -12,9 +11,14 @@ from unittest import mock
 import httpx
 import pytest
 
+from tests.helpers.connections import asgi_client
+
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+async def pool(aios_env_minimal: dict[str, str]) -> AsyncIterator[Any]:
+    """Pool against a freshly-migrated DB with NO seeded root account —
+    the bootstrap-endpoint tests need to exercise the pre-bootstrap state.
+    """
     from aios.config import get_settings
     from aios.db.pool import create_pool
 
@@ -25,50 +29,38 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 
 @pytest.fixture
-def bootstrap_env(aios_env: dict[str, str]) -> Iterator[dict[str, str]]:
+def bootstrap_env(aios_env_minimal: dict[str, str]) -> Iterator[dict[str, str]]:
     token = secrets.token_urlsafe(32)
     extra = {"AIOS_BOOTSTRAP_TOKEN": token}
     with mock.patch.dict(os.environ, extra):
         from aios.config import get_settings
 
         get_settings.cache_clear()
-        yield {**aios_env, **extra}
+        yield {**aios_env_minimal, **extra}
         get_settings.cache_clear()
-
-
-async def _build_client(pool: Any) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    get_settings.cache_clear()
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(base_url="http://testserver", transport=transport) as client:
-        yield client
 
 
 @pytest.fixture
 async def http_client(pool: Any, bootstrap_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    async for client in _build_client(pool):
+    from aios.config import get_settings
+
+    get_settings.cache_clear()
+    async with asgi_client(pool) as client:
         yield client
 
 
 @pytest.fixture
 async def http_client_no_bootstrap_env(
-    pool: Any, aios_env: dict[str, str]
+    pool: Any, aios_env_minimal: dict[str, str]
 ) -> AsyncIterator[httpx.AsyncClient]:
     """Client built without ``AIOS_BOOTSTRAP_TOKEN`` in env — used by the
     env-unset test, which would otherwise see the token set by
     ``bootstrap_env`` that the regular ``http_client`` depends on.
     """
-    async for client in _build_client(pool):
+    from aios.config import get_settings
+
+    get_settings.cache_clear()
+    async with asgi_client(pool) as client:
         yield client
 
 
@@ -104,9 +96,11 @@ class TestBootstrap:
             json={"display_name": "root"},
             headers=_bootstrap_headers(token),
         )
+        from aios.services.accounts import hash_key
+
         assert r.status_code == 201
         plaintext = r.json()["plaintext_key"]
-        expected_hash = hashlib.sha256(plaintext.encode()).digest()
+        expected_hash = hash_key(plaintext)
         async with pool.acquire() as conn:
             row = await conn.fetchrow("SELECT hash, label FROM account_keys")
         assert row is not None

--- a/tests/helpers/connections.py
+++ b/tests/helpers/connections.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from collections.abc import AsyncIterator
 from typing import Any
+from unittest import mock
 
 import httpx
 
@@ -54,6 +56,33 @@ async def issue_runtime_token(api_key: str, base_url: str, connector: str) -> st
         r = await c.post("/v1/runtime-tokens", json={"connector": connector})
         r.raise_for_status()
         return str(r.json()["plaintext"])
+
+
+@contextlib.asynccontextmanager
+async def asgi_client(pool: Any) -> AsyncIterator[httpx.AsyncClient]:
+    """In-process ``httpx.AsyncClient`` wired to a fresh FastAPI app.
+
+    The app's pool / crypto_box / db_url are populated from settings
+    (which the caller's ``aios_env*`` fixture has already mocked); the
+    procrastinate handle is a mock since e2e auth tests don't run jobs.
+    Shared by tests that build the app themselves rather than going
+    through a running uvicorn — see ``tests/e2e/test_account_auth.py``
+    and ``tests/e2e/test_accounts_bootstrap.py``.
+    """
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    settings = get_settings()
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(base_url="http://testserver", transport=transport) as client:
+        yield client
 
 
 async def wait_for_health(url: str, *, deadline_s: float = 5.0) -> None:

--- a/tests/unit/cli/test_cli_dev.py
+++ b/tests/unit/cli/test_cli_dev.py
@@ -213,11 +213,7 @@ def test_settings_env_file_tuple_layers_and_later_wins(
 
     secrets = tmp_path / "secrets.env"
     dotenv = tmp_path / ".env"
-    secrets.write_text(
-        "AIOS_API_KEY=from_secrets\n"
-        "AIOS_VAULT_KEY=vk_secrets\n"
-        "AIOS_DB_URL=postgresql://secrets/db\n"
-    )
+    secrets.write_text("AIOS_VAULT_KEY=vk_secrets\nAIOS_DB_URL=postgresql://secrets/db\n")
     dotenv.write_text("AIOS_DB_URL=postgresql://dotenv/db\n")
 
     # Clear any inherited aios vars so only the files + our explicit env
@@ -225,7 +221,6 @@ def test_settings_env_file_tuple_layers_and_later_wins(
     for k in list(monkeypatch._setenv.keys() if hasattr(monkeypatch, "_setenv") else []):
         monkeypatch.delenv(k, raising=False)
     for k in (
-        "AIOS_API_KEY",
         "AIOS_VAULT_KEY",
         "AIOS_DB_URL",
         "AIOS_INSTANCE_ID",
@@ -235,7 +230,6 @@ def test_settings_env_file_tuple_layers_and_later_wins(
         monkeypatch.delenv(k, raising=False)
 
     s = Settings(_env_file=(str(secrets), str(dotenv)))  # type: ignore[call-arg]
-    assert s.api_key.get_secret_value() == "from_secrets"
     assert s.vault_key.get_secret_value() == "vk_secrets"
     # Later file overrides earlier.
     assert s.db_url == "postgresql://dotenv/db"


### PR DESCRIPTION
## Summary

Second PR of the multi-tenancy stack (#367). Replaces the env-var bearer check with a DB lookup against \`account_keys\`, returning \`(account_id, key_id, can_mint_children)\`. No query filtering yet — that's PR 3.

- New \`queries.lookup_account_by_key_hash\` joins \`account_keys\` ↔ \`accounts\`, filters out revoked keys + archived accounts.
- \`AuthDep\` now resolves to a typed tuple alias \`AccountAuthResult\`.
- \`AIOS_API_KEY\` env var is no longer consulted by the auth path. Operators must bootstrap once; the returned plaintext is the new bearer.
- Test fixtures split: \`aios_env_minimal\` (no seed) for bootstrap tests, \`aios_env\` (seeded root) for everything else. Shared \`asgi_client\` helper consolidates in-process client setup.

## Test plan

- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1161 passed
- [x] \`pytest tests/e2e/test_account_auth.py tests/e2e/test_accounts_bootstrap.py\` — 21 passed (7 new auth tests + 14 bootstrap tests)
- [x] Sample regression check: \`pytest tests/e2e/test_agents_api.py test_vaults.py test_memory_stores_api.py\` — 50 passed (no \`aios_env\`-fixture breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)