### PR TITLE
fix(#367 follow-up): account_id WHERE on archive_memory_store

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -4050,8 +4050,9 @@ async def archive_memory_store(
 ) -> MemoryStore:
     row = await conn.fetchrow(
         "UPDATE memory_stores SET archived_at = now(), updated_at = now() "
-        "WHERE id = $1 AND archived_at IS NULL RETURNING *",
+        "WHERE id = $1 AND archived_at IS NULL AND account_id = $2 RETURNING *",
         store_id,
+        account_id,
     )
     if row is None:
         raise NotFoundError(


### PR DESCRIPTION
## Summary
Tiny one-line cross-tenant defense fix the earlier audit missed:

\`\`\`
archive_memory_store:
  UPDATE memory_stores SET archived_at = now() ...
   WHERE id = \$1 AND archived_at IS NULL
                                          + AND account_id = \$2
\`\`\`

Matches the pattern from \`archive_session\` / \`archive_vault\` / \`archive_session_template\`. Without the filter, a future caller that hadn't done a prior \`get_memory_store\` scope-check could archive another tenant's store by id.

## Test plan
- [x] \`uv run mypy src\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1206 passed
- [x] \`DOCKER_HOST=… uv run pytest tests/e2e/test_memory_stores_api.py -q\` — 19/19 passed

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)