### PR TITLE
fix(db): serialize concurrent update_environment partial writers

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -181,31 +181,35 @@ async def update_environment(
     config: EnvironmentConfig | None = None,
 ) -> Environment:
     """Update an environment. Omitted fields are preserved."""
+    # Upfront read so "not found" vs "archived" produce distinct errors;
+    # folding archived into the UPDATE WHERE collapses them.
     current = await get_environment(conn, env_id, account_id=account_id)
     if current.archived_at is not None:
         raise ConflictError(f"environment {env_id} is archived", detail={"id": env_id})
 
-    new_name = name if name is not None else current.name
-    new_config = config if config is not None else current.config
+    sets: list[str] = []
+    args: list[Any] = [env_id]
+    if name is not None:
+        args.append(name)
+        sets.append(f"name = ${len(args)}")
+    if config is not None:
+        args.append(json.dumps(config.model_dump(exclude_none=True)))
+        sets.append(f"config = ${len(args)}::jsonb")
 
-    # No-op detection.
-    if new_name == current.name and new_config == current.config:
+    if not sets:
         return current
 
-    config_json = json.dumps(new_config.model_dump(exclude_none=True))
+    args.append(account_id)
+    sql = (
+        f"UPDATE environments SET {', '.join(sets)} "
+        f"WHERE id = $1 AND account_id = ${len(args)} RETURNING *"
+    )
     try:
-        row = await conn.fetchrow(
-            "UPDATE environments SET name = $2, config = $3::jsonb "
-            "WHERE id = $1 AND account_id = $4 RETURNING *",
-            env_id,
-            new_name,
-            config_json,
-            account_id,
-        )
+        row = await conn.fetchrow(sql, *args)
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
-            f"an environment named {new_name!r} already exists",
-            detail={"name": new_name},
+            f"an environment named {name!r} already exists",
+            detail={"name": name},
         ) from exc
     assert row is not None
     return _row_to_environment(row)

--- a/tests/integration/test_update_environment_concurrent.py
+++ b/tests/integration/test_update_environment_concurrent.py
@@ -1,0 +1,100 @@
+"""Concurrent partial writers to the same environment row must not lose
+updates. Pre-fix, ``update_environment`` read ``current`` outside any
+transaction, merged in Python, then wrote BOTH columns back — so a
+config-only writer would clobber a concurrent name-only writer's
+rename (and vice versa)."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.models.environments import (
+    Environment,
+    EnvironmentConfig,
+    LimitedNetworking,
+    UnrestrictedNetworking,
+)
+from aios.services import environments as environments_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def pool_with_environment(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, Environment]]:
+    """Yield ``(pool, account_id, env)`` for a freshly-seeded environment."""
+    pool = await create_pool(migrated_db_url, min_size=2, max_size=8)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_test', NULL, TRUE, 'tenant-test')
+                """
+            )
+        env = await environments_service.create_environment(
+            pool,
+            account_id="acc_test",
+            name="initial",
+            config=EnvironmentConfig(
+                packages={"pip": ["pandas"]},
+                networking=UnrestrictedNetworking(),
+            ),
+        )
+        yield pool, "acc_test", env
+    finally:
+        await pool.close()
+
+
+async def test_concurrent_partial_updates_preserve_both_changes(
+    pool_with_environment: tuple[asyncpg.Pool[Any], str, Environment],
+) -> None:
+    pool, account_id, env = pool_with_environment
+
+    new_config = EnvironmentConfig(
+        packages={"pip": ["pandas"]},
+        networking=LimitedNetworking(type="limited", allowed_hosts=["example.com"]),
+    )
+
+    # Pool min_size=2 so both coroutines can hold connections concurrently —
+    # the race is real, not artificially serialized by pool exhaustion.
+    name_result, config_result = await asyncio.gather(
+        environments_service.update_environment(
+            pool, env.id, account_id=account_id, name="renamed"
+        ),
+        environments_service.update_environment(
+            pool, env.id, account_id=account_id, config=new_config
+        ),
+    )
+
+    final = await environments_service.get_environment(pool, env.id, account_id=account_id)
+    assert final.name == "renamed"
+    assert final.config == new_config
+    assert name_result.name == "renamed"
+    assert config_result.config == new_config
+
+
+async def test_sequential_partial_updates_preserve_omitted_fields(
+    pool_with_environment: tuple[asyncpg.Pool[Any], str, Environment],
+) -> None:
+    pool, account_id, env = pool_with_environment
+
+    renamed = await environments_service.update_environment(
+        pool, env.id, account_id=account_id, name="renamed"
+    )
+    assert renamed.name == "renamed"
+    assert renamed.config == env.config
+
+    new_config = EnvironmentConfig(packages={"pip": ["numpy"]})
+    reconfigured = await environments_service.update_environment(
+        pool, env.id, account_id=account_id, config=new_config
+    )
+    assert reconfigured.name == "renamed"
+    assert reconfigured.config == new_config


### PR DESCRIPTION
## Summary

- Two concurrent `update_environment` calls — one renaming, one swapping config — both read the same snapshot via `get_environment`, both merged in Python, then wrote BOTH columns back. The second commit clobbered the first writer's change for the column it didn't set. Silent data loss on partial PATCH-style updates.
- Conforms `update_environment` to the partial-SET pattern used by every other `update_*` function in `queries.py` (`update_session`, `update_session_template`, `update_memory_store`, `update_account`, `update_vault`, `update_vault_credential`): build the SET clause from the kwargs actually provided so concurrent partial writers don't fight over each other's columns and Postgres row-level locking serializes them naturally.
- Direct sibling shape to merged #450 (`update_agent` concurrent lost-update fix).
- The upfront `get_environment` read is kept so "not found" vs "archived" produce distinct error shapes — folding archived into the UPDATE WHERE would collapse them. The prior no-op short-circuit (echo PUT returns current without an UPDATE round trip) is dropped; the `environments` table has no `updated_at` column so an echo PUT is functionally a no-op regardless.

## Test plan

- [x] `tests/integration/test_update_environment_concurrent.py` — two tests against testcontainer Postgres:
  - `test_concurrent_partial_updates_preserve_both_changes` — two `asyncio.gather`'d `update_environment` calls (one renames, one swaps config) against a pool with `min_size=2` so the race isn't artificially serialized. Asserts both changes land. Pre-fix this fails deterministically with `final.name='initial'` (the rename was clobbered by the config-only writer's snapshot-merge).
  - `test_sequential_partial_updates_preserve_omitted_fields` — regression guard that the omit-preserves-field contract still holds under the partial-SET pattern.
- [x] mypy — clean (153 source files)
- [x] ruff check + format-check — clean
- [x] Unit suite — 1249 passed
- [ ] CI runs e2e/integration suites

## Code review notes

Reviewed via `pr-review-toolkit:code-reviewer`. **No blocking findings.** Five sub-70 findings posted per project memory (post all findings, score triages):

- **[55] Pre-read TOCTOU on `archived_at`** — Pre-existing pattern across every sibling updater. The pre-read + Python-side archived check is racy with `archive_environment`. Out of scope for this PR (would require an epic across all `update_*`/`get_*` pairs and would change error semantics). Worth a separate bughunt target.
- **[55] `name`-echo-rename can still lose updates** — If a caller passes `name=current_name` concurrent with a real rename, the partial-SET path still includes `name` in the UPDATE and clobbers the concurrent writer. PUT `/v1/environments/{id}` callers (FastAPI handler, CLI) omit unchanged fields, so this is latent rather than active. Matches sibling pattern.
- **[60] `f"...named {name!r}..."` would surface `'None'` for a hypothetical non-name unique violation** — Today the only unique index is `environments_name_uniq`, which can only fire when `name is not None`, so the message is correct. Latent footgun if a future migration adds another unique index on environments. Same shape as `update_session_template`'s error handler.
- **[50] Test doesn't deterministically force interleaving** — Relies on `asyncio.gather` scheduling for the race window rather than `pg_advisory_lock` / `asyncio.Barrier`. In practice both coroutines hit `fetchrow` essentially simultaneously and the test fails pre-fix with probability ~1. Acceptable as black-box coverage.
- **[35] Sequential test partially duplicates concurrent-test coverage** — Documents the omit-preserves-field contract linearly, useful for debug. Keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)