### PR TITLE
fix(mcp/pool): close evicted entries so the owner task can exit

### DIFF
--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -111,6 +111,11 @@ class McpSessionPool:
         self._entries: dict[_PoolKey, _Entry] = {}
         self._locks: dict[_PoolKey, asyncio.Lock] = {}
         self._reaper_task: asyncio.Task[None] | None = None
+        # Strong refs for evict()'s fire-and-forget close tasks. asyncio
+        # only weak-refs tasks, so without this the task can be GC'd
+        # before close() unwinds the owner task's contexts — defeating
+        # the leak fix.
+        self._evict_close_tasks: set[asyncio.Task[None]] = set()
 
     def _lock_for(self, key: _PoolKey) -> asyncio.Lock:
         lock = self._locks.get(key)
@@ -204,15 +209,23 @@ class McpSessionPool:
         return entry.session, entry.init_result
 
     def evict(self, url: str, vault_id: str | None) -> None:
-        """Drop a cache entry without closing it.
+        """Drop a cache entry and close it in the background.
 
-        Called when a cached session has been found to be broken. Closing
-        a broken session may hang or raise in unexpected ways, so we
-        simply drop the reference and let GC handle it; the next
-        :meth:`get_or_connect` for this key will open a fresh session.
+        Called when a cached session has been found to be broken. The
+        caller is on a retry path and can't block on close (the owner
+        task may wait up to the httpx read timeout before unwinding), so
+        the close is fire-and-forget. Skipping close entirely would
+        strand the owner task + httpx client + SSE stream — same leak
+        shape the idle reaper exists to prevent, except evict pops the
+        entry from ``_entries`` so the reaper can't reach it.
         """
         key: _PoolKey = (url, vault_id)
-        self._entries.pop(key, None)
+        entry = self._entries.pop(key, None)
+        if entry is None:
+            return
+        task = asyncio.create_task(entry.close(), name=f"mcp-pool-evict:{url}")
+        self._evict_close_tasks.add(task)
+        task.add_done_callback(self._evict_close_tasks.discard)
         log.info("mcp_pool.evicted", url=url)
 
     async def _reap_idle_once(self, *, idle_timeout: float, now: float) -> None:

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -108,6 +108,53 @@ class TestMcpSessionPool:
 
         assert r1 is not r2
 
+    async def test_evict_closes_evicted_entry(self) -> None:
+        """``evict`` must reclaim the entry, not just drop the reference.
+
+        The idle reaper's docstring spells out the leak shape: dropping a
+        reference without going through ``_Entry.close()`` strands the
+        owner task, the httpx client, and the SSE stream — exactly what
+        the reaper exists to prevent. The reaper iterates ``_entries``,
+        so an evicted entry (popped from the map) is invisible to it
+        and the leak survives until process exit. Every transient MCP
+        failure produces one such evict, so over a long-running worker
+        the leak is unbounded.
+        """
+        url = "https://m.example/"
+        headers = {"Authorization": "Bearer tok"}
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(_make_mock_session())),
+        ):
+            pool = McpSessionPool()
+            await pool.get_or_connect(url, "v", headers)
+            entry = pool._entries[(url, "v")]
+
+            closed = False
+            orig_close = entry.close
+
+            async def _tracked() -> None:
+                nonlocal closed
+                closed = True
+                await orig_close()
+
+            entry.close = _tracked  # type: ignore[method-assign]
+
+            pool.evict(url, "v")
+            # Allow any background close task scheduled by evict to run.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        assert closed, (
+            "evict must close the entry through _Entry.close() to release "
+            "the owner task + httpx client + SSE stream; a bare pop strands "
+            "them for the worker's lifetime"
+        )
+        assert entry._owner_task.done(), (
+            "the owner task must exit after evict; while parked on "
+            "shutdown.wait() it holds the httpx client and SSE stream open"
+        )
+
     async def test_thundering_herd_single_initialize(self) -> None:
         """N concurrent ``get_or_connect`` calls → exactly one ``initialize()``."""
         session = _make_mock_session()


### PR DESCRIPTION
## Summary

- `McpSessionPool.evict()` did `self._entries.pop(key, None)` — a bare drop — under the rationale "closing a broken session may hang". This strands the entry's owner task (parked on `await shutdown.wait()`), its httpx client, and its SSE stream for the worker's lifetime. The idle reaper iterates `_entries`, so an evicted entry (popped from the map) is invisible to it and the leak survives until process exit.
- The idle reaper's own docstring at `pool.py:218-226` literally calls out this leak shape — "dropping the reference alone strands the owner task, httpx client and SSE stream — exactly the leak this reaps" — but `evict()` (the high-frequency call path: every transient MCP error takes it) bypassed that reclamation entirely.
- Route eviction through the same `_Entry.close()` mechanism `close_all` and `_reap_idle_once` use, fired as a background task so the caller's retry path doesn't block on the httpx read timeout (~120s). A strong-ref set + `add_done_callback(set.discard)` keeps the task alive under asyncio's weak-ref semantics (RUF006).
- Sibling lineage: #458 (idle-TTL reaper for cold entries), #461 (re-key on stable credential identity), #448 (reaper survives release failures). This PR closes the third leg of the same triangle — the evict path that bypassed all of them.

## Test plan

- [x] New `test_evict_closes_evicted_entry` asserts both `_Entry.close()` is invoked AND `_owner_task.done()` after evict. Pre-fix it fails with `closed == False` (the bare `pop` skipped close); post-fix it passes.
- [x] All 16 `TestMcpSessionPool` tests pass (existing `test_evict_causes_reconnect`, `test_idle_reaper_closes_cold_entry`, `test_close_all_closes_entries`, etc. all still green).
- [x] mypy — clean (153 source files)
- [x] ruff check + format-check — clean (RUF006 satisfied via the strong-ref set)
- [x] Full unit suite — 1251 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)