### PR TITLE
fix(sandbox): clear runtime per-session caches on registry.release

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -273,7 +273,32 @@ class SandboxRegistry:
         )
 
     async def release(self, session_id: str) -> None:
-        """Tear down one session's sandbox + proxy. No-op if not cached."""
+        """Tear down one session's sandbox + proxy. No-op if not cached.
+
+        Also clears worker-process runtime caches keyed on this session
+        (``_session_memory_mounts``, ``_session_read_shas`` in
+        :mod:`aios.harness.runtime`). Without this cleanup, every
+        session that ran a step on this worker left an entry that
+        persisted for the worker's process lifetime — slow unbounded
+        growth across long-running workers handling many sessions. The
+        caches are documented as "after session unload" but had no
+        production caller until this hook. Re-populated naturally by
+        the next step if the session wakes back up.
+
+        Deferred import of ``aios.harness.runtime`` matches the existing
+        pattern at :meth:`_provision_with_span` (line 191) and
+        :meth:`_release_mcp_broker_secret`-adjacent paths — the runtime
+        module lists ``aios.sandbox.registry`` under ``TYPE_CHECKING``,
+        so a top-level import here would create a runtime cycle.
+
+        Cleanup is sequenced BEFORE ``backend.destroy`` so the
+        "registry says unloaded ⇒ runtime caches cleared" invariant
+        holds even when ``destroy`` raises (Docker hiccup): a
+        half-finished release shouldn't leave stale per-session caches
+        pretending the session is still live.
+        """
+        from aios.harness import runtime
+
         handle = self._handles.pop(session_id, None)
         self._last_used.pop(session_id, None)
         proxy = self._git_proxies.pop(session_id, None)
@@ -281,6 +306,8 @@ class SandboxRegistry:
         if proxy is not None:
             await self._stop_proxy_silently(proxy, session_id)
         self._release_mcp_broker_secret(session_id)
+        runtime.clear_session_memory_mounts(session_id)
+        runtime.clear_session_read_shas(session_id)
         if handle is None:
             return
         await self._backend.destroy(handle)
@@ -312,13 +339,12 @@ class SandboxRegistry:
                 session_id=session_id,
                 container_id=handle.sandbox_id[:12],
             )
-            self._handles.pop(session_id, None)
-            self._last_used.pop(session_id, None)
-            proxy = self._git_proxies.pop(session_id, None)
-            if proxy is not None:
-                await self._stop_proxy_silently(proxy, session_id)
-            self._release_mcp_broker_secret(session_id)
-            await self._backend.destroy(handle)
+            # Delegate to release() so the runtime-cache cleanup and any
+            # future unload-event side effects stay in one place. Holding
+            # the per-session lock guards against a tool task from a prior
+            # step racing with the release via get_or_provision (which
+            # acquires the same lock).
+            await self.release(session_id)
 
     def peek(self, session_id: str) -> SandboxHandle | None:
         """Return the cached handle without provisioning. ``None`` if not cached."""
@@ -331,6 +357,8 @@ class SandboxRegistry:
         suggests the sandbox itself is unhealthy; the next tool call will
         cold-start a fresh one.
         """
+        from aios.harness import runtime
+
         self._last_used.pop(session_id, None)
         if self._handles.pop(session_id, None) is not None:
             log.info("sandbox.evicted", session_id=session_id)
@@ -344,6 +372,13 @@ class SandboxRegistry:
         # Same story for the MCP broker secret: drop it immediately; a
         # fresh sandbox will get a fresh secret from the next provision.
         self._release_mcp_broker_secret(session_id)
+        # Drop the runtime read-sha cache so a fresh sandbox doesn't
+        # serve a stale precondition match against a different
+        # container's file state. Memory mounts are re-populated at the
+        # top of every step (loop.py:87) so leaving them is harmless,
+        # but symmetry argues for clearing both.
+        runtime.clear_session_memory_mounts(session_id)
+        runtime.clear_session_read_shas(session_id)
 
     async def release_all(self) -> None:
         """Tear down every sandbox + proxy. Called at worker shutdown."""

--- a/tests/unit/test_sandbox_runtime_cache_cleanup.py
+++ b/tests/unit/test_sandbox_runtime_cache_cleanup.py
@@ -1,0 +1,127 @@
+"""Unit coverage: ``SandboxRegistry.release()`` clears per-session runtime caches.
+
+``aios.harness.runtime`` holds two worker-process globals keyed on
+``session_id`` — ``_session_memory_mounts`` and ``_session_read_shas`` —
+that are populated at the top of every step (``loop.py:87``) and read by
+tool calls. They were defined with paired ``clear_session_*`` helpers
+documented as "after session unload", but production NEVER called them
+(prior audit confirmed via repo-wide grep). Every session that ran a
+step left an entry that persisted for the worker's process lifetime,
+so the dicts grew unboundedly across long-running workers handling many
+sessions.
+
+The natural unload event is ``SandboxRegistry.release()``: the idle
+reaper triggers it on per-session TTL, ``release_if_mounts_changed``
+triggers it on mount drift, and ``release_all`` triggers it at worker
+shutdown. After this PR, ``release()`` also clears the runtime caches
+keyed on the released session — re-populated naturally by the next
+step if the session wakes back up.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.harness import runtime
+from aios.models.memory_stores import MemoryStoreResourceEcho
+from aios.sandbox.backends.base import SandboxBackend, SandboxHandle
+from aios.sandbox.registry import SandboxRegistry
+
+
+def _handle(session_id: str) -> SandboxHandle:
+    return SandboxHandle(
+        sandbox_id=f"sb_{session_id}",
+        session_id=session_id,
+        workspace_path=Path(f"/tmp/{session_id}"),
+    )
+
+
+def _backend() -> SandboxBackend:
+    backend = MagicMock(spec=SandboxBackend)
+    backend.destroy = AsyncMock(return_value=None)
+    backend.name = "stub"
+    return backend
+
+
+def _echo(store_id: str, name: str) -> MemoryStoreResourceEcho:
+    return MemoryStoreResourceEcho(
+        memory_store_id=store_id,
+        access="read_write",
+        instructions="",
+        name=name,
+        description="",
+        mount_path=f"/mnt/memory/{name}",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_caches() -> Any:
+    """Clear the module-level caches between tests so leak from one
+    test can't make another's assertion incidentally pass."""
+    runtime._session_memory_mounts.clear()
+    runtime._session_read_shas.clear()
+    yield
+    runtime._session_memory_mounts.clear()
+    runtime._session_read_shas.clear()
+
+
+async def test_release_clears_session_memory_mounts() -> None:
+    """A session's ``runtime._session_memory_mounts`` entry must be gone
+    after ``SandboxRegistry.release(session_id)`` runs."""
+    registry = SandboxRegistry(_backend())
+    sid = "sess_mount_test"
+    registry._handles[sid] = _handle(sid)
+
+    echo = _echo("ms_x", "store-x")
+    runtime.set_session_memory_mounts(sid, [echo])
+    assert runtime.get_session_memory_mounts(sid) == [echo]
+
+    await registry.release(sid)
+
+    assert runtime.get_session_memory_mounts(sid) == [], (
+        "release() should have cleared the session's memory-mounts cache; "
+        "the entry persists across the worker's lifetime → unbounded growth"
+    )
+
+
+async def test_release_clears_session_read_shas() -> None:
+    """A session's ``runtime._session_read_shas`` entry must be gone
+    after ``SandboxRegistry.release(session_id)`` runs."""
+    registry = SandboxRegistry(_backend())
+    sid = "sess_shas_test"
+    registry._handles[sid] = _handle(sid)
+
+    runtime.set_read_sha(sid, "store_a", "/path/a", "sha_a")
+    assert runtime.get_read_sha(sid, "store_a", "/path/a") == "sha_a"
+
+    await registry.release(sid)
+
+    assert runtime.get_read_sha(sid, "store_a", "/path/a") is None, (
+        "release() should have cleared the session's read-sha cache; "
+        "the entry persists across the worker's lifetime → unbounded growth"
+    )
+
+
+async def test_release_does_not_disturb_other_sessions_caches() -> None:
+    """Releasing session A must not affect session B's cache entries."""
+    registry = SandboxRegistry(_backend())
+    registry._handles["sess_a"] = _handle("sess_a")
+    registry._handles["sess_b"] = _handle("sess_b")
+
+    echo_a = _echo("ms_a", "store-a")
+    echo_b = _echo("ms_b", "store-b")
+    runtime.set_session_memory_mounts("sess_a", [echo_a])
+    runtime.set_session_memory_mounts("sess_b", [echo_b])
+    runtime.set_read_sha("sess_a", "store", "/p", "sha_a")
+    runtime.set_read_sha("sess_b", "store", "/p", "sha_b")
+
+    await registry.release("sess_a")
+
+    assert runtime.get_session_memory_mounts("sess_a") == []
+    assert runtime.get_session_memory_mounts("sess_b") == [echo_b]
+    assert runtime.get_read_sha("sess_a", "store", "/p") is None
+    assert runtime.get_read_sha("sess_b", "store", "/p") == "sha_b"


### PR DESCRIPTION
## Summary

- `aios.harness.runtime` holds two worker-process globals keyed on `session_id` — `_session_memory_mounts` and `_session_read_shas` — populated at the top of every step (`loop.py:87`) and read by tool calls. Paired `clear_session_*` helpers were defined and documented as "after session unload" but **production never called them** (audit confirmed: only test callers via repo-wide grep). Every session that ran a step left an entry that persisted for the worker's process lifetime — slow unbounded growth across long-running workers handling many sessions.
- Fix: in `SandboxRegistry.release()` — the natural "session unloads from this worker" event triggered by idle TTL reaper, `release_if_mounts_changed`, and worker shutdown — clear the runtime caches keyed on the released session. Re-populated naturally by the next step if the session wakes back up.
- Cleanup is sequenced **before** `backend.destroy` so the "registry says unloaded ⇒ runtime caches cleared" invariant holds even when destroy raises (Docker hiccup).
- Deferred import of `aios.harness.runtime` matches existing pattern at `_provision_with_span` (line 191); the runtime module lists `aios.sandbox.registry` under `TYPE_CHECKING`, so a top-level import would create a runtime cycle.

## Reviewer-driven scope (per broken-windows policy)

- **[78]** `release_if_mounts_changed` now delegates to `self.release()` instead of duplicating the teardown body inline (6 lines saved; tightens "release is the single unload event" to a real invariant).
- **[72]** `evict()` now also clears the read-sha cache so a fresh sandbox doesn't serve a stale precondition match against a different container's file state. Memory mounts cleared too for symmetry.
- **[85]** Docstring rewritten to drop a factually wrong "only place" claim — `aios.sandbox` already has multiple deferred imports of `aios.harness.runtime`; this is the established pattern, not an exception.

## Test plan

- [x] New `tests/unit/test_sandbox_runtime_cache_cleanup.py` — three tests with stubbed backend:
  - `test_release_clears_session_memory_mounts`
  - `test_release_clears_session_read_shas`
  - `test_release_does_not_disturb_other_sessions_caches` (regression guard)
- [x] mypy — clean
- [x] ruff + format-check — clean
- [x] Unit suite — 1237 passed (1234 prior + 3 new)
- [ ] CI runs e2e/integration suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. Three sev ≥ 70 findings applied. Sub-70 notes (per project memory: post all findings):

- **[55] Cleanup vs destroy ordering** — reviewer confirmed the current order (cleanup before destroy) is correct: a half-finished release shouldn't leave stale per-session caches pretending the session is still live. Locked the rationale in a docstring note.
- **[40] Tests reach into `_handles` directly** — three tests targeting `release()` in isolation; if `_handles` is renamed the tests would silently miss real bugs. Acceptable for the small surface area.
- **[30] No test for "release with no cached handle"** — would codify the "cleanup runs even when handle was never set" invariant. Optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)