### PR TITLE
fix(#403 follow-up): defense-in-depth WHERE account_id on three event queries

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1471,6 +1471,7 @@ async def lookup_tool_name_by_call_id(
     raw = await conn.fetchval(
         "SELECT data->'tool_calls' FROM events "
         "WHERE session_id = $1 "
+        "  AND account_id = $3 "
         "  AND kind = 'message' "
         "  AND data->>'role' = 'assistant' "
         "  AND data ? 'tool_calls' "
@@ -1479,6 +1480,7 @@ async def lookup_tool_name_by_call_id(
         "ORDER BY seq DESC LIMIT 1",
         session_id,
         tool_call_id,
+        account_id,
     )
     if raw is None:
         return None
@@ -1927,11 +1929,13 @@ async def list_session_channels(
         SELECT DISTINCT channel
           FROM events
          WHERE session_id = $1
+           AND account_id = $2
            AND kind = 'message'
            AND channel IS NOT NULL
          ORDER BY channel
         """,
         session_id,
+        account_id,
     )
     return [str(r["channel"]) for r in rows]
 
@@ -2033,11 +2037,12 @@ async def read_windowed_events(
     # Bounded range scan: only events past the boundary.
     rows = await conn.fetch(
         "SELECT * FROM events "
-        "WHERE session_id = $1 AND kind = 'message' "
+        "WHERE session_id = $1 AND account_id = $3 AND kind = 'message' "
         "AND cumulative_tokens > $2 "
         "ORDER BY seq ASC",
         session_id,
         drop,
+        account_id,
     )
     return [_row_to_event(r) for r in rows]
 

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -102,7 +102,7 @@ async def test_insufficient_ratio_1_matches_today() -> None:
     )
     assert conn.fetch_calls, "expected bounded range scan to be called"
     # Second positional arg to conn.fetch is the drop value.
-    _session_id, drop_local = conn.fetch_calls[-1]
+    _session_id, drop_local, *_ = conn.fetch_calls[-1]
     assert drop_local == 1_000
 
 
@@ -130,7 +130,7 @@ async def test_ratio_above_1_drops_more() -> None:
         overhead_local=0,
         account_id=account_id,
     )
-    _session_id, drop_local = conn.fetch_calls[-1]
+    _session_id, drop_local, *_ = conn.fetch_calls[-1]
     assert drop_local == 667
 
 


### PR DESCRIPTION
## Summary

Three query functions in `src/aios/db/queries.py` accepted `account_id` as a kwarg but never used it in SQL. The columns are already transitively scoped via `sessions.account_id NOT NULL`, so the kwarg promised defense-in-depth that wasn't being delivered:

- `lookup_tool_name_by_call_id`
- `list_session_channels`
- `read_windowed_events` (bounded range scan at the tail)

Added `AND account_id = $N` to each. Matches the pattern from #404; catches the three that sweep missed.

`model_token_ratio` is the deliberate exception — its `account_id` kwarg is unused on purpose because the calibration aggregates spans deployment-wide.

## Test plan

- [x] `uv run pytest tests/unit -q` — 1212 passed (one test adjusted to unpack the new third positional arg)
- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)