### PR TITLE
fix(promote): include sha in ledger-append payload

### DIFF
--- a/.github/workflows/promote-sandbox.yml
+++ b/.github/workflows/promote-sandbox.yml
@@ -58,6 +58,7 @@ jobs:
             {
               "app": "aios-sandbox",
               "track": "R",
+              "sha": "${{ github.sha }}",
               "digest": "${{ steps.digest.outputs.digest }}",
               "promoted_by": "${{ github.actor }}"
             }


### PR DESCRIPTION
The eumemic-ops `deploy-ledger-append` workflow validates that incoming payloads include `sha` (alongside `app`, `track`, `promoted_by`). The promote workflow's payload was missing this field — every promote since the ledger pipeline was wired up has had its ledger-append step fail validation downstream.

Adds `"sha": "${{ github.sha }}"` to the payload. At workflow_dispatch time `github.sha` is the master HEAD ref the workflow was triggered against, which is the right answer for "which source commit produced the image being promoted."

Companion fix on eumemic-ops side (`bf7cc6d`) drops a separate broken-secret reference on the receiving workflow that was making it fail earlier in the pipeline (at checkout instead of validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)