### PR TITLE
fix(#425): owner-task model in McpSessionPool — contexts exit in their open task

### DIFF
--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -15,11 +15,21 @@ Pool lifecycle:
   broken session — closing a half-dead stack may hang.
 - :meth:`close_all` is called from ``worker_main``'s ``finally`` at
   shutdown to tear everything down.
+
+Owner-task model (#425): each entry's ``AsyncExitStack`` lives inside a
+dedicated long-lived task. The task opens the contexts, signals the
+caller they're ready, then awaits a shutdown event. ``close()`` sets the
+event and the contexts exit in the same task that entered them. This
+avoids the anyio "Attempted to exit cancel scope in a different task
+than it was entered in" error that would otherwise fire on
+:meth:`close_all` because the streamable-http client binds its cancel
+scope to the opening task.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 from contextlib import AsyncExitStack
 from typing import Any
@@ -52,21 +62,40 @@ def _headers_hash(headers: dict[str, str]) -> str:
 
 
 class _Entry:
-    """A single pooled MCP session with its associated resource stack."""
+    """A single pooled MCP session with its associated owner task.
+
+    The session's contexts (httpx client, streamable-http client,
+    ClientSession) all live inside ``_owner_task``. ``close()`` sets
+    ``_shutdown`` so the task exits the contexts in the same task that
+    entered them — see the module docstring for the anyio cancel-scope
+    background.
+    """
 
     def __init__(
         self,
         session: ClientSession,
         init_result: InitializeResult,
-        stack: AsyncExitStack,
+        shutdown: asyncio.Event,
+        owner_task: asyncio.Task[None],
     ) -> None:
         self.session = session
         self.init_result = init_result
-        self._stack = stack
+        self._shutdown = shutdown
+        self._owner_task = owner_task
 
     async def close(self) -> None:
-        """Tear down this entry's session and all its async contexts."""
-        await self._stack.aclose()
+        """Signal the owner task to exit its contexts and await its completion.
+
+        Safe to call repeatedly; the owner task only sees the first set().
+
+        The owner task's contexts may raise during exit (e.g. the remote
+        MCP server already closed the socket). The caller —
+        :meth:`McpSessionPool.close_all` — already swallows and logs such
+        errors; we surface as if shutdown completed.
+        """
+        self._shutdown.set()
+        with contextlib.suppress(Exception):
+            await self._owner_task
 
 
 class McpSessionPool:
@@ -88,24 +117,50 @@ class McpSessionPool:
         return lock
 
     async def _open_entry(self, url: str, headers: dict[str, str]) -> _Entry:
-        """Open a fresh session. Stack must outlive this frame (entry owns it)."""
-        stack: AsyncExitStack = AsyncExitStack()
-        await stack.__aenter__()
-        try:
-            http_client: Any = await stack.enter_async_context(
-                httpx.AsyncClient(headers=headers, timeout=_MCP_HTTPX_TIMEOUT)
-            )
-            read_stream, write_stream, _ = await stack.enter_async_context(
-                streamable_http_client(url, http_client=http_client)
-            )
-            session: ClientSession = await stack.enter_async_context(
-                ClientSession(read_stream, write_stream)
-            )
-            init_result: InitializeResult = await session.initialize()
-        except BaseException:
-            await stack.aclose()
-            raise
-        return _Entry(session, init_result, stack)
+        """Open a fresh session inside a dedicated long-lived owner task.
+
+        The contexts (httpx client, streamable-http client, ClientSession)
+        all enter and exit in the same task — see the module docstring on
+        the anyio cancel-scope constraint. The task signals ``ready`` once
+        the session is initialized, then awaits ``shutdown`` so the
+        contexts stay open for the entry's lifetime.
+        """
+        ready = asyncio.Event()
+        shutdown = asyncio.Event()
+        result: dict[str, Any] = {}
+
+        async def _own() -> None:
+            try:
+                async with AsyncExitStack() as stack:
+                    http_client: Any = await stack.enter_async_context(
+                        httpx.AsyncClient(headers=headers, timeout=_MCP_HTTPX_TIMEOUT)
+                    )
+                    read_stream, write_stream, _ = await stack.enter_async_context(
+                        streamable_http_client(url, http_client=http_client)
+                    )
+                    session = await stack.enter_async_context(
+                        ClientSession(read_stream, write_stream)
+                    )
+                    result["session"] = session
+                    result["init"] = await session.initialize()
+                    ready.set()
+                    await shutdown.wait()
+            except BaseException as exc:
+                result["error"] = exc
+                # Unblock the caller waiting on ready so it doesn't hang
+                # forever when the open path failed.
+                ready.set()
+                raise
+
+        task = asyncio.create_task(_own(), name=f"mcp-pool:{url}")
+        await ready.wait()
+        if "error" in result:
+            # The task already raised; await it to surface the original
+            # exception cleanly (and clear the unhandled-exception slot).
+            await task
+            # Defensive — unreachable in practice.
+            raise RuntimeError("mcp pool owner task signalled ready but produced no session")
+        return _Entry(result["session"], result["init"], shutdown, task)
 
     async def get_or_connect(
         self, url: str, headers: dict[str, str]

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -187,6 +187,63 @@ class TestMcpSessionPool:
         await pool.close_all()
         assert len(pool._entries) == 0
 
+    async def test_contexts_exit_in_same_task_they_entered(self) -> None:
+        """Cross-task close — regression for #425.
+
+        Pre-fix, the pool held an ``AsyncExitStack`` on whatever task
+        first opened the entry. ``close_all`` called ``stack.aclose()``
+        from a different task and anyio's ``streamable_http_client``
+        raised ``RuntimeError: Attempted to exit cancel scope in a
+        different task than it was entered in``. The exception was
+        swallowed by ``close_all``'s try/except but logged a warning.
+
+        ``close_all`` still swallows post-fix (defensively, for unrelated
+        teardown failures), so this test instead checks the more
+        specific invariant: the transport's ``__aenter__`` and
+        ``__aexit__`` run in the SAME task. With the owner-task model
+        that's guaranteed; with the legacy stack-on-_Entry model it
+        wasn't.
+        """
+        entered_in: dict[str, asyncio.Task[Any] | None] = {"open": None, "close": None}
+
+        def _task_recording_transport() -> MagicMock:
+            async def _enter(*_args: Any, **_kwargs: Any) -> Any:
+                entered_in["open"] = asyncio.current_task()
+                return (MagicMock(), MagicMock(), MagicMock())
+
+            async def _exit(*_args: Any, **_kwargs: Any) -> bool:
+                entered_in["close"] = asyncio.current_task()
+                return False
+
+            t = MagicMock()
+            t.__aenter__ = AsyncMock(side_effect=_enter)
+            t.__aexit__ = AsyncMock(side_effect=_exit)
+            return t
+
+        session = _make_mock_session()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_task_recording_transport()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
+        ):
+            pool = McpSessionPool()
+
+            async def opener() -> None:
+                await pool.get_or_connect("https://m.example/", {"Authorization": "tok"})
+
+            await asyncio.create_task(opener())
+
+            async def closer() -> None:
+                await pool.close_all()
+
+            await asyncio.create_task(closer())
+
+        assert entered_in["open"] is not None
+        assert entered_in["close"] is not None
+        # The invariant: contexts exit in the same task that entered them.
+        # Pre-fix this would have failed because __aexit__ ran in the
+        # closer task while __aenter__ ran in the opener task.
+        assert entered_in["open"] is entered_in["close"]
+
 
 # ── Pool integration via discover_mcp_tools / call_mcp_tool ────────────────
 


### PR DESCRIPTION
## Summary

Worker shutdown was logging `mcp_pool.close_entry_failed` warnings because `close_all` called `AsyncExitStack.aclose()` from a different asyncio task than the one that opened the stack. anyio's `streamable_http_client` cancel scope pinned to the opening task; the cross-task close raised the canonical `RuntimeError: Attempted to exit cancel scope in a different task than it was entered in`. The error was swallowed by `close_all`'s try/except, but the warning was noisy and tripped the smoke setup's startup-error grep (separately patched in #420).

Replace with an owner-task model: each `_Entry` owns a dedicated long-lived task that holds the contexts and awaits a shutdown event. `close()` sets the event, the contexts exit in the owner task. Closes #425.

## Test plan

- [x] `uv run pytest tests/unit -q` — 1215 passed (1 new regression test)
- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] Sanity: verified `test_contexts_exit_in_same_task_they_entered` fails on a simulated revert to the legacy stack-on-_Entry model

🤖 Generated with [Claude Code](https://claude.com/claude-code)