### PR TITLE
feat(#367): PR 5 — INSERT account_id + migration 0044 (backfill + NOT NULL)

### DIFF
--- a/migrations/versions/0044_account_id_not_null.py
+++ b/migrations/versions/0044_account_id_not_null.py
@@ -1,0 +1,83 @@
+"""Backfill ``account_id`` nulls to the singular active root and set
+NOT NULL on every resource table.
+
+PR 4 (migration 0043) renamed ``user_id`` → ``account_id`` and added the
+FK to ``accounts(id)`` but kept the column nullable to give application
+code time to start populating it. PR 5 (this migration) is the second
+half: backfill the rows the application hasn't tagged yet, then lock
+the column with NOT NULL.
+
+On a fresh install: backfill is a no-op (zero rows in resource tables),
+SET NOT NULL is vacuously satisfied.
+
+On an existing single-tenant deployment with data: the operator must
+have called ``POST /v1/accounts/bootstrap`` before applying migrations
+(otherwise the backfill subquery returns NULL and SET NOT NULL fails
+with a clear error pointing at the unbackfilled rows).
+
+Revision ID: 0044
+Revises: 0043
+Create Date: 2026-05-14
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0044"
+down_revision: str = "0043"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_TABLES: Sequence[str] = (
+    "connectors",
+    "bindings",
+    "chat_sessions",
+    "routing_rules",
+    "runtimes",
+    "runtime_tokens",
+    "inbound_acks",
+    "agent_versions",
+    "agents",
+    "connections",
+    "credentials",
+    "environments",
+    "events",
+    "files",
+    "memories",
+    "memory_stores",
+    "memory_versions",
+    "session_github_repositories",
+    "session_memory_stores",
+    "session_templates",
+    "session_vaults",
+    "skill_versions",
+    "skills",
+    "vault_credentials",
+    "vaults",
+    "sessions",
+)
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.execute(
+            f"""
+            UPDATE {table}
+               SET account_id = (
+                   SELECT id FROM accounts
+                    WHERE parent_account_id IS NULL AND archived_at IS NULL
+                    LIMIT 1
+               )
+             WHERE account_id IS NULL
+            """
+        )
+        op.execute(f"ALTER TABLE {table} ALTER COLUMN account_id SET NOT NULL")
+
+
+def downgrade() -> None:
+    for table in reversed(_TABLES):
+        op.execute(f"ALTER TABLE {table} ALTER COLUMN account_id DROP NOT NULL")

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -98,10 +98,11 @@ async def insert_environment(
     config_json = json.dumps((config or EnvironmentConfig()).model_dump(exclude_none=True))
     try:
         row = await conn.fetchrow(
-            "INSERT INTO environments (id, name, config) VALUES ($1, $2, $3::jsonb) RETURNING *",
+            "INSERT INTO environments (id, name, config, account_id) VALUES ($1, $2, $3::jsonb, $4) RETURNING *",
             new_id,
             name,
             config_json,
+            account_id,
         )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
@@ -299,10 +300,9 @@ async def insert_agent(
                 INSERT INTO agents (
                     id, name, model, system, tools, skills, mcp_servers,
                     description, metadata, litellm_extra,
-                    window_min, window_max, version
-                )
+                    window_min, window_max, version, account_id)
                 VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb,
-                        $8, $9::jsonb, $10::jsonb, $11, $12, 1)
+                        $8, $9::jsonb, $10::jsonb, $11, $12, 1, $13)
                 RETURNING *
                 """,
                 new_id,
@@ -317,6 +317,7 @@ async def insert_agent(
                 extra_json,
                 window_min,
                 window_max,
+                account_id,
             )
             assert row is not None
             # Snapshot version 1 into agent_versions.
@@ -324,10 +325,9 @@ async def insert_agent(
                 """
                 INSERT INTO agent_versions (
                     agent_id, version, model, system, tools, skills, mcp_servers,
-                    litellm_extra, window_min, window_max
-                )
+                    litellm_extra, window_min, window_max, account_id)
                 VALUES ($1, 1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb,
-                        $7::jsonb, $8, $9)
+                        $7::jsonb, $8, $9, $10)
                 """,
                 new_id,
                 model,
@@ -338,6 +338,7 @@ async def insert_agent(
                 extra_json,
                 window_min,
                 window_max,
+                account_id,
             )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
@@ -489,10 +490,9 @@ async def update_agent(
             """
             INSERT INTO agent_versions (
                 agent_id, version, model, system, tools, skills, mcp_servers,
-                litellm_extra, window_min, window_max
-            )
+                litellm_extra, window_min, window_max, account_id)
             VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb,
-                    $8::jsonb, $9, $10)
+                    $8::jsonb, $9, $10, $11)
             """,
             agent_id,
             new_version,
@@ -504,6 +504,7 @@ async def update_agent(
             extra_json,
             new_wmin,
             new_wmax,
+            account_id,
         )
     return _row_to_agent(row)
 
@@ -625,9 +626,8 @@ async def insert_session(
             INSERT INTO sessions (
                 id, agent_id, environment_id, agent_version, title, metadata,
                 status, workspace_volume_path, env,
-                focal_channel, focal_locked
-            )
-            VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'idle', $7, $8::jsonb, $9, $10)
+                focal_channel, focal_locked, account_id)
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'idle', $7, $8::jsonb, $9, $10, $11)
             RETURNING *
             """,
             new_id,
@@ -640,6 +640,7 @@ async def insert_session(
             json.dumps(env or {}),
             focal_channel,
             focal_locked,
+            account_id,
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(
@@ -1989,13 +1990,14 @@ async def insert_vault(
     metadata_json = json.dumps(metadata)
     row = await conn.fetchrow(
         """
-        INSERT INTO vaults (id, display_name, metadata)
-        VALUES ($1, $2, $3::jsonb)
+        INSERT INTO vaults (id, display_name, metadata, account_id)
+        VALUES ($1, $2, $3::jsonb, $4)
         RETURNING *
         """,
         new_id,
         display_name,
         metadata_json,
+        account_id,
     )
     assert row is not None
     return _row_to_vault(row)
@@ -2125,9 +2127,8 @@ async def insert_vault_credential(
             """
             INSERT INTO vault_credentials (
                 id, vault_id, display_name, mcp_server_url,
-                auth_type, ciphertext, nonce, metadata
-            )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+                auth_type, ciphertext, nonce, metadata, account_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)
             RETURNING *
             """,
             new_id,
@@ -2138,6 +2139,7 @@ async def insert_vault_credential(
             blob.ciphertext,
             blob.nonce,
             metadata_json,
+            account_id,
         )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
@@ -2368,10 +2370,11 @@ async def set_session_vaults(
         for rank, vault_id in enumerate(vault_ids):
             try:
                 await conn.execute(
-                    "INSERT INTO session_vaults (session_id, vault_id, rank) VALUES ($1, $2, $3)",
+                    "INSERT INTO session_vaults (session_id, vault_id, rank, account_id) VALUES ($1, $2, $3, $4)",
                     session_id,
                     vault_id,
                     rank,
+                    account_id,
                 )
             except asyncpg.ForeignKeyViolationError as exc:
                 raise NotFoundError(
@@ -2523,18 +2526,19 @@ async def insert_skill(
     async with conn.transaction():
         skill_row = await conn.fetchrow(
             """
-            INSERT INTO skills (id, display_title, latest_version)
-            VALUES ($1, $2, 1)
+            INSERT INTO skills (id, display_title, latest_version, account_id)
+            VALUES ($1, $2, 1, $3)
             RETURNING *
             """,
             new_id,
             display_title,
+            account_id,
         )
         assert skill_row is not None
         ver_row = await conn.fetchrow(
             """
-            INSERT INTO skill_versions (skill_id, version, directory, name, description, files)
-            VALUES ($1, 1, $2, $3, $4, $5::jsonb)
+            INSERT INTO skill_versions (skill_id, version, directory, name, description, files, account_id)
+            VALUES ($1, 1, $2, $3, $4, $5::jsonb, $6)
             RETURNING *
             """,
             new_id,
@@ -2542,6 +2546,7 @@ async def insert_skill(
             name,
             description,
             files_json,
+            account_id,
         )
         assert ver_row is not None
     return _row_to_skill(skill_row), _row_to_skill_version(ver_row)
@@ -2606,8 +2611,8 @@ async def insert_skill_version(
         new_ver = head["latest_version"] + 1
         ver_row = await conn.fetchrow(
             """
-            INSERT INTO skill_versions (skill_id, version, directory, name, description, files)
-            VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+            INSERT INTO skill_versions (skill_id, version, directory, name, description, files, account_id)
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)
             RETURNING *
             """,
             skill_id,
@@ -2616,6 +2621,7 @@ async def insert_skill_version(
             name,
             description,
             files_json,
+            account_id,
         )
         assert ver_row is not None
         await conn.execute(
@@ -2806,14 +2812,15 @@ async def insert_binding(
         await conn.execute(
             """
             INSERT INTO bindings (id, connection_id, mode,
-                                  session_id, session_template_id)
-            VALUES ($1, $2, $3, $4, $5)
+                                  session_id, session_template_id, account_id)
+            VALUES ($1, $2, $3, $4, $5, $6)
             """,
             new_id,
             connection_id,
             mode,
             session_id,
             session_template_id,
+            account_id,
         )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
@@ -3012,8 +3019,9 @@ async def insert_connection(
     # creating a connection of a fresh type after migration needs this
     # path (#328 PR 5).
     await conn.execute(
-        "INSERT INTO connectors (connector) VALUES ($1) ON CONFLICT DO NOTHING",
+        "INSERT INTO connectors (connector, account_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
         connector,
+        account_id,
     )
     for _ in range(3):
         row = await conn.fetchrow(
@@ -3021,9 +3029,8 @@ async def insert_connection(
             WITH inserted AS (
                 INSERT INTO connections (
                     id, connector, account, metadata,
-                    secrets_ciphertext, secrets_nonce
-                )
-                VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+                    secrets_ciphertext, secrets_nonce, account_id)
+                VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
                 ON CONFLICT (connector, account) WHERE archived_at IS NULL DO NOTHING
                 RETURNING *
             )
@@ -3039,6 +3046,7 @@ async def insert_connection(
             json.dumps(metadata),
             ciphertext,
             nonce,
+            account_id,
         )
         if row is not None:
             return _row_to_connection(row)
@@ -3324,14 +3332,15 @@ async def insert_chat_session(
     """
     row = await conn.fetchrow(
         """
-        INSERT INTO chat_sessions (connection_id, chat_id, session_id)
-        VALUES ($1, $2, $3)
+        INSERT INTO chat_sessions (connection_id, chat_id, session_id, account_id)
+        VALUES ($1, $2, $3, $4)
         ON CONFLICT (connection_id, chat_id) DO NOTHING
         RETURNING session_id
         """,
         connection_id,
         chat_id,
         session_id,
+        account_id,
     )
     if row is not None:
         return str(row["session_id"])
@@ -3536,8 +3545,8 @@ async def try_record_inbound_ack(
     """
     row = await conn.fetchrow(
         """
-        INSERT INTO connector_inbound_acks (connector, account, event_id, appended_seq)
-        VALUES ($1, $2, $3, $4)
+        INSERT INTO connector_inbound_acks (connector, account, event_id, appended_seq, account_id)
+        VALUES ($1, $2, $3, $4, $5)
         ON CONFLICT DO NOTHING
         RETURNING 1
         """,
@@ -3545,6 +3554,7 @@ async def try_record_inbound_ack(
         account,
         event_id,
         appended_seq,
+        account_id,
     )
     return row is not None
 
@@ -3588,8 +3598,8 @@ async def insert_session_template(
             """
             INSERT INTO session_templates
                 (id, name, agent_id, agent_version, environment_id,
-                 vault_ids, memory_store_ids, metadata)
-            VALUES ($1, $2, $3, $4, $5, $6::text[], $7::text[], $8::jsonb)
+                 vault_ids, memory_store_ids, metadata, account_id)
+            VALUES ($1, $2, $3, $4, $5, $6::text[], $7::text[], $8::jsonb, $9)
             RETURNING *
             """,
             new_id,
@@ -3600,6 +3610,7 @@ async def insert_session_template(
             vault_ids,
             memory_store_ids,
             json.dumps(metadata),
+            account_id,
         )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
@@ -3799,14 +3810,15 @@ async def insert_memory_store(
 ) -> MemoryStore:
     row = await conn.fetchrow(
         """
-        INSERT INTO memory_stores (id, name, description, metadata)
-        VALUES ($1, $2, $3, $4::jsonb)
+        INSERT INTO memory_stores (id, name, description, metadata, account_id)
+        VALUES ($1, $2, $3, $4::jsonb, $5)
         RETURNING *
         """,
         make_id(MEMORY_STORE),
         name,
         description,
         json.dumps(metadata),
+        account_id,
     )
     assert row is not None
     return _row_to_memory_store(row)
@@ -3961,8 +3973,8 @@ async def insert_memory_with_version(
                 INSERT INTO memory_versions
                     (id, memory_store_id, memory_id, seq, operation, path,
                      content, content_sha256, content_size_bytes,
-                     created_by_type, created_by_ref)
-                VALUES ($1, $2, $3, $4, 'created', $5, $6, $7, $8, $9, $10)
+                     created_by_type, created_by_ref, account_id)
+                VALUES ($1, $2, $3, $4, 'created', $5, $6, $7, $8, $9, $10, $11)
                 """,
                 version_id,
                 store_id,
@@ -3974,14 +3986,15 @@ async def insert_memory_with_version(
                 size_bytes,
                 actor_type,
                 actor_ref,
+                account_id,
             )
 
             row = await conn.fetchrow(
                 """
                 INSERT INTO memories
                     (id, memory_store_id, path, content, content_sha256,
-                     content_size_bytes, current_version_id)
-                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                     content_size_bytes, current_version_id, account_id)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
                 RETURNING *
                 """,
                 memory_id,
@@ -3991,6 +4004,7 @@ async def insert_memory_with_version(
                 content_sha256,
                 size_bytes,
                 version_id,
+                account_id,
             )
     except asyncpg.UniqueViolationError as exc:
         # Re-issue the lookup outside the rolled-back transaction so the
@@ -4192,8 +4206,8 @@ async def update_memory_with_version(
                 INSERT INTO memory_versions
                     (id, memory_store_id, memory_id, seq, operation, path,
                      content, content_sha256, content_size_bytes,
-                     created_by_type, created_by_ref)
-                VALUES ($1, $2, $3, $4, 'modified', $5, $6, $7, $8, $9, $10)
+                     created_by_type, created_by_ref, account_id)
+                VALUES ($1, $2, $3, $4, 'modified', $5, $6, $7, $8, $9, $10, $11)
                 """,
                 version_id,
                 store_id,
@@ -4205,6 +4219,7 @@ async def update_memory_with_version(
                 next_size,
                 actor_type,
                 actor_ref,
+                account_id,
             )
 
             row = await conn.fetchrow(
@@ -4270,8 +4285,8 @@ async def delete_memory_with_version(
             """
             INSERT INTO memory_versions
                 (id, memory_store_id, memory_id, seq, operation, path,
-                 created_by_type, created_by_ref)
-            VALUES ($1, $2, $3, $4, 'deleted', $5, $6, $7)
+                 created_by_type, created_by_ref, account_id)
+            VALUES ($1, $2, $3, $4, 'deleted', $5, $6, $7, $8)
             """,
             version_id,
             store_id,
@@ -4280,6 +4295,7 @@ async def delete_memory_with_version(
             cur["path"],
             actor_type,
             actor_ref,
+            account_id,
         )
 
         await conn.execute(
@@ -4426,8 +4442,8 @@ async def attach_memory_stores_to_session(
             """
             INSERT INTO session_memory_stores
                 (session_id, memory_store_id, rank, access, instructions,
-                 name_at_attach, description_at_attach)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+                 name_at_attach, description_at_attach, account_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             """,
             session_id,
             res.memory_store_id,
@@ -4436,6 +4452,7 @@ async def attach_memory_stores_to_session(
             res.instructions,
             store.name,
             store.description,
+            account_id,
         )
 
 
@@ -4499,8 +4516,8 @@ async def attach_github_repos_to_session(
             """
             INSERT INTO session_github_repositories
                 (id, session_id, rank, repo_url, mount_path, ciphertext, nonce,
-                 git_user_name, git_user_email)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                 git_user_name, git_user_email, account_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             """,
             rid,
             session_id,
@@ -4511,6 +4528,7 @@ async def attach_github_repos_to_session(
             blob.nonce,
             git_user_name,
             git_user_email,
+            account_id,
         )
 
 
@@ -4689,14 +4707,15 @@ async def update_connector_tools_schema(
     """
     await conn.execute(
         """
-        INSERT INTO connectors (connector, tools_schema, created_at, updated_at)
-        VALUES ($1, $2::jsonb, now(), now())
+        INSERT INTO connectors (connector, tools_schema, created_at, updated_at, account_id)
+        VALUES ($1, $2::jsonb, now(), now(), $3)
         ON CONFLICT (connector) DO UPDATE
            SET tools_schema = EXCLUDED.tools_schema,
                updated_at   = now()
         """,
         connector,
         json.dumps(tools_schema),
+        account_id,
     )
 
 
@@ -4717,14 +4736,15 @@ async def insert_management_call(
     await conn.execute(
         """
         INSERT INTO pending_management_calls
-            (id, connector, method, params, expires_at)
-        VALUES ($1, $2, $3, $4::jsonb, $5)
+            (id, connector, method, params, expires_at, account_id)
+        VALUES ($1, $2, $3, $4::jsonb, $5, $6)
         """,
         call_id,
         connector,
         method,
         json.dumps(params),
         expires_at,
+        account_id,
     )
 
 
@@ -4902,19 +4922,21 @@ async def insert_runtime_token(
     block first-token-on-fresh-type).
     """
     await conn.execute(
-        "INSERT INTO connectors (connector) VALUES ($1) ON CONFLICT DO NOTHING",
+        "INSERT INTO connectors (connector, account_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
         connector,
+        account_id,
     )
     row = await conn.fetchrow(
         """
-        INSERT INTO runtime_tokens (id, connector, label, token_hash)
-        VALUES ($1, $2, $3, $4)
+        INSERT INTO runtime_tokens (id, connector, label, token_hash, account_id)
+        VALUES ($1, $2, $3, $4, $5)
         RETURNING *
         """,
         make_id(RUNTIME_TOKEN),
         connector,
         label,
         token_hash,
+        account_id,
     )
     assert row is not None
     return _row_to_runtime_token(row)
@@ -5024,9 +5046,8 @@ async def insert_file(
             """
             INSERT INTO files (
                 id, session_id, filename, host_path, in_sandbox_path,
-                size, content_type, sha256
-            )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                size, content_type, sha256, account_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             RETURNING *
             """,
             file_id,
@@ -5037,6 +5058,7 @@ async def insert_file(
             size,
             content_type,
             sha256,
+            account_id,
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(


### PR DESCRIPTION
## Summary

Fifth PR of the multi-tenancy stack (#367). Stacks on PR 4 (#382).

- **queries.py INSERTs**: every \`INSERT INTO <resource_table>\` now includes \`account_id\` in the column list, gets a \`\$N\` placeholder, and the caller's positional args include \`account_id\`. 29 INSERT statements transformed.
- **Migration 0044**: backfills nullable \`account_id\` columns to the singular root account, then \`SET NOT NULL\` on every resource table. After this migration, the FK + NOT NULL combination enforces "every row belongs to exactly one account" at the schema layer.

## What's still left for full filtering enforcement

This PR makes account_id mandatory at write time. **It does NOT yet add \`WHERE account_id = \$X\` to read/list/update/delete queries** — those ~143 queries currently don't filter by account_id, so cross-tenant reads are still possible from code that knows the right resource IDs. A follow-up PR adds the WHERE clauses.

The threading-from-callers refactor (replacing the PR 4 \`""\` stubs in mock-friendly files like mcp/client, sandbox, tools) also remains.

## Test plan

- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1161 passed
- [x] \`pytest tests/e2e/test_accounts_bootstrap.py test_agents_api.py test_vaults.py\` — 45 passed (sample)

🤖 Generated with [Claude Code](https://claude.com/claude-code)