### PR TITLE
fix(db): add account_id column to pending_management_calls

### DIFF
--- a/migrations/versions/0049_pending_management_calls_account_id.py
+++ b/migrations/versions/0049_pending_management_calls_account_id.py
@@ -1,0 +1,100 @@
+"""Add ``account_id`` to ``pending_management_calls`` (the table missed by the
+multi-tenancy roll-out).
+
+The table was created in 0041, before the ``user_id → account_id`` rename
+in 0043 and the corresponding backfill + ``SET NOT NULL`` in 0044. Both
+0043 and 0044 omit it from their ``_TABLES`` lists, so the schema has
+never carried a tenancy column for it — but ``get_management_call`` and
+``mark_management_call_resolved`` were retrofitted with ``WHERE
+account_id = $N`` predicates regardless, raising
+``UndefinedColumnError`` at runtime on every connector RPC.
+
+This migration closes the gap: add the column, backfill any pre-existing
+rows to the root account (mirrors 0044's pattern), ``SET NOT NULL``, add
+the FK to ``accounts(id) ON DELETE RESTRICT``, and replace the partial
+``(connector, created_at)`` index with the account-aware
+``(connector, account_id, created_at)`` form so the SSE-backfill list
+query (filtered by ``connector`` and ``account_id``) stays index-served.
+
+Empty-database guard (same shape as 0044): tests run ``alembic upgrade
+head`` before any bootstrap. The backfill ``UPDATE`` matches zero rows,
+the ``SELECT`` subquery is never evaluated, and ``SET NOT NULL``
+succeeds on an empty table. On a populated production database, the
+operator must have already bootstrapped a root account before running
+this migration — otherwise the backfill leaves ``NULL`` rows and ``SET
+NOT NULL`` fails loudly, which is the right behavior.
+
+Revision ID: 0049
+Revises: 0048
+Create Date: 2026-05-15
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0049"
+down_revision: str = "0048"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE pending_management_calls ADD COLUMN account_id text")
+    # Backfill: any pre-existing rows (none in production yet, but tests
+    # and dev DBs may carry some) belong to the root tenant. Same shape
+    # as 0044's tenancy backfill.
+    op.execute(
+        """
+        UPDATE pending_management_calls
+           SET account_id = (
+             SELECT id FROM accounts
+              WHERE parent_account_id IS NULL AND archived_at IS NULL
+              LIMIT 1
+           )
+         WHERE account_id IS NULL
+        """
+    )
+    op.execute(
+        "ALTER TABLE pending_management_calls ALTER COLUMN account_id SET NOT NULL"
+    )
+    op.execute(
+        """
+        ALTER TABLE pending_management_calls
+          ADD CONSTRAINT pending_management_calls_account_id_fk
+          FOREIGN KEY (account_id) REFERENCES accounts(id)
+          ON DELETE RESTRICT
+        """
+    )
+    # Replace the connector-only partial index with the account-aware
+    # form so ``list_pending_management_calls_for_connector`` (now
+    # filtered by ``WHERE connector = $1 AND account_id = $2``) stays
+    # index-served.
+    op.execute("DROP INDEX IF EXISTS pending_management_calls_connector_pending_idx")
+    op.execute(
+        """
+        CREATE INDEX pending_management_calls_connector_account_pending_idx
+            ON pending_management_calls (connector, account_id, created_at)
+            WHERE status = 'pending'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS pending_management_calls_connector_account_pending_idx"
+    )
+    op.execute(
+        """
+        CREATE INDEX pending_management_calls_connector_pending_idx
+            ON pending_management_calls (connector, created_at)
+            WHERE status = 'pending'
+        """
+    )
+    op.execute(
+        "ALTER TABLE pending_management_calls "
+        "DROP CONSTRAINT pending_management_calls_account_id_fk"
+    )
+    op.execute("ALTER TABLE pending_management_calls DROP COLUMN account_id")

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -658,6 +658,4 @@ async def post_runtime_management_call_result(
         )
         if not moved:
             return
-        await queries.notify_management_call_result(
-            conn, call_id=body.call_id, account_id=account_id
-        )
+        await queries.notify_management_call_result(conn, call_id=body.call_id)

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -5001,14 +5001,15 @@ async def insert_management_call(
     await conn.execute(
         """
         INSERT INTO pending_management_calls
-            (id, connector, method, params, expires_at)
-        VALUES ($1, $2, $3, $4::jsonb, $5)
+            (id, connector, method, params, expires_at, account_id)
+        VALUES ($1, $2, $3, $4::jsonb, $5, $6)
         """,
         call_id,
         connector,
         method,
         json.dumps(params),
         expires_at,
+        account_id,
     )
 
 
@@ -5018,26 +5019,30 @@ async def list_pending_management_calls_for_connector(
     *,
     account_id: str,
 ) -> list[dict[str, Any]]:
-    """Pending, unexpired management calls for ``connector``.
+    """Pending, unexpired management calls for ``connector`` scoped to ``account_id``.
 
     Used by the runtime SSE backfill on connector reconnect.  Output dict
     shape::
 
         {"call_id": "mgmt_...", "method": "register", "params": {...}}
 
-    The partial index ``pending_management_calls_connector_pending_idx``
-    backs this query directly.
+    Filtered by ``account_id`` so a runtime container authenticated for
+    one tenant never sees another tenant's pending calls. The partial
+    index ``pending_management_calls_connector_account_pending_idx``
+    (migration 0049) backs this query directly.
     """
     rows = await conn.fetch(
         """
         SELECT id, method, params
           FROM pending_management_calls
          WHERE connector = $1
+           AND account_id = $2
            AND status = 'pending'
            AND expires_at > now()
          ORDER BY created_at ASC
         """,
         connector,
+        account_id,
     )
     return [
         {
@@ -5120,7 +5125,6 @@ async def mark_management_call_resolved(
 async def notify_management_call_dispatch(
     conn: asyncpg.Connection[Any],
     *,
-    account_id: str,
     connector: str,
     call_id: str,
 ) -> None:
@@ -5129,6 +5133,9 @@ async def notify_management_call_dispatch(
     Payload is just ``call_id`` so subscribers re-fetch full details from
     the row; keeps the NOTIFY well under Postgres' 8000-byte cap and
     means an in-flight payload can't desync from a later UPDATE.
+
+    Carries no tenancy info — subscribers fetch the row via
+    :func:`get_management_call`, which enforces ``WHERE account_id = $N``.
     """
     await conn.execute(
         "SELECT pg_notify($1, $2)",
@@ -5140,13 +5147,13 @@ async def notify_management_call_dispatch(
 async def notify_management_call_result(
     conn: asyncpg.Connection[Any],
     *,
-    account_id: str,
     call_id: str,
 ) -> None:
     """NOTIFY the per-call result channel after resolving the row.
 
     Payload is empty — listeners re-fetch the resolved row via
-    :func:`get_management_call`, mirroring the dispatch-side convention.
+    :func:`get_management_call`, mirroring the dispatch-side convention
+    (which also lets the fetch enforce tenancy).
     """
     await conn.execute(
         "SELECT pg_notify($1, $2)",

--- a/src/aios/services/management_calls.py
+++ b/src/aios/services/management_calls.py
@@ -54,7 +54,7 @@ async def submit_call(
                 account_id=account_id,
             )
             await queries.notify_management_call_dispatch(
-                conn, connector=connector, call_id=call_id, account_id=account_id
+                conn, connector=connector, call_id=call_id
             )
 
         try:

--- a/tests/integration/test_management_call_account_id.py
+++ b/tests/integration/test_management_call_account_id.py
@@ -1,0 +1,143 @@
+"""Integration tests: ``pending_management_calls`` queries enforce ``account_id``.
+
+Migration 0041 created the table without an ``account_id`` column; the
+multi-tenancy migrations (0043 rename, 0044 backfill+NOT NULL) added
+``account_id`` to every other reserved resource table but missed this
+one. ``get_management_call`` and ``mark_management_call_resolved``
+were retrofitted with ``WHERE account_id = $N`` predicates regardless,
+so every Signal connector RPC raises ``asyncpg.UndefinedColumnError``
+at runtime — invisible to the unit suite (fully mocked) and to the
+existing e2e signal test (doesn't exercise result intake).
+
+These tests pin the round trip end-to-end against the real schema:
+insert with one account id, read with the same one, read with a
+different one returns ``None``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def conn_two_accounts(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[asyncpg.Connection[Any]]:
+    """Asyncpg conn with two seeded accounts (``acc_a``, ``acc_b``)."""
+    conn = await asyncpg.connect(migrated_db_url)
+    try:
+        # One root + two children — partial unique index
+        # ``accounts_one_active_root`` permits only a single non-archived
+        # ``parent_account_id IS NULL`` row at a time.
+        await conn.execute(
+            """
+            INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+            VALUES ('acc_root', NULL,      TRUE,  'tenant-root'),
+                   ('acc_a',    'acc_root', FALSE, 'tenant-a'),
+                   ('acc_b',    'acc_root', FALSE, 'tenant-b')
+            """
+        )
+        yield conn
+    finally:
+        await conn.close()
+
+
+class TestGetManagementCallTenancy:
+    async def test_owner_can_fetch_their_pending_call(
+        self, conn_two_accounts: asyncpg.Connection[Any]
+    ) -> None:
+        await queries.insert_management_call(
+            conn_two_accounts,
+            account_id="acc_a",
+            call_id="mgmt_a_pending",
+            connector="signal",
+            method="register",
+            params={"account": "+15551234567"},
+            expires_at=datetime.now(UTC) + timedelta(seconds=60),
+        )
+
+        row = await queries.get_management_call(
+            conn_two_accounts, "mgmt_a_pending", account_id="acc_a"
+        )
+
+        assert row is not None
+        assert row["id"] == "mgmt_a_pending"
+        assert row["connector"] == "signal"
+        assert row["method"] == "register"
+        assert row["status"] == "pending"
+
+    async def test_other_tenant_cannot_fetch_call(
+        self, conn_two_accounts: asyncpg.Connection[Any]
+    ) -> None:
+        await queries.insert_management_call(
+            conn_two_accounts,
+            account_id="acc_a",
+            call_id="mgmt_a_pending",
+            connector="signal",
+            method="register",
+            params={"account": "+15551234567"},
+            expires_at=datetime.now(UTC) + timedelta(seconds=60),
+        )
+
+        row = await queries.get_management_call(
+            conn_two_accounts, "mgmt_a_pending", account_id="acc_b"
+        )
+
+        assert row is None
+
+
+class TestMarkManagementCallResolvedTenancy:
+    async def test_owner_can_resolve_their_call(
+        self, conn_two_accounts: asyncpg.Connection[Any]
+    ) -> None:
+        await queries.insert_management_call(
+            conn_two_accounts,
+            account_id="acc_a",
+            call_id="mgmt_a_pending",
+            connector="signal",
+            method="register",
+            params={"account": "+15551234567"},
+            expires_at=datetime.now(UTC) + timedelta(seconds=60),
+        )
+
+        moved = await queries.mark_management_call_resolved(
+            conn_two_accounts,
+            account_id="acc_a",
+            call_id="mgmt_a_pending",
+            result={"status": "sms_sent"},
+            is_error=False,
+        )
+
+        assert moved is True
+
+    async def test_other_tenant_cannot_resolve_call(
+        self, conn_two_accounts: asyncpg.Connection[Any]
+    ) -> None:
+        await queries.insert_management_call(
+            conn_two_accounts,
+            account_id="acc_a",
+            call_id="mgmt_a_pending",
+            connector="signal",
+            method="register",
+            params={"account": "+15551234567"},
+            expires_at=datetime.now(UTC) + timedelta(seconds=60),
+        )
+
+        moved = await queries.mark_management_call_resolved(
+            conn_two_accounts,
+            account_id="acc_b",
+            call_id="mgmt_a_pending",
+            result={"status": "stolen"},
+            is_error=False,
+        )
+
+        assert moved is False


### PR DESCRIPTION
## Summary

- `pending_management_calls` (created in migration 0041) has no `account_id` column, but `get_management_call` and `mark_management_call_resolved` execute `WHERE id = $1 AND account_id = $2`. Every Signal connector RPC (`api/routers/connectors.py:648` result intake + `api/sse.py:222` NOTIFY tail) raised `asyncpg.UndefinedColumnError` at runtime. Unit tests fully mocked the query so the bug was invisible to CI.
- Migration 0049 closes the schema gap (ADD COLUMN + backfill from root + SET NOT NULL + FK + account-aware partial index, mirroring 0044's pattern).
- `list_pending_management_calls_for_connector` also gains `WHERE account_id = $2` — closes a cross-tenant SSE backfill exposure where one tenant's runtime container would have seen other tenants' pending calls. Same root cause as the undefined-column bug (incomplete tenancy installation on this table), so bundled per the broken-windows policy.
- Drops the previously-accepted-but-unused `account_id` kwarg on `notify_management_call_dispatch` / `notify_management_call_result`. NOTIFY channels are per-connector / per-call_id and carry no tenant info; subscribers re-fetch with `get_management_call` which enforces tenancy.

## Why this slipped through

Multi-tenancy was rolled out in three phases (0043 rename, 0044 backfill+NOT NULL, then per-query WHERE sweep in #421/#426). The query side was retrofitted to enforce tenancy, but `pending_management_calls` was created in 0041 — before the rename — and never added to the tenancy-scoped table lists in 0043/0044. The SQL claimed to enforce tenancy that the schema couldn't satisfy.

## Test plan

- [x] mypy clean
- [x] ruff clean + format-check clean
- [x] Unit suite — 1226 passed
- [x] Integration suite — 8 passed (4 new round-trip + cross-tenant isolation tests; all existing tests still green)
- [ ] CI runs the full e2e + integration suites

## Code review notes

Run via `pr-review-toolkit:code-reviewer` — no critical or important findings. Lower-severity observations and the reasoning behind each design choice are captured in commit body and migration docstring (empty-DB guard, FK ordering, index naming, scope-bundling rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)