### PR TITLE
fix(harness/context): guard reply_to.text against non-string values

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -143,7 +143,8 @@ def _format_channel_header(metadata: dict[str, Any]) -> str:
         header += "\n[" + " · ".join(r_parts) + "]"
     reply_to = metadata.get("reply_to")
     if isinstance(reply_to, dict):
-        quoted = (reply_to.get("text") or "").replace("\n", " ").strip()
+        text = reply_to.get("text")
+        quoted = text.replace("\n", " ").strip() if isinstance(text, str) else ""
         quote_parts: list[str] = []
         author = reply_to.get("author_uuid")
         if isinstance(author, str) and author:

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1048,6 +1048,25 @@ class TestFocalRendering:
         assert "\n[reply_to: author_uuid=bot · timestamp_ms=1776400000000]" in content
         assert "> what I said before" in content
 
+    def test_focal_match_reply_to_text_non_string_does_not_brick_session(self) -> None:
+        """Non-string ``reply_to.text`` from a connector must not crash the
+        renderer. ``_format_channel_header`` runs on every wake while the
+        event is in the window, so a crash permanently bricks the session
+        (same failure class as #446)."""
+        md = {
+            "channel": self._CHAN_A,
+            "reply_to": {
+                "author_uuid": "bot",
+                "timestamp_ms": 1776400000000,
+                "text": {"blocks": ["unexpected shape"]},
+            },
+        }
+        events = [_evt(1, "user", content="ok", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        # Quote snippet omitted because the text isn't renderable as a string.
+        assert "[reply_to: author_uuid=bot · timestamp_ms=1776400000000]" in content
+        assert "blocks" not in content
+
     def test_focal_match_reaction_surfaced(self) -> None:
         md = {
             "channel": self._CHAN_A,


### PR DESCRIPTION
## Summary

- `_format_channel_header` did `(reply_to.get("text") or "").replace(...)` which crashes with `AttributeError` when `text` is a truthy non-string (e.g. dict or list). The renderer runs on every wake, so a single offending event in the window permanently bricks the session until the event ages out.
- Every other field in this metadata block (`mentions.uuid`, `mentions.name`, `reaction.target_*`, `reply_to.author_uuid`, `reply_to.timestamp_ms`, `sticker_emoji`) is already `isinstance(..., str)`-guarded; `reply_to.text` was the lone outlier. Restoring the guard completes the symmetry.
- Same failure class as #446 (non-dict attachment record bricks session), #449 (mime corrector mutating `Event.data`), #455 (non-dict inbound form-JSON): connector metadata arrives at an external boundary, so the harness must render robustly rather than crash on unexpected shape.

## Test plan

- [x] New `test_focal_match_reply_to_text_non_string_does_not_brick_session` fails pre-fix with the predicted `AttributeError: 'dict' object has no attribute 'replace'` at `context.py:146`; passes post-fix with the quote-snippet omitted and the safely-extractable `author_uuid` + `timestamp_ms` still surfaced.
- [x] All 24 `TestFocalRendering` tests pass (existing `test_focal_match_reply_to_surfaced` still green).
- [x] mypy — clean (153 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1250 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)