### PR TITLE
feat(#367 follow-up): HKDF per-account subkey for connections + github_repositories

### DIFF
--- a/migrations/versions/0047_reencrypt_connections_and_github_with_subkey.py
+++ b/migrations/versions/0047_reencrypt_connections_and_github_with_subkey.py
@@ -1,0 +1,120 @@
+"""Re-encrypt ``connections.secrets_*`` and ``session_github_repositories``
+ciphertext columns with per-account HKDF subkeys.
+
+Companion to migration 0046, which did the same for ``vault_credentials``.
+After this migration, every encrypted blob in the database is keyed to its
+owning account, not the master key. An attacker who recovers one tenant's
+derived key cannot decrypt any other tenant's secrets.
+
+For each table, the migration walks active rows that actually have
+ciphertext set, decrypts under the master key, and re-encrypts under
+``master.derive_account_subkey(row.account_id)``. Same fail-loud behavior
+as 0046: a decrypt error aborts the migration rather than silently
+overwriting the row with the wrong key.
+
+The master key is only loaded if at least one row needs re-encryption,
+so fresh deployments (and the integration test's empty-database upgrade)
+don't require ``AIOS_VAULT_KEY`` to be set.
+
+Revision ID: 0047
+Revises: 0046
+Create Date: 2026-05-14
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from collections.abc import Callable, Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from aios.crypto.vault import CryptoBox, EncryptedBlob
+
+revision: str = "0047"
+down_revision: str = "0046"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# (table_name, ciphertext_col, nonce_col, extra_where_clause).
+# `where` filters to rows that need rekey; archived/scrubbed rows are
+# excluded so we don't fail trying to decrypt zero bytes.
+_TABLES: Sequence[tuple[str, str, str, str]] = (
+    # connections: ciphertext / nonce are NULL when the connection has no
+    # secrets configured. archive_connection() scrubs both to NULL, so this
+    # filter naturally skips archived rows too.
+    ("connections", "secrets_ciphertext", "secrets_nonce", "secrets_ciphertext IS NOT NULL"),
+    # session_github_repositories: ciphertext / nonce are NOT NULL on
+    # active rows. No archived_at column — rows are DELETEd when detached.
+    ("session_github_repositories", "ciphertext", "nonce", "TRUE"),
+)
+
+
+def _load_master() -> CryptoBox:
+    encoded = os.environ.get("AIOS_VAULT_KEY")
+    if not encoded:
+        raise RuntimeError(
+            "AIOS_VAULT_KEY must be set when running migration 0047 — "
+            "the migration re-encrypts secrets and needs the master key"
+        )
+    return CryptoBox(base64.b64decode(encoded, validate=True))
+
+
+def _rekey(
+    build_src: Callable[[CryptoBox], Callable[[str], CryptoBox]],
+    build_dst: Callable[[CryptoBox], Callable[[str], CryptoBox]],
+) -> None:
+    """For each :data:`_TABLES` entry, walk rows with non-null ciphertext,
+    decrypt under ``src_for(account_id)``, re-encrypt under
+    ``dst_for(account_id)``, and write the new bytes back.
+
+    Master key is loaded lazily — only if at least one table has rows to
+    rekey. Empty DBs skip the env-var requirement entirely. ``build_src``
+    and ``build_dst`` take the master and return ``account_id → CryptoBox``
+    so upgrade and downgrade share the walker."""
+    bind = op.get_bind()
+    master: CryptoBox | None = None
+    src_for: Callable[[str], CryptoBox] | None = None
+    dst_for: Callable[[str], CryptoBox] | None = None
+    for name, ct_col, nn_col, where in _TABLES:
+        rows = bind.execute(
+            sa.text(
+                f"SELECT id, account_id, {ct_col} AS ct, {nn_col} AS nn FROM {name} WHERE {where}"
+            )
+        ).fetchall()
+        if not rows:
+            continue
+        if master is None:
+            master = _load_master()
+            src_for = build_src(master)
+            dst_for = build_dst(master)
+        assert src_for is not None and dst_for is not None  # for mypy
+        for row in rows:
+            plaintext = src_for(row.account_id).decrypt(
+                EncryptedBlob(ciphertext=row.ct, nonce=row.nn)
+            )
+            new_blob = dst_for(row.account_id).encrypt(plaintext)
+            bind.execute(
+                sa.text(
+                    f"UPDATE {name} "
+                    f"SET {ct_col} = :ct, {nn_col} = :nn, updated_at = now() "
+                    f"WHERE id = :id"
+                ),
+                {"ct": new_blob.ciphertext, "nn": new_blob.nonce, "id": row.id},
+            )
+
+
+def upgrade() -> None:
+    _rekey(
+        build_src=lambda master: lambda _account_id: master,
+        build_dst=lambda master: master.derive_account_subkey,
+    )
+
+
+def downgrade() -> None:
+    _rekey(
+        build_src=lambda master: master.derive_account_subkey,
+        build_dst=lambda master: lambda _account_id: master,
+    )

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -31,16 +31,22 @@ from aios.models.connections import (
 )
 
 
-def _encrypt_secrets(secrets: dict[str, str] | None, crypto_box: CryptoBox) -> EncryptedBlob | None:
+def _encrypt_secrets(
+    secrets: dict[str, str] | None, crypto_box: CryptoBox, *, account_id: str
+) -> EncryptedBlob | None:
     """Encrypt a secrets dict, or ``None`` if the dict is missing or empty.
 
     Empty / missing → no blob → schema columns NULL → ``secrets_set: False``.
     The operator surface treats ``None`` and ``{}`` identically (both
     "clear secrets") so create + PUT produce the same row state.
+
+    Encryption is keyed to ``account_id`` via :meth:`CryptoBox.derive_account_subkey`
+    so a connection's secrets can't be decrypted by another tenant's
+    derived key even if the row leaks.
     """
     if not secrets:
         return None
-    return crypto_box.encrypt_dict(secrets)
+    return crypto_box.derive_account_subkey(account_id).encrypt_dict(secrets)
 
 
 async def create_connection(
@@ -59,7 +65,7 @@ async def create_connection(
             connector=connector,
             account=account,
             metadata=metadata,
-            secrets_blob=_encrypt_secrets(secrets, crypto_box),
+            secrets_blob=_encrypt_secrets(secrets, crypto_box, account_id=account_id),
             account_id=account_id,
         )
 
@@ -82,7 +88,7 @@ async def set_connection_secrets(
         return await queries.set_connection_secrets(
             conn,
             connection_id,
-            secrets_blob=_encrypt_secrets(secrets, crypto_box),
+            secrets_blob=_encrypt_secrets(secrets, crypto_box, account_id=account_id),
             account_id=account_id,
         )
 
@@ -106,7 +112,7 @@ async def get_connection_secrets(
         blob = await queries.get_connection_secret_blob(conn, connection_id, account_id=account_id)
     if blob is None:
         return {}
-    decoded = crypto_box.decrypt_dict(blob)
+    decoded = crypto_box.derive_account_subkey(account_id).decrypt_dict(blob)
     return {str(k): str(v) for k, v in decoded.items()}
 
 

--- a/src/aios/services/github_repositories.py
+++ b/src/aios/services/github_repositories.py
@@ -28,9 +28,13 @@ from aios.models.github_repositories import (
 from aios.sandbox.github_clone import remove_session_working_tree
 
 
-def _encrypt_token(crypto_box: CryptoBox, token: str) -> Any:
-    """Encrypt a github auth token. Returns an :class:`EncryptedBlob`."""
-    return crypto_box.encrypt(token)
+def _encrypt_token(crypto_box: CryptoBox, token: str, *, account_id: str) -> Any:
+    """Encrypt a github auth token. Returns an :class:`EncryptedBlob`.
+
+    Keyed to ``account_id`` via :meth:`CryptoBox.derive_account_subkey` so
+    the embedded token can't be decrypted under another tenant's key.
+    """
+    return crypto_box.derive_account_subkey(account_id).encrypt(token)
 
 
 async def _list_attached_resource_ids(
@@ -68,7 +72,9 @@ async def attach_to_session(
         return
     entries: list[tuple[str, str, Any, str | None, str | None]] = []
     for res in resources:
-        blob = _encrypt_token(crypto_box, res.authorization_token.get_secret_value())
+        blob = _encrypt_token(
+            crypto_box, res.authorization_token.get_secret_value(), account_id=account_id
+        )
         entries.append((res.url, res.mount_path, blob, res.git_user_name, res.git_user_email))
     try:
         await queries.attach_github_repos_to_session(
@@ -166,7 +172,7 @@ async def rotate_token(
     unset and the stored ``git_user_name`` / ``git_user_email`` survive
     the rotation.
     """
-    blob = _encrypt_token(crypto_box, new_token)
+    blob = _encrypt_token(crypto_box, new_token, account_id=account_id)
     async with pool.acquire() as conn, conn.transaction():
         return await queries.update_session_github_repo_blob(
             conn,
@@ -195,4 +201,4 @@ async def get_session_token(
     _, blob = await queries.get_session_github_repo_with_blob(
         conn, session_id, resource_id, account_id=account_id
     )
-    return crypto_box.decrypt(blob)
+    return crypto_box.derive_account_subkey(account_id).decrypt(blob)


### PR DESCRIPTION
## Summary

Extends the per-account encryption pattern from #416 (vault_credentials) to the remaining ciphertext-bearing tables:

- `services/connections.py` — `_encrypt_secrets` and `get_connection_secrets` derive `crypto_box.derive_account_subkey(account_id)`.
- `services/github_repositories.py` — `_encrypt_token` and `get_session_token` derive the per-account subkey.

After this PR, every encrypted blob in the database is keyed to its owning account. An attacker who recovers one tenant's derived key cannot decrypt another tenant's secrets.

Migration 0047 walks both tables, decrypts under the master, and re-encrypts under per-account subkeys. Same lazy-load pattern as 0046 — env var only required if rows exist to rekey.

## Deployment ordering

Migrate-then-deploy, same as #416. Reads of pre-existing rows under the new code raise `CryptoDecryptError` until `alembic upgrade head` runs.

(Recreated after #416's merge auto-closed the original PR #417 by deleting the base branch.)

## Test plan

- [x] `uv run pytest tests/unit -q` — 1212 passed
- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run alembic heads` — `0047 (head)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)