### PR TITLE
fix(sessions): make confirm_tool_deny idempotent via append_tool_result

### DIFF
--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -531,6 +531,13 @@ async def confirm_tool_deny(
     Appends a tool-role error event that the model will see in its next
     context window. The deny message is formatted to match Anthropic's
     ``"Permission to use <tool> has been rejected."`` pattern.
+
+    Idempotent on ``(session_id, tool_call_id)``: a retried POST
+    returns the original event instead of appending a duplicate that
+    would violate the monotonic-context invariant (CLAUDE.md #2).
+    Delegates to :func:`append_tool_result`, which carries the dedup
+    machinery (#445) — same event shape (``role:"tool"`` with
+    ``is_error=True``), so the dedup applies uniformly to the deny path.
     """
     # Find the tool name from the event log for the error message.
     events = await read_message_events(pool, session_id, account_id=account_id)
@@ -546,16 +553,12 @@ async def confirm_tool_deny(
         },
         ensure_ascii=False,
     )
-    return await append_event(
-        pool,
-        session_id,
-        "message",
-        {
-            "role": "tool",
-            "tool_call_id": tool_call_id,
-            "name": tool_name,
-            "content": content,
-            "is_error": True,
-        },
-        account_id=account_id,
-    )
+    async with pool.acquire() as conn:
+        return await append_tool_result(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            content=content,
+            is_error=True,
+        )

--- a/tests/integration/test_tool_deny_idempotency.py
+++ b/tests/integration/test_tool_deny_idempotency.py
@@ -1,0 +1,186 @@
+"""Integration tests: ``services.confirm_tool_deny`` is idempotent on
+``(session_id, tool_call_id)``.
+
+The deny path appends a ``role:"tool"`` event (with ``is_error=True``
+and a synthesized rejection message) so the model sees the rejection
+in its next context window. Pre-fix it forwarded straight to
+``append_event``, so a retried POST
+``/v1/sessions/{id}/tool-confirmations`` with ``decision="deny"``
+appended a *second* ``role:"tool"`` event with the same
+``tool_call_id``.
+
+The bug shape is identical to the ``append_tool_result`` case fixed in
+PR #445: ``harness/context.py:499-506`` builds ``real_results: dict[tcid
+→ data]`` by iterating and overwriting, so a duplicate with different
+content (e.g. an operator who re-clicked deny with a different
+``deny_message``) silently rewrites the model's view of an earlier
+turn — direct violation of the monotonic-context invariant.
+
+This file pins the same idempotency contract for ``confirm_tool_deny``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.models.agents import ToolSpec
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def session_with_parent_tool_call(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str]]:
+    """Yield ``(pool, account_id, session_id, tool_call_id)`` for an
+    initialized session with one assistant event carrying a ``tool_calls``
+    entry. ``confirm_tool_deny`` finds the tool name via
+    ``read_message_events`` + ``_find_tool_call``."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_test', NULL, TRUE, 'tenant-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_test",
+            name="deny-test",
+            model="openrouter/test",
+            system="",
+            tools=[ToolSpec(type="bash")],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_test", name="deny-test-env"
+        )
+        async with pool.acquire() as conn:
+            session = await queries.insert_session(
+                conn,
+                account_id="acc_test",
+                agent_id=agent.id,
+                environment_id=env.id,
+                agent_version=agent.version,
+                title=None,
+                metadata={},
+            )
+            await queries.append_event(
+                conn,
+                account_id="acc_test",
+                session_id=session.id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tc_deny_test",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        }
+                    ],
+                },
+            )
+        yield pool, "acc_test", session.id, "tc_deny_test"
+    finally:
+        await pool.close()
+
+
+async def _count_tool_role_events(
+    pool: asyncpg.Pool[Any], session_id: str, tool_call_id: str
+) -> int:
+    async with pool.acquire() as conn:
+        return (
+            await conn.fetchval(
+                """
+                SELECT COUNT(*) FROM events
+                 WHERE session_id = $1
+                   AND kind = 'message'
+                   AND data->>'role' = 'tool'
+                   AND data->>'tool_call_id' = $2
+                """,
+                session_id,
+                tool_call_id,
+            )
+            or 0
+        )
+
+
+class TestConfirmToolDenyIdempotency:
+    async def test_duplicate_deny_does_not_create_second_event(
+        self,
+        session_with_parent_tool_call: tuple[asyncpg.Pool[Any], str, str, str],
+    ) -> None:
+        """Two denies on the same ``tool_call_id`` must produce ONE event.
+
+        Today the second call appends a duplicate ``role:"tool"`` event
+        and the monotonic-context invariant is violated (`real_results`
+        in ``context.py`` overwrites).
+        """
+        pool, account_id, session_id, tool_call_id = session_with_parent_tool_call
+
+        await sessions_service.confirm_tool_deny(
+            pool,
+            session_id,
+            tool_call_id,
+            "first rejection",
+            account_id=account_id,
+        )
+        await sessions_service.confirm_tool_deny(
+            pool,
+            session_id,
+            tool_call_id,
+            "second rejection",
+            account_id=account_id,
+        )
+
+        count = await _count_tool_role_events(pool, session_id, tool_call_id)
+        assert count == 1, (
+            f"duplicate deny appended a second tool-role event "
+            f"(count={count}); monotonic-context invariant violated"
+        )
+
+    async def test_duplicate_deny_returns_original_content(
+        self,
+        session_with_parent_tool_call: tuple[asyncpg.Pool[Any], str, str, str],
+    ) -> None:
+        """The idempotent return must carry the *first* call's rejection
+        message. Returning the duplicate's content would silently corrupt
+        the prior history."""
+        pool, account_id, session_id, tool_call_id = session_with_parent_tool_call
+
+        await sessions_service.confirm_tool_deny(
+            pool,
+            session_id,
+            tool_call_id,
+            "first rejection",
+            account_id=account_id,
+        )
+        second_event = await sessions_service.confirm_tool_deny(
+            pool,
+            session_id,
+            tool_call_id,
+            "second rejection",
+            account_id=account_id,
+        )
+
+        assert "first rejection" in second_event.data["content"], (
+            f"second-call return carries the wrong content "
+            f"(data={second_event.data!r}); idempotent return must "
+            f"preserve the first-call's truth"
+        )


### PR DESCRIPTION
## Summary

- `services.confirm_tool_deny` (`src/aios/services/sessions.py:521`) appended a `role:"tool"` event with `is_error=True` via `queries.append_event` unconditionally. A retried `POST /v1/sessions/{id}/tool-confirmations` (decision=`deny`) appended a *second* tool-role event with the same `tool_call_id` — same exact anti-pattern as the `append_tool_result` case fixed in PR #445.
- **Same monotonic-context invariant violation** (CLAUDE.md #2): `harness/context.py:499-506` builds `real_results: dict[tcid → data]` by iterating and overwriting, so a duplicate with different content (e.g. an operator re-clicked deny with a different `deny_message`) silently rewrites the model's view of an earlier turn.
- **Fix is a delegation**: build the rejection-message content, then call `services.append_tool_result(conn, ..., is_error=True)`. `append_tool_result` already carries the lock+check+early-return idempotency from #445; same event shape (`role:"tool"` + `is_error=True`), so the dedup applies uniformly to the deny path. No new dedup logic — pure reuse.
- **Minor behavior tightening**: `append_tool_result` raises `NotFoundError` if no parent assistant exists for the `tool_call_id`, whereas the previous code silently used `tool_name="unknown"`. The deny POST surface is only reachable via an unresolved `tool_calls` entry on an assistant event, so the parent must exist in practice — the previous fallback was a defensive guard against an unreachable state, removed per CLAUDE.md's "fail hard, no fallbacks" stance.

## Test plan

- [x] New `tests/integration/test_tool_deny_idempotency.py` — two tests against testcontainer Postgres:
  - Two denies on same `(session_id, tool_call_id)` produce ONE event in the log
  - The idempotent return carries the first-call's rejection message even if the retry passed a different `deny_message`
- [x] mypy — clean
- [x] ruff + format-check — clean
- [x] Unit suite — 1231 passed
- [x] Integration suite — 16 passed (14 prior + 2 new)
- [ ] CI runs e2e/integration suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. **No critical or important findings.** Reviewer verified: tool-name lookup equivalent between `_find_tool_call` (in-memory) and `lookup_tool_name_by_call_id` (SQL `data->'tool_calls' @>`); router `defer_wake` semantics preserved on both first-call and idempotent retry; connection-acquisition pattern correct; tests genuinely deterministic.

Sub-70 notes (per project memory: post all findings, don't filter by score):

- **[50] Redundant tool-name lookup on first call** — after delegation, both `read_message_events` + `_find_tool_call` (for the rejection-message string) AND `lookup_tool_name_by_call_id` (inside `append_tool_result`) run on the first call. Could be collapsed by dropping the tool-name interpolation from the message (or having `append_tool_result` return the name). Trade-off: clearer error vs. one fewer DB query. Leaving as-is — confirmations run at human-click rates and the model-visible string degrading to "Permission to use this tool has been rejected" loses useful signal.
- **[45] `NotFoundError` on missing parent is a tightening, not a regression** — only caller is the `tool-confirmations` route, reachable only via an unresolved `tool_calls` entry. Matches "fail hard, no fallbacks". No existing test or caller affected.
- **[35] Test class wrapper with two methods** — could be module-level functions, but consistent with the companion `test_tool_result_idempotency.py` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)