### PR TITLE
feat(sandbox): bake jq + nodejs + npm into the sandbox image

### DIFF
--- a/docker/Dockerfile.sandbox
+++ b/docker/Dockerfile.sandbox
@@ -2,8 +2,11 @@
 #
 # This is the image every aios v1 session runs inside. It's intentionally
 # minimal: a Python runtime for scripted tool calls, standard POSIX
-# utilities, curl for HTTP fetches, git, and ripgrep for the Phase 4
-# grep/glob tools. No languages beyond Python; no package manager state at
+# utilities, curl for HTTP fetches, git, ripgrep for the grep/glob tools,
+# jq for JSON-from-bash composition (notably ``mcp <server> <tool> | jq
+# ...`` flows), and Node + npm so agents can ``npm install -g`` into the
+# persistent workspace npm prefix without first apt-installing the
+# runtime themselves. No other languages; no package manager state at
 # runtime (apt lists are cleaned).
 #
 # Published as ``ghcr.io/eumemic/aios-sandbox`` by
@@ -40,6 +43,9 @@ RUN apt-get update \
         curl \
         git \
         iptables \
+        jq \
+        nodejs \
+        npm \
         ripgrep \
  && rm -rf /var/lib/apt/lists/*
 

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -31,12 +31,26 @@ IMAGE = os.environ.get("AIOS_DOCKER_IMAGE", "ghcr.io/eumemic/aios-sandbox:latest
 
 @pytest.fixture(scope="module")
 def pulled_image() -> str:
-    """Pull IMAGE once for the entire module.
+    """Ensure IMAGE is present locally; pull from registry only if absent.
 
-    Returns the image name so tests can reference it. A module-scoped
-    fixture means a single ``docker pull`` per pytest invocation, not
-    one per test.
+    Skipping the pull when the tag already resolves locally is essential
+    in CI, where the Dockerfile-changed workflow builds the image under
+    ``ghcr.io/eumemic/aios-sandbox:latest`` immediately before the e2e
+    suite runs. An unconditional ``docker pull`` would overwrite that
+    fresh local build with the older registry tag, masking the very
+    change the build was meant to validate.
+
+    Module-scoped so this check runs at most once per pytest invocation.
     """
+    check = subprocess.run(
+        ["docker", "image", "inspect", IMAGE],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    if check.returncode == 0:
+        return IMAGE
     result = subprocess.run(
         ["docker", "pull", IMAGE],
         capture_output=True,

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -77,6 +77,9 @@ def _docker_run(
         "curl",
         "git",
         "iptables",  # required for limited-networking mode
+        "jq",  # JSON-from-bash composition, esp. piping `mcp <server> <tool>`
+        "node",  # so agents can run npm packages without first apt-installing the runtime
+        "npm",
         "tail",  # the image CMD is `tail -f /dev/null`
         "cat",
         "head",


### PR DESCRIPTION
## Summary

Two friction points surfaced during recent smoke testing of the sandbox MCP CLI (PRs #378 / #380) and the multi-agent orchestration flow:

1. **`jq` was missing.** The natural composition tool for any bash that pipes structured output:
   ```bash
   mcp aios list_session_events '{"session_id":"..."}' | jq '.[]'
   mcp tavily tavily_search '{"query":"x"}' | jq '.results[0].url'
   ```
   Without it, the orchestrator agent fell back to reading raw JSON blobs and parsing in awk/grep. Wasteful.

2. **`npm` was missing.** `NPM_CONFIG_PREFIX=/workspace/.npm` persistence is already wired (closed issue #227), but `npm` itself wasn't in the image. Every session that wanted it had to `apt-get install nodejs npm` first — and that install isn't persistent (apt writes to system dirs, not `/workspace`), so the cost recurred on every cold provision.

Bake all three into the base image alongside the existing ripgrep / curl / git toolchain. Bookworm's `nodejs` (v18) is plenty for the `npm install -g <util>` case; agents that need a newer Node can still bring their own via the env-config `packages: {"apt": ["nodejs"]}` path.

## Test plan

- [x] `tests/e2e/test_sandbox_image_contract.py` updated: `jq`, `node`, `npm` added to the parametrized binary-availability test, each gets its own CI test-case ID so any future image-shrinking regression pinpoints which binary went missing
- [x] mypy + ruff + format + unit tests all clean (1197 passed)
- [ ] CI builds the new sandbox image via `.github/workflows/build-sandbox.yml` and the contract tests run against it
- [ ] Manual smoke: agent runs `mcp aios list_session_events '{...}' | jq '.[].seq'` and gets a clean newline-separated list (impossible before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)