### PR TITLE
fix(harness/loop): guard _dispatch_confirmed_tools against in-flight tasks

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -305,7 +305,13 @@ async def _run_session_step_body(
 
     # Check for confirmed-but-undispatched tool calls (always_ask → allow).
     # The sweep's case (c) ensures we passed the guard above.
-    pending = await _dispatch_confirmed_tools(pool, session_id, events, account_id=account_id)
+    pending = await _dispatch_confirmed_tools(
+        pool,
+        session_id,
+        events,
+        account_id=account_id,
+        task_registry=task_registry,
+    )
     if pending:
         pending_builtin = [tc for tc in pending if not _is_mcp_tool(_tc_name(tc))]
         pending_mcp = [tc for tc in pending if _is_mcp_tool(_tc_name(tc))]
@@ -828,11 +834,20 @@ async def _dispatch_confirmed_tools(
     message_events: list[Any],
     *,
     account_id: str,
+    task_registry: TaskRegistry,
 ) -> list[dict[str, Any]]:
     """Find tool calls that have been confirmed (allow) but not yet dispatched.
 
     Returns the original tool call dicts ready for ``launch_tool_calls``,
     or an empty list if nothing to dispatch.
+
+    Skips ``tool_call_id``s whose asyncio task is still in flight per
+    *task_registry*: procrastinate releases the per-session lock when
+    step N's job body returns, but the fire-and-forget tool task
+    outlives the body — any wake firing step N+1 before the task
+    appends its result would otherwise re-launch the same tool and
+    write a second ``tool_result`` event (violates CLAUDE.md
+    invariant #4).
     """
     # Find the latest assistant message with tool_calls.
     asst_tool_calls: list[dict[str, Any]] = []
@@ -871,9 +886,13 @@ async def _dispatch_confirmed_tools(
             if tcid:
                 confirmed.add(tcid)
 
-    # Return tool calls that are confirmed but have no result yet.
+    in_flight = task_registry.in_flight_tool_call_ids(session_id)
     pending = [
-        tc for tc in asst_tool_calls if tc.get("id") in confirmed and tc.get("id") not in completed
+        tc
+        for tc in asst_tool_calls
+        if tc.get("id") in confirmed
+        and tc.get("id") not in completed
+        and tc.get("id") not in in_flight
     ]
     return pending
 

--- a/tests/unit/test_dispatch_confirmed_tools.py
+++ b/tests/unit/test_dispatch_confirmed_tools.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aios.harness.loop import _dispatch_confirmed_tools
+from aios.harness.task_registry import TaskRegistry
 
 
 def _assistant_with_tool_calls(tool_call_ids: list[str]) -> SimpleNamespace:
@@ -32,7 +34,13 @@ class TestDispatchConfirmedTools:
             AsyncMock(return_value=[]),
         ):
             assert (
-                await _dispatch_confirmed_tools(pool, "sess_x", [], account_id="acc_test_stub")
+                await _dispatch_confirmed_tools(
+                    pool,
+                    "sess_x",
+                    [],
+                    account_id="acc_test_stub",
+                    task_registry=TaskRegistry(),
+                )
                 == []
             )
 
@@ -45,7 +53,11 @@ class TestDispatchConfirmedTools:
             AsyncMock(return_value=[_confirmed("tc1")]),
         ):
             pending = await _dispatch_confirmed_tools(
-                pool, "sess_x", msg_events, account_id="acc_test_stub"
+                pool,
+                "sess_x",
+                msg_events,
+                account_id="acc_test_stub",
+                task_registry=TaskRegistry(),
             )
         assert [tc["id"] for tc in pending] == ["tc1"]
 
@@ -60,7 +72,35 @@ class TestDispatchConfirmedTools:
         pool = MagicMock()
         with patch("aios.harness.loop.sessions_service.read_events", mock_read):
             pending = await _dispatch_confirmed_tools(
-                pool, "sess_x", msg_events, account_id="acc_test_stub"
+                pool,
+                "sess_x",
+                msg_events,
+                account_id="acc_test_stub",
+                task_registry=TaskRegistry(),
             )
         assert [tc["id"] for tc in pending] == ["tc1"]
         assert mock_read.call_args.kwargs["newest_first"] is True
+
+    async def test_skips_tool_call_with_in_flight_task(self) -> None:
+        """An in-flight task in ``task_registry`` blocks re-dispatch — without
+        this guard, a wake firing step N+1 before the task appended its
+        result would launch a second asyncio task for the same
+        ``tool_call_id`` (violates CLAUDE.md invariant #4).
+        """
+        msg_events = [_assistant_with_tool_calls(["tc1"])]
+        pool = MagicMock()
+        registry = TaskRegistry()
+        in_flight: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        registry.add("sess_x", "tc1", in_flight)  # type: ignore[arg-type]
+        with patch(
+            "aios.harness.loop.sessions_service.read_events",
+            AsyncMock(return_value=[_confirmed("tc1")]),
+        ):
+            pending = await _dispatch_confirmed_tools(
+                pool,
+                "sess_x",
+                msg_events,
+                account_id="acc_test_stub",
+                task_registry=registry,
+            )
+        assert pending == []


### PR DESCRIPTION
## Summary

\`_dispatch_confirmed_tools\` selected pending \`tool_call_id\`s purely from the event log (confirmed-without-\`tool_result\`) and never consulted the in-flight asyncio task registry. The race:

1. Step N's body calls \`_dispatch_confirmed_tools\` → returns \`[tc1]\` → \`launch_tool_calls\` registers an asyncio task in \`runtime.task_registry\` → step body returns → procrastinate's per-session \`lock\` releases.
2. The async tool task runs fire-and-forget, outliving the body. No \`tool_result\` yet.
3. Any wake fires step N+1 — most reliably a *sibling tool's* \`_trigger_sweep\` (every \`tool_dispatch._execute_tool_async\` triggers it in its \`finally\` block, guaranteeing same-batch hit for multi-allow UX); also scheduled wake, user message, SSE attach, etc.
4. Step N+1 calls \`_dispatch_confirmed_tools\` → it reads the same lifecycle (\`tool_confirmed allow\` for tc1) and the same events table (no \`tool_result\` for tc1 yet) → returns \`[tc1]\` again.
5. \`launch_tool_calls\` registers a *second* asyncio task for tc1. Two tasks race the same tool handler — side effects (bash, MCP, web_fetch, file writes) run twice and two \`tool_result\` events with the same \`tool_call_id\` are appended, violating CLAUDE.md invariant #4 and producing an invalid chat-completions log (the next inference sees two tool results for one tool_use).

## Fix

Thread \`task_registry\` into the dispatcher as a keyword-only param and add \`tc.get(\"id\") not in in_flight\` to the pending filter:

\`\`\`python
in_flight = task_registry.in_flight_tool_call_ids(session_id)
pending = [
    tc
    for tc in asst_tool_calls
    if tc.get(\"id\") in confirmed
    and tc.get(\"id\") not in completed
    and tc.get(\"id\") not in in_flight
]
\`\`\`

This mirrors the existing \`task_registry.in_flight_tool_call_ids(sid)\` gate at \`sweep.py:_filter_incomplete_batches:401\` — \`_dispatch_confirmed_tools\` was the last site that consulted only the DB-derived view and missed the locally-tracked in-flight set. The caller \`_run_session_step_body\` already has \`task_registry\` in scope (it's a positional param at \`loop.py:191\`), so we reuse it rather than re-fetching via \`runtime.require_task_registry()\`.

\`sweep.find_sessions_needing_inference\` case (c) (\"confirmed-but-undispatched\") deliberately bypasses \`_filter_incomplete_batches\` (\`sweep.py:364-375\`: \`filtered | confirmed_sessions\`), which is why this site needs its own in-flight gate rather than relying on the sweep's whole-session filter.

## Test plan

- [x] Added \`test_skips_tool_call_with_in_flight_task\` in \`tests/unit/test_dispatch_confirmed_tools.py\` — registers a never-completing \`asyncio.Future\` in \`TaskRegistry\`, asserts dispatcher returns \`[]\`. Pre-fix fails (returns \`[{\"id\": \"tc1\", ...}]\`); post-fix passes. The three existing dispatcher tests are updated to pass an empty \`TaskRegistry()\` as the kwarg (regression-coverage for the un-in-flight common case is preserved).
- [x] \`uv run mypy src\` — clean
- [x] \`uv run ruff check src tests && uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1225 passed, no regressions
- [ ] CI runs e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)