### PR TITLE
feat(#367 follow-up): CryptoBox.derive_account_subkey via HKDF-SHA256

### DIFF
--- a/src/aios/crypto/vault.py
+++ b/src/aios/crypto/vault.py
@@ -7,12 +7,20 @@ or key mismatch produces a clean error rather than silent corruption. Archived
 rows have their ciphertext and nonce zeroed out so that a future DB dump or
 query cannot leak the secret — read paths filter ``WHERE archived_at IS NULL``
 to avoid attempting to decrypt the scrubbed bytes.
+
+Multi-tenancy (#367): the master ``CryptoBox`` can derive a per-account
+subkey via HKDF-SHA256, returning a new ``CryptoBox`` whose secrets can't
+be decrypted with the master key OR any sibling tenant's derived key.
+This is the building block for per-account encryption — see
+:meth:`CryptoBox.derive_account_subkey`.
 """
 
 from __future__ import annotations
 
 import base64
 import binascii
+import hashlib
+import hmac
 import json
 from dataclasses import dataclass
 from typing import Any
@@ -46,7 +54,41 @@ class CryptoBox:
     def __init__(self, master_key: bytes) -> None:
         if len(master_key) != KEY_BYTES:
             raise ValueError(f"master key must be {KEY_BYTES} bytes, got {len(master_key)}")
+        self._key = master_key
         self._box = SecretBox(master_key)
+
+    def derive_account_subkey(self, account_id: str) -> CryptoBox:
+        """Return a new :class:`CryptoBox` keyed to ``account_id`` via HKDF.
+
+        Uses HKDF-SHA256 with the current box's key as IKM, an aios-specific
+        salt, and ``f"aios-account-{account_id}"`` as the info context.
+        Properties:
+
+        * Deterministic — re-deriving for the same account_id returns
+          the same subkey bytes.
+        * Domain-separated — two different account_ids produce two
+          unrelated 32-byte subkeys; an attacker holding one subkey
+          cannot recover the master or any sibling subkey.
+        * One-way — knowing a subkey doesn't reveal the master.
+
+        The returned subkey is itself a :class:`CryptoBox` and supports
+        ``encrypt`` / ``decrypt`` exactly like the master.
+        """
+        if not account_id:
+            raise ValueError("account_id must be non-empty")
+        # Single-extract HKDF-SHA256: the "extract" step normalises an
+        # arbitrary-strength IKM (always 32 bytes for us) into a PRK,
+        # then the "expand" step stretches PRK + info into the output.
+        # Salt is a fixed application-specific constant — operators
+        # rotate by reissuing keys, not by changing salt.
+        salt = b"aios-vault-hkdf-v1"
+        info = f"aios-account-{account_id}".encode()
+        prk = hmac.new(salt, self._key, hashlib.sha256).digest()
+        # Single-block expand: output is one SHA256 block (32 bytes),
+        # which matches SecretBox's KEY_BYTES so we don't need to chain
+        # multiple T(i) outputs.
+        t1 = hmac.new(prk, info + b"\x01", hashlib.sha256).digest()
+        return CryptoBox(t1)
 
     @classmethod
     def from_base64(cls, encoded: str) -> CryptoBox:

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -787,3 +787,56 @@ class TestRefreshCredential:
 def test_refresh_skew_seconds_is_positive() -> None:
     """Sanity check the constant — 0 would cause infinite refresh churn."""
     assert REFRESH_SKEW_SECONDS > 0
+
+
+class TestDeriveAccountSubkey:
+    """``CryptoBox.derive_account_subkey`` — HKDF-SHA256 per-account key
+    derivation (#367 follow-up). The building block for moving from a
+    single deployment-wide vault key to per-account encryption."""
+
+    def _master(self) -> CryptoBox:
+        # Use a fixed master so the derive output is deterministic across runs.
+        return CryptoBox(b"\xab" * 32)
+
+    def test_returns_a_cryptobox(self) -> None:
+        sub = self._master().derive_account_subkey("acc_alpha")
+        assert isinstance(sub, CryptoBox)
+
+    def test_subkey_round_trips_plaintext(self) -> None:
+        sub = self._master().derive_account_subkey("acc_alpha")
+        blob = sub.encrypt("secret payload")
+        assert sub.decrypt(blob) == "secret payload"
+
+    def test_deterministic_per_account(self) -> None:
+        """Same account_id → same subkey bytes (allowing the same blob
+        to decrypt across process restarts)."""
+        a1 = self._master().derive_account_subkey("acc_alpha")
+        a2 = self._master().derive_account_subkey("acc_alpha")
+        blob = a1.encrypt("payload")
+        assert a2.decrypt(blob) == "payload"
+
+    def test_subkeys_for_different_accounts_diverge(self) -> None:
+        """Two tenants get two unrelated keys — a payload encrypted with
+        one cannot be decrypted with the other."""
+        from aios.errors import CryptoDecryptError
+
+        a = self._master().derive_account_subkey("acc_alpha")
+        b = self._master().derive_account_subkey("acc_beta")
+        blob = a.encrypt("payload")
+        with pytest.raises(CryptoDecryptError):
+            b.decrypt(blob)
+
+    def test_master_cannot_decrypt_subkey_ciphertext(self) -> None:
+        """One-way property: a subkey is unreachable from the master
+        even though it was derived from it."""
+        from aios.errors import CryptoDecryptError
+
+        master = self._master()
+        sub = master.derive_account_subkey("acc_alpha")
+        blob = sub.encrypt("payload")
+        with pytest.raises(CryptoDecryptError):
+            master.decrypt(blob)
+
+    def test_empty_account_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="account_id must be non-empty"):
+            self._master().derive_account_subkey("")


### PR DESCRIPTION
## Summary
The per-account key-derivation building block called out in #403. \`CryptoBox\` now has a \`derive_account_subkey(account_id)\` method that returns a fresh \`CryptoBox\` keyed via HKDF-SHA256 over (current box's key, salt, account_id).

Properties exercised by 6 new unit tests:

- **Deterministic** — same account_id ⇒ same subkey bytes.
- **Domain-separated** — different account_ids produce unrelated keys; cross-decryption raises \`CryptoDecryptError\`.
- **One-way** — master can't decrypt subkey-encrypted ciphertext.
- **Empty account_id rejected**.

### Scope

This is the building block, not the wiring. No call sites changed yet. The follow-up will:

- Reshape \`services/vaults.py\`, \`services/github_repositories.py\`, \`services/connections.py\` to call \`crypto_box.derive_account_subkey(account_id)\` at the top of each encrypt/decrypt and use the subkey for the actual operation.
- A one-pass migration that re-encrypts existing master-keyed blobs as per-account blobs.

Splitting the building block from the wiring keeps each PR atomic and reviewable; the wiring PR will be a much larger diff with backward-compat decisions.

## Test plan
- [x] \`uv run mypy src\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1212 passed (6 new)

Closes one of the items in #403.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)