### PR TITLE
fix(harness/context): stop mime corrector from mutating Event.data

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -403,18 +403,27 @@ def _sanitize_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any
 
 def _correct_image_data_url_mimes(messages: list[dict[str, Any]]) -> None:
     """Rewrite mismatched mime declarations on ``data:<mime>;base64,...``
-    image URLs already in the assembled message list.  Mutates in place.
+    image URLs already in the assembled message list.
 
     The renderer cannot prevent persisted events from carrying a wrong
     mime — tool_result content arrives pre-formed and is appended
     verbatim, so historical events from before centralised sniffing
     will replay forever unless we re-check them every build.
+
+    Mutates the message list's content entries by *replacing* the part
+    dict (and the ``image_url`` sub-dict) with fresh copies — never
+    mutates the original dicts in place. ``build_messages`` appends
+    ``event.data`` to ``messages`` by reference (``context.py:560`` etc.)
+    before this function runs, so an in-place mutation would corrupt the
+    source-of-truth ``Event.data`` and violate the "pure function of the
+    event log" contract documented at the top of this module.
     """
-    for msg in messages:
+    for msg_idx, msg in enumerate(messages):
         content = msg.get("content")
         if not isinstance(content, list):
             continue
-        for part in content:
+        new_content: list[Any] | None = None
+        for i, part in enumerate(content):
             if not isinstance(part, dict) or part.get("type") != "image_url":
                 continue
             image_url = part.get("image_url")
@@ -429,7 +438,17 @@ def _correct_image_data_url_mimes(messages: list[dict[str, Any]]) -> None:
             declared = head.removeprefix("data:").split(";", 1)[0]
             corrected = correct_image_mime_b64(declared, data_b64)
             if corrected != declared:
-                image_url["url"] = f"data:{corrected};base64,{data_b64}"
+                if new_content is None:
+                    new_content = list(content)
+                new_content[i] = {
+                    **part,
+                    "image_url": {
+                        **image_url,
+                        "url": f"data:{corrected};base64,{data_b64}",
+                    },
+                }
+        if new_content is not None:
+            messages[msg_idx] = {**msg, "content": new_content}
 
 
 def _strip_to_spec(

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1468,3 +1468,66 @@ class TestSeparateAdjacentUserMessagesPipeline:
 
         assert [m["role"] for m in msgs] == ["user", "assistant", "user", "assistant"]
         assert not any(m == {"role": "assistant", "content": ""} for m in msgs)
+
+
+class TestEventDataImmutability:
+    """``build_messages`` is documented (``context.py:9-12``) as a pure
+    function of the event log. Callers that hold an ``Event`` reference
+    must see its ``data`` unchanged after the build runs.
+
+    Pre-fix, ``_correct_image_data_url_mimes`` mutated ``image_url["url"]``
+    in place on dicts that shared identity with ``event.data["content"]``
+    (because ``build_messages`` appended ``e.data`` to its ``messages``
+    list directly, before the ``_strip_to_spec`` copy boundary). So a
+    tool-role event with a mis-declared image MIME got its source-of-truth
+    rewritten on every render.
+    """
+
+    def test_build_messages_does_not_mutate_tool_event_data(self) -> None:
+        import base64
+        import copy
+
+        # JPEG magic bytes (\xff\xd8\xff\xe0) declared as image/png — the
+        # historical-event corruption pattern that motivated
+        # ``_correct_image_data_url_mimes`` in the first place.
+        jpeg_bytes = b"\xff\xd8\xff\xe0" + b"\x00" * 32
+        bad_url = f"data:image/png;base64,{base64.b64encode(jpeg_bytes).decode()}"
+
+        events = [
+            _evt(1, "user", content="show"),
+            _evt(2, "assistant", tool_calls=[_tc("a", name="read")]),
+            Event(
+                id="evt_3",
+                session_id="sess_01TEST",
+                seq=3,
+                kind="message",
+                data={
+                    "role": "tool",
+                    "tool_call_id": "a",
+                    "name": "read",
+                    "content": [{"type": "image_url", "image_url": {"url": bad_url}}],
+                },
+                created_at=datetime.now(tz=UTC),
+                orig_channel=None,
+                focal_channel_at_arrival=None,
+            ),
+        ]
+        snapshot = copy.deepcopy([e.data for e in events])
+
+        ctx = build_messages(events, system_prompt=None)
+
+        # The build's output is allowed to contain the corrected MIME —
+        # but the input events must remain pristine.
+        assert [e.data for e in events] == snapshot, (
+            "build_messages mutated event.data — the tool event's image_url URL "
+            "was rewritten in place, violating the 'pure function of the event "
+            "log' contract documented in context.py:9-12"
+        )
+        # Sanity: the correction did happen in the output messages (so the
+        # test isn't passing because correction was skipped).
+        tool_msg = next(m for m in ctx.messages if m.get("role") == "tool")
+        assert isinstance(tool_msg["content"], list)
+        out_url = tool_msg["content"][0]["image_url"]["url"]
+        assert out_url.startswith("data:image/jpeg;base64,"), (
+            f"renderer should have corrected png → jpeg in the output, got {out_url[:50]}"
+        )


### PR DESCRIPTION
## Summary

- `_correct_image_data_url_mimes` in `src/aios/harness/context.py:404` was documented as "Mutates in place" — and indeed rewrote `image_url["url"]` on dicts inside the assembled `messages` list. **But** `build_messages` appends `event.data` to `messages` by REFERENCE (`context.py:560/568/632`), so those dicts share identity with the source-of-truth `Event.data`. The in-place mutation rewrote `event.data["content"][i]["image_url"]["url"]` on every render that hit a mime-correction case.
- Violates the module-level contract documented at `context.py:9-12`: "It is a pure function of the event log + caller-supplied vision policy inputs..."
- **No user-observable bug today** because `loop.py` rebuilds events from DB on every step (so the corruption is per-step bounded). But the contract violation is a confusion landmine for any future consumer that re-inspects `event.data` post-build — audit log dump, events_search projection, retry path, debugger session.
- Fix uses **copy-on-write with lazy allocation**: zero allocation on the common no-correction path; when a correction is needed, replace the part dict + `image_url` dict + the outer message dict with fresh copies so the messages list no longer aliases `event.data` for that entry.

## Test plan

- [x] New `TestEventDataImmutability` in `tests/unit/test_context.py`:
  - Snapshots `event.data` via `copy.deepcopy` before `build_messages`
  - Calls `build_messages` with a tool-role event carrying a JPEG mis-declared as `image/png`
  - Asserts `event.data` matches the snapshot (= no mutation)
  - Sanity-asserts the output messages DO carry the correction (so the test isn't passing because correction was silently skipped)
- [x] mypy — clean
- [x] ruff + format-check — clean
- [x] Unit suite — 1234 passed (1233 + 1 new)
- [ ] CI runs e2e/integration suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. **No actionable findings.** Reviewer verified: (a) the copy-on-write design correctly replaces the outer message dict so the messages list no longer aliases `event.data`; (b) shallow `list(content)` is safe because uncorrected sibling parts are never mutated by this function; (c) the 2-level shallow copy (`{**part, "image_url": {**image_url, "url": ...}}`) is sufficient since the `url` value is an immutable string; (d) sibling in-place-mutation sites in `context.py` were audited and confirmed safe (`render_user_event` builds fresh dicts; `stub_missing_reasoning_content` operates on post-`_strip_to_spec` output which is already fresh).

Sub-70 calibration notes (per project memory: post all findings, don't filter by score):

- **[60] Could exercise the no-correction zero-cost path explicitly** with an `is` identity check — but doing so would lock in zero-cost aliasing as a contract, which is the opposite of what's wanted (defensive deep-copy would actually be more correct, not less). Skipped intentionally.
- **[55] Could add a multi-part-content test** where one part needs correction and others don't, exercising the `list(content)` shallow-copy + selective-replacement logic. The existing single-part test exercises the same code path; coverage is adequate.
- **[40] Local `import base64` / `import copy` in the test function** rather than module-top. Minor stylistic preference; not enforced by the project's lint config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)