### PR TITLE
fix(harness/context): skip non-dict attachment records to prevent session brick

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -285,44 +285,56 @@ def _apply_attachments(
     image_parts: list[dict[str, Any]] = []
 
     for record in attachments:
+        if not isinstance(record, dict):
+            # ``metadata.attachments`` is ``list[Any]`` at the wire boundary
+            # (``SessionUserMessage.metadata: dict[str, Any]`` doesn't drill
+            # into the value, and connector inbound payloads can be
+            # malformed). A non-dict record here would crash
+            # ``record.get(...)`` and brick the session permanently, since
+            # the renderer is called on every wake.
+            log.warning(
+                "context.attachment_record_not_dict",
+                session_id=session_id,
+                record_type=type(record).__name__,
+            )
+            continue
         host_path = _resolve_attachment_host_path(record, session_id)
         size = record.get("size")
         content_type = record.get("content_type")
-        inline = (
-            host_path is not None
-            and model is not None
-            and isinstance(content_type, str)
-            and isinstance(size, int)
-            and can_inline_image(model=model, content_type=content_type, size_bytes=size)
-        )
-        if inline:
-            # v1 deliberately re-reads + re-base64-encodes per render: the
-            # staged bytes are typically immutable (`/mnt/attachments/` is
-            # read-only) so an LRU cache on (host_path, mtime, size) would
-            # be a clean follow-up if profiling shows pressure.  See
-            # PR #216 §14 for the discussion of cache vs. encode-at-staging
-            # alternatives we deferred for v1.
-            try:
-                payload = host_path.read_bytes()
-            except OSError as err:
-                # The staged file disappeared (manual cleanup, FS corruption,
-                # GC race). Fall back to a text marker rather than raising
-                # mid-render — losing one image shouldn't fail the whole step.
-                log.warning(
-                    "context.attachment_read_failed",
-                    path=str(host_path),
-                    error=str(err),
-                )
-                marker_lines.append(text_marker(record))
-                continue
-            image_parts.append(
-                make_image_url_part(
-                    content_type=content_type,
-                    data_b64=base64.b64encode(payload).decode("ascii"),
-                )
-            )
-        else:
+        if (
+            host_path is None
+            or model is None
+            or not isinstance(content_type, str)
+            or not isinstance(size, int)
+            or not can_inline_image(model=model, content_type=content_type, size_bytes=size)
+        ):
             marker_lines.append(text_marker(record))
+            continue
+        # v1 deliberately re-reads + re-base64-encodes per render: the
+        # staged bytes are typically immutable (`/mnt/attachments/` is
+        # read-only) so an LRU cache on (host_path, mtime, size) would
+        # be a clean follow-up if profiling shows pressure.  See
+        # PR #216 §14 for the discussion of cache vs. encode-at-staging
+        # alternatives we deferred for v1.
+        try:
+            payload = host_path.read_bytes()
+        except OSError as err:
+            # The staged file disappeared (manual cleanup, FS corruption,
+            # GC race). Fall back to a text marker rather than raising
+            # mid-render — losing one image shouldn't fail the whole step.
+            log.warning(
+                "context.attachment_read_failed",
+                path=str(host_path),
+                error=str(err),
+            )
+            marker_lines.append(text_marker(record))
+            continue
+        image_parts.append(
+            make_image_url_part(
+                content_type=content_type,
+                data_b64=base64.b64encode(payload).decode("ascii"),
+            )
+        )
 
     text = leading_text
     if marker_lines:

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -99,6 +99,66 @@ class TestVisionAwareRendering:
             },
         }
 
+    def test_non_dict_attachment_record_is_skipped(self, temp_workspace_root: Path) -> None:
+        """A non-dict element in ``metadata.attachments`` must not crash the renderer.
+
+        ``SessionUserMessage.metadata: dict[str, Any]`` accepts any shape;
+        Pydantic doesn't drill into the value. A connector that mis-serializes
+        attachments — ``["filename.jpg"]`` instead of ``[{...}]`` — or a
+        pre-existing event row with corrupt metadata, used to crash
+        ``_apply_attachments`` at ``record.get(...)`` with
+        ``AttributeError: 'str' object has no attribute 'get'``. Because
+        the renderer is called on every wake, the session became
+        permanently un-renderable until manual intervention.
+        """
+        # Deliberately heterogeneous list: stray strings, None, and ints
+        # are exactly the shapes a mis-serializing connector could send.
+        malformed: list[Any] = ["malformed-string", None, 42]
+        event = _user_event(content="hi", attachments=malformed)
+        # Today: raises AttributeError mid-loop, bricking the session.
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="model/vision",
+            session_id="sess-1",
+        )
+        # No crash; malformed records produce no image parts and no marker.
+        assert msg["role"] == "user"
+        assert isinstance(msg["content"], str)
+        assert "hi" in msg["content"]
+
+    def test_mixed_valid_and_malformed_attachments(self, temp_workspace_root: Path) -> None:
+        """A valid record next to malformed ones still renders correctly —
+        the malformed entries are skipped, the valid one inlines as usual."""
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"jpegbytes"
+        )
+        mixed: list[Any] = [
+            "stray-string",
+            {
+                "filename": "photo.jpg",
+                "content_type": "image/jpeg",
+                "size": len(b"jpegbytes"),
+                "in_sandbox_path": sandbox_path,
+            },
+            None,
+        ]
+        event = _user_event(content="hello", attachments=mixed)
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="model/vision",
+            session_id="sess-1",
+        )
+        content = msg["content"]
+        assert isinstance(content, list)
+        # The valid image was inlined; the malformed records produced nothing.
+        image_parts = [p for p in content if p.get("type") == "image_url"]
+        assert len(image_parts) == 1
+        assert image_parts[0]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
     def test_oversize_image_falls_back_to_marker(self, temp_workspace_root: Path) -> None:
         sandbox_path = _stage_image(
             temp_workspace_root, "sess-1", "echo", "evt-1-big.jpg", b"\0" * (3 * 1024 * 1024)


### PR DESCRIPTION
## Summary

- `SessionUserMessage.metadata: dict[str, Any]` doesn't drill into the value; Pydantic accepts any shape inside metadata. A `POST /v1/sessions/{id}/messages` with body `{"content":"hi","metadata":{"attachments":["bad"]}}` (or a connector that mis-serializes its attachment list) lands a malformed list in the event log.
- `_apply_attachments` at `context.py:287` iterates each record and immediately calls `record.get(...)`, which raises `AttributeError: 'str' object has no attribute 'get'` when `record` isn't a dict. Because `build_messages` runs on every wake, the session is **permanently un-renderable until manual intervention** — every authenticated tenant can brick their own session with a single malformed POST.
- Fix adds an `isinstance(record, dict)` guard at the top of the loop (skip-and-warn with `session_id` stamped for operator triage). CLAUDE.md: "Only validate at system boundaries (user input, external APIs)." `metadata.attachments` IS such a boundary; this isn't a defensive guard masking a model-fixable error — the renderer crashing before the model can react makes the model unable to self-correct.
- Same change also restructures the local `inline` boolean + if/else into an explicit early-continue. Required to keep mypy clean after the new `isinstance(record, dict)` narrowed `record` from `Any` to `dict[Any, Any]`, which exposed mypy's inability to narrow `content_type` from `Any | None` to `str` through a boolean variable. The restructure is logic-equivalent and flattens one level of nesting.

## Test plan

- [x] Two new unit tests in `tests/unit/test_context_attachments.py`:
  - `test_non_dict_attachment_record_is_skipped`: fully malformed list `["str", None, 42]` → string-only message, no crash
  - `test_mixed_valid_and_malformed_attachments`: one valid dict among strings and None → valid record still inlines
- [x] mypy — clean
- [x] ruff + format-check — clean
- [x] Unit suite — 1231 passed (includes the 2 new tests)
- [ ] CI runs e2e/integration suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. Two findings applied:

- **[85] Log missing `session_id` for operator triage** — added `session_id=session_id` to the warning kwargs, matching the existing `context.attachment_read_failed` warning's pattern.
- **[80] `# type: ignore[list-item]` masks test intent** — replaced with explicit `list[Any]` typed intermediates that document "deliberately heterogeneous list".

Reviewer also flagged a follow-up consideration (not in scope here): input-time validation via a tighter Pydantic shape on `SessionUserMessage.metadata` would let the API reject malformed payloads at the boundary. That would be API-breaking and complementary to this defense-in-depth fix; worth a separate issue if pursued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)