### PR TITLE
fix(db): serialize concurrent update_agent writers in the UPDATE WHERE

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -447,12 +447,13 @@ async def update_agent(
     ``skills_json`` is a pre-serialized JSON string (resolved by the
     service layer which snapshots concrete versions).
     """
+    # ``get_agent`` reads ``current`` for the merge below and for the
+    # archived check. The version match is *not* pre-checked here — the
+    # in-transaction UPDATE's ``AND version = $expected_version`` is the
+    # authoritative serialization point; pre-checking would just emit a
+    # different error message for the obvious-stale case while letting
+    # the racy-concurrent case slip past, which was the prior bug.
     current = await get_agent(conn, agent_id, account_id=account_id)
-    if current.version != expected_version:
-        raise ConflictError(
-            f"version mismatch: expected {expected_version}, current is {current.version}",
-            detail={"expected": expected_version, "current": current.version},
-        )
     if current.archived_at is not None:
         raise ConflictError(f"agent {agent_id} is archived", detail={"id": agent_id})
 
@@ -504,6 +505,16 @@ async def update_agent(
     extra_json = json.dumps(new_extra)
 
     async with conn.transaction():
+        # ``AND version = $expected_version`` is the authoritative
+        # optimistic-concurrency check: the pre-transaction guard above
+        # is racy because two writers can both read the same
+        # ``current.version`` and both pass. Putting the version in the
+        # UPDATE ``WHERE`` lets the DB serialize the writers — exactly
+        # one matches and bumps to ``new_version``; the other matches
+        # zero rows and we raise ConflictError. Without this, the
+        # subsequent ``INSERT INTO agent_versions`` collides on
+        # ``agent_versions_pkey`` and leaks ``UniqueViolationError``
+        # as HTTP 500 to the loser instead of a clean 409.
         row = await conn.fetchrow(
             """
             UPDATE agents
@@ -513,7 +524,7 @@ async def update_agent(
                    litellm_extra = $11::jsonb,
                    window_min = $12, window_max = $13,
                    updated_at = now()
-             WHERE id = $1 AND account_id = $14
+             WHERE id = $1 AND account_id = $14 AND version = $15
             RETURNING *
             """,
             agent_id,
@@ -530,8 +541,24 @@ async def update_agent(
             new_wmin,
             new_wmax,
             account_id,
+            expected_version,
         )
-        assert row is not None
+        if row is None:
+            # Either the caller's ``expected_version`` was already stale
+            # when ``get_agent`` ran (sequential stale write) or a
+            # concurrent writer bumped the version between then and the
+            # UPDATE (race). Re-read for an accurate ``current`` —
+            # READ COMMITTED means this statement-level snapshot sees
+            # the concurrent writer's committed bump.
+            fresh = await get_agent(conn, agent_id, account_id=account_id)
+            raise ConflictError(
+                f"version mismatch: expected {expected_version}, current is {fresh.version}",
+                detail={
+                    "expected": expected_version,
+                    "current": fresh.version,
+                    "id": agent_id,
+                },
+            )
         await conn.execute(
             """
             INSERT INTO agent_versions (

--- a/tests/integration/test_update_agent_concurrent.py
+++ b/tests/integration/test_update_agent_concurrent.py
@@ -1,0 +1,159 @@
+"""Integration test: ``queries.update_agent`` serializes concurrent writers.
+
+Pre-fix: the optimistic-concurrency check at ``queries.py:451`` ran
+BEFORE the transaction. Two concurrent ``update_agent`` calls with
+the same ``expected_version`` both read the same ``current.version``,
+both passed the pre-check, both computed
+``new_version = current.version + 1``, both started transactions, and
+both ran the UPDATE (whose ``WHERE`` clause didn't include
+``version = $expected_version``). The first writer's
+``INSERT INTO agent_versions (agent_id, version)`` succeeded; the
+second's hit ``agent_versions_pkey`` → ``UniqueViolationError`` → HTTP
+500 to the loser.
+
+The loser should see a clean ``ConflictError`` (HTTP 409) — same as if
+they had been a slow writer arriving after a fast writer's version
+had already bumped, just via the sequential pre-check.
+
+Fix: add ``AND version = $expected_version`` to the UPDATE ``WHERE``
+so it is the authoritative version check. UPDATE matching zero rows
+raises ConflictError; the agent_versions INSERT only runs after a
+successful UPDATE, so PK violations are unreachable on the race path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.errors import ConflictError
+from aios.models.agents import Agent, ToolSpec
+from aios.services import agents as agents_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def pool_with_agent(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, Agent]]:
+    """Yield ``(pool, account_id, agent)`` for an initialized agent at version 1."""
+    pool = await create_pool(migrated_db_url, min_size=2, max_size=8)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_test', NULL, TRUE, 'tenant-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_test",
+            name="concurrent-test",
+            model="openrouter/test",
+            system="initial",
+            tools=[ToolSpec(type="bash")],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        yield pool, "acc_test", agent
+    finally:
+        await pool.close()
+
+
+async def test_concurrent_updates_loser_gets_clean_conflict_error(
+    pool_with_agent: tuple[asyncpg.Pool[Any], str, Agent],
+) -> None:
+    """Two concurrent ``update_agent`` calls with the same
+    ``expected_version`` must produce: one success, one
+    :class:`ConflictError`. The loser must NOT see an
+    ``asyncpg.UniqueViolationError`` (which leaks as HTTP 500)."""
+    pool, account_id, agent = pool_with_agent
+
+    async def _attempt(new_system: str) -> tuple[bool, BaseException | None]:
+        try:
+            await agents_service.update_agent(
+                pool,
+                agent.id,
+                account_id=account_id,
+                expected_version=agent.version,
+                system=new_system,
+            )
+            return True, None
+        except BaseException as e:
+            return False, e
+
+    # Pool has min_size=2 so both coroutines can hold connections
+    # concurrently — proves the race is real and not artificially
+    # serialized by pool exhaustion.
+    results = await asyncio.gather(_attempt("alpha"), _attempt("beta"))
+
+    successes = [r for r in results if r[0]]
+    failures = [r for r in results if not r[0]]
+
+    assert len(successes) == 1, (
+        f"expected exactly one success; got {len(successes)} "
+        f"(failures: {[type(f[1]).__name__ for f in failures]})"
+    )
+    assert len(failures) == 1, (
+        f"expected exactly one failure; got {len(failures)} (successes: {len(successes)})"
+    )
+
+    loser_exception = failures[0][1]
+    assert isinstance(loser_exception, ConflictError), (
+        f"loser got {type(loser_exception).__name__}: {loser_exception}; "
+        f"the pre-transaction expected_version check is racy — both "
+        f"writers pass it, then the second hits agent_versions_pkey "
+        f"and leaks UniqueViolationError as HTTP 500 instead of 409"
+    )
+    # The detail must reflect post-race truth: the winner bumped version
+    # to agent.version + 1, so the loser's ``current`` field is that.
+    # (Without the in-transaction re-read this would still be agent.version,
+    # which is stale by the time the conflict is raised.)
+    assert loser_exception.detail["expected"] == agent.version
+    assert loser_exception.detail["current"] == agent.version + 1, (
+        f"detail.current should reflect the winner's bumped version "
+        f"(agent.version+1={agent.version + 1}); got "
+        f"{loser_exception.detail['current']!r}. Indicates the error "
+        f"reports the pre-transaction value instead of the post-conflict "
+        f"actual."
+    )
+
+
+async def test_sequential_stale_version_still_raises_conflict(
+    pool_with_agent: tuple[asyncpg.Pool[Any], str, Agent],
+) -> None:
+    """Regression guard: the non-concurrent stale-version path must
+    continue to raise ConflictError after the in-transaction check is
+    added (the pre-check should still catch the obvious case)."""
+    pool, account_id, agent = pool_with_agent
+
+    # First update bumps version to 2.
+    await agents_service.update_agent(
+        pool,
+        agent.id,
+        account_id=account_id,
+        expected_version=agent.version,
+        system="bumped",
+    )
+
+    # Second update with the stale expected_version must raise.
+    with pytest.raises(ConflictError) as exc_info:
+        await agents_service.update_agent(
+            pool,
+            agent.id,
+            account_id=account_id,
+            expected_version=agent.version,  # stale (was 1, now 2)
+            system="should-fail",
+        )
+
+    assert exc_info.value.detail["expected"] == agent.version
+    assert exc_info.value.detail["current"] == agent.version + 1


### PR DESCRIPTION
## Summary

- `queries.update_agent` (`src/aios/db/queries.py:423`) ran its optimistic-concurrency check BEFORE the transaction. Two concurrent calls with the same `expected_version` both passed the pre-check, both started transactions, and both ran the UPDATE (whose WHERE clause didn't include `version = $expected_version`). The first writer's `INSERT INTO agent_versions` succeeded; the second hit `agent_versions_pkey` → `asyncpg.UniqueViolationError` → HTTP **500** to the loser, leaking the raw DB error instead of a clean **409 ConflictError**.
- Fix: add `AND version = $expected_version` to the UPDATE WHERE. UPDATE matching zero rows raises ConflictError; the agent_versions INSERT only runs after a successful UPDATE, so PK violations are unreachable on the race path.
- Re-reads `current` via `get_agent` on the failure path so `detail.current` reflects post-race truth (the winner's bumped version) under READ COMMITTED. Without the re-read the field would report the pre-transaction value, which is stale by the time the conflict is raised.
- Per code-reviewer's sev-85 finding (no belt-and-suspenders): the pre-transaction version check is deleted — the in-transaction check is authoritative; keeping both produced two different error messages for the same condition. Pre-stage `get_agent` stays (needed for the field merge and the archived check, which the UPDATE doesn't enforce).

## Test plan

- [x] New `tests/integration/test_update_agent_concurrent.py` — two tests against testcontainer Postgres:
  - `test_concurrent_updates_loser_gets_clean_conflict_error`: two `asyncio.gather`'d `update_agent` calls with same `expected_version`. Assert one success, one `ConflictError` (NOT `UniqueViolationError`), and `detail.current` equals the winner's bumped version.
  - `test_sequential_stale_version_still_raises_conflict`: regression guard for the obvious-stale-version path now routed through the same in-transaction check.
- [x] mypy — clean
- [x] ruff + format-check — clean
- [x] Unit suite — 1234 passed
- [x] Integration suite — 18 passed (16 prior + 2 new)
- [ ] CI runs e2e/integration suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. One sev-85 finding applied:

- **[85] Pre-transaction version check is now redundant** — Reviewer flagged that the in-transaction check is authoritative, making the pre-check redundant; two checks with different error messages for the same condition was "worst of both worlds." Applied: deleted the pre-check version branch, harmonized to a single error path with consistent `detail` shape. The pre-stage `get_agent` stays (needed for merge state + archived check).

Sub-70 calibration notes (per project memory: post all findings):

- **[60] Test asserts `detail.current`** — addressed by the in-transaction re-read; the field is now reliably accurate at error-raise time.
- **[55] `except BaseException` in `_attempt`** — kept intentionally to catch the buggy `UniqueViolationError` and any other unexpected exception type cleanly. `Exception` would suffice but `BaseException` is harmless under pytest.
- **[40] No-op early-return at lines 484-498** — confirmed still correct; the no-op path doesn't enter the transaction so the race doesn't apply.
- **[35] Cross-tenant access** — verified: `get_agent` raises `NotFoundError` before the UPDATE runs; the UPDATE's `AND account_id = $14` is defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)