### PR TITLE
fix(connectors): reject non-dict JSON in _parse_form_json

### DIFF
--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -93,24 +93,36 @@ _DEFAULT_ATTACHMENT_CONTENT_TYPE = "application/octet-stream"
 
 
 def _parse_form_json(field: str, raw: str | None, *, default: Any = None) -> Any:
-    """Decode an optional JSON-in-multipart-form field.
+    """Decode an optional JSON-in-multipart-form field that must be a dict.
 
     Multipart form values are always text; we expose ``sender`` and
     ``metadata`` as JSON-encoded strings so connector clients keep the
     shape the JSON inbound used (with JSON dicts) without hand-rolled
     field-flattening on either side. Raises :class:`ValidationError` on
-    bad JSON so connector authors see the parse error in the response,
-    not a 500.
+    bad JSON OR on a JSON value that decoded to something other than
+    a dict — downstream code (``_do_inbound`` and on into
+    ``services.inbound.handle_inbound``) drills into the value with
+    ``.get(...)``, so a list/scalar/null would crash at runtime as a
+    500 AND poison the connector's retry loop (the ``event_id`` never
+    reaches ``try_record_inbound_ack`` because the inbound flow dies
+    before the dedup write). Rejecting at the boundary keeps the
+    connector author's mistake visible as a 4xx.
     """
     if raw is None:
         return default
     try:
-        return json.loads(raw)
+        parsed = json.loads(raw)
     except json.JSONDecodeError as err:
         raise ValidationError(
             f"{field!r} must be a JSON-encoded string",
             detail={"field": field, "error": str(err)},
         ) from err
+    if not isinstance(parsed, dict):
+        raise ValidationError(
+            f"{field!r} must decode to a JSON object",
+            detail={"field": field, "actual_type": type(parsed).__name__},
+        )
+    return parsed
 
 
 async def _do_inbound(

--- a/tests/unit/test_parse_form_json.py
+++ b/tests/unit/test_parse_form_json.py
@@ -1,0 +1,82 @@
+"""Unit coverage for ``_parse_form_json`` at the connector inbound boundary.
+
+Pre-fix: ``_parse_form_json`` (``api/routers/connectors.py:95``) returned
+``Any`` from ``json.loads`` with no shape validation. Both call sites
+(``sender_json`` and ``metadata_json`` in ``_do_inbound`` at lines 137-138)
+typed the result as ``dict[str, Any]`` but the function happily returned
+lists, scalars, or even ``None`` for an explicit JSON ``null``. A
+connector posting ``sender='[1,2,3]'`` to ``POST /v1/connectors/runtime/
+inbound`` produced a runtime ``AttributeError`` at
+``services/inbound.py:177`` (``sender.get("display_name")``) → HTTP 500.
+
+Worse: the ``event_id`` never reached ``try_record_inbound_ack``
+(the inbound flow crashes before the dedup write), so the connector's
+retry mechanism would loop forever on the same poisoned event_id,
+permanently freezing inbound for that chat.
+
+Same anti-pattern as PR #446 (attachments validation): ``Any`` at the
+wire boundary lets arbitrary shapes through; downstream code that
+assumes ``dict`` crashes. This unit fixes the same shape at the
+JSON-form-parse boundary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.api.routers.connectors import _parse_form_json
+from aios.errors import ValidationError
+
+
+class TestParseFormJson:
+    def test_dict_json_passes_through(self) -> None:
+        assert _parse_form_json("sender", '{"display_name": "Alice"}') == {"display_name": "Alice"}
+
+    def test_empty_dict_json_returns_empty_dict(self) -> None:
+        assert _parse_form_json("sender", "{}") == {}
+
+    def test_none_returns_default(self) -> None:
+        # None input (form field absent) → caller's default.
+        assert _parse_form_json("sender", None) is None
+        assert _parse_form_json("sender", None, default={}) == {}
+
+    def test_malformed_json_raises(self) -> None:
+        # Regression guard: existing JSONDecodeError branch still raises.
+        with pytest.raises(ValidationError) as exc_info:
+            _parse_form_json("sender", "{not valid json}")
+        assert exc_info.value.detail["field"] == "sender"
+
+    def test_json_array_rejected(self) -> None:
+        """A JSON array at a dict-shaped field must raise, not pass through."""
+        with pytest.raises(ValidationError) as exc_info:
+            _parse_form_json("sender", "[1, 2, 3]")
+        assert exc_info.value.detail["field"] == "sender"
+
+    def test_json_scalar_rejected(self) -> None:
+        """A JSON scalar (number) must raise, not pass through."""
+        with pytest.raises(ValidationError) as exc_info:
+            _parse_form_json("sender", "42")
+        assert exc_info.value.detail["field"] == "sender"
+
+    def test_json_string_rejected(self) -> None:
+        """A JSON string (not an object) must raise, not pass through."""
+        with pytest.raises(ValidationError) as exc_info:
+            _parse_form_json("sender", '"just a string"')
+        assert exc_info.value.detail["field"] == "sender"
+
+    def test_json_null_rejected(self) -> None:
+        """A JSON ``null`` at a dict-shaped field must raise.
+
+        ``None`` (Python) means "field absent" and returns the default;
+        ``"null"`` (JSON literal) is a wire value that decoded to None —
+        the connector explicitly sent it, so it's a contract violation
+        rather than absence.
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            _parse_form_json("sender", "null")
+        assert exc_info.value.detail["field"] == "sender"
+
+    def test_json_boolean_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            _parse_form_json("metadata", "true")
+        assert exc_info.value.detail["field"] == "metadata"


### PR DESCRIPTION
## Summary

- `_parse_form_json` (`src/aios/api/routers/connectors.py:95`) decoded the `sender` and `metadata` multipart form fields with `json.loads` and returned the raw parsed value as `Any`. Both call sites at `:149-150` typed it as `dict[str, Any]`, but a connector posting `sender='[1,2,3]'` (JSON array) or `sender='null'` produced a list / None at runtime. `services/inbound.py:177` then crashes on `sender.get("display_name")` → `AttributeError` → HTTP 500.
- **The crash precedes `try_record_inbound_ack`** at `services/inbound.py:200`, so the connector's retry loop hammers the same poisoned event_id forever — permanent inbound freeze for that chat. Reviewer traced and confirmed: line 177 (`sender.get`) runs at lines 177-188 *before* the dedup write at line 200, so the ack row never lands.
- Same anti-pattern as PR #446 (`_apply_attachments` non-dict element validation): `Any` at the wire boundary lets arbitrary shapes through; downstream `.get()`-style access crashes. Fix at the same altitude — add `isinstance(parsed, dict)` check inside `_parse_form_json`, raise `ValidationError` on mismatch with the actual type name in `detail` so connector authors get an actionable 422 instead of a poisoned-retry 500.

## Test plan

- [x] New `tests/unit/test_parse_form_json.py` — 9 tests pin the contract:
  - Happy path: dict JSON, empty dict, None→default
  - Existing JSONDecodeError branch still raises (regression guard)
  - Array, scalar number, string, null, boolean each rejected with descriptive `ValidationError(field, actual_type)`
- [x] mypy — clean
- [x] ruff + format-check — clean
- [x] Unit suite — 1246 passed (1237 prior + 9 new)
- [ ] CI runs e2e/integration suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. **No actionable findings.** Reviewer verified the trace from form-parse → crash precedes dedup write, confirmed `ValidationError → 422` is the correct mapping, confirmed `detail.actual_type` field leaks only Python type names (no internal data), and grepped `routers/connectors.py` for sibling instances of the anti-pattern — found none in connector-supplied paths (the other `.get()` sites operate on already-validated internal data).

Sub-90 calibrations:

- **[88] Boundary placement is correct** — both call sites need dicts, centralizing the check matches the function's effective contract.
- **[84] Premature generality non-issue** — YAGNI; if a list-shaped form field ever appears, refactor then (rename + `expected_type` param is a 10-line diff).
- **[82] Nested-dict acceptance** — not explicitly asserted, but `isinstance(parsed, dict)` is unambiguous; skip per "no belt-and-suspenders without sign-off".
- **[81] `detail.actual_type` exposure** — only Python type names ("list", "int", "str", "NoneType"), safe for connector author debugging.
- **[80] Poisoned-retry-loop claim** — reviewer traced and confirmed accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)