### PR TITLE
fix(harness/context): drop leading assistant with unjoinable tool_calls

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -654,14 +654,16 @@ def _prune_leading_orphans(messages: list[dict[str, Any]]) -> list[dict[str, Any
             break  # clean start
 
         if role == "assistant":
-            tc_ids = {tc["id"] for tc in (msg.get("tool_calls") or [])}
-            if not tc_ids:
+            raw_tcs = msg.get("tool_calls") or []
+            if not raw_tcs:
                 break  # assistant with no tool_calls — clean start
-            # Check that all tool_calls have matching results in the rest.
+            # An entry without an ``id`` is unjoinable to any tool result
+            # — treat it like a tool_call whose pair was dropped by the
+            # window, falling into the "incomplete group" path below.
             remaining_result_ids = {
                 m.get("tool_call_id") for m in messages[start + 1 :] if m.get("role") == "tool"
             }
-            if tc_ids <= remaining_result_ids:
+            if all(tc.get("id") in remaining_result_ids for tc in raw_tcs):
                 break  # complete group — clean start
             # Incomplete group — drop the assistant and its partial results.
             start += 1

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -345,6 +345,21 @@ class TestBuildMessages:
                 )
                 assert has_parent, f"orphan tool result for {tc_id}"
 
+    def test_prune_handles_leading_assistant_with_malformed_tool_call(self) -> None:
+        """Leading assistant with a tool_call missing ``id`` is unjoinable and
+        must be dropped, not crash the prune."""
+        events = [
+            _evt(
+                1,
+                "assistant",
+                tool_calls=[{"type": "function", "function": {"name": "bash", "arguments": "{}"}}],
+            ),
+            _evt(2, "user", content="next"),
+        ]
+        msgs = build_messages(events, system_prompt=None).messages
+        assert [m["role"] for m in msgs] == ["user"]
+        assert msgs[0]["content"] == "next"
+
 
 # ─── monotonicity ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- ``_prune_leading_orphans`` indexed ``tc[\"id\"]`` directly, so any assistant event whose ``tool_calls`` contained an entry missing the ``id`` key raised ``KeyError: 'id'`` whenever that assistant landed at the head of the windowed message list. The harness retried the step on the same deterministic state, budget-exhausted, and the session wedged.
- The codebase's own ``_sanitize_tool_calls`` (``context.py:355-362``) documents that *\"some models produce malformed tool_calls (control characters in arguments, missing fields, extra provider keys)\"*. Every other site that reads tool_call ids — ``build_messages`` main loop (``context.py:539``), ``_sanitize_tool_calls`` itself (``context.py:378``), ``sweep.py:416``, ``loop.py:556,557,864``, ``db/queries.py:1497,1812``, ``services/sessions.py:462``, ``tools/switch_channel.py:294`` — uses ``tc.get(\"id\")`` defensively. ``_prune_leading_orphans`` was the lone unguarded site.
- An entry without an ``id`` is **unjoinable** to any tool result, so an assistant whose tool_calls include any id-less entry isn't a valid replay starting point. Fold that case into the existing \"incomplete group\" path: drop the assistant and any partial tool results before continuing.
- The previous ``if not tc_ids: break`` conflated *\"no tool_calls at all\"* (clean start) with *\"only malformed tool_calls\"* (unjoinable). Split them: the former still breaks as a clean start; the latter falls through to the drop path. Refactor lets ``raw_tcs`` carry the structural emptiness check while the (now ``.get``-safe) id comparison drives the completeness check via ``all(tc.get(\"id\") in remaining_result_ids for tc in raw_tcs)``.

## Follow-up

A separate concern not addressed here: malformed tool_calls **in mid-window positions** still flow through ``_sanitize_tool_calls`` and survive as ``{\"id\": \"\", ...}`` entries in the assembled context, producing assistant→user transitions without paired tool_results that strict providers may reject. The right fix is at the rendering boundary (``_sanitize_tool_calls`` itself, or upstream at event-write time) and needs its own audit — empirical provider behavior, scope across leading/mid-window cases, and test coverage. Filed as #435.

## Test plan

- [x] Added ``test_prune_handles_leading_assistant_with_malformed_tool_call`` in ``tests/unit/test_context.py`` — fails with ``KeyError: 'id'`` on master, passes after the fix; asserts the malformed assistant is dropped and the user message becomes the clean start.
- [x] ``uv run mypy src`` — clean
- [x] ``uv run ruff check src tests && uv run ruff format --check src tests`` — clean
- [x] ``uv run pytest tests/unit -q`` — 1222 passed, no regressions
- [ ] CI runs e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)