### PR TITLE
perf: test-suite hotspots + two production-code wins surfaced by profiling

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1226,6 +1226,11 @@ _MODEL_TOKEN_RATIO_MIN_SAMPLES = 5
 _MODEL_TOKEN_RATIO_MIN = 0.5
 _MODEL_TOKEN_RATIO_BUCKET_FLOOR = 0.001
 _MODEL_TOKEN_RATIO_CACHE_TTL_SECONDS = 60.0
+# Shorter TTL for the "not enough samples yet" path: every step on a freshly
+# deployed model fired this aggregate JSONB scan otherwise, because the
+# below-threshold branch used to skip the cache write entirely.  10 s bounds
+# the activation lag once the model crosses the sample threshold.
+_MODEL_TOKEN_RATIO_BELOW_THRESHOLD_CACHE_TTL_SECONDS = 10.0
 # Fixed per-sample stddev prior for the tokenizer ratio.  Empirically,
 # observed per-span CV is ~0.5-1.5 % across the models we've measured
 # (Opus 4.7: 0.75 %; Haiku 4.5: ~1 %), so 0.02 is a conservative upper
@@ -1274,8 +1279,10 @@ async def model_token_ratio(
     Mature calibrated ratios are cached in-process for 60 seconds.  The
     lifetime aggregate is intentionally slow-moving, and caching prevents
     every windowing call from rescanning all historical calibration spans.
-    Below-threshold results are not cached, so newly accumulating models
-    can activate as soon as the minimum sample count is reached.
+    Below-threshold results (returning the neutral ``1.0``) are cached for
+    a shorter 10-second TTL so a freshly deployed model doesn't pay the
+    aggregate scan on every step before calibration kicks in; activation
+    once samples accumulate is therefore delayed by at most one TTL.
 
     ``model`` is the raw model string (``agent.model``) — NO NORMALIZATION.
     Different LiteLLM routes (``anthropic/...`` vs
@@ -1340,6 +1347,10 @@ async def model_token_ratio(
     )
     assert row is not None
     if row["n"] < _MODEL_TOKEN_RATIO_MIN_SAMPLES:
+        _model_token_ratio_cache[cache_key] = (
+            now + _MODEL_TOKEN_RATIO_BELOW_THRESHOLD_CACHE_TTL_SECONDS,
+            1.0,
+        )
         return 1.0
 
     raw = float(row["mean_ratio"])

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -29,8 +29,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-import litellm
-
 from aios.harness.vision import (
     can_inline_image,
     correct_image_mime_b64,
@@ -633,6 +631,11 @@ def build_messages(
         messages.insert(0, {"role": "system", "content": system_prompt})
 
     _correct_image_data_url_mimes(messages)
+
+    # Defer the heavy ``litellm`` import: every consumer of this module
+    # pays ~1.18s of bootstrap otherwise, and most call sites either
+    # exit before this point or run under tests that never reach it.
+    import litellm
 
     target_supports_thinking = bool(model) and litellm.supports_reasoning(model)
     return ContextResult(

--- a/src/aios/harness/tokens.py
+++ b/src/aios/harness/tokens.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any
 
-from litellm import token_counter
-
 # ─── estimator (delegates to litellm's local tokenizers) ──────────────────
 
 
@@ -52,6 +50,11 @@ def approx_tokens(
     ``model=...``), re-run the backfill script to keep stored values
     honest.
     """
+    # Defer the heavy ``litellm`` import: every consumer of this module
+    # pays ~1.18s of bootstrap otherwise, and many CLI / test code paths
+    # never call into this helper.
+    from litellm import token_counter
+
     return int(
         token_counter(
             messages=list(messages),

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -12,8 +12,6 @@ import base64
 import binascii
 from typing import Any
 
-import litellm
-
 from aios.logging import get_logger
 from aios_connector_http.mime import sniff_image_mime
 
@@ -53,6 +51,11 @@ def supports_vision(model: str) -> bool:
     """
     if model in _VISION_OVERRIDES:
         return _VISION_OVERRIDES[model]
+    # Defer the heavy ``litellm`` import: every harness consumer of this
+    # module pays ~1.18s of bootstrap otherwise, and most call sites never
+    # reach this branch.
+    import litellm
+
     try:
         info = litellm.get_model_info(model)
     except Exception as err:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,12 @@
 * ``postgres_container`` — session-scoped testcontainer running Postgres 16
 * ``migrated_db_url`` — runs alembic upgrade head + applies the procrastinate
   schema and aios lock-release trigger against the testcontainer
+* ``_truncate_sql`` — session-scoped: the ``TRUNCATE`` statement covering
+  every public-schema table, computed once after migrations
 * ``_reset_db_state`` — function-scoped: TRUNCATEs all public-schema tables
-  before each test so the session-scoped DB stays isolated between tests
+  before each test so the session-scoped DB stays isolated between tests.
+  Yields the asyncpg connection so downstream fixtures (``aios_env``) can
+  reuse it without paying a second connect round-trip
 * ``aios_env_minimal`` — env vars only, no DB seeding. For tests that
   exercise pre-bootstrap state (bootstrap endpoint tests, etc.)
 * ``aios_env`` — ``aios_env_minimal`` plus a bootstrapped root account
@@ -21,7 +25,7 @@ import base64
 import os
 import secrets
 import subprocess
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from typing import Any
 from unittest import mock
@@ -122,22 +126,50 @@ def migrated_db_url(db_url: str) -> str:
     return db_url
 
 
+@pytest.fixture(scope="session")
+def _truncate_sql(migrated_db_url: str) -> str:
+    """Pre-built ``TRUNCATE`` statement covering every public-schema table.
+
+    The schema is fixed once :func:`migrated_db_url` has run, so the
+    ``pg_tables`` lookup belongs at session scope, not in every
+    :func:`_reset_db_state` call.  Eliminating the per-test catalog scan
+    shaves ~3 ms per test off the e2e suite.
+    """
+    import asyncio
+
+    import asyncpg
+
+    async def fetch() -> str:
+        conn = await asyncpg.connect(migrated_db_url)
+        try:
+            rows = await conn.fetch("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
+        finally:
+            await conn.close()
+        if not rows:
+            return ""
+        quoted = ", ".join(f'"{r["tablename"]}"' for r in rows)
+        return f"TRUNCATE {quoted} RESTART IDENTITY CASCADE"
+
+    return asyncio.run(fetch())
+
+
 @pytest.fixture
-async def _reset_db_state(migrated_db_url: str) -> None:
-    """TRUNCATE every public-schema table before each test.
+async def _reset_db_state(migrated_db_url: str, _truncate_sql: str) -> AsyncIterator[Any]:
+    """TRUNCATE every public-schema table before each test, yielding the
+    connection so downstream fixtures (``aios_env``) can reuse it instead
+    of opening their own.
 
     Restores the cross-test isolation that module-scoped Postgres used to
-    provide.  ``TRUNCATE`` is metadata-only in Postgres, so this is O(tables)
-    regardless of row count.
+    provide.  ``TRUNCATE`` is metadata-only in Postgres, so this is
+    O(tables) regardless of row count.
     """
     import asyncpg
 
     conn = await asyncpg.connect(migrated_db_url)
     try:
-        rows = await conn.fetch("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
-        if rows:
-            quoted = ", ".join(f'"{r["tablename"]}"' for r in rows)
-            await conn.execute(f"TRUNCATE {quoted} RESTART IDENTITY CASCADE")
+        if _truncate_sql:
+            await conn.execute(_truncate_sql)
+        yield conn
     finally:
         await conn.close()
 
@@ -178,7 +210,7 @@ def _reset_sse_starlette_shutdown_state() -> Iterator[None]:
 
 @pytest.fixture
 def aios_env_minimal(
-    migrated_db_url: str, _reset_db_state: None, tmp_path: Path
+    migrated_db_url: str, _reset_db_state: Any, tmp_path: Path
 ) -> Iterator[dict[str, str]]:
     """Set the env vars the FastAPI app needs, without seeding any data.
 
@@ -206,45 +238,42 @@ def aios_env_minimal(
 
 
 @pytest.fixture
-async def aios_env(aios_env_minimal: dict[str, str]) -> dict[str, str]:
+async def aios_env(aios_env_minimal: dict[str, str], _reset_db_state: Any) -> dict[str, str]:
     """Env vars + a bootstrapped root whose key is ``AIOS_API_KEY``.
 
     Auth looks the bearer token up against ``account_keys``, so any
     test that hits an authenticated route needs a matching DB row.
     This fixture seeds that row using ``AIOS_API_KEY``'s sha256 hash.
 
+    Reuses the connection yielded by :func:`_reset_db_state` to dodge
+    a second ``asyncpg.connect`` round-trip per test (~27 ms).
+
     Async so the seed step runs on the same event loop pytest-asyncio
     drives the test on — avoids the spurious ``asyncio.run`` event-loop
     isolation that caused ASGI-callable teardown flakiness in CI.
     """
-    import asyncpg
-
     from aios.services.accounts import hash_key
 
     plaintext = aios_env_minimal["AIOS_API_KEY"]
-    db_url = aios_env_minimal["AIOS_DB_URL"]
+    conn = _reset_db_state
 
-    conn = await asyncpg.connect(db_url)
-    try:
-        # PR 6: insert ``acc_test_stub`` as the root account itself and bind
-        # the bootstrap API key directly to it, so auth resolves the bearer
-        # to the same account_id every test body uses as its scoping arg.
-        # Bypasses ``bootstrap_root_account`` (which would generate a fresh
-        # ULID we'd have to thread back through 44 test files).
-        await conn.execute(
-            """
-            INSERT INTO accounts
-                (id, parent_account_id, can_mint_children, display_name)
-            VALUES ('acc_test_stub', NULL, TRUE, 'test-root')
-            """
-        )
-        await conn.execute(
-            """
-            INSERT INTO account_keys (key_id, account_id, hash, label)
-            VALUES ('akey_test', 'acc_test_stub', $1, 'test-root')
-            """,
-            hash_key(plaintext),
-        )
-    finally:
-        await conn.close()
+    # PR 6: insert ``acc_test_stub`` as the root account itself and bind
+    # the bootstrap API key directly to it, so auth resolves the bearer
+    # to the same account_id every test body uses as its scoping arg.
+    # Bypasses ``bootstrap_root_account`` (which would generate a fresh
+    # ULID we'd have to thread back through 44 test files).
+    await conn.execute(
+        """
+        INSERT INTO accounts
+            (id, parent_account_id, can_mint_children, display_name)
+        VALUES ('acc_test_stub', NULL, TRUE, 'test-root')
+        """
+    )
+    await conn.execute(
+        """
+        INSERT INTO account_keys (key_id, account_id, hash, label)
+        VALUES ('akey_test', 'acc_test_stub', $1, 'test-root')
+        """,
+        hash_key(plaintext),
+    )
     return aios_env_minimal

--- a/tests/e2e/test_connection_discovery_sse.py
+++ b/tests/e2e/test_connection_discovery_sse.py
@@ -87,9 +87,12 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
             await _wait_for_health(url)
             yield url
         finally:
-            server.should_exit = True
+            # See test_signal_registration.py for why ``should_exit`` alone
+            # loses the race against open SSE streams.
+            await server.shutdown()
+            serve_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await asyncio.wait_for(serve_task, timeout=5.0)
+                await serve_task
             await pool.close()
 
 

--- a/tests/e2e/test_echo_http_connector.py
+++ b/tests/e2e/test_echo_http_connector.py
@@ -80,9 +80,12 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
             await wait_for_health(url)
             yield url
         finally:
-            server.should_exit = True
+            # See test_signal_registration.py for why ``should_exit`` alone
+            # loses the race against open SSE streams.
+            await server.shutdown()
+            serve_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await asyncio.wait_for(serve_task, timeout=5.0)
+                await serve_task
             await pool.close()
 
 

--- a/tests/e2e/test_memory_cross_session_sync.py
+++ b/tests/e2e/test_memory_cross_session_sync.py
@@ -8,7 +8,16 @@ agent loop — keeps the test focused on the sync semantics.
 
 from __future__ import annotations
 
+import base64
+import os
+import secrets
+from collections.abc import AsyncIterator
 from typing import Any
+from unittest import mock
+
+import asyncpg
+import pytest
+import pytest_asyncio
 
 from aios.harness import runtime
 from aios.models.memory_stores import MemoryStoreResource
@@ -18,7 +27,178 @@ from aios.tools.edit import edit_handler
 from aios.tools.read import read_handler
 from aios.tools.write import write_handler
 from tests.conftest import needs_docker
+from tests.e2e.conftest import _noop_defer_wake
 from tests.e2e.harness import Harness
+
+# Share one event loop across every test in this module so the
+# module-scoped asyncpg pool inside ``shared_docker_harness`` and the
+# tests that acquire from it live on the same loop.  Without this,
+# pytest-asyncio's default function-scoped loops cause "another
+# operation in progress" errors when a pool created on the module
+# setup loop is acquired from on a test-body loop.
+pytestmark = pytest.mark.asyncio(loop_scope="module")
+
+# Tables this file's tests mutate.  Truncating just these between tests
+# (instead of every public-schema table from conftest's ``_reset_db_state``)
+# lets the module-scoped ``shared_docker_harness`` keep ``accounts``,
+# ``account_keys``, and ``environments`` alive across the run — the
+# harness caches an ``_env_id`` at instance scope and ditching it on
+# every test would require an extra round-trip we don't need.
+_MUTABLE_TABLES: tuple[str, ...] = (
+    "agents",
+    "memory_stores",
+    "session_templates",
+)
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
+async def shared_docker_harness(
+    migrated_db_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> AsyncIterator[Harness]:
+    """Module-scoped variant of the conftest ``docker_harness`` fixture.
+
+    The default ``docker_harness`` (in ``tests/e2e/conftest.py``) is
+    function-scoped: every test pays for ``McpBroker.start()``,
+    ``SandboxRegistry`` init, the runtime-globals swap, and the
+    asyncpg-pool spin-up.  This file's 13 tests don't need that
+    per-test reset — they just need the per-test data layer reset,
+    which the autouse ``_reset_memory_test_state`` below handles by
+    TRUNCATEing the small set of tables this file mutates.
+
+    Containers are still session-keyed (each test creates a fresh
+    session), so the savings here are the fixture-init cost only —
+    container provisioning itself happens per test as before.
+    """
+    import aios.tools  # noqa: F401  — register built-in tools
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+    from aios.db import pool as pool_module
+    from aios.db.pool import create_pool
+    from aios.harness.task_registry import TaskRegistry
+    from aios.sandbox.backends import make_backend
+    from aios.sandbox.mcp_proxy import McpBroker
+    from aios.sandbox.network import ensure_sandbox_network
+    from aios.sandbox.registry import SandboxRegistry
+    from aios.services.accounts import hash_key
+    from aios.tools.registry import registry
+    from aios_connectors.providers import SubsystemToolProvider
+
+    env_vars = {
+        "AIOS_API_KEY": "aios_" + secrets.token_urlsafe(32),
+        "AIOS_VAULT_KEY": base64.b64encode(secrets.token_bytes(32)).decode("ascii"),
+        "AIOS_DB_URL": migrated_db_url,
+        "AIOS_WORKSPACE_ROOT": str(tmp_path_factory.mktemp("ws-memsync")),
+    }
+
+    with mock.patch.dict(os.environ, env_vars):
+        get_settings.cache_clear()
+        pool_module._pool = None
+
+        # Seed acc_test_stub once.  Cleaner than the conftest aios_env
+        # path since this fixture runs at module scope: a fresh asyncpg
+        # connection is opened, the bootstrap rows are inserted, then
+        # the connection closes — no shared state with later tests.
+        bootstrap_conn = await asyncpg.connect(migrated_db_url)
+        try:
+            await bootstrap_conn.execute("TRUNCATE accounts, account_keys CASCADE")
+            await bootstrap_conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ('acc_test_stub', NULL, TRUE, 'test-root')"
+            )
+            await bootstrap_conn.execute(
+                "INSERT INTO account_keys (key_id, account_id, hash, label) "
+                "VALUES ('akey_test', 'acc_test_stub', $1, 'test-root')",
+                hash_key(env_vars["AIOS_API_KEY"]),
+            )
+        finally:
+            await bootstrap_conn.close()
+
+        settings = get_settings()
+        pool = await create_pool(settings.db_url, min_size=1, max_size=4)
+        crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+        task_reg = TaskRegistry()
+        sandbox_reg = SandboxRegistry(backend=make_backend(settings.sandbox_backend))
+        if settings.sandbox_backend == "docker":
+            await ensure_sandbox_network()
+        mcp_broker = McpBroker()
+        await mcp_broker.start()
+
+        prev = (
+            runtime.pool,
+            runtime.crypto_box,
+            runtime.task_registry,
+            runtime.sandbox_registry,
+            runtime.mcp_broker,
+            runtime.worker_id,
+            runtime.tool_provider,
+        )
+        runtime.pool = pool
+        runtime.crypto_box = crypto_box
+        runtime.task_registry = task_reg
+        runtime.sandbox_registry = sandbox_reg
+        runtime.mcp_broker = mcp_broker
+        runtime.worker_id = "worker_test"
+        runtime.tool_provider = SubsystemToolProvider()
+
+        tool_snapshot = dict(registry._tools)
+        h = Harness(pool, task_reg)
+
+        async def _fake_acompletion(**kwargs: Any) -> Any:
+            if kwargs.get("stream"):
+                return h._pop_streaming_response(**kwargs)
+            return h._pop_response(**kwargs)
+
+        def _fake_chunk_builder(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return h._build_chunk_response(*args, **kwargs)
+
+        with (
+            mock.patch("aios.harness.completion.litellm.acompletion", _fake_acompletion),
+            mock.patch("aios.harness.completion.litellm.stream_chunk_builder", _fake_chunk_builder),
+            mock.patch("aios.services.wake.defer_wake", _noop_defer_wake),
+        ):
+            yield h
+
+        registry._tools = tool_snapshot
+        (
+            runtime.pool,
+            runtime.crypto_box,
+            runtime.task_registry,
+            runtime.sandbox_registry,
+            runtime.mcp_broker,
+            runtime.worker_id,
+            runtime.tool_provider,
+        ) = prev
+        await task_reg.shutdown()
+        await sandbox_reg.release_all()
+        await mcp_broker.stop()
+        await pool.close()
+        get_settings.cache_clear()
+        pool_module._pool = None
+
+
+@pytest_asyncio.fixture(autouse=True, loop_scope="module")
+async def _reset_memory_test_state(shared_docker_harness: Harness, migrated_db_url: str) -> None:
+    """Per-test cleanup: TRUNCATE the small set of mutable tables this
+    file's tests touch, and free any leaked sandboxes from the prior
+    test so the registry's in-memory handles match the freshly empty
+    sessions table.
+
+    Keeps ``accounts``, ``account_keys``, ``environments`` alive across
+    the module so the cached ``harness._env_id`` stays valid.  The
+    explicit table list (vs. the full-schema TRUNCATE from conftest)
+    is what makes a class-scoped harness safe — the bootstrap rows
+    survive between tests.
+    """
+    sandbox = runtime.require_sandbox_registry()
+    await sandbox.release_all()
+
+    conn = await asyncpg.connect(migrated_db_url)
+    try:
+        tables = ", ".join(f'"{t}"' for t in _MUTABLE_TABLES)
+        await conn.execute(f"TRUNCATE {tables} CASCADE")
+    finally:
+        await conn.close()
 
 
 async def _attach_store(harness: Harness, store_name: str) -> str:
@@ -102,16 +282,16 @@ async def _start_session_with_store(harness: Harness, store_id: str) -> Any:
 
 @needs_docker
 class TestCrossSessionSync:
-    async def test_write_in_a_visible_to_b_via_read(self, docker_harness: Harness) -> None:
+    async def test_write_in_a_visible_to_b_via_read(self, shared_docker_harness: Harness) -> None:
         """A's write tool propagates to B's read tool through the shared FS."""
-        store_id = await _attach_store(docker_harness, "xsync-read")
-        a = await _start_session_with_store(docker_harness, store_id)
-        b = await _start_session_with_store(docker_harness, store_id)
+        store_id = await _attach_store(shared_docker_harness, "xsync-read")
+        a = await _start_session_with_store(shared_docker_harness, store_id)
+        b = await _start_session_with_store(shared_docker_harness, store_id)
 
         # Provisioning both containers materializes the shared dir once.
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
-        await sandbox.get_or_provision(b.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(a.id, pool=shared_docker_harness._pool)
+        await sandbox.get_or_provision(b.id, pool=shared_docker_harness._pool)
 
         # A writes via tool.
         result = await write_handler(
@@ -125,17 +305,17 @@ class TestCrossSessionSync:
         # cat -n format: "     1\tfrom-A"
         assert "from-A" in b_result["content"]
 
-    async def test_concurrent_writes_use_precondition(self, docker_harness: Harness) -> None:
+    async def test_concurrent_writes_use_precondition(self, shared_docker_harness: Harness) -> None:
         """Both sessions read /shared.md (caching same sha). A writes →
         commits with the cached sha. B writes → DB sha has moved on, B's
         write fails with the typed precondition error."""
-        store_id = await _attach_store(docker_harness, "xsync-race")
-        a = await _start_session_with_store(docker_harness, store_id)
-        b = await _start_session_with_store(docker_harness, store_id)
+        store_id = await _attach_store(shared_docker_harness, "xsync-race")
+        a = await _start_session_with_store(shared_docker_harness, store_id)
+        b = await _start_session_with_store(shared_docker_harness, store_id)
 
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
-        await sandbox.get_or_provision(b.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(a.id, pool=shared_docker_harness._pool)
+        await sandbox.get_or_provision(b.id, pool=shared_docker_harness._pool)
 
         # Both sessions read /seed.md — both cache the seed sha.
         a_read = await read_handler(a.id, {"path": "/mnt/memory/xsync-race/seed.md"})
@@ -167,16 +347,16 @@ class TestCrossSessionSync:
         assert "error" not in b_retry, b_retry
 
     async def test_edit_refreshes_read_sha_for_subsequent_write(
-        self, docker_harness: Harness
+        self, shared_docker_harness: Harness
     ) -> None:
         """After read -> edit, a subsequent write tool call against the same
         path must succeed: the edit should have refreshed the cached read-sha
         so the write's precondition matches the post-edit DB state."""
-        store_id = await _attach_store(docker_harness, "xsync-edit-refresh")
-        a = await _start_session_with_store(docker_harness, store_id)
+        store_id = await _attach_store(shared_docker_harness, "xsync-edit-refresh")
+        a = await _start_session_with_store(shared_docker_harness, store_id)
 
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(a.id, pool=shared_docker_harness._pool)
 
         # Read primes the cache with the seed sha.
         r = await read_handler(a.id, {"path": "/mnt/memory/xsync-edit-refresh/seed.md"})
@@ -203,13 +383,13 @@ class TestCrossSessionSync:
         )
         assert "error" not in w, w
 
-    async def test_fresh_write_no_precondition(self, docker_harness: Harness) -> None:
+    async def test_fresh_write_no_precondition(self, shared_docker_harness: Harness) -> None:
         """Writing to a path the model never read — no precondition; succeeds."""
-        store_id = await _attach_store(docker_harness, "xsync-fresh")
-        a = await _start_session_with_store(docker_harness, store_id)
+        store_id = await _attach_store(shared_docker_harness, "xsync-fresh")
+        a = await _start_session_with_store(shared_docker_harness, store_id)
 
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(a.id, pool=shared_docker_harness._pool)
 
         result = await write_handler(
             a.id,
@@ -217,19 +397,21 @@ class TestCrossSessionSync:
         )
         assert "error" not in result, result
 
-    async def test_api_write_visible_to_attached_session(self, docker_harness: Harness) -> None:
+    async def test_api_write_visible_to_attached_session(
+        self, shared_docker_harness: Harness
+    ) -> None:
         """API-driven create_memory mirrors to host dir; attached session's
         read tool sees the new content."""
         account_id = "acc_test_stub"  # PR 3 scaffolding
-        store_id = await _attach_store(docker_harness, "xsync-api")
-        a = await _start_session_with_store(docker_harness, store_id)
+        store_id = await _attach_store(shared_docker_harness, "xsync-api")
+        a = await _start_session_with_store(shared_docker_harness, store_id)
 
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(a.id, pool=shared_docker_harness._pool)
 
         # API creates a new memory while the session is up.
         await memory_service.create_memory(
-            docker_harness._pool,
+            shared_docker_harness._pool,
             store_id=store_id,
             path="/api_made.md",
             content="from-api",
@@ -242,19 +424,19 @@ class TestCrossSessionSync:
         assert "error" not in result, result
         assert "from-api" in result["content"]
 
-    async def test_bash_create_reconciles_to_version(self, docker_harness: Harness) -> None:
+    async def test_bash_create_reconciles_to_version(self, shared_docker_harness: Harness) -> None:
         """bash writes to memory mounts are reconciled into memory_versions by the post-exec hook."""
         account_id = "acc_test_stub"  # PR 3 scaffolding
         from aios.db import queries
         from aios.tools.bash import bash_handler
 
-        store_id = await _attach_store(docker_harness, "xsync-bash")
-        a = await _start_session_with_store(docker_harness, store_id)
-        b = await _start_session_with_store(docker_harness, store_id)
+        store_id = await _attach_store(shared_docker_harness, "xsync-bash")
+        a = await _start_session_with_store(shared_docker_harness, store_id)
+        b = await _start_session_with_store(shared_docker_harness, store_id)
 
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
-        await sandbox.get_or_provision(b.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(a.id, pool=shared_docker_harness._pool)
+        await sandbox.get_or_provision(b.id, pool=shared_docker_harness._pool)
 
         # A bash-writes a new file; reconcile hook fires after exec.
         a_bash = await bash_handler(
@@ -268,7 +450,7 @@ class TestCrossSessionSync:
         assert "bashed-by-a" in b_bash["stdout"]
 
         # Post-exec reconcile created a memory_versions row.
-        async with docker_harness._pool.acquire() as conn:
+        async with shared_docker_harness._pool.acquire() as conn:
             versions = await queries.list_memory_versions(conn, store_id, account_id=account_id)
         paths = [v.path for v in versions]
         assert "/from_bash.md" in paths
@@ -277,17 +459,17 @@ class TestCrossSessionSync:
         version = next(v for v in versions if v.path == "/from_bash.md")
         assert version.created_by.type == "session_actor"
 
-    async def test_bash_modify_reconciles_version(self, docker_harness: Harness) -> None:
+    async def test_bash_modify_reconciles_version(self, shared_docker_harness: Harness) -> None:
         """bash modifies existing file; a 'modified' version row appears."""
         account_id = "acc_test_stub"  # PR 3 scaffolding
         from aios.db import queries
         from aios.tools.bash import bash_handler
 
-        store_id = await _attach_store(docker_harness, "xsync-bash-mod")
-        a = await _start_session_with_store(docker_harness, store_id)
+        store_id = await _attach_store(shared_docker_harness, "xsync-bash-mod")
+        a = await _start_session_with_store(shared_docker_harness, store_id)
 
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(a.id, pool=shared_docker_harness._pool)
 
         # Modify the pre-seeded /seed.md via bash.
         # snapshot before exec sees seed.md; after exec sees changed content.
@@ -297,24 +479,24 @@ class TestCrossSessionSync:
         )
         assert result.get("exit_code", 0) == 0, result
 
-        async with docker_harness._pool.acquire() as conn:
+        async with shared_docker_harness._pool.acquire() as conn:
             versions = await queries.list_memory_versions(conn, store_id, account_id=account_id)
         # There should be at least 2 versions: created (from seed) + modified (from bash).
         seed_versions = [v for v in versions if v.path == "/seed.md"]
         operations = {v.operation for v in seed_versions}
         assert "modified" in operations
 
-    async def test_bash_delete_reconciles_version(self, docker_harness: Harness) -> None:
+    async def test_bash_delete_reconciles_version(self, shared_docker_harness: Harness) -> None:
         """bash rm's a file; a 'deleted' version row appears."""
         account_id = "acc_test_stub"  # PR 3 scaffolding
         from aios.db import queries
         from aios.tools.bash import bash_handler
 
-        store_id = await _attach_store(docker_harness, "xsync-bash-del")
-        a = await _start_session_with_store(docker_harness, store_id)
+        store_id = await _attach_store(shared_docker_harness, "xsync-bash-del")
+        a = await _start_session_with_store(shared_docker_harness, store_id)
 
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(a.id, pool=shared_docker_harness._pool)
 
         # Delete /seed.md via bash.
         result = await bash_handler(
@@ -323,23 +505,23 @@ class TestCrossSessionSync:
         )
         assert result.get("exit_code", 0) == 0, result
 
-        async with docker_harness._pool.acquire() as conn:
+        async with shared_docker_harness._pool.acquire() as conn:
             versions = await queries.list_memory_versions(conn, store_id, account_id=account_id)
         seed_versions = [v for v in versions if v.path == "/seed.md"]
         operations = {v.operation for v in seed_versions}
         assert "deleted" in operations
 
-    async def test_bash_binary_file_reconcile_warning(self, docker_harness: Harness) -> None:
+    async def test_bash_binary_file_reconcile_warning(self, shared_docker_harness: Harness) -> None:
         """bash writes binary bytes; stderr contains reconcile warning; no version row created."""
         account_id = "acc_test_stub"  # PR 3 scaffolding
         from aios.db import queries
         from aios.tools.bash import bash_handler
 
-        store_id = await _attach_store(docker_harness, "xsync-bash-bin")
-        a = await _start_session_with_store(docker_harness, store_id)
+        store_id = await _attach_store(shared_docker_harness, "xsync-bash-bin")
+        a = await _start_session_with_store(shared_docker_harness, store_id)
 
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(a.id, pool=shared_docker_harness._pool)
 
         # Write binary (non-UTF-8) bytes to a memory mount file.
         result = await bash_handler(
@@ -352,12 +534,12 @@ class TestCrossSessionSync:
         assert "[memory-reconcile]" in result["stderr"]
 
         # No version row created for the binary file.
-        async with docker_harness._pool.acquire() as conn:
+        async with shared_docker_harness._pool.acquire() as conn:
             versions = await queries.list_memory_versions(conn, store_id, account_id=account_id)
         paths = [v.path for v in versions]
         assert "/binary.bin" not in paths
 
-    async def test_bash_nohup_residual_gap(self, docker_harness: Harness) -> None:
+    async def test_bash_nohup_residual_gap(self, shared_docker_harness: Harness) -> None:
         """Background processes after bash returns may not be captured.
 
         Documents that nohup/background bash writes to memory mounts that
@@ -366,11 +548,11 @@ class TestCrossSessionSync:
         """
         from aios.tools.bash import bash_handler
 
-        store_id = await _attach_store(docker_harness, "xsync-bash-nohup")
-        a = await _start_session_with_store(docker_harness, store_id)
+        store_id = await _attach_store(shared_docker_harness, "xsync-bash-nohup")
+        a = await _start_session_with_store(shared_docker_harness, store_id)
 
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(a.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(a.id, pool=shared_docker_harness._pool)
 
         # Background process that writes after bash -c returns.
         result = await bash_handler(
@@ -389,30 +571,32 @@ class TestMountUpdateRecyclesContainer:
     container is already up triggers a recycle on the next step so the
     new mount set takes effect."""
 
-    async def test_attach_via_update_makes_mount_visible(self, docker_harness: Harness) -> None:
+    async def test_attach_via_update_makes_mount_visible(
+        self, shared_docker_harness: Harness
+    ) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         from aios.harness.loop import refresh_session_mount_state
         from aios.tools.bash import bash_handler
 
-        session = await _start_session(docker_harness, tools=("bash",))
+        session = await _start_session(shared_docker_harness, tools=("bash",))
 
         # Provision the container BEFORE attaching the store — this is the
         # critical case the recycle logic exists for.
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(session.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(session.id, pool=shared_docker_harness._pool)
 
         before = await bash_handler(session.id, {"command": "ls /mnt/memory 2>&1; true"})
         assert "attach-mount" not in before["stdout"]
 
         store = await memory_service.create_store(
-            docker_harness._pool,
+            shared_docker_harness._pool,
             name="attach-mount",
             description="attach probe",
             metadata={},
             account_id=account_id,
         )
         await sessions_service.update_session(
-            docker_harness._pool,
+            shared_docker_harness._pool,
             session.id,
             resources=[
                 MemoryStoreResource(
@@ -422,7 +606,7 @@ class TestMountUpdateRecyclesContainer:
             account_id=account_id,
         )
         await refresh_session_mount_state(
-            docker_harness._pool, session.id, account_id="acc_test_stub"
+            shared_docker_harness._pool, session.id, account_id="acc_test_stub"
         )
 
         after = await bash_handler(
@@ -431,14 +615,14 @@ class TestMountUpdateRecyclesContainer:
         assert after.get("exit_code") == 0, after
         assert "OK" in after["stdout"]
 
-    async def test_detach_via_update_drops_mount(self, docker_harness: Harness) -> None:
+    async def test_detach_via_update_drops_mount(self, shared_docker_harness: Harness) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         from aios.harness.loop import refresh_session_mount_state
         from aios.tools.bash import bash_handler
 
-        store_id = await _attach_store(docker_harness, "detach-mount")
+        store_id = await _attach_store(shared_docker_harness, "detach-mount")
         session = await _start_session(
-            docker_harness,
+            shared_docker_harness,
             resources=[
                 MemoryStoreResource(
                     type="memory_store", memory_store_id=store_id, access="read_write"
@@ -447,35 +631,35 @@ class TestMountUpdateRecyclesContainer:
             tools=("bash",),
         )
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(session.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(session.id, pool=shared_docker_harness._pool)
         before = await bash_handler(
             session.id, {"command": "ls -d /mnt/memory/detach-mount && echo OK"}
         )
         assert "OK" in before["stdout"], before
 
         await sessions_service.update_session(
-            docker_harness._pool, session.id, resources=[], account_id=account_id
+            shared_docker_harness._pool, session.id, resources=[], account_id=account_id
         )
         await refresh_session_mount_state(
-            docker_harness._pool, session.id, account_id="acc_test_stub"
+            shared_docker_harness._pool, session.id, account_id="acc_test_stub"
         )
 
         after = await bash_handler(session.id, {"command": "ls /mnt/memory 2>&1; true"})
         assert "detach-mount" not in after["stdout"]
 
-    async def test_idempotent_update_does_not_recycle(self, docker_harness: Harness) -> None:
+    async def test_idempotent_update_does_not_recycle(self, shared_docker_harness: Harness) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         from aios.harness.loop import refresh_session_mount_state
         from aios.tools.bash import bash_handler
 
-        store_id = await _attach_store(docker_harness, "idem-mount")
-        session = await _start_session_with_store(docker_harness, store_id)
+        store_id = await _attach_store(shared_docker_harness, "idem-mount")
+        session = await _start_session_with_store(shared_docker_harness, store_id)
         sandbox = runtime.require_sandbox_registry()
-        await sandbox.get_or_provision(session.id, pool=docker_harness._pool)
+        await sandbox.get_or_provision(session.id, pool=shared_docker_harness._pool)
         original_container_id = sandbox.peek(session.id).sandbox_id  # type: ignore[union-attr]
 
         await sessions_service.update_session(
-            docker_harness._pool,
+            shared_docker_harness._pool,
             session.id,
             resources=[
                 MemoryStoreResource(
@@ -485,7 +669,7 @@ class TestMountUpdateRecyclesContainer:
             account_id=account_id,
         )
         await refresh_session_mount_state(
-            docker_harness._pool, session.id, account_id="acc_test_stub"
+            shared_docker_harness._pool, session.id, account_id="acc_test_stub"
         )
 
         cached = sandbox.peek(session.id)

--- a/tests/e2e/test_signal_connector.py
+++ b/tests/e2e/test_signal_connector.py
@@ -79,9 +79,12 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
             await wait_for_health(url)
             yield url
         finally:
-            server.should_exit = True
+            # See test_signal_registration.py for why ``should_exit`` alone
+            # loses the race against open SSE streams.
+            await server.shutdown()
+            serve_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await asyncio.wait_for(serve_task, timeout=5.0)
+                await serve_task
             await pool.close()
 
 

--- a/tests/e2e/test_signal_registration.py
+++ b/tests/e2e/test_signal_registration.py
@@ -117,9 +117,15 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
             await wait_for_health(url)
             yield url
         finally:
-            server.should_exit = True
+            # uvicorn's ``should_exit`` is poll-based (500 ms tick); with an
+            # open SSE stream the poll routinely loses the race and the test
+            # eats the full 5 s wait_for timeout.  ``shutdown()`` triggers
+            # the graceful drain synchronously instead, then cancel the
+            # serve task to free the asyncio bookkeeping.
+            await server.shutdown()
+            serve_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await asyncio.wait_for(serve_task, timeout=5.0)
+                await serve_task
             await pool.close()
 
 

--- a/tests/e2e/test_telegram_connector.py
+++ b/tests/e2e/test_telegram_connector.py
@@ -77,9 +77,12 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
             await wait_for_health(url)
             yield url
         finally:
-            server.should_exit = True
+            # See test_signal_registration.py for why ``should_exit`` alone
+            # loses the race against open SSE streams.
+            await server.shutdown()
+            serve_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await asyncio.wait_for(serve_task, timeout=5.0)
+                await serve_task
             await pool.close()
 
 

--- a/tests/unit/test_mcp_mount.py
+++ b/tests/unit/test_mcp_mount.py
@@ -19,14 +19,29 @@ from typing import Any
 import pytest
 
 
-@pytest.fixture
-def polished_mcp() -> Any:
-    """Live ``FastApiMCP`` against ``create_app()``'s spec, with polish applied.
+@pytest.fixture(scope="module")
+def app() -> Any:
+    """A ``FastAPI`` instance shared across every test in this module.
 
-    Same code path as ``_mount_mcp`` minus the HTTP mount. Imports are
-    inside the fixture body because ``aios.harness.procrastinate_app``
-    runs ``get_settings()`` at module-import time and the conftest
-    env-var fixture only fires after collection.
+    ``create_app()`` is idempotent and costs ~470 ms — paying for it once
+    instead of five times saves ~2s on the unit suite.  Import is inside
+    the fixture body because ``aios.harness.procrastinate_app`` runs
+    ``get_settings()`` at module-import time and the conftest env-var
+    fixture only fires after collection.
+    """
+    from aios.api.app import create_app
+
+    return create_app()
+
+
+@pytest.fixture(scope="module")
+def polished_mcp(app: Any) -> Any:
+    """Live ``FastApiMCP`` against ``app``'s spec, with polish applied.
+
+    Same code path as ``_mount_mcp`` minus the HTTP mount.  Polish
+    mutates the MCP instance, not the app, so sharing the underlying
+    app across this fixture and the route-shape assertions below is
+    safe.
     """
     from fastapi import Depends
     from fastapi_mcp import AuthConfig, FastApiMCP
@@ -35,11 +50,9 @@ def polished_mcp() -> Any:
         MCP_INSTRUCTIONS,
         _apply_mcp_polish,
         _compute_mcp_excluded_operations,
-        create_app,
     )
     from aios.api.deps import require_bearer_auth
 
-    app = create_app()
     mcp = FastApiMCP(
         app,
         name="test",
@@ -51,16 +64,13 @@ def polished_mcp() -> Any:
     return mcp
 
 
-def test_mcp_route_is_mounted() -> None:
-    from aios.api.app import create_app
-
-    app = create_app()
+def test_mcp_route_is_mounted(app: Any) -> None:
     assert any(getattr(r, "path", None) == "/mcp" for r in app.routes), (
         "FastApiMCP did not register a /mcp route during create_app()"
     )
 
 
-def test_excluded_operations_match_x_codegen_annotations() -> None:
+def test_excluded_operations_match_x_codegen_annotations(app: Any) -> None:
     """Routes annotated with ``x-codegen.targets: []`` must be excluded from MCP.
 
     Today that's the 2 SSE / long-poll session-event routes (no JSON
@@ -68,9 +78,8 @@ def test_excluded_operations_match_x_codegen_annotations() -> None:
     envelopes deferred per #267). Routes without the annotation default
     to included.
     """
-    from aios.api.app import _compute_mcp_excluded_operations, create_app
+    from aios.api.app import _compute_mcp_excluded_operations
 
-    app = create_app()
     excluded = set(_compute_mcp_excluded_operations(app))
 
     spec = app.openapi()

--- a/tests/unit/test_model_token_ratio.py
+++ b/tests/unit/test_model_token_ratio.py
@@ -115,3 +115,22 @@ class TestModelTokenRatio:
         second = await model_token_ratio(conn, "model-cache", account_id=account_id)
         assert second == first, f"expected cached reuse, got {second} vs first={first}"
         conn.fetchrow.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_ratio_is_cached(self) -> None:
+        """The 1.0 neutral fallback gets cached too, on a shorter TTL.
+
+        Pre-fix, every windowing call on a freshly deployed model re-ran
+        the JSONB aggregate scan because the below-threshold branch
+        skipped the cache write.  The cache write now bounds the scan
+        rate at one per TTL.
+        """
+        account_id = "acc_test_stub"
+        conn = _mock_conn(n=2, mean_ratio=0.0)
+        first = await model_token_ratio(conn, "model-cold", account_id=account_id)
+        assert first == 1.0
+        # Swap the mock to verify we didn't re-fetch.
+        conn.fetchrow = AsyncMock(return_value={"n": 5, "mean_ratio": 2.0})
+        second = await model_token_ratio(conn, "model-cold", account_id=account_id)
+        assert second == 1.0
+        conn.fetchrow.assert_not_awaited()

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -32,7 +32,7 @@ def _patch_get_model_info(
             raise Exception(f"unknown model: {model}")
         return mapping[model]
 
-    monkeypatch.setattr("aios.harness.vision.litellm.get_model_info", fake)
+    monkeypatch.setattr("litellm.get_model_info", fake)
 
 
 class TestSupportsVision:


### PR DESCRIPTION
## Summary

Profiling the test suite turned up five remaining wins after rebasing onto upstream (PR #441 independently landed the `pending_management_calls.account_id` schema fix while this branch was open; the SQL/migration parts of my commit 5 were therefore absorbed, leaving just the `live_server` teardown fix).

- **Test infra** (#1, #4, #7): pool the asyncpg conn in `_reset_db_state` + `aios_env`; module-scope `create_app()` in `test_mcp_mount`; module-scope the docker harness in `test_memory_cross_session_sync`.
- **Production code** (#2, #6): lazy-import `litellm` in `vision`/`context`/`tokens` — saves ~1.4s on every worker cold start; cache below-threshold `model_token_ratio` results — bounds the per-step JSONB scan rate during model warm-up.
- **Live-server teardown** (carved out of original #5): replace the polling-based 5-second `should_exit` wait in five `live_server` fixtures (signal_registration, signal_connector, echo_http_connector, telegram_connector, connection_discovery_sse) with `await server.shutdown()` — graceful drain runs synchronously, no timeout eating.

## Numbers

|  | Before | After | Δ |
|---|---:|---:|---|
| Unit suite | ~20s | **~15s** | ~25% |
| E2E suite | 296.8s | **241.1s** | ~19% |
| Worker cold start | 2.26s | **0.99s** | ~56% |
| E2E failures | 4 fail + 2 err | **2 fail** (pre-existing, unrelated `test_sandbox_image_contract`) | restored green for everything touched |
| E2E pass count | 364 | **366** | signal_registration tests now pass cleanly |

The two remaining e2e failures are `test_binary_available[mcp]` and `TestArchitecture::test_image_architecture_matches_runner` from `test_sandbox_image_contract.py` — both failing on master too; unrelated to this PR.

## Commits

1. `refactor(tests): pool truncate-conn reuse in _reset_db_state + aios_env` — cache the TRUNCATE SQL at session scope; reuse one asyncpg conn across the test+bootstrap.
2. `refactor(harness): lazy-import litellm in vision/context/tokens` — only `completion.py` needs litellm at module top; the rest defer the ~1.18s import.
3. `perf(queries): cache below-threshold model_token_ratio results` — newly deployed models stop paying the aggregate JSONB scan on every step; 10s TTL bounds activation lag.
4. `fix(tests): faster live_server shutdown across connector e2e fixtures` — five fixtures shared an identical 5-second-timeout teardown; switch to `await server.shutdown()`.
5. `refactor(tests): module-scope docker harness in memory_cross_session_sync` — hoist `McpBroker.start` etc. out of per-test fixture init.
6. `test(unit): session-scope create_app in test_mcp_mount` — five calls to `create_app()` (~470ms each) collapse to one.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1227 passed in 15.4s (includes new tests from upstream)
- [x] `DOCKER_HOST=… uv run pytest tests/e2e -q` — 366 passed, 2 pre-existing failures (sandbox-image-contract, unrelated)
- [x] `time uv run python -c "import aios.harness.worker"` — 0.99s (was 2.26s)
- [x] Spot-check: `pytest tests/e2e/test_signal_registration.py` was failing on master, now passes in ~6s (was ~30s with errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)