### PR TITLE
feat(connections): rename account → external_account_id + typed ConflictError

### DIFF
--- a/connectors/signal/src/aios_signal/management.py
+++ b/connectors/signal/src/aios_signal/management.py
@@ -36,51 +36,56 @@ class SignalManagementMixin:
     async def register(
         self,
         *,
-        account: str,
+        external_account_id: str,
         captcha: str | None = None,
         voice: bool = False,
     ) -> dict[str, Any]:
         assert self._daemon is not None
         try:
-            await self._daemon.register(phone=account, captcha=captcha, voice=voice)
+            await self._daemon.register(
+                phone=external_account_id, captcha=captcha, voice=voice
+            )
         except RpcError as exc:
             if _is_captcha_required(exc):
                 raise ManagementHandlerError(
                     {
                         "status": "captcha_required",
                         "captcha_url": _captcha_url(exc),
-                        "account": account,
+                        "external_account_id": external_account_id,
                     }
                 ) from exc
             raise
-        return {"account": account, "status": "voice_sent" if voice else "sms_sent"}
+        return {
+            "external_account_id": external_account_id,
+            "status": "voice_sent" if voice else "sms_sent",
+        }
 
     @management_handler()
     async def verify(
         self,
         *,
-        account: str,
+        external_account_id: str,
         code: str,
         pin: str | None = None,
     ) -> dict[str, Any]:
         assert self._daemon is not None
-        result = await self._daemon.verify(phone=account, code=code, pin=pin)
-        return {"account": account, "uuid": result.get("uuid", "")}
+        result = await self._daemon.verify(phone=external_account_id, code=code, pin=pin)
+        return {"external_account_id": external_account_id, "uuid": result.get("uuid", "")}
 
     @management_handler(method="updateProfile")
     async def update_profile(
         self,
         *,
-        account: str,
+        external_account_id: str,
         given_name: str | None = None,
         family_name: str | None = None,
         about: str | None = None,
     ) -> dict[str, Any]:
         assert self._daemon is not None
         await self._daemon.update_profile(
-            phone=account,
+            phone=external_account_id,
             given_name=given_name,
             family_name=family_name,
             about=about,
         )
-        return {"account": account}
+        return {"external_account_id": external_account_id}

--- a/connectors/signal/tests/test_management.py
+++ b/connectors/signal/tests/test_management.py
@@ -48,19 +48,19 @@ def probe(daemon: MagicMock) -> _Probe:
 class TestRegister:
     @pytest.mark.asyncio
     async def test_happy_path_returns_sms_sent(self, probe: _Probe, daemon: MagicMock) -> None:
-        result = await probe.register(account="+15551234567")
-        assert result == {"account": "+15551234567", "status": "sms_sent"}
+        result = await probe.register(external_account_id="+15551234567")
+        assert result == {"external_account_id": "+15551234567", "status": "sms_sent"}
         daemon.register.assert_awaited_once_with(phone="+15551234567", captcha=None, voice=False)
 
     @pytest.mark.asyncio
     async def test_voice_routes_to_voice_sent(self, probe: _Probe, daemon: MagicMock) -> None:
-        result = await probe.register(account="+1", voice=True)
+        result = await probe.register(external_account_id="+1", voice=True)
         assert result["status"] == "voice_sent"
         daemon.register.assert_awaited_once_with(phone="+1", captcha=None, voice=True)
 
     @pytest.mark.asyncio
     async def test_passes_captcha_token_to_daemon(self, probe: _Probe, daemon: MagicMock) -> None:
-        await probe.register(account="+1", captcha="signalcaptcha://x")
+        await probe.register(external_account_id="+1", captcha="signalcaptcha://x")
         daemon.register.assert_awaited_once_with(
             phone="+1", captcha="signalcaptcha://x", voice=False
         )
@@ -71,37 +71,37 @@ class TestRegister:
     ) -> None:
         daemon.register.side_effect = RpcError("Captcha required", code=-3, data={"captcha": True})
         with pytest.raises(ManagementHandlerError) as exc_info:
-            await probe.register(account="+1")
+            await probe.register(external_account_id="+1")
         assert exc_info.value.payload == {
             "status": "captcha_required",
             "captcha_url": "https://signalcaptchas.org/registration/generate",
-            "account": "+1",
+            "external_account_id": "+1",
         }
 
     @pytest.mark.asyncio
     async def test_non_captcha_rpc_error_propagates(self, probe: _Probe, daemon: MagicMock) -> None:
         daemon.register.side_effect = RpcError("phone already registered elsewhere")
         with pytest.raises(RpcError, match="already registered"):
-            await probe.register(account="+1")
+            await probe.register(external_account_id="+1")
 
 
 class TestVerify:
     @pytest.mark.asyncio
     async def test_returns_uuid(self, probe: _Probe, daemon: MagicMock) -> None:
-        result = await probe.verify(account="+1", code="123456")
-        assert result == {"account": "+1", "uuid": "u-abc"}
+        result = await probe.verify(external_account_id="+1", code="123456")
+        assert result == {"external_account_id": "+1", "uuid": "u-abc"}
         daemon.verify.assert_awaited_once_with(phone="+1", code="123456", pin=None)
 
     @pytest.mark.asyncio
     async def test_pin_threaded_through(self, probe: _Probe, daemon: MagicMock) -> None:
-        await probe.verify(account="+1", code="000000", pin="9999")
+        await probe.verify(external_account_id="+1", code="000000", pin="9999")
         daemon.verify.assert_awaited_once_with(phone="+1", code="000000", pin="9999")
 
 
 class TestUpdateProfile:
     @pytest.mark.asyncio
     async def test_passes_only_non_none_fields(self, probe: _Probe, daemon: MagicMock) -> None:
-        await probe.update_profile(account="+1", given_name="Alice", about=None)
+        await probe.update_profile(external_account_id="+1", given_name="Alice", about=None)
         daemon.update_profile.assert_awaited_once_with(
             phone="+1", given_name="Alice", family_name=None, about=None
         )
@@ -128,7 +128,7 @@ class TestCaptchaUrl:
             "Captcha required", code=-3, data={"captcha_url": "https://x.example/123"}
         )
         with pytest.raises(ManagementHandlerError) as exc_info:
-            await probe.register(account="+1")
+            await probe.register(external_account_id="+1")
         assert exc_info.value.payload["captcha_url"] == "https://x.example/123"
 
     @pytest.mark.asyncio
@@ -137,5 +137,5 @@ class TestCaptchaUrl:
     ) -> None:
         daemon.register.side_effect = RpcError("Captcha required", code=-3)
         with pytest.raises(ManagementHandlerError) as exc_info:
-            await probe.register(account="+1")
+            await probe.register(external_account_id="+1")
         assert exc_info.value.payload["captcha_url"].startswith("https://signalcaptchas.org/")

--- a/connectors/telegram/README.md
+++ b/connectors/telegram/README.md
@@ -4,7 +4,7 @@ Telegram connector for [aios](../../README.md).  Built on
 ``aios-connector-http``.  Each connector container is one bot — the
 container's bearer token resolves to a single ``connection_id`` on
 the management API, and that connection holds the bot's identity
-(``connector="telegram"``, ``account=<bot_id>``) plus the encrypted
+(``connector="telegram"``, ``external_account_id=<bot_id>``) plus the encrypted
 ``bot_token`` secret the connector reads at startup.  Multi-bot
 deployments run multiple containers, each with its own connector
 token.
@@ -26,7 +26,7 @@ Copy the token.  Repeat for each bot you want to deploy.
 ```bash
 aios connections create \
     --connector telegram \
-    --account <bot_id> \
+    --external-account-id <bot_id> \
     --secret bot_token=<token>
 # → returns connection_id
 ```

--- a/connectors/telegram/src/aios_telegram/prompts.py
+++ b/connectors/telegram/src/aios_telegram/prompts.py
@@ -2,7 +2,7 @@
 
 Returned in the ``InitializeResult.instructions`` field of the MCP
 ``initialize`` response; the aios harness concatenates it into the
-session's system prompt under a ``## Connector: telegram/<account>``
+session's system prompt under a ``## Connector: telegram/<external_account_id>``
 heading.
 
 Covers the tools this server exposes.  Telling the model about tools
@@ -29,16 +29,17 @@ def build_instructions(
     startup.  ``bot_id`` and ``first_name`` are guaranteed by Telegram's
     schema; ``username`` is optional (a bot can exist without one during
     BotFather setup) and its bullet is omitted when absent or empty.
-    ``bot_id`` doubles as the ``<account>`` segment of this connector's
-    channel addresses.
+    ``bot_id`` doubles as the ``<external_account_id>`` segment of this
+    connector's channel addresses.
     """
     lines = [
         "## Your identity on this Telegram bot account",
         "",
         f"- **bot_id**: `{bot_id}` — this is YOU.  In group chats, any "
         f"inbound whose header shows this id is your own prior message, "
-        f"not another participant.  It also appears as the ``<account>`` "
-        f"segment of every ``telegram/<account>/<chat_id>`` address.",
+        f"not another participant.  It also appears as the "
+        f"``<external_account_id>`` segment of every "
+        f"``telegram/<external_account_id>/<chat_id>`` address.",
     ]
     if username:
         lines.append(
@@ -54,7 +55,8 @@ def build_instructions(
 TELEGRAM_SERVER_INSTRUCTIONS = """\
 ## chat_id
 
-Each Telegram channel address is path-shaped: ``telegram/<bot_id>/<chat_id>``.
+Each Telegram channel address is path-shaped: ``telegram/<external_account_id>/<chat_id>``
+(``<external_account_id>`` is the bot_id above).
 The ``chat_id`` segment is a signed integer:
 
 - Positive for direct messages (the counterparty's user id).

--- a/migrations/versions/0050_connections_external_account_id.py
+++ b/migrations/versions/0050_connections_external_account_id.py
@@ -1,0 +1,71 @@
+"""Rename ``connections.account`` (and the sibling dedup-ledger column) to
+``external_account_id`` and reindex the partial unique constraint under a
+clearer name.
+
+Predates multi-tenancy; after ``account_id`` arrived as the tenant FK,
+``account`` no longer reads as the globally-exclusive external identity
+it actually is. The same column lives on ``connector_inbound_acks`` as
+part of the dedup-ledger PK — renamed in lock-step so call sites that
+pass ``connection.external_account_id`` keep their parameter name
+aligned with the column they write to.
+
+Wire-format change with no deprecation shim. Connector runtime
+containers must redeploy in lock-step (the SDK's focal-kwarg injection
+now passes ``external_account_id`` rather than ``account``).
+
+Revision ID: 0050
+Revises: 0049
+Create Date: 2026-05-15
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0050"
+down_revision: str = "0049"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 1. Rename the column on ``connections``. ``RENAME COLUMN`` is a
+    # metadata-only catalog update — no row rewrite, indexes referencing
+    # the column track it by attnum.
+    op.execute("ALTER TABLE connections RENAME COLUMN account TO external_account_id")
+    # The partial unique index still functions (Postgres tracks columns
+    # by attnum, not name), but its name embeds the old column word.
+    # Drop+recreate under the new name so ``\d connections`` and grep
+    # both surface the right relationship.
+    op.execute("DROP INDEX IF EXISTS connections_active_account_uniq")
+    op.execute(
+        "CREATE UNIQUE INDEX connections_active_external_account_uniq "
+        "ON connections (connector, external_account_id) WHERE archived_at IS NULL"
+    )
+
+    # 2. Same rename on the dedup ledger. The PK ``(connector, account,
+    # event_id)`` becomes ``(connector, external_account_id, event_id)``
+    # — the PK constraint name (``connector_inbound_acks_pkey``) is
+    # column-list-bound, not column-name-bound, so no rename needed.
+    op.execute(
+        "ALTER TABLE connector_inbound_acks RENAME COLUMN account TO external_account_id"
+    )
+
+
+def downgrade() -> None:
+    # Rename the connections column first, then swap the index — keeping
+    # *some* partial-unique index on the renamed column for as much of
+    # the migration window as the engine allows. Postgres tracks index
+    # columns by attnum so the existing index keeps working through the
+    # rename; DROP+CREATE under the new name closes the cycle.
+    op.execute("ALTER TABLE connections RENAME COLUMN external_account_id TO account")
+    op.execute("DROP INDEX IF EXISTS connections_active_external_account_uniq")
+    op.execute(
+        "CREATE UNIQUE INDEX connections_active_account_uniq "
+        "ON connections (connector, account) WHERE archived_at IS NULL"
+    )
+    op.execute(
+        "ALTER TABLE connector_inbound_acks RENAME COLUMN external_account_id TO account"
+    )

--- a/openapi.json
+++ b/openapi.json
@@ -5195,7 +5195,7 @@
           "connections"
         ],
         "summary": "Create",
-        "description": "Create a detached connection, **idempotent on ``(connector, account)``**.\n\nPer plan decision #5, this endpoint and the supervisor's\nauto-create-on-first-inbound path race-safely converge on a single row:\nposting twice with the same ``(connector, account)`` returns 201 with the\nexisting row rather than 409.  The ``id`` may differ from a freshly-allocated\none if a concurrent writer landed first; the response always reflects the\ncanonical active row.\n\nOptional ``secrets`` carry platform credentials (e.g. Telegram\n``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``\nand only ever read back through the runtime-scoped\n``GET /v1/connectors/runtime/secrets`` route \u2014 operator-facing\nreads return ``secrets_set: bool`` instead of values.",
+        "description": "Create a detached connection, **idempotent on ``(connector, external_account_id)``**.\n\nPer plan decision #5, this endpoint and the supervisor's\nauto-create-on-first-inbound path race-safely converge on a single\nrow: posting twice with the same ``(connector, external_account_id)``\nreturns 201 with the existing row rather than 409. The ``id`` may\ndiffer from a freshly-allocated one if a concurrent writer landed\nfirst; the response always reflects the canonical active row.\n\nThe active-row partial-unique index is global, not tenant-scoped \u2014\nreal-world messaging identities (Signal phone numbers, Telegram\nbot tokens, etc.) are universally exclusive. If another tenant\nalready holds the active row for this identity, the call returns\n409 ``conflict`` rather than silently masking the collision.\n\nOptional ``secrets`` carry platform credentials (e.g. Telegram\n``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``\nand only ever read back through the runtime-scoped\n``GET /v1/connectors/runtime/secrets`` route \u2014 operator-facing\nreads return ``secrets_set: bool`` instead of values.",
         "operationId": "create_connection",
         "parameters": [
           {
@@ -6331,7 +6331,7 @@
           "connectors"
         ],
         "summary": "Get Connection Discovery",
-        "description": "SSE stream of ``added`` / ``removed`` connection events for the\nruntime container's connector type (#328 PR 5).\n\nBackfills every active connection of the caller's ``connector``\ntype at subscribe time as ``added`` events, then tails the\n``connections_<connector>`` NOTIFY channel.  Each event is keyed\n``connection`` with a JSON body shaped::\n\n    {\"event\": \"added\" | \"removed\", \"connection_id\": \"...\", \"account\": \"...\"}\n\nThe runtime container subscribes once per ``connector`` type and\nfans out to per-connection workers on ``added``; tears them down\non ``removed``.",
+        "description": "SSE stream of ``added`` / ``removed`` connection events for the\nruntime container's connector type (#328 PR 5).\n\nBackfills every active connection of the caller's ``connector``\ntype at subscribe time as ``added`` events, then tails the\n``connections_<connector>`` NOTIFY channel.  Each event is keyed\n``connection`` with a JSON body shaped::\n\n    {\"event\": \"added\" | \"removed\",\n     \"connection_id\": \"...\",\n     \"external_account_id\": \"...\"}\n\nThe runtime container subscribes once per ``connector`` type and\nfans out to per-connection workers on ``added``; tears them down\non ``removed``.",
         "operationId": "get_connection_discovery_v1_connectors_connections_get",
         "parameters": [
           {
@@ -8032,9 +8032,9 @@
             "type": "string",
             "title": "Connector"
           },
-          "account": {
+          "external_account_id": {
             "type": "string",
-            "title": "Account"
+            "title": "External Account Id"
           },
           "session_id": {
             "anyOf": [
@@ -8107,7 +8107,7 @@
         "required": [
           "id",
           "connector",
-          "account",
+          "external_account_id",
           "metadata",
           "created_at",
           "updated_at"
@@ -8153,11 +8153,11 @@
             "minLength": 1,
             "title": "Connector"
           },
-          "account": {
+          "external_account_id": {
             "type": "string",
             "maxLength": 256,
             "minLength": 1,
-            "title": "Account"
+            "title": "External Account Id"
           },
           "metadata": {
             "additionalProperties": true,
@@ -8184,10 +8184,10 @@
         "type": "object",
         "required": [
           "connector",
-          "account"
+          "external_account_id"
         ],
         "title": "ConnectionCreate",
-        "description": "Request body for ``POST /v1/connections``.\n\nCreated in detached mode \u2014 neither ``session_id`` nor\n``session_template_id`` is set.  Use ``POST .../attach`` or\n``POST .../configure-per-chat`` afterward to bind a routing mode.\n\n``connector`` and ``account`` may not contain ``/`` \u2014 they're used\nin the focal-channel address scheme ``{connector}/{account}/{chat_id}``\nand a ``/`` would create ambiguous segment boundaries."
+        "description": "Request body for ``POST /v1/connections``.\n\nCreated in detached mode \u2014 neither ``session_id`` nor\n``session_template_id`` is set.  Use ``POST .../attach`` or\n``POST .../configure-per-chat`` afterward to bind a routing mode.\n\n``connector`` and ``external_account_id`` may not contain ``/`` \u2014\nthey're used in the focal-channel address scheme\n``{connector}/{external_account_id}/{chat_id}`` and a ``/`` would\ncreate ambiguous segment boundaries."
       },
       "ConnectionSetSecrets": {
         "properties": {
@@ -10992,9 +10992,9 @@
       },
       "SignalProfileRequest": {
         "properties": {
-          "account": {
+          "external_account_id": {
             "type": "string",
-            "title": "Account"
+            "title": "External Account Id"
           },
           "given_name": {
             "anyOf": [
@@ -11033,15 +11033,15 @@
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "account"
+          "external_account_id"
         ],
         "title": "SignalProfileRequest"
       },
       "SignalRegisterRequest": {
         "properties": {
-          "account": {
+          "external_account_id": {
             "type": "string",
-            "title": "Account"
+            "title": "External Account Id"
           },
           "captcha": {
             "anyOf": [
@@ -11063,15 +11063,15 @@
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "account"
+          "external_account_id"
         ],
         "title": "SignalRegisterRequest"
       },
       "SignalRegisterResponse": {
         "properties": {
-          "account": {
+          "external_account_id": {
             "type": "string",
-            "title": "Account"
+            "title": "External Account Id"
           },
           "status": {
             "type": "string",
@@ -11096,7 +11096,7 @@
         },
         "type": "object",
         "required": [
-          "account",
+          "external_account_id",
           "status"
         ],
         "title": "SignalRegisterResponse",
@@ -11104,9 +11104,9 @@
       },
       "SignalVerifyRequest": {
         "properties": {
-          "account": {
+          "external_account_id": {
             "type": "string",
-            "title": "Account"
+            "title": "External Account Id"
           },
           "code": {
             "type": "string",
@@ -11127,16 +11127,16 @@
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "account",
+          "external_account_id",
           "code"
         ],
         "title": "SignalVerifyRequest"
       },
       "SignalVerifyResponse": {
         "properties": {
-          "account": {
+          "external_account_id": {
             "type": "string",
-            "title": "Account"
+            "title": "External Account Id"
           },
           "uuid": {
             "type": "string",
@@ -11145,7 +11145,7 @@
         },
         "type": "object",
         "required": [
-          "account",
+          "external_account_id",
           "uuid"
         ],
         "title": "SignalVerifyResponse"

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -190,7 +190,7 @@ class _ConnectionState:
     """Per-connection runtime state.  One row per active connection."""
 
     connection_id: str
-    account: str
+    external_account_id: str
     secrets: dict[str, str] = field(default_factory=dict)
     worker: asyncio.Task[None] | None = None
 
@@ -241,14 +241,15 @@ class HttpConnector:
 
     # ─── helpers (subclasses use these) ──────────────────────────────
 
-    def focal_channel(self, account: str, chat_id: str) -> str:
-        """Return the canonical ``<connector>/<account>/<chat_id>`` string.
+    def focal_channel(self, external_account_id: str, chat_id: str) -> str:
+        """Return the canonical ``<connector>/<external_account_id>/<chat_id>`` string.
 
         Outbound tool methods write this to messages they edit/react to;
-        the runtime parses it back into ``account`` / ``chat_id`` kwargs
-        on the next call (see :func:`_inject_focal_kwargs`).
+        the runtime parses it back into ``external_account_id`` /
+        ``chat_id`` kwargs on the next call (see
+        :func:`_inject_focal_kwargs`).
         """
-        return f"{self.connector}/{account}/{chat_id}"
+        return f"{self.connector}/{external_account_id}/{chat_id}"
 
     # ─── lifecycle hooks (override as needed) ────────────────────────
 
@@ -570,9 +571,9 @@ class HttpConnector:
                     payload = json.loads(msg.data)
                     event = payload.get("event")
                     connection_id = payload.get("connection_id", "")
-                    account = payload.get("account", "")
+                    external_account_id = payload.get("external_account_id", "")
                     if event == "added":
-                        await self._on_connection_added(tg, connection_id, account)
+                        await self._on_connection_added(tg, connection_id, external_account_id)
                     elif event == "removed":
                         await self._on_connection_removed(connection_id)
             # Only retry on transport-level errors (timeouts, dropped
@@ -593,7 +594,7 @@ class HttpConnector:
             backoff = min(backoff * 2, 60.0)
 
     async def _on_connection_added(
-        self, tg: asyncio.TaskGroup, connection_id: str, account: str
+        self, tg: asyncio.TaskGroup, connection_id: str, external_account_id: str
     ) -> None:
         """Fetch secrets, then spawn ``serve_connection`` in its own task.
 
@@ -628,7 +629,11 @@ class HttpConnector:
             secrets_map: dict[str, str] = {}
         else:
             secrets_map = {str(k): str(v) for k, v in raw_secrets.additional_properties.items()}
-        state = _ConnectionState(connection_id=connection_id, account=account, secrets=secrets_map)
+        state = _ConnectionState(
+            connection_id=connection_id,
+            external_account_id=external_account_id,
+            secrets=secrets_map,
+        )
         state.worker = tg.create_task(
             self._isolated_serve_connection(connection_id, secrets_map),
             name=f"aios-conn-{connection_id}",
@@ -639,7 +644,7 @@ class HttpConnector:
             "connector.connection.added",
             connector=self.connector,
             connection_id=connection_id,
-            account=account,
+            external_account_id=external_account_id,
         )
 
     async def _isolated_serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
@@ -726,10 +731,11 @@ class HttpConnector:
         """Run the tool method for ``call`` and POST the result.
 
         Tool method signatures may accept any subset of the
-        focal-injectable kwargs: ``connection_id``, ``account``,
-        ``chat_id``.  ``connection_id`` comes from the call payload;
-        ``account`` and ``chat_id`` are parsed out of
-        ``focal_channel`` (``<connector>/<account>/<chat_id>``).
+        focal-injectable kwargs: ``connection_id``,
+        ``external_account_id``, ``chat_id``.  ``connection_id`` comes
+        from the call payload; ``external_account_id`` and ``chat_id``
+        are parsed out of ``focal_channel``
+        (``<connector>/<external_account_id>/<chat_id>``).
 
         ``SandboxPath``-annotated params get their in-sandbox path
         strings resolved to host :class:`Path`s before the body runs.
@@ -1058,7 +1064,9 @@ class HttpConnector:
         return out
 
 
-_FOCAL_INJECTABLE: frozenset[str] = frozenset({"connection_id", "account", "chat_id"})
+_FOCAL_INJECTABLE: frozenset[str] = frozenset(
+    {"connection_id", "external_account_id", "chat_id"}
+)
 
 
 def _build_tool_meta(fn: ToolFn) -> _ToolMeta:
@@ -1152,23 +1160,26 @@ def _inject_focal_kwargs(
     focal_channel: str,
     connection_id: str,
 ) -> dict[str, Any]:
-    """Inject ``connection_id`` / ``account`` / ``chat_id`` kwargs.
+    """Inject ``connection_id`` / ``external_account_id`` / ``chat_id`` kwargs.
 
     The runtime SSE payload includes ``connection_id`` directly;
-    ``account`` and ``chat_id`` are parsed out of ``focal_channel``
-    (``<connector>/<account>/<chat_id>``).  Each is injected only when
-    the tool's signature accepts it AND the caller didn't already
-    pass it explicitly.
+    ``external_account_id`` and ``chat_id`` are parsed out of
+    ``focal_channel`` (``<connector>/<external_account_id>/<chat_id>``).
+    Each is injected only when the tool's signature accepts it AND the
+    caller didn't already pass it explicitly.
     """
     out = dict(args)
     if connection_id and "connection_id" in meta.focal_params and "connection_id" not in out:
         out["connection_id"] = connection_id
-    if focal_channel and meta.focal_params & {"account", "chat_id"}:
+    if focal_channel and meta.focal_params & {"external_account_id", "chat_id"}:
         parts = focal_channel.split("/", 2)
         if len(parts) >= 3:
-            _connector, account, chat_id = parts
-            if "account" in meta.focal_params and "account" not in out:
-                out["account"] = account
+            _connector, external_account_id, chat_id = parts
+            if (
+                "external_account_id" in meta.focal_params
+                and "external_account_id" not in out
+            ):
+                out["external_account_id"] = external_account_id
             if "chat_id" in meta.focal_params and "chat_id" not in out:
                 out["chat_id"] = chat_id
     return out

--- a/packages/aios-connector-http/aios_connector_http/schema.py
+++ b/packages/aios-connector-http/aios_connector_http/schema.py
@@ -63,7 +63,9 @@ from typing import Any, Literal, Union, get_args, get_origin, get_type_hints
 
 from .sandbox import _SandboxPathMarker
 
-_INJECTED_PARAMS: frozenset[str] = frozenset({"connection_id", "account", "chat_id"})
+_INJECTED_PARAMS: frozenset[str] = frozenset(
+    {"connection_id", "external_account_id", "chat_id"}
+)
 
 
 class SchemaError(ValueError):

--- a/packages/aios-connector-http/tests/test_management_dispatch.py
+++ b/packages/aios-connector-http/tests/test_management_dispatch.py
@@ -35,20 +35,31 @@ class _ManagementProbeConnector(HttpConnector):
         self._client = MagicMock()
 
     @management_handler()
-    async def register(self, *, account: str) -> dict[str, str]:
-        self.calls.append(("register", {"account": account}))
-        return {"status": "sms_sent", "account": account}
+    async def register(self, *, external_account_id: str) -> dict[str, str]:
+        self.calls.append(("register", {"external_account_id": external_account_id}))
+        return {"status": "sms_sent", "external_account_id": external_account_id}
 
     @management_handler()
-    async def captcha_path(self, *, account: str) -> dict[str, str]:
-        self.calls.append(("captcha_path", {"account": account}))
+    async def captcha_path(self, *, external_account_id: str) -> dict[str, str]:
+        self.calls.append(("captcha_path", {"external_account_id": external_account_id}))
         raise ManagementHandlerError(
-            {"status": "captcha_required", "captcha_url": "https://x", "account": account}
+            {
+                "status": "captcha_required",
+                "captcha_url": "https://x",
+                "external_account_id": external_account_id,
+            }
         )
 
     @management_handler(method="updateProfile")
-    async def update_profile(self, *, account: str, given_name: str) -> dict[str, str]:
-        self.calls.append(("update_profile", {"account": account, "given_name": given_name}))
+    async def update_profile(
+        self, *, external_account_id: str, given_name: str
+    ) -> dict[str, str]:
+        self.calls.append(
+            (
+                "update_profile",
+                {"external_account_id": external_account_id, "given_name": given_name},
+            )
+        )
         raise RuntimeError("daemon down")
 
     async def _post_management_call_result(  # type: ignore[override]
@@ -72,13 +83,17 @@ class TestDispatchManagementCall:
     @pytest.mark.asyncio
     async def test_routes_call_to_decorated_handler(self, probe: _ManagementProbeConnector) -> None:
         await probe.dispatch_management_call(
-            {"call_id": "mgmt_1", "method": "register", "params": {"account": "+15551234567"}}
+            {
+                "call_id": "mgmt_1",
+                "method": "register",
+                "params": {"external_account_id": "+15551234567"},
+            }
         )
-        assert probe.calls == [("register", {"account": "+15551234567"})]
+        assert probe.calls == [("register", {"external_account_id": "+15551234567"})]
         r = probe.results[0]
         assert r.kwargs == {
             "call_id": "mgmt_1",
-            "result": {"status": "sms_sent", "account": "+15551234567"},
+            "result": {"status": "sms_sent", "external_account_id": "+15551234567"},
             "is_error": False,
         }
 
@@ -87,14 +102,18 @@ class TestDispatchManagementCall:
         self, probe: _ManagementProbeConnector
     ) -> None:
         await probe.dispatch_management_call(
-            {"call_id": "mgmt_2", "method": "captcha_path", "params": {"account": "+1"}}
+            {
+                "call_id": "mgmt_2",
+                "method": "captcha_path",
+                "params": {"external_account_id": "+1"},
+            }
         )
         r = probe.results[0]
         assert r.kwargs["is_error"] is True
         assert r.kwargs["result"] == {
             "status": "captcha_required",
             "captcha_url": "https://x",
-            "account": "+1",
+            "external_account_id": "+1",
         }
 
     @pytest.mark.asyncio
@@ -105,7 +124,7 @@ class TestDispatchManagementCall:
             {
                 "call_id": "mgmt_3",
                 "method": "updateProfile",
-                "params": {"account": "+1", "given_name": "X"},
+                "params": {"external_account_id": "+1", "given_name": "X"},
             }
         )
         r = probe.results[0]

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -258,9 +258,13 @@ class _FocalConnector(_ProbeConnector):
         return f"sent to {chat_id}"
 
     @tool()
-    async def needs_both(self, *, account: str, chat_id: str, text: str) -> str:
-        self.focal_calls.append({"account": account, "chat_id": chat_id, "text": text})
-        return f"{account}:{chat_id}"
+    async def needs_both(
+        self, *, external_account_id: str, chat_id: str, text: str
+    ) -> str:
+        self.focal_calls.append(
+            {"external_account_id": external_account_id, "chat_id": chat_id, "text": text}
+        )
+        return f"{external_account_id}:{chat_id}"
 
     @tool()
     async def needs_connection(self, *, connection_id: str, text: str) -> str:
@@ -289,7 +293,7 @@ class TestFocalChannelInjection:
         )
         assert c.focal_calls == [{"text": "hi", "chat_id": "chat-123"}]
 
-    async def test_injects_both_account_and_chat_id(self) -> None:
+    async def test_injects_both_external_account_id_and_chat_id(self) -> None:
         c = _FocalConnector()
         await c.dispatch_call(
             {
@@ -301,7 +305,9 @@ class TestFocalChannelInjection:
                 "focal_channel": "signal/+15551234/group-abc",
             }
         )
-        assert c.focal_calls == [{"account": "+15551234", "chat_id": "group-abc", "text": "hi"}]
+        assert c.focal_calls == [
+            {"external_account_id": "+15551234", "chat_id": "group-abc", "text": "hi"}
+        ]
 
     async def test_injects_connection_id_when_signature_accepts(self) -> None:
         c = _FocalConnector()

--- a/packages/aios-connector-http/tests/test_schema.py
+++ b/packages/aios-connector-http/tests/test_schema.py
@@ -177,11 +177,11 @@ class TestSkipsInjectedParams:
         assert "chat_id" not in props
         assert "chat_id" not in spec["input_schema"]["required"]
 
-    def test_account_is_excluded_from_schema(self) -> None:
+    def test_external_account_id_is_excluded_from_schema(self) -> None:
         class C(_DummyForBindings):
             @tool()
-            async def t(self, *, account: str, chat_id: str) -> str:
-                return f"{account}/{chat_id}"
+            async def t(self, *, external_account_id: str, chat_id: str) -> str:
+                return f"{external_account_id}/{chat_id}"
 
         spec = derive_tool_spec("t", C().t)
         assert spec["input_schema"]["properties"] == {}

--- a/packages/aios-sdk/aios_sdk/_generated/api/connections/create_connection.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connections/create_connection.py
@@ -71,14 +71,20 @@ def sync_detailed(
 ) -> Response[Connection | HTTPValidationError]:
     """Create
 
-     Create a detached connection, **idempotent on ``(connector, account)``**.
+     Create a detached connection, **idempotent on ``(connector, external_account_id)``**.
 
     Per plan decision #5, this endpoint and the supervisor's
-    auto-create-on-first-inbound path race-safely converge on a single row:
-    posting twice with the same ``(connector, account)`` returns 201 with the
-    existing row rather than 409.  The ``id`` may differ from a freshly-allocated
-    one if a concurrent writer landed first; the response always reflects the
-    canonical active row.
+    auto-create-on-first-inbound path race-safely converge on a single
+    row: posting twice with the same ``(connector, external_account_id)``
+    returns 201 with the existing row rather than 409. The ``id`` may
+    differ from a freshly-allocated one if a concurrent writer landed
+    first; the response always reflects the canonical active row.
+
+    The active-row partial-unique index is global, not tenant-scoped —
+    real-world messaging identities (Signal phone numbers, Telegram
+    bot tokens, etc.) are universally exclusive. If another tenant
+    already holds the active row for this identity, the call returns
+    409 ``conflict`` rather than silently masking the collision.
 
     Optional ``secrets`` carry platform credentials (e.g. Telegram
     ``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``
@@ -94,9 +100,10 @@ def sync_detailed(
             ``session_template_id`` is set.  Use ``POST .../attach`` or
             ``POST .../configure-per-chat`` afterward to bind a routing mode.
 
-            ``connector`` and ``account`` may not contain ``/`` — they're used
-            in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
-            and a ``/`` would create ambiguous segment boundaries.
+            ``connector`` and ``external_account_id`` may not contain ``/`` —
+            they're used in the focal-channel address scheme
+            ``{connector}/{external_account_id}/{chat_id}`` and a ``/`` would
+            create ambiguous segment boundaries.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -126,14 +133,20 @@ def sync(
 ) -> Connection | HTTPValidationError | None:
     """Create
 
-     Create a detached connection, **idempotent on ``(connector, account)``**.
+     Create a detached connection, **idempotent on ``(connector, external_account_id)``**.
 
     Per plan decision #5, this endpoint and the supervisor's
-    auto-create-on-first-inbound path race-safely converge on a single row:
-    posting twice with the same ``(connector, account)`` returns 201 with the
-    existing row rather than 409.  The ``id`` may differ from a freshly-allocated
-    one if a concurrent writer landed first; the response always reflects the
-    canonical active row.
+    auto-create-on-first-inbound path race-safely converge on a single
+    row: posting twice with the same ``(connector, external_account_id)``
+    returns 201 with the existing row rather than 409. The ``id`` may
+    differ from a freshly-allocated one if a concurrent writer landed
+    first; the response always reflects the canonical active row.
+
+    The active-row partial-unique index is global, not tenant-scoped —
+    real-world messaging identities (Signal phone numbers, Telegram
+    bot tokens, etc.) are universally exclusive. If another tenant
+    already holds the active row for this identity, the call returns
+    409 ``conflict`` rather than silently masking the collision.
 
     Optional ``secrets`` carry platform credentials (e.g. Telegram
     ``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``
@@ -149,9 +162,10 @@ def sync(
             ``session_template_id`` is set.  Use ``POST .../attach`` or
             ``POST .../configure-per-chat`` afterward to bind a routing mode.
 
-            ``connector`` and ``account`` may not contain ``/`` — they're used
-            in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
-            and a ``/`` would create ambiguous segment boundaries.
+            ``connector`` and ``external_account_id`` may not contain ``/`` —
+            they're used in the focal-channel address scheme
+            ``{connector}/{external_account_id}/{chat_id}`` and a ``/`` would
+            create ambiguous segment boundaries.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -176,14 +190,20 @@ async def asyncio_detailed(
 ) -> Response[Connection | HTTPValidationError]:
     """Create
 
-     Create a detached connection, **idempotent on ``(connector, account)``**.
+     Create a detached connection, **idempotent on ``(connector, external_account_id)``**.
 
     Per plan decision #5, this endpoint and the supervisor's
-    auto-create-on-first-inbound path race-safely converge on a single row:
-    posting twice with the same ``(connector, account)`` returns 201 with the
-    existing row rather than 409.  The ``id`` may differ from a freshly-allocated
-    one if a concurrent writer landed first; the response always reflects the
-    canonical active row.
+    auto-create-on-first-inbound path race-safely converge on a single
+    row: posting twice with the same ``(connector, external_account_id)``
+    returns 201 with the existing row rather than 409. The ``id`` may
+    differ from a freshly-allocated one if a concurrent writer landed
+    first; the response always reflects the canonical active row.
+
+    The active-row partial-unique index is global, not tenant-scoped —
+    real-world messaging identities (Signal phone numbers, Telegram
+    bot tokens, etc.) are universally exclusive. If another tenant
+    already holds the active row for this identity, the call returns
+    409 ``conflict`` rather than silently masking the collision.
 
     Optional ``secrets`` carry platform credentials (e.g. Telegram
     ``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``
@@ -199,9 +219,10 @@ async def asyncio_detailed(
             ``session_template_id`` is set.  Use ``POST .../attach`` or
             ``POST .../configure-per-chat`` afterward to bind a routing mode.
 
-            ``connector`` and ``account`` may not contain ``/`` — they're used
-            in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
-            and a ``/`` would create ambiguous segment boundaries.
+            ``connector`` and ``external_account_id`` may not contain ``/`` —
+            they're used in the focal-channel address scheme
+            ``{connector}/{external_account_id}/{chat_id}`` and a ``/`` would
+            create ambiguous segment boundaries.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -229,14 +250,20 @@ async def asyncio(
 ) -> Connection | HTTPValidationError | None:
     """Create
 
-     Create a detached connection, **idempotent on ``(connector, account)``**.
+     Create a detached connection, **idempotent on ``(connector, external_account_id)``**.
 
     Per plan decision #5, this endpoint and the supervisor's
-    auto-create-on-first-inbound path race-safely converge on a single row:
-    posting twice with the same ``(connector, account)`` returns 201 with the
-    existing row rather than 409.  The ``id`` may differ from a freshly-allocated
-    one if a concurrent writer landed first; the response always reflects the
-    canonical active row.
+    auto-create-on-first-inbound path race-safely converge on a single
+    row: posting twice with the same ``(connector, external_account_id)``
+    returns 201 with the existing row rather than 409. The ``id`` may
+    differ from a freshly-allocated one if a concurrent writer landed
+    first; the response always reflects the canonical active row.
+
+    The active-row partial-unique index is global, not tenant-scoped —
+    real-world messaging identities (Signal phone numbers, Telegram
+    bot tokens, etc.) are universally exclusive. If another tenant
+    already holds the active row for this identity, the call returns
+    409 ``conflict`` rather than silently masking the collision.
 
     Optional ``secrets`` carry platform credentials (e.g. Telegram
     ``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``
@@ -252,9 +279,10 @@ async def asyncio(
             ``session_template_id`` is set.  Use ``POST .../attach`` or
             ``POST .../configure-per-chat`` afterward to bind a routing mode.
 
-            ``connector`` and ``account`` may not contain ``/`` — they're used
-            in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
-            and a ``/`` would create ambiguous segment boundaries.
+            ``connector`` and ``external_account_id`` may not contain ``/`` —
+            they're used in the focal-channel address scheme
+            ``{connector}/{external_account_id}/{chat_id}`` and a ``/`` would
+            create ambiguous segment boundaries.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/get_connection_discovery_v1_connectors_connections_get.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/get_connection_discovery_v1_connectors_connections_get.py
@@ -70,7 +70,9 @@ def sync_detailed(
     ``connections_<connector>`` NOTIFY channel.  Each event is keyed
     ``connection`` with a JSON body shaped::
 
-        {\"event\": \"added\" | \"removed\", \"connection_id\": \"...\", \"account\": \"...\"}
+        {\"event\": \"added\" | \"removed\",
+         \"connection_id\": \"...\",
+         \"external_account_id\": \"...\"}
 
     The runtime container subscribes once per ``connector`` type and
     fans out to per-connection workers on ``added``; tears them down
@@ -113,7 +115,9 @@ def sync(
     ``connections_<connector>`` NOTIFY channel.  Each event is keyed
     ``connection`` with a JSON body shaped::
 
-        {\"event\": \"added\" | \"removed\", \"connection_id\": \"...\", \"account\": \"...\"}
+        {\"event\": \"added\" | \"removed\",
+         \"connection_id\": \"...\",
+         \"external_account_id\": \"...\"}
 
     The runtime container subscribes once per ``connector`` type and
     fans out to per-connection workers on ``added``; tears them down
@@ -151,7 +155,9 @@ async def asyncio_detailed(
     ``connections_<connector>`` NOTIFY channel.  Each event is keyed
     ``connection`` with a JSON body shaped::
 
-        {\"event\": \"added\" | \"removed\", \"connection_id\": \"...\", \"account\": \"...\"}
+        {\"event\": \"added\" | \"removed\",
+         \"connection_id\": \"...\",
+         \"external_account_id\": \"...\"}
 
     The runtime container subscribes once per ``connector`` type and
     fans out to per-connection workers on ``added``; tears them down
@@ -192,7 +198,9 @@ async def asyncio(
     ``connections_<connector>`` NOTIFY channel.  Each event is keyed
     ``connection`` with a JSON body shaped::
 
-        {\"event\": \"added\" | \"removed\", \"connection_id\": \"...\", \"account\": \"...\"}
+        {\"event\": \"added\" | \"removed\",
+         \"connection_id\": \"...\",
+         \"external_account_id\": \"...\"}
 
     The runtime container subscribes once per ``connector`` type and
     fans out to per-connection workers on ``added``; tears them down

--- a/packages/aios-sdk/aios_sdk/_generated/models/connection.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/connection.py
@@ -43,7 +43,7 @@ class Connection:
         Attributes:
             id (str):
             connector (str):
-            account (str):
+            external_account_id (str):
             metadata (ConnectionMetadata):
             created_at (datetime.datetime):
             updated_at (datetime.datetime):
@@ -56,7 +56,7 @@ class Connection:
 
     id: str
     connector: str
-    account: str
+    external_account_id: str
     metadata: ConnectionMetadata
     created_at: datetime.datetime
     updated_at: datetime.datetime
@@ -72,7 +72,7 @@ class Connection:
 
         connector = self.connector
 
-        account = self.account
+        external_account_id = self.external_account_id
 
         metadata = self.metadata.to_dict()
 
@@ -116,7 +116,7 @@ class Connection:
             {
                 "id": id,
                 "connector": connector,
-                "account": account,
+                "external_account_id": external_account_id,
                 "metadata": metadata,
                 "created_at": created_at,
                 "updated_at": updated_at,
@@ -144,7 +144,7 @@ class Connection:
 
         connector = d.pop("connector")
 
-        account = d.pop("account")
+        external_account_id = d.pop("external_account_id")
 
         metadata = ConnectionMetadata.from_dict(d.pop("metadata"))
 
@@ -211,7 +211,7 @@ class Connection:
         connection = cls(
             id=id,
             connector=connector,
-            account=account,
+            external_account_id=external_account_id,
             metadata=metadata,
             created_at=created_at,
             updated_at=updated_at,

--- a/packages/aios-sdk/aios_sdk/_generated/models/connection_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/connection_create.py
@@ -23,13 +23,14 @@ class ConnectionCreate:
     ``session_template_id`` is set.  Use ``POST .../attach`` or
     ``POST .../configure-per-chat`` afterward to bind a routing mode.
 
-    ``connector`` and ``account`` may not contain ``/`` — they're used
-    in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
-    and a ``/`` would create ambiguous segment boundaries.
+    ``connector`` and ``external_account_id`` may not contain ``/`` —
+    they're used in the focal-channel address scheme
+    ``{connector}/{external_account_id}/{chat_id}`` and a ``/`` would
+    create ambiguous segment boundaries.
 
         Attributes:
             connector (str):
-            account (str):
+            external_account_id (str):
             metadata (ConnectionCreateMetadata | Unset):
             secrets (ConnectionCreateSecretsType0 | None | Unset): Platform credentials (e.g. ``bot_token``).  Encrypted at
                 rest via the server's ``AIOS_VAULT_KEY``; only ever read back via the runtime-scoped ``GET
@@ -37,7 +38,7 @@ class ConnectionCreate:
     """
 
     connector: str
-    account: str
+    external_account_id: str
     metadata: ConnectionCreateMetadata | Unset = UNSET
     secrets: ConnectionCreateSecretsType0 | None | Unset = UNSET
 
@@ -48,7 +49,7 @@ class ConnectionCreate:
 
         connector = self.connector
 
-        account = self.account
+        external_account_id = self.external_account_id
 
         metadata: dict[str, Any] | Unset = UNSET
         if not isinstance(self.metadata, Unset):
@@ -67,7 +68,7 @@ class ConnectionCreate:
         field_dict.update(
             {
                 "connector": connector,
-                "account": account,
+                "external_account_id": external_account_id,
             }
         )
         if metadata is not UNSET:
@@ -87,7 +88,7 @@ class ConnectionCreate:
         d = dict(src_dict)
         connector = d.pop("connector")
 
-        account = d.pop("account")
+        external_account_id = d.pop("external_account_id")
 
         _metadata = d.pop("metadata", UNSET)
         metadata: ConnectionCreateMetadata | Unset
@@ -115,7 +116,7 @@ class ConnectionCreate:
 
         connection_create = cls(
             connector=connector,
-            account=account,
+            external_account_id=external_account_id,
             metadata=metadata,
             secrets=secrets,
         )

--- a/packages/aios-sdk/aios_sdk/_generated/models/signal_profile_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/signal_profile_request.py
@@ -14,19 +14,19 @@ T = TypeVar("T", bound="SignalProfileRequest")
 class SignalProfileRequest:
     """
     Attributes:
-        account (str):
+        external_account_id (str):
         given_name (None | str | Unset):
         family_name (None | str | Unset):
         about (None | str | Unset):
     """
 
-    account: str
+    external_account_id: str
     given_name: None | str | Unset = UNSET
     family_name: None | str | Unset = UNSET
     about: None | str | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
-        account = self.account
+        external_account_id = self.external_account_id
 
         given_name: None | str | Unset
         if isinstance(self.given_name, Unset):
@@ -50,7 +50,7 @@ class SignalProfileRequest:
 
         field_dict.update(
             {
-                "account": account,
+                "external_account_id": external_account_id,
             }
         )
         if given_name is not UNSET:
@@ -65,7 +65,7 @@ class SignalProfileRequest:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        account = d.pop("account")
+        external_account_id = d.pop("external_account_id")
 
         def _parse_given_name(data: object) -> None | str | Unset:
             if data is None:
@@ -95,7 +95,7 @@ class SignalProfileRequest:
         about = _parse_about(d.pop("about", UNSET))
 
         signal_profile_request = cls(
-            account=account,
+            external_account_id=external_account_id,
             given_name=given_name,
             family_name=family_name,
             about=about,

--- a/packages/aios-sdk/aios_sdk/_generated/models/signal_register_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/signal_register_request.py
@@ -14,17 +14,17 @@ T = TypeVar("T", bound="SignalRegisterRequest")
 class SignalRegisterRequest:
     """
     Attributes:
-        account (str):
+        external_account_id (str):
         captcha (None | str | Unset):
         voice (bool | Unset):  Default: False.
     """
 
-    account: str
+    external_account_id: str
     captcha: None | str | Unset = UNSET
     voice: bool | Unset = False
 
     def to_dict(self) -> dict[str, Any]:
-        account = self.account
+        external_account_id = self.external_account_id
 
         captcha: None | str | Unset
         if isinstance(self.captcha, Unset):
@@ -38,7 +38,7 @@ class SignalRegisterRequest:
 
         field_dict.update(
             {
-                "account": account,
+                "external_account_id": external_account_id,
             }
         )
         if captcha is not UNSET:
@@ -51,7 +51,7 @@ class SignalRegisterRequest:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        account = d.pop("account")
+        external_account_id = d.pop("external_account_id")
 
         def _parse_captcha(data: object) -> None | str | Unset:
             if data is None:
@@ -65,7 +65,7 @@ class SignalRegisterRequest:
         voice = d.pop("voice", UNSET)
 
         signal_register_request = cls(
-            account=account,
+            external_account_id=external_account_id,
             captcha=captcha,
             voice=voice,
         )

--- a/packages/aios-sdk/aios_sdk/_generated/models/signal_register_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/signal_register_response.py
@@ -19,18 +19,18 @@ class SignalRegisterResponse:
     the URL inside FastAPI's error envelope.
 
         Attributes:
-            account (str):
+            external_account_id (str):
             status (SignalRegisterResponseStatus):
             captcha_url (None | str | Unset):
     """
 
-    account: str
+    external_account_id: str
     status: SignalRegisterResponseStatus
     captcha_url: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        account = self.account
+        external_account_id = self.external_account_id
 
         status = self.status.value
 
@@ -44,7 +44,7 @@ class SignalRegisterResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "account": account,
+                "external_account_id": external_account_id,
                 "status": status,
             }
         )
@@ -56,7 +56,7 @@ class SignalRegisterResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        account = d.pop("account")
+        external_account_id = d.pop("external_account_id")
 
         status = SignalRegisterResponseStatus(d.pop("status"))
 
@@ -70,7 +70,7 @@ class SignalRegisterResponse:
         captcha_url = _parse_captcha_url(d.pop("captcha_url", UNSET))
 
         signal_register_response = cls(
-            account=account,
+            external_account_id=external_account_id,
             status=status,
             captcha_url=captcha_url,
         )

--- a/packages/aios-sdk/aios_sdk/_generated/models/signal_verify_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/signal_verify_request.py
@@ -14,17 +14,17 @@ T = TypeVar("T", bound="SignalVerifyRequest")
 class SignalVerifyRequest:
     """
     Attributes:
-        account (str):
+        external_account_id (str):
         code (str):
         pin (None | str | Unset):
     """
 
-    account: str
+    external_account_id: str
     code: str
     pin: None | str | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
-        account = self.account
+        external_account_id = self.external_account_id
 
         code = self.code
 
@@ -38,7 +38,7 @@ class SignalVerifyRequest:
 
         field_dict.update(
             {
-                "account": account,
+                "external_account_id": external_account_id,
                 "code": code,
             }
         )
@@ -50,7 +50,7 @@ class SignalVerifyRequest:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        account = d.pop("account")
+        external_account_id = d.pop("external_account_id")
 
         code = d.pop("code")
 
@@ -64,7 +64,7 @@ class SignalVerifyRequest:
         pin = _parse_pin(d.pop("pin", UNSET))
 
         signal_verify_request = cls(
-            account=account,
+            external_account_id=external_account_id,
             code=code,
             pin=pin,
         )

--- a/packages/aios-sdk/aios_sdk/_generated/models/signal_verify_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/signal_verify_response.py
@@ -13,16 +13,16 @@ T = TypeVar("T", bound="SignalVerifyResponse")
 class SignalVerifyResponse:
     """
     Attributes:
-        account (str):
+        external_account_id (str):
         uuid (str):
     """
 
-    account: str
+    external_account_id: str
     uuid: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        account = self.account
+        external_account_id = self.external_account_id
 
         uuid = self.uuid
 
@@ -30,7 +30,7 @@ class SignalVerifyResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "account": account,
+                "external_account_id": external_account_id,
                 "uuid": uuid,
             }
         )
@@ -40,12 +40,12 @@ class SignalVerifyResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        account = d.pop("account")
+        external_account_id = d.pop("external_account_id")
 
         uuid = d.pop("uuid")
 
         signal_verify_response = cls(
-            account=account,
+            external_account_id=external_account_id,
             uuid=uuid,
         )
 

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -39,14 +39,20 @@ router = APIRouter(prefix="/v1/connections", tags=["connections"])
 async def create(
     body: ConnectionCreate, pool: PoolDep, crypto_box: CryptoBoxDep, _auth: AuthDep
 ) -> Connection:
-    """Create a detached connection, **idempotent on ``(connector, account)``**.
+    """Create a detached connection, **idempotent on ``(connector, external_account_id)``**.
 
     Per plan decision #5, this endpoint and the supervisor's
-    auto-create-on-first-inbound path race-safely converge on a single row:
-    posting twice with the same ``(connector, account)`` returns 201 with the
-    existing row rather than 409.  The ``id`` may differ from a freshly-allocated
-    one if a concurrent writer landed first; the response always reflects the
-    canonical active row.
+    auto-create-on-first-inbound path race-safely converge on a single
+    row: posting twice with the same ``(connector, external_account_id)``
+    returns 201 with the existing row rather than 409. The ``id`` may
+    differ from a freshly-allocated one if a concurrent writer landed
+    first; the response always reflects the canonical active row.
+
+    The active-row partial-unique index is global, not tenant-scoped —
+    real-world messaging identities (Signal phone numbers, Telegram
+    bot tokens, etc.) are universally exclusive. If another tenant
+    already holds the active row for this identity, the call returns
+    409 ``conflict`` rather than silently masking the collision.
 
     Optional ``secrets`` carry platform credentials (e.g. Telegram
     ``bot_token``).  They are encrypted at rest via ``AIOS_VAULT_KEY``
@@ -58,7 +64,7 @@ async def create(
     return await service.create_connection(
         pool,
         connector=body.connector,
-        account=body.account,
+        external_account_id=body.external_account_id,
         metadata=body.metadata,
         secrets=body.secrets,
         crypto_box=crypto_box,

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -267,7 +267,9 @@ async def get_connection_discovery(
     ``connections_<connector>`` NOTIFY channel.  Each event is keyed
     ``connection`` with a JSON body shaped::
 
-        {"event": "added" | "removed", "connection_id": "...", "account": "..."}
+        {"event": "added" | "removed",
+         "connection_id": "...",
+         "external_account_id": "..."}
 
     The runtime container subscribes once per ``connector`` type and
     fans out to per-connection workers on ``added``; tears them down
@@ -471,7 +473,7 @@ async def get_runtime_management_calls(
 class SignalRegisterRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    account: str
+    external_account_id: str
     captcha: str | None = None
     voice: bool = False
 
@@ -481,7 +483,7 @@ class SignalRegisterResponse(BaseModel):
     next step (solve the captcha, repost with the token), and 4xx would bury
     the URL inside FastAPI's error envelope."""
 
-    account: str
+    external_account_id: str
     status: Literal["sms_sent", "voice_sent", "captcha_required"]
     captcha_url: str | None = None
 
@@ -489,20 +491,20 @@ class SignalRegisterResponse(BaseModel):
 class SignalVerifyRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    account: str
+    external_account_id: str
     code: str
     pin: str | None = None
 
 
 class SignalVerifyResponse(BaseModel):
-    account: str
+    external_account_id: str
     uuid: str
 
 
 class SignalProfileRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    account: str
+    external_account_id: str
     given_name: str | None = None
     family_name: str | None = None
     about: str | None = None
@@ -565,12 +567,12 @@ async def post_signal_register(
     )
     if _is_captcha_required(result):
         return SignalRegisterResponse(
-            account=body.account,
+            external_account_id=body.external_account_id,
             status="captcha_required",
             captcha_url=result["captcha_url"],
         )
     return SignalRegisterResponse(
-        account=body.account,
+        external_account_id=body.external_account_id,
         status="voice_sent" if body.voice else "sms_sent",
     )
 
@@ -600,7 +602,9 @@ async def post_signal_verify(
         params=body.model_dump(exclude_none=True),
         timeout_s=60.0,
     )
-    return SignalVerifyResponse(account=body.account, uuid=str(result.get("uuid", "")))
+    return SignalVerifyResponse(
+        external_account_id=body.external_account_id, uuid=str(result.get("uuid", ""))
+    )
 
 
 @router.post(

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -267,7 +267,7 @@ async def connection_discovery_stream(
                         {
                             "event": "added",
                             "connection_id": connection.id,
-                            "account": connection.account,
+                            "external_account_id": connection.external_account_id,
                         }
                     ),
                     event="connection",
@@ -278,16 +278,16 @@ async def connection_discovery_stream(
 
         while True:
             payload = await queue.get()
-            # Payload format: "<event>|<connection_id>|<event_account_id>|<account>".
+            # Payload format: "<event>|<connection_id>|<event_account_id>|<external_account_id>".
             parts = payload.split("|", 3)
             if len(parts) != 4:
                 log.warning("sse.discovery.malformed_payload", payload=payload)
                 continue
-            event, connection_id, event_account_id, account = parts
+            event, connection_id, event_account_id, external_account_id = parts
             # Tenant isolation: a runtime token scopes a subscriber to one
-            # account; drop NOTIFY events for other tenants on the same
-            # connector type. Pre-fix this was an existence-leak (sibling
-            # account_ids surfaced via the tail).
+            # tenant; dropping cross-tenant NOTIFY events here closes an
+            # existence-leak (sibling account_ids would otherwise surface
+            # via the tail).
             if event_account_id != account_id:
                 continue
             if event == "added" and connection_id in emitted_added:
@@ -301,7 +301,7 @@ async def connection_discovery_stream(
                     {
                         "event": event,
                         "connection_id": connection_id,
-                        "account": account,
+                        "external_account_id": external_account_id,
                     }
                 ),
                 event="connection",

--- a/src/aios/cli/commands/connections.py
+++ b/src/aios/cli/commands/connections.py
@@ -42,8 +42,20 @@ from aios_sdk._generated.models.list_connections_mode_type_0 import ListConnecti
 
 app = typer.Typer(name="connections", help="Manage connector connections.", no_args_is_help=True)
 
-_COLS = ("id", "connector", "account", "session_id", "session_template_id", "updated_at")
-_MAXW = {"connector": 20, "account": 40, "session_id": 24, "session_template_id": 24}
+_COLS = (
+    "id",
+    "connector",
+    "external_account_id",
+    "session_id",
+    "session_template_id",
+    "updated_at",
+)
+_MAXW = {
+    "connector": 20,
+    "external_account_id": 40,
+    "session_id": 24,
+    "session_template_id": 24,
+}
 
 
 @app.command("list")
@@ -109,8 +121,12 @@ def create(
     connector: Annotated[
         str | None, typer.Option("--connector", help="Connector type (e.g. signal).")
     ] = None,
-    account: Annotated[
-        str | None, typer.Option("--account", help="Account identifier (e.g. bot uuid).")
+    external_account_id: Annotated[
+        str | None,
+        typer.Option(
+            "--external-account-id",
+            help="External messaging identity (e.g. Signal phone, Telegram bot id).",
+        ),
     ] = None,
     metadata_json: Annotated[
         str | None,
@@ -133,11 +149,11 @@ def create(
 ) -> None:
     def _run() -> int | None:
         ergonomic: dict[str, Any] | None = None
-        if connector is not None or account is not None or secret:
-            if connector is None or account is None:
-                print_error("--connector and --account are both required")
+        if connector is not None or external_account_id is not None or secret:
+            if connector is None or external_account_id is None:
+                print_error("--connector and --external-account-id are both required")
                 return 64
-            ergonomic = {"connector": connector, "account": account}
+            ergonomic = {"connector": connector, "external_account_id": external_account_id}
             if metadata_json is not None:
                 try:
                     ergonomic["metadata"] = load_json_object(metadata_json, "--metadata-json")

--- a/src/aios/cli/commands/signal.py
+++ b/src/aios/cli/commands/signal.py
@@ -50,7 +50,7 @@ def register(
 
     def _run() -> None:
         with get_state(ctx).sdk_client() as client:
-            body = SignalRegisterRequest(account=phone, captcha=captcha, voice=voice)
+            body = SignalRegisterRequest(external_account_id=phone, captcha=captcha, voice=voice)
             result = unwrap(post_connector_signal_register.sync_detailed(client=client, body=body))
         payload = result.to_dict()
         if payload.get("status") == "captcha_required":
@@ -89,7 +89,7 @@ def verify(
 
     def _run() -> None:
         with get_state(ctx).sdk_client() as client:
-            body = SignalVerifyRequest(account=phone, code=code, pin=pin)
+            body = SignalVerifyRequest(external_account_id=phone, code=code, pin=pin)
             result = unwrap(post_connector_signal_verify.sync_detailed(client=client, body=body))
         payload = result.to_dict()
         print_note(f"verified {phone} (uuid={payload.get('uuid', '?')})")
@@ -115,7 +115,7 @@ def profile(
     def _run() -> None:
         with get_state(ctx).sdk_client() as client:
             body = SignalProfileRequest(
-                account=phone,
+                external_account_id=phone,
                 given_name=given_name,
                 family_name=family_name,
                 about=about,

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -3236,7 +3236,7 @@ def _row_to_connection(row: asyncpg.Record) -> Connection:
     return Connection(
         id=row["id"],
         connector=row["connector"],
-        account=row["account"],
+        external_account_id=row["external_account_id"],
         session_id=row["binding_session_id"],
         session_template_id=row["binding_session_template_id"],
         metadata=parse_jsonb(row["metadata"]),
@@ -3253,7 +3253,7 @@ async def insert_connection(
     *,
     account_id: str,
     connector: str,
-    account: str,
+    external_account_id: str,
     metadata: dict[str, Any],
     secrets_blob: EncryptedBlob | None = None,
 ) -> Connection:
@@ -3262,10 +3262,13 @@ async def insert_connection(
     Per plan decision #5, both the explicit ``POST /v1/connections`` and
     the supervisor's auto-create-on-first-inbound path race-safely
     converge on a single row via ``INSERT ... ON CONFLICT DO NOTHING
-    RETURNING``: empty RETURNING means another writer beat us, so we
-    re-read the existing active row and hand it back.  The unique index
-    is ``(connector, account) WHERE archived_at IS NULL`` — an archived
-    row with the same pair will not collide; a fresh insert will land.
+    RETURNING``. The unique index
+    ``(connector, external_account_id) WHERE archived_at IS NULL`` is
+    globally exclusive across tenants, mirroring real-world identities
+    (Signal phone numbers, Telegram bot tokens, etc. are universally
+    unique by construction). On conflict, re-read within the tenant; a
+    same-tenant miss is either an archive race (loop once) or a
+    cross-tenant collision (raise :class:`ConflictError`).
 
     ``secrets_blob`` carries the encrypted credential dict.  ``None``
     leaves both secret columns NULL; the schema's
@@ -3275,12 +3278,6 @@ async def insert_connection(
     Use ``attach_connection`` or ``configure_per_chat_connection`` to bind
     a routing mode after creation.
     """
-    # Retry loop: each iteration is INSERT-then-(if-conflict)-re-read.  Three
-    # concurrent writers + an archive-between-attempts can force a second
-    # round-trip, but the loop converges within at most two iterations under
-    # any realistic contention pattern.  The bound is defensive — three
-    # iterations is enough that exhaustion would mean the system is wedged
-    # in a hot insert/archive cycle that no retry strategy can resolve.
     ciphertext = secrets_blob.ciphertext if secrets_blob is not None else None
     nonce = secrets_blob.nonce if secrets_blob is not None else None
     # Upsert into the connectors catalog so the runtime_tokens /
@@ -3292,16 +3289,19 @@ async def insert_connection(
         "INSERT INTO connectors (connector) VALUES ($1) ON CONFLICT DO NOTHING",
         connector,
     )
-    for _ in range(3):
+    # Two attempts: the second only fires on the archive-race path
+    # (same-tenant row archived between our INSERT and re-read).
+    for _ in range(2):
         row = await conn.fetchrow(
             """
             WITH inserted AS (
                 INSERT INTO connections (
-                    id, connector, account, metadata,
+                    id, connector, external_account_id, metadata,
                     secrets_ciphertext, secrets_nonce, account_id
                 )
                 VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
-                ON CONFLICT (connector, account) WHERE archived_at IS NULL DO NOTHING
+                ON CONFLICT (connector, external_account_id)
+                    WHERE archived_at IS NULL DO NOTHING
                 RETURNING *
             )
             SELECT i.*,
@@ -3312,7 +3312,7 @@ async def insert_connection(
             """,
             make_id(CONNECTION),
             connector,
-            account,
+            external_account_id,
             json.dumps(metadata),
             ciphertext,
             nonce,
@@ -3321,14 +3321,29 @@ async def insert_connection(
         if row is not None:
             return _row_to_connection(row)
         existing = await get_connection_for_account(
-            conn, connector=connector, account=account, account_id=account_id
+            conn,
+            connector=connector,
+            external_account_id=external_account_id,
+            account_id=account_id,
         )
         if existing is not None:
             return existing
-        # Active row was archived between INSERT and re-read; loop to retry the
-        # INSERT, which the partial unique index now permits.
+        other_row = await conn.fetchrow(
+            "SELECT 1 FROM connections "
+            "WHERE connector = $1 AND external_account_id = $2 AND archived_at IS NULL",
+            connector,
+            external_account_id,
+        )
+        if other_row is not None:
+            raise ConflictError(
+                "connector external_account_id already registered",
+                detail={"connector": connector, "external_account_id": external_account_id},
+            )
+    # The archive race converges within two iterations under any realistic
+    # contention pattern; if a third attempt would still be needed, the
+    # system is in a hot insert/archive cycle that no retry resolves.
     raise RuntimeError(
-        f"insert_connection({connector=}, {account=}) failed to converge after 3 attempts"
+        f"insert_connection({connector=}, {external_account_id=}) exhausted archive-race retries"
     )
 
 
@@ -3469,20 +3484,21 @@ async def list_connection_tools_for_session(
 async def get_connection_for_account(
     conn: asyncpg.Connection[Any],
     connector: str,
-    account: str,
+    external_account_id: str,
     *,
     account_id: str,
 ) -> Connection | None:
-    """Active connection for ``(connector, account)``, or ``None``."""
+    """Active connection for ``(connector, external_account_id)`` within
+    the caller's tenant, or ``None``."""
     row = await conn.fetchrow(
         f"""
         SELECT {_CONNECTION_COLUMNS}
           FROM {_CONNECTION_FROM}
-         WHERE c.connector = $1 AND c.account = $2 AND c.archived_at IS NULL
+         WHERE c.connector = $1 AND c.external_account_id = $2 AND c.archived_at IS NULL
            AND c.account_id = $3
         """,
         connector,
-        account,
+        external_account_id,
         account_id,
     )
     if row is None:
@@ -3748,15 +3764,20 @@ async def list_routing_rules_for_connection(
 
 
 async def list_recent_chat_ids(
-    conn: asyncpg.Connection[Any], connector: str, account: str, *, account_id: str, limit: int
+    conn: asyncpg.Connection[Any],
+    connector: str,
+    external_account_id: str,
+    *,
+    account_id: str,
+    limit: int,
 ) -> list[tuple[str, datetime]]:
     """Distinct ``(chat_id, last_seen_at)`` for inbound user events
-    matching the ``<connector>/<account>/<chat_id>`` channel prefix.
+    matching the ``<connector>/<external_account_id>/<chat_id>`` channel prefix.
 
-    Used by the operator's "what chats has this account produced
-    inbound on?" helper — the input to ``aios connections bind-chat``
-    when the operator doesn't know the chat_id off the top of their
-    head.
+    Used by the operator's "what chats has this external identity
+    produced inbound on?" helper — the input to ``aios connections
+    bind-chat`` when the operator doesn't know the chat_id off the top
+    of their head.
 
     The chat_id is the third path segment of the derived
     ``events.channel`` column; events arriving on a different
@@ -3766,11 +3787,11 @@ async def list_recent_chat_ids(
     that share the channel.
     """
     # Escape LIKE metacharacters in operator-supplied ``connector`` and
-    # ``account``: ``_`` and ``%`` would otherwise act as wildcards
-    # against the stored channel, e.g. an operator looking up account
-    # ``bot_a`` would see chats from ``botXa`` too. Mirrors the
+    # ``external_account_id``: ``_`` and ``%`` would otherwise act as
+    # wildcards against the stored channel, e.g. an operator looking up
+    # identity ``bot_a`` would see chats from ``botXa`` too. Mirrors the
     # ``_escape_like`` usage at the memory-prefix query below.
-    prefix = f"{_escape_like(connector)}/{_escape_like(account)}/"
+    prefix = f"{_escape_like(connector)}/{_escape_like(external_account_id)}/"
     rows = await conn.fetch(
         """
         SELECT
@@ -3822,18 +3843,19 @@ async def try_record_inbound_ack(
     *,
     account_id: str,
     connector: str,
-    account: str,
+    external_account_id: str,
     event_id: str,
     appended_seq: int,
 ) -> bool:
     """Insert a dedup-ledger row, returning ``True`` iff it actually inserted.
 
     Called from the worker's inbound handler in the same transaction as
-    :func:`append_event`.  The PK ``(connector, account, event_id)``
-    enforces at-most-once event append: a duplicate inbound (same ULID
-    re-emitted on connector reconnect because the previous worker
-    crashed before acking) hits ``ON CONFLICT DO NOTHING`` and the
-    caller rolls back the txn so no second event lands.
+    :func:`append_event`.  The PK
+    ``(connector, external_account_id, event_id)`` enforces at-most-once
+    event append: a duplicate inbound (same ULID re-emitted on connector
+    reconnect because the previous worker crashed before acking) hits
+    ``ON CONFLICT DO NOTHING`` and the caller rolls back the txn so no
+    second event lands.
 
     The ``appended_seq`` is the gapless seq the in-flight ``append_event``
     just allocated; it makes the ledger row queryable for the operator
@@ -3841,13 +3863,15 @@ async def try_record_inbound_ack(
     """
     row = await conn.fetchrow(
         """
-        INSERT INTO connector_inbound_acks (connector, account, event_id, appended_seq)
+        INSERT INTO connector_inbound_acks (
+            connector, external_account_id, event_id, appended_seq
+        )
         VALUES ($1, $2, $3, $4)
         ON CONFLICT DO NOTHING
         RETURNING 1
         """,
         connector,
-        account,
+        external_account_id,
         event_id,
         appended_seq,
     )
@@ -5039,21 +5063,22 @@ async def notify_connection_change(
     account_id: str,
     connector: str,
     connection_id: str,
-    account: str,
+    external_account_id: str,
     event: str,
 ) -> None:
     """Emit a ``connections_<connector>`` NOTIFY for discovery SSE consumers.
 
-    Payload: ``"<event>|<connection_id>|<account_id>|<account>"`` — the
-    SSE generator parses this into an ``added``/``removed`` event and uses
-    ``account_id`` to filter cross-tenant events. Caller runs this on a
-    pool-acquired (autocommit) connection OUTSIDE any transaction so
-    subscribers never see a payload for an uncommitted row.
+    Payload: ``"<event>|<connection_id>|<account_id>|<external_account_id>"``
+    — the SSE generator parses this into an ``added``/``removed`` event
+    and uses ``account_id`` (tenant) to filter cross-tenant events.
+    Caller runs this on a pool-acquired (autocommit) connection OUTSIDE
+    any transaction so subscribers never see a payload for an
+    uncommitted row.
     """
     await conn.execute(
         "SELECT pg_notify($1, $2)",
         f"connections_{connector}",
-        f"{event}|{connection_id}|{account_id}|{account}",
+        f"{event}|{connection_id}|{account_id}|{external_account_id}",
     )
 
 

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -66,14 +66,14 @@ class ConflictError(AiosError):
 
 
 class AccountDriftError(ConflictError):
-    """Operator tried to attach a connection for an account the connector no longer serves.
+    """Operator tried to attach a connection for an identity the connector no longer serves.
 
     Raised by :func:`aios.services.connections.attach_connection` when
     the supervisor's current account snapshot doesn't include the
-    connection's ``account``.  Without this guard the attach would
-    succeed silently and inbound for that account would drop forever
-    with the ``account_drift`` reason — operator pain that's better
-    surfaced at attach time than discovered hours later.
+    connection's ``external_account_id``.  Without this guard the
+    attach would succeed silently and inbound for that identity would
+    drop forever with the ``account_drift`` reason — operator pain
+    that's better surfaced at attach time than discovered hours later.
     """
 
     error_type = "account_drift"

--- a/src/aios/models/connections.py
+++ b/src/aios/models/connections.py
@@ -1,22 +1,22 @@
 """Connection resource — the unified routing primitive.
 
-A *connection* is a registered ``(connector, account)`` pair, optionally
-attached to a routing target via the ``bindings`` table.  Three valid
-shapes derived from the active binding:
+A *connection* is a registered ``(connector, external_account_id)``
+pair, optionally attached to a routing target via the ``bindings``
+table.  Three valid shapes derived from the active binding:
 
 * **detached** — no active binding row.  Inbound messages drop with a
   counter increment.
 * **single_session** — active binding with ``mode='single_session'`` and
-  ``session_id`` populated.  Every inbound for this account appends to
+  ``session_id`` populated.  Every inbound for this identity appends to
   that one session.
 * **per_chat** — active binding with ``mode='per_chat'`` and
   ``session_template_id`` populated.  Each new chat partner spawns a
   fresh session via the template; the ``chat_id`` → ``session_id`` map
   lives in ``chat_sessions``.
 
-The active-row uniqueness on ``(connector, account)`` enforces
-"one session per account" by schema — operators can't accidentally
-double-bind a phone number to two sessions.  The
+The active-row uniqueness on ``(connector, external_account_id)``
+enforces "one session per external identity" by schema — operators
+can't accidentally double-bind a phone number to two sessions.  The
 ``bindings_connection_active_uniq`` partial-unique index gives the same
 guarantee at the binding level (at most one active binding per
 connection).
@@ -45,15 +45,16 @@ class ConnectionCreate(BaseModel):
     ``session_template_id`` is set.  Use ``POST .../attach`` or
     ``POST .../configure-per-chat`` afterward to bind a routing mode.
 
-    ``connector`` and ``account`` may not contain ``/`` — they're used
-    in the focal-channel address scheme ``{connector}/{account}/{chat_id}``
-    and a ``/`` would create ambiguous segment boundaries.
+    ``connector`` and ``external_account_id`` may not contain ``/`` —
+    they're used in the focal-channel address scheme
+    ``{connector}/{external_account_id}/{chat_id}`` and a ``/`` would
+    create ambiguous segment boundaries.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     connector: str = Field(min_length=1, max_length=64)
-    account: str = Field(min_length=1, max_length=256)
+    external_account_id: str = Field(min_length=1, max_length=256)
     metadata: dict[str, Any] = Field(default_factory=dict)
     secrets: dict[str, str] | None = Field(
         default=None,
@@ -63,7 +64,7 @@ class ConnectionCreate(BaseModel):
         "Operator-facing reads return ``secrets_set: bool`` instead of values.",
     )
 
-    @field_validator("connector", "account")
+    @field_validator("connector", "external_account_id")
     @classmethod
     def _no_slash(cls, v: str) -> str:
         if "/" in v:
@@ -112,7 +113,7 @@ class Connection(BaseModel):
 
     id: str
     connector: str
-    account: str
+    external_account_id: str
     session_id: str | None = None
     session_template_id: str | None = None
     metadata: dict[str, Any]

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -54,7 +54,7 @@ async def create_connection(
     *,
     account_id: str,
     connector: str,
-    account: str,
+    external_account_id: str,
     metadata: dict[str, Any],
     secrets: dict[str, str] | None = None,
     crypto_box: CryptoBox,
@@ -63,7 +63,7 @@ async def create_connection(
         return await queries.insert_connection(
             conn,
             connector=connector,
-            account=account,
+            external_account_id=external_account_id,
             metadata=metadata,
             secrets_blob=_encrypt_secrets(secrets, crypto_box, account_id=account_id),
             account_id=account_id,
@@ -189,7 +189,7 @@ async def attach_connection(
             conn,
             connector=connection.connector,
             connection_id=connection.id,
-            account=connection.account,
+            external_account_id=connection.external_account_id,
             event="added",
             account_id=account_id,
         )
@@ -358,14 +358,18 @@ async def list_recent_chats(
     pool: asyncpg.Pool[Any], connection_id: str, *, account_id: str, limit: int = 50
 ) -> list[RecentChat]:
     """Distinct chat_ids that have produced inbound on this connection's
-    account, ordered most-recent first.  Used as the input to
+    external identity, ordered most-recent first.  Used as the input to
     ``bind-chat`` when an operator needs to find a specific chat's
     ``chat_id`` without digging through event logs.
     """
     async with pool.acquire() as conn:
         connection = await queries.get_connection(conn, connection_id, account_id=account_id)
         rows = await queries.list_recent_chat_ids(
-            conn, connection.connector, connection.account, limit=limit, account_id=account_id
+            conn,
+            connection.connector,
+            connection.external_account_id,
+            limit=limit,
+            account_id=account_id,
         )
     return [
         RecentChat(chat_id=chat_id, last_seen_at=last_seen_at) for chat_id, last_seen_at in rows
@@ -399,7 +403,7 @@ async def archive_connection(
             conn,
             connector=archived.connector,
             connection_id=archived.id,
-            account=archived.account,
+            external_account_id=archived.external_account_id,
             event="removed",
             account_id=account_id,
         )

--- a/src/aios/services/inbound.py
+++ b/src/aios/services/inbound.py
@@ -120,7 +120,7 @@ async def handle_inbound(
         appended = await _append_with_dedup(
             pool,
             connector=connection.connector,
-            account=connection.account,
+            external_account_id=connection.external_account_id,
             event_id=event_id,
             session_id=target_session_id,
             chat_id=chat_id,
@@ -157,7 +157,7 @@ async def _append_with_dedup(
     *,
     account_id: str,
     connector: str,
-    account: str,
+    external_account_id: str,
     event_id: str,
     session_id: str,
     chat_id: str,
@@ -173,7 +173,7 @@ async def _append_with_dedup(
     txn back via :class:`_DedupRollback`.  Returns True on first-append,
     False on dedup hit.
     """
-    channel = f"{connector}/{account}/{chat_id}"
+    channel = f"{connector}/{external_account_id}/{chat_id}"
     sender_name = sender.get("display_name")
     metadata: dict[str, Any] = {}
     if connector_metadata is not None:
@@ -200,7 +200,7 @@ async def _append_with_dedup(
             inserted = await queries.try_record_inbound_ack(
                 conn,
                 connector=connector,
-                account=account,
+                external_account_id=external_account_id,
                 event_id=event_id,
                 appended_seq=event.seq,
                 account_id=account_id,

--- a/src/aios_connectors/resolver.py
+++ b/src/aios_connectors/resolver.py
@@ -160,7 +160,7 @@ async def _spawn_per_chat_session(
     if template.archived_at is not None:
         return ResolveResult(session_id=None, drop=ResolveDrop.ARCHIVED_TEMPLATE)
 
-    focal_channel = f"{connection.connector}/{connection.account}/{chat_id}"
+    focal_channel = f"{connection.connector}/{connection.external_account_id}/{chat_id}"
     session = await sessions_service.create_session(
         pool,
         agent_id=template.agent_id,

--- a/tests/e2e/test_connection_discovery_sse.py
+++ b/tests/e2e/test_connection_discovery_sse.py
@@ -98,7 +98,9 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
 
 async def _create_connection(api_key: str, base_url: str, account: str) -> str:
     async with authed_client(base_url, api_key) as c:
-        r = await c.post("/v1/connections", json={"connector": "echo", "account": account})
+        r = await c.post(
+            "/v1/connections", json={"connector": "echo", "external_account_id": account}
+        )
         r.raise_for_status()
         return str(r.json()["id"])
 

--- a/tests/e2e/test_connection_tools.py
+++ b/tests/e2e/test_connection_tools.py
@@ -75,7 +75,7 @@ class TestConnectionToolsInPrelude:
         connection = await connections_service.create_connection(
             harness._pool,
             connector="echo",
-            account="echo-1",
+            external_account_id="echo-1",
             metadata={},
             crypto_box=crypto_box,
             account_id=account_id,
@@ -168,7 +168,7 @@ class TestConnectionToolsInPrelude:
         connection = await connections_service.create_connection(
             harness._pool,
             connector="echo",
-            account="echo-pc",
+            external_account_id="echo-pc",
             metadata={},
             crypto_box=crypto_box,
             account_id=account_id,
@@ -264,7 +264,7 @@ class TestConnectionToolDispatch:
         connection = await connections_service.create_connection(
             harness._pool,
             connector="echo",
-            account="echo-d",
+            external_account_id="echo-d",
             metadata={},
             crypto_box=crypto_box,
             account_id=account_id,

--- a/tests/e2e/test_connector_secrets.py
+++ b/tests/e2e/test_connector_secrets.py
@@ -30,7 +30,7 @@ async def _create_with_secrets(
     account: str,
     secrets: dict[str, str] | None,
 ) -> str:
-    body: dict[str, object] = {"connector": "echo", "account": account}
+    body: dict[str, object] = {"connector": "echo", "external_account_id": account}
     if secrets is not None:
         body["secrets"] = secrets
     async with authed_client(base_url, api_key) as c:

--- a/tests/e2e/test_echo_http_connector.py
+++ b/tests/e2e/test_echo_http_connector.py
@@ -91,7 +91,9 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
 
 async def _create_connection(api_key: str, base_url: str, account: str) -> str:
     async with authed_client(base_url, api_key) as c:
-        r = await c.post("/v1/connections", json={"connector": "echo", "account": account})
+        r = await c.post(
+            "/v1/connections", json={"connector": "echo", "external_account_id": account}
+        )
         r.raise_for_status()
         return str(r.json()["id"])
 

--- a/tests/e2e/test_inbound_attachment.py
+++ b/tests/e2e/test_inbound_attachment.py
@@ -34,7 +34,7 @@ def _new_event_id() -> str:
 async def _create_connection(http_client: httpx.AsyncClient, account: str) -> str:
     r = await http_client.post(
         "/v1/connections",
-        json={"connector": "echo", "account": account},
+        json={"connector": "echo", "external_account_id": account},
     )
     assert r.status_code == 201, r.text
     return str(r.json()["id"])

--- a/tests/e2e/test_runtime_tokens.py
+++ b/tests/e2e/test_runtime_tokens.py
@@ -61,7 +61,7 @@ class TestRuntimeTokensRoundtrip:
         # has a valid connection_id; the runtime token is revoked, so
         # the failure must come from auth, not from the connection check.
         r = await http_client.post(  # type: ignore[attr-defined]
-            "/v1/connections", json={"connector": "echo", "account": "acct-rev"}
+            "/v1/connections", json={"connector": "echo", "external_account_id": "acct-rev"}
         )
         r.raise_for_status()
         connection_id = r.json()["id"]
@@ -83,11 +83,11 @@ class TestRuntimeTokensRoundtrip:
         route.  This is the headline guard on the new auth path."""
         # Echo connection + telegram connection (different connector types).
         r = await http_client.post(  # type: ignore[attr-defined]
-            "/v1/connections", json={"connector": "echo", "account": "acct-cross-e"}
+            "/v1/connections", json={"connector": "echo", "external_account_id": "acct-cross-e"}
         )
         r.raise_for_status()
         r = await http_client.post(  # type: ignore[attr-defined]
-            "/v1/connections", json={"connector": "telegram", "account": "acct-cross-t"}
+            "/v1/connections", json={"connector": "telegram", "external_account_id": "acct-cross-t"}
         )
         r.raise_for_status()
         telegram_conn_id = r.json()["id"]

--- a/tests/e2e/test_signal_connector.py
+++ b/tests/e2e/test_signal_connector.py
@@ -94,7 +94,7 @@ async def _create_signal_connection(
     async with authed_client(base_url, api_key) as c:
         r = await c.post(
             "/v1/connections",
-            json={"connector": "signal", "account": account, "secrets": secrets},
+            json={"connector": "signal", "external_account_id": account, "secrets": secrets},
         )
         r.raise_for_status()
         return str(r.json()["id"])

--- a/tests/e2e/test_signal_registration.py
+++ b/tests/e2e/test_signal_registration.py
@@ -36,29 +36,46 @@ class _FakeSignalConnector(HttpConnector):
 
     @management_handler()
     async def register(
-        self, *, account: str, captcha: str | None = None, voice: bool = False
+        self, *, external_account_id: str, captcha: str | None = None, voice: bool = False
     ) -> dict:
-        self.calls.append(("register", {"account": account, "captcha": captcha, "voice": voice}))
+        self.calls.append(
+            (
+                "register",
+                {
+                    "external_account_id": external_account_id,
+                    "captcha": captcha,
+                    "voice": voice,
+                },
+            )
+        )
         if self.captcha_on_register and captcha is None:
             raise ManagementHandlerError(
                 {
                     "status": "captcha_required",
                     "captcha_url": "https://signalcaptchas.org/registration/generate",
-                    "account": account,
+                    "external_account_id": external_account_id,
                 }
             )
-        return {"account": account, "status": "voice_sent" if voice else "sms_sent"}
+        return {
+            "external_account_id": external_account_id,
+            "status": "voice_sent" if voice else "sms_sent",
+        }
 
     @management_handler()
-    async def verify(self, *, account: str, code: str, pin: str | None = None) -> dict:
-        self.calls.append(("verify", {"account": account, "code": code, "pin": pin}))
-        return {"account": account, "uuid": "u-from-fake"}
+    async def verify(self, *, external_account_id: str, code: str, pin: str | None = None) -> dict:
+        self.calls.append(
+            (
+                "verify",
+                {"external_account_id": external_account_id, "code": code, "pin": pin},
+            )
+        )
+        return {"external_account_id": external_account_id, "uuid": "u-from-fake"}
 
     @management_handler(method="updateProfile")
     async def update_profile(
         self,
         *,
-        account: str,
+        external_account_id: str,
         given_name: str | None = None,
         family_name: str | None = None,
         about: str | None = None,
@@ -67,14 +84,14 @@ class _FakeSignalConnector(HttpConnector):
             (
                 "updateProfile",
                 {
-                    "account": account,
+                    "external_account_id": external_account_id,
                     "given_name": given_name,
                     "family_name": family_name,
                     "about": about,
                 },
             )
         )
-        return {"account": account}
+        return {"external_account_id": external_account_id}
 
 
 @pytest.fixture
@@ -163,13 +180,13 @@ class TestSignalRegistration:
                 # Register.
                 r = await c.post(
                     "/v1/connectors/signal/register",
-                    json={"account": "+15551234567"},
+                    json={"external_account_id": "+15551234567"},
                     timeout=10.0,
                 )
                 assert r.status_code == 200, r.text
                 body = r.json()
                 assert body == {
-                    "account": "+15551234567",
+                    "external_account_id": "+15551234567",
                     "status": "sms_sent",
                     "captcha_url": None,
                 }
@@ -177,16 +194,19 @@ class TestSignalRegistration:
                 # Verify.
                 r = await c.post(
                     "/v1/connectors/signal/verify",
-                    json={"account": "+15551234567", "code": "123456"},
+                    json={"external_account_id": "+15551234567", "code": "123456"},
                     timeout=10.0,
                 )
                 assert r.status_code == 200, r.text
-                assert r.json() == {"account": "+15551234567", "uuid": "u-from-fake"}
+                assert r.json() == {
+                    "external_account_id": "+15551234567",
+                    "uuid": "u-from-fake",
+                }
 
                 # Profile (only given_name).
                 r = await c.post(
                     "/v1/connectors/signal/profile",
-                    json={"account": "+15551234567", "given_name": "Alice"},
+                    json={"external_account_id": "+15551234567", "given_name": "Alice"},
                     timeout=10.0,
                 )
                 assert r.status_code == 204, r.text
@@ -194,11 +214,11 @@ class TestSignalRegistration:
             # The handler was hit with the right kwargs.
             assert (
                 "register",
-                {"account": "+15551234567", "captcha": None, "voice": False},
+                {"external_account_id": "+15551234567", "captcha": None, "voice": False},
             ) in connector.calls
             assert (
                 "verify",
-                {"account": "+15551234567", "code": "123456", "pin": None},
+                {"external_account_id": "+15551234567", "code": "123456", "pin": None},
             ) in connector.calls
             profile_call = next(c for c in connector.calls if c[0] == "updateProfile")
             assert profile_call[1]["given_name"] == "Alice"
@@ -232,7 +252,7 @@ class TestSignalRegistration:
             async with authed_client(live_server, api_key) as c:
                 r = await c.post(
                     "/v1/connectors/signal/register",
-                    json={"account": "+15559999999"},
+                    json={"external_account_id": "+15559999999"},
                     timeout=10.0,
                 )
                 assert r.status_code == 200, r.text
@@ -245,7 +265,7 @@ class TestSignalRegistration:
                 r = await c.post(
                     "/v1/connectors/signal/register",
                     json={
-                        "account": "+15559999999",
+                        "external_account_id": "+15559999999",
                         "captcha": "signalcaptcha://solved",
                     },
                     timeout=10.0,

--- a/tests/e2e/test_telegram_connector.py
+++ b/tests/e2e/test_telegram_connector.py
@@ -92,7 +92,7 @@ async def _create_telegram_connection(
     async with authed_client(base_url, api_key) as c:
         r = await c.post(
             "/v1/connections",
-            json={"connector": "telegram", "account": account, "secrets": secrets},
+            json={"connector": "telegram", "external_account_id": account, "secrets": secrets},
         )
         r.raise_for_status()
         return str(r.json()["id"])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,39 @@
+"""Shared fixtures for ``tests/integration/`` (DB-backed, testcontainer-Postgres).
+
+Anything that seeds reusable account / tenant state belongs here so
+individual test modules don't re-roll the same scaffolding.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+
+@pytest.fixture
+async def conn_two_accounts(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[asyncpg.Connection[Any]]:
+    """Asyncpg conn with one root + two child tenants (``acc_a``, ``acc_b``).
+
+    The partial unique index ``accounts_one_active_root`` permits only
+    a single non-archived ``parent_account_id IS NULL`` row at a time,
+    so the root + two children layout is the minimum that supports
+    cross-tenant tests.
+    """
+    conn = await asyncpg.connect(migrated_db_url)
+    try:
+        await conn.execute(
+            """
+            INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+            VALUES ('acc_root', NULL,      TRUE,  'tenant-root'),
+                   ('acc_a',    'acc_root', FALSE, 'tenant-a'),
+                   ('acc_b',    'acc_root', FALSE, 'tenant-b')
+            """
+        )
+        yield conn
+    finally:
+        await conn.close()

--- a/tests/integration/test_insert_connection_cross_tenant.py
+++ b/tests/integration/test_insert_connection_cross_tenant.py
@@ -1,0 +1,119 @@
+"""Integration test: ``insert_connection`` surfaces cross-tenant collisions as ``ConflictError``.
+
+The ``connections`` table carries a globally-unique partial index on
+``(connector, external_account_id) WHERE archived_at IS NULL``. Real
+messaging identities (Signal phone numbers, Telegram bot tokens, Matrix
+accounts, etc.) are universally exclusive, so the constraint mirrors
+physical reality — and a cross-tenant collision on the active row is a
+caller-visible error, not contention to swallow.
+
+Pins the contract: a tenant inserting on another tenant's active
+identity raises :class:`aios.errors.ConflictError` carrying
+``connector`` + ``external_account_id`` in ``detail``. No silent
+retry, no existence-leak via failure shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.errors import ConflictError
+
+pytestmark = pytest.mark.integration
+
+
+class TestInsertConnectionCrossTenant:
+    async def test_cross_tenant_collision_raises_conflict_error(
+        self, conn_two_accounts: asyncpg.Connection[Any]
+    ) -> None:
+        """Tenant B inserting on tenant A's active identity → ``ConflictError``."""
+        await queries.insert_connection(
+            conn_two_accounts,
+            account_id="acc_a",
+            connector="signal",
+            external_account_id="+15550001",
+            metadata={},
+        )
+        with pytest.raises(ConflictError) as excinfo:
+            await queries.insert_connection(
+                conn_two_accounts,
+                account_id="acc_b",
+                connector="signal",
+                external_account_id="+15550001",
+                metadata={},
+            )
+        assert excinfo.value.detail == {
+            "connector": "signal",
+            "external_account_id": "+15550001",
+        }
+
+    async def test_same_tenant_repeat_returns_existing(
+        self, conn_two_accounts: asyncpg.Connection[Any]
+    ) -> None:
+        """Idempotency on ``(connector, external_account_id)`` within one tenant."""
+        first = await queries.insert_connection(
+            conn_two_accounts,
+            account_id="acc_a",
+            connector="signal",
+            external_account_id="+15550001",
+            metadata={},
+        )
+        second = await queries.insert_connection(
+            conn_two_accounts,
+            account_id="acc_a",
+            connector="signal",
+            external_account_id="+15550001",
+            metadata={},
+        )
+        assert second.id == first.id
+
+    async def test_archived_then_reinsert_same_tenant(
+        self, conn_two_accounts: asyncpg.Connection[Any]
+    ) -> None:
+        """The partial unique index permits a fresh insert after archive."""
+        first = await queries.insert_connection(
+            conn_two_accounts,
+            account_id="acc_a",
+            connector="signal",
+            external_account_id="+15550001",
+            metadata={},
+        )
+        await queries.archive_connection(conn_two_accounts, first.id, account_id="acc_a")
+        second = await queries.insert_connection(
+            conn_two_accounts,
+            account_id="acc_a",
+            connector="signal",
+            external_account_id="+15550001",
+            metadata={},
+        )
+        assert second.id != first.id
+        assert second.archived_at is None
+
+    async def test_archived_other_tenant_lets_new_tenant_take_identity(
+        self, conn_two_accounts: asyncpg.Connection[Any]
+    ) -> None:
+        """When A's row is archived, B may claim the same external identity.
+
+        The partial index excludes archived rows, so the constraint
+        doesn't fire — and B is the sole tenant on the active row.
+        """
+        a_first = await queries.insert_connection(
+            conn_two_accounts,
+            account_id="acc_a",
+            connector="signal",
+            external_account_id="+15550001",
+            metadata={},
+        )
+        await queries.archive_connection(conn_two_accounts, a_first.id, account_id="acc_a")
+        b_takes = await queries.insert_connection(
+            conn_two_accounts,
+            account_id="acc_b",
+            connector="signal",
+            external_account_id="+15550001",
+            metadata={},
+        )
+        assert b_takes.id != a_first.id

--- a/tests/integration/test_list_recent_chats_like.py
+++ b/tests/integration/test_list_recent_chats_like.py
@@ -1,19 +1,20 @@
 """Integration test: ``list_recent_chat_ids`` escapes LIKE wildcards in
-``account``.
+``external_account_id``.
 
 Pre-fix: ``list_recent_chat_ids`` (``db/queries.py:3750``) built the
 LIKE pattern by f-string concatenation:
 
-    prefix = f"{connector}/{account}/"
+    prefix = f"{connector}/{external_account_id}/"
     ... WHERE channel LIKE $1 ..., prefix + "%", ...
 
-``account`` is operator-supplied (``ConnectionCreate.account`` allows
-``%``, ``_``, ``\\``). SQL ``LIKE`` treats ``_`` as "any single char"
-and ``%`` as "any string". So an operator with two connections under
-the same tenant — e.g. accounts ``bot_a`` and ``botXa`` — calling the
-helper for ``bot_a`` would match channel ``telegram/botXa/...`` too,
-since ``_`` in the pattern position matches the ``X`` literal in the
-stored channel. The result is same-tenant data confusion: chats from
+``external_account_id`` is operator-supplied
+(``ConnectionCreate.external_account_id`` allows ``%``, ``_``, ``\\``).
+SQL ``LIKE`` treats ``_`` as "any single char" and ``%`` as "any
+string". So an operator with two connections under the same tenant —
+e.g. identities ``bot_a`` and ``botXa`` — calling the helper for
+``bot_a`` would match channel ``telegram/botXa/...`` too, since ``_``
+in the pattern position matches the ``X`` literal in the stored
+channel. The result is same-tenant data confusion: chats from
 ``botXa`` get reported as belonging to ``bot_a``.
 
 The sibling helper at ``queries.py:4454`` already escapes with

--- a/tests/integration/test_management_call_account_id.py
+++ b/tests/integration/test_management_call_account_id.py
@@ -16,7 +16,6 @@ different one returns ``None``.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -26,29 +25,6 @@ import pytest
 from aios.db import queries
 
 pytestmark = pytest.mark.integration
-
-
-@pytest.fixture
-async def conn_two_accounts(
-    migrated_db_url: str, _reset_db_state: None
-) -> AsyncIterator[asyncpg.Connection[Any]]:
-    """Asyncpg conn with two seeded accounts (``acc_a``, ``acc_b``)."""
-    conn = await asyncpg.connect(migrated_db_url)
-    try:
-        # One root + two children — partial unique index
-        # ``accounts_one_active_root`` permits only a single non-archived
-        # ``parent_account_id IS NULL`` row at a time.
-        await conn.execute(
-            """
-            INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
-            VALUES ('acc_root', NULL,      TRUE,  'tenant-root'),
-                   ('acc_a',    'acc_root', FALSE, 'tenant-a'),
-                   ('acc_b',    'acc_root', FALSE, 'tenant-b')
-            """
-        )
-        yield conn
-    finally:
-        await conn.close()
 
 
 class TestGetManagementCallTenancy:

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -110,7 +110,7 @@ _RESOURCE_BASES: dict[str, dict[str, Any]] = {
     "connection": {
         "id": "conn_01",
         "connector": "signal",
-        "account": "acct-1",
+        "external_account_id": "acct-1",
         "metadata": {},
         "created_at": _FIXED_TS,
         "updated_at": _FIXED_TS,

--- a/tests/unit/cli/test_cli_connections.py
+++ b/tests/unit/cli/test_cli_connections.py
@@ -58,7 +58,7 @@ def test_create_ergonomic(mocked_cli):
             "create",
             "--connector",
             "signal",
-            "--account",
+            "--external-account-id",
             "acct-123",
         ],
     )
@@ -67,7 +67,7 @@ def test_create_ergonomic(mocked_cli):
     assert mocked_cli.captured.path == "/v1/connections"
     assert mocked_cli.captured.body == {
         "connector": "signal",
-        "account": "acct-123",
+        "external_account_id": "acct-123",
     }
 
 
@@ -82,7 +82,7 @@ def test_create_ergonomic_with_metadata_json(mocked_cli):
             "create",
             "--connector",
             "signal",
-            "--account",
+            "--external-account-id",
             "acct-123",
             "--metadata-json",
             '{"region": "us-east"}',
@@ -98,7 +98,7 @@ def test_create_missing_ergonomic_flag(mocked_cli):
         ["connections", "create", "--connector", "signal"],
     )
     assert result.exit_code == 64
-    assert "--account" in result.output
+    assert "--external-account-id" in result.output
 
 
 def test_create_rejects_mixed_sources(mocked_cli):
@@ -109,7 +109,7 @@ def test_create_rejects_mixed_sources(mocked_cli):
             "create",
             "--connector",
             "signal",
-            "--account",
+            "--external-account-id",
             "acct-1",
             "--data",
             "{}",

--- a/tests/unit/test_connection_models.py
+++ b/tests/unit/test_connection_models.py
@@ -28,18 +28,18 @@ from aios.models.session_templates import (
 
 class TestConnectionCreate:
     def test_minimal(self) -> None:
-        body = ConnectionCreate(connector="signal", account="+15550001")
+        body = ConnectionCreate(connector="signal", external_account_id="+15550001")
         assert body.connector == "signal"
-        assert body.account == "+15550001"
+        assert body.external_account_id == "+15550001"
         assert body.metadata == {}
 
     def test_rejects_slash_in_connector(self) -> None:
         with pytest.raises(ValueError, match="must not contain '/'"):
-            ConnectionCreate(connector="signal/bad", account="acct")
+            ConnectionCreate(connector="signal/bad", external_account_id="acct")
 
-    def test_rejects_slash_in_account(self) -> None:
+    def test_rejects_slash_in_external_account_id(self) -> None:
         with pytest.raises(ValueError, match="must not contain '/'"):
-            ConnectionCreate(connector="signal", account="acct/with/slash")
+            ConnectionCreate(connector="signal", external_account_id="acct/with/slash")
 
     def test_rejects_extra_fields(self) -> None:
         """``extra="forbid"`` keeps wire shape strict — the old model
@@ -50,7 +50,7 @@ class TestConnectionCreate:
             ConnectionCreate.model_validate(
                 {
                     "connector": "signal",
-                    "account": "acct",
+                    "external_account_id": "acct",
                     "mcp_url": "https://m",  # removed in #200
                 }
             )
@@ -64,10 +64,15 @@ class TestConnectionCreate:
             ConnectionCreate.model_validate(
                 {
                     "connector": "signal",
-                    "account": "+1",
+                    "external_account_id": "+1",
                     "tools": [{"type": "custom", "name": "x", "input_schema": {}}],
                 }
             )
+
+    def test_rejects_legacy_account_field(self) -> None:
+        """Pre-rename clients sending ``account`` must 422, not silently coerce."""
+        with pytest.raises(ValueError):
+            ConnectionCreate.model_validate({"connector": "signal", "account": "+15550001"})
 
 
 class TestConnectionAttach:
@@ -96,7 +101,7 @@ class TestConnectionReadView:
         c = Connection(
             id="conn_1",
             connector="signal",
-            account="+1",
+            external_account_id="+1",
             metadata={},
             created_at=self._now(),
             updated_at=self._now(),
@@ -108,7 +113,7 @@ class TestConnectionReadView:
         c = Connection(
             id="conn_1",
             connector="signal",
-            account="+1",
+            external_account_id="+1",
             session_id="sess_1",
             metadata={},
             created_at=self._now(),
@@ -122,7 +127,7 @@ class TestConnectionReadView:
         c = Connection(
             id="conn_1",
             connector="signal",
-            account="+1",
+            external_account_id="+1",
             session_template_id="stpl_1",
             metadata={},
             created_at=self._now(),

--- a/tests/unit/test_management_calls_service.py
+++ b/tests/unit/test_management_calls_service.py
@@ -46,7 +46,7 @@ class TestSubmitCall:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         conn = MagicMock()
         pool = fake_pool_yielding_conn(conn)
-        expected: dict[str, Any] = {"status": "sms_sent", "account": "+15551234567"}
+        expected: dict[str, Any] = {"status": "sms_sent", "external_account_id": "+15551234567"}
 
         with (
             patch(
@@ -70,7 +70,7 @@ class TestSubmitCall:
                 pool,
                 connector="signal",
                 method="register",
-                params={"account": "+15551234567"},
+                params={"external_account_id": "+15551234567"},
                 timeout_s=1.0,
                 account_id=account_id,
             )
@@ -110,7 +110,7 @@ class TestSubmitCall:
                 pool,
                 connector="signal",
                 method="register",
-                params={"account": "+15551234567"},
+                params={"external_account_id": "+15551234567"},
                 timeout_s=1.0,
                 account_id=account_id,
             )
@@ -140,7 +140,7 @@ class TestSubmitCall:
                 pool,
                 connector="signal",
                 method="register",
-                params={"account": "+15551234567"},
+                params={"external_account_id": "+15551234567"},
                 timeout_s=0.05,
                 account_id=account_id,
             )


### PR DESCRIPTION
## Summary

- Rename ``connections.account`` (and the sibling ``connector_inbound_acks.account``) → ``external_account_id`` across DB schema, Python model, queries, services, API wire-format, SSE/NOTIFY payloads, CLI ``--external-account-id`` flag, runtime SDK focal-kwarg injection, and the in-tree Signal/Telegram connectors. No deprecation shim; runtime containers redeploy in lock-step.
- Replace ``insert_connection``'s silent 3-attempt retry + ``RuntimeError("...failed to converge")`` with a one-shot unscoped probe that raises typed ``ConflictError`` on cross-tenant identity collisions. Archive-race path preserved (one loop iteration). The pre-rename code masked cross-tenant collisions as contention bugs and leaked existence via failure shape.

## Test plan

- [x] mypy clean (`uv run mypy src`)
- [x] ruff check + format-check clean
- [x] Unit suite — 1249 passed
- [x] Integration suite — 28 passed, including new ``test_insert_connection_cross_tenant.py`` covering (cross-tenant → ConflictError, same-tenant idempotent, archive-then-reinsert same-tenant, archive-then-claim other-tenant)
- [x] Migration up/down/up cycle clean (manually verified against testcontainer Postgres)
- [x] Signed-off-by code-reviewer agent (3 findings actioned: runner.py dispatch_call docstring, migration downgrade ordering, AccountDriftError docstring rot)
- [ ] CI runs e2e suite

## Notes for reviewer

- ``params["account"]`` references in the Signal connector daemon and `rpc.py` are signal-cli's own protocol naming and stay unchanged — the aios boundary is renamed.
- ``params.account`` in agent-visible Telegram prompt text is updated to ``params.external_account_id`` for consistency with the renamed segment in the focal-channel format.
- The pre-existing ``tests/e2e/test_sandbox_image_contract.py`` failures (missing `mcp` binary, arch mismatch) are infrastructure issues unrelated to this PR; verified by stashing the diff and reproducing on master.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)