### PR TITLE
refactor(tool_dispatch): drop dead 'if True:' branch in MCP dispatch

### DIFF
--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -441,32 +441,27 @@ async def _execute_mcp_tool_async(
         if suffix is not None:
             meta[FOCAL_CHANNEL_META_KEY] = suffix
 
-        # Agent-declared HTTP MCP server.  Connector dispatch was the
-        # other branch here historically — connectors now run as peer
-        # services and route via the custom-tool / requires_action flow
-        # (see #301), so this dispatcher only handles HTTP MCP.
-        if True:
-            url = mcp_server_map.get(server_name)
-            if url is None:
-                bound_log.warning("mcp_tool.server_not_found", server_name=server_name)
-                is_error = True
-                await _append_tool_result(
-                    pool,
-                    session_id,
-                    call_id,
-                    name,
-                    account_id=account_id,
-                    error=f"MCP server {server_name!r} not found",
-                )
-                return
-
-            from aios.mcp.client import call_mcp_tool, resolve_auth_for_url
-
-            crypto_box = runtime.require_crypto_box()
-            vault_id, headers = await resolve_auth_for_url(
-                pool, crypto_box, session_id, url, account_id=account_id
+        url = mcp_server_map.get(server_name)
+        if url is None:
+            bound_log.warning("mcp_tool.server_not_found", server_name=server_name)
+            is_error = True
+            await _append_tool_result(
+                pool,
+                session_id,
+                call_id,
+                name,
+                account_id=account_id,
+                error=f"MCP server {server_name!r} not found",
             )
-            result = await call_mcp_tool(url, vault_id, headers, tool_name, arguments, meta=meta)
+            return
+
+        from aios.mcp.client import call_mcp_tool, resolve_auth_for_url
+
+        crypto_box = runtime.require_crypto_box()
+        vault_id, headers = await resolve_auth_for_url(
+            pool, crypto_box, session_id, url, account_id=account_id
+        )
+        result = await call_mcp_tool(url, vault_id, headers, tool_name, arguments, meta=meta)
 
         content_str = json.dumps(result, ensure_ascii=False)
         mcp_is_error = "error" in result


### PR DESCRIPTION
## Summary

- Removes the single-arm `if True:` conditional in `_execute_mcp_tool_async`, a scar left by PR #318 (connector-to-peer-service migration) when the historical if/else collapsed to one branch.
- Removes the 4-line historical-context comment that explained the removed branch (`(see #301)`).
- De-indents the 22 inner lines.

Pure code-shape change — no behavior change. Net `-5` LOC.

Found by a `/kaizen` audit: cross-corroborated by the invariant-maintenance and craftsmanship reviewers, who both landed on this function. Aligns with CLAUDE.md: "don't deprecate, delete" and "avoid backwards-compatibility hacks like `// removed comments for removed code`."

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1249 passed
- [ ] CI runs e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)