### PR TITLE
fix(#403 follow-up): account_id defense in sandbox memory materializer

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -4306,16 +4306,25 @@ async def get_memory_by_path(
 async def list_active_memory_paths_and_content(
     conn: asyncpg.Connection[Any],
     store_id: str,
+    *,
+    account_id: str,
 ) -> list[tuple[str, str]]:
     """Bulk-fetch ``(path, content)`` for every non-deleted memory in the store.
 
     Used by sandbox materialization, which needs all live memories in one
     DB roundtrip rather than ``list_memories`` (metadata only) followed by
     a per-memory ``get_memory(include_content=True)`` fan-out.
+
+    ``account_id`` is enforced in SQL even though the upstream caller has
+    already account-validated ``store_id`` via
+    ``list_session_memory_store_echoes`` — defense in depth so the
+    materializer can't be coerced into reading another tenant's memories.
     """
     rows = await conn.fetch(
-        "SELECT path, content FROM memories WHERE memory_store_id = $1 AND deleted_at IS NULL",
+        "SELECT path, content FROM memories "
+        "WHERE memory_store_id = $1 AND account_id = $2 AND deleted_at IS NULL",
         store_id,
+        account_id,
     )
     return [(r["path"], r["content"]) for r in rows]
 

--- a/src/aios/sandbox/memory_mounts.py
+++ b/src/aios/sandbox/memory_mounts.py
@@ -38,6 +38,7 @@ async def materialize_store_to_host(
     conn: asyncpg.Connection[Any],
     *,
     store_id: str,
+    account_id: str,
 ) -> None:
     """Ensure ``store_id``'s host dir is populated from DB. Idempotent.
 
@@ -61,7 +62,9 @@ async def materialize_store_to_host(
                 return  # another waiter materialized while we blocked
             host_dir.mkdir(parents=True, exist_ok=True)
 
-            entries = await queries.list_active_memory_paths_and_content(conn, store_id)
+            entries = await queries.list_active_memory_paths_and_content(
+                conn, store_id, account_id=account_id
+            )
             for path, content in entries:
                 # Memory paths are guaranteed to start with "/" by the SQL CHECK.
                 atomic_write(host_dir / path.lstrip("/"), content or "")

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -142,7 +142,9 @@ async def _materialize_memory_mounts(
             conn, session_id, account_id=account_id
         )
         for echo in echoes:
-            await materialize_store_to_host(conn, store_id=echo.memory_store_id)
+            await materialize_store_to_host(
+                conn, store_id=echo.memory_store_id, account_id=account_id
+            )
     return list(echoes)
 
 


### PR DESCRIPTION
## Summary

`list_active_memory_paths_and_content` and `materialize_store_to_host` didn't accept or enforce `account_id`. Upstream callers already account-validate `store_id` via `list_session_memory_store_echoes`, but the materializer was a defense-in-depth gap — a future caller bypassing the echo path could read another tenant's memories.

Thread `account_id` through:
- `queries.list_active_memory_paths_and_content` — adds `AND account_id = $2` to the SELECT
- `sandbox.memory_mounts.materialize_store_to_host` — new kw-arg
- `sandbox.spec._materialize_memory_mounts` — caller already has `account_id` in scope

## Test plan

- [x] `uv run pytest tests/unit -q` — 1215 passed
- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)