### PR TITLE
fix(#298): unlink smoke logs on restart

### DIFF
--- a/.claude/skills/aios-smoke-setup/scripts/setup.sh
+++ b/.claude/skills/aios-smoke-setup/scripts/setup.sh
@@ -154,8 +154,11 @@ start_runtime() {
   sleep 0.5
 
   say "starting api + worker"
-  : > "$WORKTREE/.logs/api.log"
-  : > "$WORKTREE/.logs/worker.log"
+  # Unlink rather than truncate: the previous worker's still-open stdout
+  # fd keeps appending to the inode it opened, which is now anonymous,
+  # so its shutdown traceback can't bleed into the new log file. The
+  # new processes open a fresh inode at the same path. See #298.
+  rm -f "$WORKTREE/.logs/api.log" "$WORKTREE/.logs/worker.log"
   ( set -a; source "$WORKTREE/.env"; set +a
     nohup uv run python -m aios api > "$WORKTREE/.logs/api.log" 2>&1 &
     nohup uv run python -m aios worker > "$WORKTREE/.logs/worker.log" 2>&1 & )


### PR DESCRIPTION
## Summary

- Smoke setup.sh's restart path truncated `.logs/{api,worker}.log` with `: >`. The previous worker's still-open stdout fd kept appending to the same inode, so its SIGTERM shutdown traceback bled into what the script reads as the new worker.log — false-alarming `runtime startup failed`.
- Switch to `rm -f`: severs the fd entirely, old writes vanish with the unlinked inode, new processes open a fresh file.
- Per option B in #298. The separable anyio cross-task cancel-scope bug in `mcp/pool.py` shutdown isn't fixed here.

Fixes #298.

## Test plan

- [x] Diff verified — only the truncate vs. unlink change.
- [ ] Manual: run `setup.sh --restart` after a previous run; verify no false-alarm on the second start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)