### PR TITLE
refactor(harness): drop _trigger_sweep broad-except swallow

### DIFF
--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -214,7 +214,7 @@ async def _execute_tool_async(
             },
             account_id=account_id,
         )
-        await _trigger_sweep(pool, session_id, bound_log, account_id=account_id)
+        await _trigger_sweep(pool, session_id, account_id=account_id)
 
 
 def _parse_arguments(raw_args: Any) -> dict[str, Any] | None:
@@ -294,7 +294,6 @@ def _evict_session_container(session_id: str) -> None:
 async def _trigger_sweep(
     pool: asyncpg.Pool[Any],
     session_id: str,
-    bound_log: Any,
     *,
     account_id: str,
 ) -> None:
@@ -312,12 +311,9 @@ async def _trigger_sweep(
     )
     result = SweepResult(repaired_ghosts=0, woken_sessions=0)
     try:
-        try:
-            result = await wake_sessions_needing_inference(
-                pool, runtime.require_task_registry(), session_id=session_id
-            )
-        except Exception:
-            bound_log.warning("tool.sweep_failed")
+        result = await wake_sessions_needing_inference(
+            pool, runtime.require_task_registry(), session_id=session_id
+        )
     finally:
         await sessions_service.append_event(
             pool,
@@ -522,4 +518,4 @@ async def _execute_mcp_tool_async(
             },
             account_id=account_id,
         )
-        await _trigger_sweep(pool, session_id, bound_log, account_id=account_id)
+        await _trigger_sweep(pool, session_id, account_id=account_id)

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -54,7 +54,7 @@ class TestTailSweepSpan:
             ),
             patch("aios.harness.sweep.wake_sessions_needing_inference", wake_mock),
         ):
-            await _trigger_sweep(MagicMock(), "sess_x", MagicMock(), account_id="acc_test_stub")
+            await _trigger_sweep(MagicMock(), "sess_x", account_id="acc_test_stub")
 
         sweep_events = _sweep_events(append_event)
         assert [e["event"] for e in sweep_events] == ["sweep_start", "sweep_end"]
@@ -67,14 +67,15 @@ class TestTailSweepSpan:
         }
 
     async def test_sweep_end_fires_when_sweep_raises(self) -> None:
-        """``_trigger_sweep`` catches and logs sweep failures, so the pair
-        still closes cleanly — but the counts fall back to zero because
-        no ``SweepResult`` was produced."""
+        """Sweep failures propagate out of ``_trigger_sweep``, but the
+        ``sweep_start``/``sweep_end`` pair still closes cleanly via the
+        outer try/finally — counts fall back to zero because no
+        ``SweepResult`` was produced. Mirrors the entry-site behavior in
+        ``test_sweep_end_fires_when_find_raises``."""
         from aios.harness.tool_dispatch import _trigger_sweep
 
         append_event = AsyncMock(return_value=SimpleNamespace(id="ev_sweep"))
         wake_mock = AsyncMock(side_effect=RuntimeError("db down"))
-        bound_log = MagicMock()
 
         with (
             patch("aios.harness.tool_dispatch.sessions_service.append_event", append_event),
@@ -82,14 +83,14 @@ class TestTailSweepSpan:
                 "aios.harness.tool_dispatch.runtime.require_task_registry", return_value=MagicMock()
             ),
             patch("aios.harness.sweep.wake_sessions_needing_inference", wake_mock),
+            pytest.raises(RuntimeError, match="db down"),
         ):
-            await _trigger_sweep(MagicMock(), "sess_x", bound_log, account_id="acc_test_stub")
+            await _trigger_sweep(MagicMock(), "sess_x", account_id="acc_test_stub")
 
         sweep_events = _sweep_events(append_event)
         assert [e["event"] for e in sweep_events] == ["sweep_start", "sweep_end"]
         assert sweep_events[1]["repaired_ghosts"] == 0
         assert sweep_events[1]["woken_sessions"] == 0
-        bound_log.warning.assert_called_once_with("tool.sweep_failed")
 
 
 # ─── entry site (loop._run_session_step_body guard) ──────────────────────────


### PR DESCRIPTION
## Summary

- Remove the inner `try/except Exception: bound_log.warning(\"tool.sweep_failed\")` swallow inside `_trigger_sweep`. This violated CLAUDE.md's "fail hard, no fallbacks" stance — sweep failures were silently absorbed with no `exc_info`, masking real bugs in `wake_sessions_needing_inference`.
- After removal, the inner `bound_log` parameter became dead, so dropped from the `_trigger_sweep` signature and the two call sites.
- The load-bearing `sweep_start`/`sweep_end` pair-always-closes invariant is preserved by the unchanged outer try/finally. The test now asserts BOTH the pair-closes invariant AND that the underlying exception propagates (`pytest.raises`), mirroring the entry-site test `test_sweep_end_fires_when_find_raises`.

### Why this is a real fix

Three signals converged:

1. **CLAUDE.md violation:** "Fail hard, no fallbacks — no silent skipping, no dummy values, no error suppression. The model sees raw errors and retries through the session log; that IS the design." The removed catch was a silent skip with degraded observability (no `exc_info`).
2. **Inconsistent peer:** `tool_dispatch.py:188` uses `bound_log.exception("tool.handler_failed")` (full traceback). The sweep_failed warning used `bound_log.warning(...)` with no traceback — strictly worse diagnostics than asyncio's default unhandled-task-exception logging.
3. **Cross-site symmetry:** the entry-site sweep at `_run_session_step_body` already lets `find_sessions_needing_inference` failures propagate (verified by `test_sweep_end_fires_when_find_raises`). The tail-site was the inconsistent outlier; this change restores symmetry.

### Follow-up kaizen candidates surfaced

The `/simplify` reuse pass flagged that after this change, the entry-site sweep (`loop.py:223-245`) and tail-site sweep (`tool_dispatch.py:305-329`) share an even more identical span-bracket pattern — `append_event(sweep_start) → try/finally → append_event(sweep_end, counts)`. A future kaizen iteration could extract a `sweep_span` async context manager that collapses both. Deferring per CLAUDE.md's "three similar lines is better than premature abstraction" — flagged here so the next iteration can re-evaluate.

## Test plan

- [x] mypy — clean
- [x] ruff check + format — clean
- [x] Unit suite — 1226 passed
- [x] `test_sweep_end_fires_when_sweep_raises` updated to expect propagation
- [ ] CI runs e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)