### PR TITLE
fix(sandbox): release pipe FDs on the subprocess give-up path

### DIFF
--- a/src/aios/sandbox/_subprocess.py
+++ b/src/aios/sandbox/_subprocess.py
@@ -61,6 +61,15 @@ async def run_subprocess_with_timeout(
                 proc.communicate(), timeout=_DRAIN_AFTER_KILL_TIMEOUT_S
             )
         except (TimeoutError, OSError):
+            # Child wedged in uninterruptible D-state: the SIGKILL above
+            # stays pending until it leaves the syscall, so communicate()
+            # never reaches its pipe-close/reap. The cancelled
+            # communicate() left the parent-side stdout/stderr pipe FDs
+            # open, and the loop only reclaims them on a child-exit EOF
+            # that won't come. Close the transport to free them now —
+            # await proc.wait() would re-introduce the very hang this
+            # branch defends against.
+            proc._transport.close()  # type: ignore[attr-defined]  # typeshed omits Process._transport
             stdout_bytes, stderr_bytes = b"", b""
         return -1, stdout_bytes, stderr_bytes, True
 

--- a/tests/unit/sandbox/test_subprocess.py
+++ b/tests/unit/sandbox/test_subprocess.py
@@ -1,0 +1,69 @@
+"""The double-timeout give-up path must close the subprocess transport.
+
+When the post-SIGKILL drain in ``run_subprocess_with_timeout`` also
+times out (a child wedged in uninterruptible D-state — ``docker``
+against a flapping daemon, ``git`` on a dead mount), the give-up branch
+must close ``proc._transport`` so the cancelled ``communicate()``
+doesn't strand the parent-side stdout/stderr pipe FDs. Every container
+provision and host git-clone funnels through this runner; pre-fix,
+repeated wedges exhaust the worker's FD ceiling and starve both
+connection pools. The mechanism is documented at the fix site in
+``_subprocess.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from aios.sandbox import _subprocess
+from aios.sandbox._subprocess import run_subprocess_with_timeout
+
+
+class _WedgedProc:
+    """A child stuck in D-state: ``communicate()`` never completes and
+    the pending SIGKILL from ``kill()`` never takes effect."""
+
+    def __init__(self) -> None:
+        self.returncode: int | None = None
+        # The sole non-blocking handle to the parent-side pipe FDs.
+        # asyncio.subprocess.Process.kill() also delegates to the
+        # transport, so route kill through the same mock — the fake
+        # can't drift from Process's real kill/_transport coupling.
+        self._transport = MagicMock(name="transport")
+
+    def kill(self) -> None:
+        self._transport.kill()
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        await asyncio.sleep(3600)  # outlives both (tiny) timeouts
+        raise AssertionError("unreachable: communicate must be cancelled")
+
+
+async def test_give_up_path_closes_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Outer drain times out → SIGKILL → inner drain *also* times out.
+
+    The give-up branch must close ``proc._transport`` so the parent-side
+    stdout/stderr pipe FDs are released; otherwise they leak for as long
+    as the wedged child lives (effectively forever under a flapping
+    daemon)."""
+    proc = _WedgedProc()
+
+    async def _fake_spawn(*_argv: Any, **_kwargs: Any) -> _WedgedProc:
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    # Keep the secondary drain tiny so the test is fast and deterministic.
+    monkeypatch.setattr(_subprocess, "_DRAIN_AFTER_KILL_TIMEOUT_S", 0.01)
+
+    rc, out, err, timed_out = await run_subprocess_with_timeout(["docker", "ps"], timeout_s=0.01)
+
+    # The (-1, b"", b"", True) tuple is only reachable after proc.kill()
+    # on the SIGKILL path, so this also pins that we took the give-up
+    # branch rather than the happy or drain-succeeded paths.
+    assert (rc, out, err, timed_out) == (-1, b"", b"", True)
+
+    proc._transport.close.assert_called_once()


### PR DESCRIPTION
## Summary

- `run_subprocess_with_timeout` SIGKILLs on the outer timeout, then runs a bounded secondary `communicate()` drain. When that drain **also** times out — child wedged in uninterruptible **D-state** (`docker` against a flapping daemon, `git` on a dead mount) — the `except (TimeoutError, OSError)` give-up branch returned `(-1, b"", b"", True)` **without closing the subprocess transport**.
- `asyncio.wait_for` cancels `communicate()` before it closes its pipes / reaps; the event loop only reclaims the parent-side stdout/stderr pipe FDs on a child-exit EOF that **never comes** for a D-state child. The function then drops its only `proc` reference, so the FDs leak for the wedge's lifetime. Every container provision (`backends/docker.py`, `network.py`) and host git-clone (`github_clone.py`) funnels through this runner — under a flapping daemon this exhausts the worker FD ceiling and starves **both** connection pools (asyncpg + psycopg3).
- Fix: `proc._transport.close()` on the give-up branch — non-blocking, idempotent, frees the pipe FDs immediately. `await proc.wait()` would re-introduce the exact hang this branch defends against, so it is deliberately not used; the zombie child is left for the asyncio `ThreadedChildWatcher` to reap once D-state clears (bounded, kernel-paced, no live `proc` ref needed).

Found via the bughunt parallel-agent audit (resource-lifecycle dimension); root cause is the only `create_subprocess_exec` call site in the tree, so the fix lives at the sole owner of the raw `Process`.

## Code review (pr-review-toolkit:code-reviewer) — all findings, score-annotated

Per project policy findings are posted in full; score triages, it does not suppress.

- **[80 — applied]** `_WedgedProc` test fake modelled `kill` and `_transport` as decoupled `MagicMock`s, but real `asyncio.subprocess.Process.kill()` delegates to `self._transport.kill()` — a fidelity gap a successor could over-trust. Fixed at root: the fake's `kill()` now delegates to `self._transport`, so the double cannot structurally drift from `Process`.
- **[35 — no action, YAGNI]** Fake omits `stdin`/`stdout`/`stderr`/`pid`. Minimal-surface is the correct unit-test approach and matches the project's simplicity stance; adding them would be speculative.
- **[20 — no action, house style]** Trailing `# type: ignore[attr-defined]  # typeshed omits Process._transport` is dense but matches the `cli/commands/accounts.py:67` precedent; ruff passes; the ignore is provably load-bearing under `strict`/`warn_unused_ignores`.
- **[15 — no action, house style]** Docstrings are long; consistent with the repo convention for "successor re-learns the hard way" context.

Reviewer verdict: fix is correct, sufficient, minimal, on-stance; cannot double-close or close a mid-use transport (mutually-exclusive `return` paths + idempotent `BaseSubprocessTransport.close()`); regression test verified **red pre-fix** (`Expected 'close' to have been called once. Called 0 times.`) and **green post-fix** (stash-verified).

## Test plan

- [x] New regression test `tests/unit/sandbox/test_subprocess.py` — fails pre-fix for the predicted reason, passes post-fix
- [x] `mypy src` — clean (153 files)
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pytest tests/unit` — 1247 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)