### PR TITLE
fix(sessions): make append_tool_result idempotent on tool_call_id

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1493,6 +1493,39 @@ async def _derive_event_channel(
     return None
 
 
+async def find_tool_result_event(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    tool_call_id: str,
+    *,
+    account_id: str,
+) -> Event | None:
+    """Return the existing tool-role event for ``tool_call_id``, or ``None``.
+
+    Used by ``services.append_tool_result`` to make the intake idempotent
+    on ``(session_id, tool_call_id)``: a retried POST returns the original
+    event instead of appending a duplicate that would later violate the
+    monotonic-context invariant (``harness/context.py:499-506`` keeps the
+    latest tool_result per id by dict-overwrite — duplicates silently
+    rewrite history).
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT * FROM events
+         WHERE session_id = $1
+           AND account_id = $2
+           AND kind = 'message'
+           AND data->>'role' = 'tool'
+           AND data->>'tool_call_id' = $3
+         LIMIT 1
+        """,
+        session_id,
+        account_id,
+        tool_call_id,
+    )
+    return _row_to_event(row) if row is not None else None
+
+
 async def lookup_tool_name_by_call_id(
     conn: asyncpg.Connection[Any],
     session_id: str,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -246,6 +246,13 @@ async def append_tool_result(
 ) -> Event:
     """Append a tool-role event for a custom tool call (#133).
 
+    Idempotent on ``(session_id, tool_call_id)``: a retried POST (network
+    blip, 502, mid-flight client disconnect) returns the existing event
+    instead of appending a duplicate that would violate the
+    monotonic-context invariant (CLAUDE.md #2) by silently rewriting the
+    model's view of an earlier turn. Mirrors the ``WHERE status =
+    'pending'`` guard in :func:`queries.mark_management_call_resolved`.
+
     Stamps the tool's ``name`` from the parent assistant's ``tool_calls``
     array so the derived ``tool_name`` column on ``events`` stays
     populated for custom tools.  Raises :class:`NotFoundError` if there's
@@ -258,25 +265,50 @@ async def append_tool_result(
     """
     from aios.errors import NotFoundError
 
-    name = await queries.lookup_tool_name_by_call_id(
-        conn, session_id, tool_call_id, account_id=account_id
-    )
-    if name is None:
-        raise NotFoundError(
-            f"tool_call_id {tool_call_id!r} not found",
-            detail={"session_id": session_id, "tool_call_id": tool_call_id},
+    async with conn.transaction():
+        # Lock the session row up-front so a concurrent retry serializes
+        # behind us and observes the appended event on its check. The
+        # ``WHERE … RETURNING`` shape gives us the row-presence check
+        # as a free side effect — the primary purpose is the lock.
+        locked = await conn.fetchval(
+            "SELECT id FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
+            session_id,
+            account_id,
         )
-    data: dict[str, Any] = {
-        "role": "tool",
-        "tool_call_id": tool_call_id,
-        "content": content,
-        "name": name,
-    }
-    if is_error:
-        data["is_error"] = True
-    return await queries.append_event(
-        conn, session_id=session_id, kind="message", data=data, account_id=account_id
-    )
+        if locked is None:
+            raise NotFoundError(
+                f"session {session_id} not found",
+                detail={"session_id": session_id},
+            )
+        existing = await queries.find_tool_result_event(
+            conn, session_id, tool_call_id, account_id=account_id
+        )
+        if existing is not None:
+            return existing
+
+        name = await queries.lookup_tool_name_by_call_id(
+            conn, session_id, tool_call_id, account_id=account_id
+        )
+        if name is None:
+            raise NotFoundError(
+                f"tool_call_id {tool_call_id!r} not found",
+                detail={"session_id": session_id, "tool_call_id": tool_call_id},
+            )
+        data: dict[str, Any] = {
+            "role": "tool",
+            "tool_call_id": tool_call_id,
+            "content": content,
+            "name": name,
+        }
+        if is_error:
+            data["is_error"] = True
+        return await queries.append_event(
+            conn,
+            session_id=session_id,
+            kind="message",
+            data=data,
+            account_id=account_id,
+        )
 
 
 async def read_events(

--- a/tests/integration/test_tool_result_idempotency.py
+++ b/tests/integration/test_tool_result_idempotency.py
@@ -1,0 +1,193 @@
+"""Integration tests: ``services.append_tool_result`` is idempotent on
+``(session_id, tool_call_id)``.
+
+Pre-fix: the custom-tool result intake at
+``POST /v1/sessions/{id}/tool-results`` (``api/routers/sessions.py:350``)
+and the connector-runtime intake at
+``POST /v1/connectors/runtime/tool-results`` (``api/routers/connectors.py:332``)
+both forwarded straight to ``services.append_tool_result``, which
+unconditionally appended a new tool-role event via ``append_event``. A
+network retry (502, transient client disconnect, mid-flight timeout)
+appends a *second* tool-role event with the same ``tool_call_id``.
+
+Two consequences:
+
+1. **Monotonic context invariant violated** (CLAUDE.md key invariant #2):
+   ``harness/context.py:499-506`` builds ``real_results: dict[tcid →
+   data]`` by iterating events and overwriting the dict, so a duplicate
+   with different content silently rewrites the model's view of an
+   earlier turn — the prompt cache invalidates and history changes
+   after the fact.
+2. ``cumulative_tokens`` double-counts the duplicate, perturbing the
+   windowing-overhead estimate; the duplicate also burns a seq number.
+
+The companion ``mark_management_call_resolved`` (``queries.py``) uses
+``WHERE status = 'pending'`` as an atomic dedup. This test pins the same
+guarantee for tool-result intake.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.models.agents import ToolSpec
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def session_with_parent_tool_call(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str]]:
+    """Yield ``(pool, account_id, session_id, tool_call_id)`` for an
+    initialized session with one assistant event carrying a ``tool_calls``
+    entry. ``append_tool_result`` will find a matching parent via
+    ``lookup_tool_name_by_call_id``."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_test', NULL, TRUE, 'tenant-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_test",
+            name="dedup-test",
+            model="openrouter/test",
+            system="",
+            tools=[ToolSpec(type="bash")],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_test", name="dedup-test-env"
+        )
+        async with pool.acquire() as conn:
+            session = await queries.insert_session(
+                conn,
+                account_id="acc_test",
+                agent_id=agent.id,
+                environment_id=env.id,
+                agent_version=agent.version,
+                title=None,
+                metadata={},
+            )
+            # Append the parent assistant event with a tool_calls entry.
+            await queries.append_event(
+                conn,
+                account_id="acc_test",
+                session_id=session.id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tc_dup_test",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        }
+                    ],
+                },
+            )
+        yield pool, "acc_test", session.id, "tc_dup_test"
+    finally:
+        await pool.close()
+
+
+async def _count_tool_results(pool: asyncpg.Pool[Any], session_id: str, tool_call_id: str) -> int:
+    """Count tool-role events for this (session_id, tool_call_id)."""
+    async with pool.acquire() as conn:
+        return (
+            await conn.fetchval(
+                """
+            SELECT COUNT(*) FROM events
+             WHERE session_id = $1
+               AND kind = 'message'
+               AND data->>'role' = 'tool'
+               AND data->>'tool_call_id' = $2
+            """,
+                session_id,
+                tool_call_id,
+            )
+            or 0
+        )
+
+
+class TestAppendToolResultIdempotency:
+    async def test_duplicate_post_does_not_create_second_event(
+        self,
+        session_with_parent_tool_call: tuple[asyncpg.Pool[Any], str, str, str],
+    ) -> None:
+        """Two appends with the same ``tool_call_id`` must produce ONE
+        event in the session log. Today the second call creates a
+        duplicate; this test fails with 2 events instead of 1."""
+        pool, account_id, session_id, tool_call_id = session_with_parent_tool_call
+
+        async with pool.acquire() as conn:
+            await sessions_service.append_tool_result(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                content="first",
+            )
+        async with pool.acquire() as conn:
+            await sessions_service.append_tool_result(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                content="second-retry",
+            )
+
+        count = await _count_tool_results(pool, session_id, tool_call_id)
+        assert count == 1, (
+            f"duplicate POST appended a second tool_result event "
+            f"(count={count}); monotonic-context invariant violated"
+        )
+
+    async def test_duplicate_post_returns_original_content(
+        self,
+        session_with_parent_tool_call: tuple[asyncpg.Pool[Any], str, str, str],
+    ) -> None:
+        """The idempotent return must carry the *first* content. Returning
+        the duplicate's content would silently corrupt prior history."""
+        pool, account_id, session_id, tool_call_id = session_with_parent_tool_call
+
+        async with pool.acquire() as conn:
+            await sessions_service.append_tool_result(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                content="first",
+            )
+        async with pool.acquire() as conn:
+            second_event = await sessions_service.append_tool_result(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                content="second-retry",
+            )
+
+        assert second_event.data["content"] == "first", (
+            f"duplicate POST returned the second-call's content "
+            f"(data={second_event.data!r}); idempotent return must "
+            f"preserve the first-call's truth"
+        )


### PR DESCRIPTION
## Summary

- `services.append_tool_result` (`src/aios/services/sessions.py:238`) unconditionally appended a new tool-role event via `queries.append_event`. Both intake endpoints — `POST /v1/sessions/{id}/tool-results` (custom tools) and `POST /v1/connectors/runtime/tool-results` (connector runtime) — forwarded straight to it, so a retried POST (network blip, 502, mid-flight client disconnect) appended a *second* tool-role event with the same `tool_call_id`.
- **Monotonic context invariant violated** (CLAUDE.md key invariant #2): `harness/context.py:499-506` builds `real_results: dict[tcid → data]` by iterating events and overwriting the dict, so a duplicate with different content silently rewrites the model's view of an earlier turn — prompt cache invalidates and history changes after the fact. Plus: `cumulative_tokens` double-counts, the duplicate burns a seq number, windowing-overhead is perturbed.
- Fix mirrors the established `queries.mark_management_call_resolved` (`queries.py:5117`) dedup pattern. `append_tool_result` now wraps the logic in `conn.transaction()` with `SELECT … FOR UPDATE` on the session row to serialize concurrent retries, then early-returns the existing event if a new `find_tool_result_event` query finds one. The first call's content + `is_error` remain canonical regardless of the retry's payload.

## Test plan

- [x] New `tests/integration/test_tool_result_idempotency.py` — two tests against testcontainer Postgres:
  - Two appends with the same `(session_id, tool_call_id)` produce ONE event in the log
  - The idempotent-return carries the first-call's content (the retry's content does NOT corrupt the original)
- [x] mypy — clean
- [x] ruff + format-check — clean
- [x] Unit suite — 1229 passed
- [x] Integration suite — 14 passed (12 prior + 2 new)
- [ ] CI runs e2e/integration suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. Two findings applied:

- **[85] Dead-code branch in test** — `_row_to_event` already calls `parse_jsonb`, so `event.data` is always a `dict`. Removed the `json.loads(...) if isinstance(..., str) else ...` guard and unused `json` import. Per project stance: no belt-and-suspenders.
- **[82] Clarify `SELECT FOR UPDATE` comment** — added one line noting the existence-check is a side effect of needing the lock target; the primary purpose is the lock.

Reviewer verified: outer `SELECT FOR UPDATE` serializes concurrent retries correctly under `READ COMMITTED`; nested `conn.transaction()` becomes a SAVEPOINT in asyncpg with no rollback semantics concern; `append_event`'s inner `UPDATE sessions` re-acquiring the row lock is a Postgres no-op within the same transaction; idempotent-return preserving the first-call's `is_error` is the right policy (canonical truth, not last-writer-wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)