### PR TITLE
fix(#345): scrub orphan mcp_toolset entries

### DIFF
--- a/migrations/versions/0046_reencrypt_vault_credentials_with_subkey.py
+++ b/migrations/versions/0046_reencrypt_vault_credentials_with_subkey.py
@@ -1,0 +1,103 @@
+"""Re-encrypt every ``vault_credentials`` row with its per-account subkey.
+
+Pairs with the application-side wiring that derives an HKDF-SHA256 subkey
+from the master ``AIOS_VAULT_KEY`` and uses it for all encrypt/decrypt
+operations against ``vault_credentials``. Pre-existing rows are encrypted
+under the master key alone, so this migration walks each active row,
+decrypts with the master, and re-encrypts under
+``master.derive_account_subkey(row.account_id)`` in place.
+
+Archived rows are skipped — their ciphertext/nonce columns were scrubbed
+to zero bytes at archive time and re-encrypting zero bytes would either
+fail or produce a meaningless blob.
+
+Operator requirements:
+
+* ``AIOS_VAULT_KEY`` must be set in the environment when ``alembic
+  upgrade`` runs. The application already requires this at boot, so the
+  migration inherits the same constraint.
+* Failure mode is fail-loud: a decrypt error on any row aborts the
+  migration. The row is most likely encrypted with a different master
+  key than the operator has configured, which is exactly the case where
+  re-encrypting would silently lose the secret.
+
+Downgrade reverses the operation (decrypt with subkey, re-encrypt with
+master) so the migration is symmetric.
+
+Revision ID: 0046
+Revises: 0045
+Create Date: 2026-05-14
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from collections.abc import Callable, Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from aios.crypto.vault import CryptoBox, EncryptedBlob
+
+revision: str = "0046"
+down_revision: str = "0045"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _load_master() -> CryptoBox:
+    encoded = os.environ.get("AIOS_VAULT_KEY")
+    if not encoded:
+        raise RuntimeError(
+            "AIOS_VAULT_KEY must be set when running migration 0046 — "
+            "the migration re-encrypts vault_credentials and needs the master key"
+        )
+    return CryptoBox(base64.b64decode(encoded, validate=True))
+
+
+def _rekey(
+    src_for: Callable[[str], CryptoBox],
+    dst_for: Callable[[str], CryptoBox],
+) -> None:
+    """Walk active vault_credentials, decrypt with ``src_for(account_id)``,
+    encrypt with ``dst_for(account_id)``, and write the new (ciphertext,
+    nonce) back. Both lookups take the row's ``account_id`` so the same
+    helper covers upgrade (master→subkey) and downgrade (subkey→master)."""
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, account_id, ciphertext, nonce "
+            "FROM vault_credentials "
+            "WHERE archived_at IS NULL"
+        )
+    ).fetchall()
+    for row in rows:
+        plaintext = src_for(row.account_id).decrypt(
+            EncryptedBlob(ciphertext=row.ciphertext, nonce=row.nonce)
+        )
+        new_blob = dst_for(row.account_id).encrypt(plaintext)
+        bind.execute(
+            sa.text(
+                "UPDATE vault_credentials "
+                "SET ciphertext = :ct, nonce = :nn, updated_at = now() "
+                "WHERE id = :id"
+            ),
+            {"ct": new_blob.ciphertext, "nn": new_blob.nonce, "id": row.id},
+        )
+
+
+def upgrade() -> None:
+    master = _load_master()
+    _rekey(
+        src_for=lambda _account_id: master,
+        dst_for=master.derive_account_subkey,
+    )
+
+
+def downgrade() -> None:
+    master = _load_master()
+    _rekey(
+        src_for=master.derive_account_subkey,
+        dst_for=lambda _account_id: master,
+    )

--- a/migrations/versions/0046_reencrypt_vault_credentials_with_subkey.py
+++ b/migrations/versions/0046_reencrypt_vault_credentials_with_subkey.py
@@ -14,8 +14,10 @@ fail or produce a meaningless blob.
 Operator requirements:
 
 * ``AIOS_VAULT_KEY`` must be set in the environment when ``alembic
-  upgrade`` runs. The application already requires this at boot, so the
-  migration inherits the same constraint.
+  upgrade`` runs against a database that has existing ``vault_credentials``
+  rows. The application already requires this at boot, so the migration
+  inherits the same constraint. Empty databases (fresh deployments,
+  ``alembic upgrade head`` in CI) skip the env-var check.
 * Failure mode is fail-loud: a decrypt error on any row aborts the
   migration. The row is most likely encrypted with a different master
   key than the operator has configured, which is exactly the case where
@@ -57,13 +59,19 @@ def _load_master() -> CryptoBox:
 
 
 def _rekey(
-    src_for: Callable[[str], CryptoBox],
-    dst_for: Callable[[str], CryptoBox],
+    build_src: Callable[[CryptoBox], Callable[[str], CryptoBox]],
+    build_dst: Callable[[CryptoBox], Callable[[str], CryptoBox]],
 ) -> None:
     """Walk active vault_credentials, decrypt with ``src_for(account_id)``,
     encrypt with ``dst_for(account_id)``, and write the new (ciphertext,
-    nonce) back. Both lookups take the row's ``account_id`` so the same
-    helper covers upgrade (master→subkey) and downgrade (subkey→master)."""
+    nonce) back.
+
+    The master key is only loaded if there are rows to re-encrypt. An
+    empty database — the common case for ``alembic upgrade head`` in CI
+    and fresh deployments — skips the env-var check entirely. ``build_src``
+    and ``build_dst`` take the master and return ``account_id → CryptoBox``
+    so upgrade (master→subkey) and downgrade (subkey→master) share the
+    walker."""
     bind = op.get_bind()
     rows = bind.execute(
         sa.text(
@@ -72,6 +80,11 @@ def _rekey(
             "WHERE archived_at IS NULL"
         )
     ).fetchall()
+    if not rows:
+        return
+    master = _load_master()
+    src_for = build_src(master)
+    dst_for = build_dst(master)
     for row in rows:
         plaintext = src_for(row.account_id).decrypt(
             EncryptedBlob(ciphertext=row.ciphertext, nonce=row.nonce)
@@ -88,16 +101,14 @@ def _rekey(
 
 
 def upgrade() -> None:
-    master = _load_master()
     _rekey(
-        src_for=lambda _account_id: master,
-        dst_for=master.derive_account_subkey,
+        build_src=lambda master: lambda _account_id: master,
+        build_dst=lambda master: master.derive_account_subkey,
     )
 
 
 def downgrade() -> None:
-    master = _load_master()
     _rekey(
-        src_for=master.derive_account_subkey,
-        dst_for=lambda _account_id: master,
+        build_src=lambda master: master.derive_account_subkey,
+        build_dst=lambda master: lambda _account_id: master,
     )

--- a/migrations/versions/0047_reencrypt_connections_and_github_with_subkey.py
+++ b/migrations/versions/0047_reencrypt_connections_and_github_with_subkey.py
@@ -1,0 +1,120 @@
+"""Re-encrypt ``connections.secrets_*`` and ``session_github_repositories``
+ciphertext columns with per-account HKDF subkeys.
+
+Companion to migration 0046, which did the same for ``vault_credentials``.
+After this migration, every encrypted blob in the database is keyed to its
+owning account, not the master key. An attacker who recovers one tenant's
+derived key cannot decrypt any other tenant's secrets.
+
+For each table, the migration walks active rows that actually have
+ciphertext set, decrypts under the master key, and re-encrypts under
+``master.derive_account_subkey(row.account_id)``. Same fail-loud behavior
+as 0046: a decrypt error aborts the migration rather than silently
+overwriting the row with the wrong key.
+
+The master key is only loaded if at least one row needs re-encryption,
+so fresh deployments (and the integration test's empty-database upgrade)
+don't require ``AIOS_VAULT_KEY`` to be set.
+
+Revision ID: 0047
+Revises: 0046
+Create Date: 2026-05-14
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from collections.abc import Callable, Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from aios.crypto.vault import CryptoBox, EncryptedBlob
+
+revision: str = "0047"
+down_revision: str = "0046"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# (table_name, ciphertext_col, nonce_col, extra_where_clause).
+# `where` filters to rows that need rekey; archived/scrubbed rows are
+# excluded so we don't fail trying to decrypt zero bytes.
+_TABLES: Sequence[tuple[str, str, str, str]] = (
+    # connections: ciphertext / nonce are NULL when the connection has no
+    # secrets configured. archive_connection() scrubs both to NULL, so this
+    # filter naturally skips archived rows too.
+    ("connections", "secrets_ciphertext", "secrets_nonce", "secrets_ciphertext IS NOT NULL"),
+    # session_github_repositories: ciphertext / nonce are NOT NULL on
+    # active rows. No archived_at column — rows are DELETEd when detached.
+    ("session_github_repositories", "ciphertext", "nonce", "TRUE"),
+)
+
+
+def _load_master() -> CryptoBox:
+    encoded = os.environ.get("AIOS_VAULT_KEY")
+    if not encoded:
+        raise RuntimeError(
+            "AIOS_VAULT_KEY must be set when running migration 0047 — "
+            "the migration re-encrypts secrets and needs the master key"
+        )
+    return CryptoBox(base64.b64decode(encoded, validate=True))
+
+
+def _rekey(
+    build_src: Callable[[CryptoBox], Callable[[str], CryptoBox]],
+    build_dst: Callable[[CryptoBox], Callable[[str], CryptoBox]],
+) -> None:
+    """For each :data:`_TABLES` entry, walk rows with non-null ciphertext,
+    decrypt under ``src_for(account_id)``, re-encrypt under
+    ``dst_for(account_id)``, and write the new bytes back.
+
+    Master key is loaded lazily — only if at least one table has rows to
+    rekey. Empty DBs skip the env-var requirement entirely. ``build_src``
+    and ``build_dst`` take the master and return ``account_id → CryptoBox``
+    so upgrade and downgrade share the walker."""
+    bind = op.get_bind()
+    master: CryptoBox | None = None
+    src_for: Callable[[str], CryptoBox] | None = None
+    dst_for: Callable[[str], CryptoBox] | None = None
+    for name, ct_col, nn_col, where in _TABLES:
+        rows = bind.execute(
+            sa.text(
+                f"SELECT id, account_id, {ct_col} AS ct, {nn_col} AS nn FROM {name} WHERE {where}"
+            )
+        ).fetchall()
+        if not rows:
+            continue
+        if master is None:
+            master = _load_master()
+            src_for = build_src(master)
+            dst_for = build_dst(master)
+        assert src_for is not None and dst_for is not None  # for mypy
+        for row in rows:
+            plaintext = src_for(row.account_id).decrypt(
+                EncryptedBlob(ciphertext=row.ct, nonce=row.nn)
+            )
+            new_blob = dst_for(row.account_id).encrypt(plaintext)
+            bind.execute(
+                sa.text(
+                    f"UPDATE {name} "
+                    f"SET {ct_col} = :ct, {nn_col} = :nn, updated_at = now() "
+                    f"WHERE id = :id"
+                ),
+                {"ct": new_blob.ciphertext, "nn": new_blob.nonce, "id": row.id},
+            )
+
+
+def upgrade() -> None:
+    _rekey(
+        build_src=lambda master: lambda _account_id: master,
+        build_dst=lambda master: master.derive_account_subkey,
+    )
+
+
+def downgrade() -> None:
+    _rekey(
+        build_src=lambda master: master.derive_account_subkey,
+        build_dst=lambda master: lambda _account_id: master,
+    )

--- a/migrations/versions/0048_scrub_orphan_mcp_toolset_entries.py
+++ b/migrations/versions/0048_scrub_orphan_mcp_toolset_entries.py
@@ -1,0 +1,83 @@
+"""Strip orphan ``mcp_toolset`` tool entries that reference removed servers.
+
+Pre-#301 agents (created before the MCP-out cutover in PR 5 of #328) still
+carry an ``mcp_toolset`` entry in ``tools`` for a server name that has
+since been removed from the same row's ``mcp_servers`` list. Runtime
+already ignores these — ``to_openai_tools`` skips entries whose
+``mcp_server_name`` doesn't match any active server — but they inflate
+operator-facing tool counts and confuse reads of the resource. See #345.
+
+This migration walks ``agents.tools`` and ``agent_versions.tools`` and
+removes any element where:
+
+* ``type = 'mcp_toolset'``
+* AND ``mcp_server_name`` is not present in the same row's
+  ``mcp_servers[*].name`` array.
+
+Only the ``tools`` column is rewritten; ``mcp_servers`` is the source of
+truth and untouched. Idempotent — re-running is a no-op once the orphans
+are gone.
+
+Revision ID: 0048
+Revises: 0047
+Create Date: 2026-05-14
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0048"
+down_revision: str = "0047"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# (table_name,) — both tables share the same column shape (`tools` jsonb
+# array, `mcp_servers` jsonb array) so the same SQL template covers both.
+_TABLES: Sequence[str] = ("agents", "agent_versions")
+
+
+def _scrub_sql(table: str) -> str:
+    # Inline a CTE that names the active server set as a jsonb array of
+    # strings, then filter the ``tools`` array's elements to those that
+    # are NOT orphan ``mcp_toolset`` entries. ``jsonb_path_query_array``
+    # would be cleaner on PG 17+; this form works on PG 14+ (our floor).
+    return f"""
+    UPDATE {table} a SET tools = COALESCE((
+        SELECT jsonb_agg(t)
+          FROM jsonb_array_elements(a.tools) t
+         WHERE NOT (
+            t->>'type' = 'mcp_toolset'
+            AND NOT EXISTS (
+                SELECT 1
+                  FROM jsonb_array_elements(a.mcp_servers) s
+                 WHERE s->>'name' = t->>'mcp_server_name'
+            )
+         )
+    ), '[]'::jsonb)
+    WHERE EXISTS (
+        SELECT 1
+          FROM jsonb_array_elements(a.tools) t
+         WHERE t->>'type' = 'mcp_toolset'
+           AND NOT EXISTS (
+                SELECT 1
+                  FROM jsonb_array_elements(a.mcp_servers) s
+                 WHERE s->>'name' = t->>'mcp_server_name'
+           )
+    )
+    """
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.execute(_scrub_sql(table))
+
+
+def downgrade() -> None:
+    # Re-introducing orphans intentionally would require knowing which
+    # server names had been removed, which is information this migration
+    # discards. The cleanup is forward-only.
+    pass

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2581,11 +2581,14 @@ async def resolve_mcp_credential(
          WHERE sv.session_id = $1
            AND vc.mcp_server_url = $2
            AND vc.archived_at IS NULL
+           AND sv.account_id = $3
+           AND vc.account_id = $3
          ORDER BY sv.rank
          LIMIT 1
         """,
         session_id,
         mcp_server_url,
+        account_id,
     )
     if row is None:
         return None

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -103,9 +103,10 @@ async def resolve_auth_for_url(
         if session_result is None:
             return {}
         blob, auth_type, vault_id = session_result
+        subkey = crypto_box.derive_account_subkey(account_id)
 
         if auth_type == "mcp_oauth":
-            payload = json.loads(crypto_box.decrypt(blob))
+            payload = json.loads(subkey.decrypt(blob))
             if is_expiring(payload):
                 await refresh_credential(
                     crypto_box,
@@ -120,10 +121,10 @@ async def resolve_auth_for_url(
                 if refreshed is None:
                     return {}
                 blob = refreshed[0]
-                payload = json.loads(crypto_box.decrypt(blob))
+                payload = json.loads(subkey.decrypt(blob))
             token = str(payload.get("access_token", ""))
         else:
-            payload = json.loads(crypto_box.decrypt(blob))
+            payload = json.loads(subkey.decrypt(blob))
             token = _token_from_payload(payload, auth_type)
 
     if not token:

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -31,16 +31,22 @@ from aios.models.connections import (
 )
 
 
-def _encrypt_secrets(secrets: dict[str, str] | None, crypto_box: CryptoBox) -> EncryptedBlob | None:
+def _encrypt_secrets(
+    secrets: dict[str, str] | None, crypto_box: CryptoBox, *, account_id: str
+) -> EncryptedBlob | None:
     """Encrypt a secrets dict, or ``None`` if the dict is missing or empty.
 
     Empty / missing → no blob → schema columns NULL → ``secrets_set: False``.
     The operator surface treats ``None`` and ``{}`` identically (both
     "clear secrets") so create + PUT produce the same row state.
+
+    Encryption is keyed to ``account_id`` via :meth:`CryptoBox.derive_account_subkey`
+    so a connection's secrets can't be decrypted by another tenant's
+    derived key even if the row leaks.
     """
     if not secrets:
         return None
-    return crypto_box.encrypt_dict(secrets)
+    return crypto_box.derive_account_subkey(account_id).encrypt_dict(secrets)
 
 
 async def create_connection(
@@ -59,7 +65,7 @@ async def create_connection(
             connector=connector,
             account=account,
             metadata=metadata,
-            secrets_blob=_encrypt_secrets(secrets, crypto_box),
+            secrets_blob=_encrypt_secrets(secrets, crypto_box, account_id=account_id),
             account_id=account_id,
         )
 
@@ -82,7 +88,7 @@ async def set_connection_secrets(
         return await queries.set_connection_secrets(
             conn,
             connection_id,
-            secrets_blob=_encrypt_secrets(secrets, crypto_box),
+            secrets_blob=_encrypt_secrets(secrets, crypto_box, account_id=account_id),
             account_id=account_id,
         )
 
@@ -106,7 +112,7 @@ async def get_connection_secrets(
         blob = await queries.get_connection_secret_blob(conn, connection_id, account_id=account_id)
     if blob is None:
         return {}
-    decoded = crypto_box.decrypt_dict(blob)
+    decoded = crypto_box.derive_account_subkey(account_id).decrypt_dict(blob)
     return {str(k): str(v) for k, v in decoded.items()}
 
 

--- a/src/aios/services/github_repositories.py
+++ b/src/aios/services/github_repositories.py
@@ -28,9 +28,13 @@ from aios.models.github_repositories import (
 from aios.sandbox.github_clone import remove_session_working_tree
 
 
-def _encrypt_token(crypto_box: CryptoBox, token: str) -> Any:
-    """Encrypt a github auth token. Returns an :class:`EncryptedBlob`."""
-    return crypto_box.encrypt(token)
+def _encrypt_token(crypto_box: CryptoBox, token: str, *, account_id: str) -> Any:
+    """Encrypt a github auth token. Returns an :class:`EncryptedBlob`.
+
+    Keyed to ``account_id`` via :meth:`CryptoBox.derive_account_subkey` so
+    the embedded token can't be decrypted under another tenant's key.
+    """
+    return crypto_box.derive_account_subkey(account_id).encrypt(token)
 
 
 async def _list_attached_resource_ids(
@@ -68,7 +72,9 @@ async def attach_to_session(
         return
     entries: list[tuple[str, str, Any, str | None, str | None]] = []
     for res in resources:
-        blob = _encrypt_token(crypto_box, res.authorization_token.get_secret_value())
+        blob = _encrypt_token(
+            crypto_box, res.authorization_token.get_secret_value(), account_id=account_id
+        )
         entries.append((res.url, res.mount_path, blob, res.git_user_name, res.git_user_email))
     try:
         await queries.attach_github_repos_to_session(
@@ -166,7 +172,7 @@ async def rotate_token(
     unset and the stored ``git_user_name`` / ``git_user_email`` survive
     the rotation.
     """
-    blob = _encrypt_token(crypto_box, new_token)
+    blob = _encrypt_token(crypto_box, new_token, account_id=account_id)
     async with pool.acquire() as conn, conn.transaction():
         return await queries.update_session_github_repo_blob(
             conn,
@@ -195,4 +201,4 @@ async def get_session_token(
     _, blob = await queries.get_session_github_repo_with_blob(
         conn, session_id, resource_id, account_id=account_id
     )
-    return crypto_box.decrypt(blob)
+    return crypto_box.derive_account_subkey(account_id).decrypt(blob)

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -109,8 +109,9 @@ async def refresh_credential(
                 detail={"vault_id": vault_id, "mcp_server_url": mcp_server_url},
             )
         credential_id, blob = locked
+        subkey = crypto_box.derive_account_subkey(account_id)
         try:
-            payload = crypto_box.decrypt_dict(blob)
+            payload = subkey.decrypt_dict(blob)
         except Exception as exc:
             raise OAuthRefreshError(
                 "failed to decrypt stored credential",
@@ -207,7 +208,7 @@ async def refresh_credential(
         if seconds > 0:
             payload["expires_at"] = (datetime.now(UTC) + timedelta(seconds=seconds)).isoformat()
 
-        new_blob = crypto_box.encrypt_dict(payload)
+        new_blob = subkey.encrypt_dict(payload)
         await conn.execute(
             "UPDATE vault_credentials "
             "SET ciphertext = $1, nonce = $2, updated_at = now() "
@@ -350,7 +351,7 @@ async def create_vault_credential(
     body: VaultCredentialCreate,
 ) -> VaultCredential:
     payload = _extract_auth_payload(body)
-    blob = crypto_box.encrypt_dict(payload)
+    blob = crypto_box.derive_account_subkey(account_id).encrypt_dict(payload)
     async with pool.acquire() as conn, conn.transaction():
         # Lock the parent vault row to serialize concurrent credential inserts
         # within this vault. Without it, two parallel inserts can both observe
@@ -423,9 +424,10 @@ async def update_vault_credential(
         cred, existing_blob = await queries.get_vault_credential_with_blob(
             conn, vault_id, credential_id, account_id=account_id
         )
-        existing_payload = crypto_box.decrypt_dict(existing_blob)
+        subkey = crypto_box.derive_account_subkey(account_id)
+        existing_payload = subkey.decrypt_dict(existing_blob)
         merged = _merge_auth_payload(existing_payload, body, cred.auth_type)
-        new_blob = crypto_box.encrypt_dict(merged)
+        new_blob = subkey.encrypt_dict(merged)
 
         return await queries.update_vault_credential(
             conn,

--- a/tests/e2e/test_vaults.py
+++ b/tests/e2e/test_vaults.py
@@ -509,7 +509,7 @@ class TestQueries:
         # Verify the blob actually decrypts to the original payload.
         import json as _json
 
-        payload = _json.loads(crypto_box.decrypt(blob))
+        payload = _json.loads(crypto_box.derive_account_subkey(account_id).decrypt(blob))
         assert payload == {"token": "combo-token"}
 
     async def test_get_credential_with_blob_excludes_archived(
@@ -667,7 +667,7 @@ class TestOAuthRefreshE2E:
             ciphertext=bytes(row["ciphertext"]),
             nonce=bytes(row["nonce"]),
         )
-        new_payload = _json.loads(crypto_box.decrypt(new_blob))
+        new_payload = _json.loads(crypto_box.derive_account_subkey(account_id).decrypt(new_blob))
         assert new_payload["access_token"] == "fresh-at"
 
     async def test_concurrent_resolve_only_refreshes_once(self, pool: Any, crypto_box: Any) -> None:

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -35,7 +35,7 @@ class TestResolveAuthForUrl:
 
     async def test_resolves_via_session_vaults(self, crypto_box: CryptoBox) -> None:
         payload = json.dumps({"token": "session-token"})
-        blob = crypto_box.encrypt(payload)
+        blob = crypto_box.derive_account_subkey("acc_test_stub").encrypt(payload)
         pool = fake_pool_yielding_conn(MagicMock())
         with patch(
             "aios.mcp.client.queries.resolve_mcp_credential",
@@ -62,7 +62,7 @@ class TestResolveAuthForUrl:
 
     async def test_empty_token_returns_empty(self, crypto_box: CryptoBox) -> None:
         payload = json.dumps({"token": ""})
-        blob = crypto_box.encrypt(payload)
+        blob = crypto_box.derive_account_subkey("acc_test_stub").encrypt(payload)
         pool = fake_pool_yielding_conn(MagicMock())
         with patch(
             "aios.mcp.client.queries.resolve_mcp_credential",
@@ -76,7 +76,7 @@ class TestResolveAuthForUrl:
 
     async def test_mcp_oauth_static_token(self, crypto_box: CryptoBox) -> None:
         payload = json.dumps({"access_token": "oauth-token"})
-        blob = crypto_box.encrypt(payload)
+        blob = crypto_box.derive_account_subkey("acc_test_stub").encrypt(payload)
         pool = fake_pool_yielding_conn(MagicMock())
         with patch(
             "aios.mcp.client.queries.resolve_mcp_credential",
@@ -103,8 +103,8 @@ class TestResolveAuthForUrl:
             }
         )
         fresh = json.dumps({"access_token": "fresh"})
-        stale_blob = crypto_box.encrypt(expiring)
-        fresh_blob = crypto_box.encrypt(fresh)
+        stale_blob = crypto_box.derive_account_subkey("acc_test_stub").encrypt(expiring)
+        fresh_blob = crypto_box.derive_account_subkey("acc_test_stub").encrypt(fresh)
         pool = fake_pool_yielding_conn(MagicMock())
 
         refresh_mock = AsyncMock()
@@ -140,7 +140,7 @@ class TestResolveAuthForUrl:
                 "expires_at": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
             }
         )
-        blob = crypto_box.encrypt(far_future)
+        blob = crypto_box.derive_account_subkey("acc_test_stub").encrypt(far_future)
         pool = fake_pool_yielding_conn(MagicMock())
         refresh_mock = AsyncMock()
 
@@ -170,7 +170,7 @@ class TestResolveAuthForUrl:
                 "expires_at": (datetime.now(UTC) + timedelta(seconds=5)).isoformat(),
             }
         )
-        blob = crypto_box.encrypt(expiring)
+        blob = crypto_box.derive_account_subkey("acc_test_stub").encrypt(expiring)
         pool = fake_pool_yielding_conn(MagicMock())
 
         with (

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -901,3 +901,44 @@ class TestServiceWiringIsAccountScoped:
                 body=VaultCredentialUpdate(display_name="renamed"),
                 account_id="acc_b",
             )
+
+    @pytest.mark.asyncio
+    async def test_same_account_decrypt_succeeds(self, crypto_box: CryptoBox) -> None:
+        """Positive case — completes the regression net.
+
+        The cross-account test above asserts a *failure* path, which a
+        hypothetical revert to ``crypto_box.decrypt_dict`` would *also*
+        satisfy (the master key can't decrypt a subkey blob either).
+        This test exercises the success path: a blob written under
+        account A's subkey must decrypt cleanly when the service is
+        called with the same account_id. If the wiring is reverted, the
+        decrypt happens with the master key against subkey-encrypted
+        bytes and this test fails.
+        """
+        blob_for_a = crypto_box.derive_account_subkey("acc_a").encrypt(
+            json.dumps({"access_token": "secret-of-a"})
+        )
+        conn = MagicMock()
+        pool = fake_pool_yielding_conn(conn)
+
+        with (
+            patch.object(
+                vaults_service.queries,
+                "get_vault_credential_with_blob",
+                AsyncMock(return_value=(_existing_credential(), blob_for_a)),
+            ),
+            patch.object(
+                vaults_service.queries,
+                "update_vault_credential",
+                AsyncMock(return_value=_existing_credential()),
+            ),
+        ):
+            # Same account_id as the blob was encrypted under — must succeed.
+            await vaults_service.update_vault_credential(
+                pool,
+                crypto_box,
+                vault_id="vlt_1",
+                credential_id="vc_1",
+                body=VaultCredentialUpdate(display_name="renamed"),
+                account_id="acc_a",
+            )

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -261,7 +261,9 @@ class TestUpdateVaultCredentialCallSite:
     async def test_omits_display_name_when_not_in_fields_set(self, crypto_box: CryptoBox) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         existing = _existing_credential()
-        existing_blob = crypto_box.encrypt(json.dumps({"access_token": "at"}))
+        existing_blob = crypto_box.derive_account_subkey(account_id).encrypt(
+            json.dumps({"access_token": "at"})
+        )
         conn = MagicMock()
         pool = fake_pool_yielding_conn(conn)
 
@@ -297,7 +299,9 @@ class TestUpdateVaultCredentialCallSite:
     async def test_passes_display_name_when_set_even_to_none(self, crypto_box: CryptoBox) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         existing = _existing_credential()
-        existing_blob = crypto_box.encrypt(json.dumps({"access_token": "at"}))
+        existing_blob = crypto_box.derive_account_subkey(account_id).encrypt(
+            json.dumps({"access_token": "at"})
+        )
         conn = MagicMock()
         pool = fake_pool_yielding_conn(conn)
 
@@ -427,7 +431,7 @@ class TestRefreshCredential:
         payload = _expiring_oauth_payload(
             expires_at=(datetime.now(UTC) + timedelta(hours=1)).isoformat(),
         )
-        blob = crypto_box.encrypt(json.dumps(payload))
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
         conn = _conn_with_transaction()
         client = _async_client_returning(_http_response(body={"access_token": "new"}))
 
@@ -458,7 +462,7 @@ class TestRefreshCredential:
         payload = _expiring_oauth_payload(
             token_endpoint_auth={"method": "client_secret_basic", "client_secret": "shh"},
         )
-        blob = crypto_box.encrypt(json.dumps(payload))
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
         conn = _conn_with_transaction()
         client = _async_client_returning(_http_response(body={"access_token": "new"}))
 
@@ -491,7 +495,7 @@ class TestRefreshCredential:
         payload = _expiring_oauth_payload(
             token_endpoint_auth={"method": "client_secret_post", "client_secret": "shh"},
         )
-        blob = crypto_box.encrypt(json.dumps(payload))
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
         conn = _conn_with_transaction()
         client = _async_client_returning(_http_response(body={"access_token": "new"}))
 
@@ -522,7 +526,7 @@ class TestRefreshCredential:
         payload = _expiring_oauth_payload(
             token_endpoint_auth={"method": "none"},
         )
-        blob = crypto_box.encrypt(json.dumps(payload))
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
         conn = _conn_with_transaction()
         client = _async_client_returning(_http_response(body={"access_token": "new"}))
 
@@ -557,7 +561,7 @@ class TestRefreshCredential:
         """
         account_id = "acc_test_stub"  # PR 3 scaffolding
         payload = _expiring_oauth_payload()
-        blob = crypto_box.encrypt(json.dumps(payload))
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
         conn = _conn_with_transaction()
         client = _async_client_returning(
             _http_response(body={"access_token": "fresh", "expires_in": "3600"}),
@@ -581,7 +585,7 @@ class TestRefreshCredential:
 
         args = conn.execute.await_args.args
         new_blob = EncryptedBlob(ciphertext=args[1], nonce=args[2])
-        new_payload = json.loads(crypto_box.decrypt(new_blob))
+        new_payload = json.loads(crypto_box.derive_account_subkey(account_id).decrypt(new_blob))
         assert "expires_at" in new_payload
         # is_expiring on the new payload should be False (token is fresh).
         assert is_expiring(new_payload) is False
@@ -590,7 +594,7 @@ class TestRefreshCredential:
     async def test_persists_new_access_token_and_expires_at(self, crypto_box: CryptoBox) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         payload = _expiring_oauth_payload()
-        blob = crypto_box.encrypt(json.dumps(payload))
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
         conn = _conn_with_transaction()
         client = _async_client_returning(
             _http_response(body={"access_token": "fresh-at", "expires_in": 3600})
@@ -617,7 +621,7 @@ class TestRefreshCredential:
         conn.execute.assert_awaited_once()
         args = conn.execute.await_args.args
         new_blob = EncryptedBlob(ciphertext=args[1], nonce=args[2])
-        new_payload = json.loads(crypto_box.decrypt(new_blob))
+        new_payload = json.loads(crypto_box.derive_account_subkey(account_id).decrypt(new_blob))
         assert new_payload["access_token"] == "fresh-at"
         # expires_at is updated to ~1 hour out.
         assert "expires_at" in new_payload
@@ -626,7 +630,7 @@ class TestRefreshCredential:
     async def test_rotates_refresh_token_when_returned(self, crypto_box: CryptoBox) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         payload = _expiring_oauth_payload()
-        blob = crypto_box.encrypt(json.dumps(payload))
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
         conn = _conn_with_transaction()
         client = _async_client_returning(
             _http_response(body={"access_token": "fresh", "refresh_token": "rt-2"})
@@ -650,13 +654,18 @@ class TestRefreshCredential:
 
         args = conn.execute.await_args.args
         new_blob = EncryptedBlob(ciphertext=args[1], nonce=args[2])
-        assert json.loads(crypto_box.decrypt(new_blob))["refresh_token"] == "rt-2"
+        assert (
+            json.loads(crypto_box.derive_account_subkey(account_id).decrypt(new_blob))[
+                "refresh_token"
+            ]
+            == "rt-2"
+        )
 
     @pytest.mark.asyncio
     async def test_keeps_refresh_token_when_omitted(self, crypto_box: CryptoBox) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         payload = _expiring_oauth_payload()
-        blob = crypto_box.encrypt(json.dumps(payload))
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
         conn = _conn_with_transaction()
         # Response omits refresh_token.
         client = _async_client_returning(_http_response(body={"access_token": "fresh"}))
@@ -679,13 +688,18 @@ class TestRefreshCredential:
 
         args = conn.execute.await_args.args
         new_blob = EncryptedBlob(ciphertext=args[1], nonce=args[2])
-        assert json.loads(crypto_box.decrypt(new_blob))["refresh_token"] == "rt-1"  # preserved
+        assert (
+            json.loads(crypto_box.derive_account_subkey(account_id).decrypt(new_blob))[
+                "refresh_token"
+            ]
+            == "rt-1"
+        )  # preserved
 
     @pytest.mark.asyncio
     async def test_http_error_raises_oauth_refresh_error(self, crypto_box: CryptoBox) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         payload = _expiring_oauth_payload()
-        blob = crypto_box.encrypt(json.dumps(payload))
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
         conn = _conn_with_transaction()
         client = _async_client_returning(_http_response(status=401))
 
@@ -713,7 +727,7 @@ class TestRefreshCredential:
     async def test_malformed_response_raises(self, crypto_box: CryptoBox) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         payload = _expiring_oauth_payload()
-        blob = crypto_box.encrypt(json.dumps(payload))
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
         conn = _conn_with_transaction()
         # 200 OK but missing access_token in body.
         client = _async_client_returning(_http_response(body={"expires_in": 3600}))
@@ -764,7 +778,7 @@ class TestRefreshCredential:
             "expires_at": _expiring_oauth_payload()["expires_at"],
             "client_id": "cid",
         }
-        blob = crypto_box.encrypt(json.dumps(payload))
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
         conn = _conn_with_transaction()
 
         with (
@@ -840,3 +854,50 @@ class TestDeriveAccountSubkey:
     def test_empty_account_id_rejected(self) -> None:
         with pytest.raises(ValueError, match="account_id must be non-empty"):
             self._master().derive_account_subkey("")
+
+
+class TestServiceWiringIsAccountScoped:
+    """End-to-end integration: a vault_credential blob written by the service
+    under ``account_a`` must NOT be decryptable when fetched under ``account_b``.
+
+    The unit-level isolation in :class:`TestDeriveAccountSubkey` proves the
+    primitive; this class proves the service code paths actually use the
+    primitive. A regression here would mean the wiring was reverted or a
+    new call site bypassed the subkey.
+    """
+
+    @pytest.mark.asyncio
+    async def test_update_credential_cross_account_decrypt_fails(
+        self, crypto_box: CryptoBox
+    ) -> None:
+        # Encrypt as account_a writes (matches create_vault_credential path).
+        blob_for_a = crypto_box.derive_account_subkey("acc_a").encrypt(
+            json.dumps({"access_token": "secret-of-a"})
+        )
+        conn = MagicMock()
+        pool = fake_pool_yielding_conn(conn)
+
+        with (
+            patch.object(
+                vaults_service.queries,
+                "get_vault_credential_with_blob",
+                AsyncMock(return_value=(_existing_credential(), blob_for_a)),
+            ),
+            patch.object(
+                vaults_service.queries,
+                "update_vault_credential",
+                AsyncMock(return_value=_existing_credential()),
+            ),
+            pytest.raises(CryptoDecryptError),
+        ):
+            # account_b's service call must fail when trying to decrypt
+            # account_a's blob — proves the WHERE-clause defense is paired
+            # with crypto-layer defense.
+            await vaults_service.update_vault_credential(
+                pool,
+                crypto_box,
+                vault_id="vlt_1",
+                credential_id="vc_1",
+                body=VaultCredentialUpdate(display_name="renamed"),
+                account_id="acc_b",
+            )


### PR DESCRIPTION
## Summary

- Migration 0048 strips `mcp_toolset` entries from `agents.tools` and `agent_versions.tools` whose `mcp_server_name` references a server that's no longer in the same row's `mcp_servers`.
- These are inert at runtime (`to_openai_tools` already filters by server presence) but inflate operator-facing tool counts.
- `mcp_servers` is the source of truth and untouched. Idempotent.

Stacked on #422.

Closes #345.

## Test plan

- [x] `uv run alembic heads` — `0048 (head)`
- [x] `uv run pytest tests/unit -q` — 1214 passed
- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests migrations && uv run ruff format --check migrations/versions/0048_*.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)