### PR TITLE
fix(sandbox): release subprocess + pipe FDs on outer cancellation

### DIFF
--- a/src/aios/sandbox/_subprocess.py
+++ b/src/aios/sandbox/_subprocess.py
@@ -72,6 +72,15 @@ async def run_subprocess_with_timeout(
             proc._transport.close()  # type: ignore[attr-defined]  # typeshed omits Process._transport
             stdout_bytes, stderr_bytes = b"", b""
         return -1, stdout_bytes, stderr_bytes, True
+    except BaseException:
+        # CancelledError is a BaseException, not a TimeoutError, so the
+        # outer-cancel path (caller's job timeout, worker shutdown)
+        # skips the give-up cleanup above — child keeps running and
+        # pipe FDs leak. SIGKILL + close the transport before propagating.
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        proc._transport.close()  # type: ignore[attr-defined]
+        raise
 
 
 async def run_docker_cli(

--- a/tests/unit/sandbox/test_subprocess.py
+++ b/tests/unit/sandbox/test_subprocess.py
@@ -14,6 +14,7 @@ connection pools. The mechanism is documented at the fix site in
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -66,4 +67,30 @@ async def test_give_up_path_closes_transport(monkeypatch: pytest.MonkeyPatch) ->
     # branch rather than the happy or drain-succeeded paths.
     assert (rc, out, err, timed_out) == (-1, b"", b"", True)
 
+    proc._transport.close.assert_called_once()
+
+
+async def test_outer_cancellation_kills_and_closes_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Outer cancellation must SIGKILL the child and close the transport
+    before propagating. ``CancelledError`` is a ``BaseException``, not a
+    ``TimeoutError``, so it skips the give-up branch from #457."""
+    proc = _WedgedProc()
+
+    async def _fake_spawn(*_argv: Any, **_kwargs: Any) -> _WedgedProc:
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+
+    # Generous timeout so the wait_for itself never fires — outer
+    # cancellation is what we're testing.
+    task = asyncio.create_task(run_subprocess_with_timeout(["docker", "ps"], timeout_s=60.0))
+    # Let the task reach `await asyncio.wait_for(proc.communicate(), ...)`.
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    assert proc._transport.kill.called
     proc._transport.close.assert_called_once()


### PR DESCRIPTION
## Summary

- **Sibling of #457.** `run_subprocess_with_timeout`'s existing `except TimeoutError` branch covers the `wait_for`'s own deadline firing. But **outer cancellation** — the caller's job timeout (`loop.py`'s `_JOB_TIMEOUT_S`), worker shutdown signal, or any other cancel scope above us — surfaces as `CancelledError`, which is a `BaseException`, **not** a `TimeoutError`. The cleanup branch was skipped, so the child kept running and the parent-side stdout/stderr pipe FDs stayed open for the wedge's lifetime. Real trigger: a slow bash tool against a flapping daemon, the harness job timeout fires, and every wedge leaks 2 FDs + a zombie.
- **Fix mirrors 8 sibling sites.** Add an `except BaseException: kill + transport.close + raise` branch sibling to the existing `except TimeoutError`. Body is sync-only (`proc.kill()` + `proc._transport.close()`) so re-delivered cancellation cannot interrupt mid-cleanup. Pattern: `registry.py:158/175`, `spec.py:295`, `atomic_mirror.py:29`, `files.py:102`, `services/attachment_staging.py:156`, `mcp/pool.py:151`, `git_proxy.py:188` (from #463).

## TDD

`tests/unit/sandbox/test_subprocess.py::test_outer_cancellation_kills_and_closes_transport` — reuses the existing `_WedgedProc` fake (its `kill` already delegates to `_transport.kill` so the fake mirrors CPython's coupling). Outer task awaits `run_subprocess_with_timeout(..., timeout_s=60.0)`, brief sleep, `task.cancel()`, asserts `_transport.kill.called` + `_transport.close.assert_called_once()`. **Verified red on pre-fix code**: `proc._transport.kill.called = False` — exactly the predicted symptom.

## Code review (pr-review-toolkit:code-reviewer)

**Verdict: ship it. No defects.** Each focus axis scored 85-95 with concrete confirmation:
- (a) `except BaseException` cleanup body verified sync-only against CPython sources — cancellation re-delivery cannot interrupt;
- (b) clause order vs `TimeoutError` mutually exclusive;
- (c) test fidelity robust — `task.cancel()` delivers at the next await regardless of scheduler timing;
- (d) `proc.kill()` + `transport.close()` releases both ends; the (intentional) skip of a secondary drain on the propagate-path avoids re-cancellation risk;
- (e) `except TimeoutError` path byte-identical to #457 (existing `test_give_up_path_closes_transport` still green);
- (f) project stance clean — established 8-site lifecycle-cleanup idiom, bare re-raise, WHY-focused comment.

No sub-threshold findings.

## Test plan

- [x] Type-checker (mypy) — clean, 153 files
- [x] Linter + format (ruff) — clean
- [x] Unit suite — **1248 passed** (was 1247; +1 new test)
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)