### PR TITLE
fix(mcp): reap idle pooled MCP sessions to bound the OAuth-refresh leak

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -152,6 +152,13 @@ class Settings(BaseSettings):
         description="Seconds of inactivity before a session's sandbox container "
         "is released. The idle reaper checks every 60s.",
     )
+    mcp_pool_idle_timeout_seconds: int = Field(
+        default=900,
+        ge=30,
+        description="Seconds of inactivity before a pooled MCP session is "
+        "closed. An OAuth token refresh rotates the bearer, orphaning the "
+        "old keyed entry; the idle reaper (checks every 60s) reclaims it.",
+    )
 
     # ── database pool ──────────────────────────────────────────────────────
     db_pool_max_size: int = Field(

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -176,8 +176,9 @@ async def worker_main() -> None:
         if reaped:
             log.info("worker.reaped_orphan_containers", count=reaped)
 
-        # Start container idle-TTL reaper.
+        # Start container + MCP-pool idle-TTL reapers.
         sandbox_registry.start_reaper(idle_timeout=settings.container_idle_timeout_seconds)
+        mcp_session_pool.start_reaper(idle_timeout=settings.mcp_pool_idle_timeout_seconds)
 
         # Start periodic sweep (every 30s).
         sweep_task = asyncio.create_task(
@@ -234,6 +235,7 @@ async def worker_main() -> None:
         if sandbox_registry is not None:
             await sandbox_registry.release_all()
         if mcp_session_pool is not None:
+            mcp_session_pool.stop_reaper()
             await mcp_session_pool.close_all()
         if mcp_broker is not None:
             await mcp_broker.stop()

--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hashlib
+import time
 from contextlib import AsyncExitStack
 from typing import Any
 
@@ -77,11 +78,20 @@ class _Entry:
         init_result: InitializeResult,
         shutdown: asyncio.Event,
         owner_task: asyncio.Task[None],
+        last_used: float,
     ) -> None:
         self.session = session
         self.init_result = init_result
         self._shutdown = shutdown
         self._owner_task = owner_task
+        # monotonic() of the last get_or_connect that returned this
+        # entry. The idle reaper keys off this, NOT owner-task liveness:
+        # the owner task is *always* alive (parked on `await
+        # shutdown.wait()` for the entry's whole life), so liveness is
+        # a useless staleness signal — an entry whose token was
+        # superseded by an OAuth refresh is never hit again yet its
+        # task runs forever.
+        self.last_used = last_used
 
     async def close(self) -> None:
         """Signal the owner task to exit its contexts and await its completion.
@@ -108,6 +118,7 @@ class McpSessionPool:
     def __init__(self) -> None:
         self._entries: dict[_PoolKey, _Entry] = {}
         self._locks: dict[_PoolKey, asyncio.Lock] = {}
+        self._reaper_task: asyncio.Task[None] | None = None
 
     def _lock_for(self, key: _PoolKey) -> asyncio.Lock:
         lock = self._locks.get(key)
@@ -160,7 +171,7 @@ class McpSessionPool:
             await task
             # Defensive — unreachable in practice.
             raise RuntimeError("mcp pool owner task signalled ready but produced no session")
-        return _Entry(result["session"], result["init"], shutdown, task)
+        return _Entry(result["session"], result["init"], shutdown, task, time.monotonic())
 
     async def get_or_connect(
         self, url: str, headers: dict[str, str]
@@ -175,11 +186,13 @@ class McpSessionPool:
 
         entry = self._entries.get(key)
         if entry is not None:
+            entry.last_used = time.monotonic()
             return entry.session, entry.init_result
 
         async with self._lock_for(key):
             entry = self._entries.get(key)
             if entry is not None:
+                entry.last_used = time.monotonic()
                 return entry.session, entry.init_result
 
             log.info("mcp_pool.connecting", url=url)
@@ -200,6 +213,57 @@ class McpSessionPool:
         key: _PoolKey = (url, _headers_hash(headers))
         self._entries.pop(key, None)
         log.info("mcp_pool.evicted", url=url)
+
+    async def _reap_idle_once(self, *, idle_timeout: float, now: float) -> None:
+        """Close entries idle longer than ``idle_timeout`` seconds.
+
+        Keyed on ``_Entry.last_used``, not owner-task liveness — see
+        :class:`_Entry`. Reclamation goes through ``_Entry.close()``
+        (same path as :meth:`close_all`), NOT a bare ``pop``: dropping
+        the reference alone strands the owner task, httpx client and SSE
+        stream — exactly the leak this reaps.
+        """
+        stale = [k for k, e in self._entries.items() if now - e.last_used > idle_timeout]
+        for key in stale:
+            entry = self._entries.pop(key, None)
+            if entry is None:
+                continue
+            log.info("mcp_pool.idle_close", url=key[0])
+            await entry.close()
+
+    async def _reap_idle_loop(self, idle_timeout: float, interval: float = 60.0) -> None:
+        """Background loop: close pooled sessions idle > idle_timeout.
+
+        The try/except is nested INSIDE ``while True`` (mirroring
+        :meth:`aios.sandbox.registry.SandboxRegistry._reap_idle_loop`
+        and the PR #443 fix for ``_run_interrupt_listener``): a teardown
+        error from one entry's ``close()`` must not silently disable the
+        reaper for the worker's lifetime — that would leak every
+        subsequently-superseded entry until process exit.
+        ``CancelledError`` is not an :class:`Exception` subclass, so
+        :meth:`stop_reaper`'s cancel still exits the loop cleanly.
+        """
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                await self._reap_idle_once(idle_timeout=idle_timeout, now=time.monotonic())
+            except Exception:
+                log.exception("mcp_pool.reap_idle_loop_failed")
+
+    def start_reaper(self, idle_timeout: float) -> None:
+        """Start the idle-TTL reaper background task."""
+        if self._reaper_task is not None:
+            return
+        self._reaper_task = asyncio.create_task(
+            self._reap_idle_loop(idle_timeout),
+            name="mcp-pool-idle-reaper",
+        )
+
+    def stop_reaper(self) -> None:
+        """Cancel the idle-TTL reaper."""
+        if self._reaper_task is not None:
+            self._reaper_task.cancel()
+            self._reaper_task = None
 
     async def close_all(self) -> None:
         """Tear down all pooled sessions. Called at worker shutdown."""

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -187,6 +187,59 @@ class TestMcpSessionPool:
         await pool.close_all()
         assert len(pool._entries) == 0
 
+    async def test_idle_reaper_closes_superseded_entry(self) -> None:
+        """An OAuth-superseded entry must be reclaimed via the clean path.
+
+        When an ``mcp_oauth`` token is refreshed, the rotated bearer
+        produces a new ``headers_hash`` → a new pool key → a fresh
+        entry. Nothing ever hits the old key again, so the predecessor
+        entry (its owner task, httpx client, SSE stream) is orphaned.
+        Pre-reaper the pool had no reclamation between exception-evict
+        and worker-shutdown ``close_all``, so it leaked for the worker's
+        lifetime — one per token TTL per active connector.
+
+        The idle reaper must close the idle entry through the clean
+        ``_Entry.close()`` shutdown path (NOT a bare ``pop`` — that
+        leaves the owner task and socket dangling) and drop it, while
+        the freshly-used entry is left untouched.
+        """
+        s_old, s_new = _make_mock_session(), _make_mock_session()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_old, s_new])),
+        ):
+            pool = McpSessionPool()
+            url = "https://m.example/"
+            await pool.get_or_connect(url, {"Authorization": "Bearer old"})
+            await pool.get_or_connect(url, {"Authorization": "Bearer new"})
+            assert len(pool._entries) == 2
+
+            key_old = (url, _headers_hash({"Authorization": "Bearer old"}))
+            key_new = (url, _headers_hash({"Authorization": "Bearer new"}))
+
+            closed: list[tuple[str, str]] = []
+            for key, entry in pool._entries.items():
+                orig = entry.close
+
+                async def _tracked(k: tuple[str, str] = key, o: Any = orig) -> None:
+                    closed.append(k)
+                    await o()
+
+                entry.close = _tracked  # type: ignore[method-assign]
+
+            # Entry A idle since t=1000; B freshly used at t=9000.
+            pool._entries[key_old].last_used = 1000.0
+            pool._entries[key_new].last_used = 9000.0
+
+            await pool._reap_idle_once(idle_timeout=300.0, now=9100.0)
+
+        assert closed == [key_old], (
+            f"idle reaper must close exactly the superseded entry via the "
+            f"clean _Entry.close() path; closed={closed!r}"
+        )
+        assert key_old not in pool._entries
+        assert key_new in pool._entries
+
     async def test_contexts_exit_in_same_task_they_entered(self) -> None:
         """Cross-task close — regression for #425.
 


### PR DESCRIPTION
## Summary

- **Confirmed leak.** `McpSessionPool` keys entries on `(url, sha256(headers))`. `resolve_auth_for_url` (`mcp/client.py:110-132`) transparently refreshes an expiring `mcp_oauth` token and returns a rotated `Bearer`, so a refresh produces a new `headers_hash` → a new `_PoolKey` → `get_or_connect` cache-misses and opens a fresh `_Entry` (owner asyncio task parked on `await shutdown.wait()`, an open `httpx.AsyncClient`, a live streamable-http/SSE stream). The **predecessor entry is never evicted** — `evict()` fires only on a broken-session exception, never on rotation — so it lingered in `_entries` until `close_all()` at worker shutdown. One orphaned task+socket per token TTL per active OAuth connector, **unbounded** (no reaper/LRU). Reachability ~0.9 (documented normal refresh flow); severity ~6.
- **Fix (bounded mitigation).** Add an idle-TTL reaper mirroring the proven `SandboxRegistry` one: `_Entry.last_used` (monotonic, bumped on every `get_or_connect` hit — keyed on *activity*, not owner-task liveness, which is a useless signal since the task is always alive); `_reap_idle_once` closing stale entries through the clean `_Entry.close()` shutdown path (**not** a bare `pop`, which would strand the task/socket — the very leak); `_reap_idle_loop` with `try/except` nested inside `while True`; `start_reaper`/`stop_reaper` wired into the worker lifecycle next to the container reaper. New setting `mcp_pool_idle_timeout_seconds` (default 900s, `ge=30`).
- **Not the root cause — deliberately.** The pool key collapses credential identity into an opaque rotating header. The root-cause re-key on stable `(url, vault_id)` (verified stable: `refresh_credential` does an in-place `UPDATE vault_credentials`) is **filed as a separate follow-up** — it changes the pool's keying contract and has multi-tenant implications (the worker pool is shared across accounts; a naive same-URL displacement would tear down a co-tenant's live session). Signed off by the maintainer.

## TDD

Red→green: `tests/unit/test_mcp_pool.py::test_idle_reaper_closes_superseded_entry` reproduces the exact refresh mechanism (two `get_or_connect` with different bearers → 2 entries), ages the predecessor, and asserts it is closed **via the clean `_Entry.close()` path** (the load-bearing assertion — a bare-`pop` anti-fix would leave `closed == []`) and dropped, while the fresh entry is untouched. Reviewer independently confirmed it is structurally red pre-fix (no `_reap_idle_once`/`last_used`).

## Code review (pr-review-toolkit:code-reviewer) — all findings, score-annotated

Policy: all findings posted; score triages, does not suppress. **Verdict: ship as-is. Nothing at/above the 80 threshold; nothing above 15.**

| Finding | Sev | Disposition |
|---|---|---|
| Reap-loop use-after-close under concurrent `get_or_connect` | 0 | Provably safe — single-loop; the only `await` is *after* the key is popped; fast-path bump+return has no yield between get and return |
| `stop_reaper` cancel mid-`entry.close()` strands ≤1 entry at process death | 15 | No action — bounded to ≤1 entry, **only at worker process exit** (OS reclaims the socket; no next request); matches the existing `SandboxRegistry` shutdown wiring. A drain handshake would be unsanctioned defensive complexity |
| `_reap_idle_once` factored out vs inlined in `SandboxRegistry` | 10 | No action — justified deterministic test seam; also reads cleaner |
| `start_reaper` has no default `idle_timeout` (deviates from sandbox's 300.0 default) | 0 | No action — improvement; required arg prevents a future caller silently getting a wrong magic default |
| Test lacks an explicit positive "bump prevents reap" assertion | 15 | Deferred (out of scope) — the "B untouched" assertion covers static survival; an explicit bump-interaction test is optional future hardening, and over-instrumenting a regression test is against project stance |
| Default 900s | 0 | No action — justified (must exceed refresh skew; MCP sessions cheaper to hold than containers; documented inline) |
| Project-stance compliance | 0 | Clean — mirrors proven pattern, fail-hard, WHY-comments, single-loop documented |

## Test plan

- [x] Type-checker (mypy) — clean, 153 files
- [x] Linter + format (ruff) — clean
- [x] Unit suite — 1248 passed (was 1247; +1 new reaper test)
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)