### PR TITLE
refactor(queries): unify partial-update sentinel on EllipsisType

### DIFF
--- a/src/aios/api/routers/session_templates.py
+++ b/src/aios/api/routers/session_templates.py
@@ -15,7 +15,6 @@ from typing import Annotated
 from fastapi import APIRouter, Query, status
 
 from aios.api.deps import AuthDep, PoolDep
-from aios.db.queries import _UNSET
 from aios.models.common import ListResponse
 from aios.models.session_templates import (
     SessionTemplate,
@@ -96,7 +95,7 @@ async def update(
         template_id,
         name=body.name,
         agent_id=body.agent_id,
-        agent_version=(body.agent_version if "agent_version" in body.model_fields_set else _UNSET),
+        agent_version=(body.agent_version if "agent_version" in body.model_fields_set else ...),
         environment_id=body.environment_id,
         vault_ids=body.vault_ids,
         memory_store_ids=body.memory_store_ids,

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -133,7 +133,6 @@ async def update(
     _auth: AuthDep,
 ) -> Session:
     account_id, _, _ = _auth
-    from aios.db.queries import _UNSET
 
     # Use model_fields_set to distinguish "not provided" from "explicitly null".
     # agent_version=null means "latest" (auto-updating); omitted means "keep current".
@@ -141,8 +140,8 @@ async def update(
         pool,
         session_id,
         agent_id=body.agent_id,
-        agent_version=body.agent_version if "agent_version" in body.model_fields_set else _UNSET,
-        title=body.title if "title" in body.model_fields_set else _UNSET,
+        agent_version=body.agent_version if "agent_version" in body.model_fields_set else ...,
+        title=body.title if "title" in body.model_fields_set else ...,
         metadata=body.metadata,
         vault_ids=body.vault_ids,
         resources=body.resources,

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1021,34 +1021,26 @@ async def list_attachment_paths_for_sessions(
     return result
 
 
-_UNSET: Any = object()
-
-
 async def update_session(
     conn: asyncpg.Connection[Any],
     session_id: str,
     *,
     account_id: str,
     agent_id: str | None = None,
-    agent_version: int | None = _UNSET,
-    title: str | None = _UNSET,
+    agent_version: int | None | EllipsisType = ...,
+    title: str | None | EllipsisType = ...,
     metadata: dict[str, Any] | None = None,
 ) -> Session:
-    """Partial update of a session. Omitted fields are preserved.
-
-    ``agent_version`` and ``title`` use a sentinel to distinguish "not
-    provided" from "explicitly set to None".
-    """
     sets: list[str] = []
     args: list[Any] = [session_id]  # $1 = session_id
 
     if agent_id is not None:
         args.append(agent_id)
         sets.append(f"agent_id = ${len(args)}")
-    if agent_version is not _UNSET:
+    if agent_version is not ...:
         args.append(agent_version)
         sets.append(f"agent_version = ${len(args)}")
-    if title is not _UNSET:
+    if title is not ...:
         args.append(title)
         sets.append(f"title = ${len(args)}")
     if metadata is not None:
@@ -3995,7 +3987,7 @@ async def update_session_template(
     account_id: str,
     name: str | None = None,
     agent_id: str | None = None,
-    agent_version: int | None = _UNSET,
+    agent_version: int | None | EllipsisType = ...,
     environment_id: str | None = None,
     vault_ids: list[str] | None = None,
     memory_store_ids: list[str] | None = None,
@@ -4009,7 +4001,7 @@ async def update_session_template(
     if agent_id is not None:
         args.append(agent_id)
         sets.append(f"agent_id = ${len(args)}")
-    if agent_version is not _UNSET:
+    if agent_version is not ...:
         args.append(agent_version)
         sets.append(f"agent_version = ${len(args)}")
     if environment_id is not None:

--- a/src/aios/services/session_templates.py
+++ b/src/aios/services/session_templates.py
@@ -6,12 +6,12 @@ what the schema enforces.
 
 from __future__ import annotations
 
+from types import EllipsisType
 from typing import Any
 
 import asyncpg
 
 from aios.db import queries
-from aios.db.queries import _UNSET
 from aios.models.session_templates import SessionTemplate
 
 
@@ -64,7 +64,7 @@ async def update_session_template(
     account_id: str,
     name: str | None = None,
     agent_id: str | None = None,
-    agent_version: int | None = _UNSET,
+    agent_version: int | None | EllipsisType = ...,
     environment_id: str | None = None,
     vault_ids: list[str] | None = None,
     memory_store_ids: list[str] | None = None,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -9,6 +9,7 @@ and inject environment variables at container provisioning time.
 from __future__ import annotations
 
 import json
+from types import EllipsisType
 from typing import Any
 
 import asyncpg
@@ -433,8 +434,8 @@ async def update_session(
     *,
     account_id: str,
     agent_id: str | None = None,
-    agent_version: int | None = queries._UNSET,
-    title: str | None = queries._UNSET,
+    agent_version: int | None | EllipsisType = ...,
+    title: str | None | EllipsisType = ...,
     metadata: dict[str, Any] | None = None,
     vault_ids: list[str] | None = None,
     resources: list[SessionResource] | None = None,

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -235,7 +235,7 @@ class TestMergeAuthPayload:
         assert merged["access_token"] == "at"
 
 
-# ── update_vault_credential: no _UNSET sentinel leaks into queries ───────────
+# ── update_vault_credential: no private sentinel leaks into queries ──────────
 
 
 def _existing_credential() -> VaultCredential:


### PR DESCRIPTION
## Summary

- `update_session` and `update_session_template` used a private `_UNSET = object()` sentinel imported directly from `aios.db.queries` by routers and services — a layering violation. `update_vault_credential` had already moved to `EllipsisType` (`...`), and `tests/unit/test_vault.py:255-258` already pins this as the project's chosen idiom (callers "must build kwargs from `model_fields_set` and pass `...` (Ellipsis) — never reach into a private query-layer sentinel"). This PR applies that stance to the two siblings: delete `_UNSET`, retype both signatures, replace `is not _UNSET` with `is not ...`, drop the four cross-module imports.
- Drop the docstring on `update_session` for consistency with the two sibling update functions that have no docstring — the tri-state semantics (`None` = "latest auto-updating" vs. omitted = "keep current") live at the router boundary, not the query layer.
- Strengthens types: the previous `_UNSET: Any` defeated mypy on those parameters; `int | None | EllipsisType = ...` is type-precise and matches the existing `update_vault_credential` signature shape.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests` + format check — clean
- [x] `uv run pytest tests/unit -q` — 1249 passed
- [ ] CI e2e suite

## Code review notes

`/simplify` and the `pr-review-toolkit:code-reviewer` agent converged on "ship as-is." Sub-30 nits, all addressed in-place per the broken-windows policy:

- Sev 25 — stale `_UNSET` token in `tests/unit/test_vault.py:238` section divider comment. Rephrased to "no private sentinel leaks into queries" (the symbol is gone; the principle remains).
- Sev 20 — the dropped `update_session` docstring did encode a non-obvious WHY (`None` vs. omitted distinction), but that WHY lives at the router layer (already documented at `src/aios/api/routers/sessions.py:139-140`); the query layer just executes the SET clause. Aligning with the two sibling functions that have no docstring is the correct simplification.
- Sev 15 — three signatures now write `int | None | EllipsisType` / `str | None | EllipsisType`, slightly longer than the old `_UNSET` defaults but matches the established `update_vault_credential` shape and expresses the actual contract to mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)