### PR TITLE
fix(#435): filter unjoinable tool_calls at render, not just leading-orphan prune

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -359,9 +359,17 @@ def _sanitize_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any
     arguments, missing fields, extra provider keys) that break strict
     downstream providers.  Returns a cleaned copy with only spec fields
     and valid JSON arguments.
+
+    Entries without a usable ``id`` are dropped: an id-less tool_call
+    cannot be joined to any tool_result, so leaving it in the assistant
+    message produces an assistant→user transition with no paired
+    ``tool``-role message — invalid per the chat-completions schema.
     """
     sanitized = []
     for tc in tool_calls:
+        tcid = tc.get("id")
+        if not tcid:
+            continue
         fn = tc.get("function") or {}
         raw_args = fn.get("arguments", "{}")
         if isinstance(raw_args, dict):
@@ -375,7 +383,7 @@ def _sanitize_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any
             raw_args = "{}"
         sanitized.append(
             {
-                "id": tc.get("id") or "",
+                "id": tcid,
                 "type": "function",
                 "function": {"name": fn.get("name") or "", "arguments": raw_args},
             }
@@ -429,8 +437,14 @@ def _strip_to_spec(
     if role == "assistant" and target_supports_thinking:
         allowed = allowed | _THINKING_FIELDS
     out = {k: v for k, v in msg.items() if k in allowed}
-    if out.get("tool_calls"):
-        out["tool_calls"] = _sanitize_tool_calls(out["tool_calls"])
+    if raw_tcs := out.get("tool_calls"):
+        sanitized = _sanitize_tool_calls(raw_tcs)
+        if sanitized:
+            out["tool_calls"] = sanitized
+        else:
+            # Strict providers reject an empty tool_calls array; drop
+            # the key so the assistant is a plain text-only turn.
+            del out["tool_calls"]
     return out
 
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -877,15 +877,38 @@ class TestToolCallSanitization:
         msgs = build_messages(events, system_prompt=None).messages
         assert msgs[1]["tool_calls"][0]["function"]["name"] == ""
 
-    def test_missing_id_defaults_empty(self) -> None:
-        """Missing tool_call id defaults to empty string."""
+    def test_missing_id_filtered_out(self) -> None:
+        """A tool_call entry without an ``id`` is unjoinable — dropped, not preserved with id=''."""
         bad_tc = {"type": "function", "function": {"name": "bash", "arguments": "{}"}}
         events = [
             _evt(1, "user", content="go"),
             _evt(2, "assistant", tool_calls=[bad_tc]),
         ]
         msgs = build_messages(events, system_prompt=None).messages
-        assert msgs[1]["tool_calls"][0]["id"] == ""
+        assert "tool_calls" not in msgs[1]
+
+    def test_empty_id_string_filtered(self) -> None:
+        """An explicit empty-string id is also unjoinable and filtered."""
+        bad_tc = {"id": "", "type": "function", "function": {"name": "bash", "arguments": "{}"}}
+        events = [
+            _evt(1, "user", content="go"),
+            _evt(2, "assistant", tool_calls=[bad_tc]),
+        ]
+        msgs = build_messages(events, system_prompt=None).messages
+        assert "tool_calls" not in msgs[1]
+
+    def test_mid_window_malformed_filtered_among_valid(self) -> None:
+        """Mid-window assistant with mixed valid + malformed tool_calls keeps only the valid entry."""
+        malformed = {"type": "function", "function": {"name": "bash", "arguments": "{}"}}
+        events = [
+            _evt(1, "user", content="go"),
+            _evt(2, "assistant", tool_calls=[_tc("call_a", "bash"), malformed]),
+            _evt(3, "tool", tool_call_id="call_a", content="done"),
+            _evt(4, "user", content="next"),
+        ]
+        msgs = build_messages(events, system_prompt=None).messages
+        asst = next(m for m in msgs if m.get("role") == "assistant")
+        assert asst["tool_calls"] == [_tc("call_a", "bash")]
 
     def test_extra_fields_stripped_from_tool_call(self) -> None:
         """Provider-specific fields inside tool_call dicts are excluded."""


### PR DESCRIPTION
## Summary

- PR #434 fixed the leading-orphan ``KeyError: 'id'`` by dropping assistants whose ``tool_calls`` all lacked usable ids at the head of a windowed message list.  The same malformed shape sitting **mid-window** survived ``_sanitize_tool_calls`` because it normalized to ``{\"id\": \"\", ...}`` rather than dropping the entry.  Final assembled context could contain an assistant whose ``tool_calls`` reference a ``tool``-role result that cannot exist — invalid per the chat-completions schema and rejected by strict providers.
- Fix at the render boundary in ``_sanitize_tool_calls``: skip entries whose ``id`` is falsy.  In ``_strip_to_spec``, drop the ``tool_calls`` key entirely when the post-filter list is empty (providers reject empty arrays).  The event log retains the model's output verbatim — replay fidelity preserved.
- Decision recorded: layer (a) (sanitize-time filter) chosen over layer (b) (event-write rejection).  (a) is most localized — single render site, no cross-cutting writes — and correct-by-construction regardless of provider tolerance, since the shape violates the chat-completions schema.

## Test plan

- [x] ``uv run mypy src`` — clean
- [x] ``uv run ruff check src tests && uv run ruff format --check src tests`` — clean
- [x] ``uv run pytest tests/unit -q`` — 1226 passed
- [x] New test ``test_mid_window_malformed_filtered_among_valid`` covers the actual scenario from the issue; ``test_missing_id_filtered_out`` replaces the prior ``test_missing_id_defaults_empty`` (which codified the bug as documented behavior); ``test_empty_id_string_filtered`` covers the explicit empty-string id shape.
- [ ] CI runs e2e suite

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)