### PR TITLE
fix(#389): rename ?after_seq to ?after on session events endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1848,6 +1848,7 @@
           "sessions"
         ],
         "summary": "List Events",
+        "description": "List events for a session, paginated by sequence number.\n\nPass the response's ``next_after`` field as ``?after=`` on the next call\nto walk forward through the stream. (The query param was previously\nnamed ``after_seq``, which didn't match the ``next_after`` response\nfield \u2014 clients following the natural roundtrip pattern sent\n``?after=`` and got it silently ignored, causing pagination to loop on\nthe first page. See issue #389.)",
         "operationId": "list_session_events",
         "parameters": [
           {
@@ -1860,13 +1861,13 @@
             }
           },
           {
-            "name": "after_seq",
+            "name": "after",
             "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
               "default": 0,
-              "title": "After Seq"
+              "title": "After"
             }
           },
           {
@@ -2087,7 +2088,7 @@
           "sessions"
         ],
         "summary": "Wait For Events",
-        "description": "Long-poll for new events past ``after_seq``.\n\nBlocks up to ``timeout`` seconds for events to arrive; returns an empty\nlist if none land in time. Alternative to SSE for clients whose HTTP\nstack can't reliably consume server-sent events (notably Node's\n``fetch`` \u2014 see issue #40).",
+        "description": "Long-poll for new events past sequence number ``after``.\n\nBlocks up to ``timeout`` seconds for events to arrive; returns an empty\nlist if none land in time. Alternative to SSE for clients whose HTTP\nstack can't reliably consume server-sent events (notably Node's\n``fetch`` \u2014 see issue #40).\n\nPass the response's ``next_after`` as ``?after=`` on the next call to\nresume from where you left off. (The query param was previously named\n``after_seq``; see issue #389.)",
         "operationId": "wait_for_events_v1_sessions__session_id__wait_get",
         "parameters": [
           {
@@ -2100,13 +2101,13 @@
             }
           },
           {
-            "name": "after_seq",
+            "name": "after",
             "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
               "default": 0,
-              "title": "After Seq"
+              "title": "After"
             }
           },
           {

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/list_session_events.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/list_session_events.py
@@ -15,7 +15,7 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     session_id: str,
     *,
-    after_seq: int | Unset = 0,
+    after: int | Unset = 0,
     kind: ListSessionEventsKindType0 | None | Unset = UNSET,
     limit: int | Unset = 200,
     error_only: bool | Unset = False,
@@ -27,7 +27,7 @@ def _get_kwargs(
 
     params: dict[str, Any] = {}
 
-    params["after_seq"] = after_seq
+    params["after"] = after
 
     json_kind: None | str | Unset
     if isinstance(kind, Unset):
@@ -90,7 +90,7 @@ def sync_detailed(
     session_id: str,
     *,
     client: AuthenticatedClient | Client,
-    after_seq: int | Unset = 0,
+    after: int | Unset = 0,
     kind: ListSessionEventsKindType0 | None | Unset = UNSET,
     limit: int | Unset = 200,
     error_only: bool | Unset = False,
@@ -98,9 +98,18 @@ def sync_detailed(
 ) -> Response[HTTPValidationError | ListResponseEvent]:
     """List Events
 
+     List events for a session, paginated by sequence number.
+
+    Pass the response's ``next_after`` field as ``?after=`` on the next call
+    to walk forward through the stream. (The query param was previously
+    named ``after_seq``, which didn't match the ``next_after`` response
+    field — clients following the natural roundtrip pattern sent
+    ``?after=`` and got it silently ignored, causing pagination to loop on
+    the first page. See issue #389.)
+
     Args:
         session_id (str):
-        after_seq (int | Unset):  Default: 0.
+        after (int | Unset):  Default: 0.
         kind (ListSessionEventsKindType0 | None | Unset):
         limit (int | Unset):  Default: 200.
         error_only (bool | Unset):  Default: False.
@@ -116,7 +125,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         session_id=session_id,
-        after_seq=after_seq,
+        after=after,
         kind=kind,
         limit=limit,
         error_only=error_only,
@@ -134,7 +143,7 @@ def sync(
     session_id: str,
     *,
     client: AuthenticatedClient | Client,
-    after_seq: int | Unset = 0,
+    after: int | Unset = 0,
     kind: ListSessionEventsKindType0 | None | Unset = UNSET,
     limit: int | Unset = 200,
     error_only: bool | Unset = False,
@@ -142,9 +151,18 @@ def sync(
 ) -> HTTPValidationError | ListResponseEvent | None:
     """List Events
 
+     List events for a session, paginated by sequence number.
+
+    Pass the response's ``next_after`` field as ``?after=`` on the next call
+    to walk forward through the stream. (The query param was previously
+    named ``after_seq``, which didn't match the ``next_after`` response
+    field — clients following the natural roundtrip pattern sent
+    ``?after=`` and got it silently ignored, causing pagination to loop on
+    the first page. See issue #389.)
+
     Args:
         session_id (str):
-        after_seq (int | Unset):  Default: 0.
+        after (int | Unset):  Default: 0.
         kind (ListSessionEventsKindType0 | None | Unset):
         limit (int | Unset):  Default: 200.
         error_only (bool | Unset):  Default: False.
@@ -161,7 +179,7 @@ def sync(
     return sync_detailed(
         session_id=session_id,
         client=client,
-        after_seq=after_seq,
+        after=after,
         kind=kind,
         limit=limit,
         error_only=error_only,
@@ -173,7 +191,7 @@ async def asyncio_detailed(
     session_id: str,
     *,
     client: AuthenticatedClient | Client,
-    after_seq: int | Unset = 0,
+    after: int | Unset = 0,
     kind: ListSessionEventsKindType0 | None | Unset = UNSET,
     limit: int | Unset = 200,
     error_only: bool | Unset = False,
@@ -181,9 +199,18 @@ async def asyncio_detailed(
 ) -> Response[HTTPValidationError | ListResponseEvent]:
     """List Events
 
+     List events for a session, paginated by sequence number.
+
+    Pass the response's ``next_after`` field as ``?after=`` on the next call
+    to walk forward through the stream. (The query param was previously
+    named ``after_seq``, which didn't match the ``next_after`` response
+    field — clients following the natural roundtrip pattern sent
+    ``?after=`` and got it silently ignored, causing pagination to loop on
+    the first page. See issue #389.)
+
     Args:
         session_id (str):
-        after_seq (int | Unset):  Default: 0.
+        after (int | Unset):  Default: 0.
         kind (ListSessionEventsKindType0 | None | Unset):
         limit (int | Unset):  Default: 200.
         error_only (bool | Unset):  Default: False.
@@ -199,7 +226,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         session_id=session_id,
-        after_seq=after_seq,
+        after=after,
         kind=kind,
         limit=limit,
         error_only=error_only,
@@ -215,7 +242,7 @@ async def asyncio(
     session_id: str,
     *,
     client: AuthenticatedClient | Client,
-    after_seq: int | Unset = 0,
+    after: int | Unset = 0,
     kind: ListSessionEventsKindType0 | None | Unset = UNSET,
     limit: int | Unset = 200,
     error_only: bool | Unset = False,
@@ -223,9 +250,18 @@ async def asyncio(
 ) -> HTTPValidationError | ListResponseEvent | None:
     """List Events
 
+     List events for a session, paginated by sequence number.
+
+    Pass the response's ``next_after`` field as ``?after=`` on the next call
+    to walk forward through the stream. (The query param was previously
+    named ``after_seq``, which didn't match the ``next_after`` response
+    field — clients following the natural roundtrip pattern sent
+    ``?after=`` and got it silently ignored, causing pagination to loop on
+    the first page. See issue #389.)
+
     Args:
         session_id (str):
-        after_seq (int | Unset):  Default: 0.
+        after (int | Unset):  Default: 0.
         kind (ListSessionEventsKindType0 | None | Unset):
         limit (int | Unset):  Default: 200.
         error_only (bool | Unset):  Default: False.
@@ -243,7 +279,7 @@ async def asyncio(
         await asyncio_detailed(
             session_id=session_id,
             client=client,
-            after_seq=after_seq,
+            after=after,
             kind=kind,
             limit=limit,
             error_only=error_only,

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/wait_for_events_v1_sessions_session_id_wait_get.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/wait_for_events_v1_sessions_session_id_wait_get.py
@@ -14,7 +14,7 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     session_id: str,
     *,
-    after_seq: int | Unset = 0,
+    after: int | Unset = 0,
     timeout: int | Unset = 30,
     authorization: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
@@ -24,7 +24,7 @@ def _get_kwargs(
 
     params: dict[str, Any] = {}
 
-    params["after_seq"] = after_seq
+    params["after"] = after
 
     params["timeout"] = timeout
 
@@ -76,22 +76,26 @@ def sync_detailed(
     session_id: str,
     *,
     client: AuthenticatedClient | Client,
-    after_seq: int | Unset = 0,
+    after: int | Unset = 0,
     timeout: int | Unset = 30,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | WaitResponse]:
     """Wait For Events
 
-     Long-poll for new events past ``after_seq``.
+     Long-poll for new events past sequence number ``after``.
 
     Blocks up to ``timeout`` seconds for events to arrive; returns an empty
     list if none land in time. Alternative to SSE for clients whose HTTP
     stack can't reliably consume server-sent events (notably Node's
     ``fetch`` — see issue #40).
 
+    Pass the response's ``next_after`` as ``?after=`` on the next call to
+    resume from where you left off. (The query param was previously named
+    ``after_seq``; see issue #389.)
+
     Args:
         session_id (str):
-        after_seq (int | Unset):  Default: 0.
+        after (int | Unset):  Default: 0.
         timeout (int | Unset):  Default: 30.
         authorization (None | str | Unset):
 
@@ -105,7 +109,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         session_id=session_id,
-        after_seq=after_seq,
+        after=after,
         timeout=timeout,
         authorization=authorization,
     )
@@ -121,22 +125,26 @@ def sync(
     session_id: str,
     *,
     client: AuthenticatedClient | Client,
-    after_seq: int | Unset = 0,
+    after: int | Unset = 0,
     timeout: int | Unset = 30,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | WaitResponse | None:
     """Wait For Events
 
-     Long-poll for new events past ``after_seq``.
+     Long-poll for new events past sequence number ``after``.
 
     Blocks up to ``timeout`` seconds for events to arrive; returns an empty
     list if none land in time. Alternative to SSE for clients whose HTTP
     stack can't reliably consume server-sent events (notably Node's
     ``fetch`` — see issue #40).
 
+    Pass the response's ``next_after`` as ``?after=`` on the next call to
+    resume from where you left off. (The query param was previously named
+    ``after_seq``; see issue #389.)
+
     Args:
         session_id (str):
-        after_seq (int | Unset):  Default: 0.
+        after (int | Unset):  Default: 0.
         timeout (int | Unset):  Default: 30.
         authorization (None | str | Unset):
 
@@ -151,7 +159,7 @@ def sync(
     return sync_detailed(
         session_id=session_id,
         client=client,
-        after_seq=after_seq,
+        after=after,
         timeout=timeout,
         authorization=authorization,
     ).parsed
@@ -161,22 +169,26 @@ async def asyncio_detailed(
     session_id: str,
     *,
     client: AuthenticatedClient | Client,
-    after_seq: int | Unset = 0,
+    after: int | Unset = 0,
     timeout: int | Unset = 30,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | WaitResponse]:
     """Wait For Events
 
-     Long-poll for new events past ``after_seq``.
+     Long-poll for new events past sequence number ``after``.
 
     Blocks up to ``timeout`` seconds for events to arrive; returns an empty
     list if none land in time. Alternative to SSE for clients whose HTTP
     stack can't reliably consume server-sent events (notably Node's
     ``fetch`` — see issue #40).
 
+    Pass the response's ``next_after`` as ``?after=`` on the next call to
+    resume from where you left off. (The query param was previously named
+    ``after_seq``; see issue #389.)
+
     Args:
         session_id (str):
-        after_seq (int | Unset):  Default: 0.
+        after (int | Unset):  Default: 0.
         timeout (int | Unset):  Default: 30.
         authorization (None | str | Unset):
 
@@ -190,7 +202,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         session_id=session_id,
-        after_seq=after_seq,
+        after=after,
         timeout=timeout,
         authorization=authorization,
     )
@@ -204,22 +216,26 @@ async def asyncio(
     session_id: str,
     *,
     client: AuthenticatedClient | Client,
-    after_seq: int | Unset = 0,
+    after: int | Unset = 0,
     timeout: int | Unset = 30,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | WaitResponse | None:
     """Wait For Events
 
-     Long-poll for new events past ``after_seq``.
+     Long-poll for new events past sequence number ``after``.
 
     Blocks up to ``timeout`` seconds for events to arrive; returns an empty
     list if none land in time. Alternative to SSE for clients whose HTTP
     stack can't reliably consume server-sent events (notably Node's
     ``fetch`` — see issue #40).
 
+    Pass the response's ``next_after`` as ``?after=`` on the next call to
+    resume from where you left off. (The query param was previously named
+    ``after_seq``; see issue #389.)
+
     Args:
         session_id (str):
-        after_seq (int | Unset):  Default: 0.
+        after (int | Unset):  Default: 0.
         timeout (int | Unset):  Default: 30.
         authorization (None | str | Unset):
 
@@ -235,7 +251,7 @@ async def asyncio(
         await asyncio_detailed(
             session_id=session_id,
             client=client,
-            after_seq=after_seq,
+            after=after,
             timeout=timeout,
             authorization=authorization,
         )

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -404,13 +404,22 @@ async def list_events(
     session_id: str,
     pool: PoolDep,
     _auth: AuthDep,
-    after_seq: int = 0,
+    after: int = 0,
     kind: EventKind | None = None,
     limit: int = 200,
     error_only: bool = False,
 ) -> ListResponse[Event]:
+    """List events for a session, paginated by sequence number.
+
+    Pass the response's ``next_after`` field as ``?after=`` on the next call
+    to walk forward through the stream. (The query param was previously
+    named ``after_seq``, which didn't match the ``next_after`` response
+    field — clients following the natural roundtrip pattern sent
+    ``?after=`` and got it silently ignored, causing pagination to loop on
+    the first page. See issue #389.)
+    """
     items = await service.read_events(
-        pool, session_id, after_seq=after_seq, kind=kind, limit=limit, error_only=error_only
+        pool, session_id, after_seq=after, kind=kind, limit=limit, error_only=error_only
     )
     return ListResponse[Event](
         data=items,
@@ -519,20 +528,24 @@ async def wait_for_events(
     db_url: DbUrlDep,
     pool: PoolDep,
     _auth: AuthDep,
-    after_seq: int = 0,
+    after: int = 0,
     timeout_seconds: Annotated[int, Query(alias="timeout", ge=0, le=60)] = 30,
 ) -> WaitResponse:
-    """Long-poll for new events past ``after_seq``.
+    """Long-poll for new events past sequence number ``after``.
 
     Blocks up to ``timeout`` seconds for events to arrive; returns an empty
     list if none land in time. Alternative to SSE for clients whose HTTP
     stack can't reliably consume server-sent events (notably Node's
     ``fetch`` — see issue #40).
+
+    Pass the response's ``next_after`` as ``?after=`` on the next call to
+    resume from where you left off. (The query param was previously named
+    ``after_seq``; see issue #389.)
     """
     await service.get_session(pool, session_id)
 
     async with listen_for_events(db_url, session_id) as queue:
-        events = await service.read_events(pool, session_id, after_seq=after_seq)
+        events = await service.read_events(pool, session_id, after_seq=after)
         if not events and timeout_seconds > 0:
             # The channel carries both committed-event IDs and transient
             # streaming delta payloads (shaped like {"delta": "..."}); only
@@ -549,7 +562,7 @@ async def wait_for_events(
                     break
                 if payload.startswith("{"):
                     continue
-                events = await service.read_events(pool, session_id, after_seq=after_seq)
+                events = await service.read_events(pool, session_id, after_seq=after)
                 if events:
                     break
 
@@ -558,5 +571,5 @@ async def wait_for_events(
         events=events,
         session_status=session.status,
         session_stop_reason=session.stop_reason,
-        next_after=events[-1].seq if events else after_seq,
+        next_after=events[-1].seq if events else after,
     )

--- a/src/aios/cli/commands/_shared.py
+++ b/src/aios/cli/commands/_shared.py
@@ -190,7 +190,7 @@ def fetch_all_events(
         page = client.request(
             "GET",
             f"/v1/sessions/{session_id}/events",
-            params={"after_seq": cursor_seq, "kind": kind, "limit": page_size},
+            params={"after": cursor_seq, "kind": kind, "limit": page_size},
         )
         assert isinstance(page, dict)
         page_data = page.get("data", [])

--- a/tests/e2e/test_events_pagination.py
+++ b/tests/e2e/test_events_pagination.py
@@ -1,0 +1,151 @@
+"""E2E tests for ``GET /v1/sessions/{id}/events`` pagination round-trip.
+
+Regression coverage for issue #389: the query param was named ``after_seq``
+while the response field was ``next_after``, so a naive client following the
+documented pattern (use ``next_after`` as the next call's ``?after=``) saw
+the value silently ignored and got the first page repeated forever.
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+
+import httpx
+import pytest
+
+from tests.helpers.connections import authed_client
+
+
+def _uniq() -> str:
+    return secrets.token_hex(4)
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    settings = get_settings()
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    transport = httpx.ASGITransport(app=app)
+    async with authed_client(
+        "http://testserver",
+        aios_env["AIOS_API_KEY"],
+        transport=transport,
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def session_with_events(pool: Any) -> str:
+    from aios.db import queries
+    from aios.services import agents as agents_svc
+    from aios.services import sessions as sessions_svc
+
+    async with pool.acquire() as conn:
+        env = await queries.insert_environment(conn, name=f"events-env-{_uniq()}")
+    agent = await agents_svc.create_agent(
+        pool,
+        name=f"events-agent-{_uniq()}",
+        model="openai/gpt-4o-mini",
+        system="",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    session = await sessions_svc.create_session(
+        pool, agent_id=agent.id, environment_id=env.id, title=None, metadata={}
+    )
+    for i in range(5):
+        await sessions_svc.append_user_message(pool, session.id, f"message {i}")
+    return session.id
+
+
+class TestEventsPaginationRoundTrip:
+    """The ``next_after`` cursor returned by one call must be acceptable as
+    ``?after=`` on the next call. Forward-paginating walks all events without
+    repeats. This was issue #389.
+    """
+
+    async def test_after_advances_pagination(
+        self, http_client: httpx.AsyncClient, session_with_events: str
+    ) -> None:
+        # First page, limit=2 → seqs 1..2 with has_more=True
+        r1 = await http_client.get(
+            f"/v1/sessions/{session_with_events}/events",
+            params={"limit": 2},
+        )
+        assert r1.status_code == 200, r1.text
+        page1 = r1.json()
+        assert len(page1["data"]) == 2
+        assert page1["has_more"] is True
+        assert page1["next_after"] is not None
+        page1_last_seq = page1["data"][-1]["seq"]
+        assert str(page1_last_seq) == page1["next_after"]
+
+        # Second page, ?after=<page1.next_after> → seqs MUST be > page1_last_seq.
+        # Pre-fix this returned seqs 1..2 again because `after_seq` defaulted to 0.
+        r2 = await http_client.get(
+            f"/v1/sessions/{session_with_events}/events",
+            params={"limit": 2, "after": page1["next_after"]},
+        )
+        assert r2.status_code == 200, r2.text
+        page2 = r2.json()
+        assert len(page2["data"]) == 2
+        for event in page2["data"]:
+            assert event["seq"] > page1_last_seq, (
+                f"page 2 returned seq {event['seq']}; expected > {page1_last_seq}. "
+                f"Pre-fix symptom: `?after=` was ignored and the same page came back."
+            )
+
+    async def test_full_walk_terminates_without_repeats(
+        self, http_client: httpx.AsyncClient, session_with_events: str
+    ) -> None:
+        # Walk the full event stream paginated; assert no seq appears twice and
+        # the loop terminates (has_more eventually False or empty data).
+        seen: set[int] = set()
+        cursor: str | None = None
+        for iteration in range(20):  # guardrail; should terminate in ~3 iterations
+            params: dict[str, Any] = {"limit": 2}
+            if cursor is not None:
+                params["after"] = cursor
+            r = await http_client.get(
+                f"/v1/sessions/{session_with_events}/events",
+                params=params,
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            for event in body["data"]:
+                assert event["seq"] not in seen, (
+                    f"seq {event['seq']} returned twice during forward walk "
+                    f"(iteration {iteration}). Symptom of issue #389."
+                )
+                seen.add(event["seq"])
+            if not body["has_more"]:
+                break
+            cursor = body["next_after"]
+            assert cursor is not None
+        else:
+            pytest.fail("Pagination did not terminate within 20 iterations")

--- a/tests/e2e/test_wait_endpoint.py
+++ b/tests/e2e/test_wait_endpoint.py
@@ -86,7 +86,7 @@ class TestWaitEndpoint:
 
         r = await http_client.get(
             f"/v1/sessions/{session_id}/wait",
-            params={"after_seq": 0, "timeout": 30},
+            params={"after": 0, "timeout": 30},
         )
 
         assert r.status_code == 200, r.text
@@ -103,7 +103,7 @@ class TestWaitEndpoint:
     ) -> None:
         r = await http_client.get(
             f"/v1/sessions/{session_id}/wait",
-            params={"after_seq": 9999, "timeout": 1},
+            params={"after": 9999, "timeout": 1},
         )
 
         assert r.status_code == 200, r.text
@@ -119,7 +119,7 @@ class TestWaitEndpoint:
         async def wait_call() -> httpx.Response:
             return await http_client.get(
                 f"/v1/sessions/{session_id}/wait",
-                params={"after_seq": 0, "timeout": 10},
+                params={"after": 0, "timeout": 10},
             )
 
         async def delayed_append() -> None:
@@ -144,7 +144,7 @@ class TestWaitEndpoint:
         """Request-level validation rejects out-of-range ``timeout``."""
         r = await http_client.get(
             f"/v1/sessions/{session_id}/wait",
-            params={"after_seq": 0, "timeout": 3600},
+            params={"after": 0, "timeout": 3600},
         )
         assert r.status_code == 422, r.text
 
@@ -179,7 +179,7 @@ class TestWaitEndpoint:
         async def wait_call() -> httpx.Response:
             return await http_client.get(
                 f"/v1/sessions/{session_id}/wait",
-                params={"after_seq": 0, "timeout": 5},
+                params={"after": 0, "timeout": 5},
             )
 
         wait_task = asyncio.create_task(wait_call())


### PR DESCRIPTION
Closes #389.

## Why

The `GET /v1/sessions/{id}/events` and `/wait` endpoints accepted `?after_seq=` while their response field is named `next_after`. A client following the natural roundtrip pattern (using `next_after` as the next call's `?after=`) saw the value silently dropped (FastAPI ignores unknown query params), causing `after_seq` to default to 0 and the first page to repeat indefinitely.

Hit operationally 2026-05-14 while inspecting the tail of a 110k-event session — the walker hung in a tight loop hammering `?after=500` against the API.

## Fix

Rename the public query param to `after` on both paginated endpoints. The internal `service.read_events` keeps its descriptive `after_seq` kwarg name; only the public HTTP surface changes.

The SSE `stream_events` endpoint also takes `?after_seq=` but is single-shot (no paginator roundtrip), so its original name is preserved.

## Changes

- `src/aios/api/routers/sessions.py` — rename query param on `list_events` and `wait_for_events`; docstrings reference #389.
- `src/aios/cli/commands/_shared.py` — `fetch_all_events` helper sends `after` (was `after_seq`).
- `tests/e2e/test_wait_endpoint.py` — 5 call sites updated.
- `tests/e2e/test_events_pagination.py` — NEW. Two regression tests covering the roundtrip pattern; both would have caught the bug.
- `openapi.json` + generated SDK — regenerated.

## Migration

No external consumers use `after_seq` today — only aios's own CLI helper (updated here) and tests (updated here). The auto-generated SDK regenerates against the new shape.

## Test plan

- [x] All 1197 unit tests pass
- [x] All 5 `test_wait_endpoint` e2e tests pass
- [x] 2 new regression tests pass
- [x] pre-commit ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)