### PR TITLE
fix(mcp): re-key session pool on stable credential identity (url, vault_id)

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -811,10 +811,10 @@ async def discover_session_mcp_tools(
     crypto_box = runtime.require_crypto_box()
 
     async def _discover_one(name: str, url: str) -> tuple[list[dict[str, Any]], str | None]:
-        headers = await resolve_auth_for_url(
+        vault_id, headers = await resolve_auth_for_url(
             pool, crypto_box, session_id, url, account_id=account_id
         )
-        return await discover_mcp_tools(url, name, headers)
+        return await discover_mcp_tools(url, vault_id, headers, name)
 
     results = await asyncio.gather(*[_discover_one(n, u) for n, u in servers])
     tools: list[dict[str, Any]] = [

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -463,10 +463,10 @@ async def _execute_mcp_tool_async(
             from aios.mcp.client import call_mcp_tool, resolve_auth_for_url
 
             crypto_box = runtime.require_crypto_box()
-            headers = await resolve_auth_for_url(
+            vault_id, headers = await resolve_auth_for_url(
                 pool, crypto_box, session_id, url, account_id=account_id
             )
-            result = await call_mcp_tool(url, headers, tool_name, arguments, meta=meta)
+            result = await call_mcp_tool(url, vault_id, headers, tool_name, arguments, meta=meta)
 
         content_str = json.dumps(result, ensure_ascii=False)
         mcp_is_error = "error" in result

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -85,9 +85,17 @@ async def resolve_auth_for_url(
     mcp_server_url: str,
     *,
     account_id: str,
-) -> dict[str, str]:
-    """Resolve MCP auth headers for ``mcp_server_url`` via the session's
-    bound vaults.
+) -> tuple[str | None, dict[str, str]]:
+    """Resolve MCP auth identity + headers for ``mcp_server_url`` via
+    the session's bound vaults.
+
+    Returns ``(vault_id, headers)`` on the success path, or
+    ``(None, {})`` whenever there are no auth headers to send (no
+    credential bound, or a credential whose token is empty / a refresh
+    re-read missed). ``vault_id`` is the row id of the
+    ``vault_credentials`` entry — stable across OAuth token rotation
+    (``refresh_credential`` updates the row in place), so callers feed
+    it to the pool as a stable cache key (see #459).
 
     For ``mcp_oauth`` credentials whose ``expires_at`` falls within the
     refresh skew window, the access token is transparently refreshed
@@ -101,7 +109,7 @@ async def resolve_auth_for_url(
             conn, session_id, mcp_server_url, account_id=account_id
         )
         if session_result is None:
-            return {}
+            return None, {}
         blob, auth_type, vault_id = session_result
         subkey = crypto_box.derive_account_subkey(account_id)
 
@@ -119,7 +127,7 @@ async def resolve_auth_for_url(
                     conn, vault_id=vault_id, mcp_server_url=mcp_server_url, account_id=account_id
                 )
                 if refreshed is None:
-                    return {}
+                    return None, {}
                 blob = refreshed[0]
                 payload = json.loads(subkey.decrypt(blob))
             token = str(payload.get("access_token", ""))
@@ -128,14 +136,15 @@ async def resolve_auth_for_url(
             token = _token_from_payload(payload, auth_type)
 
     if not token:
-        return {}
-    return {"Authorization": f"Bearer {token}"}
+        return None, {}
+    return vault_id, {"Authorization": f"Bearer {token}"}
 
 
 async def discover_mcp_tools(
     url: str,
-    server_name: str,
+    vault_id: str | None,
     headers: dict[str, str],
+    server_name: str,
 ) -> tuple[list[dict[str, Any]], str | None]:
     """Connect to an MCP server and discover available tools.
 
@@ -159,11 +168,11 @@ async def discover_mcp_tools(
         if _pool is not None:
             # Pool path: reuse cached session; on failure evict + retry once.
             try:
-                session, init_result = await _pool.get_or_connect(url, headers)
+                session, init_result = await _pool.get_or_connect(url, vault_id, headers)
                 result = await session.list_tools()
             except Exception:
-                _pool.evict(url, headers)
-                session, init_result = await _pool.get_or_connect(url, headers)
+                _pool.evict(url, vault_id)
+                session, init_result = await _pool.get_or_connect(url, vault_id, headers)
                 result = await session.list_tools()
         else:
             # Fallback: fresh connection per call (API process, tests).
@@ -217,6 +226,7 @@ def shape_call_result(result: Any) -> dict[str, Any]:
 
 async def call_mcp_tool(
     url: str,
+    vault_id: str | None,
     headers: dict[str, str],
     tool_name: str,
     arguments: dict[str, Any],
@@ -239,14 +249,14 @@ async def call_mcp_tool(
 
         if _pool is not None:
             try:
-                session, _ = await _pool.get_or_connect(url, headers)
+                session, _ = await _pool.get_or_connect(url, vault_id, headers)
                 result = await asyncio.wait_for(
                     session.call_tool(tool_name, arguments, meta=meta),
                     timeout=_TOOL_CALL_TIMEOUT_S,
                 )
             except Exception:
-                _pool.evict(url, headers)
-                session, _ = await _pool.get_or_connect(url, headers)
+                _pool.evict(url, vault_id)
+                session, _ = await _pool.get_or_connect(url, vault_id, headers)
                 result = await asyncio.wait_for(
                     session.call_tool(tool_name, arguments, meta=meta),
                     timeout=_TOOL_CALL_TIMEOUT_S,

--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -1,6 +1,7 @@
 """Worker-scoped MCP session pool.
 
-Holds a persistent ``ClientSession`` per ``(url, headers_hash)`` key so
+Holds a persistent ``ClientSession`` per ``(url, vault_id)`` key (stable
+across OAuth token rotation — see :func:`get_or_connect` and #459) so
 tool discovery and invocation can reuse an already-initialized MCP
 connection instead of opening a fresh one on every call.
 
@@ -30,7 +31,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import hashlib
 import time
 from contextlib import AsyncExitStack
 from typing import Any
@@ -49,17 +49,7 @@ log = get_logger("aios.mcp.pool")
 # can't keep the worker on a dead socket indefinitely.
 _MCP_HTTPX_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0)
 
-type _PoolKey = tuple[str, str]
-
-
-def _headers_hash(headers: dict[str, str]) -> str:
-    """Stable SHA-256 hash of a headers dict, sorted for determinism.
-
-    Using the hash (rather than the raw key material) as part of the pool
-    key avoids keeping bearer tokens in in-memory dict keys.
-    """
-    blob = "&".join(f"{k}={v}" for k, v in sorted(headers.items()))
-    return hashlib.sha256(blob.encode()).hexdigest()
+type _PoolKey = tuple[str, str | None]
 
 
 class _Entry:
@@ -85,12 +75,14 @@ class _Entry:
         self._shutdown = shutdown
         self._owner_task = owner_task
         # monotonic() of the last get_or_connect that returned this
-        # entry. The idle reaper keys off this, NOT owner-task liveness:
-        # the owner task is *always* alive (parked on `await
-        # shutdown.wait()` for the entry's whole life), so liveness is
-        # a useless staleness signal — an entry whose token was
-        # superseded by an OAuth refresh is never hit again yet its
-        # task runs forever.
+        # entry. Reaper keys off this, NOT owner-task liveness: the
+        # task parks on `await shutdown.wait()` for the entry's whole
+        # life, so liveness is a useless staleness signal.
+        #
+        # Post-#459 the pool keys on (url, vault_id), stable across
+        # OAuth refresh. The reaper's remaining job is the cold-entry
+        # vector (a vault whose tenant never returns) — defense-in-depth
+        # signed off in #459's planning round, not silent accretion.
         self.last_used = last_used
 
     async def close(self) -> None:
@@ -174,15 +166,24 @@ class McpSessionPool:
         return _Entry(result["session"], result["init"], shutdown, task, time.monotonic())
 
     async def get_or_connect(
-        self, url: str, headers: dict[str, str]
+        self, url: str, vault_id: str | None, headers: dict[str, str]
     ) -> tuple[ClientSession, InitializeResult]:
         """Return a cached session, opening a fresh one if none exists.
 
-        Double-checked locking: the fast unsynchronised check avoids lock
-        contention on the common (already-connected) path; the slow path
-        acquires the per-key lock and re-checks before opening.
+        Keyed on ``(url, vault_id)`` — stable across OAuth token rotation
+        because ``vault_id`` is the row id of the ``vault_credentials``
+        entry that ``refresh_credential`` updates in place (see #459).
+        ``vault_id`` is ``None`` for the no-credential case (an
+        unauthenticated MCP server); all such callers on the same URL
+        share one entry, which is safe because no auth identity is
+        being keyed on.
+
+        Double-checked locking: the fast unsynchronised check avoids
+        lock contention on the common (already-connected) path; the
+        slow path acquires the per-key lock and re-checks before
+        opening.
         """
-        key: _PoolKey = (url, _headers_hash(headers))
+        key: _PoolKey = (url, vault_id)
 
         entry = self._entries.get(key)
         if entry is not None:
@@ -202,7 +203,7 @@ class McpSessionPool:
 
         return entry.session, entry.init_result
 
-    def evict(self, url: str, headers: dict[str, str]) -> None:
+    def evict(self, url: str, vault_id: str | None) -> None:
         """Drop a cache entry without closing it.
 
         Called when a cached session has been found to be broken. Closing
@@ -210,7 +211,7 @@ class McpSessionPool:
         simply drop the reference and let GC handle it; the next
         :meth:`get_or_connect` for this key will open a fresh session.
         """
-        key: _PoolKey = (url, _headers_hash(headers))
+        key: _PoolKey = (url, vault_id)
         self._entries.pop(key, None)
         log.info("mcp_pool.evicted", url=url)
 

--- a/src/aios/sandbox/mcp_proxy.py
+++ b/src/aios/sandbox/mcp_proxy.py
@@ -278,10 +278,12 @@ class McpBroker:
         pool = runtime.require_pool()
         crypto_box = runtime.require_crypto_box()
         account_id = await sessions_service.load_session_account_id(pool, session_id)
-        headers = await resolve_auth_for_url(
+        vault_id, headers = await resolve_auth_for_url(
             pool, crypto_box, session_id, server.url, account_id=account_id
         )
-        tool_dicts, _instructions = await discover_mcp_tools(server.url, server_name, headers)
+        tool_dicts, _instructions = await discover_mcp_tools(
+            server.url, vault_id, headers, server_name
+        )
 
         out: list[dict[str, Any]] = []
         for td in tool_dicts:
@@ -309,10 +311,10 @@ class McpBroker:
         pool = runtime.require_pool()
         crypto_box = runtime.require_crypto_box()
         account_id = await sessions_service.load_session_account_id(pool, session_id)
-        headers = await resolve_auth_for_url(
+        vault_id, headers = await resolve_auth_for_url(
             pool, crypto_box, session_id, server.url, account_id=account_id
         )
-        tool_dicts, _ = await discover_mcp_tools(server.url, server.name, headers)
+        tool_dicts, _ = await discover_mcp_tools(server.url, vault_id, headers, server.name)
         qualified = f"mcp__{server.name}__{tool_name}"
         for td in tool_dicts:
             fn = td.get("function", {})
@@ -346,7 +348,7 @@ class McpBroker:
         pool = runtime.require_pool()
         crypto_box = runtime.require_crypto_box()
         account_id = await sessions_service.load_session_account_id(pool, session_id)
-        headers = await resolve_auth_for_url(
+        vault_id, headers = await resolve_auth_for_url(
             pool, crypto_box, session_id, server.url, account_id=account_id
         )
         log.info(
@@ -355,7 +357,7 @@ class McpBroker:
             server=server.name,
             tool=tool_name,
         )
-        envelope = await call_mcp_tool(server.url, headers, tool_name, arguments)
+        envelope = await call_mcp_tool(server.url, vault_id, headers, tool_name, arguments)
         return JSONResponse(envelope)
 
 

--- a/tests/e2e/test_vaults.py
+++ b/tests/e2e/test_vaults.py
@@ -647,7 +647,7 @@ class TestOAuthRefreshE2E:
             post_calls,
             body={"access_token": "fresh-at", "expires_in": 3600},
         ):
-            headers = await resolve_auth_for_url(
+            _, headers = await resolve_auth_for_url(
                 pool, crypto_box, session_id, url, account_id="acc_test_stub"
             )
 
@@ -709,7 +709,7 @@ class TestOAuthRefreshE2E:
                 )
             )
 
-        assert all(r == {"Authorization": "Bearer fresh-at"} for r in results)
+        assert all(r[1] == {"Authorization": "Bearer fresh-at"} for r in results)
         assert len(post_calls) == 1, (
             f"expected 1 POST but got {len(post_calls)} — row lock or double-check is broken"
         )
@@ -809,7 +809,7 @@ class TestOAuthRefreshE2E:
                 resolve_auth_for_url(pool, crypto_box, sess2, url2, account_id="acc_test_stub"),
             )
 
-        assert all(r == {"Authorization": "Bearer fresh-at"} for r in results)
+        assert all(r[1] == {"Authorization": "Bearer fresh-at"} for r in results)
         # Two distinct credentials → two POSTs (one each), not one shared.
         assert len(post_calls) == 2, (
             f"expected 2 POSTs (one per credential) but got {len(post_calls)} "

--- a/tests/unit/sandbox/test_broker_http_contract.py
+++ b/tests/unit/sandbox/test_broker_http_contract.py
@@ -68,8 +68,8 @@ def _mock_crypto_and_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("aios.harness.runtime.require_crypto_box", lambda: object())
     monkeypatch.setattr("aios.harness.runtime.require_pool", lambda: object())
 
-    async def _stub_auth(*_args: Any, **_kwargs: Any) -> dict[str, str]:
-        return {}
+    async def _stub_auth(*_args: Any, **_kwargs: Any) -> tuple[str | None, dict[str, str]]:
+        return None, {}
 
     monkeypatch.setattr("aios.sandbox.mcp_proxy.resolve_auth_for_url", _stub_auth)
 
@@ -119,7 +119,7 @@ class TestMcpCli:
         monkeypatch.setattr(broker, "_load_agent", _load)
 
         async def _discover(
-            _url: str, name: str, _h: dict[str, str]
+            _url: str, _vault_id: str | None, _h: dict[str, str], name: str
         ) -> tuple[list[dict[str, Any]], str | None]:
             return [
                 {
@@ -174,7 +174,7 @@ class TestMcpCli:
         captured: dict[str, Any] = {}
 
         async def _call(
-            _url: str, _h: dict[str, str], _tool: str, args: dict[str, Any]
+            _url: str, _vault_id: str | None, _h: dict[str, str], _tool: str, args: dict[str, Any]
         ) -> dict[str, Any]:
             captured["args"] = args
             return {"content": "ok"}

--- a/tests/unit/sandbox/test_mcp_proxy.py
+++ b/tests/unit/sandbox/test_mcp_proxy.py
@@ -94,8 +94,8 @@ def _mock_crypto_and_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("aios.harness.runtime.require_crypto_box", lambda: object())
     monkeypatch.setattr("aios.harness.runtime.require_pool", lambda: object())
 
-    async def _stub_auth(*_args: Any, **_kwargs: Any) -> dict[str, str]:
-        return {}
+    async def _stub_auth(*_args: Any, **_kwargs: Any) -> tuple[str | None, dict[str, str]]:
+        return None, {}
 
     monkeypatch.setattr("aios.sandbox.mcp_proxy.resolve_auth_for_url", _stub_auth)
 
@@ -173,7 +173,7 @@ class TestListTools:
         monkeypatch.setattr(broker, "_load_agent", _async_returning(agent))
 
         async def _discover(
-            _url: str, name: str, _headers: dict[str, str]
+            _url: str, _vault_id: str | None, _headers: dict[str, str], name: str
         ) -> tuple[list[dict[str, Any]], str | None]:
             return [
                 _tool_dict(name, "web_search", description="Search the web"),
@@ -214,7 +214,7 @@ class TestToolHelp:
         monkeypatch.setattr(broker, "_load_agent", _async_returning(agent))
 
         async def _discover(
-            _url: str, name: str, _headers: dict[str, str]
+            _url: str, _vault_id: str | None, _headers: dict[str, str], name: str
         ) -> tuple[list[dict[str, Any]], str | None]:
             return [
                 _tool_dict(
@@ -290,7 +290,11 @@ class TestInvoke:
         captured: dict[str, Any] = {}
 
         async def _call(
-            _url: str, _headers: dict[str, str], tool: str, args: dict[str, Any]
+            _url: str,
+            _vault_id: str | None,
+            _headers: dict[str, str],
+            tool: str,
+            args: dict[str, Any],
         ) -> dict[str, Any]:
             captured["tool"] = tool
             captured["args"] = args

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -69,7 +69,7 @@ class TestDiscoverSessionMcpTools:
         )
 
         async def _discover(
-            url: str, name: str, _headers: dict[str, str]
+            url: str, _vault_id: str | None, _headers: dict[str, str], name: str
         ) -> tuple[list[dict[str, Any]], str | None]:
             return [{"name": f"mcp__{name}__t", "url": url}], None
 
@@ -77,7 +77,7 @@ class TestDiscoverSessionMcpTools:
             patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
             patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
         ):
-            resolve.return_value = {}
+            resolve.return_value = (None, {})
             tools, _instructions = await discover_session_mcp_tools(
                 pool=AsyncMock(),
                 session_id="sess_x",
@@ -108,12 +108,12 @@ class TestDiscoverSessionMcpTools:
 
         async def _fake_resolve(
             _pool: Any, _cb: Any, _sid: str, url: str, **kwargs: Any
-        ) -> dict[str, str]:
+        ) -> tuple[str | None, dict[str, str]]:
             seen_urls.append(url)
-            return {"Authorization": f"Bearer token-for-{url}"}
+            return None, {"Authorization": f"Bearer token-for-{url}"}
 
         async def _discover(
-            url: str, name: str, headers: dict[str, str]
+            url: str, _vault_id: str | None, headers: dict[str, str], name: str
         ) -> tuple[list[dict[str, Any]], str | None]:
             return [{"name": f"mcp__{name}__t", "auth": headers["Authorization"]}], None
 
@@ -153,7 +153,7 @@ class TestDiscoverSessionMcpTools:
         )
 
         async def _discover(
-            url: str, name: str, _headers: dict[str, str]
+            url: str, _vault_id: str | None, _headers: dict[str, str], name: str
         ) -> tuple[list[dict[str, Any]], str | None]:
             if name == "gh":
                 return [], None
@@ -163,7 +163,7 @@ class TestDiscoverSessionMcpTools:
             patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
             patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
         ):
-            resolve.return_value = {}
+            resolve.return_value = (None, {})
             _tools, instructions = await discover_session_mcp_tools(
                 pool=AsyncMock(),
                 session_id="sess_x",
@@ -186,7 +186,7 @@ class TestDiscoverSessionMcpTools:
         )
 
         async def _discover(
-            _url: str, _name: str, _headers: dict[str, str]
+            _url: str, _vault_id: str | None, _headers: dict[str, str], _name: str
         ) -> tuple[list[dict[str, Any]], str | None]:
             return [], ""
 
@@ -194,7 +194,7 @@ class TestDiscoverSessionMcpTools:
             patch("aios.mcp.client.resolve_auth_for_url", new_callable=AsyncMock) as resolve,
             patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
         ):
-            resolve.return_value = {}
+            resolve.return_value = (None, {})
             _tools, instructions = await discover_session_mcp_tools(
                 pool=AsyncMock(),
                 session_id="sess_x",

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -42,9 +42,10 @@ class TestResolveAuthForUrl:
             new_callable=AsyncMock,
         ) as s:
             s.return_value = (blob, "static_bearer", "vlt_s1")
-            result = await resolve_auth_for_url(
+            vault_id, result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
+        assert vault_id == "vlt_s1"
         assert result == {"Authorization": "Bearer session-token"}
         s.assert_awaited_once()
 
@@ -55,9 +56,10 @@ class TestResolveAuthForUrl:
             new_callable=AsyncMock,
         ) as s:
             s.return_value = None
-            result = await resolve_auth_for_url(
+            vault_id, result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
+        assert vault_id is None
         assert result == {}
 
     async def test_empty_token_returns_empty(self, crypto_box: CryptoBox) -> None:
@@ -69,9 +71,12 @@ class TestResolveAuthForUrl:
             new_callable=AsyncMock,
         ) as s:
             s.return_value = (blob, "static_bearer", "vlt_s1")
-            result = await resolve_auth_for_url(
+            vault_id, result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
+        # Empty-token path returns (None, {}) — a transient stateless
+        # resolution does not cache an unauth entry under an identity key.
+        assert vault_id is None
         assert result == {}
 
     async def test_mcp_oauth_static_token(self, crypto_box: CryptoBox) -> None:
@@ -83,9 +88,10 @@ class TestResolveAuthForUrl:
             new_callable=AsyncMock,
         ) as s:
             s.return_value = (blob, "mcp_oauth", "vlt_s1")
-            result = await resolve_auth_for_url(
+            vault_id, result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
+        assert vault_id == "vlt_s1"
         assert result == {"Authorization": "Bearer oauth-token"}
 
     # ── OAuth refresh ─────────────────────────────────────────────────────
@@ -121,7 +127,7 @@ class TestResolveAuthForUrl:
         ):
             s.return_value = (stale_blob, "mcp_oauth", "vlt_s1")
             v.return_value = (fresh_blob, "mcp_oauth")
-            result = await resolve_auth_for_url(
+            vault_id, result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
 
@@ -129,6 +135,7 @@ class TestResolveAuthForUrl:
         kwargs = refresh_mock.await_args.kwargs
         assert kwargs["vault_id"] == "vlt_s1"
         assert kwargs["mcp_server_url"] == "https://mcp.example.com"
+        assert vault_id == "vlt_s1"
         assert result == {"Authorization": "Bearer fresh"}
 
     async def test_oauth_refresh_not_triggered_when_fresh(self, crypto_box: CryptoBox) -> None:
@@ -152,11 +159,12 @@ class TestResolveAuthForUrl:
             patch("aios.mcp.client.refresh_credential", refresh_mock),
         ):
             s.return_value = (blob, "mcp_oauth", "vlt_s1")
-            result = await resolve_auth_for_url(
+            vault_id, result = await resolve_auth_for_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
 
         refresh_mock.assert_not_awaited()
+        assert vault_id == "vlt_s1"
         assert result == {"Authorization": "Bearer still-good"}
 
     async def test_oauth_refresh_failure_bubbles(self, crypto_box: CryptoBox) -> None:
@@ -234,7 +242,9 @@ class TestDiscoverMcpTools:
             mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
             mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            tools, instructions = await discover_mcp_tools("https://mcp.github.com/", "github", {})
+            tools, instructions = await discover_mcp_tools(
+                "https://mcp.github.com/", None, {}, "github"
+            )
 
         assert len(tools) == 1
         assert tools[0]["type"] == "function"
@@ -267,7 +277,7 @@ class TestDiscoverMcpTools:
             mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
             tools, _instructions = await discover_mcp_tools(
-                "https://mcp.example.com/", "myserver", {}
+                "https://mcp.example.com/", None, {}, "myserver"
             )
 
         assert len(tools) == 2
@@ -279,7 +289,7 @@ class TestDiscoverMcpTools:
             mock_transport.return_value.__aenter__ = AsyncMock(side_effect=ConnectionError("down"))
             mock_transport.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            result = await discover_mcp_tools("https://bad.example.com/", "bad", {})
+            result = await discover_mcp_tools("https://bad.example.com/", None, {}, "bad")
 
         assert result == ([], None)
 
@@ -310,7 +320,9 @@ class TestDiscoverMcpTools:
             mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
             mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            tools, instructions = await discover_mcp_tools("https://mcp.signal/", "signal", {})
+            tools, instructions = await discover_mcp_tools(
+                "https://mcp.signal/", None, {}, "signal"
+            )
 
         assert len(tools) == 1
         assert instructions == "## Signal\n\nUse signal_send to reply."
@@ -345,6 +357,7 @@ class TestCallMcpTool:
 
             result = await call_mcp_tool(
                 "https://mcp.github.com/",
+                None,
                 {"Authorization": "Bearer token"},
                 "create_issue",
                 {"title": "Test"},
@@ -375,7 +388,7 @@ class TestCallMcpTool:
             mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
             mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            result = await call_mcp_tool("https://mcp.github.com/", {}, "create_issue", {})
+            result = await call_mcp_tool("https://mcp.github.com/", None, {}, "create_issue", {})
 
         assert result == {"error": "Permission denied", "code": "tool_error"}
 
@@ -386,7 +399,7 @@ class TestCallMcpTool:
             )
             mock_transport.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            result = await call_mcp_tool("https://bad.example.com/", {}, "tool", {})
+            result = await call_mcp_tool("https://bad.example.com/", None, {}, "tool", {})
 
         assert "error" in result
         assert "MCP server error" in result["error"]
@@ -424,6 +437,7 @@ class TestCallMcpTool:
 
             await call_mcp_tool(
                 "https://example.com/",
+                None,
                 {},
                 "signal_send",
                 {"text": "hi"},
@@ -459,7 +473,7 @@ class TestCallMcpTool:
             mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
             mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            await call_mcp_tool("https://example.com/", {}, "tool", {})
+            await call_mcp_tool("https://example.com/", None, {}, "tool", {})
 
         mock_session.call_tool.assert_awaited_once_with("tool", {}, meta=None)
 
@@ -486,6 +500,6 @@ class TestCallMcpTool:
             mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
             mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            result = await call_mcp_tool("https://example.com/", {}, "tool", {})
+            result = await call_mcp_tool("https://example.com/", None, {}, "tool", {})
 
         assert result == {"content": "[image content]"}

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -13,29 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aios.harness import runtime
-from aios.mcp.pool import McpSessionPool, _headers_hash
-
-# ── _headers_hash ──────────────────────────────────────────────────────────
-
-
-class TestHeadersHash:
-    def test_same_headers_same_hash(self) -> None:
-        h = {"Authorization": "Bearer tok", "X-Extra": "v"}
-        assert _headers_hash(h) == _headers_hash(h)
-
-    def test_order_independent(self) -> None:
-        h1 = {"A": "1", "B": "2"}
-        h2 = {"B": "2", "A": "1"}
-        assert _headers_hash(h1) == _headers_hash(h2)
-
-    def test_different_values_different_hash(self) -> None:
-        assert _headers_hash({"Authorization": "Bearer tok1"}) != _headers_hash(
-            {"Authorization": "Bearer tok2"}
-        )
-
-    def test_empty_headers(self) -> None:
-        assert _headers_hash({}) == _headers_hash({})
-
+from aios.mcp.pool import McpSessionPool
 
 # ── helpers ────────────────────────────────────────────────────────────────
 
@@ -88,22 +66,28 @@ class TestMcpSessionPool:
         ):
             pool = McpSessionPool()
             headers = {"Authorization": "Bearer tok"}
-            s1, _ = await pool.get_or_connect("https://m.example/", headers)
-            s2, _ = await pool.get_or_connect("https://m.example/", headers)
+            s1, _ = await pool.get_or_connect("https://m.example/", "v", headers)
+            s2, _ = await pool.get_or_connect("https://m.example/", "v", headers)
 
         assert s1 is s2
         session.initialize.assert_awaited_once()
 
-    async def test_pool_miss_different_headers(self) -> None:
-        """Different auth headers → two separate sessions."""
+    async def test_pool_miss_different_vault_ids(self) -> None:
+        """Different vault_ids on the same URL → two separate sessions
+        (the multi-tenant safety surface: per-account vaults yield
+        per-account pool entries even when sharing an MCP URL)."""
         s_a, s_b = _make_mock_session(), _make_mock_session()
         with (
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
         ):
             pool = McpSessionPool()
-            r1, _ = await pool.get_or_connect("https://m.example/", {"Authorization": "Bearer t1"})
-            r2, _ = await pool.get_or_connect("https://m.example/", {"Authorization": "Bearer t2"})
+            r1, _ = await pool.get_or_connect(
+                "https://m.example/", "vault_a", {"Authorization": "Bearer t1"}
+            )
+            r2, _ = await pool.get_or_connect(
+                "https://m.example/", "vault_b", {"Authorization": "Bearer t2"}
+            )
 
         assert r1 is not r2
         assert s_a.initialize.await_count == 1
@@ -118,9 +102,9 @@ class TestMcpSessionPool:
             patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
         ):
             pool = McpSessionPool()
-            r1, _ = await pool.get_or_connect("https://m.example/", headers)
-            pool.evict("https://m.example/", headers)
-            r2, _ = await pool.get_or_connect("https://m.example/", headers)
+            r1, _ = await pool.get_or_connect("https://m.example/", "v", headers)
+            pool.evict("https://m.example/", "v")
+            r2, _ = await pool.get_or_connect("https://m.example/", "v", headers)
 
         assert r1 is not r2
 
@@ -146,7 +130,7 @@ class TestMcpSessionPool:
             pool = McpSessionPool()
             headers = {"Authorization": "Bearer tok"}
             results = await asyncio.gather(
-                *[pool.get_or_connect("https://m.example/", headers) for _ in range(8)]
+                *[pool.get_or_connect("https://m.example/", "v", headers) for _ in range(8)]
             )
 
         assert init_count == 1
@@ -162,8 +146,8 @@ class TestMcpSessionPool:
             patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
         ):
             pool = McpSessionPool()
-            await pool.get_or_connect("https://a.example/", {"Authorization": "A"})
-            await pool.get_or_connect("https://b.example/", {"Authorization": "B"})
+            await pool.get_or_connect("https://a.example/", "vault_a", {"Authorization": "A"})
+            await pool.get_or_connect("https://b.example/", "vault_b", {"Authorization": "B"})
 
             close_calls: list[str] = []
             for key, entry in pool._entries.items():
@@ -187,21 +171,60 @@ class TestMcpSessionPool:
         await pool.close_all()
         assert len(pool._entries) == 0
 
-    async def test_idle_reaper_closes_superseded_entry(self) -> None:
-        """An OAuth-superseded entry must be reclaimed via the clean path.
+    async def test_idle_reaper_closes_cold_entry(self) -> None:
+        """A cold pool entry must be reclaimed via ``_Entry.close()``.
 
-        When an ``mcp_oauth`` token is refreshed, the rotated bearer
-        produces a new ``headers_hash`` → a new pool key → a fresh
-        entry. Nothing ever hits the old key again, so the predecessor
-        entry (its owner task, httpx client, SSE stream) is orphaned.
-        Pre-reaper the pool had no reclamation between exception-evict
-        and worker-shutdown ``close_all``, so it leaked for the worker's
-        lifetime — one per token TTL per active connector.
+        Post-#459 re-key, the reaper guards the cold-entry vector: a
+        ``(url, vault_id)`` whose tenant never returns. A bare ``pop``
+        would leave the owner task + httpx + SSE stream dangling —
+        exactly the leak this defends against.
+        """
+        s_cold, s_warm = _make_mock_session(), _make_mock_session()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_cold, s_warm])),
+        ):
+            pool = McpSessionPool()
+            url = "https://m.example/"
+            await pool.get_or_connect(url, "vault_cold", {"Authorization": "Bearer A"})
+            await pool.get_or_connect(url, "vault_warm", {"Authorization": "Bearer B"})
+            assert len(pool._entries) == 2
 
-        The idle reaper must close the idle entry through the clean
-        ``_Entry.close()`` shutdown path (NOT a bare ``pop`` — that
-        leaves the owner task and socket dangling) and drop it, while
-        the freshly-used entry is left untouched.
+            # Locate each entry by the session it wraps (keying-agnostic
+            # so this test stays a pure reaper-mechanism test).
+            key_cold = next(k for k, e in pool._entries.items() if e.session is s_cold)
+            key_warm = next(k for k, e in pool._entries.items() if e.session is s_warm)
+
+            closed: list[tuple[str, str | None]] = []
+            for key, entry in pool._entries.items():
+                orig = entry.close
+
+                async def _tracked(k: tuple[str, str | None] = key, o: Any = orig) -> None:
+                    closed.append(k)
+                    await o()
+
+                entry.close = _tracked  # type: ignore[method-assign]
+
+            # Cold tenant idle since t=1000; warm tenant freshly used at t=9000.
+            pool._entries[key_cold].last_used = 1000.0
+            pool._entries[key_warm].last_used = 9000.0
+
+            await pool._reap_idle_once(idle_timeout=300.0, now=9100.0)
+
+        assert closed == [key_cold], (
+            f"idle reaper must close exactly the cold entry via the clean "
+            f"_Entry.close() path; closed={closed!r}"
+        )
+        assert key_cold not in pool._entries
+        assert key_warm in pool._entries
+
+    async def test_oauth_refresh_does_not_orphan_entry(self) -> None:
+        """A token rotation on the same vault must reuse the pool key.
+
+        Pre-#459 the pool keyed on ``(url, sha256(headers))``, so a
+        rotated bearer produced a second key while the predecessor
+        ``_Entry`` lingered. Keyed on ``(url, vault_id)``, rotation hits
+        the same key and ``len(_entries)`` stays put.
         """
         s_old, s_new = _make_mock_session(), _make_mock_session()
         with (
@@ -210,35 +233,50 @@ class TestMcpSessionPool:
         ):
             pool = McpSessionPool()
             url = "https://m.example/"
-            await pool.get_or_connect(url, {"Authorization": "Bearer old"})
-            await pool.get_or_connect(url, {"Authorization": "Bearer new"})
-            assert len(pool._entries) == 2
+            # Same vault (identity), two bearer values — the exact shape
+            # an OAuth refresh produces at the inbound boundary.
+            await pool.get_or_connect(url, "vault_a", {"Authorization": "Bearer old"})
+            await pool.get_or_connect(url, "vault_a", {"Authorization": "Bearer new"})
 
-            key_old = (url, _headers_hash({"Authorization": "Bearer old"}))
-            key_new = (url, _headers_hash({"Authorization": "Bearer new"}))
-
-            closed: list[tuple[str, str]] = []
-            for key, entry in pool._entries.items():
-                orig = entry.close
-
-                async def _tracked(k: tuple[str, str] = key, o: Any = orig) -> None:
-                    closed.append(k)
-                    await o()
-
-                entry.close = _tracked  # type: ignore[method-assign]
-
-            # Entry A idle since t=1000; B freshly used at t=9000.
-            pool._entries[key_old].last_used = 1000.0
-            pool._entries[key_new].last_used = 9000.0
-
-            await pool._reap_idle_once(idle_timeout=300.0, now=9100.0)
-
-        assert closed == [key_old], (
-            f"idle reaper must close exactly the superseded entry via the "
-            f"clean _Entry.close() path; closed={closed!r}"
+        assert len(pool._entries) == 1, (
+            f"a token refresh of the same vault must NOT orphan an entry; "
+            f"got len(_entries)={len(pool._entries)} (pre-fix the rotated "
+            f"bearer produced a second key while the predecessor lingered)"
         )
-        assert key_old not in pool._entries
-        assert key_new in pool._entries
+
+    async def test_cross_tenant_refresh_does_not_disturb_other_tenant(self) -> None:
+        """Multi-tenant invariant the #459 re-key is built on.
+
+        ``vault_id`` is account-filtered at the query layer
+        (``resolve_mcp_credential(..., account_id=...)``), so two
+        tenants sharing an MCP URL hold independent entries and one's
+        refresh reuses its OWN entry without disturbing the other.
+        Pre-fix the rotation would open a third entry under a new
+        headers_hash (orphaning A's first entry); post-fix it reuses
+        A's stable ``(url, vault_id)`` key.
+        """
+        # Exactly 2 sessions: A's, B's. Pre-fix A's rotation pulls a
+        # third → StopIteration; post-fix it reuses A's cached entry.
+        s_a, s_b = _make_mock_session(), _make_mock_session()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
+        ):
+            pool = McpSessionPool()
+            url = "https://shared.example/"
+            sess_a1, _ = await pool.get_or_connect(url, "vault_A", {"Authorization": "Bearer tokA"})
+            sess_b1, _ = await pool.get_or_connect(url, "vault_B", {"Authorization": "Bearer tokB"})
+            # A rotates: must reuse A's cached entry (no new open).
+            sess_a2, _ = await pool.get_or_connect(
+                url, "vault_A", {"Authorization": "Bearer tokA_v2"}
+            )
+
+        assert len(pool._entries) == 2, (
+            f"A's refresh must reuse A's entry, not orphan a third; "
+            f"got len(_entries)={len(pool._entries)}"
+        )
+        assert sess_a2 is sess_a1, "A's session must be reused across rotation"
+        assert sess_b1 is not sess_a1, "tenants must hold distinct entries"
 
     async def test_contexts_exit_in_same_task_they_entered(self) -> None:
         """Cross-task close — regression for #425.
@@ -281,7 +319,7 @@ class TestMcpSessionPool:
             pool = McpSessionPool()
 
             async def opener() -> None:
-                await pool.get_or_connect("https://m.example/", {"Authorization": "tok"})
+                await pool.get_or_connect("https://m.example/", "v", {"Authorization": "tok"})
 
             await asyncio.create_task(opener())
 
@@ -322,8 +360,8 @@ class TestDiscoverMcpToolsWithPool:
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
         ):
-            await discover_mcp_tools("https://m.example/", "srv", {})
-            await discover_mcp_tools("https://m.example/", "srv", {})
+            await discover_mcp_tools("https://m.example/", "v", {}, "srv")
+            await discover_mcp_tools("https://m.example/", "v", {}, "srv")
 
         session.initialize.assert_awaited_once()
 
@@ -342,7 +380,7 @@ class TestDiscoverMcpToolsWithPool:
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
         ):
-            tools, _ = await discover_mcp_tools("https://m.example/", "srv", {})
+            tools, _ = await discover_mcp_tools("https://m.example/", "v", {}, "srv")
 
         assert tools == []
         assert s_a.initialize.await_count == 1
@@ -358,7 +396,7 @@ class TestDiscoverMcpToolsWithPool:
             patch("aios.mcp.client.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.client.ClientSession", _session_ctx(session)),
         ):
-            tools, _ = await discover_mcp_tools("https://m.example/", "srv", {})
+            tools, _ = await discover_mcp_tools("https://m.example/", "v", {}, "srv")
 
         assert tools == []
         session.initialize.assert_awaited_once()
@@ -377,8 +415,8 @@ class TestCallMcpToolWithPool:
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
         ):
-            await call_mcp_tool("https://m.example/", {}, "do_thing", {})
-            await call_mcp_tool("https://m.example/", {}, "do_thing", {})
+            await call_mcp_tool("https://m.example/", "v", {}, "do_thing", {})
+            await call_mcp_tool("https://m.example/", "v", {}, "do_thing", {})
 
         session.initialize.assert_awaited_once()
 
@@ -397,7 +435,7 @@ class TestCallMcpToolWithPool:
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
         ):
-            result = await call_mcp_tool("https://m.example/", {}, "do_thing", {})
+            result = await call_mcp_tool("https://m.example/", "v", {}, "do_thing", {})
 
         assert result == {"content": ""}
         assert s_a.initialize.await_count == 1


### PR DESCRIPTION
## Summary

- **Root-cause fix for the leak whose bounded mitigation shipped in #458.** `McpSessionPool` keyed pooled MCP sessions on `(url, sha256(headers))`. `resolve_auth_for_url` transparently refreshes an expiring `mcp_oauth` token and returns a rotated `Bearer`. A refresh produced a new `headers_hash` → a new pool key → a fresh `_Entry` (owner task + httpx + SSE stream); the predecessor entry orphaned until worker shutdown. The reaper from #458 bounded the dwell time; this PR removes the orphan-creating mechanism at the source.
- **Re-key on `(url, vault_id)`.** `vault_id` is the row id of the `vault_credentials` entry — **verified stable across token rotation**: `refresh_credential` does an in-place `UPDATE vault_credentials` (`src/aios/services/vaults.py:213`). The same vault now reuses the same pool key on refresh; no orphan accumulates. Cross-tenant safety is inherited structurally — `vault_id` is produced by `resolve_mcp_credential(..., account_id=account_id)`, account-filtered at the query layer (`queries.py:2703-2704`), so Account A's resolution structurally cannot collide with B's.
- **`_PoolKey = tuple[str, str | None]`** — `None` is the no-credential / empty-token / refresh-re-read-empty case (all unauth callers on the same URL share one entry, safe because no auth identity is keyed on). `_headers_hash` and the `hashlib` import are deleted ("don't deprecate, delete").
- **API contract change**: `resolve_auth_for_url` returns `(vault_id, headers)`; `discover_mcp_tools(url, vault_id, headers, server_name)` and `call_mcp_tool(url, vault_id, headers, tool_name, args, *, meta=None)` group the auth bundle immediately after `url` for consistency.
- **#459's mandatory call-site enumeration** is satisfied. Beyond the 5 `resolve_auth_for_url` callers the issue listed, the migration covers 6 test files including a critical e2e site (`tests/e2e/test_vaults.py`) that would have failed only at CI — the `/simplify` reviewer caught it.
- **The #458 idle-TTL reaper is deliberately retained** as defense-in-depth for the cold-entry vector (a vault whose tenant never returns still pins a live task+socket under the stable key). Explicit architectural sign-off documented in `_Entry.last_used`'s WHY comment ("not silent accretion").

## TDD

- `tests/unit/test_mcp_pool.py::test_oauth_refresh_does_not_orphan_entry` — **proven red on pre-fix master** (ran the orphan scenario directly: `len(pool._entries) == 2`); post-fix asserts `== 1`. The exact bug-symptom red→green.
- `tests/unit/test_mcp_pool.py::test_cross_tenant_refresh_does_not_disturb_other_tenant` — pins the multi-tenant invariant; provides exactly 2 mock sessions so a pre-fix orphan would raise `StopIteration`, plus asserts `len(_entries) == 2` and A's session is reused across rotation.

## Code review (pr-review-toolkit:code-reviewer) — all findings, score-annotated

Policy: all findings posted; score triages, does not suppress.

| Finding | Sev | Disposition |
|---|---|---|
| Cross-tenant test's `sess_b is sess_b` assertion held under BOTH pre- and post-fix keying — didn't actually pin the invariant | **82** | **Applied** — re-shaped to use exactly 2 mock sessions (pre-fix would pull a 3rd) + assert `len(_entries) == 2` and `sess_a2 is sess_a1`. Now genuinely red on pre-fix. |
| `resolve_auth_for_url` unit tests discarded `vault_id` with `_`; a regression returning `(None, headers)` on success would silently pass and collapse all tenants to the unauth bucket | **82** | **Applied** — 6 tests now assert `vault_id == "vlt_s1"` on success paths and `vault_id is None` on the empty-token / no-cred paths. |
| Pool log records omit `vault_id` (operator can't tell whose entry was torn down) | 60 | Noted; cosmetic logging follow-up, not in scope for the keying change. |
| `_open_entry` task name doesn't include vault_id (debugging niceness) | 55 | Noted; cosmetic. |
| `self._locks` accumulates per-vault entries (pre-existing #458 gap; same shape as the prior pre-fix accumulation but bounded by distinct-vaults-ever-seen) | 50 | Pre-existing; out of scope. |

Reviewer's question-by-question verdict: concurrency SAFE, cross-tenant safety SAFE, same-key-old-bearer SEMANTICALLY CORRECT (refresh is pre-emptive against expiry; OLD bearer valid mid-stream; rotation onto new token happens at next miss/evict), `(None, {})` collapse SAFE (no caller needed the partial-identity distinction), call-site enumeration COMPLETE.

## Test plan

- [x] Type-checker (mypy) — clean, 153 files
- [x] Linter + format (ruff) — clean
- [x] Unit suite — **1246 passed** (was 1247 with the `TestHeadersHash` 4 tests; deleted per "don't deprecate, delete"; +2 new pool tests + +2 distinguishing assertions on existing tests)
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #459