### PR TITLE
fix(sandbox): managed Docker network for cross-container worker reachability

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -89,12 +89,6 @@ class Settings(BaseSettings):
         "Each session gets <workspace_root>/<session_id> bind-mounted to /workspace "
         "inside its sandbox container.",
     )
-    sandbox_network_mode: str = Field(
-        default="bridge",
-        description="Docker network mode for sandbox containers. 'bridge' (default) "
-        "gives full outbound internet access, which the HN demo needs. 'none' "
-        "disables networking entirely; 'host' shares the host network namespace.",
-    )
     sandbox_cpu_quota: float | None = Field(
         default=None,
         ge=0.01,

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -52,6 +52,7 @@ from aios.logging import configure_logging, get_logger
 from aios.mcp.pool import McpSessionPool
 from aios.sandbox.backends import make_backend
 from aios.sandbox.mcp_proxy import McpBroker
+from aios.sandbox.network import ensure_sandbox_network
 from aios.sandbox.registry import SandboxRegistry
 
 # Hashed (via Postgres ``hashtextextended($1, 0)``) into the 64-bit
@@ -113,6 +114,8 @@ async def worker_main() -> None:
         sandbox_registry = SandboxRegistry(backend=make_backend(settings.sandbox_backend))
         task_registry = TaskRegistry()
         mcp_session_pool = McpSessionPool()
+        if settings.sandbox_backend == "docker":
+            await ensure_sandbox_network()
         mcp_broker = McpBroker()
         await mcp_broker.start()
 

--- a/src/aios/sandbox/_subprocess.py
+++ b/src/aios/sandbox/_subprocess.py
@@ -22,6 +22,10 @@ from aios.sandbox.backends.base import SandboxBackendError
 # state can't hold the worker indefinitely past the wait_for timeout.
 _DRAIN_AFTER_KILL_TIMEOUT_S = 2.0
 
+# Bound every ``docker`` management call so a stalled daemon can't wedge
+# the worker step path (per issue #179 / commit e675ed2).
+DOCKER_CLI_TIMEOUT_S = 30.0
+
 
 async def run_subprocess_with_timeout(
     argv: list[str], *, timeout_s: float
@@ -59,3 +63,20 @@ async def run_subprocess_with_timeout(
         except (TimeoutError, OSError):
             stdout_bytes, stderr_bytes = b"", b""
         return -1, stdout_bytes, stderr_bytes, True
+
+
+async def run_docker_cli(
+    argv: list[str], *, timeout_s: float = DOCKER_CLI_TIMEOUT_S
+) -> tuple[int, bytes, bytes]:
+    """Run a ``docker`` CLI invocation. Returns ``(exit_code, stdout, stderr)``.
+
+    Raises :class:`SandboxBackendError` on launch failure or timeout. A
+    nonzero ``docker`` exit is returned as a regular tuple — callers
+    decide whether it's fatal.
+    """
+    rc, stdout_bytes, stderr_bytes, timed_out = await run_subprocess_with_timeout(
+        argv, timeout_s=timeout_s
+    )
+    if timed_out:
+        raise SandboxBackendError(f"docker cli timed out after {timeout_s}s: {' '.join(argv)}")
+    return rc, stdout_bytes, stderr_bytes

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -20,9 +20,8 @@ expected to run arbitrary shell inside the sandbox.
 
 from __future__ import annotations
 
-from aios.config import get_settings
 from aios.logging import get_logger
-from aios.sandbox._subprocess import run_subprocess_with_timeout
+from aios.sandbox._subprocess import run_docker_cli, run_subprocess_with_timeout
 from aios.sandbox.backends.base import (
     INSTANCE_LABEL_KEY,
     MANAGED_LABEL_KEY,
@@ -36,30 +35,9 @@ from aios.sandbox.backends.base import (
     SandboxHandle,
     SandboxSpec,
 )
+from aios.sandbox.network import SANDBOX_NETWORK_NAME
 
 log = get_logger("aios.sandbox.backends.docker")
-
-# Bound every ``docker`` management call so a stalled daemon can't wedge
-# the worker step path (per issue #179 / commit e675ed2).
-_DOCKER_CLI_TIMEOUT_S = 30.0
-
-
-async def _run_docker(
-    argv: list[str], *, timeout_s: float = _DOCKER_CLI_TIMEOUT_S
-) -> tuple[int, bytes, bytes]:
-    """Run a ``docker`` CLI invocation and return (exit_code, stdout, stderr).
-
-    Raises :class:`SandboxBackendError` if the subprocess cannot be
-    launched (missing binary, OS error) or if it runs longer than
-    ``timeout_s`` (stalled daemon). A nonzero exit from docker itself is
-    returned as a regular tuple — callers decide whether it's fatal.
-    """
-    rc, stdout_bytes, stderr_bytes, timed_out = await run_subprocess_with_timeout(
-        argv, timeout_s=timeout_s
-    )
-    if timed_out:
-        raise SandboxBackendError(f"docker cli timed out after {timeout_s}s: {' '.join(argv)}")
-    return rc, stdout_bytes, stderr_bytes
 
 
 def _decode_and_truncate(raw: bytes, max_bytes: int) -> tuple[str, bool]:
@@ -82,7 +60,6 @@ class DockerBackend:
 
     async def create(self, spec: SandboxSpec) -> SandboxHandle:
         """Run ``docker run`` per ``spec`` and return a handle to the started container."""
-        settings = get_settings()
         argv: list[str] = [
             "docker",
             "run",
@@ -106,21 +83,16 @@ class DockerBackend:
         for key, value in spec.labels.items():
             argv.extend(["--label", f"{key}={value}"])
 
-        # Network mode: Disabled overrides the deployment-wide default.
         if isinstance(spec.network_policy, Disabled):
             argv.extend(["--network", "none"])
         else:
-            argv.extend(["--network", settings.sandbox_network_mode])
+            argv.extend(["--network", SANDBOX_NETWORK_NAME])
 
         # Limited policy needs NET_ADMIN so the iptables script (applied
         # later by the registry via aios.sandbox.setup) can install rules.
         if isinstance(spec.network_policy, Limited):
             argv.extend(["--cap-add", "NET_ADMIN"])
 
-        # Host gateway alias — Docker maps it to host-gateway so the
-        # sandbox can reach host-side services (e.g. the credential proxy).
-        # The explicit alias is required on Linux; on Docker Desktop the
-        # name auto-resolves but ``--add-host`` is harmless.
         if spec.host_gateway_alias is not None:
             argv.extend(["--add-host", f"{spec.host_gateway_alias}:host-gateway"])
 
@@ -152,7 +124,7 @@ class DockerBackend:
 
         argv.append(spec.image)
 
-        rc, stdout_bytes, stderr_bytes = await _run_docker(argv)
+        rc, stdout_bytes, stderr_bytes = await run_docker_cli(argv)
         if rc != 0:
             raise SandboxBackendError(
                 f"docker run failed (exit {rc}): "
@@ -207,7 +179,7 @@ class DockerBackend:
         """``docker rm --force`` the container. No-op if already gone."""
         argv = ["docker", "rm", "--force", handle.sandbox_id]
         try:
-            rc, _, stderr_bytes = await _run_docker(argv)
+            rc, _, stderr_bytes = await run_docker_cli(argv)
         except SandboxBackendError as err:
             log.warning(
                 "sandbox.destroy_launch_failed",
@@ -242,7 +214,7 @@ class DockerBackend:
             "--filter",
             f"label={INSTANCE_LABEL_KEY}={instance_id}",
         ]
-        rc, stdout_bytes, stderr_bytes = await _run_docker(ps_argv)
+        rc, stdout_bytes, stderr_bytes = await run_docker_cli(ps_argv)
         if rc != 0:
             raise SandboxBackendError(
                 f"docker ps failed (exit {rc}): "
@@ -256,7 +228,7 @@ class DockerBackend:
 
         fmt = '{{.Id}}\t{{index .Config.Labels "' + SESSION_LABEL_KEY + '"}}'
         inspect_argv = ["docker", "inspect", "--format", fmt, *container_ids]
-        rc, stdout_bytes, stderr_bytes = await _run_docker(inspect_argv)
+        rc, stdout_bytes, stderr_bytes = await run_docker_cli(inspect_argv)
         if rc != 0:
             raise SandboxBackendError(
                 f"docker inspect failed (exit {rc}): "
@@ -276,7 +248,7 @@ class DockerBackend:
         """``docker rm --force`` a container by id. Logs but does not raise."""
         argv = ["docker", "rm", "--force", sandbox_id]
         try:
-            rc, _, stderr_bytes = await _run_docker(argv)
+            rc, _, stderr_bytes = await run_docker_cli(argv)
         except SandboxBackendError as err:
             log.warning(
                 "sandbox.force_remove_launch_failed",

--- a/src/aios/sandbox/git_proxy.py
+++ b/src/aios/sandbox/git_proxy.py
@@ -1,8 +1,8 @@
-"""Per-session HTTP proxy that holds GitHub PATs on the host side and
+"""Per-session HTTP proxy that holds GitHub PATs on the worker side and
 injects them into outbound git traffic from the sandbox.
 
 The token never enters the container. The container's working tree has
-``origin = http://host.docker.internal:<port>/git/<secret>/<owner>/<repo>``;
+``origin = http://aios-worker:<port>/git/<secret>/<owner>/<repo>``;
 git speaks smart-HTTP to that URL; the proxy forwards each request to
 ``https://github.com/<owner>/<repo>/...`` with the ``Authorization``
 header injected from the precomputed per-repo basic-auth map.
@@ -147,11 +147,11 @@ class GitProxy:
         return f"http://{host}:{self.port}/git/{self._secret}/{repo_key(repo_url)}"
 
     async def start(self) -> None:
-        """Bind ``0.0.0.0:0`` (ephemeral port, all interfaces) and begin
-        serving. Binding to 0.0.0.0 is required for the docker container
-        to reach the proxy via ``host.docker.internal``; per-session
-        secret + per-repo path keep the blast radius bounded if the port
-        is exposed."""
+        """Bind ``0.0.0.0:0`` and begin serving. ``0.0.0.0`` covers every
+        interface the worker has — the sandbox may reach in via any of
+        them depending on deployment topology. Per-session secret +
+        per-repo path keep the blast radius bounded if the port is
+        exposed."""
         app = Starlette(
             routes=[
                 Route(

--- a/src/aios/sandbox/mcp_proxy.py
+++ b/src/aios/sandbox/mcp_proxy.py
@@ -116,9 +116,9 @@ class McpBroker:
             self._secrets.pop(s, None)
 
     async def start(self) -> None:
-        """Bind ``0.0.0.0:0`` and begin serving. Binding to 0.0.0.0 is
-        required for sandbox containers to reach the broker via
-        ``host.docker.internal``."""
+        """Bind ``0.0.0.0:0`` and begin serving. ``0.0.0.0`` covers every
+        interface the worker has — the sandbox may reach in via any of
+        them depending on deployment topology."""
         app = Starlette(
             routes=[
                 Route("/v1/{secret}/servers", self._list_servers, methods=["GET"]),

--- a/src/aios/sandbox/network.py
+++ b/src/aios/sandbox/network.py
@@ -1,0 +1,125 @@
+"""Worker-managed Docker network the sandbox uses to reach the worker.
+
+Two resolution paths share one hostname (``aios-worker``): Docker's
+embedded DNS when the worker is on the sandbox network, ``/etc/hosts``
+populated by ``--add-host`` when the worker runs on the host.
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+from aios.logging import get_logger
+from aios.sandbox._subprocess import run_docker_cli
+
+log = get_logger("aios.sandbox.network")
+
+SANDBOX_NETWORK_NAME = "aios-sandbox"
+WORKER_NETWORK_ALIAS = "aios-worker"
+
+
+def is_running_in_container() -> bool:
+    """``True`` when ``/.dockerenv`` exists."""
+    return Path("/.dockerenv").exists()
+
+
+async def ensure_sandbox_network() -> None:
+    """Idempotently create the sandbox network; if in-container, join it
+    under :data:`WORKER_NETWORK_ALIAS`.
+
+    Safe under concurrent-startup races: a failed create or connect is
+    re-checked against the live state, and treated as success if the
+    desired condition now holds. Other failures raise.
+
+    Self-identification uses :func:`socket.gethostname`, which equals the
+    Docker container name in Coolify and docker-compose. Deployments
+    that split ``--hostname`` from ``--name`` will fail here.
+    """
+    if not await _network_exists(SANDBOX_NETWORK_NAME):
+        rc, _, stderr_bytes = await run_docker_cli(
+            ["docker", "network", "create", SANDBOX_NETWORK_NAME]
+        )
+        if rc == 0:
+            log.info("sandbox.network_created", network=SANDBOX_NETWORK_NAME)
+        elif not await _network_exists(SANDBOX_NETWORK_NAME):
+            raise RuntimeError(
+                "failed to create sandbox network "
+                f"{SANDBOX_NETWORK_NAME!r}: "
+                f"{stderr_bytes.decode('utf-8', errors='replace').strip()}"
+            )
+
+    if not is_running_in_container():
+        log.info(
+            "sandbox.network_worker_on_host",
+            network=SANDBOX_NETWORK_NAME,
+            alias=WORKER_NETWORK_ALIAS,
+        )
+        return
+
+    hostname = socket.gethostname()
+    if await _container_on_network(hostname, SANDBOX_NETWORK_NAME):
+        log.info(
+            "sandbox.network_worker_already_joined",
+            network=SANDBOX_NETWORK_NAME,
+            alias=WORKER_NETWORK_ALIAS,
+            hostname=hostname,
+        )
+        return
+
+    rc, _, stderr_bytes = await run_docker_cli(
+        [
+            "docker",
+            "network",
+            "connect",
+            "--alias",
+            WORKER_NETWORK_ALIAS,
+            SANDBOX_NETWORK_NAME,
+            hostname,
+        ]
+    )
+    if rc != 0 and not await _container_on_network(hostname, SANDBOX_NETWORK_NAME):
+        raise RuntimeError(
+            f"failed to join worker {hostname!r} to sandbox network "
+            f"{SANDBOX_NETWORK_NAME!r}: "
+            f"{stderr_bytes.decode('utf-8', errors='replace').strip()}"
+        )
+    log.info(
+        "sandbox.network_worker_joined",
+        network=SANDBOX_NETWORK_NAME,
+        alias=WORKER_NETWORK_ALIAS,
+        hostname=hostname,
+    )
+
+
+async def _network_exists(name: str) -> bool:
+    rc, _, _ = await run_docker_cli(["docker", "network", "inspect", name])
+    return rc == 0
+
+
+async def _container_on_network(container: str, network: str) -> bool:
+    # Network name lands inside a Go ``index`` template; that wants a
+    # double-quoted string, not Python's single-quoted ``repr``.
+    rc, stdout_bytes, _ = await run_docker_cli(
+        [
+            "docker",
+            "inspect",
+            "--format",
+            f'{{{{index .NetworkSettings.Networks "{network}"}}}}',
+            container,
+        ]
+    )
+    if rc != 0:
+        return False
+    # ``docker inspect --format`` prints ``<nil>`` when the network key
+    # is absent; a non-empty, non-``<nil>`` value means joined.
+    out = stdout_bytes.decode("utf-8", errors="replace").strip()
+    return bool(out) and out != "<nil>"
+
+
+__all__ = [
+    "SANDBOX_NETWORK_NAME",
+    "WORKER_NETWORK_ALIAS",
+    "ensure_sandbox_network",
+    "is_running_in_container",
+]

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING, Any
 from aios.logging import get_logger
 from aios.sandbox.backends.base import CommandResult, SandboxBackend, SandboxHandle
 from aios.sandbox.git_proxy import GitProxy
+from aios.sandbox.network import WORKER_NETWORK_ALIAS
 from aios.sandbox.setup import (
     apply_network_lockdown,
     ensure_workspace_runtime_dirs,
@@ -193,16 +194,11 @@ class SandboxRegistry:
         networking = plan.env_config.networking if plan.env_config else None
         if not isinstance(networking, LimitedNetworking):
             return
-        # ``host_gateway_alias`` is always set on plans the worker
-        # produces (every sandbox has access to the MCP broker), so the
-        # host-port allowlist always includes the broker; ``git_proxy``
-        # is added conditionally.
-        assert plan.spec.host_gateway_alias is not None
         extra_host_ports: list[tuple[str, int]] = [
-            (plan.spec.host_gateway_alias, runtime.require_mcp_broker().port),
+            (WORKER_NETWORK_ALIAS, runtime.require_mcp_broker().port),
         ]
         if plan.git_proxy is not None:
-            extra_host_ports.append((plan.spec.host_gateway_alias, plan.git_proxy.port))
+            extra_host_ports.append((WORKER_NETWORK_ALIAS, plan.git_proxy.port))
         await apply_network_lockdown(
             self._backend,
             handle,

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -51,19 +51,11 @@ from aios.sandbox.github_clone import (
     ensure_cache_clone,
     ensure_session_working_tree,
 )
+from aios.sandbox.network import WORKER_NETWORK_ALIAS, is_running_in_container
 from aios.sandbox.setup import WORKSPACE_RUNTIME_ENV
 from aios.services import sessions as sessions_service
 
 log = get_logger("aios.sandbox.spec")
-
-
-# Hostname the sandbox uses to reach host-side proxies (``git_proxy`` for
-# GitHub PAT injection, ``mcp_proxy`` for MCP tool invocations). Docker
-# maps this to the host gateway IP via ``--add-host``; on Docker Desktop
-# the name auto-resolves but the explicit alias is required on Linux.
-# The registry threads the same string through the iptables script so
-# limited-networking sessions can still reach the proxy ports.
-PROXY_HOST_ALIAS = "host.docker.internal"
 
 
 @dataclass(frozen=True, slots=True)
@@ -209,7 +201,7 @@ async def _materialize_github_clones(
                 repo_url=echo.url,
                 token=token,
                 cache_dir=cache_dir,
-                proxy_url=proxy.proxy_url(echo.url, host=PROXY_HOST_ALIAS),
+                proxy_url=proxy.proxy_url(echo.url, host=WORKER_NETWORK_ALIAS),
                 git_user_name=echo.git_user_name,
                 git_user_email=echo.git_user_email,
             )
@@ -282,7 +274,7 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     mcp_broker = runtime.require_mcp_broker()
     mcp_broker_secret = secrets.token_urlsafe(32)
     mcp_broker.register_session(session_id, mcp_broker_secret)
-    mcp_broker_url = f"http://{PROXY_HOST_ALIAS}:{mcp_broker.port}"
+    mcp_broker_url = f"http://{WORKER_NETWORK_ALIAS}:{mcp_broker.port}"
 
     try:
         return _assemble_plan(
@@ -358,13 +350,6 @@ def _assemble_plan(
     extra_mounts: list[Mount] = [
         Mount(host_path=attachments_path, sandbox_path="/mnt/attachments", read_only=True),
         Mount(host_path=uploads_path, sandbox_path="/mnt/uploads", read_only=True),
-        # NOTE: the ``mcp`` CLI used to be bind-mounted from
-        # ``<repo_root>/bin/mcp`` here. That was incorrect: Docker resolves
-        # bind sources on the daemon's (host's) filesystem, not the calling
-        # container's, so the bind silently degraded to an auto-created
-        # empty directory on every host where the worker container ran.
-        # See issue #392. ``mcp`` now lives in the sandbox image directly
-        # (see ``docker/Dockerfile.sandbox``).
     ]
 
     # Bind-mount each attached memory store. Read-only attaches make the
@@ -407,10 +392,7 @@ def _assemble_plan(
         environment=merged_env,
         labels=labels,
         network_policy=_network_policy_from_config(env_config),
-        # Always set: every sandbox can reach the MCP broker on the host
-        # gateway; ``git_proxy`` and any other host-side proxies share the
-        # same alias.
-        host_gateway_alias=PROXY_HOST_ALIAS,
+        host_gateway_alias=None if is_running_in_container() else WORKER_NETWORK_ALIAS,
         image=image,
         mount_snapshot=snapshot,
         # Resource caps come from deployment-wide settings (multi-tenancy

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -174,6 +174,7 @@ async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     from aios.harness.task_registry import TaskRegistry
     from aios.sandbox.backends import make_backend
     from aios.sandbox.mcp_proxy import McpBroker
+    from aios.sandbox.network import ensure_sandbox_network
     from aios.sandbox.registry import SandboxRegistry
     from aios.tools.registry import registry
     from aios_connectors.providers import SubsystemToolProvider
@@ -183,6 +184,12 @@ async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
     crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
     task_reg = TaskRegistry()
     sandbox_reg = SandboxRegistry(backend=make_backend(settings.sandbox_backend))
+    # Mirror worker startup: create+attach the sandbox network before
+    # bringing the broker up. Otherwise the very first sandbox a test
+    # provisions hits ``docker run --network aios-sandbox`` against a
+    # network that doesn't exist on this host yet.
+    if settings.sandbox_backend == "docker":
+        await ensure_sandbox_network()
     mcp_broker = McpBroker()
     await mcp_broker.start()
 

--- a/tests/e2e/test_sandbox_broker_reachability.py
+++ b/tests/e2e/test_sandbox_broker_reachability.py
@@ -1,0 +1,151 @@
+"""E2E test that a sandbox container can resolve and reach
+``aios-worker`` via Docker DNS on the ``aios-sandbox`` network.
+
+Boots a sidecar with that alias running ``python -m http.server``,
+spawns a sandbox via :class:`DockerBackend` with
+``host_gateway_alias=None`` (DNS-only resolution), and curls the alias
+from inside the sandbox."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from aios.sandbox.backends import make_backend
+from aios.sandbox.backends.base import (
+    INSTANCE_LABEL_KEY,
+    MANAGED_LABEL_KEY,
+    MANAGED_LABEL_VALUE,
+    SESSION_LABEL_KEY,
+    Mount,
+    SandboxSpec,
+    Unrestricted,
+)
+from aios.sandbox.network import (
+    SANDBOX_NETWORK_NAME,
+    WORKER_NETWORK_ALIAS,
+    ensure_sandbox_network,
+)
+from tests.conftest import needs_docker
+
+pytestmark = needs_docker
+
+IMAGE = os.environ.get("AIOS_DOCKER_IMAGE", "ghcr.io/eumemic/aios-sandbox:latest")
+SIDECAR_PORT = 7777
+
+
+async def _run(argv: list[str], *, deadline_s: float) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess in a worker thread (async functions must not call
+    blocking ``subprocess.run`` directly)."""
+    return await asyncio.to_thread(
+        subprocess.run,
+        argv,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=deadline_s,
+    )
+
+
+@pytest.fixture
+async def _network_ready() -> None:
+    """Create the sandbox network if absent. No-op cleanup — other tests
+    on this host (and the live worker) keep using the network."""
+    await ensure_sandbox_network()
+
+
+@pytest.fixture
+async def broker_sidecar(_network_ready: None) -> AsyncIterator[None]:
+    """Start an ``aios-worker``-aliased container running an HTTP server.
+
+    Stands in for the worker's broker on the sandbox network. Cleans
+    up unconditionally so a failed assertion doesn't leak the container.
+    """
+    name = f"aios-broker-sidecar-{uuid.uuid4().hex[:8]}"
+    result = await _run(
+        [
+            "docker",
+            "run",
+            "--detach",
+            "--rm",
+            "--name",
+            name,
+            "--network",
+            SANDBOX_NETWORK_NAME,
+            "--network-alias",
+            WORKER_NETWORK_ALIAS,
+            IMAGE,
+            "python3",
+            "-m",
+            "http.server",
+            str(SIDECAR_PORT),
+        ],
+        deadline_s=30,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"sidecar docker run failed: {result.stderr.strip()}")
+    container_id = result.stdout.strip()
+
+    try:
+        yield
+    finally:
+        await _run(
+            ["docker", "rm", "--force", container_id],
+            deadline_s=15,
+        )
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    return ws
+
+
+async def test_sandbox_resolves_worker_alias_via_docker_dns(
+    broker_sidecar: None, workspace: Path
+) -> None:
+    backend = make_backend("docker")
+    instance_id = f"test_{uuid.uuid4().hex[:8]}"
+    session_id = f"sess_{uuid.uuid4().hex[:8]}"
+    spec = SandboxSpec(
+        session_id=session_id,
+        instance_id=instance_id,
+        workspace=Mount(host_path=workspace, sandbox_path="/workspace"),
+        extra_mounts=(),
+        environment={},
+        labels={
+            MANAGED_LABEL_KEY: MANAGED_LABEL_VALUE,
+            INSTANCE_LABEL_KEY: instance_id,
+            SESSION_LABEL_KEY: session_id,
+        },
+        network_policy=Unrestricted(),
+        host_gateway_alias=None,
+        image=IMAGE,
+    )
+    handle = await backend.create(spec)
+    try:
+        # ``--retry-connrefused`` absorbs the ~few-hundred-ms race between
+        # docker reporting "container started" and the sidecar's
+        # http.server actually binding the port.
+        result = await backend.exec(
+            handle,
+            (
+                f"curl -fs --max-time 5 --retry 10 --retry-delay 1 "
+                f"--retry-connrefused http://{WORKER_NETWORK_ALIAS}:{SIDECAR_PORT}/"
+            ),
+            timeout_seconds=20,
+            max_output_bytes=10_000,
+        )
+        assert result.exit_code == 0, (
+            f"sandbox failed to reach {WORKER_NETWORK_ALIAS}:{SIDECAR_PORT}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+    finally:
+        await backend.destroy(handle)

--- a/tests/unit/sandbox/test_broker_http_contract.py
+++ b/tests/unit/sandbox/test_broker_http_contract.py
@@ -1,14 +1,8 @@
-"""Integration tests for the ``bin/mcp`` CLI against a real broker.
-
-Boots a real :class:`aios.sandbox.mcp_proxy.McpBroker` on a loopback
-port, mocks the upstream MCP discovery/invocation, then shells out to
-``bin/mcp`` as a subprocess with ``MCP_BROKER_URL`` / ``MCP_BROKER_SECRET``
-pointed at the test broker. Verifies the CLI parses the broker's
-JSON envelope correctly and surfaces the right exit codes.
-
-No Docker — this exercises the binary end-to-end at the HTTP/subprocess
-boundary, which is what a real sandbox sees.
-"""
+"""Contract tests for the HTTP/JSON envelope between ``bin/mcp`` and
+:class:`aios.sandbox.mcp_proxy.McpBroker`. Pins request/response shape,
+exit codes, and secret validation. Runs over loopback — cross-container
+reachability is covered by
+:mod:`tests.e2e.test_sandbox_broker_reachability`."""
 
 from __future__ import annotations
 

--- a/tests/unit/sandbox/test_sandbox_network.py
+++ b/tests/unit/sandbox/test_sandbox_network.py
@@ -1,0 +1,189 @@
+"""Unit tests for :mod:`aios.sandbox.network`. The Docker subprocess
+runner is patched so no real daemon is required."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from aios.sandbox import network as sandbox_network
+from aios.sandbox.network import (
+    SANDBOX_NETWORK_NAME,
+    WORKER_NETWORK_ALIAS,
+    ensure_sandbox_network,
+)
+
+DockerResponder = Callable[[list[str]], tuple[int, bytes, bytes]]
+
+
+def install_docker_responder(
+    monkeypatch: pytest.MonkeyPatch, responder: DockerResponder
+) -> list[list[str]]:
+    """Patch the docker subprocess runner and return a log of argv lists.
+
+    Each docker invocation is recorded in the returned list (callers can
+    introspect order/contents) and routed through ``responder`` for the
+    return triple.
+    """
+    calls: list[list[str]] = []
+
+    async def fake_run(argv: list[str], *, timeout_s: float = 30.0) -> tuple[int, bytes, bytes]:
+        del timeout_s
+        calls.append(list(argv))
+        return responder(argv)
+
+    monkeypatch.setattr(sandbox_network, "run_docker_cli", fake_run)
+    return calls
+
+
+# ── ensure_sandbox_network: on-host worker ───────────────────────────────────
+
+
+class TestEnsureNetworkOnHost:
+    """Worker running on the host (no /.dockerenv) — no self-connect."""
+
+    @pytest.fixture(autouse=True)
+    def _on_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sandbox_network, "is_running_in_container", lambda: False)
+
+    async def test_existing_network_is_reused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def responder(argv: list[str]) -> tuple[int, bytes, bytes]:
+            assert argv[:3] == ["docker", "network", "inspect"]
+            return 0, b"[]", b""
+
+        calls = install_docker_responder(monkeypatch, responder)
+        await ensure_sandbox_network()
+
+        # Only ``inspect`` runs (no create), and no connect.
+        assert calls == [["docker", "network", "inspect", SANDBOX_NETWORK_NAME]]
+
+    async def test_missing_network_is_created(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def responder(argv: list[str]) -> tuple[int, bytes, bytes]:
+            if argv[:3] == ["docker", "network", "inspect"]:
+                return 1, b"", b"Error: No such network"
+            if argv[:3] == ["docker", "network", "create"]:
+                return 0, b"netid\n", b""
+            pytest.fail(f"unexpected argv: {argv}")
+
+        calls = install_docker_responder(monkeypatch, responder)
+        await ensure_sandbox_network()
+        assert [c[:3] for c in calls] == [
+            ["docker", "network", "inspect"],
+            ["docker", "network", "create"],
+        ]
+
+
+# ── ensure_sandbox_network: in-container worker ──────────────────────────────
+
+
+class TestEnsureNetworkInContainer:
+    """Worker in container — self-connect with alias on the sandbox network."""
+
+    @pytest.fixture(autouse=True)
+    def _in_container(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sandbox_network, "is_running_in_container", lambda: True)
+        monkeypatch.setattr(sandbox_network.socket, "gethostname", lambda: "worker-abc")
+
+    async def test_connects_self_with_alias_when_not_joined(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def responder(argv: list[str]) -> tuple[int, bytes, bytes]:
+            if argv[:3] == ["docker", "network", "inspect"]:
+                return 0, b"[]", b""  # network exists
+            if argv[:2] == ["docker", "inspect"]:
+                # container membership check -> not on network
+                return 0, b"<nil>\n", b""
+            if argv[:3] == ["docker", "network", "connect"]:
+                return 0, b"", b""
+            pytest.fail(f"unexpected argv: {argv}")
+
+        calls = install_docker_responder(monkeypatch, responder)
+        await ensure_sandbox_network()
+        connect_calls = [c for c in calls if c[:3] == ["docker", "network", "connect"]]
+        assert connect_calls == [
+            [
+                "docker",
+                "network",
+                "connect",
+                "--alias",
+                WORKER_NETWORK_ALIAS,
+                SANDBOX_NETWORK_NAME,
+                "worker-abc",
+            ]
+        ]
+
+    async def test_skip_connect_when_already_joined(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def responder(argv: list[str]) -> tuple[int, bytes, bytes]:
+            if argv[:3] == ["docker", "network", "inspect"]:
+                return 0, b"[]", b""
+            if argv[:2] == ["docker", "inspect"]:
+                # container is already on the network — non-empty, non-<nil>
+                return 0, b"map[Endpoint:abc]\n", b""
+            pytest.fail(f"unexpected argv: {argv}")
+
+        calls = install_docker_responder(monkeypatch, responder)
+        await ensure_sandbox_network()
+        assert not [c for c in calls if c[:3] == ["docker", "network", "connect"]]
+
+
+# ── ensure_sandbox_network: failure modes ────────────────────────────────────
+
+
+class TestEnsureNetworkFailures:
+    @pytest.fixture(autouse=True)
+    def _on_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sandbox_network, "is_running_in_container", lambda: False)
+
+    async def test_create_race_resolved_by_reinspect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A concurrent worker created the network between our inspect and
+        our create — the re-inspect should resolve the apparent failure."""
+        inspect_calls = 0
+
+        def responder(argv: list[str]) -> tuple[int, bytes, bytes]:
+            nonlocal inspect_calls
+            if argv[:3] == ["docker", "network", "inspect"]:
+                inspect_calls += 1
+                if inspect_calls == 1:
+                    return 1, b"", b"Error: No such network"
+                return 0, b"[]", b""  # second inspect: now exists
+            if argv[:3] == ["docker", "network", "create"]:
+                return 1, b"", b"Error: network with name aios-sandbox already exists\n"
+            pytest.fail(f"unexpected argv: {argv}")
+
+        install_docker_responder(monkeypatch, responder)
+        await ensure_sandbox_network()  # should not raise
+
+    async def test_create_hard_failure_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def responder(argv: list[str]) -> tuple[int, bytes, bytes]:
+            if argv[:3] == ["docker", "network", "inspect"]:
+                return 1, b"", b"Error: No such network"
+            if argv[:3] == ["docker", "network", "create"]:
+                return 1, b"", b"Error: daemon unreachable\n"
+            pytest.fail(f"unexpected argv: {argv}")
+
+        install_docker_responder(monkeypatch, responder)
+        with pytest.raises(RuntimeError, match="failed to create sandbox network"):
+            await ensure_sandbox_network()
+
+
+class TestEnsureConnectFailureInContainer:
+    @pytest.fixture(autouse=True)
+    def _in_container(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sandbox_network, "is_running_in_container", lambda: True)
+        monkeypatch.setattr(sandbox_network.socket, "gethostname", lambda: "worker-abc")
+
+    async def test_connect_hard_failure_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def responder(argv: list[str]) -> tuple[int, bytes, bytes]:
+            if argv[:3] == ["docker", "network", "inspect"]:
+                return 0, b"[]", b""
+            if argv[:2] == ["docker", "inspect"]:
+                # not joined, before or after the failed connect
+                return 0, b"<nil>\n", b""
+            if argv[:3] == ["docker", "network", "connect"]:
+                return 1, b"", b"Error: container not found\n"
+            pytest.fail(f"unexpected argv: {argv}")
+
+        install_docker_responder(monkeypatch, responder)
+        with pytest.raises(RuntimeError, match="failed to join worker"):
+            await ensure_sandbox_network()

--- a/tests/unit/test_github_clone_identity.py
+++ b/tests/unit/test_github_clone_identity.py
@@ -69,7 +69,7 @@ async def _run_with_captured_git(
             repo_url="https://github.com/octocat/Hello-World",
             token="ghp_secret",
             cache_dir=repos_root / "cache",
-            proxy_url="http://host.docker.internal:9090/o/r",
+            proxy_url="http://aios-worker:9090/o/r",
             git_user_name=git_user_name,
             git_user_email=git_user_email,
         )

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -129,9 +129,9 @@ class TestBuildIptablesScript:
     def test_extra_host_ports_added(self) -> None:
         script = build_iptables_script(
             allowed_hosts=set(),
-            extra_host_ports=[("host.docker.internal", 8765)],
+            extra_host_ports=[("aios-worker", 8765)],
         )
-        assert "host.docker.internal:8765" in script
+        assert "aios-worker:8765" in script
         assert "--dport 8765 -j ACCEPT" in script
 
 
@@ -161,7 +161,7 @@ async def _capture_docker_argv(spec: SandboxSpec) -> list[str]:
         captured.append(argv)
         return 0, b"container_abc123\n", b""
 
-    with patch("aios.sandbox.backends.docker._run_docker", fake_run_docker):
+    with patch("aios.sandbox.backends.docker.run_docker_cli", fake_run_docker):
         await DockerBackend().create(spec)
     return captured[0]
 
@@ -247,11 +247,11 @@ class TestApplyNetworkLockdown:
             backend,
             handle,
             networking,
-            extra_host_ports=[("host.docker.internal", 8765)],
+            extra_host_ports=[("aios-worker", 8765)],
         )
 
         script = backend.calls[0][1]["command"]
-        assert "host.docker.internal:8765" in script
+        assert "aios-worker:8765" in script
 
     def test_package_registry_hosts_constant_is_populated(self) -> None:
         # Sanity: the constant exists and contains representative hosts.

--- a/tests/unit/test_sandbox_resource_caps.py
+++ b/tests/unit/test_sandbox_resource_caps.py
@@ -49,7 +49,7 @@ async def _capture_argv(spec: SandboxSpec) -> list[str]:
         captured["argv"] = argv
         return 0, b"deadbeef1234\n", b""
 
-    with patch("aios.sandbox.backends.docker._run_docker", side_effect=fake_run_docker):
+    with patch("aios.sandbox.backends.docker.run_docker_cli", side_effect=fake_run_docker):
         await DockerBackend().create(spec)
     return captured["argv"]
 

--- a/tests/unit/test_workspace_runtime_dirs.py
+++ b/tests/unit/test_workspace_runtime_dirs.py
@@ -68,7 +68,7 @@ def _make_spec(environment: dict[str, str]) -> SandboxSpec:
 
 
 async def _capture_docker_argv(spec: SandboxSpec, monkeypatch: pytest.MonkeyPatch) -> list[str]:
-    """Call DockerBackend.create(spec) with _run_docker patched; return argv."""
+    """Call DockerBackend.create(spec) with run_docker_cli patched; return argv."""
     captured: list[list[str]] = []
 
     async def fake_run_docker(
@@ -77,7 +77,7 @@ async def _capture_docker_argv(spec: SandboxSpec, monkeypatch: pytest.MonkeyPatc
         captured.append(argv)
         return 0, b"container_abc123\n", b""
 
-    monkeypatch.setattr("aios.sandbox.backends.docker._run_docker", fake_run_docker)
+    monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_cli", fake_run_docker)
     await DockerBackend().create(spec)
     return captured[0]
 


### PR DESCRIPTION
## Summary

- Production hung on every `mcp` call inside a sandbox because the worker and sandbox landed on different Docker networks (Coolify project network vs default `bridge`); `host.docker.internal` resolved to a gateway with no route to the broker. Same shape affected `git_proxy`.
- Replaces `host.docker.internal` + `--add-host host-gateway` with a worker-managed `aios-sandbox` Docker network. The sandbox always spawns onto it; the worker joins it with alias `aios-worker` when in-container (Coolify) or stays reachable via `--add-host aios-worker:host-gateway` when on-host (dev). Same broker URL in both modes: `http://aios-worker:<port>`. `git_proxy` rides the same alias.
- New `tests/e2e/test_sandbox_broker_reachability.py` is the regression test that was missing — spawns a sidecar with alias `aios-worker` and curls it from inside a real sandbox spawned via `DockerBackend`. `test_mcp_cli_binary.py` was relabeled to `test_broker_http_contract.py` to honestly reflect what it pins (HTTP envelope, not cross-container reachability).

Drops the `AIOS_SANDBOX_NETWORK_MODE` setting — any override silently re-broke Coolify, so the setting was a footgun. `Disabled` policy still hardcodes `--network none` in the backend.

## Test plan

- [x] `uv run mypy src` clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` clean
- [x] `uv run pytest tests/unit -q` (1219 tests)
- [x] `uv run pytest tests/e2e/test_sandbox_broker_reachability.py tests/e2e/test_networking.py -q` (4 tests, Docker)
- [ ] Manual smoke (worker on host, dev): `mcp` inside a sandbox returns the server list (no hang); `mcp <server> <tool>` invokes successfully
- [ ] Manual smoke (worker in container, prod-equivalent): observe `sandbox.network_worker_joined` log at worker startup; `mcp` inside a sandbox succeeds
- [ ] Manual smoke: `git_proxy` working trees can `git fetch` from inside a sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)