### PR TITLE
fix(harness): keep interrupt listener alive across dispatch failures

### DIFF
--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -361,11 +361,18 @@ async def _run_interrupt_listener(
     db_url: str,
     task_registry: TaskRegistry,
 ) -> None:
-    """Drain pg_notify on the session-interrupt channel and cancel matching steps."""
+    """Drain pg_notify on the session-interrupt channel and cancel matching steps.
+
+    The try/except is nested INSIDE ``while True`` (mirroring
+    :func:`_periodic_sweep`): a transient failure dispatching one
+    interrupt must not silently disable the listener for the worker's
+    lifetime. ``CancelledError`` is not an :class:`Exception` subclass
+    and propagates through, so worker shutdown still exits cleanly.
+    """
     log = get_logger("aios.worker.interrupt_listener")
-    try:
-        async with listen_for_session_interrupts(db_url) as queue:
-            while True:
+    async with listen_for_session_interrupts(db_url) as queue:
+        while True:
+            try:
                 session_id = await queue.get()
                 step_cancelled = task_registry.cancel_step(session_id)
                 tools_cancelled = task_registry.cancel_session(session_id)
@@ -375,5 +382,5 @@ async def _run_interrupt_listener(
                     step_cancelled=step_cancelled,
                     tools_cancelled=tools_cancelled,
                 )
-    except Exception:
-        log.exception("interrupt_listener.failed")
+            except Exception:
+                log.exception("interrupt_listener.dispatch_failed")

--- a/tests/unit/test_interrupt_listener.py
+++ b/tests/unit/test_interrupt_listener.py
@@ -1,0 +1,97 @@
+"""Unit coverage for :func:`aios.harness.worker._run_interrupt_listener`.
+
+The session-interrupt listener is one long-lived background task in the
+worker. Any exception that escapes its inner dispatch — a transient
+``cancel_step`` failure, a logger blip, a registry race — used to land
+in the outer ``except Exception`` wrapping the ``while True``, killing
+the task for the worker's lifetime. Subsequent ``POST
+/v1/sessions/{id}/interrupt`` requests succeed at the API (the NOTIFY
+fires) but nothing on the worker side observes them, silently disabling
+a documented endpoint.
+
+The companion ``_periodic_sweep`` next door (``worker.py:334``) nests
+the ``try`` INSIDE the ``while True`` for exactly this reason. This
+test pins the listener to the same survivability contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from aios.harness.task_registry import TaskRegistry
+from aios.harness.worker import _run_interrupt_listener
+
+
+async def test_listener_survives_dispatch_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One exception in dispatch must not disable the listener.
+
+    Drive a real ``asyncio.Queue`` through the listener, with a
+    ``TaskRegistry`` whose ``cancel_step`` raises on the first call.
+    The listener must log the failure and continue processing
+    subsequent interrupts — today the first exception escapes the
+    outer try/except wrapping ``while True`` and kills the task.
+    """
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    @asynccontextmanager
+    async def fake_listen(_db_url: str) -> AsyncIterator[asyncio.Queue[str]]:
+        yield queue
+
+    monkeypatch.setattr(
+        "aios.harness.worker.listen_for_session_interrupts",
+        fake_listen,
+    )
+
+    registry = MagicMock(spec=TaskRegistry)
+
+    first_dispatched = asyncio.Event()
+    second_dispatched = asyncio.Event()
+    call_count = 0
+
+    def cancel_step(_session_id: str) -> bool:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            first_dispatched.set()
+            raise RuntimeError("simulated transient cancel_step failure")
+        second_dispatched.set()
+        return True
+
+    registry.cancel_step.side_effect = cancel_step
+    registry.cancel_session.return_value = 0
+
+    listener_task = asyncio.create_task(_run_interrupt_listener("postgresql://stub", registry))
+
+    try:
+        # First interrupt — drives cancel_step into the exception path.
+        await queue.put("session_first")
+        await asyncio.wait_for(first_dispatched.wait(), timeout=1.0)
+
+        # Second interrupt — the listener must still be alive to process it.
+        # If the outer-try/except bug were still in effect, the listener
+        # task would have exited cleanly and ``second_dispatched`` would
+        # never fire; ``wait_for`` would raise ``TimeoutError``.
+        await queue.put("session_second")
+        try:
+            await asyncio.wait_for(second_dispatched.wait(), timeout=1.0)
+        except TimeoutError as exc:
+            raise AssertionError(
+                f"listener did not process second interrupt within 1s — "
+                f"done={listener_task.done()}, "
+                f"exception="
+                f"{listener_task.exception() if listener_task.done() else None}"
+            ) from exc
+
+        assert registry.cancel_step.call_count == 2
+    finally:
+        listener_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await listener_task


### PR DESCRIPTION
## Summary

- `_run_interrupt_listener` (`src/aios/harness/worker.py:360`) wrapped its entire `async with listen_for_session_interrupts(db_url): while True:` body in one `except Exception:`. Any failure inside the loop body — transient `task_registry.cancel_step` exception, logger blip, asyncpg-driven registry race — escaped to the outer except and let the function return. The listener task ended cleanly with no exception attached (silent death). Every subsequent `POST /v1/sessions/{id}/interrupt` then succeeded at the API and fired its `pg_notify` — but no one was listening anymore. The documented endpoint was silently disabled for the worker's lifetime.
- The fix nests the `try/except` INSIDE the `while True`, mirroring `_periodic_sweep` immediately above (`worker.py:343`). `CancelledError` is not an `Exception` subclass since Python 3.8, so worker-shutdown cancellation still propagates and exits the loop cleanly. The log event renames from `interrupt_listener.failed` → `interrupt_listener.dispatch_failed` (more accurate; no operator dashboards reference it — grepped the repo).
- Same anti-pattern shape as PR #440 fixed for `_trigger_sweep`, but the trade-off is reversed: `_trigger_sweep` is a single-shot ladder rung where failure must reach the model (no swallow); `_run_interrupt_listener` is a long-lived infrastructure pump translating `LISTEN/NOTIFY` events into registry calls (must survive transient failures or the endpoint goes dark).

## Test plan

- [x] New `tests/unit/test_interrupt_listener.py` — pins the contract via real `asyncio.Event` coordination (no sleep-based timing gates). A `TaskRegistry` whose `cancel_step` raises once, two interrupts pushed through a real `asyncio.Queue`, both must dispatch.
- [x] mypy — clean
- [x] ruff + format-check — clean
- [x] Unit suite — 1227 passed (including the new test)
- [ ] CI runs e2e/integration suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. One actionable finding applied (sev 80: test-timing fragility — replaced `asyncio.sleep(0.05)` gates with `asyncio.Event` + `wait_for` to remove wall-clock flakiness). Reviewer otherwise verified the philosophy trade-off, `CancelledError` propagation, no hot-loop risk on dying LISTEN connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)