### PR TITLE
feat(#367): PR 7 — management endpoints for /v1/accounts/...

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -94,6 +94,475 @@
         }
       }
     },
+    "/v1/accounts/me": {
+      "get": {
+        "tags": [
+          "accounts"
+        ],
+        "summary": "Get My Account",
+        "description": "Return the account the bearer token resolved to.",
+        "operationId": "get_my_account",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/accounts/children": {
+      "get": {
+        "tags": [
+          "accounts"
+        ],
+        "summary": "List My Children",
+        "description": "List direct child accounts under the caller.",
+        "operationId": "list_my_children",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Account"
+                  },
+                  "title": "Response List My Children"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "accounts"
+        ],
+        "summary": "Mint Child",
+        "description": "Mint a direct child account under the caller and its first API key.\n\nRequires the caller's ``can_mint_children`` to be true. Returns the\nnew account id, the first key's id, and the plaintext bearer (the\nonly time that plaintext is recoverable).",
+        "operationId": "mint_child_account",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MintAccountRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MintAccountResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/accounts/{target_id}": {
+      "get": {
+        "tags": [
+          "accounts"
+        ],
+        "summary": "Get Account",
+        "description": "Read a specific account that's the caller or a direct child.",
+        "operationId": "get_account",
+        "parameters": [
+          {
+            "name": "target_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Target Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "accounts"
+        ],
+        "summary": "Archive Account",
+        "description": "Archive a direct child of the caller.\n\nRefuses if the child has non-archived children of its own. Returns\nthe archived account row (idempotent \u2014 calling twice returns the\nsame row with the original ``archived_at``).",
+        "operationId": "archive_account",
+        "parameters": [
+          {
+            "name": "target_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Target Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/accounts/{target_id}/keys": {
+      "post": {
+        "tags": [
+          "accounts"
+        ],
+        "summary": "Mint Account Key",
+        "description": "Mint an additional API key on a caller-or-child account.",
+        "operationId": "mint_account_key",
+        "parameters": [
+          {
+            "name": "target_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Target Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MintKeyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MintKeyResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "accounts"
+        ],
+        "summary": "List Account Keys",
+        "description": "List key summaries (sans hash) for a caller-or-child account.",
+        "operationId": "list_account_keys",
+        "parameters": [
+          {
+            "name": "target_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Target Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountKeySummary"
+                  },
+                  "title": "Response List Account Keys"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/accounts/{target_id}/keys/{key_id}": {
+      "delete": {
+        "tags": [
+          "accounts"
+        ],
+        "summary": "Revoke Account Key",
+        "description": "Revoke an API key on a caller-or-child account. Idempotent.",
+        "operationId": "revoke_account_key",
+        "parameters": [
+          {
+            "name": "target_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Target Id"
+            }
+          },
+          {
+            "name": "key_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/environments": {
       "post": {
         "tags": [
@@ -6457,6 +6926,102 @@
   },
   "components": {
     "schemas": {
+      "Account": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "parent_account_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Account Id"
+          },
+          "can_mint_children": {
+            "type": "boolean",
+            "title": "Can Mint Children"
+          },
+          "display_name": {
+            "type": "string",
+            "title": "Display Name"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "archived_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Archived At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "parent_account_id",
+          "can_mint_children",
+          "display_name",
+          "metadata",
+          "created_at"
+        ],
+        "title": "Account"
+      },
+      "AccountKeySummary": {
+        "properties": {
+          "key_id": {
+            "type": "string",
+            "title": "Key Id"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "key_id",
+          "label",
+          "created_at"
+        ],
+        "title": "AccountKeySummary",
+        "description": "Key metadata as returned by the management API.\n\nIntentionally omits the bytes ``hash`` column \u2014 operators have no use\nfor the on-disk hash, and surfacing it widens the audit footprint."
+      },
       "Actor": {
         "properties": {
           "type": {
@@ -9113,6 +9678,84 @@
         ],
         "title": "MemoryVersion",
         "description": "Read view of an immutable memory version. Redacted versions null the\n``path`` / ``content`` / ``content_sha256`` / ``content_size_bytes`` fields\nwhile preserving the audit trail."
+      },
+      "MintAccountRequest": {
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Display Name"
+          },
+          "can_mint_children": {
+            "type": "boolean",
+            "title": "Can Mint Children",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "display_name"
+        ],
+        "title": "MintAccountRequest"
+      },
+      "MintAccountResponse": {
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "title": "Account Id"
+          },
+          "key_id": {
+            "type": "string",
+            "title": "Key Id"
+          },
+          "plaintext_key": {
+            "type": "string",
+            "title": "Plaintext Key"
+          }
+        },
+        "type": "object",
+        "required": [
+          "account_id",
+          "key_id",
+          "plaintext_key"
+        ],
+        "title": "MintAccountResponse"
+      },
+      "MintKeyRequest": {
+        "properties": {
+          "label": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Label"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "label"
+        ],
+        "title": "MintKeyRequest"
+      },
+      "MintKeyResponse": {
+        "properties": {
+          "key_id": {
+            "type": "string",
+            "title": "Key Id"
+          },
+          "plaintext_key": {
+            "type": "string",
+            "title": "Plaintext Key"
+          }
+        },
+        "type": "object",
+        "required": [
+          "key_id",
+          "plaintext_key"
+        ],
+        "title": "MintKeyResponse"
       },
       "RecentChat": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/accounts/archive_account.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/accounts/archive_account.py
@@ -1,0 +1,203 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.account import Account
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    target_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/accounts/{target_id}".format(
+            target_id=quote(str(target_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Account | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Account.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Account | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Account | HTTPValidationError]:
+    """Archive Account
+
+     Archive a direct child of the caller.
+
+    Refuses if the child has non-archived children of its own. Returns
+    the archived account row (idempotent — calling twice returns the
+    same row with the original ``archived_at``).
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Account | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        target_id=target_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Account | HTTPValidationError | None:
+    """Archive Account
+
+     Archive a direct child of the caller.
+
+    Refuses if the child has non-archived children of its own. Returns
+    the archived account row (idempotent — calling twice returns the
+    same row with the original ``archived_at``).
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Account | HTTPValidationError
+    """
+
+    return sync_detailed(
+        target_id=target_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Account | HTTPValidationError]:
+    """Archive Account
+
+     Archive a direct child of the caller.
+
+    Refuses if the child has non-archived children of its own. Returns
+    the archived account row (idempotent — calling twice returns the
+    same row with the original ``archived_at``).
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Account | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        target_id=target_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Account | HTTPValidationError | None:
+    """Archive Account
+
+     Archive a direct child of the caller.
+
+    Refuses if the child has non-archived children of its own. Returns
+    the archived account row (idempotent — calling twice returns the
+    same row with the original ``archived_at``).
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Account | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            target_id=target_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/accounts/get_account.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/accounts/get_account.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.account import Account
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    target_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/accounts/{target_id}".format(
+            target_id=quote(str(target_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Account | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Account.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Account | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Account | HTTPValidationError]:
+    """Get Account
+
+     Read a specific account that's the caller or a direct child.
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Account | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        target_id=target_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Account | HTTPValidationError | None:
+    """Get Account
+
+     Read a specific account that's the caller or a direct child.
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Account | HTTPValidationError
+    """
+
+    return sync_detailed(
+        target_id=target_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Account | HTTPValidationError]:
+    """Get Account
+
+     Read a specific account that's the caller or a direct child.
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Account | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        target_id=target_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Account | HTTPValidationError | None:
+    """Get Account
+
+     Read a specific account that's the caller or a direct child.
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Account | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            target_id=target_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/accounts/get_my_account.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/accounts/get_my_account.py
@@ -1,0 +1,171 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.account import Account
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/accounts/me",
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Account | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Account.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Account | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Account | HTTPValidationError]:
+    """Get My Account
+
+     Return the account the bearer token resolved to.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Account | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Account | HTTPValidationError | None:
+    """Get My Account
+
+     Return the account the bearer token resolved to.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Account | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Account | HTTPValidationError]:
+    """Get My Account
+
+     Return the account the bearer token resolved to.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Account | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Account | HTTPValidationError | None:
+    """Get My Account
+
+     Return the account the bearer token resolved to.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Account | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/accounts/list_account_keys.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/accounts/list_account_keys.py
@@ -1,0 +1,192 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.account_key_summary import AccountKeySummary
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    target_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/accounts/{target_id}/keys".format(
+            target_id=quote(str(target_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | list[AccountKeySummary] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = AccountKeySummary.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | list[AccountKeySummary]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | list[AccountKeySummary]]:
+    """List Account Keys
+
+     List key summaries (sans hash) for a caller-or-child account.
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[AccountKeySummary]]
+    """
+
+    kwargs = _get_kwargs(
+        target_id=target_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | list[AccountKeySummary] | None:
+    """List Account Keys
+
+     List key summaries (sans hash) for a caller-or-child account.
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[AccountKeySummary]
+    """
+
+    return sync_detailed(
+        target_id=target_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | list[AccountKeySummary]]:
+    """List Account Keys
+
+     List key summaries (sans hash) for a caller-or-child account.
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[AccountKeySummary]]
+    """
+
+    kwargs = _get_kwargs(
+        target_id=target_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | list[AccountKeySummary] | None:
+    """List Account Keys
+
+     List key summaries (sans hash) for a caller-or-child account.
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[AccountKeySummary]
+    """
+
+    return (
+        await asyncio_detailed(
+            target_id=target_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/accounts/list_my_children.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/accounts/list_my_children.py
@@ -1,0 +1,176 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.account import Account
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/accounts/children",
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | list[Account] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = Account.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | list[Account]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | list[Account]]:
+    """List My Children
+
+     List direct child accounts under the caller.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[Account]]
+    """
+
+    kwargs = _get_kwargs(
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | list[Account] | None:
+    """List My Children
+
+     List direct child accounts under the caller.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[Account]
+    """
+
+    return sync_detailed(
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | list[Account]]:
+    """List My Children
+
+     List direct child accounts under the caller.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[Account]]
+    """
+
+    kwargs = _get_kwargs(
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | list[Account] | None:
+    """List My Children
+
+     List direct child accounts under the caller.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[Account]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/accounts/mint_account_key.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/accounts/mint_account_key.py
@@ -1,0 +1,205 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.mint_key_request import MintKeyRequest
+from ...models.mint_key_response import MintKeyResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    target_id: str,
+    *,
+    body: MintKeyRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/accounts/{target_id}/keys".format(
+            target_id=quote(str(target_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MintKeyResponse | None:
+    if response.status_code == 201:
+        response_201 = MintKeyResponse.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MintKeyResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MintKeyRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MintKeyResponse]:
+    """Mint Account Key
+
+     Mint an additional API key on a caller-or-child account.
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+        body (MintKeyRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MintKeyResponse]
+    """
+
+    kwargs = _get_kwargs(
+        target_id=target_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MintKeyRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MintKeyResponse | None:
+    """Mint Account Key
+
+     Mint an additional API key on a caller-or-child account.
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+        body (MintKeyRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MintKeyResponse
+    """
+
+    return sync_detailed(
+        target_id=target_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MintKeyRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MintKeyResponse]:
+    """Mint Account Key
+
+     Mint an additional API key on a caller-or-child account.
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+        body (MintKeyRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MintKeyResponse]
+    """
+
+    kwargs = _get_kwargs(
+        target_id=target_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    target_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: MintKeyRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MintKeyResponse | None:
+    """Mint Account Key
+
+     Mint an additional API key on a caller-or-child account.
+
+    Args:
+        target_id (str):
+        authorization (None | str | Unset):
+        body (MintKeyRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MintKeyResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            target_id=target_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/accounts/mint_child_account.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/accounts/mint_child_account.py
@@ -1,0 +1,205 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.mint_account_request import MintAccountRequest
+from ...models.mint_account_response import MintAccountResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: MintAccountRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/accounts/children",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MintAccountResponse | None:
+    if response.status_code == 201:
+        response_201 = MintAccountResponse.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MintAccountResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: MintAccountRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MintAccountResponse]:
+    """Mint Child
+
+     Mint a direct child account under the caller and its first API key.
+
+    Requires the caller's ``can_mint_children`` to be true. Returns the
+    new account id, the first key's id, and the plaintext bearer (the
+    only time that plaintext is recoverable).
+
+    Args:
+        authorization (None | str | Unset):
+        body (MintAccountRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MintAccountResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: MintAccountRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MintAccountResponse | None:
+    """Mint Child
+
+     Mint a direct child account under the caller and its first API key.
+
+    Requires the caller's ``can_mint_children`` to be true. Returns the
+    new account id, the first key's id, and the plaintext bearer (the
+    only time that plaintext is recoverable).
+
+    Args:
+        authorization (None | str | Unset):
+        body (MintAccountRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MintAccountResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: MintAccountRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | MintAccountResponse]:
+    """Mint Child
+
+     Mint a direct child account under the caller and its first API key.
+
+    Requires the caller's ``can_mint_children`` to be true. Returns the
+    new account id, the first key's id, and the plaintext bearer (the
+    only time that plaintext is recoverable).
+
+    Args:
+        authorization (None | str | Unset):
+        body (MintAccountRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MintAccountResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: MintAccountRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | MintAccountResponse | None:
+    """Mint Child
+
+     Mint a direct child account under the caller and its first API key.
+
+    Requires the caller's ``can_mint_children`` to be true. Returns the
+    new account id, the first key's id, and the plaintext bearer (the
+    only time that plaintext is recoverable).
+
+    Args:
+        authorization (None | str | Unset):
+        body (MintAccountRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MintAccountResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/accounts/revoke_account_key.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/accounts/revoke_account_key.py
@@ -1,0 +1,199 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    target_id: str,
+    key_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/accounts/{target_id}/keys/{key_id}".format(
+            target_id=quote(str(target_id), safe=""),
+            key_id=quote(str(key_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    target_id: str,
+    key_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Revoke Account Key
+
+     Revoke an API key on a caller-or-child account. Idempotent.
+
+    Args:
+        target_id (str):
+        key_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        target_id=target_id,
+        key_id=key_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    target_id: str,
+    key_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Revoke Account Key
+
+     Revoke an API key on a caller-or-child account. Idempotent.
+
+    Args:
+        target_id (str):
+        key_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        target_id=target_id,
+        key_id=key_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    target_id: str,
+    key_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Revoke Account Key
+
+     Revoke an API key on a caller-or-child account. Idempotent.
+
+    Args:
+        target_id (str):
+        key_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        target_id=target_id,
+        key_id=key_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    target_id: str,
+    key_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Revoke Account Key
+
+     Revoke an API key on a caller-or-child account. Idempotent.
+
+    Args:
+        target_id (str):
+        key_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            target_id=target_id,
+            key_id=key_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -1,5 +1,8 @@
 """Contains all the data models used in inputs/outputs"""
 
+from .account import Account
+from .account_key_summary import AccountKeySummary
+from .account_metadata import AccountMetadata
 from .actor import Actor
 from .actor_type import ActorType
 from .agent import Agent
@@ -98,6 +101,10 @@ from .memory_update import MemoryUpdate
 from .memory_update_precondition import MemoryUpdatePrecondition
 from .memory_version import MemoryVersion
 from .memory_version_operation import MemoryVersionOperation
+from .mint_account_request import MintAccountRequest
+from .mint_account_response import MintAccountResponse
+from .mint_key_request import MintKeyRequest
+from .mint_key_response import MintKeyResponse
 from .recent_chat import RecentChat
 from .runtime_management_call_result_request import RuntimeManagementCallResultRequest
 from .runtime_token import RuntimeToken
@@ -176,6 +183,9 @@ from .wait_response_session_status import WaitResponseSessionStatus
 from .wait_response_session_stop_reason_type_0 import WaitResponseSessionStopReasonType0
 
 __all__ = (
+    "Account",
+    "AccountKeySummary",
+    "AccountMetadata",
     "Actor",
     "ActorType",
     "Agent",
@@ -270,6 +280,10 @@ __all__ = (
     "MemoryUpdatePrecondition",
     "MemoryVersion",
     "MemoryVersionOperation",
+    "MintAccountRequest",
+    "MintAccountResponse",
+    "MintKeyRequest",
+    "MintKeyResponse",
     "RecentChat",
     "RuntimeManagementCallResultRequest",
     "RuntimeToken",

--- a/packages/aios-sdk/aios_sdk/_generated/models/account.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/account.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.account_metadata import AccountMetadata
+
+
+T = TypeVar("T", bound="Account")
+
+
+@_attrs_define
+class Account:
+    """
+    Attributes:
+        id (str):
+        parent_account_id (None | str):
+        can_mint_children (bool):
+        display_name (str):
+        metadata (AccountMetadata):
+        created_at (datetime.datetime):
+        archived_at (datetime.datetime | None | Unset):
+    """
+
+    id: str
+    parent_account_id: None | str
+    can_mint_children: bool
+    display_name: str
+    metadata: AccountMetadata
+    created_at: datetime.datetime
+    archived_at: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        parent_account_id: None | str
+        parent_account_id = self.parent_account_id
+
+        can_mint_children = self.can_mint_children
+
+        display_name = self.display_name
+
+        metadata = self.metadata.to_dict()
+
+        created_at = self.created_at.isoformat()
+
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "parent_account_id": parent_account_id,
+                "can_mint_children": can_mint_children,
+                "display_name": display_name,
+                "metadata": metadata,
+                "created_at": created_at,
+            }
+        )
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.account_metadata import AccountMetadata
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        def _parse_parent_account_id(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        parent_account_id = _parse_parent_account_id(d.pop("parent_account_id"))
+
+        can_mint_children = d.pop("can_mint_children")
+
+        display_name = d.pop("display_name")
+
+        metadata = AccountMetadata.from_dict(d.pop("metadata"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
+        account = cls(
+            id=id,
+            parent_account_id=parent_account_id,
+            can_mint_children=can_mint_children,
+            display_name=display_name,
+            metadata=metadata,
+            created_at=created_at,
+            archived_at=archived_at,
+        )
+
+        account.additional_properties = d
+        return account
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/account_key_summary.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/account_key_summary.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AccountKeySummary")
+
+
+@_attrs_define
+class AccountKeySummary:
+    """Key metadata as returned by the management API.
+
+    Intentionally omits the bytes ``hash`` column — operators have no use
+    for the on-disk hash, and surfacing it widens the audit footprint.
+
+        Attributes:
+            key_id (str):
+            label (str):
+            created_at (datetime.datetime):
+            revoked_at (datetime.datetime | None | Unset):
+    """
+
+    key_id: str
+    label: str
+    created_at: datetime.datetime
+    revoked_at: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        key_id = self.key_id
+
+        label = self.label
+
+        created_at = self.created_at.isoformat()
+
+        revoked_at: None | str | Unset
+        if isinstance(self.revoked_at, Unset):
+            revoked_at = UNSET
+        elif isinstance(self.revoked_at, datetime.datetime):
+            revoked_at = self.revoked_at.isoformat()
+        else:
+            revoked_at = self.revoked_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "key_id": key_id,
+                "label": label,
+                "created_at": created_at,
+            }
+        )
+        if revoked_at is not UNSET:
+            field_dict["revoked_at"] = revoked_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        key_id = d.pop("key_id")
+
+        label = d.pop("label")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        def _parse_revoked_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                revoked_at_type_0 = isoparse(data)
+
+                return revoked_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        revoked_at = _parse_revoked_at(d.pop("revoked_at", UNSET))
+
+        account_key_summary = cls(
+            key_id=key_id,
+            label=label,
+            created_at=created_at,
+            revoked_at=revoked_at,
+        )
+
+        account_key_summary.additional_properties = d
+        return account_key_summary
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/account_metadata.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/account_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="AccountMetadata")
+
+
+@_attrs_define
+class AccountMetadata:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        account_metadata = cls()
+
+        account_metadata.additional_properties = d
+        return account_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/mint_account_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/mint_account_request.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="MintAccountRequest")
+
+
+@_attrs_define
+class MintAccountRequest:
+    """
+    Attributes:
+        display_name (str):
+        can_mint_children (bool | Unset):  Default: False.
+    """
+
+    display_name: str
+    can_mint_children: bool | Unset = False
+
+    def to_dict(self) -> dict[str, Any]:
+        display_name = self.display_name
+
+        can_mint_children = self.can_mint_children
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "display_name": display_name,
+            }
+        )
+        if can_mint_children is not UNSET:
+            field_dict["can_mint_children"] = can_mint_children
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        display_name = d.pop("display_name")
+
+        can_mint_children = d.pop("can_mint_children", UNSET)
+
+        mint_account_request = cls(
+            display_name=display_name,
+            can_mint_children=can_mint_children,
+        )
+
+        return mint_account_request

--- a/packages/aios-sdk/aios_sdk/_generated/models/mint_account_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/mint_account_response.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="MintAccountResponse")
+
+
+@_attrs_define
+class MintAccountResponse:
+    """
+    Attributes:
+        account_id (str):
+        key_id (str):
+        plaintext_key (str):
+    """
+
+    account_id: str
+    key_id: str
+    plaintext_key: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        account_id = self.account_id
+
+        key_id = self.key_id
+
+        plaintext_key = self.plaintext_key
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "account_id": account_id,
+                "key_id": key_id,
+                "plaintext_key": plaintext_key,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        account_id = d.pop("account_id")
+
+        key_id = d.pop("key_id")
+
+        plaintext_key = d.pop("plaintext_key")
+
+        mint_account_response = cls(
+            account_id=account_id,
+            key_id=key_id,
+            plaintext_key=plaintext_key,
+        )
+
+        mint_account_response.additional_properties = d
+        return mint_account_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/mint_key_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/mint_key_request.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="MintKeyRequest")
+
+
+@_attrs_define
+class MintKeyRequest:
+    """
+    Attributes:
+        label (str):
+    """
+
+    label: str
+
+    def to_dict(self) -> dict[str, Any]:
+        label = self.label
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "label": label,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        label = d.pop("label")
+
+        mint_key_request = cls(
+            label=label,
+        )
+
+        return mint_key_request

--- a/packages/aios-sdk/aios_sdk/_generated/models/mint_key_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/mint_key_response.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="MintKeyResponse")
+
+
+@_attrs_define
+class MintKeyResponse:
+    """
+    Attributes:
+        key_id (str):
+        plaintext_key (str):
+    """
+
+    key_id: str
+    plaintext_key: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        key_id = self.key_id
+
+        plaintext_key = self.plaintext_key
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "key_id": key_id,
+                "plaintext_key": plaintext_key,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        key_id = d.pop("key_id")
+
+        plaintext_key = d.pop("plaintext_key")
+
+        mint_key_response = cls(
+            key_id=key_id,
+            plaintext_key=plaintext_key,
+        )
+
+        mint_key_response.additional_properties = d
+        return mint_key_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/routers/accounts.py
+++ b/src/aios/api/routers/accounts.py
@@ -7,12 +7,21 @@ from typing import Annotated
 
 from fastapi import APIRouter, Header, status
 
-from aios.api.deps import PoolDep, _extract_bearer_token
+from aios.api.deps import AuthDep, PoolDep, _extract_bearer_token
 from aios.config import get_settings
 from aios.db import queries
 from aios.errors import NotFoundError, UnauthorizedError
 from aios.logging import get_logger
-from aios.models.accounts import BootstrapRequest, BootstrapResponse
+from aios.models.accounts import (
+    Account,
+    AccountKeySummary,
+    BootstrapRequest,
+    BootstrapResponse,
+    MintAccountRequest,
+    MintAccountResponse,
+    MintKeyRequest,
+    MintKeyResponse,
+)
 from aios.services import accounts as service
 
 router = APIRouter(prefix="/v1/accounts", tags=["accounts"])
@@ -63,3 +72,156 @@ async def bootstrap(
         outcome="success",
     )
     return response
+
+
+# ─── management plane — caller-or-child scoped (#367 PR 7) ──────────────────
+
+
+@router.get("/me", operation_id="get_my_account")
+async def get_my_account(pool: PoolDep, auth: AuthDep) -> Account:
+    """Return the account the bearer token resolved to."""
+    account_id, _key_id, _can_mint = auth
+    async with pool.acquire() as conn:
+        row = await queries.get_account(conn, account_id)
+    if row is None:
+        # The auth dep just resolved this id; a missing row here means
+        # someone archived the account between auth and route. Surface as
+        # 404 rather than 500 — operator-side cleanup is the right next step.
+        raise NotFoundError(f"account {account_id} not found", detail={"id": account_id})
+    return row
+
+
+@router.get("/children", operation_id="list_my_children")
+async def list_my_children(pool: PoolDep, auth: AuthDep) -> list[Account]:
+    """List direct child accounts under the caller."""
+    account_id, _key_id, _can_mint = auth
+    return await service.list_children(pool, parent_account_id=account_id)
+
+
+@router.post(
+    "/children",
+    operation_id="mint_child_account",
+    status_code=status.HTTP_201_CREATED,
+)
+async def mint_child(body: MintAccountRequest, pool: PoolDep, auth: AuthDep) -> MintAccountResponse:
+    """Mint a direct child account under the caller and its first API key.
+
+    Requires the caller's ``can_mint_children`` to be true. Returns the
+    new account id, the first key's id, and the plaintext bearer (the
+    only time that plaintext is recoverable).
+    """
+    account_id, key_id, can_mint = auth
+    response = await service.mint_child(
+        pool,
+        caller_account_id=account_id,
+        caller_can_mint_children=can_mint,
+        display_name=body.display_name,
+        can_mint_children=body.can_mint_children,
+    )
+    log.info(
+        "account.operation",
+        actor_account_id=account_id,
+        actor_key_id=key_id,
+        target_account_id=response.account_id,
+        action="account.mint_child",
+        outcome="success",
+    )
+    return response
+
+
+@router.get("/{target_id}", operation_id="get_account")
+async def get_account(target_id: str, pool: PoolDep, auth: AuthDep) -> Account:
+    """Read a specific account that's the caller or a direct child."""
+    account_id, _key_id, _can_mint = auth
+    return await service.get_account_in_scope(pool, target_id, caller_account_id=account_id)
+
+
+@router.delete(
+    "/{target_id}",
+    operation_id="archive_account",
+)
+async def archive_account(target_id: str, pool: PoolDep, auth: AuthDep) -> Account:
+    """Archive a direct child of the caller.
+
+    Refuses if the child has non-archived children of its own. Returns
+    the archived account row (idempotent — calling twice returns the
+    same row with the original ``archived_at``).
+    """
+    account_id, key_id, _can_mint = auth
+    archived = await service.archive_child(
+        pool, target_account_id=target_id, caller_account_id=account_id
+    )
+    log.info(
+        "account.operation",
+        actor_account_id=account_id,
+        actor_key_id=key_id,
+        target_account_id=target_id,
+        action="account.archive",
+        outcome="success",
+    )
+    return archived
+
+
+@router.post(
+    "/{target_id}/keys",
+    operation_id="mint_account_key",
+    status_code=status.HTTP_201_CREATED,
+)
+async def mint_account_key(
+    target_id: str, body: MintKeyRequest, pool: PoolDep, auth: AuthDep
+) -> MintKeyResponse:
+    """Mint an additional API key on a caller-or-child account."""
+    account_id, actor_key_id, _can_mint = auth
+    response = await service.mint_key(
+        pool,
+        target_account_id=target_id,
+        caller_account_id=account_id,
+        label=body.label,
+    )
+    log.info(
+        "account.operation",
+        actor_account_id=account_id,
+        actor_key_id=actor_key_id,
+        target_account_id=target_id,
+        target_key_id=response.key_id,
+        action="account.mint_key",
+        outcome="success",
+    )
+    return response
+
+
+@router.get(
+    "/{target_id}/keys",
+    operation_id="list_account_keys",
+)
+async def list_account_keys(
+    target_id: str, pool: PoolDep, auth: AuthDep
+) -> list[AccountKeySummary]:
+    """List key summaries (sans hash) for a caller-or-child account."""
+    account_id, _key_id, _can_mint = auth
+    return await service.list_keys(pool, target_account_id=target_id, caller_account_id=account_id)
+
+
+@router.delete(
+    "/{target_id}/keys/{key_id}",
+    operation_id="revoke_account_key",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def revoke_account_key(target_id: str, key_id: str, pool: PoolDep, auth: AuthDep) -> None:
+    """Revoke an API key on a caller-or-child account. Idempotent."""
+    account_id, actor_key_id, _can_mint = auth
+    await service.revoke_key(
+        pool,
+        target_account_id=target_id,
+        key_id=key_id,
+        caller_account_id=account_id,
+    )
+    log.info(
+        "account.operation",
+        actor_account_id=account_id,
+        actor_key_id=actor_key_id,
+        target_account_id=target_id,
+        target_key_id=key_id,
+        action="account.revoke_key",
+        outcome="success",
+    )

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -5360,3 +5360,199 @@ async def unscoped_get_session_account_id(conn: asyncpg.Connection[Any], session
     if row is None:
         raise NotFoundError(f"session {session_id} not found", detail={"session_id": session_id})
     return cast("str", row["account_id"])
+
+
+# ─── account management (#367 PR 7) ───────────────────────────────────────────
+
+
+async def get_account(conn: asyncpg.Connection[Any], account_id: str) -> Account | None:
+    """Look up an account by id, including archived rows. ``None`` on miss.
+
+    Caller is responsible for any authorization scoping (e.g. "is this the
+    caller's account or a descendant?"). This query is intentionally unscoped
+    so the management plane can serve both self-reads and child-reads from
+    one helper.
+    """
+    row = await conn.fetchrow("SELECT * FROM accounts WHERE id = $1", account_id)
+    return _row_to_account(row) if row is not None else None
+
+
+async def list_child_accounts(
+    conn: asyncpg.Connection[Any], parent_account_id: str
+) -> list[Account]:
+    """Return non-archived direct children of ``parent_account_id``."""
+    rows = await conn.fetch(
+        """
+        SELECT * FROM accounts
+         WHERE parent_account_id = $1
+           AND archived_at IS NULL
+         ORDER BY id DESC
+        """,
+        parent_account_id,
+    )
+    return [_row_to_account(r) for r in rows]
+
+
+async def insert_child_account(
+    conn: asyncpg.Connection[Any],
+    *,
+    parent_account_id: str,
+    display_name: str,
+    can_mint_children: bool,
+    key_hash: bytes,
+    key_label: str,
+) -> tuple[Account, str]:
+    """Atomically create a child account and its first API key.
+
+    Returns ``(account, key_id)``. The plaintext key is the caller's
+    responsibility — this helper sees only the hash.
+    """
+    account_id = make_id(ACCOUNT)
+    key_id = make_id(ACCOUNT_KEY)
+    async with conn.transaction():
+        try:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO accounts
+                    (id, parent_account_id, can_mint_children, display_name)
+                VALUES ($1, $2, $3, $4)
+                RETURNING *
+                """,
+                account_id,
+                parent_account_id,
+                can_mint_children,
+                display_name,
+            )
+        except asyncpg.UniqueViolationError as exc:
+            # ``accounts_sibling_unique_display_name`` collision.
+            raise ConflictError(
+                f"display_name {display_name!r} is already in use under this parent",
+                detail={"display_name": display_name, "parent_account_id": parent_account_id},
+            ) from exc
+        assert row is not None
+        await conn.execute(
+            """
+            INSERT INTO account_keys (key_id, account_id, hash, label)
+            VALUES ($1, $2, $3, $4)
+            """,
+            key_id,
+            account_id,
+            key_hash,
+            key_label,
+        )
+    return _row_to_account(row), key_id
+
+
+async def insert_account_key(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    key_hash: bytes,
+    label: str,
+) -> str:
+    """Mint an additional API key on an existing account.
+
+    Returns the new ``key_id``. The plaintext key is the caller's
+    responsibility — this helper sees only the hash.
+    """
+    key_id = make_id(ACCOUNT_KEY)
+    await conn.execute(
+        """
+        INSERT INTO account_keys (key_id, account_id, hash, label)
+        VALUES ($1, $2, $3, $4)
+        """,
+        key_id,
+        account_id,
+        key_hash,
+        label,
+    )
+    return key_id
+
+
+async def list_account_keys(conn: asyncpg.Connection[Any], account_id: str) -> list[dict[str, Any]]:
+    """Return ``[{key_id, label, created_at, revoked_at}, ...]`` for the account.
+
+    Excludes the ``hash`` column on purpose — operators never need to read it
+    back, and surfacing it widens the audit footprint. Revoked keys are
+    included with their ``revoked_at`` populated so operators can see the
+    full history.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT key_id, label, created_at, revoked_at
+          FROM account_keys
+         WHERE account_id = $1
+         ORDER BY created_at DESC
+        """,
+        account_id,
+    )
+    return [dict(r) for r in rows]
+
+
+async def revoke_account_key(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    key_id: str,
+) -> bool:
+    """Revoke an API key by setting ``revoked_at = now()``.
+
+    Returns ``True`` iff a previously-unrevoked key was just revoked.
+    Returns ``False`` if the key was already revoked OR doesn't exist
+    on this account — the caller decides how to translate that.
+    """
+    result = await conn.execute(
+        """
+        UPDATE account_keys
+           SET revoked_at = now()
+         WHERE key_id = $1
+           AND account_id = $2
+           AND revoked_at IS NULL
+        """,
+        key_id,
+        account_id,
+    )
+    return bool(result.endswith(" 1"))
+
+
+async def archive_account(conn: asyncpg.Connection[Any], account_id: str) -> Account | None:
+    """Soft-archive an account by stamping ``archived_at``.
+
+    Idempotent: returns the already-archived account unchanged when called
+    twice. Returns ``None`` if the account doesn't exist at all so callers
+    can map to 404. Does NOT cascade to children — the resource-table FKs
+    use ``ON DELETE RESTRICT``, so a populated account can't be deleted at
+    the DB level; the service layer should refuse archive when active
+    children or resources exist.
+    """
+    row = await conn.fetchrow(
+        """
+        UPDATE accounts
+           SET archived_at = now()
+         WHERE id = $1 AND archived_at IS NULL
+        RETURNING *
+        """,
+        account_id,
+    )
+    if row is not None:
+        return _row_to_account(row)
+    # Already archived or missing — distinguish by re-reading.
+    existing = await conn.fetchrow("SELECT * FROM accounts WHERE id = $1", account_id)
+    return _row_to_account(existing) if existing is not None else None
+
+
+async def count_active_child_accounts(conn: asyncpg.Connection[Any], parent_account_id: str) -> int:
+    """Number of non-archived direct children of ``parent_account_id``.
+
+    Used by ``archive_account`` callers to refuse archive when descendants
+    still exist (FK RESTRICT would surface as a 500 otherwise).
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT COUNT(*) AS cnt FROM accounts
+         WHERE parent_account_id = $1 AND archived_at IS NULL
+        """,
+        parent_account_id,
+    )
+    assert row is not None
+    return cast("int", row["cnt"])

--- a/src/aios/models/accounts.py
+++ b/src/aios/models/accounts.py
@@ -29,3 +29,43 @@ class BootstrapResponse(BaseModel):
     key_id: str
     # Returned exactly once at mint; not recoverable after this response.
     plaintext_key: str
+
+
+class MintAccountRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: str = Field(min_length=1, max_length=128)
+    # Defaults to False — child accounts can't mint grandchildren unless the
+    # parent explicitly delegates. Two-level trees are the common case.
+    can_mint_children: bool = False
+
+
+class MintAccountResponse(BaseModel):
+    account_id: str
+    key_id: str
+    # The first key on a freshly-minted account. Returned exactly once.
+    plaintext_key: str
+
+
+class MintKeyRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    label: str = Field(min_length=1, max_length=64)
+
+
+class MintKeyResponse(BaseModel):
+    key_id: str
+    plaintext_key: str
+
+
+class AccountKeySummary(BaseModel):
+    """Key metadata as returned by the management API.
+
+    Intentionally omits the bytes ``hash`` column — operators have no use
+    for the on-disk hash, and surfacing it widens the audit footprint.
+    """
+
+    key_id: str
+    label: str
+    created_at: datetime
+    revoked_at: datetime | None = None

--- a/src/aios/services/accounts.py
+++ b/src/aios/services/accounts.py
@@ -9,11 +9,19 @@ from typing import Any
 import asyncpg
 
 from aios.db import queries
-from aios.models.accounts import BootstrapResponse
+from aios.errors import ConflictError, ForbiddenError, NotFoundError
+from aios.models.accounts import (
+    Account,
+    AccountKeySummary,
+    BootstrapResponse,
+    MintAccountResponse,
+    MintKeyResponse,
+)
 
 _KEY_PREFIX = "aios_"
 _KEY_BODY_BYTES = 32
 _BOOTSTRAP_KEY_LABEL = "bootstrap"
+_FIRST_CHILD_KEY_LABEL = "initial"
 
 
 def _generate_plaintext_key() -> str:
@@ -47,3 +55,166 @@ async def bootstrap_root(
         key_id=key_id,
         plaintext_key=plaintext,
     )
+
+
+async def get_account_in_scope(
+    pool: asyncpg.Pool[Any], target_id: str, *, caller_account_id: str
+) -> Account:
+    """Read an account that's either the caller or a direct child.
+
+    Raises :class:`NotFoundError` for "not in scope" — the management API
+    deliberately doesn't distinguish "account doesn't exist" from "account
+    belongs to a different tenant" so cross-tenant probes can't enumerate
+    ids.
+    """
+    async with pool.acquire() as conn:
+        row = await queries.get_account(conn, target_id)
+    if row is None or (row.id != caller_account_id and row.parent_account_id != caller_account_id):
+        raise NotFoundError(f"account {target_id} not found", detail={"id": target_id})
+    return row
+
+
+async def list_children(pool: asyncpg.Pool[Any], *, parent_account_id: str) -> list[Account]:
+    """Return non-archived direct children of ``parent_account_id``."""
+    async with pool.acquire() as conn:
+        return await queries.list_child_accounts(conn, parent_account_id)
+
+
+async def mint_child(
+    pool: asyncpg.Pool[Any],
+    *,
+    caller_account_id: str,
+    caller_can_mint_children: bool,
+    display_name: str,
+    can_mint_children: bool,
+) -> MintAccountResponse:
+    """Mint a direct child under ``caller_account_id`` and its first API key.
+
+    Refuses with :class:`ForbiddenError` if the caller lacks
+    ``can_mint_children``. The new key's plaintext is returned exactly
+    once in the response — there's no way to recover it after.
+    """
+    if not caller_can_mint_children:
+        raise ForbiddenError(
+            "caller account is not authorized to mint children",
+            detail={"account_id": caller_account_id},
+        )
+    plaintext = _generate_plaintext_key()
+    key_hash = hash_key(plaintext)
+    async with pool.acquire() as conn:
+        account, key_id = await queries.insert_child_account(
+            conn,
+            parent_account_id=caller_account_id,
+            display_name=display_name,
+            can_mint_children=can_mint_children,
+            key_hash=key_hash,
+            key_label=_FIRST_CHILD_KEY_LABEL,
+        )
+    return MintAccountResponse(
+        account_id=account.id,
+        key_id=key_id,
+        plaintext_key=plaintext,
+    )
+
+
+async def mint_key(
+    pool: asyncpg.Pool[Any],
+    *,
+    target_account_id: str,
+    caller_account_id: str,
+    label: str,
+) -> MintKeyResponse:
+    """Mint an additional API key on an account that's caller-or-direct-child."""
+    # Authorization: the target must be the caller's own account or a
+    # direct child. ``get_account_in_scope`` enforces the check + 404s
+    # cross-tenant probes.
+    await get_account_in_scope(pool, target_account_id, caller_account_id=caller_account_id)
+    plaintext = _generate_plaintext_key()
+    key_hash = hash_key(plaintext)
+    async with pool.acquire() as conn:
+        key_id = await queries.insert_account_key(
+            conn,
+            account_id=target_account_id,
+            key_hash=key_hash,
+            label=label,
+        )
+    return MintKeyResponse(key_id=key_id, plaintext_key=plaintext)
+
+
+async def list_keys(
+    pool: asyncpg.Pool[Any],
+    *,
+    target_account_id: str,
+    caller_account_id: str,
+) -> list[AccountKeySummary]:
+    """Return the key summaries (no hash) for a caller-or-child account."""
+    await get_account_in_scope(pool, target_account_id, caller_account_id=caller_account_id)
+    async with pool.acquire() as conn:
+        rows = await queries.list_account_keys(conn, target_account_id)
+    return [AccountKeySummary(**r) for r in rows]
+
+
+async def revoke_key(
+    pool: asyncpg.Pool[Any],
+    *,
+    target_account_id: str,
+    key_id: str,
+    caller_account_id: str,
+) -> None:
+    """Revoke an API key on a caller-or-child account.
+
+    Idempotent: revoking an already-revoked key is a no-op (returns
+    silently). Raises :class:`NotFoundError` when the key doesn't exist
+    on the target at all.
+    """
+    await get_account_in_scope(pool, target_account_id, caller_account_id=caller_account_id)
+    async with pool.acquire() as conn:
+        revoked = await queries.revoke_account_key(
+            conn, account_id=target_account_id, key_id=key_id
+        )
+    if revoked:
+        return
+    # The UPDATE matched zero rows. Distinguish missing from already-revoked.
+    async with pool.acquire() as conn:
+        keys = await queries.list_account_keys(conn, target_account_id)
+    if not any(k["key_id"] == key_id for k in keys):
+        raise NotFoundError(
+            f"key {key_id} not found on account {target_account_id}",
+            detail={"key_id": key_id, "account_id": target_account_id},
+        )
+
+
+async def archive_child(
+    pool: asyncpg.Pool[Any],
+    *,
+    target_account_id: str,
+    caller_account_id: str,
+) -> Account:
+    """Archive a direct child of the caller. Refuses if the child has children of its own.
+
+    The caller can't archive itself — top-level archival is operator-side
+    DB work, not a management API responsibility.
+    """
+    if target_account_id == caller_account_id:
+        raise ConflictError(
+            "an account cannot archive itself via the management API",
+            detail={"account_id": caller_account_id},
+        )
+    target = await get_account_in_scope(
+        pool, target_account_id, caller_account_id=caller_account_id
+    )
+    async with pool.acquire() as conn:
+        active_kids = await queries.count_active_child_accounts(conn, target_account_id)
+    if active_kids > 0:
+        raise ConflictError(
+            f"account {target_account_id} has {active_kids} non-archived children; "
+            "archive them first",
+            detail={"account_id": target_account_id, "active_children": active_kids},
+        )
+    async with pool.acquire() as conn:
+        archived = await queries.archive_account(conn, target_account_id)
+    assert archived is not None, "scope check just confirmed the account exists"
+    # When the row was already archived, ``archive_account`` returns it
+    # unchanged. Callers see idempotent behavior.
+    _ = target
+    return archived

--- a/tests/e2e/test_accounts_mgmt.py
+++ b/tests/e2e/test_accounts_mgmt.py
@@ -1,0 +1,271 @@
+"""E2E tests for the management plane on ``/v1/accounts``.
+
+Covers self-read, child mint / list / get / archive, key mint / list / revoke,
+and the authorization invariants (scope = self-or-direct-child, mint requires
+``can_mint_children``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.helpers.connections import asgi_client
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    async with asgi_client(pool) as client:
+        yield client
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestSelfRead:
+    async def test_get_me_returns_caller_account(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        r = await http_client.get("/v1/accounts/me", headers=_bearer(aios_env["AIOS_API_KEY"]))
+        assert r.status_code == 200, r.text
+        body = r.json()
+        # The aios_env fixture inserts acc_test_stub as the root with can_mint_children=True.
+        assert body["id"] == "acc_test_stub"
+        assert body["parent_account_id"] is None
+        assert body["can_mint_children"] is True
+
+
+class TestMintChild:
+    async def test_mint_child_returns_plaintext_once(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        r = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "tenant-a", "can_mint_children": False},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["account_id"].startswith("acc_")
+        assert body["key_id"].startswith("acckey_")
+        assert body["plaintext_key"].startswith("aios_")
+
+    async def test_minted_child_can_authenticate(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        r = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "tenant-b", "can_mint_children": False},
+        )
+        assert r.status_code == 201, r.text
+        child_key = r.json()["plaintext_key"]
+        me = await http_client.get("/v1/accounts/me", headers=_bearer(child_key))
+        assert me.status_code == 200
+        assert me.json()["display_name"] == "tenant-b"
+        assert me.json()["parent_account_id"] == "acc_test_stub"
+        assert me.json()["can_mint_children"] is False
+
+    async def test_child_without_mint_flag_403s_on_grandchild(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        r = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "tenant-c", "can_mint_children": False},
+        )
+        assert r.status_code == 201
+        child_key = r.json()["plaintext_key"]
+        r2 = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(child_key),
+            json={"display_name": "grandchild", "can_mint_children": False},
+        )
+        assert r2.status_code == 403, r2.text
+
+    async def test_sibling_unique_display_name(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        a = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "dup-name"},
+        )
+        assert a.status_code == 201
+        b = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "dup-name"},
+        )
+        assert b.status_code == 409, b.text
+
+
+class TestChildScope:
+    async def test_list_children_shows_minted(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "kid-1"},
+        )
+        await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "kid-2"},
+        )
+        r = await http_client.get(
+            "/v1/accounts/children", headers=_bearer(aios_env["AIOS_API_KEY"])
+        )
+        assert r.status_code == 200
+        names = {a["display_name"] for a in r.json()}
+        assert {"kid-1", "kid-2"} <= names
+
+    async def test_get_child_by_id(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        m = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "kid-3"},
+        )
+        child_id = m.json()["account_id"]
+        r = await http_client.get(
+            f"/v1/accounts/{child_id}", headers=_bearer(aios_env["AIOS_API_KEY"])
+        )
+        assert r.status_code == 200
+        assert r.json()["id"] == child_id
+
+    async def test_cross_tenant_get_404(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        """Account A can't see account B even if both exist under the same root."""
+        # Two siblings under root.
+        a = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "siblingA"},
+        )
+        b = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "siblingB"},
+        )
+        a_key = a.json()["plaintext_key"]
+        b_id = b.json()["account_id"]
+        # A tries to read B → 404 (not 403 — the API doesn't reveal existence).
+        r = await http_client.get(f"/v1/accounts/{b_id}", headers=_bearer(a_key))
+        assert r.status_code == 404, r.text
+
+
+class TestKeys:
+    async def test_mint_key_on_self(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        r = await http_client.post(
+            "/v1/accounts/acc_test_stub/keys",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"label": "ci-rotation-1"},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["key_id"].startswith("acckey_")
+        assert body["plaintext_key"].startswith("aios_")
+        # New key authenticates immediately.
+        me = await http_client.get("/v1/accounts/me", headers=_bearer(body["plaintext_key"]))
+        assert me.status_code == 200
+        assert me.json()["id"] == "acc_test_stub"
+
+    async def test_list_keys_excludes_hash(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        await http_client.post(
+            "/v1/accounts/acc_test_stub/keys",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"label": "rotation-2"},
+        )
+        r = await http_client.get(
+            "/v1/accounts/acc_test_stub/keys", headers=_bearer(aios_env["AIOS_API_KEY"])
+        )
+        assert r.status_code == 200
+        rows = r.json()
+        assert len(rows) >= 2  # bootstrap key + the one we just minted
+        for row in rows:
+            assert "hash" not in row
+            assert set(row.keys()) == {"key_id", "label", "created_at", "revoked_at"}
+
+    async def test_revoke_key_then_fails_auth(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        # Mint a key, use it once, revoke it, use again → 401.
+        m = await http_client.post(
+            "/v1/accounts/acc_test_stub/keys",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"label": "shortlived"},
+        )
+        new_key = m.json()["plaintext_key"]
+        new_key_id = m.json()["key_id"]
+        ok = await http_client.get("/v1/accounts/me", headers=_bearer(new_key))
+        assert ok.status_code == 200
+        rev = await http_client.delete(
+            f"/v1/accounts/acc_test_stub/keys/{new_key_id}",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+        )
+        assert rev.status_code == 204
+        denied = await http_client.get("/v1/accounts/me", headers=_bearer(new_key))
+        assert denied.status_code == 401
+
+    async def test_revoke_unknown_key_404(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        r = await http_client.delete(
+            "/v1/accounts/acc_test_stub/keys/acckey_nonexistent",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+        )
+        assert r.status_code == 404, r.text
+
+
+class TestArchive:
+    async def test_self_archive_409(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        r = await http_client.delete(
+            "/v1/accounts/acc_test_stub", headers=_bearer(aios_env["AIOS_API_KEY"])
+        )
+        assert r.status_code == 409, r.text
+
+    async def test_archive_child(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        m = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "to-archive"},
+        )
+        child_id = m.json()["account_id"]
+        r = await http_client.delete(
+            f"/v1/accounts/{child_id}", headers=_bearer(aios_env["AIOS_API_KEY"])
+        )
+        assert r.status_code == 200
+        assert r.json()["archived_at"] is not None
+        # Listing children no longer surfaces it.
+        listed = await http_client.get(
+            "/v1/accounts/children", headers=_bearer(aios_env["AIOS_API_KEY"])
+        )
+        ids = {a["id"] for a in listed.json()}
+        assert child_id not in ids


### PR DESCRIPTION
## Summary
The agent-facing management plane: every account can read itself, mint and manage direct children (if it has \`can_mint_children\`), and rotate / revoke its own keys. Keeps the design's two-level-trees-are-the-common-case shape — children can't read or mint grandchildren unless the parent explicitly delegates.

### Endpoints
- \`GET  /v1/accounts/me\` — the caller's account row.
- \`GET  /v1/accounts/children\` — direct non-archived children.
- \`POST /v1/accounts/children\` — mint a child (requires \`caller.can_mint_children\`); returns \`{account_id, key_id, plaintext_key}\` once.
- \`GET  /v1/accounts/{id}\` — read a caller-or-direct-child account. Cross-tenant probes return **404** (not 403) so the API doesn't reveal existence of accounts outside scope.
- \`DELETE /v1/accounts/{id}\` — archive a direct child. **409** if the caller targets itself; **409** if the child still has non-archived children of its own.
- \`POST /v1/accounts/{id}/keys\` — mint an additional key on a caller-or-child account.
- \`GET  /v1/accounts/{id}/keys\` — list key summaries: \`{key_id, label, created_at, revoked_at}\`. The hash is **never** returned.
- \`DELETE /v1/accounts/{id}/keys/{key_id}\` — revoke a key. Idempotent; 404 only for genuinely-unknown keys.

### Implementation
- \`queries.py\`: \`get_account\`, \`list_child_accounts\`, \`insert_child_account\`, \`insert_account_key\`, \`list_account_keys\`, \`revoke_account_key\`, \`archive_account\`, \`count_active_child_accounts\`.
- \`services/accounts.py\`: scope-checked wrappers anchored on \`get_account_in_scope\` (every \`{target_id}\` endpoint runs through it).
- \`models/accounts.py\`: \`MintAccountRequest\` / \`MintAccountResponse\` / \`MintKeyRequest\` / \`MintKeyResponse\` / \`AccountKeySummary\`.
- 14 new e2e tests in \`test_accounts_mgmt.py\` covering self-read, mint + auth round-trip, \`can_mint_children\` gate, sibling-unique display name, cross-tenant 404, key rotation + revocation auth, self-archive refusal, and child archive.
- \`openapi.json\` and the generated SDK refreshed for the 8 new operations.

Stacked onto \`epic/multitenancy\` post-PR-6 merge.

## Test plan
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1161 passed
- [x] \`DOCKER_HOST=… uv run pytest tests/e2e --ignore=test_sandbox_image_contract -q\` — 310/313 pass; the 3 failures are the persistent signal/telegram infra flakes

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)