### PR TITLE
feat(#234): sandbox-native MCP CLI (Part B v1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ RUN uv sync --frozen --no-dev --no-install-project
 # Project source. Order: leaf-most-likely-to-change LAST.
 COPY alembic.ini README.md ./
 COPY migrations ./migrations
+# Sandbox-mounted CLI(s) — bind-mounted from /app/bin/ into every
+# sandbox container at provision time. Source path must exist in the
+# worker image; the worker resolves it via ``Path(__file__).parents[3]``.
+COPY bin ./bin
 COPY src ./src
 RUN uv sync --frozen --no-dev
 

--- a/bin/mcp
+++ b/bin/mcp
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""``mcp`` — sandbox-side CLI for invoking permitted MCP server tools.
+
+The worker injects ``MCP_BROKER_URL`` and a per-session
+``MCP_BROKER_SECRET`` into the sandbox at provisioning time. Every
+invocation here is one HTTP round-trip to the worker-side broker, which
+applies the session's authorization envelope and proxies to the upstream
+MCP server. Credentials never enter the sandbox.
+
+Usage:
+  mcp                                 list permitted servers
+  mcp <server>                        list permitted tools on a server
+  mcp <server> <tool> --help          show description + JSON schema
+  mcp <server> <tool> --json '{...}'  invoke with JSON arguments
+
+Output:
+  By default, invocation prints the tool's ``content`` (text) to stdout.
+  Pass ``--full`` to print the full ``{content|error,code}`` envelope as
+  JSON. A tool error exits 1 with the error message on stderr.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+USAGE = """Usage:
+  mcp                                 list permitted servers
+  mcp <server>                        list permitted tools on a server
+  mcp <server> <tool> --help          show description + JSON schema
+  mcp <server> <tool> --json '{...}'  invoke with JSON arguments
+
+Options for invocation:
+  --json '<json>'   tool arguments as a JSON object (default: {})
+  --full            print full JSON envelope instead of just content text
+"""
+
+
+def _env(name: str) -> str:
+    val = os.environ.get(name)
+    if not val:
+        sys.stderr.write(f"mcp: {name} is not set in the environment\n")
+        sys.exit(2)
+    return val
+
+
+def _request(method: str, path: str, body: dict | None = None) -> dict:
+    base = _env("MCP_BROKER_URL").rstrip("/")
+    secret = _env("MCP_BROKER_SECRET")
+    url = f"{base}/v1/{urllib.parse.quote(secret)}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Content-Type": "application/json"} if data else {}
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            payload = resp.read()
+            return json.loads(payload) if payload else {}
+    except urllib.error.HTTPError as e:
+        try:
+            err_body = json.loads(e.read())
+            msg = err_body.get("error") or err_body.get("detail") or f"HTTP {e.code}"
+        except Exception:
+            msg = f"HTTP {e.code}"
+        sys.stderr.write(f"mcp: {msg}\n")
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        sys.stderr.write(f"mcp: broker unreachable: {e.reason}\n")
+        sys.exit(2)
+
+
+def _list_servers() -> None:
+    result = _request("GET", "/servers")
+    servers = result.get("servers") or []
+    if not servers:
+        print("(no MCP servers available to this session)")
+        return
+    for s in servers:
+        name = s.get("name", "?")
+        desc = s.get("description") or ""
+        print(f"{name}\t{desc}" if desc else name)
+
+
+def _list_tools(server: str) -> None:
+    result = _request("GET", f"/servers/{urllib.parse.quote(server)}/tools")
+    tools = result.get("tools") or []
+    if not tools:
+        print(f"(no tools available on server '{server}')")
+        return
+    for t in tools:
+        name = t.get("name", "?")
+        desc = (t.get("description") or "").split("\n", 1)[0]
+        print(f"{name}\t{desc}" if desc else name)
+
+
+def _tool_help(server: str, tool: str) -> None:
+    result = _request(
+        "GET",
+        f"/servers/{urllib.parse.quote(server)}/tools/{urllib.parse.quote(tool)}",
+    )
+    print(f"TOOL: {server} {tool}")
+    print()
+    print("DESCRIPTION:")
+    print(f"  {result.get('description') or '(no description)'}")
+    print()
+    print("ARGUMENTS (JSON Schema):")
+    print(json.dumps(result.get("input_schema") or {}, indent=2))
+    print()
+    print("INVOKE:")
+    print(f"  mcp {server} {tool} --json '{{...}}'")
+
+
+def _invoke(server: str, tool: str, json_arg: str, *, full_envelope: bool) -> None:
+    try:
+        args = json.loads(json_arg)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"mcp: --json arg is not valid JSON: {e}\n")
+        sys.exit(2)
+    if not isinstance(args, dict):
+        sys.stderr.write("mcp: --json must be a JSON object\n")
+        sys.exit(2)
+    result = _request(
+        "POST",
+        f"/servers/{urllib.parse.quote(server)}/tools/{urllib.parse.quote(tool)}",
+        {"arguments": args},
+    )
+    if full_envelope:
+        print(json.dumps(result, indent=2))
+        return
+    if "error" in result:
+        sys.stderr.write(f"mcp: {result['error']}\n")
+        sys.exit(1)
+    content = result.get("content", "")
+    if content:
+        print(content)
+
+
+def main(argv: list[str]) -> None:
+    if len(argv) <= 1:
+        _list_servers()
+        return
+    if argv[1] in ("-h", "--help"):
+        sys.stdout.write(USAGE)
+        return
+
+    server = argv[1]
+    if len(argv) == 2:
+        _list_tools(server)
+        return
+
+    tool = argv[2]
+    show_help = False
+    json_arg: str | None = None
+    full_envelope = False
+
+    i = 3
+    while i < len(argv):
+        a = argv[i]
+        if a in ("-h", "--help"):
+            show_help = True
+            i += 1
+        elif a == "--json":
+            if i + 1 >= len(argv):
+                sys.stderr.write("mcp: --json requires an argument\n")
+                sys.exit(2)
+            json_arg = argv[i + 1]
+            i += 2
+        elif a == "--full":
+            full_envelope = True
+            i += 1
+        else:
+            sys.stderr.write(f"mcp: unknown argument: {a}\n")
+            sys.exit(2)
+
+    if show_help:
+        _tool_help(server, tool)
+        return
+
+    _invoke(server, tool, json_arg or "{}", full_envelope=full_envelope)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/src/aios/harness/runtime.py
+++ b/src/aios/harness/runtime.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from aios.harness.task_registry import TaskRegistry
     from aios.mcp.pool import McpSessionPool
     from aios.models.memory_stores import MemoryStoreResourceEcho
+    from aios.sandbox.mcp_proxy import McpBroker
     from aios.sandbox.registry import SandboxRegistry
     from aios.tools.providers import ToolProvider
 
@@ -36,6 +37,7 @@ worker_id: str | None = None
 sandbox_registry: SandboxRegistry | None = None
 task_registry: TaskRegistry | None = None
 mcp_session_pool: McpSessionPool | None = None
+mcp_broker: McpBroker | None = None
 tool_provider: ToolProvider | None = None
 
 # Per-session memory-mount cache. Populated at the top of every step (in
@@ -144,6 +146,15 @@ def require_mcp_session_pool() -> McpSessionPool:
             "this code is running outside a worker_main context"
         )
     return mcp_session_pool
+
+
+def require_mcp_broker() -> McpBroker:
+    if mcp_broker is None:
+        raise RuntimeError(
+            "aios.harness.runtime.mcp_broker is not initialized; "
+            "this code is running outside a worker_main context"
+        )
+    return mcp_broker
 
 
 def require_tool_provider() -> ToolProvider:

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -38,11 +38,60 @@ from aios.tools.registry import to_openai_tools
 if TYPE_CHECKING:
     import asyncpg
 
-    from aios.models.agents import Agent, AgentVersion, McpServerSpec
+    from aios.models.agents import Agent, AgentVersion, McpServerSpec, ToolSpec
     from aios.models.events import Event
     from aios.models.memory_stores import MemoryStoreResourceEcho
     from aios.models.sessions import Session
     from aios.models.skills import SkillVersion
+
+
+# Generic affordance prose explaining the in-sandbox ``mcp`` CLI. Rendered
+# into the system prompt whenever the agent has at least one
+# ``always_allow`` MCP toolset entry. Worded in stable runtime terms — no
+# dev-world references — so it remains agent-actionable across releases.
+_MCP_CLI_HINT = (
+    "## Sandbox MCP CLI\n\n"
+    "Permitted MCP tools are also callable from inside the sandbox via the "
+    "`mcp` binary, so you can invoke them programmatically from `bash` "
+    "without paying an inference cycle per call:\n\n"
+    "    mcp                                 list available MCP servers\n"
+    "    mcp <server>                        list tools on a server\n"
+    "    mcp <server> <tool> --help          show description + JSON schema\n"
+    "    mcp <server> <tool> --json '{...}'  invoke with JSON arguments\n\n"
+    "Use the CLI when you want scriptable invocation (composition with `jq`, "
+    "`xargs`, redirection, scheduled wakes). The model-tool invocation path "
+    "remains available for the same tools."
+)
+
+
+def _has_always_allow_mcp_tool(agent_tools: list[ToolSpec]) -> bool:
+    """True iff at least one enabled mcp_toolset entry resolves any tool
+    to ``always_allow``.
+
+    The CLI hint is purely informational — emitting it for an agent whose
+    toolset has only ``always_ask`` policies would lie to the model
+    (every CLI call would 403). Showing it whenever there's at least one
+    ``always_allow`` path is the conservative truthful default.
+    """
+    for spec in agent_tools:
+        if spec.type != "mcp_toolset" or not spec.enabled:
+            continue
+        default = spec.default_config
+        if (
+            default
+            and default.permission_policy
+            and default.permission_policy.type == "always_allow"
+        ):
+            return True
+        if spec.configs:
+            for cfg in spec.configs:
+                if (
+                    cfg.enabled
+                    and cfg.permission_policy
+                    and cfg.permission_policy.type == "always_allow"
+                ):
+                    return True
+    return False
 
 
 @dataclass(frozen=True)
@@ -113,11 +162,13 @@ async def compute_step_prelude(
     if channels:
         tools.append(_switch_channel_tool_spec())
 
-    instructions_block = ""
+    mcp_servers_block = ""
     if agent.mcp_servers:
         mcp_tools, mcp_instructions = await discover_session_mcp_tools(pool, session_id, agent)
         tools.extend(mcp_tools)
-        instructions_block = _build_instructions_block(agent.mcp_servers, mcp_instructions)
+        mcp_servers_block = _build_instructions_block(agent.mcp_servers, mcp_instructions)
+    cli_hint = _MCP_CLI_HINT if _has_always_allow_mcp_tool(agent.tools) else ""
+    instructions_block = "\n\n".join(s for s in (cli_hint, mcp_servers_block) if s)
 
     # Custom tools declared on connections attached to this session
     # (single_session, per_chat origin, or operator-bound chat).  Each

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -51,6 +51,7 @@ from aios.harness.task_registry import TaskRegistry
 from aios.logging import configure_logging, get_logger
 from aios.mcp.pool import McpSessionPool
 from aios.sandbox.backends import make_backend
+from aios.sandbox.mcp_proxy import McpBroker
 from aios.sandbox.registry import SandboxRegistry
 
 # Hashed (via Postgres ``hashtextextended($1, 0)``) into the 64-bit
@@ -100,6 +101,7 @@ async def worker_main() -> None:
     sandbox_registry: SandboxRegistry | None = None
     task_registry: TaskRegistry | None = None
     mcp_session_pool: McpSessionPool | None = None
+    mcp_broker: McpBroker | None = None
     procrastinate_opened = False
     sweep_task: asyncio.Task[None] | None = None
     interrupt_task: asyncio.Task[None] | None = None
@@ -111,6 +113,8 @@ async def worker_main() -> None:
         sandbox_registry = SandboxRegistry(backend=make_backend(settings.sandbox_backend))
         task_registry = TaskRegistry()
         mcp_session_pool = McpSessionPool()
+        mcp_broker = McpBroker()
+        await mcp_broker.start()
 
         # Register the connector subsystem's ToolProvider impl against the
         # Protocol slot from PR 3 (#328). The harness reaches the
@@ -126,6 +130,7 @@ async def worker_main() -> None:
         runtime.sandbox_registry = sandbox_registry
         runtime.task_registry = task_registry
         runtime.mcp_session_pool = mcp_session_pool
+        runtime.mcp_broker = mcp_broker
         runtime.tool_provider = SubsystemToolProvider()
 
         await procrastinate_app.open_async()
@@ -227,6 +232,8 @@ async def worker_main() -> None:
             await sandbox_registry.release_all()
         if mcp_session_pool is not None:
             await mcp_session_pool.close_all()
+        if mcp_broker is not None:
+            await mcp_broker.stop()
         if procrastinate_opened:
             await procrastinate_app.close_async()
         if pool is not None:

--- a/src/aios/sandbox/mcp_proxy.py
+++ b/src/aios/sandbox/mcp_proxy.py
@@ -1,0 +1,349 @@
+"""Worker-side HTTP broker that exposes permitted MCP tools to
+sandboxed agents.
+
+Architecture mirror of :class:`aios.sandbox.git_proxy.GitProxy` but
+scoped worker-wide instead of per-session: one shared
+Starlette/uvicorn instance, demultiplexing by per-session secret
+embedded in the URL path. Each session's secret is minted by the
+sandbox provisioner and registered with :meth:`register_session`
+before the container starts; the secret is injected into the sandbox
+as ``MCP_BROKER_SECRET`` so the in-sandbox ``mcp`` CLI can present it
+on every request.
+
+Credentials never enter the sandbox: the broker holds vault-decrypted
+auth headers in memory (via the existing :mod:`aios.mcp.client` pool)
+and the sandbox only ever sees the broker's HTTP surface.
+
+Authorization model (v1): only tools where the session's resolved
+``mcp_toolset`` permission is ``always_allow`` are callable through
+the CLI. Everything else returns 403 with an explanatory message;
+the model-tool path remains available for those tools.
+
+The per-session secret in the URL path is a sanity check, not a true
+isolation primitive — the agent can read the secret from
+``$MCP_BROKER_SECRET`` inside the container. Its job is to limit
+blast radius if the broker port is reachable from the wider network
+and to ensure the broker can identify which session is calling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import Any
+from urllib.parse import urlsplit
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+from aios.logging import get_logger
+from aios.mcp.client import call_mcp_tool, discover_mcp_tools, resolve_auth_for_url
+from aios.models.agents import McpServerSpec, ToolSpec
+
+log = get_logger("aios.sandbox.mcp_proxy")
+
+_BIND_TIMEOUT_S = 5.0
+
+
+def _resolve_tool_permission(toolset: ToolSpec, tool_name: str) -> tuple[bool, str | None]:
+    """Resolve ``(enabled, permission_policy_type)`` for a specific tool
+    under an ``mcp_toolset`` entry.
+
+    Precedence: explicit per-tool override in ``configs`` first; otherwise
+    ``default_config``; otherwise ``(enabled=True, policy=None)``.
+    """
+    if toolset.configs:
+        for cfg in toolset.configs:
+            if cfg.name == tool_name:
+                policy = cfg.permission_policy.type if cfg.permission_policy else None
+                return cfg.enabled, policy
+    default = toolset.default_config
+    if default is not None:
+        policy = default.permission_policy.type if default.permission_policy else None
+        return default.enabled, policy
+    return True, None
+
+
+def _find_toolset(agent_tools: list[ToolSpec], server_name: str) -> ToolSpec | None:
+    for spec in agent_tools:
+        if spec.type == "mcp_toolset" and spec.enabled and spec.mcp_server_name == server_name:
+            return spec
+    return None
+
+
+def _find_server(agent_servers: list[McpServerSpec], server_name: str) -> McpServerSpec | None:
+    for s in agent_servers:
+        if s.name == server_name:
+            return s
+    return None
+
+
+def _err(status: int, message: str) -> JSONResponse:
+    return JSONResponse({"error": message}, status_code=status)
+
+
+class McpBroker:
+    """One shared HTTP broker per worker.
+
+    Lifecycle: instantiated and started during ``worker_main``,
+    registered on ``aios.harness.runtime.mcp_broker``, stopped during
+    shutdown. Sandbox provisioning calls :meth:`register_session` to
+    bind a freshly minted per-session secret to a session id; release
+    calls :meth:`unregister_session`.
+    """
+
+    def __init__(self) -> None:
+        self._secrets: dict[str, str] = {}
+        self._server: uvicorn.Server | None = None
+        self._serve_task: asyncio.Task[None] | None = None
+        self._port: int | None = None
+
+    @property
+    def port(self) -> int:
+        assert self._port is not None, "McpBroker.start() has not completed"
+        return self._port
+
+    def register_session(self, session_id: str, secret: str) -> None:
+        self._secrets[secret] = session_id
+
+    def unregister_session(self, session_id: str) -> None:
+        stale = [s for s, sid in self._secrets.items() if sid == session_id]
+        for s in stale:
+            self._secrets.pop(s, None)
+
+    async def start(self) -> None:
+        """Bind ``0.0.0.0:0`` and begin serving. Binding to 0.0.0.0 is
+        required for sandbox containers to reach the broker via
+        ``host.docker.internal``."""
+        app = Starlette(
+            routes=[
+                Route("/v1/{secret}/servers", self._list_servers, methods=["GET"]),
+                Route(
+                    "/v1/{secret}/servers/{server}/tools",
+                    self._list_tools,
+                    methods=["GET"],
+                ),
+                Route(
+                    "/v1/{secret}/servers/{server}/tools/{tool}",
+                    self._tool_help,
+                    methods=["GET"],
+                ),
+                Route(
+                    "/v1/{secret}/servers/{server}/tools/{tool}",
+                    self._invoke,
+                    methods=["POST"],
+                ),
+            ]
+        )
+        config = uvicorn.Config(
+            app,
+            host="0.0.0.0",
+            port=0,
+            log_level="error",
+            access_log=False,
+            lifespan="off",
+        )
+        self._server = uvicorn.Server(config)
+        self._serve_task = asyncio.create_task(self._server.serve(), name="mcp-broker-serve")
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _BIND_TIMEOUT_S
+        while loop.time() < deadline:
+            await asyncio.sleep(0.01)
+            if self._server.started and self._server.servers:
+                sockets = self._server.servers[0].sockets
+                if sockets:
+                    self._port = sockets[0].getsockname()[1]
+                    log.info("mcp_broker.started", port=self._port)
+                    return
+        raise RuntimeError(f"mcp broker failed to bind within {_BIND_TIMEOUT_S}s")
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.should_exit = True
+        try:
+            if self._serve_task is not None:
+                with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+                    await asyncio.wait_for(self._serve_task, timeout=5.0)
+        finally:
+            if self._serve_task is not None and not self._serve_task.done():
+                self._serve_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._serve_task
+        log.info("mcp_broker.stopped", port=self._port)
+
+    async def _resolve_session(self, request: Request) -> str | Response:
+        secret = request.path_params["secret"]
+        session_id = self._secrets.get(secret)
+        if session_id is None:
+            return _err(403, "forbidden: unknown or expired secret")
+        return session_id
+
+    async def _load_agent(self, session_id: str) -> Any:
+        """Fetch the agent (or agent_version) attached to ``session_id``.
+
+        Mirrors the loading dance in
+        :func:`aios.harness.loop.run_session_step` — session→agent
+        with optional version pinning.
+        """
+        from aios.harness import runtime
+        from aios.services import agents as agents_service
+        from aios.services import sessions as sessions_service
+
+        pool = runtime.require_pool()
+        session = await sessions_service.get_session(pool, session_id)
+        if session.agent_version is not None:
+            return await agents_service.get_agent_version(
+                pool, session.agent_id, session.agent_version
+            )
+        return await agents_service.get_agent(pool, session.agent_id)
+
+    async def _list_servers(self, request: Request) -> Response:
+        resolved = await self._resolve_session(request)
+        if isinstance(resolved, Response):
+            return resolved
+        agent = await self._load_agent(resolved)
+        enabled_names: set[str] = {
+            spec.mcp_server_name
+            for spec in agent.tools
+            if spec.type == "mcp_toolset" and spec.enabled and spec.mcp_server_name is not None
+        }
+        servers = [
+            {"name": s.name, "host": urlsplit(s.url).netloc}
+            for s in agent.mcp_servers
+            if s.name in enabled_names
+        ]
+        return JSONResponse({"servers": servers})
+
+    async def _resolve_for_tool(
+        self, request: Request, *, require_invoke: bool
+    ) -> tuple[str, McpServerSpec, ToolSpec, str] | Response:
+        """Common prelude for tool routes: resolve session, agent,
+        toolset, server, and authorize the tool. Returns
+        ``(session_id, server_spec, toolset, tool_name)`` on success or
+        a ``Response`` to return immediately on failure.
+
+        ``require_invoke`` selects between "browsing" semantics (--help
+        and listing accept any always_allow tool) and "invoke"
+        semantics (currently the same; kept for forward-compat with the
+        always_ask path that will need a different short-circuit).
+        """
+        del require_invoke  # reserved for v2 always_ask path
+        resolved = await self._resolve_session(request)
+        if isinstance(resolved, Response):
+            return resolved
+        session_id = resolved
+        server_name = request.path_params["server"]
+        tool_name = request.path_params["tool"]
+        agent = await self._load_agent(session_id)
+        toolset = _find_toolset(agent.tools, server_name)
+        if toolset is None:
+            return _err(404, f"server '{server_name}' is not available to this session")
+        enabled, policy = _resolve_tool_permission(toolset, tool_name)
+        if not enabled:
+            return _err(403, f"tool '{tool_name}' is disabled on this agent")
+        if policy != "always_allow":
+            return _err(
+                403,
+                f"tool '{tool_name}' is not callable via CLI "
+                f"(permission policy: {policy or 'unset'}). Use the model-tool path.",
+            )
+        server = _find_server(agent.mcp_servers, server_name)
+        if server is None:
+            return _err(404, f"server '{server_name}' has no URL configured")
+        return session_id, server, toolset, tool_name
+
+    async def _list_tools(self, request: Request) -> Response:
+        resolved = await self._resolve_session(request)
+        if isinstance(resolved, Response):
+            return resolved
+        session_id = resolved
+        server_name = request.path_params["server"]
+        agent = await self._load_agent(session_id)
+        toolset = _find_toolset(agent.tools, server_name)
+        if toolset is None:
+            return _err(404, f"server '{server_name}' is not available to this session")
+        server = _find_server(agent.mcp_servers, server_name)
+        if server is None:
+            return _err(404, f"server '{server_name}' has no URL configured")
+
+        from aios.harness import runtime
+
+        pool = runtime.require_pool()
+        crypto_box = runtime.require_crypto_box()
+        headers = await resolve_auth_for_url(pool, crypto_box, session_id, server.url)
+        tool_dicts, _instructions = await discover_mcp_tools(server.url, server_name, headers)
+
+        out: list[dict[str, Any]] = []
+        for td in tool_dicts:
+            fn = td.get("function", {})
+            qualified = fn.get("name", "")
+            parts = qualified.split("__", 2)
+            if len(parts) != 3 or parts[0] != "mcp" or parts[1] != server_name:
+                continue
+            tool_name = parts[2]
+            enabled, policy = _resolve_tool_permission(toolset, tool_name)
+            if not enabled or policy != "always_allow":
+                continue
+            out.append({"name": tool_name, "description": fn.get("description", "")})
+        return JSONResponse({"tools": out})
+
+    async def _tool_help(self, request: Request) -> Response:
+        resolved = await self._resolve_for_tool(request, require_invoke=False)
+        if isinstance(resolved, Response):
+            return resolved
+        session_id, server, _toolset, tool_name = resolved
+
+        from aios.harness import runtime
+
+        pool = runtime.require_pool()
+        crypto_box = runtime.require_crypto_box()
+        headers = await resolve_auth_for_url(pool, crypto_box, session_id, server.url)
+        tool_dicts, _ = await discover_mcp_tools(server.url, server.name, headers)
+        qualified = f"mcp__{server.name}__{tool_name}"
+        for td in tool_dicts:
+            fn = td.get("function", {})
+            if fn.get("name") == qualified:
+                return JSONResponse(
+                    {
+                        "name": tool_name,
+                        "description": fn.get("description", ""),
+                        "input_schema": fn.get("parameters", {}),
+                    }
+                )
+        return _err(404, f"tool '{tool_name}' not found on server '{server.name}'")
+
+    async def _invoke(self, request: Request) -> Response:
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            return _err(400, "request body must be JSON")
+        arguments = body.get("arguments") if isinstance(body, dict) else None
+        if not isinstance(arguments, dict):
+            return _err(400, 'request body must contain {"arguments": <object>}')
+
+        resolved = await self._resolve_for_tool(request, require_invoke=True)
+        if isinstance(resolved, Response):
+            return resolved
+        session_id, server, _toolset, tool_name = resolved
+
+        from aios.harness import runtime
+
+        pool = runtime.require_pool()
+        crypto_box = runtime.require_crypto_box()
+        headers = await resolve_auth_for_url(pool, crypto_box, session_id, server.url)
+        log.info(
+            "mcp_broker.invoke",
+            session_id=session_id,
+            server=server.name,
+            tool=tool_name,
+        )
+        envelope = await call_mcp_tool(server.url, headers, tool_name, arguments)
+        return JSONResponse(envelope)
+
+
+__all__ = ["McpBroker"]

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -152,12 +152,13 @@ class SandboxRegistry:
         try:
             handle = await self._backend.create(plan.spec)
         except BaseException:
-            # Spec was built (proxy may be running) but the backend
-            # couldn't create the sandbox. Stop the proxy so its port +
-            # token map don't leak.
+            # Spec was built (proxy may be running, broker secret is
+            # registered) but the backend couldn't create the sandbox.
+            # Drop both so their port + token map + secret map don't leak.
             self._git_proxies.pop(session_id, None)
             if plan.git_proxy is not None:
                 await self._stop_proxy_silently(plan.git_proxy, session_id)
+            self._release_mcp_broker_secret(session_id)
             raise
 
         # Setup steps after create. If any of these raise, tear the
@@ -183,13 +184,21 @@ class SandboxRegistry:
 
     async def _maybe_apply_lockdown(self, handle: SandboxHandle, plan: ProvisioningPlan) -> None:
         """Apply network lockdown if the plan calls for it."""
+        from aios.harness import runtime
         from aios.models.environments import LimitedNetworking
 
         networking = plan.env_config.networking if plan.env_config else None
         if not isinstance(networking, LimitedNetworking):
             return
-        extra_host_ports: list[tuple[str, int]] = []
-        if plan.git_proxy is not None and plan.spec.host_gateway_alias is not None:
+        # ``host_gateway_alias`` is always set on plans the worker
+        # produces (every sandbox has access to the MCP broker), so the
+        # host-port allowlist always includes the broker; ``git_proxy``
+        # is added conditionally.
+        assert plan.spec.host_gateway_alias is not None
+        extra_host_ports: list[tuple[str, int]] = [
+            (plan.spec.host_gateway_alias, runtime.require_mcp_broker().port),
+        ]
+        if plan.git_proxy is not None:
             extra_host_ports.append((plan.spec.host_gateway_alias, plan.git_proxy.port))
         await apply_network_lockdown(
             self._backend,
@@ -214,6 +223,17 @@ class SandboxRegistry:
                 error=str(err),
             )
 
+    def _release_mcp_broker_secret(self, session_id: str) -> None:
+        """Drop the per-session entry from the MCP broker's secret map.
+
+        Idempotent: a missing entry is silently ignored. Called at every
+        sandbox teardown site so the broker doesn't accumulate dangling
+        secrets for sessions whose sandboxes are gone.
+        """
+        from aios.harness import runtime
+
+        runtime.require_mcp_broker().unregister_session(session_id)
+
     async def _destroy_quietly(self, handle: SandboxHandle, session_id: str) -> None:
         """Tear down the handle's sandbox and stop the session's proxy.
 
@@ -233,6 +253,7 @@ class SandboxRegistry:
         proxy = self._git_proxies.pop(session_id, None)
         if proxy is not None:
             await self._stop_proxy_silently(proxy, session_id)
+        self._release_mcp_broker_secret(session_id)
 
     async def exec(
         self,
@@ -260,6 +281,7 @@ class SandboxRegistry:
 
         if proxy is not None:
             await self._stop_proxy_silently(proxy, session_id)
+        self._release_mcp_broker_secret(session_id)
         if handle is None:
             return
         await self._backend.destroy(handle)
@@ -296,6 +318,7 @@ class SandboxRegistry:
             proxy = self._git_proxies.pop(session_id, None)
             if proxy is not None:
                 await self._stop_proxy_silently(proxy, session_id)
+            self._release_mcp_broker_secret(session_id)
             await self._backend.destroy(handle)
 
     def peek(self, session_id: str) -> SandboxHandle | None:
@@ -319,6 +342,9 @@ class SandboxRegistry:
             # Fire-and-forget — eviction is best-effort cleanup; worker
             # shutdown's ``release_all`` is the authoritative final stop.
             asyncio.create_task(self._stop_proxy_silently(proxy, session_id))  # noqa: RUF006
+        # Same story for the MCP broker secret: drop it immediately; a
+        # fresh sandbox will get a fresh secret from the next provision.
+        self._release_mcp_broker_secret(session_id)
 
     async def release_all(self) -> None:
         """Tear down every sandbox + proxy. Called at worker shutdown."""

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -23,6 +23,7 @@ backend, or anything else is decided by the worker's selected backend.
 
 from __future__ import annotations
 
+import secrets
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -54,12 +55,19 @@ from aios.sandbox.setup import WORKSPACE_RUNTIME_ENV
 log = get_logger("aios.sandbox.spec")
 
 
-# Hostname the sandbox uses to reach the host-side credential proxy.
-# Docker maps this to the host gateway IP via ``--add-host``; on Docker
-# Desktop the name auto-resolves but the explicit alias is required on
-# Linux. The registry threads the same string through the iptables script
-# so limited-networking sessions can still reach the proxy.
+# Hostname the sandbox uses to reach host-side proxies (``git_proxy`` for
+# GitHub PAT injection, ``mcp_proxy`` for MCP tool invocations). Docker
+# maps this to the host gateway IP via ``--add-host``; on Docker Desktop
+# the name auto-resolves but the explicit alias is required on Linux.
+# The registry threads the same string through the iptables script so
+# limited-networking sessions can still reach the proxy ports.
 PROXY_HOST_ALIAS = "host.docker.internal"
+
+# Host-side path of the ``mcp`` CLI bind-mounted into every sandbox.
+# ``parents[3]`` yields the repo root in both dev (worktree root) and
+# Docker (``/app``), matching the convention in
+# ``aios.db.migrations._REPO_ROOT``.
+_MCP_CLI_HOST_PATH = Path(__file__).resolve().parents[3] / "bin" / "mcp"
 
 
 @dataclass(frozen=True, slots=True)
@@ -249,13 +257,15 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
 
     Reads the session row, loads the environment config, materializes
     memory stores and github clones (starting a GitProxy if any github
-    repos are attached), then assembles the :class:`SandboxSpec` and
-    related artifacts.
+    repos are attached), mints a per-session MCP-broker secret, then
+    assembles the :class:`SandboxSpec` and related artifacts.
 
-    On any failure after the GitProxy is started, the proxy is stopped
-    before the exception propagates so the port + token map don't leak
-    for the worker's lifetime.
+    On any failure after the GitProxy is started or the broker secret
+    is registered, both are cleaned up before the exception propagates
+    so the port, token map, and secret map don't leak for the worker's
+    lifetime.
     """
+    from aios.harness import runtime
     from aios.sandbox.volumes import ensure_workspace_path
 
     settings = get_settings()
@@ -264,6 +274,11 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     env_config = await _load_environment_config(session_id)
     memory_echoes = await _materialize_memory_mounts(session_id)
     github_echoes, git_proxy = await _materialize_github_clones(session_id)
+
+    mcp_broker = runtime.require_mcp_broker()
+    mcp_broker_secret = secrets.token_urlsafe(32)
+    mcp_broker.register_session(session_id, mcp_broker_secret)
+    mcp_broker_url = f"http://{PROXY_HOST_ALIAS}:{mcp_broker.port}"
 
     try:
         return _assemble_plan(
@@ -276,12 +291,15 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
             memory_echoes=memory_echoes,
             github_echoes=github_echoes,
             git_proxy=git_proxy,
+            mcp_broker_url=mcp_broker_url,
+            mcp_broker_secret=mcp_broker_secret,
         )
     except BaseException:
-        # The proxy holds an open port + in-memory token map. Anything
-        # that raises before we hand back a plan must stop the proxy on
-        # the way out, otherwise the port and tokens leak for the
-        # worker's lifetime.
+        # Both proxies hold worker-process state (ports, token maps,
+        # secret-to-session bindings). Anything that raises before we
+        # hand back a plan must clean up both on the way out, otherwise
+        # state leaks for the worker's lifetime.
+        mcp_broker.unregister_session(session_id)
         if git_proxy is not None:
             try:
                 await git_proxy.stop()
@@ -305,6 +323,8 @@ def _assemble_plan(
     memory_echoes: list[MemoryStoreResourceEcho],
     github_echoes: list[GithubRepositoryResourceEcho],
     git_proxy: GitProxy | None,
+    mcp_broker_url: str,
+    mcp_broker_secret: str,
 ) -> ProvisioningPlan:
     """Pure assembly of the plan from already-materialized inputs."""
     from aios.sandbox.volumes import (
@@ -318,6 +338,8 @@ def _assemble_plan(
         **WORKSPACE_RUNTIME_ENV,
         **(env_config.env if env_config and env_config.env else {}),
         **session_env,
+        "MCP_BROKER_URL": mcp_broker_url,
+        "MCP_BROKER_SECRET": mcp_broker_secret,
     }
 
     # Bind the per-session attachments and uploads dirs at every provision
@@ -332,6 +354,14 @@ def _assemble_plan(
     extra_mounts: list[Mount] = [
         Mount(host_path=attachments_path, sandbox_path="/mnt/attachments", read_only=True),
         Mount(host_path=uploads_path, sandbox_path="/mnt/uploads", read_only=True),
+        # The ``mcp`` CLI script lets the agent invoke permitted MCP tools
+        # through the worker-side broker. Bind-mounted (not baked) so a
+        # script update doesn't require rebuilding the sandbox image.
+        Mount(
+            host_path=_MCP_CLI_HOST_PATH,
+            sandbox_path="/usr/local/bin/mcp",
+            read_only=True,
+        ),
     ]
 
     # Bind-mount each attached memory store. Read-only attaches make the
@@ -373,7 +403,10 @@ def _assemble_plan(
         environment=merged_env,
         labels=labels,
         network_policy=_network_policy_from_config(env_config),
-        host_gateway_alias=PROXY_HOST_ALIAS if git_proxy is not None else None,
+        # Always set: every sandbox can reach the MCP broker on the host
+        # gateway; ``git_proxy`` and any other host-side proxies share the
+        # same alias.
+        host_gateway_alias=PROXY_HOST_ALIAS,
         image=image,
         mount_snapshot=snapshot,
     )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -172,6 +172,7 @@ async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     from aios.harness import runtime
     from aios.harness.task_registry import TaskRegistry
     from aios.sandbox.backends import make_backend
+    from aios.sandbox.mcp_proxy import McpBroker
     from aios.sandbox.registry import SandboxRegistry
     from aios.tools.registry import registry
     from aios_connectors.providers import SubsystemToolProvider
@@ -181,12 +182,15 @@ async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
     task_reg = TaskRegistry()
     sandbox_reg = SandboxRegistry(backend=make_backend(settings.sandbox_backend))
+    mcp_broker = McpBroker()
+    await mcp_broker.start()
 
     prev = (
         runtime.pool,
         runtime.crypto_box,
         runtime.task_registry,
         runtime.sandbox_registry,
+        runtime.mcp_broker,
         runtime.worker_id,
         runtime.tool_provider,
     )
@@ -194,6 +198,7 @@ async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     runtime.crypto_box = crypto_box
     runtime.task_registry = task_reg
     runtime.sandbox_registry = sandbox_reg
+    runtime.mcp_broker = mcp_broker
     runtime.worker_id = "worker_test"
     runtime.tool_provider = SubsystemToolProvider()
 
@@ -221,11 +226,13 @@ async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
         runtime.crypto_box,
         runtime.task_registry,
         runtime.sandbox_registry,
+        runtime.mcp_broker,
         runtime.worker_id,
         runtime.tool_provider,
     ) = prev
     await task_reg.shutdown()
     await sandbox_reg.release_all()
+    await mcp_broker.stop()
     await pool.close()
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -59,6 +59,27 @@ def _unit_runtime_tool_provider() -> Iterator[None]:
         runtime.tool_provider = None
 
 
+@pytest.fixture(autouse=True)
+def _unit_runtime_mcp_broker() -> Iterator[None]:
+    """Register an unstarted ``McpBroker`` on ``runtime`` for unit tests.
+
+    Sandbox provisioning and teardown paths call
+    ``runtime.require_mcp_broker()`` to register and clear per-session
+    secrets; without an instance the helper raises. Tests that exercise
+    those paths don't need a live HTTP server — only the in-memory
+    secret map — so we hand them an instance that was never ``.start()``-ed.
+    Tests that actually need ``.port`` should set ``broker._port`` directly.
+    """
+    from aios.harness import runtime
+    from aios.sandbox.mcp_proxy import McpBroker
+
+    runtime.mcp_broker = McpBroker()
+    try:
+        yield
+    finally:
+        runtime.mcp_broker = None
+
+
 @pytest.fixture
 async def in_memory_app() -> AsyncIterator[App]:
     """Patch the aios procrastinate app to use an in-memory connector.

--- a/tests/unit/sandbox/test_mcp_cli_binary.py
+++ b/tests/unit/sandbox/test_mcp_cli_binary.py
@@ -1,0 +1,192 @@
+"""Integration tests for the ``bin/mcp`` CLI against a real broker.
+
+Boots a real :class:`aios.sandbox.mcp_proxy.McpBroker` on a loopback
+port, mocks the upstream MCP discovery/invocation, then shells out to
+``bin/mcp`` as a subprocess with ``MCP_BROKER_URL`` / ``MCP_BROKER_SECRET``
+pointed at the test broker. Verifies the CLI parses the broker's
+JSON envelope correctly and surfaces the right exit codes.
+
+No Docker — this exercises the binary end-to-end at the HTTP/subprocess
+boundary, which is what a real sandbox sees.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+import sys
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from aios.models.agents import (
+    McpPermissionPolicy,
+    McpServerSpec,
+    McpToolsetConfig,
+    ToolSpec,
+)
+from aios.sandbox.mcp_proxy import McpBroker
+
+# bin/mcp lives at the repo root; resolve relative to this test file so
+# the path is stable regardless of pytest's cwd.
+_MCP_BINARY = Path(__file__).resolve().parents[3] / "bin" / "mcp"
+
+
+async def _run_cli(
+    *args: str, broker: McpBroker, secret: str = "s"
+) -> subprocess.CompletedProcess[str]:
+    """Run ``bin/mcp`` and return the completed process.
+
+    Dispatches to a thread so the broker (running in this same event
+    loop) can keep serving requests while the CLI waits on HTTP.
+    """
+    return await asyncio.to_thread(
+        subprocess.run,
+        [sys.executable, str(_MCP_BINARY), *args],
+        env={
+            "MCP_BROKER_URL": f"http://127.0.0.1:{broker.port}",
+            "MCP_BROKER_SECRET": secret,
+            "PATH": "/usr/bin:/bin",
+        },
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+@pytest.fixture
+async def broker() -> AsyncIterator[McpBroker]:
+    b = McpBroker()
+    await b.start()
+    try:
+        yield b
+    finally:
+        await b.stop()
+
+
+@pytest.fixture(autouse=True)
+def _mock_crypto_and_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("aios.harness.runtime.require_crypto_box", lambda: object())
+    monkeypatch.setattr("aios.harness.runtime.require_pool", lambda: object())
+
+    async def _stub_auth(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {}
+
+    monkeypatch.setattr("aios.sandbox.mcp_proxy.resolve_auth_for_url", _stub_auth)
+
+
+def _agent_with_one_tool() -> SimpleNamespace:
+    return SimpleNamespace(
+        mcp_servers=[McpServerSpec(name="tav", url="https://tav.example/mcp")],
+        tools=[
+            ToolSpec(
+                type="mcp_toolset",
+                enabled=True,
+                mcp_server_name="tav",
+                default_config=McpToolsetConfig(
+                    enabled=True,
+                    permission_policy=McpPermissionPolicy(type="always_allow"),
+                ),
+            )
+        ],
+    )
+
+
+class TestMcpCli:
+    async def test_list_servers_prints_server_name(
+        self, broker: McpBroker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        broker.register_session("sess_X", "s")
+        agent = _agent_with_one_tool()
+
+        async def _load(*_a: Any, **_k: Any) -> Any:
+            return agent
+
+        monkeypatch.setattr(broker, "_load_agent", _load)
+
+        result = await _run_cli(broker=broker)
+        assert result.returncode == 0
+        assert "tav" in result.stdout
+
+    async def test_list_tools_prints_tool_name(
+        self, broker: McpBroker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        broker.register_session("sess_X", "s")
+        agent = _agent_with_one_tool()
+
+        async def _load(*_a: Any, **_k: Any) -> Any:
+            return agent
+
+        monkeypatch.setattr(broker, "_load_agent", _load)
+
+        async def _discover(
+            _url: str, name: str, _h: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": f"mcp__{name}__web_search",
+                        "description": "Search the web",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ], None
+
+        monkeypatch.setattr("aios.sandbox.mcp_proxy.discover_mcp_tools", _discover)
+
+        result = await _run_cli("tav", broker=broker)
+        assert result.returncode == 0
+        assert "web_search" in result.stdout
+        assert "Search the web" in result.stdout
+
+    async def test_invoke_prints_content_and_exits_zero(
+        self, broker: McpBroker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        broker.register_session("sess_X", "s")
+        agent = _agent_with_one_tool()
+
+        async def _load(*_a: Any, **_k: Any) -> Any:
+            return agent
+
+        monkeypatch.setattr(broker, "_load_agent", _load)
+
+        async def _call(*_a: Any, **_k: Any) -> dict[str, Any]:
+            return {"content": "the result"}
+
+        monkeypatch.setattr("aios.sandbox.mcp_proxy.call_mcp_tool", _call)
+
+        result = await _run_cli("tav", "web_search", "--json", "{}", broker=broker)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "the result"
+
+    async def test_invoke_unknown_secret_exits_nonzero(self, broker: McpBroker) -> None:
+        result = await _run_cli("tav", "web_search", "--json", "{}", broker=broker, secret="wrong")
+        assert result.returncode != 0
+        assert "mcp:" in result.stderr.lower()
+
+    async def test_invoke_full_envelope(
+        self, broker: McpBroker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        broker.register_session("sess_X", "s")
+        agent = _agent_with_one_tool()
+
+        async def _load(*_a: Any, **_k: Any) -> Any:
+            return agent
+
+        monkeypatch.setattr(broker, "_load_agent", _load)
+
+        async def _call(*_a: Any, **_k: Any) -> dict[str, Any]:
+            return {"content": "ok"}
+
+        monkeypatch.setattr("aios.sandbox.mcp_proxy.call_mcp_tool", _call)
+
+        result = await _run_cli("tav", "web_search", "--json", "{}", "--full", broker=broker)
+        assert result.returncode == 0
+        # --full prints the JSON envelope, not the bare content.
+        assert json.loads(result.stdout) == {"content": "ok"}

--- a/tests/unit/sandbox/test_mcp_proxy.py
+++ b/tests/unit/sandbox/test_mcp_proxy.py
@@ -1,0 +1,353 @@
+"""Unit tests for :class:`aios.sandbox.mcp_proxy.McpBroker`.
+
+Boots a real broker (so we exercise the actual starlette + uvicorn
+routing) and stubs the upstream MCP calls + the session→agent lookup.
+Verifies the v1 authorization model — unknown secret, server not
+visible, tool disabled, tool requires confirmation — alongside the
+happy-path listing / --help / invocation flow.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+
+from aios.models.agents import (
+    McpPermissionPolicy,
+    McpServerSpec,
+    McpToolConfig,
+    McpToolsetConfig,
+    ToolSpec,
+)
+from aios.sandbox.mcp_proxy import McpBroker
+
+
+def _agent(*, mcp_servers: list[McpServerSpec], tools: list[ToolSpec]) -> SimpleNamespace:
+    return SimpleNamespace(mcp_servers=mcp_servers, tools=tools)
+
+
+def _server(name: str = "tav", url: str = "https://tavily.example/mcp") -> McpServerSpec:
+    return McpServerSpec(name=name, url=url)
+
+
+def _toolset(
+    server_name: str = "tav",
+    *,
+    enabled: bool = True,
+    default_policy: str | None = "always_allow",
+    configs: list[McpToolConfig] | None = None,
+) -> ToolSpec:
+    return ToolSpec(
+        type="mcp_toolset",
+        enabled=enabled,
+        mcp_server_name=server_name,
+        default_config=McpToolsetConfig(
+            enabled=True,
+            permission_policy=(
+                McpPermissionPolicy(type=default_policy) if default_policy else None
+            ),
+        ),
+        configs=configs,
+    )
+
+
+def _tool_dict(
+    server: str, tool: str, *, description: str = "", parameters: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Replicate the shape that ``discover_mcp_tools`` returns — namespaced
+    OpenAI-format function tools."""
+    return {
+        "type": "function",
+        "function": {
+            "name": f"mcp__{server}__{tool}",
+            "description": description,
+            "parameters": parameters or {"type": "object", "properties": {}},
+        },
+    }
+
+
+@pytest.fixture
+async def broker() -> AsyncIterator[McpBroker]:
+    """Boot a real broker for the test; tear it down on cleanup."""
+    b = McpBroker()
+    await b.start()
+    try:
+        yield b
+    finally:
+        await b.stop()
+
+
+@pytest.fixture
+def base_url(broker: McpBroker) -> str:
+    return f"http://127.0.0.1:{broker.port}"
+
+
+@pytest.fixture(autouse=True)
+def _mock_crypto_and_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The broker reaches into the runtime crypto box only to call
+    ``resolve_auth_for_url``. Both can be stubbed wholesale — tests
+    don't care about the actual headers."""
+    monkeypatch.setattr("aios.harness.runtime.require_crypto_box", lambda: object())
+    monkeypatch.setattr("aios.harness.runtime.require_pool", lambda: object())
+
+    async def _stub_auth(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {}
+
+    monkeypatch.setattr("aios.sandbox.mcp_proxy.resolve_auth_for_url", _stub_auth)
+
+
+class TestSessionResolution:
+    async def test_unknown_secret_is_403(self, base_url: str) -> None:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{base_url}/v1/bogus/servers")
+        assert resp.status_code == 403
+        assert "unknown" in resp.json()["error"].lower()
+
+    async def test_unregister_makes_secret_unknown(
+        self, broker: McpBroker, base_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        broker.register_session("sess_X", "secret123")
+        monkeypatch.setattr(
+            broker, "_load_agent", _async_returning(_agent(mcp_servers=[], tools=[]))
+        )
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{base_url}/v1/secret123/servers")
+            assert resp.status_code == 200
+
+            broker.unregister_session("sess_X")
+            resp2 = await client.get(f"{base_url}/v1/secret123/servers")
+            assert resp2.status_code == 403
+
+
+class TestListServers:
+    async def test_lists_only_enabled_toolset_servers(
+        self, broker: McpBroker, base_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent = _agent(
+            mcp_servers=[
+                _server("tav", "https://tav.example/mcp"),
+                _server("off", "https://off.example/mcp"),
+                _server("noset", "https://noset.example/mcp"),
+            ],
+            tools=[
+                _toolset("tav", enabled=True),
+                _toolset("off", enabled=False),
+                # noset is in mcp_servers but has no mcp_toolset entry
+            ],
+        )
+        broker.register_session("sess_X", "s")
+        monkeypatch.setattr(broker, "_load_agent", _async_returning(agent))
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{base_url}/v1/s/servers")
+        assert resp.status_code == 200
+        names = {s["name"] for s in resp.json()["servers"]}
+        assert names == {"tav"}
+
+
+class TestListTools:
+    async def test_filters_to_always_allow(
+        self, broker: McpBroker, base_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent = _agent(
+            mcp_servers=[_server()],
+            tools=[
+                _toolset(
+                    "tav",
+                    default_policy="always_allow",
+                    configs=[
+                        McpToolConfig(
+                            name="confirm_me",
+                            permission_policy=McpPermissionPolicy(type="always_ask"),
+                        ),
+                        McpToolConfig(name="disabled_tool", enabled=False),
+                    ],
+                )
+            ],
+        )
+        broker.register_session("sess_X", "s")
+        monkeypatch.setattr(broker, "_load_agent", _async_returning(agent))
+
+        async def _discover(
+            _url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [
+                _tool_dict(name, "web_search", description="Search the web"),
+                _tool_dict(name, "confirm_me"),
+                _tool_dict(name, "disabled_tool"),
+            ], None
+
+        monkeypatch.setattr("aios.sandbox.mcp_proxy.discover_mcp_tools", _discover)
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{base_url}/v1/s/servers/tav/tools")
+        assert resp.status_code == 200
+        names = {t["name"] for t in resp.json()["tools"]}
+        # Only web_search resolves to always_allow; the other two are filtered.
+        assert names == {"web_search"}
+
+    async def test_unknown_server_is_404(
+        self, broker: McpBroker, base_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        broker.register_session("sess_X", "s")
+        monkeypatch.setattr(
+            broker, "_load_agent", _async_returning(_agent(mcp_servers=[], tools=[]))
+        )
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{base_url}/v1/s/servers/nope/tools")
+        assert resp.status_code == 404
+
+
+class TestToolHelp:
+    async def test_returns_schema_for_always_allow_tool(
+        self, broker: McpBroker, base_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent = _agent(
+            mcp_servers=[_server()],
+            tools=[_toolset("tav", default_policy="always_allow")],
+        )
+        broker.register_session("sess_X", "s")
+        monkeypatch.setattr(broker, "_load_agent", _async_returning(agent))
+
+        async def _discover(
+            _url: str, name: str, _headers: dict[str, str]
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [
+                _tool_dict(
+                    name,
+                    "web_search",
+                    description="Search the web",
+                    parameters={
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                )
+            ], None
+
+        monkeypatch.setattr("aios.sandbox.mcp_proxy.discover_mcp_tools", _discover)
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{base_url}/v1/s/servers/tav/tools/web_search")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["name"] == "web_search"
+        assert body["description"] == "Search the web"
+        assert body["input_schema"]["required"] == ["query"]
+
+    async def test_always_ask_tool_is_403(
+        self, broker: McpBroker, base_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent = _agent(
+            mcp_servers=[_server()],
+            tools=[_toolset("tav", default_policy="always_ask")],
+        )
+        broker.register_session("sess_X", "s")
+        monkeypatch.setattr(broker, "_load_agent", _async_returning(agent))
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{base_url}/v1/s/servers/tav/tools/web_search")
+        assert resp.status_code == 403
+        assert "model-tool" in resp.json()["error"]
+
+    async def test_disabled_per_tool_config_is_403(
+        self, broker: McpBroker, base_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent = _agent(
+            mcp_servers=[_server()],
+            tools=[
+                _toolset(
+                    "tav",
+                    default_policy="always_allow",
+                    configs=[McpToolConfig(name="dangerous", enabled=False)],
+                )
+            ],
+        )
+        broker.register_session("sess_X", "s")
+        monkeypatch.setattr(broker, "_load_agent", _async_returning(agent))
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{base_url}/v1/s/servers/tav/tools/dangerous")
+        assert resp.status_code == 403
+        assert "disabled" in resp.json()["error"]
+
+
+class TestInvoke:
+    async def test_happy_path_returns_envelope(
+        self, broker: McpBroker, base_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent = _agent(
+            mcp_servers=[_server()],
+            tools=[_toolset("tav", default_policy="always_allow")],
+        )
+        broker.register_session("sess_X", "s")
+        monkeypatch.setattr(broker, "_load_agent", _async_returning(agent))
+
+        captured: dict[str, Any] = {}
+
+        async def _call(
+            _url: str, _headers: dict[str, str], tool: str, args: dict[str, Any]
+        ) -> dict[str, Any]:
+            captured["tool"] = tool
+            captured["args"] = args
+            return {"content": "match found"}
+
+        monkeypatch.setattr("aios.sandbox.mcp_proxy.call_mcp_tool", _call)
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{base_url}/v1/s/servers/tav/tools/web_search",
+                json={"arguments": {"query": "aios"}},
+            )
+        assert resp.status_code == 200
+        assert resp.json() == {"content": "match found"}
+        assert captured == {"tool": "web_search", "args": {"query": "aios"}}
+
+    async def test_always_ask_tool_is_403(
+        self, broker: McpBroker, base_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent = _agent(
+            mcp_servers=[_server()],
+            tools=[_toolset("tav", default_policy="always_ask")],
+        )
+        broker.register_session("sess_X", "s")
+        monkeypatch.setattr(broker, "_load_agent", _async_returning(agent))
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{base_url}/v1/s/servers/tav/tools/web_search",
+                json={"arguments": {}},
+            )
+        assert resp.status_code == 403
+
+    async def test_missing_arguments_is_400(
+        self, broker: McpBroker, base_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        broker.register_session("sess_X", "s")
+        monkeypatch.setattr(
+            broker, "_load_agent", _async_returning(_agent(mcp_servers=[], tools=[]))
+        )
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{base_url}/v1/s/servers/tav/tools/web_search",
+                json={"no_arguments_key": "here"},
+            )
+        assert resp.status_code == 400
+
+
+def _async_returning(value: Any) -> Any:
+    """Return an async callable that always returns ``value``.
+
+    Used to mock ``McpBroker._load_agent`` so tests don't go through the
+    DB. The broker calls ``await self._load_agent(session_id)``; the
+    callable here ignores its argument and returns the canned agent.
+    """
+
+    async def _impl(*_args: Any, **_kwargs: Any) -> Any:
+        return value
+
+    return _impl

--- a/tests/unit/test_step_context_mcp_hint.py
+++ b/tests/unit/test_step_context_mcp_hint.py
@@ -1,0 +1,79 @@
+"""Tests for the ``mcp`` CLI system-prompt hint predicate.
+
+The hint is rendered into the system prompt whenever the agent has at
+least one ``always_allow`` MCP toolset entry. Emitting it for an agent
+whose toolset has only ``always_ask`` policies would lie to the model
+(every CLI call would 403), so the predicate has to walk both
+``default_config`` and per-tool ``configs`` overrides.
+"""
+
+from __future__ import annotations
+
+from aios.harness.step_context import _has_always_allow_mcp_tool
+from aios.models.agents import (
+    McpPermissionPolicy,
+    McpToolConfig,
+    McpToolsetConfig,
+    ToolSpec,
+)
+
+
+def _ts(
+    *,
+    enabled: bool = True,
+    default_policy: str | None = "always_allow",
+    configs: list[McpToolConfig] | None = None,
+) -> ToolSpec:
+    return ToolSpec(
+        type="mcp_toolset",
+        enabled=enabled,
+        mcp_server_name="s",
+        default_config=McpToolsetConfig(
+            enabled=True,
+            permission_policy=(
+                McpPermissionPolicy(type=default_policy) if default_policy else None
+            ),
+        ),
+        configs=configs,
+    )
+
+
+class TestHasAlwaysAllowMcpTool:
+    def test_empty_tools(self) -> None:
+        assert _has_always_allow_mcp_tool([]) is False
+
+    def test_only_builtin_tool(self) -> None:
+        assert _has_always_allow_mcp_tool([ToolSpec(type="bash")]) is False
+
+    def test_disabled_toolset_does_not_count(self) -> None:
+        assert _has_always_allow_mcp_tool([_ts(enabled=False)]) is False
+
+    def test_default_always_allow(self) -> None:
+        assert _has_always_allow_mcp_tool([_ts(default_policy="always_allow")]) is True
+
+    def test_default_always_ask(self) -> None:
+        assert _has_always_allow_mcp_tool([_ts(default_policy="always_ask")]) is False
+
+    def test_per_tool_override_to_always_allow(self) -> None:
+        spec = _ts(
+            default_policy="always_ask",
+            configs=[
+                McpToolConfig(name="x", permission_policy=McpPermissionPolicy(type="always_allow"))
+            ],
+        )
+        assert _has_always_allow_mcp_tool([spec]) is True
+
+    def test_per_tool_override_disabled(self) -> None:
+        # Disabled per-tool overrides shouldn't count even if their policy
+        # is always_allow.
+        spec = _ts(
+            default_policy="always_ask",
+            configs=[
+                McpToolConfig(
+                    name="x",
+                    enabled=False,
+                    permission_policy=McpPermissionPolicy(type="always_allow"),
+                )
+            ],
+        )
+        assert _has_always_allow_mcp_tool([spec]) is False


### PR DESCRIPTION
## Summary

- Adds a generic MCP-to-CLI bridge: a sandboxed agent can now invoke any permitted MCP server's tools programmatically from bash, without paying a wake-step-inference cycle per call.
- New worker-scoped ``McpBroker`` (Starlette/uvicorn) demultiplexes per-session secrets in the URL path and delegates to the existing ``aios.mcp.client`` functions. Vault credentials never enter the sandbox.
- ``bin/mcp`` (Python stdlib script, bind-mounted into every sandbox at ``/usr/local/bin/mcp``) is the agent-facing CLI. ``compute_step_prelude`` prepends a short CLI hint to the system prompt whenever the agent has at least one ``always_allow`` mcp_toolset entry.
- This is **Part B v1** of umbrella issue #234. Parts A (``aios-mcp``) and C (transport split ``cli``/``prompt``/``both``) remain tracked under #234 as follow-ups; see the [v1-scope comment](https://github.com/eumemic/aios/issues/234#issuecomment-4454003113) for the rationale.

## Design decisions (locked from conversation)

| Decision | Choice |
|---|---|
| Scope | Part B only — no prompt-token reduction in v1 |
| Authorization | ``enabled=true`` AND ``permission_policy=always_allow`` → CLI-callable; everything else 403s |
| Broker placement | In the worker process |
| Broker lifecycle | One shared FastAPI/uvicorn started at worker boot; demultiplexes by per-session secret |
| Secret distribution | In-memory ``secret → session_id`` map; minted in ``build_spec_from_session`` |
| Sandbox env wiring | ``MCP_BROKER_URL`` + ``MCP_BROKER_SECRET``; reached via ``host.docker.internal:<port>`` |
| Network lockdown | Broker port added unconditionally to ``extra_host_ports`` |
| CLI binary language | Python stdlib (sandbox base image is ``python:3.13-slim-bookworm``) |
| Discoverability | System-prompt hint + good ``--help`` |

## What this PR explicitly does NOT deliver

- **Prompt-token reduction.** Every tool surfaced via CLI is *also* still in the model's ``tools`` array. (Reducing the prompt is Part C.)
- **``always_ask`` support.** Tools with ``permission_policy: always_ask`` return 403 from the broker; agent uses the model-tool path. Adding broker → event-log coupling is a v2 concern.
- **Flag generation from JSON schema.** ``--json '{...}'`` is the only arg-passing path; ``--help`` dumps the schema.
- **Response streaming.**

## Test plan

- [x] ``uv run mypy src`` — 148 files, no issues
- [x] ``uv run ruff check src tests && uv run ruff format --check src tests``
- [x] ``uv run pytest tests/unit -q`` — 1184 passed (23 new tests added across broker, CLI binary, and system-prompt hint)
- [ ] Manual smoke test:
  - Bring up runtime on this branch via ``aios-smoke-setup``
  - Configure an agent with one MCP server + one ``always_allow`` toolset entry
  - DM the bot: ``run "mcp" in your sandbox and tell me what you see``
  - Verify the agent lists the server, lists tools, runs ``mcp <server> <tool> --json '{...}'``, and gets a sane response
  - Test 403 path: same flow with ``always_ask`` policy — agent should fall back to model-tool path
- [ ] CI runs the unit suite on push

### Why no Docker e2e test

The full Docker e2e (bind-mount + env-var + host-gateway + agent flow) is deferred to manual smoke testing. The unit tests cover the broker logic comprehensively (11 tests); ``test_mcp_cli_binary.py`` covers the CLI ↔ broker HTTP boundary via real subprocess invocation (5 tests). The remaining uncovered surface — that Docker correctly bind-mounts the script and the iptables allowlist reaches the broker — uses the same pattern as ``git_proxy``, which is itself covered by ``test_networking.py``. Adding a full Docker e2e is a scope question for follow-up; happy to add it if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)