### PR TITLE
feat(#367 follow-up): per-tenant workspace paths

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -644,7 +644,11 @@ async def insert_session(
 
     new_id = make_id(SESSION)
     if workspace_path is None:
-        workspace_path = str(get_settings().workspace_root / new_id)
+        # Per-tenant subdir (#367 follow-up): each account's sessions
+        # live under ``workspace_root/{account_id}/{session_id}`` so a
+        # stray bind-mount can't reach across tenants, and so per-tenant
+        # disk quotas / backups can scope to one directory.
+        workspace_path = str(get_settings().workspace_root / account_id / new_id)
     try:
         row = await conn.fetchrow(
             """
@@ -1092,7 +1096,11 @@ async def clone_session(
 
     new_id = make_id(SESSION)
     if workspace_path is None:
-        workspace_path = str(get_settings().workspace_root / new_id)
+        # Per-tenant subdir (#367 follow-up): each account's sessions
+        # live under ``workspace_root/{account_id}/{session_id}`` so a
+        # stray bind-mount can't reach across tenants, and so per-tenant
+        # disk quotas / backups can scope to one directory.
+        workspace_path = str(get_settings().workspace_root / account_id / new_id)
 
     async with conn.transaction():
         status = await conn.fetchval(


### PR DESCRIPTION
## Summary

Default workspace path nests under the tenant:

\`\`\`
workspace_root/{account_id}/{session_id}     ← new
workspace_root/{session_id}                  ← old
\`\`\`

Why:

- **Stray bind-mounts can't accidentally cross tenant boundaries.** A filesystem-level mistake (a path-traversal bug, a misconfigured Docker volume) can at worst leak data within one tenant rather than across them.
- **Per-tenant disk quotas / backups / retention / cleanup** can scope to one directory tree.

### Backward-compat

Only the default path computation changes (\`insert_session\` and the clone-from-session path). Existing sessions' paths are already stored verbatim in \`sessions.workspace_volume_path\` and resolve through the unchanged \`ensure_workspace_path\` helper. Operators passing an explicit override are unaffected.

## Test plan
- [x] \`uv run mypy src\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1206 passed
- [x] \`DOCKER_HOST=… uv run pytest tests/e2e --ignore=signal/telegram-flakes -q\` — 315 passed

Closes one of the items in #403.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)