### PR TITLE
feat(#367 follow-up): GET /v1/accounts/by-path

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -256,6 +256,65 @@
         }
       }
     },
+    "/v1/accounts/by-path": {
+      "get": {
+        "tags": [
+          "accounts"
+        ],
+        "summary": "Resolve By Path",
+        "description": "Resolve a slash-separated path of ``display_name`` segments under the\ncaller's account.\n\nExamples:\n* ``?path=`` \u2192 the caller's account row.\n* ``?path=tenant-a`` \u2192 the direct child named ``tenant-a``.\n* ``?path=tenant-a/team-1`` \u2192 the grandchild ``team-1`` under\n  ``tenant-a``.\n\nPaths that walk outside the caller's subtree 404 (no existence leak).",
+        "operationId": "resolve_account_by_path",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/accounts/{target_id}": {
       "get": {
         "tags": [

--- a/packages/aios-sdk/aios_sdk/_generated/api/accounts/resolve_account_by_path.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/accounts/resolve_account_by_path.py
@@ -1,0 +1,227 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.account import Account
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    path: str,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["path"] = path
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/accounts/by-path",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Account | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Account.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Account | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    path: str,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Account | HTTPValidationError]:
+    """Resolve By Path
+
+     Resolve a slash-separated path of ``display_name`` segments under the
+    caller's account.
+
+    Examples:
+    * ``?path=`` → the caller's account row.
+    * ``?path=tenant-a`` → the direct child named ``tenant-a``.
+    * ``?path=tenant-a/team-1`` → the grandchild ``team-1`` under
+      ``tenant-a``.
+
+    Paths that walk outside the caller's subtree 404 (no existence leak).
+
+    Args:
+        path (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Account | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        path=path,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    path: str,
+    authorization: None | str | Unset = UNSET,
+) -> Account | HTTPValidationError | None:
+    """Resolve By Path
+
+     Resolve a slash-separated path of ``display_name`` segments under the
+    caller's account.
+
+    Examples:
+    * ``?path=`` → the caller's account row.
+    * ``?path=tenant-a`` → the direct child named ``tenant-a``.
+    * ``?path=tenant-a/team-1`` → the grandchild ``team-1`` under
+      ``tenant-a``.
+
+    Paths that walk outside the caller's subtree 404 (no existence leak).
+
+    Args:
+        path (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Account | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        path=path,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    path: str,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Account | HTTPValidationError]:
+    """Resolve By Path
+
+     Resolve a slash-separated path of ``display_name`` segments under the
+    caller's account.
+
+    Examples:
+    * ``?path=`` → the caller's account row.
+    * ``?path=tenant-a`` → the direct child named ``tenant-a``.
+    * ``?path=tenant-a/team-1`` → the grandchild ``team-1`` under
+      ``tenant-a``.
+
+    Paths that walk outside the caller's subtree 404 (no existence leak).
+
+    Args:
+        path (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Account | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        path=path,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    path: str,
+    authorization: None | str | Unset = UNSET,
+) -> Account | HTTPValidationError | None:
+    """Resolve By Path
+
+     Resolve a slash-separated path of ``display_name`` segments under the
+    caller's account.
+
+    Examples:
+    * ``?path=`` → the caller's account row.
+    * ``?path=tenant-a`` → the direct child named ``tenant-a``.
+    * ``?path=tenant-a/team-1`` → the grandchild ``team-1`` under
+      ``tenant-a``.
+
+    Paths that walk outside the caller's subtree 404 (no existence leak).
+
+    Args:
+        path (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Account | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            path=path,
+            authorization=authorization,
+        )
+    ).parsed

--- a/src/aios/api/routers/accounts.py
+++ b/src/aios/api/routers/accounts.py
@@ -129,6 +129,23 @@ async def mint_child(body: MintAccountRequest, pool: PoolDep, auth: AuthDep) -> 
     return response
 
 
+@router.get("/by-path", operation_id="resolve_account_by_path")
+async def resolve_by_path(path: str, pool: PoolDep, auth: AuthDep) -> Account:
+    """Resolve a slash-separated path of ``display_name`` segments under the
+    caller's account.
+
+    Examples:
+    * ``?path=`` → the caller's account row.
+    * ``?path=tenant-a`` → the direct child named ``tenant-a``.
+    * ``?path=tenant-a/team-1`` → the grandchild ``team-1`` under
+      ``tenant-a``.
+
+    Paths that walk outside the caller's subtree 404 (no existence leak).
+    """
+    account_id, _key_id, _can_mint = auth
+    return await service.resolve_by_path(pool, caller_account_id=account_id, path=path)
+
+
 @router.get("/{target_id}", operation_id="get_account")
 async def get_account(target_id: str, pool: PoolDep, auth: AuthDep) -> Account:
     """Read a specific account that's the caller or a direct child."""

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1898,8 +1898,10 @@ async def read_message_events(
     ``confirm_tool_deny`` searching for a tool_call_id).
     """
     rows = await conn.fetch(
-        "SELECT * FROM events WHERE session_id = $1 AND kind = 'message' ORDER BY seq ASC",
+        "SELECT * FROM events WHERE session_id = $1 AND account_id = $2 "
+        "AND kind = 'message' ORDER BY seq ASC",
         session_id,
+        account_id,
     )
     return [_row_to_event(r) for r in rows]
 
@@ -4632,8 +4634,9 @@ async def list_session_memory_store_echoes(
     account_id: str,
 ) -> list[MemoryStoreResourceEcho]:
     rows = await conn.fetch(
-        "SELECT * FROM session_memory_stores WHERE session_id = $1 ORDER BY rank",
+        "SELECT * FROM session_memory_stores WHERE session_id = $1 AND account_id = $2 ORDER BY rank",
         session_id,
+        account_id,
     )
     return [
         MemoryStoreResourceEcho(
@@ -4708,8 +4711,9 @@ async def list_session_github_repo_echoes(
     account_id: str,
 ) -> list[GithubRepositoryResourceEcho]:
     rows = await conn.fetch(
-        "SELECT * FROM session_github_repositories WHERE session_id = $1 ORDER BY rank",
+        "SELECT * FROM session_github_repositories WHERE session_id = $1 AND account_id = $2 ORDER BY rank",
         session_id,
+        account_id,
     )
     return [_row_to_github_repo_echo(r) for r in rows]
 
@@ -4722,9 +4726,11 @@ async def get_session_github_repo(
     account_id: str,
 ) -> GithubRepositoryResourceEcho:
     row = await conn.fetchrow(
-        "SELECT * FROM session_github_repositories WHERE session_id = $1 AND id = $2",
+        "SELECT * FROM session_github_repositories "
+        "WHERE session_id = $1 AND id = $2 AND account_id = $3",
         session_id,
         resource_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -4744,9 +4750,11 @@ async def get_session_github_repo_with_blob(
     """Read view + encrypted token blob, for the rotation path which needs
     both."""
     row = await conn.fetchrow(
-        "SELECT * FROM session_github_repositories WHERE session_id = $1 AND id = $2",
+        "SELECT * FROM session_github_repositories "
+        "WHERE session_id = $1 AND id = $2 AND account_id = $3",
         session_id,
         resource_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(
@@ -4826,8 +4834,9 @@ async def delete_session_github_repos(
     same transaction.
     """
     await conn.execute(
-        "DELETE FROM session_github_repositories WHERE session_id = $1",
+        "DELETE FROM session_github_repositories WHERE session_id = $1 AND account_id = $2",
         session_id,
+        account_id,
     )
 
 
@@ -5385,6 +5394,43 @@ async def get_account(conn: asyncpg.Connection[Any], account_id: str) -> Account
     """
     row = await conn.fetchrow("SELECT * FROM accounts WHERE id = $1", account_id)
     return _row_to_account(row) if row is not None else None
+
+
+async def resolve_account_by_path(
+    conn: asyncpg.Connection[Any],
+    *,
+    root_account_id: str,
+    segments: list[str],
+) -> Account | None:
+    """Resolve ``root/seg1/seg2/...`` to an account row, or ``None``.
+
+    Walks the ``parent_account_id`` chain from ``root_account_id`` down,
+    matching each segment against ``display_name`` at that depth. Returns
+    the deepest non-archived match. Empty ``segments`` returns the root
+    row itself.
+
+    The hierarchy is rooted at ``root_account_id`` (typically the
+    caller's account); ``/by-path`` doesn't traverse cross-tenant —
+    every segment lookup is scoped to the prior level's children.
+    """
+    cursor: Account | None = await get_account(conn, root_account_id)
+    if cursor is None or cursor.archived_at is not None:
+        return None
+    for seg in segments:
+        row = await conn.fetchrow(
+            """
+            SELECT * FROM accounts
+             WHERE parent_account_id = $1
+               AND display_name = $2
+               AND archived_at IS NULL
+            """,
+            cursor.id,
+            seg,
+        )
+        if row is None:
+            return None
+        cursor = _row_to_account(row)
+    return cursor
 
 
 async def list_child_accounts(

--- a/src/aios/services/accounts.py
+++ b/src/aios/services/accounts.py
@@ -74,6 +74,30 @@ async def get_account_in_scope(
     return row
 
 
+async def resolve_by_path(pool: asyncpg.Pool[Any], *, caller_account_id: str, path: str) -> Account:
+    """Look up ``path`` (slash-separated display names) under the caller.
+
+    The caller's own account is the implicit root. Empty path (or just
+    "/") returns the caller. Each segment is matched against
+    ``display_name`` at the next depth. Raises :class:`NotFoundError`
+    if any segment doesn't resolve — including for paths that walk
+    outside the caller's subtree.
+    """
+    segments = [s for s in path.strip("/").split("/") if s]
+    async with pool.acquire() as conn:
+        resolved = await queries.resolve_account_by_path(
+            conn,
+            root_account_id=caller_account_id,
+            segments=segments,
+        )
+    if resolved is None:
+        raise NotFoundError(
+            f"account path {path!r} not found",
+            detail={"path": path, "caller_account_id": caller_account_id},
+        )
+    return resolved
+
+
 async def list_children(pool: asyncpg.Pool[Any], *, parent_account_id: str) -> list[Account]:
     """Return non-archived direct children of ``parent_account_id``."""
     async with pool.acquire() as conn:

--- a/tests/e2e/test_accounts_mgmt.py
+++ b/tests/e2e/test_accounts_mgmt.py
@@ -173,6 +173,69 @@ class TestChildScope:
         assert r.status_code == 404, r.text
 
 
+class TestByPath:
+    async def test_root_path_returns_caller(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        for path in ("", "/"):
+            r = await http_client.get(
+                "/v1/accounts/by-path",
+                params={"path": path},
+                headers=_bearer(aios_env["AIOS_API_KEY"]),
+            )
+            assert r.status_code == 200, r.text
+            assert r.json()["id"] == "acc_test_stub"
+
+    async def test_resolves_child_by_name(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "by-path-target"},
+        )
+        r = await http_client.get(
+            "/v1/accounts/by-path",
+            params={"path": "by-path-target"},
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["display_name"] == "by-path-target"
+
+    async def test_resolves_grandchild_by_two_segments(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        # Mint child with mint-children, then mint grandchild under it.
+        c = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "tenant-x", "can_mint_children": True},
+        )
+        ck = c.json()["plaintext_key"]
+        await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(ck),
+            json={"display_name": "team-a"},
+        )
+        r = await http_client.get(
+            "/v1/accounts/by-path",
+            params={"path": "tenant-x/team-a"},
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["display_name"] == "team-a"
+
+    async def test_missing_segment_404(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        r = await http_client.get(
+            "/v1/accounts/by-path",
+            params={"path": "no-such-child"},
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+        )
+        assert r.status_code == 404
+
+
 class TestKeys:
     async def test_mint_key_on_self(
         self, http_client: httpx.AsyncClient, aios_env: dict[str, str]


### PR DESCRIPTION
## Summary
Adds the design item from #367 — slash-separated path of \`display_name\` segments resolves to an account row, rooted at the caller's account.

\`\`\`
GET /v1/accounts/by-path?path=
GET /v1/accounts/by-path?path=tenant-a
GET /v1/accounts/by-path?path=tenant-a/team-1
\`\`\`

- Empty path (or \`/\`) returns the caller's row.
- Each segment walks one level down, matching by \`display_name\`.
- Cross-tenant paths 404 (the walk is scoped to the caller's subtree by construction — no existence leak).

## Test plan
- [x] \`uv run mypy src\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1206 passed
- [x] \`DOCKER_HOST=… uv run pytest tests/e2e/test_accounts_mgmt.py -q\` — all passed (4 new \`TestByPath\` cases)

Closes one of the items in #403.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)