### PR TITLE
fix(sandbox): keep idle-TTL reaper alive across release failures

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -416,17 +416,30 @@ class SandboxRegistry:
     # ── idle-TTL reaper ──────────────────────────────────────────────────
 
     async def _reap_idle_loop(self, idle_timeout: float, interval: float = 60.0) -> None:
-        """Background loop: release sandboxes idle > idle_timeout seconds."""
+        """Background loop: release sandboxes idle > idle_timeout seconds.
+
+        The try/except is nested INSIDE ``while True`` (mirroring
+        :func:`aios.harness.worker._periodic_sweep` and the PR #443 fix
+        for ``_run_interrupt_listener``): a Docker daemon hiccup raising
+        ``SandboxBackendError`` from ``release()`` must not silently
+        disable the reaper for the worker's lifetime — that would
+        leak every subsequent idle sandbox until process exit.
+        ``CancelledError`` is not an :class:`Exception` subclass, so
+        ``stop_reaper()``'s cancel still exits the loop cleanly.
+        """
         while True:
-            await asyncio.sleep(interval)
-            now = time.monotonic()
-            to_release: list[str] = []
-            for sid, last in list(self._last_used.items()):
-                if now - last > idle_timeout:
-                    to_release.append(sid)
-            for sid in to_release:
-                log.info("sandbox.idle_release", session_id=sid)
-                await self.release(sid)
+            try:
+                await asyncio.sleep(interval)
+                now = time.monotonic()
+                to_release: list[str] = []
+                for sid, last in list(self._last_used.items()):
+                    if now - last > idle_timeout:
+                        to_release.append(sid)
+                for sid in to_release:
+                    log.info("sandbox.idle_release", session_id=sid)
+                    await self.release(sid)
+            except Exception:
+                log.exception("sandbox.reap_idle_loop_failed")
 
     def start_reaper(self, idle_timeout: float = 300.0) -> None:
         """Start the idle-TTL reaper background task."""

--- a/tests/unit/test_sandbox_reaper.py
+++ b/tests/unit/test_sandbox_reaper.py
@@ -1,0 +1,134 @@
+"""Unit coverage for :meth:`SandboxRegistry._reap_idle_loop`.
+
+The idle-TTL reaper is one long-lived background task that releases
+sandboxes idle past ``idle_timeout``. ``release()`` calls
+``backend.destroy(handle)`` which talks to Docker — any daemon hiccup
+(network blip, container already gone, paused daemon) raises
+``SandboxBackendError``. Pre-fix, that exception escaped the
+``while True`` loop and the reaper task ended; ``start_reaper`` is
+single-shot, so no idle sandbox was ever reaped again for the worker's
+lifetime. Containers accumulated silently until process exit.
+
+Same anti-pattern as ``_run_interrupt_listener`` (fixed in PR #443).
+``_periodic_sweep`` (``worker.py:343``) demonstrates the correct
+template: nest try/except INSIDE the ``while True``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from aios.sandbox.backends.base import SandboxBackend, SandboxBackendError, SandboxHandle
+from aios.sandbox.registry import SandboxRegistry
+
+
+def _handle(session_id: str) -> SandboxHandle:
+    return SandboxHandle(
+        sandbox_id=f"sb_{session_id}",
+        session_id=session_id,
+        workspace_path=Path(f"/tmp/{session_id}"),
+    )
+
+
+def _backend_with_destroy(destroy: Any) -> SandboxBackend:
+    backend = MagicMock(spec=SandboxBackend)
+    backend.destroy = destroy
+    backend.name = "stub"
+    return backend
+
+
+async def test_reaper_survives_release_failure() -> None:
+    """One ``backend.destroy`` failure must not disable the reaper.
+
+    Two idle sandboxes; first ``release()`` propagates ``SandboxBackendError``
+    from the backend; the second must still be reaped on a subsequent tick.
+    """
+    destroy_calls: list[SandboxHandle] = []
+    both_attempted = asyncio.Event()
+
+    async def destroy(handle: SandboxHandle) -> None:
+        destroy_calls.append(handle)
+        if len(destroy_calls) >= 2:
+            both_attempted.set()
+        if len(destroy_calls) == 1:
+            raise SandboxBackendError("simulated docker hiccup")
+
+    registry = SandboxRegistry(_backend_with_destroy(AsyncMock(side_effect=destroy)))
+
+    # Pre-populate two idle sandboxes (last_used=0 → far past any idle_timeout).
+    registry._handles["sess_a"] = _handle("sess_a")
+    registry._handles["sess_b"] = _handle("sess_b")
+    registry._last_used["sess_a"] = 0.0
+    registry._last_used["sess_b"] = 0.0
+
+    # Tight loop so the test completes quickly — idle_timeout=0 means
+    # every entry is idle; interval=0.01 means a fresh tick every ~10ms.
+    reaper = asyncio.create_task(registry._reap_idle_loop(idle_timeout=0.0, interval=0.01))
+    try:
+        try:
+            await asyncio.wait_for(both_attempted.wait(), timeout=1.0)
+        except TimeoutError as exc:
+            raise AssertionError(
+                f"reaper did not attempt the second release within 1s "
+                f"(destroy_calls={len(destroy_calls)}, "
+                f"reaper.done={reaper.done()}, "
+                f"exception={reaper.exception() if reaper.done() else None}); "
+                f"the first destroy's exception escaped while True and killed the task"
+            ) from exc
+
+        assert not reaper.done(), (
+            f"reaper task died after one destroy failure (exception={reaper.exception()})"
+        )
+    finally:
+        reaper.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await reaper
+
+
+async def test_reaper_processes_sandboxes_added_after_initial_failure() -> None:
+    """A sandbox added AFTER the initial failure is still reaped.
+
+    Pins the survivability contract one step further: after the reaper
+    survives one bad tick, future ticks pick up newly-idle entries.
+    """
+    destroy_calls: list[SandboxHandle] = []
+    initial_attempted = asyncio.Event()
+    later_attempted = asyncio.Event()
+
+    async def destroy(handle: SandboxHandle) -> None:
+        destroy_calls.append(handle)
+        if handle.session_id == "sess_initial":
+            initial_attempted.set()
+            raise SandboxBackendError("simulated transient")
+        if handle.session_id == "sess_later":
+            later_attempted.set()
+
+    registry = SandboxRegistry(_backend_with_destroy(AsyncMock(side_effect=destroy)))
+
+    registry._handles["sess_initial"] = _handle("sess_initial")
+    registry._last_used["sess_initial"] = 0.0
+
+    reaper = asyncio.create_task(registry._reap_idle_loop(idle_timeout=0.0, interval=0.01))
+    try:
+        await asyncio.wait_for(initial_attempted.wait(), timeout=1.0)
+
+        # Add a fresh idle sandbox after the first failure.
+        registry._handles["sess_later"] = _handle("sess_later")
+        registry._last_used["sess_later"] = 0.0
+
+        try:
+            await asyncio.wait_for(later_attempted.wait(), timeout=1.0)
+        except TimeoutError as exc:
+            raise AssertionError(
+                f"sess_later not reaped after initial failure "
+                f"(reaper.done={reaper.done()}, "
+                f"exception={reaper.exception() if reaper.done() else None})"
+            ) from exc
+    finally:
+        reaper.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await reaper


### PR DESCRIPTION
## Summary

- `SandboxRegistry._reap_idle_loop` (`src/aios/sandbox/registry.py:418`) had no `try/except` anywhere around the `while True:` body. `release()` → `backend.destroy(handle)` raises `SandboxBackendError` on any Docker daemon hiccup. Pre-fix, that exception propagated out of the loop and the reaper task ended cleanly. Because `start_reaper` is single-shot, **no idle sandbox was ever reaped for the worker's lifetime** after the first hiccup — containers accumulated silently until process exit.
- Same anti-pattern as `_run_interrupt_listener` (fixed in PR #443). `_periodic_sweep` (`worker.py:343`) demonstrates the correct template: `try/except` INSIDE the `while True` with `log.exception`. This is the **third (and per audit, the last)** instance of the same anti-pattern getting the same correct response.
- Code-review audit confirms all three long-lived infrastructure pumps in the codebase (`_periodic_sweep`, `_run_interrupt_listener`, `_reap_idle_loop`) are now consistent. SSE loops are request-scoped (terminate on disconnect); streaming-read loops are bounded. No more outliers.

## Test plan

- [x] New `tests/unit/test_sandbox_reaper.py` — two unit tests using `asyncio.Event` coordination (no sleep-based timing gates, carrying forward the PR #443 review lesson):
  - `test_reaper_survives_release_failure`: two idle sandboxes, first `release()` raises `SandboxBackendError` — second must still be reaped and reaper task must not be `done()`
  - `test_reaper_processes_sandboxes_added_after_initial_failure`: a fresh sandbox added AFTER the initial failure still gets reaped
- [x] mypy — clean
- [x] ruff + format-check — clean
- [x] Unit suite — 1233 passed (1231 + 2 new)
- [ ] CI runs e2e/integration suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. **No actionable findings.** Reviewer verified the fix matches established precedent (third instance of the same template), broad `except Exception` is the right choice over `except SandboxBackendError` (consistent with `_periodic_sweep`'s broad catch, defends against unforeseen `RuntimeError`/`AttributeError` from runtime-global misconfiguration), and tests are deterministic via `asyncio.Event` rather than timing gates.

Bonus signal: the audit surveyed all long-lived loops in the codebase and confirmed this is the final outlier — after this PR merges, the survivability contract is uniform across all three background pumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)