### PR TITLE
fix(db): validate agent window bounds on both writers

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -29,6 +29,7 @@ from aios.errors import (
     MemoryPreconditionFailedError,
     MemoryStoreArchivedError,
     NotFoundError,
+    ValidationError,
 )
 from aios.ids import (
     ACCOUNT,
@@ -308,6 +309,11 @@ async def insert_agent(
     window_min: int,
     window_max: int,
 ) -> Agent:
+    if window_min >= window_max:
+        raise ValidationError(
+            "window_min must be strictly less than window_max",
+            detail={"window_min": window_min, "window_max": window_max},
+        )
     new_id = make_id(AGENT)
     tools_json = json.dumps([t.model_dump() for t in tools])
     mcp_json = json.dumps([s.model_dump() for s in mcp_servers])
@@ -463,6 +469,17 @@ async def update_agent(
     new_extra = litellm_extra if litellm_extra is not None else current.litellm_extra
     new_wmin = window_min if window_min is not None else current.window_min
     new_wmax = window_max if window_max is not None else current.window_max
+    if new_wmin >= new_wmax:
+        # Partial-merge semantics: a one-sided update (e.g. ``window_max``
+        # alone, set at-or-below the current ``window_min``) only
+        # produces an invalid pair AFTER the merge, so the check has to
+        # live on the resolved values rather than the input kwargs.
+        # Without this, the row commits and the next session step
+        # ``ZeroDivisionError``s in :func:`aios.harness.tokens.tokens_to_drop`.
+        raise ValidationError(
+            "window_min must be strictly less than window_max",
+            detail={"window_min": new_wmin, "window_max": new_wmax},
+        )
 
     # No-op detection.
     if (

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -33,13 +33,6 @@ async def create_agent(
     window_min: int,
     window_max: int,
 ) -> Agent:
-    if window_min >= window_max:
-        from aios.errors import ValidationError
-
-        raise ValidationError(
-            "window_min must be strictly less than window_max",
-            detail={"window_min": window_min, "window_max": window_max},
-        )
     skill_refs = skills or []
     resolved = await skills_service.resolve_skill_refs(pool, skill_refs, account_id=account_id)
     snapshot_json = skills_service.serialize_skills_for_snapshot(skill_refs, resolved)

--- a/tests/integration/test_agent_window_validation.py
+++ b/tests/integration/test_agent_window_validation.py
@@ -1,0 +1,163 @@
+"""Integration tests: agent window bounds are validated on both writers.
+
+Pre-fix: ``services.create_agent`` validated ``window_min < window_max``
+at the service entrance, but the matching check was missing from the
+update path. ``services.update_agent`` forwarded ``window_min`` /
+``window_max`` to ``queries.update_agent``, which does partial-merge
+(omitted = current state). A one-sided ``PUT`` setting only
+``window_max`` to a value at-or-below the current ``window_min``
+produced an agent version with ``window_min == window_max``. The next
+session step then called ``read_windowed_events`` →
+``harness.tokens.tokens_to_drop``, computing
+``chunk = window_max - window_min`` (= 0) and raising
+``ZeroDivisionError`` — the session burned its retry budget and landed
+in terminal ``errored``.
+
+The fix moves both checks to the queries layer (``insert_agent`` and
+``update_agent``), so any caller — service, future direct caller,
+batch backfill — gets the same invariant in one place. The update-side
+check fires on the *resolved* (post-merge) values, which is the only
+altitude at which the partial-merge case can be caught.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.errors import ValidationError
+from aios.models.agents import ToolSpec
+from aios.services import agents as agents_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def pool_and_account(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str]]:
+    """Yield a pool + seeded account id."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_test', NULL, TRUE, 'tenant-test')
+                """
+            )
+        yield pool, "acc_test"
+    finally:
+        await pool.close()
+
+
+async def _seed_valid_agent(pool: asyncpg.Pool[Any], account_id: str, name: str) -> Any:
+    return await agents_service.create_agent(
+        pool,
+        account_id=account_id,
+        name=name,
+        model="openrouter/test",
+        system="",
+        tools=[ToolSpec(type="bash")],
+        description=None,
+        metadata={},
+        window_min=5_000,
+        window_max=10_000,
+    )
+
+
+class TestUpdateAgentWindowValidation:
+    async def test_partial_put_setting_window_max_to_current_min_is_rejected(
+        self, pool_and_account: tuple[asyncpg.Pool[Any], str]
+    ) -> None:
+        """PUT setting only ``window_max`` equal to current ``window_min`` must raise.
+
+        After the queries-level merge, this produces
+        ``new_wmin == new_wmax`` — a downstream session step would
+        ``ZeroDivisionError`` in ``tokens_to_drop`` without this guard.
+        """
+        pool, account_id = pool_and_account
+        agent = await _seed_valid_agent(pool, account_id, "bound-test")
+
+        with pytest.raises(ValidationError) as exc_info:
+            await agents_service.update_agent(
+                pool,
+                agent.id,
+                account_id=account_id,
+                expected_version=agent.version,
+                window_max=5_000,
+            )
+
+        assert exc_info.value.detail == {"window_min": 5_000, "window_max": 5_000}
+
+    async def test_partial_put_setting_window_min_to_current_max_is_rejected(
+        self, pool_and_account: tuple[asyncpg.Pool[Any], str]
+    ) -> None:
+        """Symmetric merge direction: bumping ``window_min`` up to the
+        current max also produces an invalid resolved pair."""
+        pool, account_id = pool_and_account
+        agent = await _seed_valid_agent(pool, account_id, "bound-test-reverse")
+
+        with pytest.raises(ValidationError) as exc_info:
+            await agents_service.update_agent(
+                pool,
+                agent.id,
+                account_id=account_id,
+                expected_version=agent.version,
+                window_min=10_000,
+            )
+
+        assert exc_info.value.detail == {"window_min": 10_000, "window_max": 10_000}
+
+    async def test_simultaneous_both_invalid_pair_is_rejected(
+        self, pool_and_account: tuple[asyncpg.Pool[Any], str]
+    ) -> None:
+        """PUT supplying both ``window_min`` and ``window_max`` as an
+        invalid pair must raise — the queries-layer guard fires on
+        resolved values, so the both-provided path is covered too.
+        """
+        pool, account_id = pool_and_account
+        agent = await _seed_valid_agent(pool, account_id, "bound-test-both")
+
+        with pytest.raises(ValidationError) as exc_info:
+            await agents_service.update_agent(
+                pool,
+                agent.id,
+                account_id=account_id,
+                expected_version=agent.version,
+                window_min=8_000,
+                window_max=8_000,
+            )
+
+        assert exc_info.value.detail == {"window_min": 8_000, "window_max": 8_000}
+
+
+class TestCreateAgentWindowValidation:
+    async def test_create_rejects_invalid_pair(
+        self, pool_and_account: tuple[asyncpg.Pool[Any], str]
+    ) -> None:
+        """Create still rejects invalid pairs — the symmetric guard was
+        moved from ``services.create_agent`` down into
+        ``queries.insert_agent`` so both writers enforce the same
+        invariant in one place."""
+        pool, account_id = pool_and_account
+
+        with pytest.raises(ValidationError) as exc_info:
+            await agents_service.create_agent(
+                pool,
+                account_id=account_id,
+                name="invalid-bounds",
+                model="openrouter/test",
+                system="",
+                tools=[ToolSpec(type="bash")],
+                description=None,
+                metadata={},
+                window_min=10_000,
+                window_max=5_000,
+            )
+
+        assert exc_info.value.detail == {"window_min": 10_000, "window_max": 5_000}


### PR DESCRIPTION
## Summary

- `services.create_agent` validated `window_min >= window_max` at the service entrance; the matching check was missing from the update path. `services.update_agent` forwarded the kwargs straight to `queries.update_agent`, which does partial-merge (omitted = current state, `queries.py:464-465`). A one-sided `PUT /v1/agents/{id}` setting only `window_max` to a value at-or-below the current `window_min` produced an agent version with `new_wmin == new_wmax`. The next session step then ran `read_windowed_events` → `harness.tokens.tokens_to_drop`, computed `chunk = window_max - window_min` (= 0), and raised `ZeroDivisionError`. The session burned its 4-step retry budget (~160s of wakes) and landed in terminal `errored`. Every subsequent session on the same broken agent version repeated the fate.
- Validation moves to the queries layer on both writers (`insert_agent` + `update_agent`). The queries layer is the *single writer* for agent versions and the *single site* of the partial-merge logic; the update-side check must fire on the *resolved* (post-merge) values, an altitude only the queries layer has cleanly. Mirroring the check at `insert_agent` and removing it from `services.create_agent` keeps placement symmetric and prevents future divergence — direct queries-layer callers (batch backfill, admin paths) also benefit.

## Test plan

- [x] New `tests/integration/test_agent_window_validation.py` — four tests against a real testcontainer Postgres + real services:
  - `update_agent` with only `window_max` set to current `window_min` → raises `ValidationError`
  - Symmetric: `update_agent` with only `window_min` set to current `window_max` → raises
  - Both supplied as an invalid pair → raises (the post-merge guard fires on the both-provided path too)
  - `create_agent` regression via the new `insert_agent` guard
- [x] All assertions go through `exc_info.value.detail` (stable contract) rather than message strings
- [x] mypy — clean
- [x] ruff + format-check — clean
- [x] Unit suite — 1229 passed
- [x] Integration suite — 12 passed (8 prior + 4 new)
- [ ] CI runs e2e/integration suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. Applied two sev ≥ 80 findings:

- **[85] Placement asymmetry between create and update validation** — reviewer recommended option (b): add the check at `queries.insert_agent` and delete the service-layer create check, putting both writers on the same plane. Applied; queries layer is now the single enforcement site.
- **[82] Missing test case for simultaneous-both invalid pair** — added `test_simultaneous_both_invalid_pair_is_rejected` exercising the both-supplied path through the post-merge guard.

Also applied:
- **[70] Test string-matching on error message** — switched to `exc_info.value.detail` dict comparison (stable contract).
- **[65] Comment leaning on create-side check as justification** — rewrote the inline comment in `queries.update_agent` to justify queries-layer placement on its own merits (partial-merge semantics) rather than as belt-and-suspenders to the service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)