### PR TITLE
fix(api): constrain limit param on all paginated list endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -873,6 +873,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -1183,6 +1185,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -1460,6 +1464,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -1700,6 +1706,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -2669,6 +2677,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
               "default": 200,
               "title": "Limit"
             }
@@ -3010,6 +3020,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -3271,6 +3283,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -3473,6 +3487,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -3865,6 +3881,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -4285,6 +4303,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 100,
               "title": "Limit"
             }
@@ -4981,6 +5001,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 100,
               "title": "Limit"
             }
@@ -5293,6 +5315,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -6011,6 +6035,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -6934,6 +6960,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }

--- a/src/aios/api/routers/agents.py
+++ b/src/aios/api/routers/agents.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
+from typing import Annotated
+
+from fastapi import APIRouter, Query, status
 
 from aios.api.deps import AuthDep, PoolDep
 from aios.models.agents import Agent, AgentCreate, AgentUpdate, AgentVersion
@@ -41,7 +43,7 @@ async def create(body: AgentCreate, pool: PoolDep, _auth: AuthDep) -> Agent:
 async def list_(
     pool: PoolDep,
     _auth: AuthDep,
-    limit: int = 50,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
     name: str | None = None,
 ) -> ListResponse[Agent]:
@@ -115,7 +117,7 @@ async def list_versions(
     agent_id: str,
     pool: PoolDep,
     _auth: AuthDep,
-    limit: int = 50,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: int | None = None,
 ) -> ListResponse[AgentVersion]:
     """List historical versions of an agent, newest first.

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -13,7 +13,9 @@ strand the template a per_chat binding spawns from).
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
+from typing import Annotated
+
+from fastapi import APIRouter, Query, status
 
 from aios.api.deps import AuthDep, CryptoBoxDep, PoolDep
 from aios.models.common import ListResponse
@@ -94,7 +96,7 @@ async def list_(
     connector: str | None = None,
     session_id: str | None = None,
     mode: ConnectionMode | None = None,
-    limit: int = 50,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[Connection]:
     """List connections, newest first, excluding archived. Cursor pagination via ``after``.
@@ -273,7 +275,7 @@ async def recent_chats(
     connection_id: str,
     pool: PoolDep,
     _auth: AuthDep,
-    limit: int = 50,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
 ) -> ListResponse[RecentChat]:
     """List chats that recently sent inbound on this connection, newest first.
 

--- a/src/aios/api/routers/environments.py
+++ b/src/aios/api/routers/environments.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
+from typing import Annotated
+
+from fastapi import APIRouter, Query, status
 
 from aios.api.deps import AuthDep, PoolDep
 from aios.models.common import ListResponse
@@ -31,7 +33,7 @@ async def create(body: EnvironmentCreate, pool: PoolDep, _auth: AuthDep) -> Envi
 async def list_(
     pool: PoolDep,
     _auth: AuthDep,
-    limit: int = 50,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[Environment]:
     """List environments, newest first, excluding archived.

--- a/src/aios/api/routers/memory_stores.py
+++ b/src/aios/api/routers/memory_stores.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
+from typing import Annotated
+
+from fastapi import APIRouter, Query, status
 
 from aios.api.deps import AuthDep, PoolDep
 from aios.models.common import ListResponse
@@ -47,7 +49,7 @@ async def list_stores(
     pool: PoolDep,
     _auth: AuthDep,
     include_archived: bool = False,
-    limit: int = 100,
+    limit: Annotated[int, Query(ge=1, le=200)] = 100,
 ) -> ListResponse[MemoryStore]:
     """List memory stores, newest first.
 
@@ -254,7 +256,7 @@ async def list_versions(
     pool: PoolDep,
     _auth: AuthDep,
     memory_id: str | None = None,
-    limit: int = 100,
+    limit: Annotated[int, Query(ge=1, le=200)] = 100,
 ) -> ListResponse[MemoryVersion]:
     """List memory versions in a store, newest first.
 

--- a/src/aios/api/routers/session_templates.py
+++ b/src/aios/api/routers/session_templates.py
@@ -10,7 +10,9 @@ will fail at the inbound handler until the connection is reconfigured.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
+from typing import Annotated
+
+from fastapi import APIRouter, Query, status
 
 from aios.api.deps import AuthDep, PoolDep
 from aios.db.queries import _UNSET
@@ -52,7 +54,7 @@ async def create(body: SessionTemplateCreate, pool: PoolDep, _auth: AuthDep) -> 
 async def list_(
     pool: PoolDep,
     _auth: AuthDep,
-    limit: int = 50,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[SessionTemplate]:
     """List session templates, newest first, excluding archived.

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -99,7 +99,7 @@ async def list_(
         SessionStatus | None,
         Query(alias="status"),
     ] = None,
-    limit: int = 50,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[Session]:
     account_id, _, _ = _auth
@@ -449,7 +449,11 @@ async def list_events(
     _auth: AuthDep,
     after: int = 0,
     kind: EventKind | None = None,
-    limit: int = 200,
+    # Higher cap than the standard 200: operators paginate through full
+    # session event logs via ``aios sessions events`` (one page per
+    # request), and a 200-row cap would multiply round-trip count by 2.5x
+    # for any meaningful session. 500 is the audit-recommended ceiling.
+    limit: Annotated[int, Query(ge=1, le=500)] = 200,
     error_only: bool = False,
 ) -> ListResponse[Event]:
     """List events for a session, paginated by sequence number.

--- a/src/aios/api/routers/skills.py
+++ b/src/aios/api/routers/skills.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
+from typing import Annotated
+
+from fastapi import APIRouter, Query, status
 
 from aios.api.deps import AuthDep, PoolDep
 from aios.models.common import ListResponse
@@ -35,7 +37,7 @@ async def create(body: SkillCreate, pool: PoolDep, _auth: AuthDep) -> Skill:
 async def list_(
     pool: PoolDep,
     _auth: AuthDep,
-    limit: int = 50,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[Skill]:
     """List skills (latest version of each), newest first, excluding archived.
@@ -99,7 +101,7 @@ async def list_versions(
     skill_id: str,
     pool: PoolDep,
     _auth: AuthDep,
-    limit: int = 50,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: int | None = None,
 ) -> ListResponse[SkillVersion]:
     """List historical versions of a skill, newest first.

--- a/src/aios/api/routers/vaults.py
+++ b/src/aios/api/routers/vaults.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
+from typing import Annotated
+
+from fastapi import APIRouter, Query, status
 
 from aios.api.deps import AuthDep, CryptoBoxDep, PoolDep
 from aios.models.common import ListResponse
@@ -38,7 +40,7 @@ async def create(body: VaultCreate, pool: PoolDep, _auth: AuthDep) -> Vault:
 async def list_(
     pool: PoolDep,
     _auth: AuthDep,
-    limit: int = 50,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[Vault]:
     """List vaults, newest first, excluding archived.
@@ -145,7 +147,7 @@ async def list_credentials(
     vault_id: str,
     pool: PoolDep,
     _auth: AuthDep,
-    limit: int = 50,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[VaultCredential]:
     """List credentials in a vault, newest first, excluding archived.

--- a/src/aios/models/common.py
+++ b/src/aios/models/common.py
@@ -4,20 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
-
-
-class Pagination(BaseModel):
-    """Standard cursor-paginated query parameters.
-
-    `after` is the id of the last item from the previous page (for keyset
-    pagination); `limit` caps page size.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    limit: int = Field(default=50, ge=1, le=200)
-    after: str | None = None
+from pydantic import BaseModel
 
 
 class ListResponse[T](BaseModel):

--- a/tests/e2e/test_pagination_limit_validation.py
+++ b/tests/e2e/test_pagination_limit_validation.py
@@ -1,0 +1,125 @@
+"""E2E test: every list endpoint rejects out-of-range ``?limit=`` values.
+
+Pre-fix: every paginated route declared ``limit: int = N`` with no
+Pydantic constraints. Three symptoms:
+
+* ``?limit=0`` returned ``has_more=True, data=[]`` (the standard
+  ``has_more=len(items) == limit`` shortcut evaluated to ``0 == 0``
+  → ``True``; clients that loop on ``has_more`` without null-checking
+  ``next_after`` would spin).
+* ``?limit=-1`` reached Postgres as ``LIMIT -1`` → ``asyncpg`` raised
+  ``InvalidRowCountInLimitClauseError`` → unhandled 500.
+* No upper bound — a single client request could pull unbounded rows
+  (DoS surface; one request fetching ~1 GB of event data).
+
+Fix: every paginated route now declares
+``limit: Annotated[int, Query(ge=1, le=200)]`` (or ``le=500`` for the
+events endpoint). Pydantic / FastAPI rejects at the request boundary
+with 422; the routes never see invalid values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+
+import httpx
+import pytest
+
+from tests.helpers.connections import authed_client
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    settings = get_settings()
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    transport = httpx.ASGITransport(app=app)
+    async with authed_client(
+        "http://testserver",
+        aios_env["AIOS_API_KEY"],
+        transport=transport,
+    ) as client:
+        yield client
+
+
+# Path-free GET-list endpoints. Excludes endpoints that need an existing
+# session_id / store_id (events list, memories list, etc.) — those go
+# through the same Pydantic validation, the path-free set is enough to
+# pin the contract that the validation is uniformly applied.
+_LIST_PATHS = [
+    "/v1/agents",
+    "/v1/sessions",
+    "/v1/skills",
+    "/v1/environments",
+    "/v1/vaults",
+    "/v1/connections",
+    "/v1/memory-stores",
+    "/v1/session-templates",
+]
+
+
+class TestPaginationLimitValidation:
+    @pytest.mark.parametrize("path", _LIST_PATHS)
+    async def test_limit_zero_rejected_with_422(
+        self, http_client: httpx.AsyncClient, path: str
+    ) -> None:
+        r = await http_client.get(path, params={"limit": 0})
+        assert r.status_code == 422, (
+            f"{path}?limit=0 should reject with 422 (Pydantic Field ge=1); "
+            f"got {r.status_code} body={r.text[:200]}"
+        )
+
+    @pytest.mark.parametrize("path", _LIST_PATHS)
+    async def test_limit_negative_rejected_with_422(
+        self, http_client: httpx.AsyncClient, path: str
+    ) -> None:
+        r = await http_client.get(path, params={"limit": -1})
+        assert r.status_code == 422, (
+            f"{path}?limit=-1 should reject with 422 (Pydantic Field ge=1); "
+            f"got {r.status_code} body={r.text[:200]} — without the "
+            f"constraint the value reaches Postgres as ``LIMIT -1`` and "
+            f"raises asyncpg.InvalidRowCountInLimitClauseError → 500"
+        )
+
+    @pytest.mark.parametrize("path", _LIST_PATHS)
+    async def test_limit_over_max_rejected_with_422(
+        self, http_client: httpx.AsyncClient, path: str
+    ) -> None:
+        r = await http_client.get(path, params={"limit": 201})
+        assert r.status_code == 422, (
+            f"{path}?limit=201 should reject with 422 (Pydantic Field le=200); "
+            f"got {r.status_code} body={r.text[:200]} — without the cap "
+            f"a single request can pull unbounded rows (DoS surface)"
+        )
+
+    @pytest.mark.parametrize("path", _LIST_PATHS)
+    async def test_limit_at_default_works(self, http_client: httpx.AsyncClient, path: str) -> None:
+        """Regression guard: omitting limit (default) succeeds."""
+        r = await http_client.get(path)
+        assert r.status_code == 200, (
+            f"{path} default-limit request should succeed; got {r.status_code} body={r.text[:200]}"
+        )
+        body = r.json()
+        assert "data" in body
+        assert isinstance(body["data"], list)


### PR DESCRIPTION
## Summary

- Every paginated GET-list endpoint declared `limit: int = N` with no Pydantic constraints. Three distinct symptoms unified by one fix:
  1. **`?limit=0`** returned `has_more=True, data=[]` — `has_more=len(items) == limit` evaluated to `0 == 0` → True, so clients looping on `has_more` without null-checking `next_after` would spin.
  2. **`?limit=-1`** reached Postgres as `LIMIT -1` → `asyncpg.InvalidRowCountInLimitClauseError` → unhandled HTTP 500 with a raw DB stack trace.
  3. **No upper bound** — a single client request could pull unbounded rows. The events endpoint with ~1 GB of JSONB event payloads made this a real DoS surface.
- Route-hygiene sweep across all 14 paginated sites in 8 router files (per memory `feedback_phase_a_pile_onto_one_pr.md`): `limit: int = N` → `limit: Annotated[int, Query(ge=1, le=200)] = N`. Existing defaults preserved (50, 100, 200). The events endpoint gets `le=500` for operator log-scanning use case via `aios sessions events` — audit-recommended.
- `openapi.json` regenerated via `scripts/regen-openapi.sh`. The orphan `Pagination` model in `src/aios/models/common.py` deleted (reviewer-flagged at sev 72; grep-confirmed zero imports project-wide).

## Test plan

- [x] New `tests/e2e/test_pagination_limit_validation.py` — 32 parametrized tests across 8 path-free GET-list endpoints × 4 scenarios:
  - `test_limit_zero_rejected_with_422`
  - `test_limit_negative_rejected_with_422`
  - `test_limit_over_max_rejected_with_422`
  - `test_limit_at_default_works` (regression guard)
- [x] mypy — clean
- [x] ruff + format-check — clean
- [x] Unit suite — 1237 passed (includes regenerated OpenAPI snapshot)
- [x] Integration suite — 22 passed
- [x] New e2e suite — 32 passed
- [ ] CI runs e2e/integration suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. Three sev ≥ 70 findings applied:

- **[80] Dead `_uniq = secrets.token_hex` line and unused `secrets` import** — removed (vulture isn't configured in the project; the "quiet vulture" comment was misleading).
- **[72] Orphan `Pagination` model in `models/common.py`** — deleted per CLAUDE.md "don't deprecate, delete." Grep confirmed zero imports project-wide. The inline `Annotated[int, Query(...)]` pattern preserves per-endpoint defaults (50/100/200) cleanly without dependency-injection plumbing, so the model was never going to find a use.
- **[35] Missing rationale comment on events 500-cap** — added a one-line comment explaining the higher cap for log-scanning use case.

Sub-70 calibration note (per project memory: post all findings):

- **[28] Tests don't check error body shape** — tests assert status 422 only, not that the error envelope conforms to `ErrorResponse` `{"error": {"type": ..., "message": ...}}`. The status code is the load-bearing assertion; body-shape testing is a separate concern that would need a dedicated test class. Deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)