### PR TITLE
feat(#367): PR 6 (partial) — WHERE account_id on primary resource gets

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -537,9 +537,10 @@ async def get_agent_version(
     account_id: str,
 ) -> AgentVersion:
     row = await conn.fetchrow(
-        "SELECT * FROM agent_versions WHERE agent_id = $1 AND version = $2",
+        "SELECT * FROM agent_versions WHERE agent_id = $1 AND version = $2 AND account_id = $3",
         agent_id,
         version,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -3376,12 +3377,13 @@ async def archive_connection(
                    updated_at         = now(),
                    secrets_ciphertext = NULL,
                    secrets_nonce      = NULL
-             WHERE id = $1 AND archived_at IS NULL
+             WHERE id = $1 AND archived_at IS NULL AND account_id = $2
             RETURNING *
         )
         {_CONNECTION_UPDATE_CTE_TAIL}
         """,
         connection_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -3464,9 +3466,10 @@ async def delete_chat_session(
     it returns the chat to the connection's mode-default fallback.
     """
     result = await conn.execute(
-        "DELETE FROM chat_sessions WHERE connection_id = $1 AND chat_id = $2",
+        "DELETE FROM chat_sessions WHERE connection_id = $1 AND chat_id = $2 AND account_id = $3",
         connection_id,
         chat_id,
+        account_id,
     )
     return bool(result.endswith(" 1"))
 
@@ -3488,10 +3491,11 @@ async def get_chat_session_row(
         """
         SELECT chat_id, session_id, created_at
           FROM chat_sessions
-         WHERE connection_id = $1 AND chat_id = $2
+         WHERE connection_id = $1 AND chat_id = $2 AND account_id = $3
         """,
         connection_id,
         chat_id,
+        account_id,
     )
     if row is None:
         return None
@@ -3515,10 +3519,11 @@ async def list_chat_sessions_for_connection(
         """
         SELECT chat_id, session_id, created_at
           FROM chat_sessions
-         WHERE connection_id = $1
+         WHERE connection_id = $1 AND account_id = $2
          ORDER BY chat_id
         """,
         connection_id,
+        account_id,
     )
     return [(r["chat_id"], r["session_id"], r["created_at"]) for r in rows]
 
@@ -3547,8 +3552,10 @@ async def list_routing_rules_for_connection(
           JOIN bindings b ON b.id = rr.binding_id
          WHERE b.connection_id = $1
            AND b.archived_at IS NULL
+           AND b.account_id = $2
         """,
         connection_id,
+        account_id,
     )
     return [(row["prefix"], row["target_type"], row["target_id"]) for row in rows]
 
@@ -5060,10 +5067,11 @@ async def list_runtime_tokens(
     rows = await conn.fetch(
         """
         SELECT * FROM runtime_tokens
-         WHERE connector = $1
+         WHERE connector = $1 AND account_id = $2
          ORDER BY created_at DESC
         """,
         connector,
+        account_id,
     )
     return [_row_to_runtime_token(r) for r in rows]
 
@@ -5076,10 +5084,11 @@ async def revoke_runtime_token(
         """
         UPDATE runtime_tokens
            SET revoked_at = now()
-         WHERE id = $1 AND revoked_at IS NULL
+         WHERE id = $1 AND revoked_at IS NULL AND account_id = $2
         RETURNING *
         """,
         token_id,
+        account_id,
     )
     if row is not None:
         return _row_to_runtime_token(row)

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1037,8 +1037,16 @@ async def delete_session(
                 f"session {session_id} is running and cannot be deleted",
                 detail={"id": session_id},
             )
-        await conn.execute("DELETE FROM session_vaults WHERE session_id = $1", session_id)
-        await conn.execute("DELETE FROM events WHERE session_id = $1", session_id)
+        await conn.execute(
+            "DELETE FROM session_vaults WHERE session_id = $1 AND account_id = $2",
+            session_id,
+            account_id,
+        )
+        await conn.execute(
+            "DELETE FROM events WHERE session_id = $1 AND account_id = $2",
+            session_id,
+            account_id,
+        )
         await conn.execute(
             "DELETE FROM sessions WHERE id = $1 AND account_id = $2",
             session_id,
@@ -2464,8 +2472,9 @@ async def get_session_vault_ids(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> list[str]:
     rows = await conn.fetch(
-        "SELECT vault_id FROM session_vaults WHERE session_id = $1 ORDER BY rank",
+        "SELECT vault_id FROM session_vaults WHERE session_id = $1 AND account_id = $2 ORDER BY rank",
         session_id,
+        account_id,
     )
     return [str(r["vault_id"]) for r in rows]
 
@@ -2690,8 +2699,9 @@ async def insert_skill_version(
     files_json = json.dumps(files)
     async with conn.transaction():
         head = await conn.fetchrow(
-            "SELECT latest_version FROM skills WHERE id = $1 FOR UPDATE",
+            "SELECT latest_version FROM skills WHERE id = $1 AND account_id = $2 FOR UPDATE",
             skill_id,
+            account_id,
         )
         if head is None:
             raise NotFoundError(f"skill {skill_id} not found", detail={"id": skill_id})
@@ -2712,9 +2722,10 @@ async def insert_skill_version(
         )
         assert ver_row is not None
         await conn.execute(
-            "UPDATE skills SET latest_version = $2, updated_at = now() WHERE id = $1",
+            "UPDATE skills SET latest_version = $2, updated_at = now() WHERE id = $1 AND account_id = $3",
             skill_id,
             new_ver,
+            account_id,
         )
     return _row_to_skill_version(ver_row)
 
@@ -2727,9 +2738,10 @@ async def get_skill_version(
     account_id: str,
 ) -> SkillVersion:
     row = await conn.fetchrow(
-        "SELECT * FROM skill_versions WHERE skill_id = $1 AND version = $2",
+        "SELECT * FROM skill_versions WHERE skill_id = $1 AND version = $2 AND account_id = $3",
         skill_id,
         version,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -3405,9 +3417,10 @@ async def lookup_chat_session(
 ) -> str | None:
     """Existing session_id for ``(connection_id, chat_id)``, else ``None``."""
     val: str | None = await conn.fetchval(
-        "SELECT session_id FROM chat_sessions WHERE connection_id = $1 AND chat_id = $2",
+        "SELECT session_id FROM chat_sessions WHERE connection_id = $1 AND chat_id = $2 AND account_id = $3",
         connection_id,
         chat_id,
+        account_id,
     )
     return val
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -3155,8 +3155,9 @@ async def get_connection(
     conn: asyncpg.Connection[Any], connection_id: str, *, account_id: str
 ) -> Connection:
     row = await conn.fetchrow(
-        f"SELECT {_CONNECTION_COLUMNS} FROM {_CONNECTION_FROM} WHERE c.id = $1",
+        f"SELECT {_CONNECTION_COLUMNS} FROM {_CONNECTION_FROM} WHERE c.id = $1 AND c.account_id = $2",
         connection_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -3191,7 +3192,7 @@ async def set_connection_secrets(
                SET secrets_ciphertext = $2,
                    secrets_nonce      = $3,
                    updated_at         = now()
-             WHERE id = $1 AND archived_at IS NULL
+             WHERE id = $1 AND archived_at IS NULL AND account_id = $4
             RETURNING *
         )
         {_CONNECTION_UPDATE_CTE_TAIL}
@@ -3199,6 +3200,7 @@ async def set_connection_secrets(
         connection_id,
         ciphertext,
         nonce,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -3225,9 +3227,10 @@ async def get_connection_secret_blob(
         """
         SELECT secrets_ciphertext, secrets_nonce
           FROM connections
-         WHERE id = $1 AND archived_at IS NULL
+         WHERE id = $1 AND archived_at IS NULL AND account_id = $2
         """,
         connection_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -3289,9 +3292,11 @@ async def get_connection_for_account(
         SELECT {_CONNECTION_COLUMNS}
           FROM {_CONNECTION_FROM}
          WHERE c.connector = $1 AND c.account = $2 AND c.archived_at IS NULL
+           AND c.account_id = $3
         """,
         connector,
         account,
+        account_id,
     )
     if row is None:
         return None
@@ -3317,8 +3322,8 @@ async def list_connections(
     ``session_template_id`` instead).  ``mode`` filters on the active
     binding's mode or its absence (detached).
     """
-    clauses: list[str] = ["c.archived_at IS NULL"]
-    args: list[Any] = []
+    args: list[Any] = [account_id]
+    clauses: list[str] = ["c.archived_at IS NULL", "c.account_id = $1"]
     if connector is not None:
         args.append(connector)
         clauses.append(f"c.connector = ${len(args)}")

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -380,8 +380,8 @@ async def list_agents(
     after: str | None = None,
     name: str | None = None,
 ) -> list[Agent]:
-    where = ["archived_at IS NULL"]
-    args: list[Any] = []
+    args: list[Any] = [account_id]
+    where = ["archived_at IS NULL", "account_id = $1"]
     if name is not None:
         args.append(name)
         where.append(f"name = ${len(args)}")
@@ -560,16 +560,19 @@ async def list_agent_versions(
     """List versions in descending order (newest first)."""
     if after is None:
         rows = await conn.fetch(
-            "SELECT * FROM agent_versions WHERE agent_id = $1 ORDER BY version DESC LIMIT $2",
+            "SELECT * FROM agent_versions WHERE agent_id = $1 AND account_id = $2 "
+            "ORDER BY version DESC LIMIT $3",
             agent_id,
+            account_id,
             limit,
         )
     else:
         rows = await conn.fetch(
             "SELECT * FROM agent_versions WHERE agent_id = $1 AND version < $2 "
-            "ORDER BY version DESC LIMIT $3",
+            "AND account_id = $3 ORDER BY version DESC LIMIT $4",
             agent_id,
             after,
+            account_id,
             limit,
         )
     return [_row_to_agent_version(r) for r in rows]
@@ -783,8 +786,8 @@ async def list_sessions(
     limit: int = 50,
     after: str | None = None,
 ) -> list[Session]:
-    clauses: list[str] = ["archived_at IS NULL"]
-    args: list[Any] = []
+    args: list[Any] = [account_id]
+    clauses: list[str] = ["archived_at IS NULL", "account_id = $1"]
     if agent_id is not None:
         args.append(agent_id)
         clauses.append(f"agent_id = ${len(args)}")
@@ -2051,13 +2054,17 @@ async def list_vaults(
 ) -> list[Vault]:
     if after is None:
         rows = await conn.fetch(
-            "SELECT * FROM vaults WHERE archived_at IS NULL ORDER BY id DESC LIMIT $1",
+            "SELECT * FROM vaults WHERE archived_at IS NULL AND account_id = $1 "
+            "ORDER BY id DESC LIMIT $2",
+            account_id,
             limit,
         )
     else:
         rows = await conn.fetch(
-            "SELECT * FROM vaults WHERE archived_at IS NULL AND id < $1 ORDER BY id DESC LIMIT $2",
+            "SELECT * FROM vaults WHERE archived_at IS NULL AND id < $1 AND account_id = $2 "
+            "ORDER BY id DESC LIMIT $3",
             after,
+            account_id,
             limit,
         )
     return [_row_to_vault(r) for r in rows]
@@ -2609,13 +2616,17 @@ async def list_skills(
 ) -> list[Skill]:
     if after is None:
         rows = await conn.fetch(
-            "SELECT * FROM skills WHERE archived_at IS NULL ORDER BY id DESC LIMIT $1",
+            "SELECT * FROM skills WHERE archived_at IS NULL AND account_id = $1 "
+            "ORDER BY id DESC LIMIT $2",
+            account_id,
             limit,
         )
     else:
         rows = await conn.fetch(
-            "SELECT * FROM skills WHERE archived_at IS NULL AND id < $1 ORDER BY id DESC LIMIT $2",
+            "SELECT * FROM skills WHERE archived_at IS NULL AND id < $1 AND account_id = $2 "
+            "ORDER BY id DESC LIMIT $3",
             after,
+            account_id,
             limit,
         )
     return [_row_to_skill(r) for r in rows]
@@ -2727,16 +2738,19 @@ async def list_skill_versions(
     """List versions in descending order (newest first)."""
     if after is None:
         rows = await conn.fetch(
-            "SELECT * FROM skill_versions WHERE skill_id = $1 ORDER BY version DESC LIMIT $2",
+            "SELECT * FROM skill_versions WHERE skill_id = $1 AND account_id = $2 "
+            "ORDER BY version DESC LIMIT $3",
             skill_id,
+            account_id,
             limit,
         )
     else:
         rows = await conn.fetch(
             "SELECT * FROM skill_versions WHERE skill_id = $1 AND version < $2 "
-            "ORDER BY version DESC LIMIT $3",
+            "AND account_id = $3 ORDER BY version DESC LIMIT $4",
             skill_id,
             after,
+            account_id,
             limit,
         )
     return [_row_to_skill_version(r) for r in rows]

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -858,12 +858,13 @@ async def increment_session_usage(
         "output_tokens = output_tokens + $3, "
         "cache_read_input_tokens = cache_read_input_tokens + $4, "
         "cache_creation_input_tokens = cache_creation_input_tokens + $5 "
-        "WHERE id = $1",
+        "WHERE id = $1 AND account_id = $6",
         session_id,
         input_tokens,
         output_tokens,
         cache_read_input_tokens,
         cache_creation_input_tokens,
+        account_id,
     )
 
 
@@ -988,7 +989,11 @@ async def update_session(
         return await get_session(conn, session_id, account_id=account_id)
 
     sets.append("updated_at = now()")
-    sql = f"UPDATE sessions SET {', '.join(sets)} WHERE id = $1 RETURNING *"
+    args.append(account_id)
+    sql = (
+        f"UPDATE sessions SET {', '.join(sets)} "
+        f"WHERE id = $1 AND account_id = ${len(args)} RETURNING *"
+    )
     row = await conn.fetchrow(sql, *args)
     if row is None:
         raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
@@ -1000,8 +1005,9 @@ async def archive_session(
 ) -> Session:
     row = await conn.fetchrow(
         "UPDATE sessions SET archived_at = now(), updated_at = now() "
-        "WHERE id = $1 AND archived_at IS NULL RETURNING *",
+        "WHERE id = $1 AND archived_at IS NULL AND account_id = $2 RETURNING *",
         session_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -1510,8 +1516,9 @@ async def append_event(
     async with conn.transaction():
         seq_row = await conn.fetchrow(
             "UPDATE sessions SET last_event_seq = last_event_seq + 1 "
-            "WHERE id = $1 RETURNING last_event_seq, focal_channel",
+            "WHERE id = $1 AND account_id = $2 RETURNING last_event_seq, focal_channel",
             session_id,
+            account_id,
         )
         if seq_row is None:
             raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
@@ -3577,8 +3584,9 @@ async def flip_quiescent_to_pending(
     """
     await conn.execute(
         "UPDATE sessions SET status = 'pending', updated_at = now() "
-        "WHERE id = $1 AND status IN ('idle', 'errored')",
+        "WHERE id = $1 AND status IN ('idle', 'errored') AND account_id = $2",
         session_id,
+        account_id,
     )
 
 
@@ -3907,10 +3915,16 @@ async def list_memory_stores(
     limit: int = 100,
 ) -> list[MemoryStore]:
     if include_archived:
-        rows = await conn.fetch("SELECT * FROM memory_stores ORDER BY id DESC LIMIT $1", limit)
+        rows = await conn.fetch(
+            "SELECT * FROM memory_stores WHERE account_id = $1 ORDER BY id DESC LIMIT $2",
+            account_id,
+            limit,
+        )
     else:
         rows = await conn.fetch(
-            "SELECT * FROM memory_stores WHERE archived_at IS NULL ORDER BY id DESC LIMIT $1",
+            "SELECT * FROM memory_stores WHERE archived_at IS NULL AND account_id = $1 "
+            "ORDER BY id DESC LIMIT $2",
+            account_id,
             limit,
         )
     return [_row_to_memory_store(r) for r in rows]

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2149,8 +2149,9 @@ async def archive_vault(conn: asyncpg.Connection[Any], vault_id: str, *, account
             "UPDATE vault_credentials "
             "SET ciphertext = ''::bytea, nonce = ''::bytea, "
             "    archived_at = now(), updated_at = now() "
-            "WHERE vault_id = $1 AND archived_at IS NULL",
+            "WHERE vault_id = $1 AND archived_at IS NULL AND account_id = $2",
             vault_id,
+            account_id,
         )
     return _row_to_vault(row)
 
@@ -2525,10 +2526,12 @@ async def resolve_vault_credential(
          WHERE vault_id = $1
            AND mcp_server_url = $2
            AND archived_at IS NULL
+           AND account_id = $3
          LIMIT 1
         """,
         vault_id,
         mcp_server_url,
+        account_id,
     )
     if row is None:
         return None
@@ -3857,8 +3860,9 @@ async def archive_session_template(
     """
     row = await conn.fetchrow(
         "UPDATE session_templates SET archived_at = now(), updated_at = now() "
-        "WHERE id = $1 AND archived_at IS NULL RETURNING *",
+        "WHERE id = $1 AND archived_at IS NULL AND account_id = $2 RETURNING *",
         template_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -3956,7 +3960,11 @@ async def insert_memory_store(
 async def get_memory_store(
     conn: asyncpg.Connection[Any], store_id: str, *, account_id: str, allow_archived: bool = True
 ) -> MemoryStore:
-    row = await conn.fetchrow("SELECT * FROM memory_stores WHERE id = $1", store_id)
+    row = await conn.fetchrow(
+        "SELECT * FROM memory_stores WHERE id = $1 AND account_id = $2",
+        store_id,
+        account_id,
+    )
     if row is None:
         raise NotFoundError(f"memory store {store_id} not found", detail={"id": store_id})
     store = _row_to_memory_store(row)
@@ -4056,7 +4064,9 @@ async def delete_memory_store(
 # Memory + version (single-txn helpers) ────────────────────────────────────
 
 
-async def _allocate_version_seq(conn: asyncpg.Connection[Any], store_id: str) -> int:
+async def _allocate_version_seq(
+    conn: asyncpg.Connection[Any], store_id: str, *, account_id: str
+) -> int:
     """Bump ``last_version_seq`` on the store row and return the allocated seq.
 
     Mirror of the events seq allocation at append_event: row-lock the parent,
@@ -4065,13 +4075,16 @@ async def _allocate_version_seq(conn: asyncpg.Connection[Any], store_id: str) ->
     """
     row = await conn.fetchrow(
         "UPDATE memory_stores SET last_version_seq = last_version_seq + 1, "
-        "updated_at = now() WHERE id = $1 AND archived_at IS NULL "
+        "updated_at = now() WHERE id = $1 AND archived_at IS NULL AND account_id = $2 "
         "RETURNING last_version_seq",
         store_id,
+        account_id,
     )
     if row is None:
         existing = await conn.fetchrow(
-            "SELECT archived_at FROM memory_stores WHERE id = $1", store_id
+            "SELECT archived_at FROM memory_stores WHERE id = $1 AND account_id = $2",
+            store_id,
+            account_id,
         )
         if existing is None:
             raise NotFoundError(f"memory store {store_id} not found", detail={"id": store_id})
@@ -4106,7 +4119,7 @@ async def insert_memory_with_version(
 
     try:
         async with conn.transaction():
-            seq = await _allocate_version_seq(conn, store_id)
+            seq = await _allocate_version_seq(conn, store_id, account_id=account_id)
 
             # Version first — its `memory_id` column is non-FK, so the
             # not-yet-inserted memory row doesn't block this. Memory row
@@ -4344,7 +4357,7 @@ async def update_memory_with_version(
             next_path: str = new_path if new_path is not None else cur["path"]
             next_path_for_conflict = next_path
 
-            seq = await _allocate_version_seq(conn, store_id)
+            seq = await _allocate_version_seq(conn, store_id, account_id=account_id)
             version_id = make_id(MEMORY_VERSION)
             await conn.execute(
                 """
@@ -4424,7 +4437,7 @@ async def delete_memory_with_version(
                 detail={"id": memory_id, "memory_store_id": store_id},
             )
 
-        seq = await _allocate_version_seq(conn, store_id)
+        seq = await _allocate_version_seq(conn, store_id, account_id=account_id)
         version_id = make_id(MEMORY_VERSION)
         await conn.execute(
             """
@@ -4943,9 +4956,10 @@ async def get_management_call(
         """
         SELECT id, connector, method, params, status, result, is_error
           FROM pending_management_calls
-         WHERE id = $1
+         WHERE id = $1 AND account_id = $2
         """,
         call_id,
+        account_id,
     )
     if row is None:
         return None
@@ -4984,12 +4998,14 @@ async def mark_management_call_resolved(
                resolved_at = now()
          WHERE id = $1
            AND status = 'pending'
+           AND account_id = $5
          RETURNING id
         """,
         call_id,
         new_status,
         json.dumps(result),
         is_error,
+        account_id,
     )
     return row is not None
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1022,8 +1022,9 @@ async def delete_session(
 ) -> None:
     async with conn.transaction():
         row = await conn.fetchrow(
-            "SELECT status FROM sessions WHERE id = $1",
+            "SELECT status FROM sessions WHERE id = $1 AND account_id = $2",
             session_id,
+            account_id,
         )
         if row is None:
             raise NotFoundError(
@@ -1037,7 +1038,11 @@ async def delete_session(
             )
         await conn.execute("DELETE FROM session_vaults WHERE session_id = $1", session_id)
         await conn.execute("DELETE FROM events WHERE session_id = $1", session_id)
-        await conn.execute("DELETE FROM sessions WHERE id = $1", session_id)
+        await conn.execute(
+            "DELETE FROM sessions WHERE id = $1 AND account_id = $2",
+            session_id,
+            account_id,
+        )
 
 
 _CLONEABLE_STATUSES: tuple[SessionStatus, ...] = ("idle", "terminated")
@@ -2096,7 +2101,11 @@ async def update_vault(
     if not sets:
         return await get_vault(conn, vault_id, account_id=account_id)
     sets.append("updated_at = now()")
-    sql = f"UPDATE vaults SET {', '.join(sets)} WHERE id = $1 RETURNING *"
+    args.append(account_id)
+    sql = (
+        f"UPDATE vaults SET {', '.join(sets)} "
+        f"WHERE id = $1 AND account_id = ${len(args)} RETURNING *"
+    )
     row = await conn.fetchrow(sql, *args)
     if row is None:
         raise NotFoundError(f"vault {vault_id} not found", detail={"id": vault_id})
@@ -2113,8 +2122,9 @@ async def archive_vault(conn: asyncpg.Connection[Any], vault_id: str, *, account
     async with conn.transaction():
         row = await conn.fetchrow(
             "UPDATE vaults SET archived_at = now(), updated_at = now() "
-            "WHERE id = $1 AND archived_at IS NULL RETURNING *",
+            "WHERE id = $1 AND archived_at IS NULL AND account_id = $2 RETURNING *",
             vault_id,
+            account_id,
         )
         if row is None:
             raise NotFoundError(
@@ -3697,7 +3707,11 @@ async def insert_session_template(
 async def get_session_template(
     conn: asyncpg.Connection[Any], template_id: str, *, account_id: str
 ) -> SessionTemplate:
-    row = await conn.fetchrow("SELECT * FROM session_templates WHERE id = $1", template_id)
+    row = await conn.fetchrow(
+        "SELECT * FROM session_templates WHERE id = $1 AND account_id = $2",
+        template_id,
+        account_id,
+    )
     if row is None:
         raise NotFoundError(
             f"session template {template_id} not found",
@@ -3763,7 +3777,11 @@ async def update_session_template(
     if not sets:
         return await get_session_template(conn, template_id, account_id=account_id)
     sets.append("updated_at = now()")
-    sql = f"UPDATE session_templates SET {', '.join(sets)} WHERE id = $1 RETURNING *"
+    args.append(account_id)
+    sql = (
+        f"UPDATE session_templates SET {', '.join(sets)} "
+        f"WHERE id = $1 AND account_id = ${len(args)} RETURNING *"
+    )
     try:
         row = await conn.fetchrow(sql, *args)
     except asyncpg.UniqueViolationError as exc:
@@ -3953,7 +3971,11 @@ async def update_memory_store(
     if not sets:
         return await get_memory_store(conn, store_id, account_id=account_id)
     sets.append("updated_at = now()")
-    sql = f"UPDATE memory_stores SET {', '.join(sets)} WHERE id = $1 RETURNING *"
+    args.append(account_id)
+    sql = (
+        f"UPDATE memory_stores SET {', '.join(sets)} "
+        f"WHERE id = $1 AND account_id = ${len(args)} RETURNING *"
+    )
     row = await conn.fetchrow(sql, *args)
     if row is None:
         raise NotFoundError(f"memory store {store_id} not found", detail={"id": store_id})
@@ -3979,7 +4001,11 @@ async def archive_memory_store(
 async def delete_memory_store(
     conn: asyncpg.Connection[Any], store_id: str, *, account_id: str
 ) -> None:
-    result = await conn.execute("DELETE FROM memory_stores WHERE id = $1", store_id)
+    result = await conn.execute(
+        "DELETE FROM memory_stores WHERE id = $1 AND account_id = $2",
+        store_id,
+        account_id,
+    )
     if result == "DELETE 0":
         raise NotFoundError(f"memory store {store_id} not found", detail={"id": store_id})
 
@@ -5041,7 +5067,11 @@ async def revoke_runtime_token(
     )
     if row is not None:
         return _row_to_runtime_token(row)
-    existing = await conn.fetchrow("SELECT * FROM runtime_tokens WHERE id = $1", token_id)
+    existing = await conn.fetchrow(
+        "SELECT * FROM runtime_tokens WHERE id = $1 AND account_id = $2",
+        token_id,
+        account_id,
+    )
     if existing is None:
         raise NotFoundError(
             f"runtime_token {token_id} not found",

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2228,9 +2228,10 @@ async def get_vault_credential(
     account_id: str,
 ) -> VaultCredential:
     row = await conn.fetchrow(
-        "SELECT * FROM vault_credentials WHERE id = $1 AND vault_id = $2",
+        "SELECT * FROM vault_credentials WHERE id = $1 AND vault_id = $2 AND account_id = $3",
         credential_id,
         vault_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -2256,9 +2257,10 @@ async def lock_oauth_credential_for_refresh(
     row = await conn.fetchrow(
         "SELECT id, ciphertext, nonce FROM vault_credentials "
         "WHERE vault_id = $1 AND mcp_server_url = $2 AND archived_at IS NULL "
-        "FOR UPDATE",
+        "AND account_id = $3 FOR UPDATE",
         vault_id,
         mcp_server_url,
+        account_id,
     )
     if row is None:
         return None
@@ -2279,9 +2281,10 @@ async def get_vault_credential_with_blob(
     (and gets zeroed out at archive time).
     """
     row = await conn.fetchrow(
-        "SELECT * FROM vault_credentials WHERE id = $1 AND vault_id = $2 AND archived_at IS NULL",
+        "SELECT * FROM vault_credentials WHERE id = $1 AND vault_id = $2 AND archived_at IS NULL AND account_id = $3",
         credential_id,
         vault_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -2304,17 +2307,20 @@ async def list_vault_credentials(
     if after is None:
         rows = await conn.fetch(
             "SELECT * FROM vault_credentials "
-            "WHERE vault_id = $1 AND archived_at IS NULL ORDER BY id DESC LIMIT $2",
+            "WHERE vault_id = $1 AND archived_at IS NULL AND account_id = $2 "
+            "ORDER BY id DESC LIMIT $3",
             vault_id,
+            account_id,
             limit,
         )
     else:
         rows = await conn.fetch(
             "SELECT * FROM vault_credentials "
             "WHERE vault_id = $1 AND archived_at IS NULL AND id < $2 "
-            "ORDER BY id DESC LIMIT $3",
+            "AND account_id = $3 ORDER BY id DESC LIMIT $4",
             vault_id,
             after,
+            account_id,
             limit,
         )
     return [_row_to_vault_credential(r) for r in rows]
@@ -2346,9 +2352,10 @@ async def update_vault_credential(
     if not sets:
         return await get_vault_credential(conn, vault_id, credential_id, account_id=account_id)
     sets.append("updated_at = now()")
+    args.append(account_id)
     sql = (
         f"UPDATE vault_credentials SET {', '.join(sets)} "
-        f"WHERE id = $1 AND vault_id = $2 RETURNING *"
+        f"WHERE id = $1 AND vault_id = $2 AND account_id = ${len(args)} RETURNING *"
     )
     row = await conn.fetchrow(sql, *args)
     if row is None:
@@ -2376,9 +2383,10 @@ async def archive_vault_credential(
         "UPDATE vault_credentials "
         "SET ciphertext = ''::bytea, nonce = ''::bytea, "
         "    archived_at = now(), updated_at = now() "
-        "WHERE id = $1 AND vault_id = $2 AND archived_at IS NULL RETURNING *",
+        "WHERE id = $1 AND vault_id = $2 AND archived_at IS NULL AND account_id = $3 RETURNING *",
         credential_id,
         vault_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -2396,9 +2404,10 @@ async def delete_vault_credential(
     account_id: str,
 ) -> None:
     result = await conn.execute(
-        "DELETE FROM vault_credentials WHERE id = $1 AND vault_id = $2",
+        "DELETE FROM vault_credentials WHERE id = $1 AND vault_id = $2 AND account_id = $3",
         credential_id,
         vault_id,
+        account_id,
     )
     if result == "DELETE 0":
         raise NotFoundError(
@@ -2411,8 +2420,10 @@ async def count_active_vault_credentials(
     conn: asyncpg.Connection[Any], vault_id: str, *, account_id: str
 ) -> int:
     row = await conn.fetchrow(
-        "SELECT count(*) AS cnt FROM vault_credentials WHERE vault_id = $1 AND archived_at IS NULL",
+        "SELECT count(*) AS cnt FROM vault_credentials "
+        "WHERE vault_id = $1 AND archived_at IS NULL AND account_id = $2",
         vault_id,
+        account_id,
     )
     assert row is not None
     result: int = row["cnt"]

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -116,7 +116,11 @@ async def insert_environment(
 async def get_environment(
     conn: asyncpg.Connection[Any], env_id: str, *, account_id: str
 ) -> Environment:
-    row = await conn.fetchrow("SELECT * FROM environments WHERE id = $1", env_id)
+    row = await conn.fetchrow(
+        "SELECT * FROM environments WHERE id = $1 AND account_id = $2",
+        env_id,
+        account_id,
+    )
     if row is None:
         raise NotFoundError(f"environment {env_id} not found", detail={"id": env_id})
     return _row_to_environment(row)
@@ -127,14 +131,17 @@ async def list_environments(
 ) -> list[Environment]:
     if after is None:
         rows = await conn.fetch(
-            "SELECT * FROM environments WHERE archived_at IS NULL ORDER BY id DESC LIMIT $1",
+            "SELECT * FROM environments WHERE archived_at IS NULL AND account_id = $1 "
+            "ORDER BY id DESC LIMIT $2",
+            account_id,
             limit,
         )
     else:
         rows = await conn.fetch(
             "SELECT * FROM environments WHERE archived_at IS NULL AND id < $1 "
-            "ORDER BY id DESC LIMIT $2",
+            "AND account_id = $2 ORDER BY id DESC LIMIT $3",
             after,
+            account_id,
             limit,
         )
     return [_row_to_environment(r) for r in rows]
@@ -144,8 +151,10 @@ async def archive_environment(
     conn: asyncpg.Connection[Any], env_id: str, *, account_id: str
 ) -> None:
     result = await conn.execute(
-        "UPDATE environments SET archived_at = now() WHERE id = $1 AND archived_at IS NULL",
+        "UPDATE environments SET archived_at = now() "
+        "WHERE id = $1 AND archived_at IS NULL AND account_id = $2",
         env_id,
+        account_id,
     )
     if result == "UPDATE 0":
         raise NotFoundError(f"environment {env_id} not found or already archived")
@@ -174,10 +183,12 @@ async def update_environment(
     config_json = json.dumps(new_config.model_dump(exclude_none=True))
     try:
         row = await conn.fetchrow(
-            "UPDATE environments SET name = $2, config = $3::jsonb WHERE id = $1 RETURNING *",
+            "UPDATE environments SET name = $2, config = $3::jsonb "
+            "WHERE id = $1 AND account_id = $4 RETURNING *",
             env_id,
             new_name,
             config_json,
+            account_id,
         )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
@@ -351,7 +362,11 @@ async def insert_agent(
 
 
 async def get_agent(conn: asyncpg.Connection[Any], agent_id: str, *, account_id: str) -> Agent:
-    row = await conn.fetchrow("SELECT * FROM agents WHERE id = $1", agent_id)
+    row = await conn.fetchrow(
+        "SELECT * FROM agents WHERE id = $1 AND account_id = $2",
+        agent_id,
+        account_id,
+    )
     if row is None:
         raise NotFoundError(f"agent {agent_id} not found", detail={"id": agent_id})
     return _row_to_agent(row)
@@ -381,8 +396,10 @@ async def list_agents(
 
 async def archive_agent(conn: asyncpg.Connection[Any], agent_id: str, *, account_id: str) -> None:
     result = await conn.execute(
-        "UPDATE agents SET archived_at = now() WHERE id = $1 AND archived_at IS NULL",
+        "UPDATE agents SET archived_at = now() "
+        "WHERE id = $1 AND archived_at IS NULL AND account_id = $2",
         agent_id,
+        account_id,
     )
     if result == "UPDATE 0":
         raise NotFoundError(f"agent {agent_id} not found or already archived")
@@ -661,7 +678,11 @@ async def insert_session(
 async def get_session(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> Session:
-    row = await conn.fetchrow("SELECT * FROM sessions WHERE id = $1", session_id)
+    row = await conn.fetchrow(
+        "SELECT * FROM sessions WHERE id = $1 AND account_id = $2",
+        session_id,
+        account_id,
+    )
     if row is None:
         raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
     return _row_to_session(row)
@@ -672,7 +693,9 @@ async def get_session_workspace_path(
 ) -> str:
     """Return the host-side workspace path stored on the session row."""
     val: str | None = await conn.fetchval(
-        "SELECT workspace_volume_path FROM sessions WHERE id = $1", session_id
+        "SELECT workspace_volume_path FROM sessions WHERE id = $1 AND account_id = $2",
+        session_id,
+        account_id,
     )
     if val is None:
         raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
@@ -684,8 +707,9 @@ async def get_session_focal_channel(
 ) -> str | None:
     """Return the session's current ``focal_channel`` (or NULL = phone down)."""
     focal: str | None = await conn.fetchval(
-        "SELECT focal_channel FROM sessions WHERE id = $1",
+        "SELECT focal_channel FROM sessions WHERE id = $1 AND account_id = $2",
         session_id,
+        account_id,
     )
     return focal
 
@@ -704,8 +728,9 @@ async def is_session_focal_locked(
     session id, so a missing row is a real bug, not a permission state.
     """
     locked: bool | None = await conn.fetchval(
-        "SELECT focal_locked FROM sessions WHERE id = $1",
+        "SELECT focal_locked FROM sessions WHERE id = $1 AND account_id = $2",
         session_id,
+        account_id,
     )
     if locked is None:
         raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
@@ -738,7 +763,9 @@ async def get_session_provisioning(
 ) -> tuple[str, dict[str, str]]:
     """Return ``(workspace_volume_path, env)`` for provisioning a session's container."""
     row = await conn.fetchrow(
-        "SELECT workspace_volume_path, env FROM sessions WHERE id = $1", session_id
+        "SELECT workspace_volume_path, env FROM sessions WHERE id = $1 AND account_id = $2",
+        session_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
@@ -2009,7 +2036,11 @@ async def insert_vault(
 
 
 async def get_vault(conn: asyncpg.Connection[Any], vault_id: str, *, account_id: str) -> Vault:
-    row = await conn.fetchrow("SELECT * FROM vaults WHERE id = $1", vault_id)
+    row = await conn.fetchrow(
+        "SELECT * FROM vaults WHERE id = $1 AND account_id = $2",
+        vault_id,
+        account_id,
+    )
     if row is None:
         raise NotFoundError(f"vault {vault_id} not found", detail={"id": vault_id})
     return _row_to_vault(row)
@@ -2090,7 +2121,11 @@ async def archive_vault(conn: asyncpg.Connection[Any], vault_id: str, *, account
 
 async def delete_vault(conn: asyncpg.Connection[Any], vault_id: str, *, account_id: str) -> None:
     # Child credentials are removed by ``ON DELETE CASCADE`` (migration 0015).
-    result = await conn.execute("DELETE FROM vaults WHERE id = $1", vault_id)
+    result = await conn.execute(
+        "DELETE FROM vaults WHERE id = $1 AND account_id = $2",
+        vault_id,
+        account_id,
+    )
     if result == "DELETE 0":
         raise NotFoundError(f"vault {vault_id} not found", detail={"id": vault_id})
 
@@ -2559,7 +2594,11 @@ async def insert_skill(
 
 
 async def get_skill(conn: asyncpg.Connection[Any], skill_id: str, *, account_id: str) -> Skill:
-    row = await conn.fetchrow("SELECT * FROM skills WHERE id = $1", skill_id)
+    row = await conn.fetchrow(
+        "SELECT * FROM skills WHERE id = $1 AND account_id = $2",
+        skill_id,
+        account_id,
+    )
     if row is None:
         raise NotFoundError(f"skill {skill_id} not found", detail={"id": skill_id})
     return _row_to_skill(row)
@@ -2584,8 +2623,10 @@ async def list_skills(
 
 async def archive_skill(conn: asyncpg.Connection[Any], skill_id: str, *, account_id: str) -> None:
     result = await conn.execute(
-        "UPDATE skills SET archived_at = now() WHERE id = $1 AND archived_at IS NULL",
+        "UPDATE skills SET archived_at = now() "
+        "WHERE id = $1 AND archived_at IS NULL AND account_id = $2",
         skill_id,
+        account_id,
     )
     if result == "UPDATE 0":
         raise NotFoundError(f"skill {skill_id} not found or already archived")

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -4159,9 +4159,11 @@ async def get_memory(
     include_content: bool = True,
 ) -> Memory:
     row = await conn.fetchrow(
-        "SELECT * FROM memories WHERE memory_store_id = $1 AND id = $2 AND deleted_at IS NULL",
+        "SELECT * FROM memories WHERE memory_store_id = $1 AND id = $2 "
+        "AND deleted_at IS NULL AND account_id = $3",
         store_id,
         memory_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -4180,9 +4182,11 @@ async def get_memory_by_path(
     include_content: bool = True,
 ) -> Memory | None:
     row = await conn.fetchrow(
-        "SELECT * FROM memories WHERE memory_store_id = $1 AND path = $2 AND deleted_at IS NULL",
+        "SELECT * FROM memories WHERE memory_store_id = $1 AND path = $2 "
+        "AND deleted_at IS NULL AND account_id = $3",
         store_id,
         path,
+        account_id,
     )
     if row is None:
         return None
@@ -4438,8 +4442,8 @@ async def list_memory_versions(
     memory_id: str | None = None,
     limit: int = 100,
 ) -> list[MemoryVersion]:
-    where = "memory_store_id = $1"
-    args: list[Any] = [store_id]
+    args: list[Any] = [store_id, account_id]
+    where = "memory_store_id = $1 AND account_id = $2"
     if memory_id is not None:
         args.append(memory_id)
         where += f" AND memory_id = ${len(args)}"
@@ -4459,9 +4463,10 @@ async def get_memory_version(
     account_id: str,
 ) -> MemoryVersion:
     row = await conn.fetchrow(
-        "SELECT * FROM memory_versions WHERE memory_store_id = $1 AND id = $2",
+        "SELECT * FROM memory_versions WHERE memory_store_id = $1 AND id = $2 AND account_id = $3",
         store_id,
         version_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -487,7 +487,7 @@ async def update_agent(
                    litellm_extra = $11::jsonb,
                    window_min = $12, window_max = $13,
                    updated_at = now()
-             WHERE id = $1
+             WHERE id = $1 AND account_id = $14
             RETURNING *
             """,
             agent_id,
@@ -503,6 +503,7 @@ async def update_agent(
             extra_json,
             new_wmin,
             new_wmax,
+            account_id,
         )
         assert row is not None
         await conn.execute(
@@ -1092,8 +1093,9 @@ async def clone_session(
 
     async with conn.transaction():
         status = await conn.fetchval(
-            "SELECT status FROM sessions WHERE id = $1 FOR UPDATE",
+            "SELECT status FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
             parent_session_id,
+            account_id,
         )
         if status is None:
             raise NotFoundError(
@@ -1720,8 +1722,9 @@ async def list_pending_calls_for_session_and_connection(
 
     sess_row = await conn.fetchrow(
         "SELECT stop_reason, status, focal_channel FROM sessions "
-        "WHERE id = $1 AND archived_at IS NULL",
+        "WHERE id = $1 AND archived_at IS NULL AND account_id = $2",
         session_id,
+        account_id,
     )
     if sess_row is None:
         return []
@@ -2451,7 +2454,11 @@ async def set_session_vaults(
 ) -> None:
     """Replace the session's vault bindings. Order is preserved via rank."""
     async with conn.transaction():
-        await conn.execute("DELETE FROM session_vaults WHERE session_id = $1", session_id)
+        await conn.execute(
+            "DELETE FROM session_vaults WHERE session_id = $1 AND account_id = $2",
+            session_id,
+            account_id,
+        )
         for rank, vault_id in enumerate(vault_ids):
             try:
                 await conn.execute(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,7 +185,6 @@ async def aios_env(aios_env_minimal: dict[str, str]) -> dict[str, str]:
     """
     import asyncpg
 
-    from aios.db import queries
     from aios.services.accounts import hash_key
 
     plaintext = aios_env_minimal["AIOS_API_KEY"]
@@ -193,24 +192,24 @@ async def aios_env(aios_env_minimal: dict[str, str]) -> dict[str, str]:
 
     conn = await asyncpg.connect(db_url)
     try:
-        root, _key_id = await queries.bootstrap_root_account(
-            conn,
-            display_name="root",
-            key_hash=hash_key(plaintext),
-            key_label="test-root",
-        )
-        # PR 4: many tests still pass the PR 3 stub literal ``"acc_test_stub"``
-        # as the account_id arg. Now that migration 0043 enforces NOT NULL +
-        # FK on every resource table, the stub must correspond to an actual
-        # row. Insert it as a child of root so existing test bodies keep
-        # working without sweeping rewrites.
+        # PR 6: insert ``acc_test_stub`` as the root account itself and bind
+        # the bootstrap API key directly to it, so auth resolves the bearer
+        # to the same account_id every test body uses as its scoping arg.
+        # Bypasses ``bootstrap_root_account`` (which would generate a fresh
+        # ULID we'd have to thread back through 44 test files).
         await conn.execute(
             """
             INSERT INTO accounts
                 (id, parent_account_id, can_mint_children, display_name)
-            VALUES ('acc_test_stub', $1, FALSE, 'test-stub')
+            VALUES ('acc_test_stub', NULL, TRUE, 'test-root')
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO account_keys (key_id, account_id, hash, label)
+            VALUES ('akey_test', 'acc_test_stub', $1, 'test-root')
             """,
-            root.id,
+            hash_key(plaintext),
         )
     finally:
         await conn.close()


### PR DESCRIPTION
## Summary
Adds `WHERE account_id = $N` to ~50 queries across queries.py covering primary resource lookups, lists, mutations, and the auth-critical management-calls path.

**Test fixture reshaping:** the `aios_env` fixture now inserts `acc_test_stub` directly as a root account with the bootstrap API key bound to it. Without this, the bearer auth would resolve to a fresh root ULID while test bodies pass `acc_test_stub` — every WHERE clause would filter out test-seeded rows. Bypasses `bootstrap_root_account` for tests (which would generate a ULID we'd have to thread back through 44 test files).

## Coverage

**Per-id reads / archives / updates:**
- `environments` (get / list / archive / update)
- `agents` (get / archive / update — incl. dynamic-SET 14-arg form)
- `vaults` (get / delete / update / archive / ensure_active)
- `skills` (get / archive / atomic latest-version bump FOR UPDATE + UPDATE)
- `memory_stores` (get / list / update / archive / delete / get-leftover / `_allocate_version_seq` internal helper)
- `sessions` (get / workspace_path / focal_channel / focal_locked / provisioning / status mutations / tokens / dynamic-update / archive / delete / last_event_seq / inbound-ack flip / clone status FOR UPDATE / pending-call dispatch)
- `session_templates` (get / update / archive)
- `vault_credentials` (full: get x2 / list x2 branches / update / archive / delete / count + `resolve_mcp_credential`'s FOR UPDATE + LIMIT 1 by-url variant)
- `runtime_tokens` (get / list / revoke)
- `connections` (get / set_secrets / get_secret_blob / get_for_account / list / archive — CTE WHERE)
- `chat_sessions` (delete / get / list / session-id lookup)
- `routing_rules` (list — via bindings.account_id JOIN)
- `agent_versions` (get / list / paginator)
- `skill_versions` (get / list / paginator)
- `memories` (get-by-id / get-by-path)
- `memory_versions` (get / list — dynamic WHERE)
- `management_calls` (get / mark_resolved)
- `delete_session` cascade DELETEs on `session_vaults`, `events`
- `rebind_session_vaults` DELETE
- `get_session_vault_ids`

**List queries with dynamic clause builders:** `list_agents`, `list_sessions`, `list_vaults`, `list_skills`, `list_agent_versions`, `list_skill_versions`, `list_memory_stores`, `list_connections`, `list_memory_versions`.

**Skipped — transitively scoped:** events / files / session_vaults / session_memory_stores / session_github_repositories selects keyed by `session_id` (which is FK-NOT-NULL on `sessions.account_id`); adding account_id is belt-and-suspenders not flagged for this PR.

## Test plan
- [x] `uv run mypy src` — clean (150 files)
- [x] `uv run ruff check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1161 passed
- [x] `DOCKER_HOST=… uv run pytest tests/e2e --ignore=test_sandbox_image_contract -q` — 296/299 pass; the 3 failures are the persistent signal/telegram/registration infra flakes (same set that admin-merged on PR 5b)

Stacked onto `epic/multitenancy` post-PR-5b merge. Rebased; mergeable.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
