### PR TITLE
fix(#367 follow-up): defense-in-depth WHERE account_id on session-scoped reads

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1898,8 +1898,10 @@ async def read_message_events(
     ``confirm_tool_deny`` searching for a tool_call_id).
     """
     rows = await conn.fetch(
-        "SELECT * FROM events WHERE session_id = $1 AND kind = 'message' ORDER BY seq ASC",
+        "SELECT * FROM events WHERE session_id = $1 AND account_id = $2 "
+        "AND kind = 'message' ORDER BY seq ASC",
         session_id,
+        account_id,
     )
     return [_row_to_event(r) for r in rows]
 
@@ -4632,8 +4634,9 @@ async def list_session_memory_store_echoes(
     account_id: str,
 ) -> list[MemoryStoreResourceEcho]:
     rows = await conn.fetch(
-        "SELECT * FROM session_memory_stores WHERE session_id = $1 ORDER BY rank",
+        "SELECT * FROM session_memory_stores WHERE session_id = $1 AND account_id = $2 ORDER BY rank",
         session_id,
+        account_id,
     )
     return [
         MemoryStoreResourceEcho(
@@ -4708,8 +4711,9 @@ async def list_session_github_repo_echoes(
     account_id: str,
 ) -> list[GithubRepositoryResourceEcho]:
     rows = await conn.fetch(
-        "SELECT * FROM session_github_repositories WHERE session_id = $1 ORDER BY rank",
+        "SELECT * FROM session_github_repositories WHERE session_id = $1 AND account_id = $2 ORDER BY rank",
         session_id,
+        account_id,
     )
     return [_row_to_github_repo_echo(r) for r in rows]
 
@@ -4722,9 +4726,11 @@ async def get_session_github_repo(
     account_id: str,
 ) -> GithubRepositoryResourceEcho:
     row = await conn.fetchrow(
-        "SELECT * FROM session_github_repositories WHERE session_id = $1 AND id = $2",
+        "SELECT * FROM session_github_repositories "
+        "WHERE session_id = $1 AND id = $2 AND account_id = $3",
         session_id,
         resource_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -4744,9 +4750,11 @@ async def get_session_github_repo_with_blob(
     """Read view + encrypted token blob, for the rotation path which needs
     both."""
     row = await conn.fetchrow(
-        "SELECT * FROM session_github_repositories WHERE session_id = $1 AND id = $2",
+        "SELECT * FROM session_github_repositories "
+        "WHERE session_id = $1 AND id = $2 AND account_id = $3",
         session_id,
         resource_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -4826,8 +4834,9 @@ async def delete_session_github_repos(
     same transaction.
     """
     await conn.execute(
-        "DELETE FROM session_github_repositories WHERE session_id = $1",
+        "DELETE FROM session_github_repositories WHERE session_id = $1 AND account_id = $2",
         session_id,
+        account_id,
     )
 
 


### PR DESCRIPTION
## Summary
Closes one of the items in issue #403: PR 6's transitively-scoped session reads gain explicit \`AND account_id = \$N\` clauses.

Five queries promoted from "transitively safe via session_id FK" to "filtered by account_id in SQL":

* \`read_message_events\` (the assistant-history read used by tool dispatch)
* \`delete_session_github_repositories\` cascade
* \`list_session_memory_store_echoes\`
* \`list_session_github_repo_echoes\`
* \`get_session_github_repo\` (the unique-by-(session_id, id) variant)

Pre-fix, a future caller constructing a \`session_id\` from input could leak the row's data despite the bearer's account scope. After this PR, the filter is a SQL invariant.

## Test plan
- [x] \`uv run mypy src\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1206 passed
- [x] \`DOCKER_HOST=… uv run pytest tests/e2e --ignore=signal/telegram-flakes -q\` — 315 passed

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)