### PR TITLE
feat(#367): PR 5a — thread account_id from callers, drop bootstrap stubs

### DIFF
--- a/src/aios/api/deps.py
+++ b/src/aios/api/deps.py
@@ -66,11 +66,10 @@ async def require_bearer_auth(
     timing or wording can't distinguish "unknown key" from "revoked key"
     from "archived account."
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
     token = _extract_bearer_token(authorization)
     async with pool.acquire() as conn:
         result = await queries.lookup_account_by_key_hash(
-            conn, key_hash=accounts_service.hash_key(token), account_id=account_id
+            conn, key_hash=accounts_service.hash_key(token)
         )
     if result is None:
         raise UnauthorizedError("invalid api key")
@@ -81,20 +80,20 @@ async def require_bearer_auth(
 async def require_runtime_auth(
     pool: Annotated[asyncpg.Pool, Depends(get_pool)],
     authorization: Annotated[str | None, Header(alias="Authorization")] = None,
-) -> tuple[str, str]:
-    """Resolve a bearer runtime token to ``(runtime_token_id, connector)``.
+) -> tuple[str, str, str]:
+    """Resolve a bearer runtime token to ``(token_id, connector, account_id)``.
 
     Accepts only tokens issued via ``POST /v1/runtime-tokens``. Routes
     that take ``RuntimeAuthDep`` receive the resolved tuple — the
     ``connector`` half is used to scope the runtime-facing routes
-    (``/connectors/runtime/...`` family) to one connector type.
+    (``/connectors/runtime/...`` family) to one connector type;
+    ``account_id`` scopes resource queries to the token's tenant.
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
     token = _extract_bearer_token(authorization)
-    resolved = await runtime_tokens_service.resolve(pool, token, account_id=account_id)
+    resolved = await runtime_tokens_service.resolve(pool, token)
     if resolved is None:
         raise UnauthorizedError("invalid or revoked runtime token")
-    return (resolved.token_id, resolved.connector)
+    return (resolved.token_id, resolved.connector, resolved.account_id)
 
 
 # Type aliases for clarity at the route definitions.
@@ -105,4 +104,4 @@ CryptoBoxDep = Annotated[CryptoBox, Depends(get_crypto_box)]
 ProcrastinateDep = Annotated[ProcrastinateApp, Depends(get_procrastinate)]
 DbUrlDep = Annotated[str, Depends(get_db_url)]
 AuthDep = Annotated[AccountAuthResult, Depends(require_bearer_auth)]
-RuntimeAuthDep = Annotated[tuple[str, str], Depends(require_runtime_auth)]
+RuntimeAuthDep = Annotated[tuple[str, str, str], Depends(require_runtime_auth)]

--- a/src/aios/api/routers/accounts.py
+++ b/src/aios/api/routers/accounts.py
@@ -45,18 +45,15 @@ async def bootstrap(
     ``plaintext_key`` in the response is the only time the operator key
     is returned in plaintext.
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
     async with pool.acquire() as conn:
-        if await queries.has_active_root_account(conn, account_id=account_id):
+        if await queries.has_active_root_account(conn):
             raise NotFoundError("bootstrap endpoint closed: root account already exists")
     token = _extract_bearer_token(authorization)
     expected_secret = get_settings().bootstrap_token
     expected = expected_secret.get_secret_value() if expected_secret is not None else ""
     if not expected or not secrets.compare_digest(token, expected):
         raise UnauthorizedError("invalid bootstrap token")
-    response = await service.bootstrap_root(
-        pool, display_name=body.display_name, account_id=account_id
-    )
+    response = await service.bootstrap_root(pool, display_name=body.display_name)
     log.info(
         "account.operation",
         actor_account_id=None,

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -116,6 +116,7 @@ def _parse_form_json(field: str, raw: str | None, *, default: Any = None) -> Any
 async def _do_inbound(
     pool: Any,
     *,
+    account_id: str,
     connection_id: str,
     event_id: str,
     chat_id: str,
@@ -133,7 +134,6 @@ async def _do_inbound(
     attachment shaping, the handle_inbound call, drop-reason mapping
     — is identical.
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
     sender_dict: dict[str, Any] = _parse_form_json("sender", sender_json, default={}) or {}
     metadata_dict: dict[str, Any] | None = _parse_form_json("metadata", metadata_json)
     inbound_attachments = [
@@ -230,8 +230,7 @@ async def put_tools_schema(
     Authorization: the runtime bearer's ``connector`` must match the
     path's ``connector``.
     """
-    _, auth_connector = auth
-    account_id = ""  # PR 3 stub for runtime-auth routes; PR 4 derives from connection
+    _, auth_connector, account_id = auth
     _check_runtime_scope(auth_connector, connector)
     async with pool.acquire() as conn:
         await queries.update_connector_tools_schema(
@@ -262,9 +261,9 @@ async def get_connection_discovery(
     fans out to per-connection workers on ``added``; tears them down
     on ``removed``.
     """
-    _, connector = auth
+    _, connector, account_id = auth
     return EventSourceResponse(
-        connection_discovery_stream(db_url, pool, connector),
+        connection_discovery_stream(db_url, pool, connector, account_id=account_id),
         ping=15,
     )
 
@@ -311,13 +310,13 @@ async def post_runtime_inbound(
     a body explaining the reason (operator-config issue vs server
     error vs payload).
     """
-    _, auth_connector = auth
-    account_id = ""  # PR 3 stub for runtime-auth routes; PR 4 derives from connection
+    _, auth_connector, account_id = auth
     async with pool.acquire() as conn:
         connection = await queries.get_connection(conn, connection_id, account_id=account_id)
     _check_runtime_scope(auth_connector, connection.connector)
     return await _do_inbound(
         pool,
+        account_id=account_id,
         connection_id=connection_id,
         event_id=event_id,
         chat_id=chat_id,
@@ -344,8 +343,7 @@ async def post_runtime_tool_result(
     Authorization: the bearer's connector must match ``body.connection_id``'s
     connector, and the session must be bound to that connection.
     """
-    _, auth_connector = auth
-    account_id = ""  # PR 3 stub for runtime-auth routes; PR 4 derives from connection
+    _, auth_connector, account_id = auth
     async with pool.acquire() as conn:
         connection = await queries.get_connection(conn, body.connection_id, account_id=account_id)
         _check_runtime_scope(auth_connector, connection.connector)
@@ -390,8 +388,7 @@ async def get_runtime_secrets(
     type.  Returns ``{"secrets": {}}`` when none are configured —
     callers decide whether that's acceptable.
     """
-    _, auth_connector = auth
-    account_id = ""  # PR 3 stub for runtime-auth routes; PR 4 derives from connection
+    _, auth_connector, account_id = auth
     async with pool.acquire() as conn:
         connection = await queries.get_connection(conn, connection_id, account_id=account_id)
     _check_runtime_scope(auth_connector, connection.connector)
@@ -428,9 +425,9 @@ async def get_runtime_calls(
     The ``connection_id`` field lets the runtime container fan out to
     its per-connection workers client-side.
     """
-    _, connector = auth
+    _, connector, account_id = auth
     return EventSourceResponse(
-        runtime_connector_calls_stream(db_url, pool, connector),
+        runtime_connector_calls_stream(db_url, pool, connector, account_id=account_id),
         ping=15,
     )
 
@@ -449,9 +446,9 @@ async def get_runtime_management_calls(
     Per-connector-type only (no session/connection scope).  Each event is
     keyed ``call`` with body ``{"call_id": "mgmt_...", "method": str, "params": dict}``.
     """
-    _, connector = auth
+    _, connector, account_id = auth
     return EventSourceResponse(
-        management_calls_stream(db_url, pool, connector),
+        management_calls_stream(db_url, pool, connector, account_id=account_id),
         ping=15,
     )
 
@@ -642,8 +639,7 @@ async def post_runtime_management_call_result(
     pool: PoolDep,
     auth: RuntimeAuthDep,
 ) -> None:
-    _, auth_connector = auth
-    account_id = ""  # PR 3 stub for runtime-auth routes; PR 4 derives from connection
+    _, auth_connector, account_id = auth
     # Autocommit conn (no ``async with conn.transaction()``): the UPDATE
     # commits before the NOTIFY fires.  Don't wrap these in a
     # transaction — subscribers would see uncommitted state.  See

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -506,6 +506,7 @@ async def get_context(
     prelude = await compute_step_prelude(
         pool,
         session_id,
+        account_id=account_id,
         session=session,
         agent=agent,
         channels=channels,

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -141,6 +141,8 @@ async def runtime_connector_calls_stream(
     db_url: str,
     pool: asyncpg.Pool[Any],
     connector: str,
+    *,
+    account_id: str,
 ) -> AsyncIterator[ServerSentEvent]:
     """Yield SSE events for pending custom tool calls across every active
     connection of ``connector`` type (#328 PR 5).
@@ -152,7 +154,6 @@ async def runtime_connector_calls_stream(
     Backfills any pending calls at subscribe time, then tails the
     ``connector_calls_<connector>`` NOTIFY channel.
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
     async with listen_for_connector_calls_by_type(db_url, connector) as queue:
         emitted: set[str] = set()
 
@@ -190,6 +191,8 @@ async def management_calls_stream(
     db_url: str,
     pool: asyncpg.Pool[Any],
     connector: str,
+    *,
+    account_id: str,
 ) -> AsyncIterator[ServerSentEvent]:
     """Yield SSE events for pending management calls of ``connector`` type.
 
@@ -197,7 +200,6 @@ async def management_calls_stream(
     ``connector_management_calls_<connector>``.  Each event:
     ``{"call_id": "mgmt_...", "method": str, "params": dict}``.
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
     async with listen_for_management_calls(db_url, connector) as queue:
         emitted: set[str] = set()
 
@@ -234,6 +236,8 @@ async def connection_discovery_stream(
     db_url: str,
     pool: asyncpg.Pool[Any],
     connector: str,
+    *,
+    account_id: str,
 ) -> AsyncIterator[ServerSentEvent]:
     """Yield ``added`` SSE events backfilling every active connection of
     ``connector`` type, then ``added`` / ``removed`` events as connections
@@ -245,7 +249,6 @@ async def connection_discovery_stream(
     side lives in :mod:`aios.services.connections.attach_connection` /
     ``archive_connection``.
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
     async with listen_for_connection_discovery(db_url, connector) as queue:
         emitted_added: set[str] = set()
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -832,7 +832,7 @@ async def increment_session_usage(
     )
 
 
-async def list_running_session_ids(conn: asyncpg.Connection[Any], *, account_id: str) -> list[str]:
+async def list_running_session_ids(conn: asyncpg.Connection[Any]) -> list[str]:
     """Return ids of sessions with ``status = 'running'``.
 
     Used by the sandbox orphan reaper at worker startup: any Docker
@@ -878,8 +878,6 @@ async def get_session_model(
 async def list_attachment_paths_for_sessions(
     conn: asyncpg.Connection[Any],
     session_ids: list[str],
-    *,
-    account_id: str,
 ) -> dict[str, set[str]]:
     """Return ``in_sandbox_path`` values referenced by each session's events.
 
@@ -4055,8 +4053,6 @@ async def get_memory_by_path(
 async def list_active_memory_paths_and_content(
     conn: asyncpg.Connection[Any],
     store_id: str,
-    *,
-    account_id: str,
 ) -> list[tuple[str, str]]:
     """Bulk-fetch ``(path, content)`` for every non-deleted memory in the store.
 
@@ -4962,25 +4958,26 @@ async def revoke_runtime_token(
 async def resolve_runtime_token(
     conn: asyncpg.Connection[Any],
     token_hash: str,
-    *,
-    account_id: str,
-) -> tuple[str, str] | None:
+) -> tuple[str, str, str] | None:
     """Look up an unrevoked token by hash; touch ``last_used_at`` in one round-trip.
 
-    Returns ``(token_id, connector)`` on hit, ``None`` on miss/revoked.
+    Returns ``(token_id, connector, account_id)`` on hit, ``None`` on miss/revoked.
+    The token hash is globally unique (one row owns the secret), so the lookup
+    does not filter by account; account_id is read off the matched row and
+    becomes the authenticated scope for the request.
     """
     row = await conn.fetchrow(
         """
         UPDATE runtime_tokens
            SET last_used_at = now()
          WHERE token_hash = $1 AND revoked_at IS NULL
-        RETURNING id, connector
+        RETURNING id, connector, account_id
         """,
         token_hash,
     )
     if row is None:
         return None
-    return (row["id"], row["connector"])
+    return (row["id"], row["connector"], row["account_id"])
 
 
 # ─── files ───────────────────────────────────────────────────────────────────
@@ -5064,7 +5061,7 @@ def _row_to_account(row: asyncpg.Record) -> Account:
     )
 
 
-async def has_active_root_account(conn: asyncpg.Connection[Any], *, account_id: str) -> bool:
+async def has_active_root_account(conn: asyncpg.Connection[Any]) -> bool:
     """Whether a non-archived root account exists.
 
     The bootstrap endpoint gates on this — once a root exists, the
@@ -5081,7 +5078,6 @@ async def has_active_root_account(conn: asyncpg.Connection[Any], *, account_id: 
 async def bootstrap_root_account(
     conn: asyncpg.Connection[Any],
     *,
-    account_id: str,
     display_name: str,
     key_hash: bytes,
     key_label: str,
@@ -5133,7 +5129,6 @@ async def bootstrap_root_account(
 async def lookup_account_by_key_hash(
     conn: asyncpg.Connection[Any],
     *,
-    account_id: str,
     key_hash: bytes,
 ) -> tuple[Account, str] | None:
     """Resolve a bearer-key sha256 hash to its account and key_id.

--- a/src/aios/harness/attachment_gc.py
+++ b/src/aios/harness/attachment_gc.py
@@ -51,7 +51,6 @@ async def sweep_orphan_attachments(pool: asyncpg.Pool[Any]) -> int:
     files from cleanup of empty dirs (the latter is a future polish
     item alongside session deletion).
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
     root = attachments_root()
     if not root.exists():
         return 0
@@ -77,7 +76,7 @@ async def sweep_orphan_attachments(pool: asyncpg.Pool[Any]) -> int:
 
     async with pool.acquire() as conn:
         referenced_by_session = await queries.list_attachment_paths_for_sessions(
-            conn, list(on_disk_by_session), account_id=account_id
+            conn, list(on_disk_by_session)
         )
 
     deleted = 0

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -67,7 +67,7 @@ def _retry_delay_for_attempt(attempt: int) -> float | None:
 
 
 async def refresh_session_mount_state(
-    pool: asyncpg.Pool[Any], session_id: str
+    pool: asyncpg.Pool[Any], session_id: str, *, account_id: str
 ) -> list[MemoryStoreResourceEcho]:
     """Refresh the cached resource echoes and the sandbox drift check.
 
@@ -75,7 +75,6 @@ async def refresh_session_mount_state(
     Github echoes are cached and fed into the registry's drift check but
     not returned — no current caller in the step body needs them.
     """
-    account_id = await sessions_service.load_session_account_id(pool, session_id)
     from aios.db import queries
 
     async with pool.acquire() as conn:
@@ -134,7 +133,12 @@ async def run_session_step(
         try:
             retry_delay = await asyncio.wait_for(
                 _run_session_step_body(
-                    pool, task_registry, session_id, cause=cause, wake_reason=wake_reason
+                    pool,
+                    task_registry,
+                    session_id,
+                    cause=cause,
+                    wake_reason=wake_reason,
+                    account_id=account_id,
                 ),
                 timeout=_JOB_TIMEOUT_S,
             )
@@ -173,13 +177,13 @@ async def _run_session_step_body(
     *,
     cause: str,
     wake_reason: str | None,
+    account_id: str,
 ) -> float | None:
     """Returns the retry backoff delay when the model errored and the
     outer function should defer a ``cause="reschedule"`` wake after
     ``step_end``; ``None`` otherwise.  Keeping the actual ``defer_wake``
     call outside the body is what makes the reschedule's
     ``wake_deferred`` land in the next step's temporal window."""
-    account_id = await sessions_service.load_session_account_id(pool, session_id)
     if cause == "scheduled" and wake_reason:
         await sessions_service.append_event(
             pool,
@@ -246,7 +250,7 @@ async def _run_session_step_body(
     agent, channels, memory_echoes = await asyncio.gather(
         agent_task,
         list_session_channels(pool, session_id, account_id=account_id),
-        refresh_session_mount_state(pool, session_id),
+        refresh_session_mount_state(pool, session_id, account_id=account_id),
     )
 
     mcp_server_map: dict[str, str] = {s.name: s.url for s in agent.mcp_servers}
@@ -258,6 +262,7 @@ async def _run_session_step_body(
     prelude = await compute_step_prelude(
         pool,
         session_id,
+        account_id=account_id,
         session=session,
         agent=agent,
         channels=channels,
@@ -750,6 +755,8 @@ async def discover_session_mcp_tools(
     pool: Any,
     session_id: str,
     agent: Any,
+    *,
+    account_id: str,
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
     """Discover MCP tools from agent-declared servers, filtered by enabled
     ``mcp_toolset`` entries.
@@ -774,7 +781,9 @@ async def discover_session_mcp_tools(
     crypto_box = runtime.require_crypto_box()
 
     async def _discover_one(name: str, url: str) -> tuple[list[dict[str, Any]], str | None]:
-        headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
+        headers = await resolve_auth_for_url(
+            pool, crypto_box, session_id, url, account_id=account_id
+        )
         return await discover_mcp_tools(url, name, headers)
 
     results = await asyncio.gather(*[_discover_one(n, u) for n, u in servers])

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -110,7 +110,7 @@ async def run_session_step(
     appended before the sweep guard so the model has something to
     react to on this step.
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
+    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     pool = runtime.require_pool()
     task_registry = runtime.require_task_registry()
 

--- a/src/aios/harness/skills.py
+++ b/src/aios/harness/skills.py
@@ -20,17 +20,18 @@ model inference call.
 from __future__ import annotations
 
 from aios.db import queries
+from aios.harness import runtime
 from aios.logging import get_logger
 from aios.models.skills import SkillVersion
 from aios.sandbox.volumes import ensure_workspace_path
+from aios.services import sessions as sessions_service
 
 log = get_logger("aios.harness.skills")
 
 
 async def _load_workspace_path(session_id: str) -> str:
     """Load the workspace volume path for a session from the DB."""
-    account_id = ""  # PR 4 stub; needs upstream threading
-    from aios.harness import runtime
+    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
 
     pool = runtime.require_pool()
     async with pool.acquire() as conn:

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -33,6 +33,7 @@ from aios.harness.context import (
     separate_adjacent_user_messages,
     stub_missing_reasoning_content,
 )
+from aios.services import sessions as sessions_service
 from aios.tools.registry import to_openai_tools
 
 if TYPE_CHECKING:
@@ -95,7 +96,7 @@ async def compute_step_prelude(
     :func:`compose_step_context` unchanged, so the composed prompt stays
     byte-identical to what it was before the split.
     """
-    account_id = ""  # PR 4 stub; PR 5 threads from caller
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
     from aios.harness.channels import (
         augment_with_focal_paradigm,
         max_tail_block_local,

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -33,7 +33,6 @@ from aios.harness.context import (
     separate_adjacent_user_messages,
     stub_missing_reasoning_content,
 )
-from aios.services import sessions as sessions_service
 from aios.tools.registry import to_openai_tools
 
 if TYPE_CHECKING:
@@ -84,6 +83,7 @@ async def compute_step_prelude(
     pool: asyncpg.Pool[Any],
     session_id: str,
     *,
+    account_id: str,
     session: Session,
     agent: Agent | AgentVersion,
     channels: list[str],
@@ -96,7 +96,6 @@ async def compute_step_prelude(
     :func:`compose_step_context` unchanged, so the composed prompt stays
     byte-identical to what it was before the split.
     """
-    account_id = await sessions_service.load_session_account_id(pool, session_id)
     from aios.harness.channels import (
         augment_with_focal_paradigm,
         max_tail_block_local,
@@ -117,7 +116,9 @@ async def compute_step_prelude(
 
     instructions_block = ""
     if agent.mcp_servers:
-        mcp_tools, mcp_instructions = await discover_session_mcp_tools(pool, session_id, agent)
+        mcp_tools, mcp_instructions = await discover_session_mcp_tools(
+            pool, session_id, agent, account_id=account_id
+        )
         tools.extend(mcp_tools)
         instructions_block = _build_instructions_block(agent.mcp_servers, mcp_instructions)
 

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -180,9 +180,6 @@ async def find_and_repair_ghosts(
     Returns a list of ``(session_id, tool_call_id)`` pairs that were
     repaired.
     """
-    account_id = (
-        await sessions_service.load_session_account_id(pool, session_id) if session_id else ""
-    )  # cross-session sweeps run unscoped
     in_flight = task_registry.all_in_flight_tool_call_ids()
 
     scope_clause = "AND e.session_id = $1" if session_id else ""
@@ -268,6 +265,10 @@ async def find_and_repair_ghosts(
             {"error": "No result was received for this tool call."},
             ensure_ascii=False,
         )
+        # Load each ghost's session account_id individually so the
+        # cross-session sweeper (session_id=None) doesn't stamp empty
+        # account_id onto repair events for real tenants.
+        sid_account_id = await sessions_service.load_session_account_id(pool, sid)
         await sessions_service.append_event(
             pool,
             sid,
@@ -279,7 +280,7 @@ async def find_and_repair_ghosts(
                 "content": content,
                 "is_error": True,
             },
-            account_id=account_id,
+            account_id=sid_account_id,
         )
         log.info("sweep.ghost_repaired", session_id=sid, tool_call_id=tcid, tool_name=name)
 
@@ -507,11 +508,12 @@ async def wake_sessions_needing_inference(
     the number of procrastinate wakes deferred, so the tail-site
     ``sweep_end`` span can stamp both without unrolling the composition.
     """
-    account_id = (
-        await sessions_service.load_session_account_id(pool, session_id) if session_id else ""
-    )  # cross-session sweeps run unscoped
     repaired = await find_and_repair_ghosts(pool, task_registry, session_id=session_id)
     woken = await find_sessions_needing_inference(pool, task_registry, session_id=session_id)
+    # Load each woken session's account_id individually: the cross-session
+    # sweeper (session_id=None) doesn't have one in scope, and using "" would
+    # leak an empty account onto the wake_deferred event for a real tenant.
     for sid in woken:
-        await defer_wake(pool, sid, cause="sweep", account_id=account_id)
+        sid_account_id = await sessions_service.load_session_account_id(pool, sid)
+        await defer_wake(pool, sid, cause="sweep", account_id=sid_account_id)
     return SweepResult(repaired_ghosts=len(repaired), woken_sessions=len(woken))

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -110,7 +110,12 @@ async def _execute_tool_async(
             bound_log.warning("tool.bad_arguments")
             is_error = True
             await _append_tool_result(
-                pool, session_id, call_id, name, error="arguments were not valid JSON"
+                pool,
+                session_id,
+                call_id,
+                name,
+                account_id=account_id,
+                error="arguments were not valid JSON",
             )
             return
 
@@ -120,7 +125,9 @@ async def _execute_tool_async(
         except ToolNotFoundError as err:
             bound_log.warning("tool.not_registered")
             is_error = True
-            await _append_tool_result(pool, session_id, call_id, name, error=err.message)
+            await _append_tool_result(
+                pool, session_id, call_id, name, account_id=account_id, error=err.message
+            )
             return
 
         # Validate arguments against the tool's parameters_schema before
@@ -135,7 +142,9 @@ async def _execute_tool_async(
         if schema_error is not None:
             bound_log.info("tool.schema_error", error=schema_error)
             is_error = True
-            await _append_tool_result(pool, session_id, call_id, name, error=schema_error)
+            await _append_tool_result(
+                pool, session_id, call_id, name, account_id=account_id, error=schema_error
+            )
             return
 
         # Invoke handler.  Handlers return either a plain dict (JSON-
@@ -171,14 +180,21 @@ async def _execute_tool_async(
     except asyncio.CancelledError:
         bound_log.info("tool.cancelled")
         is_error = True
-        await _append_tool_result(pool, session_id, call_id, name, error="cancelled")
+        await _append_tool_result(
+            pool, session_id, call_id, name, account_id=account_id, error="cancelled"
+        )
 
     except Exception as err:
         bound_log.exception("tool.handler_failed")
         is_error = True
         _evict_session_container(session_id)
         await _append_tool_result(
-            pool, session_id, call_id, name, error=f"{type(err).__name__}: {err}"
+            pool,
+            session_id,
+            call_id,
+            name,
+            account_id=account_id,
+            error=f"{type(err).__name__}: {err}",
         )
 
     finally:
@@ -195,7 +211,7 @@ async def _execute_tool_async(
             },
             account_id=account_id,
         )
-        await _trigger_sweep(pool, session_id, bound_log)
+        await _trigger_sweep(pool, session_id, bound_log, account_id=account_id)
 
 
 def _parse_arguments(raw_args: Any) -> dict[str, Any] | None:
@@ -245,10 +261,10 @@ async def _append_tool_result(
     call_id: str,
     name: str,
     *,
+    account_id: str,
     error: str,
 ) -> None:
     """Append a tool-role error event."""
-    account_id = await sessions_service.load_session_account_id(pool, session_id)
     content = json.dumps({"error": error}, ensure_ascii=False)
     await sessions_service.append_event(
         pool,
@@ -276,11 +292,12 @@ async def _trigger_sweep(
     pool: asyncpg.Pool[Any],
     session_id: str,
     bound_log: Any,
+    *,
+    account_id: str,
 ) -> None:
     """Run the sweep for this session. Called from the finally block of
     every tool task — both built-in and MCP.
     """
-    account_id = await sessions_service.load_session_account_id(pool, session_id)
     from aios.harness.sweep import SweepResult, wake_sessions_needing_inference
 
     sweep_start = await sessions_service.append_event(
@@ -397,7 +414,12 @@ async def _execute_mcp_tool_async(
             bound_log.warning("mcp_tool.bad_arguments")
             is_error = True
             await _append_tool_result(
-                pool, session_id, call_id, name, error="arguments were not valid JSON"
+                pool,
+                session_id,
+                call_id,
+                name,
+                account_id=account_id,
+                error="arguments were not valid JSON",
             )
             return
 
@@ -428,6 +450,7 @@ async def _execute_mcp_tool_async(
                     session_id,
                     call_id,
                     name,
+                    account_id=account_id,
                     error=f"MCP server {server_name!r} not found",
                 )
                 return
@@ -435,7 +458,9 @@ async def _execute_mcp_tool_async(
             from aios.mcp.client import call_mcp_tool, resolve_auth_for_url
 
             crypto_box = runtime.require_crypto_box()
-            headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
+            headers = await resolve_auth_for_url(
+                pool, crypto_box, session_id, url, account_id=account_id
+            )
             result = await call_mcp_tool(url, headers, tool_name, arguments, meta=meta)
 
         content_str = json.dumps(result, ensure_ascii=False)
@@ -458,13 +483,20 @@ async def _execute_mcp_tool_async(
     except asyncio.CancelledError:
         bound_log.info("mcp_tool.cancelled")
         is_error = True
-        await _append_tool_result(pool, session_id, call_id, name, error="cancelled")
+        await _append_tool_result(
+            pool, session_id, call_id, name, account_id=account_id, error="cancelled"
+        )
 
     except Exception as err:
         bound_log.exception("mcp_tool.handler_failed")
         is_error = True
         await _append_tool_result(
-            pool, session_id, call_id, name, error=f"{type(err).__name__}: {err}"
+            pool,
+            session_id,
+            call_id,
+            name,
+            account_id=account_id,
+            error=f"{type(err).__name__}: {err}",
         )
 
     finally:
@@ -481,4 +513,4 @@ async def _execute_mcp_tool_async(
             },
             account_id=account_id,
         )
-        await _trigger_sweep(pool, session_id, bound_log)
+        await _trigger_sweep(pool, session_id, bound_log, account_id=account_id)

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -82,7 +82,7 @@ async def _execute_tool_async(
 
     Brackets the lifecycle in a ``tool_execute_*`` span pair (issue #78).
     """
-    account_id = ""  # PR 4 stub; PR 5 threads from caller
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
     call_id = call.get("id") or "unknown"
     function = call.get("function") or {}
     name = function.get("name") or ""
@@ -248,7 +248,7 @@ async def _append_tool_result(
     error: str,
 ) -> None:
     """Append a tool-role error event."""
-    account_id = ""  # PR 4 stub; PR 5 threads from caller
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
     content = json.dumps({"error": error}, ensure_ascii=False)
     await sessions_service.append_event(
         pool,
@@ -280,7 +280,7 @@ async def _trigger_sweep(
     """Run the sweep for this session. Called from the finally block of
     every tool task — both built-in and MCP.
     """
-    account_id = ""  # PR 4 stub; PR 5 threads from caller
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
     from aios.harness.sweep import SweepResult, wake_sessions_needing_inference
 
     sweep_start = await sessions_service.append_event(
@@ -370,7 +370,7 @@ async def _execute_mcp_tool_async(
     emission-time — a concurrent ``switch_channel`` in the same
     assistant batch does not race this injection.
     """
-    account_id = ""  # PR 4 stub; PR 5 threads from caller
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
     call_id = call.get("id") or "unknown"
     function = call.get("function") or {}
     name: str = function.get("name") or ""

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -75,7 +75,6 @@ def _make_worker_id() -> str:
 
 
 async def worker_main() -> None:
-    account_id = ""  # PR 4 stub; needs upstream threading
     settings = get_settings()
     configure_logging(settings.log_level)
     log = get_logger("aios.worker")
@@ -164,7 +163,7 @@ async def worker_main() -> None:
 
         # Reap orphaned sandbox containers.
         async with pool.acquire() as conn:
-            active_session_ids = await queries.list_running_session_ids(conn, account_id=account_id)
+            active_session_ids = await queries.list_running_session_ids(conn)
         reaped = await sandbox_registry.reap_orphans(active_session_ids)
         if reaped:
             log.info("worker.reaped_orphan_containers", count=reaped)

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -29,6 +29,7 @@ from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.logging import get_logger
 from aios.mcp.schema import make_function_tool
+from aios.services import sessions as sessions_service
 from aios.services.vaults import is_expiring, refresh_credential
 
 log = get_logger("aios.mcp.client")
@@ -94,7 +95,7 @@ async def resolve_auth_for_url(
     bubble up as :class:`OAuthRefreshError`; there is no silent fallback
     to the stale token.
     """
-    account_id = ""  # PR 4 stub; PR 5 threads from caller
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
     async with pool.acquire() as conn:
         session_result = await queries.resolve_mcp_credential(
             conn, session_id, mcp_server_url, account_id=account_id

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -29,7 +29,6 @@ from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.logging import get_logger
 from aios.mcp.schema import make_function_tool
-from aios.services import sessions as sessions_service
 from aios.services.vaults import is_expiring, refresh_credential
 
 log = get_logger("aios.mcp.client")
@@ -84,6 +83,8 @@ async def resolve_auth_for_url(
     crypto_box: CryptoBox,
     session_id: str,
     mcp_server_url: str,
+    *,
+    account_id: str,
 ) -> dict[str, str]:
     """Resolve MCP auth headers for ``mcp_server_url`` via the session's
     bound vaults.
@@ -95,7 +96,6 @@ async def resolve_auth_for_url(
     bubble up as :class:`OAuthRefreshError`; there is no silent fallback
     to the stale token.
     """
-    account_id = await sessions_service.load_session_account_id(pool, session_id)
     async with pool.acquire() as conn:
         session_result = await queries.resolve_mcp_credential(
             conn, session_id, mcp_server_url, account_id=account_id

--- a/src/aios/sandbox/memory_mounts.py
+++ b/src/aios/sandbox/memory_mounts.py
@@ -47,7 +47,6 @@ async def materialize_store_to_host(
     Subsequent DB drift is propagated by the per-write mirror helpers,
     not by re-materialization.
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
     host_dir = memory_store_host_dir(store_id)
     marker = host_dir / MATERIALIZED_MARKER
     if marker.exists():
@@ -62,9 +61,7 @@ async def materialize_store_to_host(
                 return  # another waiter materialized while we blocked
             host_dir.mkdir(parents=True, exist_ok=True)
 
-            entries = await queries.list_active_memory_paths_and_content(
-                conn, store_id, account_id=account_id
-            )
+            entries = await queries.list_active_memory_paths_and_content(conn, store_id)
             for path, content in entries:
                 # Memory paths are guaranteed to start with "/" by the SQL CHECK.
                 atomic_write(host_dir / path.lstrip("/"), content or "")

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -114,12 +114,12 @@ class SandboxRegistry:
     async def _provision_with_span(
         self, session_id: str, *, pool: asyncpg.Pool[Any] | None
     ) -> SandboxHandle:
-        account_id = ""  # PR 4 stub; PR 5 threads from caller
         if pool is None:
             return await self._provision(session_id)
 
         from aios.services import sessions as sessions_service
 
+        account_id = await sessions_service.load_session_account_id(pool, session_id)
         span_start = await sessions_service.append_event(
             pool, session_id, "span", {"event": "sandbox_provision_start"}, account_id=account_id
         )

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -104,13 +104,12 @@ def mount_snapshot_from_echoes(
     return frozenset(items)
 
 
-async def _load_environment_config(session_id: str) -> EnvironmentConfig | None:
+async def _load_environment_config(session_id: str, *, account_id: str) -> EnvironmentConfig | None:
     """Load the environment config for a session from the DB.
 
     Returns ``None`` if the session or environment doesn't exist (shouldn't
     happen in normal flow, but callers handle it gracefully).
     """
-    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
 
     pool = runtime.require_pool()
     async with pool.acquire() as conn:
@@ -119,9 +118,10 @@ async def _load_environment_config(session_id: str) -> EnvironmentConfig | None:
         )
 
 
-async def _load_session_provisioning(session_id: str) -> tuple[str, dict[str, str]]:
+async def _load_session_provisioning(
+    session_id: str, *, account_id: str
+) -> tuple[str, dict[str, str]]:
     """Load workspace path and env from the session row in one query."""
-    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
 
     pool = runtime.require_pool()
     async with pool.acquire() as conn:
@@ -130,6 +130,8 @@ async def _load_session_provisioning(session_id: str) -> tuple[str, dict[str, st
 
 async def _materialize_memory_mounts(
     session_id: str,
+    *,
+    account_id: str,
 ) -> list[MemoryStoreResourceEcho]:
     """Materialize each attached memory store and return the echo list.
 
@@ -138,7 +140,6 @@ async def _materialize_memory_mounts(
     the unit-test mocking surface tight — tests mock this single
     function and don't need a live pool.
     """
-    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     from aios.sandbox.memory_mounts import materialize_store_to_host
 
     pool = runtime.require_pool()
@@ -153,6 +154,8 @@ async def _materialize_memory_mounts(
 
 async def _materialize_github_clones(
     session_id: str,
+    *,
+    account_id: str,
 ) -> tuple[list[GithubRepositoryResourceEcho], GitProxy | None]:
     """Decrypt tokens, start a per-session :class:`GitProxy`, then run
     the host-side clone for each attached github_repository — rewriting
@@ -167,7 +170,6 @@ async def _materialize_github_clones(
     working tree won't be bind-mounted). The proxy stays alive for
     sibling repos.
     """
-    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     from aios.sandbox.git_proxy import repo_key
     from aios.services import github_repositories as github_repo_service
 
@@ -266,11 +268,12 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     from aios.sandbox.volumes import ensure_workspace_path
 
     settings = get_settings()
-    raw_path, session_env = await _load_session_provisioning(session_id)
+    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
+    raw_path, session_env = await _load_session_provisioning(session_id, account_id=account_id)
     workspace_path = ensure_workspace_path(raw_path)
-    env_config = await _load_environment_config(session_id)
-    memory_echoes = await _materialize_memory_mounts(session_id)
-    github_echoes, git_proxy = await _materialize_github_clones(session_id)
+    env_config = await _load_environment_config(session_id, account_id=account_id)
+    memory_echoes = await _materialize_memory_mounts(session_id, account_id=account_id)
+    github_echoes, git_proxy = await _materialize_github_clones(session_id, account_id=account_id)
 
     try:
         return _assemble_plan(

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 from aios.config import get_settings
 from aios.db import queries
+from aios.harness import runtime
 from aios.logging import get_logger
 from aios.models.environments import EnvironmentConfig, LimitedNetworking
 from aios.models.github_repositories import GithubRepositoryResourceEcho
@@ -50,6 +51,7 @@ from aios.sandbox.github_clone import (
     ensure_session_working_tree,
 )
 from aios.sandbox.setup import WORKSPACE_RUNTIME_ENV
+from aios.services import sessions as sessions_service
 
 log = get_logger("aios.sandbox.spec")
 
@@ -108,8 +110,7 @@ async def _load_environment_config(session_id: str) -> EnvironmentConfig | None:
     Returns ``None`` if the session or environment doesn't exist (shouldn't
     happen in normal flow, but callers handle it gracefully).
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
-    from aios.harness import runtime
+    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
 
     pool = runtime.require_pool()
     async with pool.acquire() as conn:
@@ -120,8 +121,7 @@ async def _load_environment_config(session_id: str) -> EnvironmentConfig | None:
 
 async def _load_session_provisioning(session_id: str) -> tuple[str, dict[str, str]]:
     """Load workspace path and env from the session row in one query."""
-    account_id = ""  # PR 4 stub; needs upstream threading
-    from aios.harness import runtime
+    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
 
     pool = runtime.require_pool()
     async with pool.acquire() as conn:
@@ -138,8 +138,7 @@ async def _materialize_memory_mounts(
     the unit-test mocking surface tight — tests mock this single
     function and don't need a live pool.
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
-    from aios.harness import runtime
+    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     from aios.sandbox.memory_mounts import materialize_store_to_host
 
     pool = runtime.require_pool()
@@ -168,8 +167,7 @@ async def _materialize_github_clones(
     working tree won't be bind-mounted). The proxy stays alive for
     sibling repos.
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
-    from aios.harness import runtime
+    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     from aios.sandbox.git_proxy import repo_key
     from aios.services import github_repositories as github_repo_service
 
@@ -219,8 +217,6 @@ async def _materialize_github_clones(
     # Log + append failure events outside the conn block so we don't
     # hold one connection while acquiring a second from the same pool.
     if failures:
-        from aios.services import sessions as sessions_service
-
         for failed_echo, failure in failures:
             log.warning(
                 "sandbox.github_clone_failed",

--- a/src/aios/services/accounts.py
+++ b/src/aios/services/accounts.py
@@ -30,7 +30,6 @@ def hash_key(plaintext: str) -> bytes:
 async def bootstrap_root(
     pool: asyncpg.Pool[Any],
     *,
-    account_id: str,
     display_name: str,
 ) -> BootstrapResponse:
     """Create the root account and mint its first API key."""
@@ -42,7 +41,6 @@ async def bootstrap_root(
             display_name=display_name,
             key_hash=key_hash,
             key_label=_BOOTSTRAP_KEY_LABEL,
-            account_id=account_id,
         )
     return BootstrapResponse(
         account_id=account.id,

--- a/src/aios/services/runtime_tokens.py
+++ b/src/aios/services/runtime_tokens.py
@@ -27,6 +27,7 @@ class ResolvedRuntimeToken(NamedTuple):
 
     token_id: str
     connector: str
+    account_id: str
 
 
 _TOKEN_PREFIX = "aios_runtime_"
@@ -77,19 +78,21 @@ async def revoke(pool: asyncpg.Pool[Any], token_id: str, *, account_id: str) -> 
         return await queries.revoke_runtime_token(conn, token_id, account_id=account_id)
 
 
-async def resolve(
-    pool: asyncpg.Pool[Any], plaintext: str, *, account_id: str
-) -> ResolvedRuntimeToken | None:
+async def resolve(pool: asyncpg.Pool[Any], plaintext: str) -> ResolvedRuntimeToken | None:
     """Resolve a plaintext bearer to a ``ResolvedRuntimeToken`` or ``None``.
 
     Touches ``last_used_at`` as a side effect.  Returns ``None`` for
     misses, revoked tokens, and plaintext lacking the prefix.
+
+    No ``account_id`` parameter: this is the auth-bootstrap entry point.
+    The matched row's account_id becomes the authenticated scope for
+    downstream queries.
     """
     if not plaintext.startswith(_TOKEN_PREFIX):
         return None
     async with pool.acquire() as conn:
-        row = await queries.resolve_runtime_token(conn, _hash(plaintext), account_id=account_id)
+        row = await queries.resolve_runtime_token(conn, _hash(plaintext))
     if row is None:
         return None
-    token_id, connector = row
-    return ResolvedRuntimeToken(token_id=token_id, connector=connector)
+    token_id, connector, account_id = row
+    return ResolvedRuntimeToken(token_id=token_id, connector=connector, account_id=account_id)

--- a/src/aios/tools/bash_memory_reconcile.py
+++ b/src/aios/tools/bash_memory_reconcile.py
@@ -28,6 +28,7 @@ from aios.models.memory_stores import MAX_CONTENT_BYTES
 from aios.sandbox.memory_mounts import MATERIALIZED_MARKER
 from aios.sandbox.volumes import memory_store_host_dir
 from aios.services import memory_stores as memory_service
+from aios.services import sessions as sessions_service
 from aios.services.memory_stores import SessionActor
 
 log = get_logger("aios.tools.bash_memory_reconcile")
@@ -188,7 +189,7 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
     warning string (collected and returned).  DB errors propagate — they are
     the session's problem to recover from through the normal error channel.
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
+    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     # Build after snapshot as (store_id, store_path) -> bytes in one pass.
     # Using bytes avoids re-reading files during the create/modify loops.
     after_bytes = _snapshot_with_bytes(session_id)

--- a/src/aios/tools/edit.py
+++ b/src/aios/tools/edit.py
@@ -40,6 +40,7 @@ from aios.errors import (
 from aios.harness import runtime
 from aios.models.memory_stores import MAX_CONTENT_BYTES
 from aios.services import memory_stores as memory_service
+from aios.services import sessions as sessions_service
 from aios.tools.memory_intercept import resolve_memory_target
 from aios.tools.registry import registry
 
@@ -97,7 +98,7 @@ EDIT_PARAMETERS_SCHEMA: dict[str, Any] = {
 
 async def edit_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
     """Handler for the edit tool. See module docstring for the return shape."""
-    account_id = ""  # PR 4 stub; needs upstream threading
+    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     path = arguments.get("path")
     if not isinstance(path, str) or not path.strip():
         raise EditArgumentError("edit tool requires a non-empty 'path' string")

--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -153,7 +153,7 @@ async def _read_image(
     handle: SandboxHandle,
     pool: Any,
 ) -> ToolResult:
-    account_id = ""  # PR 4 stub; PR 5 threads from caller
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
     mime = _EXT_TO_MIME[os.path.splitext(path)[1].lower()]
     model = await sessions_service.get_session_model(pool, session_id, account_id=account_id)
 

--- a/src/aios/tools/schedule_wake.py
+++ b/src/aios/tools/schedule_wake.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from aios.errors import AiosError
 from aios.harness import runtime
+from aios.services import sessions as sessions_service
 from aios.services.wake import defer_wake
 from aios.tools.registry import registry
 
@@ -63,7 +64,7 @@ SCHEDULE_WAKE_PARAMETERS_SCHEMA: dict[str, Any] = {
 
 
 async def schedule_wake_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
-    account_id = ""  # PR 4 stub; needs upstream threading
+    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     delay_seconds = arguments.get("delay_seconds")
     if not isinstance(delay_seconds, int):
         raise ScheduleWakeArgumentError("delay_seconds must be an integer")

--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -30,6 +30,7 @@ from aios.harness.channels import (
 from aios.harness.context import render_user_event
 from aios.harness.tokens import approx_tokens
 from aios.models.events import Event
+from aios.services import sessions as sessions_service
 from aios.tools.registry import ToolResult, registry
 
 # Minimum rendered-content size the recap pads up to when there isn't
@@ -87,7 +88,7 @@ async def switch_channel_handler(session_id: str, arguments: dict[str, Any]) -> 
     current focal) return a terse ack with empty metadata — they didn't
     actually change the agent's attention and shouldn't anchor anything.
     """
-    account_id = ""  # PR 4 stub; needs upstream threading
+    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     target = arguments.get("channel_id")
     if target is not None and not isinstance(target, str):
         return ToolResult(

--- a/src/aios/tools/write.py
+++ b/src/aios/tools/write.py
@@ -42,6 +42,7 @@ from aios.errors import (
 from aios.harness import runtime
 from aios.models.memory_stores import MAX_CONTENT_BYTES
 from aios.services import memory_stores as memory_service
+from aios.services import sessions as sessions_service
 from aios.tools.memory_intercept import resolve_memory_target
 from aios.tools.registry import registry
 
@@ -81,7 +82,7 @@ WRITE_PARAMETERS_SCHEMA: dict[str, Any] = {
 
 async def write_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
     """Handler for the write tool. See module docstring for the return shape."""
-    account_id = ""  # PR 4 stub; needs upstream threading
+    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     path = arguments.get("path")
     if not isinstance(path, str) or not path.strip():
         raise WriteArgumentError("write tool requires a non-empty 'path' string")

--- a/src/aios_connectors/providers.py
+++ b/src/aios_connectors/providers.py
@@ -17,6 +17,7 @@ from typing import Any
 import asyncpg
 
 from aios.services import connections as connections_service
+from aios.services import sessions as sessions_service
 
 
 class SubsystemToolProvider:
@@ -31,7 +32,7 @@ class SubsystemToolProvider:
     async def list_tools_for_session(
         self, pool: asyncpg.Pool[Any], session_id: str
     ) -> list[dict[str, Any]]:
-        account_id = ""  # PR 3 stub; PR 4 threads real id
+        account_id = await sessions_service.load_session_account_id(pool, session_id)
         return await connections_service.list_tools_for_session(
             pool, session_id, account_id=account_id
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,7 +183,6 @@ async def aios_env(aios_env_minimal: dict[str, str]) -> dict[str, str]:
     drives the test on — avoids the spurious ``asyncio.run`` event-loop
     isolation that caused ASGI-callable teardown flakiness in CI.
     """
-    account_id = "acc_test_stub"  # PR 3 scaffolding
     import asyncpg
 
     from aios.db import queries
@@ -199,7 +198,6 @@ async def aios_env(aios_env_minimal: dict[str, str]) -> dict[str, str]:
             display_name="root",
             key_hash=hash_key(plaintext),
             key_label="test-root",
-            account_id=account_id,
         )
         # PR 4: many tests still pass the PR 3 stub literal ``"acc_test_stub"``
         # as the account_id arg. Now that migration 0043 enforces NOT NULL +

--- a/tests/e2e/test_accounts_bootstrap.py
+++ b/tests/e2e/test_accounts_bootstrap.py
@@ -213,7 +213,6 @@ class TestBootstrap:
         (404), matching the post-bootstrap behavior — otherwise the
         endpoint's stated invariant breaks under concurrency.
         """
-        account_id = "acc_test_stub"  # PR 3 scaffolding
         # Pre-seed a root to put the DB in the "already bootstrapped"
         # state, then call ``bootstrap_root_account`` directly — this is
         # the same code path the race-loser hits at the INSERT step.
@@ -233,7 +232,6 @@ class TestBootstrap:
                     display_name="loser",
                     key_hash=b"\x00" * 32,
                     key_label="bootstrap",
-                    account_id=account_id,
                 )
 
 

--- a/tests/e2e/test_connection_tools.py
+++ b/tests/e2e/test_connection_tools.py
@@ -105,6 +105,7 @@ class TestConnectionToolsInPrelude:
         prelude = await compute_step_prelude(
             pool=harness._pool,
             session_id=session.id,
+            account_id=account_id,
             session=await sess_svc.get_session(harness._pool, session.id, account_id=account_id),
             agent=agent,
             channels=[],
@@ -214,6 +215,7 @@ class TestConnectionToolsInPrelude:
         prelude = await compute_step_prelude(
             pool=harness._pool,
             session_id=session.id,
+            account_id=account_id,
             session=await sess_svc.get_session(harness._pool, session.id, account_id=account_id),
             agent=agent,
             channels=[],

--- a/tests/e2e/test_memory_cross_session_sync.py
+++ b/tests/e2e/test_memory_cross_session_sync.py
@@ -86,7 +86,7 @@ async def _start_session(
         resources=resources,
         account_id=account_id,
     )
-    await refresh_session_mount_state(harness._pool, session.id)
+    await refresh_session_mount_state(harness._pool, session.id, account_id="acc_test_stub")
     return session
 
 
@@ -421,7 +421,9 @@ class TestMountUpdateRecyclesContainer:
             ],
             account_id=account_id,
         )
-        await refresh_session_mount_state(docker_harness._pool, session.id)
+        await refresh_session_mount_state(
+            docker_harness._pool, session.id, account_id="acc_test_stub"
+        )
 
         after = await bash_handler(
             session.id, {"command": "ls -d /mnt/memory/attach-mount && echo OK"}
@@ -454,7 +456,9 @@ class TestMountUpdateRecyclesContainer:
         await sessions_service.update_session(
             docker_harness._pool, session.id, resources=[], account_id=account_id
         )
-        await refresh_session_mount_state(docker_harness._pool, session.id)
+        await refresh_session_mount_state(
+            docker_harness._pool, session.id, account_id="acc_test_stub"
+        )
 
         after = await bash_handler(session.id, {"command": "ls /mnt/memory 2>&1; true"})
         assert "detach-mount" not in after["stdout"]
@@ -480,7 +484,9 @@ class TestMountUpdateRecyclesContainer:
             ],
             account_id=account_id,
         )
-        await refresh_session_mount_state(docker_harness._pool, session.id)
+        await refresh_session_mount_state(
+            docker_harness._pool, session.id, account_id="acc_test_stub"
+        )
 
         cached = sandbox.peek(session.id)
         assert cached is not None

--- a/tests/e2e/test_vaults.py
+++ b/tests/e2e/test_vaults.py
@@ -647,7 +647,9 @@ class TestOAuthRefreshE2E:
             post_calls,
             body={"access_token": "fresh-at", "expires_in": 3600},
         ):
-            headers = await resolve_auth_for_url(pool, crypto_box, session_id, url)
+            headers = await resolve_auth_for_url(
+                pool, crypto_box, session_id, url, account_id="acc_test_stub"
+            )
 
         assert len(post_calls) == 1, "expected exactly one POST to the token endpoint"
         assert post_calls[0][0] == "https://issuer.example/token"
@@ -699,7 +701,12 @@ class TestOAuthRefreshE2E:
             body={"access_token": "fresh-at", "expires_in": 3600},
         ):
             results = await asyncio.gather(
-                *(resolve_auth_for_url(pool, crypto_box, session_id, url) for _ in range(5))
+                *(
+                    resolve_auth_for_url(
+                        pool, crypto_box, session_id, url, account_id="acc_test_stub"
+                    )
+                    for _ in range(5)
+                )
             )
 
         assert all(r == {"Authorization": "Bearer fresh-at"} for r in results)
@@ -747,7 +754,9 @@ class TestOAuthRefreshE2E:
             patch("aios.services.vaults.httpx.AsyncClient", MagicMock(return_value=client)),
             pytest.raises(OAuthRefreshError),
         ):
-            await resolve_auth_for_url(pool, crypto_box, session_id, url)
+            await resolve_auth_for_url(
+                pool, crypto_box, session_id, url, account_id="acc_test_stub"
+            )
 
     async def test_concurrent_refresh_of_different_credentials_runs_in_parallel(
         self, pool: Any, crypto_box: Any
@@ -796,8 +805,8 @@ class TestOAuthRefreshE2E:
             body={"access_token": "fresh-at", "expires_in": 3600},
         ):
             results = await asyncio.gather(
-                resolve_auth_for_url(pool, crypto_box, sess1, url1),
-                resolve_auth_for_url(pool, crypto_box, sess2, url2),
+                resolve_auth_for_url(pool, crypto_box, sess1, url1, account_id="acc_test_stub"),
+                resolve_auth_for_url(pool, crypto_box, sess2, url2, account_id="acc_test_stub"),
             )
 
         assert all(r == {"Authorization": "Bearer fresh-at"} for r in results)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -80,3 +80,21 @@ def fake_pool_yielding_conn(conn: Any, **kwargs: Any) -> Any:
     cm.__aexit__ = AsyncMock(return_value=None)
     pool.acquire.return_value = cm
     return pool
+
+
+@pytest.fixture(autouse=True)
+def _unit_load_session_account_id_stub() -> Iterator[None]:
+    """Auto-mock the worker-side account_id bootstrap.
+
+    Most unit tests mock ``pool`` and ``conn`` to MagicMocks; the real
+    ``load_session_account_id`` calls ``conn.fetchrow`` which a MagicMock
+    can't await. Patching the function globally with an AsyncMock that
+    returns the test stub means tests don't have to know about the
+    bootstrap helper at all.
+    """
+    with mock.patch(
+        "aios.services.sessions.load_session_account_id",
+        new_callable=AsyncMock,
+        return_value="acc_test_stub",
+    ):
+        yield

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -46,6 +46,7 @@ class TestDiscoverSessionMcpTools:
             pool=AsyncMock(),
             session_id="sess_x",
             agent=_agent(),
+            account_id="acc_test_stub",
         )
         assert tools == []
         assert instructions == {}
@@ -81,6 +82,7 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
+                account_id="acc_test_stub",
             )
         names = {t["name"] for t in tools}
         assert names == {"mcp__gh__t"}
@@ -123,6 +125,7 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
+                account_id="acc_test_stub",
             )
         assert sorted(seen_urls) == ["https://mcp.github", "https://mcp.linear"]
         auths = {t["auth"] for t in tools}
@@ -165,6 +168,7 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
+                account_id="acc_test_stub",
             )
         # 'gh' returned None → omitted; 'ln' returned prose → present.
         assert instructions == {"ln": "## linear\n\nbe brief"}
@@ -195,5 +199,6 @@ class TestDiscoverSessionMcpTools:
                 pool=AsyncMock(),
                 session_id="sess_x",
                 agent=agent,
+                account_id="acc_test_stub",
             )
         assert instructions == {}

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -43,7 +43,7 @@ class TestResolveAuthForUrl:
         ) as s:
             s.return_value = (blob, "static_bearer", "vlt_s1")
             result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
+                pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
         assert result == {"Authorization": "Bearer session-token"}
         s.assert_awaited_once()
@@ -56,7 +56,7 @@ class TestResolveAuthForUrl:
         ) as s:
             s.return_value = None
             result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
+                pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
         assert result == {}
 
@@ -70,7 +70,7 @@ class TestResolveAuthForUrl:
         ) as s:
             s.return_value = (blob, "static_bearer", "vlt_s1")
             result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
+                pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
         assert result == {}
 
@@ -84,7 +84,7 @@ class TestResolveAuthForUrl:
         ) as s:
             s.return_value = (blob, "mcp_oauth", "vlt_s1")
             result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
+                pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
         assert result == {"Authorization": "Bearer oauth-token"}
 
@@ -122,7 +122,7 @@ class TestResolveAuthForUrl:
             s.return_value = (stale_blob, "mcp_oauth", "vlt_s1")
             v.return_value = (fresh_blob, "mcp_oauth")
             result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
+                pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
 
         refresh_mock.assert_awaited_once()
@@ -153,7 +153,7 @@ class TestResolveAuthForUrl:
         ):
             s.return_value = (blob, "mcp_oauth", "vlt_s1")
             result = await resolve_auth_for_url(
-                pool, crypto_box, "sess_123", "https://mcp.example.com"
+                pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
 
         refresh_mock.assert_not_awaited()
@@ -185,7 +185,9 @@ class TestResolveAuthForUrl:
             pytest.raises(OAuthRefreshError),
         ):
             s.return_value = (blob, "mcp_oauth", "vlt_s1")
-            await resolve_auth_for_url(pool, crypto_box, "sess_123", "https://mcp.example.com")
+            await resolve_auth_for_url(
+                pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
+            )
 
 
 # ── discover_mcp_tools ────────────────────────────────────────────────────────

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -54,7 +54,7 @@ class TestTailSweepSpan:
             ),
             patch("aios.harness.sweep.wake_sessions_needing_inference", wake_mock),
         ):
-            await _trigger_sweep(MagicMock(), "sess_x", MagicMock())
+            await _trigger_sweep(MagicMock(), "sess_x", MagicMock(), account_id="acc_test_stub")
 
         sweep_events = _sweep_events(append_event)
         assert [e["event"] for e in sweep_events] == ["sweep_start", "sweep_end"]
@@ -83,7 +83,7 @@ class TestTailSweepSpan:
             ),
             patch("aios.harness.sweep.wake_sessions_needing_inference", wake_mock),
         ):
-            await _trigger_sweep(MagicMock(), "sess_x", bound_log)
+            await _trigger_sweep(MagicMock(), "sess_x", bound_log, account_id="acc_test_stub")
 
         sweep_events = _sweep_events(append_event)
         assert [e["event"] for e in sweep_events] == ["sweep_start", "sweep_end"]


### PR DESCRIPTION
## Summary
- Replaces the `account_id = ""` stubs PR 4 deliberately left in mock-friendly call sites with real values threaded from each caller.
- Where session_id is in scope (tools, harness, sandbox, mcp, `sse_event_stream`): loads account_id via `sessions_service.load_session_account_id`.
- Where the path is genuinely cross-tenant (auth bootstrap, account bootstrap, orphan-container reap, attachment GC, per-store memory materialization, cross-account runtime SSE streams): drops the now-redundant `account_id` parameter from the underlying queries, which never used it in SQL.
- `resolve_runtime_token` now returns account_id from the matched row, so `require_runtime_auth` produces `(token_id, connector, account_id)`. The six runtime-auth routes in `routers/connectors.py` and three streams in `api/sse.py` thread on the third element.
- Static-scope bug fix in `sandbox/spec.py`: four functions had inner `from aios.harness import runtime` *after* my added load call, which made Python treat the symbol as local for the whole function and raised `UnboundLocalError` at the use line. Hoisted the import to module scope and removed the four redundant inner imports.
- Unit tests gain an autouse fixture mocking `load_session_account_id` so MagicMock-backed pool tests don't try to await a Mock.

## Test plan
- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1161 passed
- [x] `DOCKER_HOST=… uv run pytest tests/e2e -q` — 322/323 passed; the one fail is unrelated `test_image_architecture_matches_runner` (arm64 host vs amd64 sandbox image)

Stacked onto `epic/multitenancy` (merge into master once PR 4's earlier merges land in line). Capstone unblocks PR 5b (INSERT account_id + backfill migration + SET NOT NULL).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)