### PR TITLE
fix(telegram): distinct inbound event_id for edited messages

### DIFF
--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -225,14 +225,30 @@ class TelegramConnector(HttpConnector):
         }
         metadata = build_metadata(msg, state.bot_id)
         attachments = await self._download_attachments(state, msg.attachments)
+        # Telegram's (chat_id, message_id) pair is the platform's
+        # canonical message identity; feeding it as ``event_id`` lets
+        # aios's ``inbound_acks`` dedupe a redelivered update after a
+        # runtime restart (PTB's offset rewinds replay unread updates
+        # the new container also sees). But Telegram PRESERVES
+        # message_id across edits — an edit arrives as a fresh update
+        # with the same id — so a naive (chat_id, message_id) event_id
+        # makes every edit collide with the original and get silently
+        # dropped by the dedup ledger, contradicting the documented
+        # contract (prompts.py: "Edits arrive as a fresh inbound").
+        # Suffix the edit timestamp so each revision is a distinct
+        # inbound; non-edited messages keep the bare id, preserving the
+        # restart-redelivery dedup property for the common case.
+        # Ceiling: Telegram's edit_date is second-resolution, so two
+        # edits of the same message within one wall-clock second still
+        # collide and the second is dedup-dropped. That's the platform's
+        # observability limit (no finer timestamp is exposed), not a
+        # fixable gap here.
+        event_id = f"telegram-{msg.chat_id}-{msg.message_id}"
+        if msg.edit_date_ms is not None:
+            event_id = f"{event_id}-e{msg.edit_date_ms}"
         await self.emit_inbound(
             connection_id=connection_id,
-            # Telegram's (chat_id, message_id) pair is the platform's
-            # canonical message identity; feeding it as ``event_id``
-            # lets aios's ``inbound_acks`` dedupe a redelivered update
-            # after a runtime restart (PTB's offset rewinds replay
-            # unread updates the new container also sees).
-            event_id=f"telegram-{msg.chat_id}-{msg.message_id}",
+            event_id=event_id,
             chat_id=str(msg.chat_id),
             sender=sender_payload,
             content=msg.text,

--- a/connectors/telegram/src/aios_telegram/parse.py
+++ b/connectors/telegram/src/aios_telegram/parse.py
@@ -47,6 +47,11 @@ class InboundMessage:
     attachments: tuple[Attachment, ...]
     reply: Reply | None
     edited: bool = False
+    # Epoch-ms of the most recent edit, or None if never edited. Telegram
+    # preserves message_id across edits, so this is the only field that
+    # distinguishes one edit revision from another (and from the
+    # original) — load-bearing for inbound event_id uniqueness.
+    edit_date_ms: int | None = None
     # Emoji that came with a sticker, when the inbound was a sticker.
     # Sometimes the sticker file is non-vision-readable (animated/video),
     # and the emoji is the only text-side cue the model gets.
@@ -217,6 +222,9 @@ def parse_message(message: Message, *, bot_id: int) -> InboundMessage | None:
         attachments=attachments,
         reply=reply,
         edited=message.edit_date is not None,
+        edit_date_ms=(
+            int(message.edit_date.timestamp() * 1000) if message.edit_date is not None else None
+        ),
         sticker_emoji=sticker_emoji,
     )
 

--- a/connectors/telegram/tests/test_inbound_event_id.py
+++ b/connectors/telegram/tests/test_inbound_event_id.py
@@ -1,0 +1,145 @@
+"""An edited Telegram message must NOT collide with the original's event_id.
+
+``_emit_message`` (``connector.py:235``) built
+``event_id=f"telegram-{chat_id}-{message_id}"``. Telegram preserves
+``message_id`` across edits (it delivers an ``edited_message`` update
+with the same id), so an edit produced the SAME ``event_id`` as the
+original. aios's ``inbound_acks`` table dedups on
+``(connector, account, event_id)`` → the edit is rejected as a replay
+and its content is silently dropped.
+
+This directly contradicts the connector's own system prompt
+(``prompts.py:149``): "Edits arrive as a fresh inbound with
+``metadata.edited == True`` — the ``message_id`` is the same as the
+original message ... and the body is the new (post-edit) text." The
+model is told to expect edits; the dedup layer silently eats them.
+
+The fix threads the edit timestamp into the event_id so each edit
+revision is a distinct inbound, while a non-edited message keeps its
+original event_id (preserving the redelivery-dedup-after-restart
+property the original comment describes).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from telegram import Bot, Message
+
+from aios_telegram.parse import parse_message
+from tests.conftest import CONNECTION_ID
+
+
+@pytest.fixture
+def bot() -> Any:
+    """Minimal mocked PTB Bot — the ``connector`` fixture wires this in.
+
+    ``_emit_message`` for a text message (no attachments) never touches
+    the bot, so a bare MagicMock suffices."""
+    return MagicMock()
+
+
+def _msg(ptb_bot: Bot, *, edit_date: int | None) -> Message:
+    """A DM text message with a fixed message_id; ``edit_date`` toggles
+    whether it's the original or an edit of that same message."""
+    data: dict[str, Any] = {
+        "message_id": 730,
+        "date": 1700000030,
+        "chat": {"id": 123456789, "type": "private"},
+        "from": {"id": 123456789, "is_bot": False, "first_name": "Alice"},
+        "text": "fixed typo" if edit_date else "fixd typo",
+    }
+    if edit_date is not None:
+        data["edit_date"] = edit_date
+    parsed = Message.de_json(data, ptb_bot)
+    assert parsed is not None
+    return parsed
+
+
+async def test_edit_does_not_collide_with_original_event_id(
+    connector: Any, ptb_bot: Bot, bot_id: int
+) -> None:
+    """Original + edit of the same message_id must emit distinct event_ids."""
+    original = parse_message(_msg(ptb_bot, edit_date=None), bot_id=bot_id)
+    edited = parse_message(_msg(ptb_bot, edit_date=1700000040), bot_id=bot_id)
+    assert original is not None and edited is not None
+    # Telegram preserves message_id across edits — this is exactly why
+    # the naive (chat_id, message_id) event_id collides.
+    assert original.message_id == edited.message_id
+
+    captured: list[str | None] = []
+
+    async def _fake_emit(**kwargs: Any) -> None:
+        captured.append(kwargs.get("event_id"))
+        return None
+
+    state = connector.state[CONNECTION_ID]
+    with patch.object(connector, "emit_inbound", side_effect=_fake_emit):
+        await connector._emit_message(CONNECTION_ID, state, original)
+        await connector._emit_message(CONNECTION_ID, state, edited)
+
+    assert captured[0] is not None and captured[1] is not None
+    assert captured[0] != captured[1], (
+        f"edit emitted the same event_id as the original "
+        f"({captured[0]!r}); aios inbound_acks dedups on "
+        f"(connector, account, event_id) so the edit is silently "
+        f"dropped — contradicting the prompts.py:149 contract that the "
+        f"model is told to rely on"
+    )
+
+
+async def test_two_successive_edits_get_distinct_event_ids(
+    connector: Any, ptb_bot: Bot, bot_id: int
+) -> None:
+    """Edit #1 and edit #2 of the same message must also differ — a
+    single ``edited: bool`` flag couldn't disambiguate them; the edit
+    *timestamp* is what makes each revision a distinct inbound."""
+    edit1 = parse_message(_msg(ptb_bot, edit_date=1700000040), bot_id=bot_id)
+    edit2 = parse_message(_msg(ptb_bot, edit_date=1700000055), bot_id=bot_id)
+    assert edit1 is not None and edit2 is not None
+
+    captured: list[str | None] = []
+
+    async def _fake_emit(**kwargs: Any) -> None:
+        captured.append(kwargs.get("event_id"))
+        return None
+
+    state = connector.state[CONNECTION_ID]
+    with patch.object(connector, "emit_inbound", side_effect=_fake_emit):
+        await connector._emit_message(CONNECTION_ID, state, edit1)
+        await connector._emit_message(CONNECTION_ID, state, edit2)
+
+    assert captured[0] != captured[1], (
+        f"two successive edits of one message emitted the same "
+        f"event_id ({captured[0]!r}); the second edit is silently "
+        f"dropped by inbound_acks dedup"
+    )
+
+
+async def test_non_edited_message_keeps_stable_event_id(
+    connector: Any, ptb_bot: Bot, bot_id: int
+) -> None:
+    """Regression guard: a non-edited message's event_id must stay
+    ``telegram-{chat_id}-{message_id}`` so a redelivered update after a
+    runtime restart still dedups (the property the original comment at
+    connector.py:230-234 documents)."""
+    msg = parse_message(_msg(ptb_bot, edit_date=None), bot_id=bot_id)
+    assert msg is not None
+
+    captured: list[str | None] = []
+
+    async def _fake_emit(**kwargs: Any) -> None:
+        captured.append(kwargs.get("event_id"))
+        return None
+
+    state = connector.state[CONNECTION_ID]
+    with patch.object(connector, "emit_inbound", side_effect=_fake_emit):
+        await connector._emit_message(CONNECTION_ID, state, msg)
+
+    assert captured[0] == f"telegram-{msg.chat_id}-{msg.message_id}", (
+        f"non-edited message event_id changed to {captured[0]!r}; this "
+        f"breaks redelivery dedup across runtime restarts for the "
+        f"common (unedited) case"
+    )


### PR DESCRIPTION
## Summary

- `TelegramConnector._emit_message` built `event_id=f"telegram-{chat_id}-{message_id}"`. Telegram preserves `message_id` across edits (an edit arrives as an `edited_message` update with the same id), so an edit produced the **same** event_id as the original. aios's `inbound_acks` table dedups on `(connector, account, event_id)` → the edit was rejected as a replay and **its content silently dropped**.
- This directly contradicts the connector's own system prompt (`prompts.py:149`): "Edits arrive as a fresh inbound with `metadata.edited == True` ... and the body is the new (post-edit) text." The model is explicitly told to expect edits; the dedup layer ate them.
- Fix threads the edit timestamp into the event_id: `parse.py` adds `edit_date_ms: int | None` to `InboundMessage`; `connector.py` appends `-e{edit_date_ms}` to the event_id **only when the message was edited**. Non-edited messages keep the bare `telegram-{chat_id}-{message_id}` form — preserving the restart-redelivery dedup property the original comment documents and avoiding a deploy-window dup for in-flight unedited messages.
- The existing `edited: bool` flag is kept (it drives the model-facing `metadata.edited`); `edit_date_ms` is dedup-key plumbing. Different questions, correctly separated.

## Test plan

- [x] New `connectors/telegram/tests/test_inbound_event_id.py` — 3 tests:
  - original vs edit of same message_id → distinct event_ids
  - two successive edits (different edit_date) → distinct event_ids
  - non-edited message → event_id stays exactly `telegram-{chat_id}-{message_id}` (restart-redelivery regression guard)
- [x] Telegram connector: `uv run pytest tests/` — 79 passed
- [x] Telegram connector: `uv run mypy src` — clean
- [x] Telegram connector: `uv run ruff check src tests` + format — clean
- [x] Main repo pre-commit (mypy src, ruff, pytest tests/unit 1246) — clean (telegram is a separate workspace package; main tooling unaffected)
- [ ] CI runs the connector + e2e suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. **No critical or important findings.** Reviewer verified the `prompts.py:149` contract claim, confirmed the Signal connector does NOT share the bug (its edit envelope carries the edited content's own root timestamp, so `signal-{sender_uuid}-{timestamp_ms}` already differs per revision — correctly out of scope), confirmed backward-compat across the deploy window, and confirmed the `metadata.edited` vs `edit_date_ms` separation is correct (not redundant).

Sub-70 notes (per project memory: post all findings):

- **[55] Second-resolution `edit_date` ceiling** — Telegram exposes only second-resolution `edit_date`, so two edits of the same message within one wall-clock second still collide and the second is dedup-dropped. This is the platform's observability limit, not a fixable gap. **Applied**: documented the ceiling explicitly in the `connector.py` comment so a future reader doesn't assume edit uniqueness is total.
- **[40] Same-second characterization test** — reviewer suggested a 4th test asserting the same-second collision to document it as intentional. Skipped: a test that pins a platform limitation we'd *want* to improve if Telegram ever exposed finer resolution would over-specify; the caveat comment carries the knowledge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)