### PR TITLE
fix(sandbox): close GitProxy resources on a failed bind in start()

### DIFF
--- a/src/aios/sandbox/git_proxy.py
+++ b/src/aios/sandbox/git_proxy.py
@@ -172,27 +172,39 @@ class GitProxy:
         self._server = uvicorn.Server(config)
         self._serve_task = asyncio.create_task(self._server.serve(), name="git-proxy-serve")
 
-        # Wait for the bind to complete and grab the port.
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + _BIND_TIMEOUT_S
-        while loop.time() < deadline:
-            await asyncio.sleep(0.01)
-            if self._server.started and self._server.servers:
-                sockets = self._server.servers[0].sockets
-                if sockets:
-                    self._port = sockets[0].getsockname()[1]
-                    log.info("git_proxy.started", port=self._port)
-                    return
-        raise RuntimeError(f"git proxy failed to bind within {_BIND_TIMEOUT_S}s")
+        try:
+            # Wait for the bind to complete and grab the port.
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + _BIND_TIMEOUT_S
+            while loop.time() < deadline:
+                await asyncio.sleep(0.01)
+                if self._server.started and self._server.servers:
+                    sockets = self._server.servers[0].sockets
+                    if sockets:
+                        self._port = sockets[0].getsockname()[1]
+                        log.info("git_proxy.started", port=self._port)
+                        return
+            raise RuntimeError(f"git proxy failed to bind within {_BIND_TIMEOUT_S}s")
+        except BaseException:
+            # Bind never completed; the caller will drop its reference,
+            # so nothing else will call stop() — without this the serve
+            # task, the httpx client, and the half-bound socket leak.
+            await self.stop()
+            raise
 
     async def stop(self) -> None:
         """Gracefully stop the server and close the httpx client."""
-        if self._server is not None:
-            self._server.should_exit = True
         try:
-            if self._serve_task is not None:
-                with contextlib.suppress(TimeoutError, asyncio.CancelledError):
-                    await asyncio.wait_for(self._serve_task, timeout=5.0)
+            # Graceful drain only matters once the server actually
+            # bound — `should_exit` is checked inside the uvicorn main
+            # loop, which never runs on a failed-bind path, so without
+            # this gate the failed-bind cleanup pays a pointless 5s
+            # wait on every retry.
+            if self._server is not None and self._server.started:
+                self._server.should_exit = True
+                if self._serve_task is not None:
+                    with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+                        await asyncio.wait_for(self._serve_task, timeout=5.0)
         finally:
             # Always cancel the serve task and close the httpx client.
             # Skipping either on a non-timeout exception leaks the

--- a/tests/unit/test_git_proxy.py
+++ b/tests/unit/test_git_proxy.py
@@ -16,11 +16,13 @@ No docker, no real github, no PAT.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 from collections.abc import AsyncIterator
 
 import httpx
 import pytest
+import uvicorn
 
 from aios.sandbox.git_proxy import GitProxy, repo_key
 
@@ -202,6 +204,26 @@ class TestUpstreamFailure:
                 assert r.status_code == 502
         finally:
             await p.stop()
+
+
+class TestStartBindFailureCleanup:
+    async def test_bind_timeout_closes_serve_task_and_httpx_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # uvicorn.Server.serve that never starts — bind never completes.
+        async def _hang(_self: uvicorn.Server, *_a: object, **_k: object) -> None:
+            await asyncio.sleep(60)
+
+        monkeypatch.setattr(uvicorn.Server, "serve", _hang)
+        monkeypatch.setattr("aios.sandbox.git_proxy._BIND_TIMEOUT_S", 0.05)
+
+        p = GitProxy({"acme/foo": "ghp_TEST"})
+        with pytest.raises(RuntimeError, match="git proxy failed to bind"):
+            await p.start()
+
+        assert p._serve_task is not None
+        assert p._serve_task.done()
+        assert p._client.is_closed
 
 
 def test_module_exports() -> None:


### PR DESCRIPTION
## Summary

- **Confirmed leak.** `GitProxy.start()` (`src/aios/sandbox/git_proxy.py`) spawned the `git-proxy-serve` asyncio task and the `httpx.AsyncClient` (allocated in `__init__`), then `raise RuntimeError(...)` on bind-timeout **without cleaning up**. The caller drops its reference to the proxy on return, so nothing else ever called `stop()`. The spawned task, the open httpx client, and the half-bound socket leaked for the worker's lifetime — one per failed provision (bind contention, port exhaustion, transient uvicorn startup failure).
- **Fix mirrors 7 sibling sites.** Wrap the bind-wait loop in `try: ...; except BaseException: await self.stop(); raise`. The `except BaseException` choice matches the established pattern at `sandbox/registry.py:158/175`, `sandbox/spec.py:295`, `sandbox/atomic_mirror.py:29`, `services/files.py:102`, `services/attachment_staging.py:156`, `mcp/pool.py:151`. Reuses the existing well-tested `stop()` to cancel the serve task + close the httpx client.
- **Adjacent cleanup-on-cleanup tightening.** `stop()`'s graceful drain (`should_exit = True` + 5s `wait_for`) is now gated on `self._server.started`. `should_exit` is checked inside uvicorn's `main_loop` which **never runs** on a failed-bind path, so the unconditional 5s wait was a pointless wait that this PR newly exercises on every failed-bind cleanup. Strictly faster on the never-started path; identical behavior on the bound-and-serving path. New test latency drops from ~5.5s to ~50ms; production retry fast-fails too.

## TDD

`tests/unit/test_git_proxy.py::TestStartBindFailureCleanup::test_bind_timeout_closes_serve_task_and_httpx_client` — monkeypatches `uvicorn.Server.serve` to hang and `_BIND_TIMEOUT_S=0.05`. Verified **red on pre-fix code**: `<Task pending name='git-proxy-serve' ...>` — the serve task was still alive after `start()` raised. Post-fix asserts `_serve_task.done()` and `_client.is_closed`.

## Code review (pr-review-toolkit:code-reviewer) — all findings, score-annotated

Policy: all findings posted; score triages, does not suppress. **Verdict: safe to merge. Nothing at/above the 80 threshold.**

| Finding | Sev | Disposition |
|---|---|---|
| Test models `serve()` hanging pre-`startup()` but does not exercise the real-OS bind-failure path (uvicorn `sys.exit(1)` on `OSError`) where `_serve_task.done() == True` early | 30 | "Complete-the-coverage" suggestion; reviewer explicitly says **"isn't a defect"**. The current test exercises the harder cancel-then-await branch in `stop()`'s finally. Deferred. |
| `RuntimeError` message says "failed to bind" but conflates "bind failed" with "didn't observe bind completing" (lifespan hook, CPU starvation, etc.) | 25 | Operator-readable as is. No change. |
| Test uses private-attr surgery (`p._serve_task`, `p._client.is_closed`) | 15 | Consistent with existing test file (lines 75-76 do the same). Keep. |
| `except BaseException` correctness, `stop()` gate race trace, resource cleanup completeness, no belt-and-suspenders, no caller depends on the 5s drain | 5-10 | All SAFE per the reviewer's detailed traces; no action. |

Found via the bughunt parallel-agent audit (resource-lifecycle dimension, score 1.12 — the highest un-shipped candidate carrying over from iteration #16's audit, now re-confirmed on current master).

## Test plan

- [x] Type-checker (mypy) — clean, 153 files
- [x] Linter + format (ruff) — clean
- [x] Unit suite — **1247 passed** (was 1246; +1 new test)
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)