### PR TITLE
refactor(queries): fold flip_quiescent_to_pending into append_event

### DIFF
--- a/migrations/versions/0040_errored_session_status.py
+++ b/migrations/versions/0040_errored_session_status.py
@@ -3,9 +3,8 @@
 When the wake-step retry budget is spent (4 consecutive ``rescheduling``
 turn_ends) the harness now parks the session in ``errored`` instead of
 ``idle`` so the periodic sweep stops re-firing wakes that just time out
-again.  ``flip_quiescent_to_pending`` is widened in the same change to
-also clear ``errored`` on the next user message, preserving the operator
-recovery contract from #353.
+again.  The user-message append path is widened to clear ``errored`` as
+well as ``idle``, preserving the operator recovery contract from #353.
 
 Downgrade rewrites ``errored`` to ``terminated`` rather than ``idle`` —
 the original constraint can't represent the parked-after-budget state,

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1639,12 +1639,29 @@ async def append_event(
     new_id = make_id(EVENT)
     data_json = json.dumps(data)
 
+    # role/tool_name/is_error/sender_name: indexed-column promotions for
+    # events_search (migration 0022); not on the Event model.
+    role: str | None = None
+    if kind == "message":
+        raw_role = data.get("role")
+        if isinstance(raw_role, str):
+            role = raw_role
+    # User messages lift idle/errored → pending in the seq UPDATE so the
+    # sweep stops ignoring an errored session (#39, #353).
+    is_user_message = kind == "message" and role == "user"
+
     async with conn.transaction():
         seq_row = await conn.fetchrow(
-            "UPDATE sessions SET last_event_seq = last_event_seq + 1 "
+            "UPDATE sessions "
+            "SET last_event_seq = last_event_seq + 1, "
+            "    status = CASE WHEN $3 AND status IN ('idle', 'errored') "
+            "                  THEN 'pending' ELSE status END, "
+            "    updated_at = CASE WHEN $3 AND status IN ('idle', 'errored') "
+            "                      THEN now() ELSE updated_at END "
             "WHERE id = $1 AND account_id = $2 RETURNING last_event_seq, focal_channel",
             session_id,
             account_id,
+            is_user_message,
         )
         if seq_row is None:
             raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
@@ -1658,7 +1675,7 @@ async def append_event(
         cum_tokens: int | None = None
         if kind == "message":
             prev = await _latest_cumulative_tokens(conn, session_id)
-            if data.get("role") == "user" and orig_channel is not None:
+            if is_user_message and orig_channel is not None:
                 # TODO(vision): plumb ``agent.model`` through here so
                 # :func:`render_user_event` matches build-time output for
                 # image-bearing events.  Today this call site renders without
@@ -1677,15 +1694,6 @@ async def append_event(
         channel = await _derive_event_channel(
             conn, session_id, kind, data, orig_channel, focal_at_arrival
         )
-        # Pure promotions: role and the three tool/user-derived columns are
-        # stamped from the same JSON paths the 0022 backfill uses.  Agents
-        # query these via events_search; they're absent from the Event
-        # pydantic model (query-side surface only).
-        role: str | None = None
-        if kind == "message":
-            raw_role = data.get("role")
-            if isinstance(raw_role, str):
-                role = raw_role
         tool_name = _derive_tool_name(kind, data)
         is_error = _derive_is_error(kind, data)
         sender_name = _derive_sender_name(kind, data)
@@ -3810,28 +3818,6 @@ async def list_recent_chat_ids(
 
 
 # ─── connector_inbound_acks (dedup ledger) ──────────────────────────────────
-
-
-async def flip_quiescent_to_pending(
-    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
-) -> None:
-    """Flip ``sessions.status`` to ``pending`` if currently quiescent.
-
-    Quiescent here means either ``idle`` (clean turn end) or ``errored``
-    (retry budget spent — #353).  Called after appending a user message
-    so polling orchestrators can distinguish queued-but-not-started from
-    turn-finished, AND so a fresh user message lifts an ``errored``
-    session out of the sweep's blacklist (errored is opaque to the
-    sweep; ``pending`` is not).  Other states (running / rescheduling /
-    terminated) are left alone — the worker owns the running status, and
-    changing rescheduling would lose the retry-in-progress signal.
-    """
-    await conn.execute(
-        "UPDATE sessions SET status = 'pending', updated_at = now() "
-        "WHERE id = $1 AND status IN ('idle', 'errored') AND account_id = $2",
-        session_id,
-        account_id,
-    )
 
 
 async def try_record_inbound_ack(

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -928,7 +928,7 @@ async def _apply_retry_or_failure(pool: Any, session_id: str, *, account_id: str
     # Terminal landing pad (#353): sweep skips ``errored`` (see
     # ``CANDIDATE_ROWS_SQL`` / ``CONFIRMED_ROWS_SQL``); any in-flight
     # tool task that completes after this point sits unreaped until a
-    # user message flips status via ``flip_quiescent_to_pending``.
+    # user message lifts status back to ``pending`` (via ``append_event``).
     await sessions_service.set_session_status(
         pool, session_id, "errored", stop_reason={"type": "error"}, account_id=account_id
     )

--- a/src/aios/services/inbound.py
+++ b/src/aios/services/inbound.py
@@ -207,7 +207,6 @@ async def _append_with_dedup(
             )
             if not inserted:
                 raise _DedupRollback()
-            await queries.flip_quiescent_to_pending(conn, session_id, account_id=account_id)
     except _DedupRollback:
         return False
     return True

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -205,7 +205,7 @@ async def append_user_message(
         if isinstance(channel, str):
             orig_channel = channel
     async with pool.acquire() as conn:
-        event = await queries.append_event(
+        return await queries.append_event(
             conn,
             session_id=session_id,
             kind="message",
@@ -213,12 +213,6 @@ async def append_user_message(
             orig_channel=orig_channel,
             account_id=account_id,
         )
-        # Narrow scope by design: the tool-result and tool-confirmation
-        # paths have the same race but are deferred; an orchestrator
-        # resolving those still has to combine status polling with
-        # event-cursor tracking.  See issue #39.
-        await queries.flip_quiescent_to_pending(conn, session_id, account_id=account_id)
-        return event
 
 
 async def append_event(

--- a/tests/e2e/test_errored_session_sweep.py
+++ b/tests/e2e/test_errored_session_sweep.py
@@ -4,8 +4,8 @@ Asserts the two halves of the fix:
 
 - ``errored`` is opaque to ``find_sessions_needing_inference`` even when
   the session has an unreacted user message (the loop trigger #353 hit).
-- A fresh user message lifts ``errored → pending`` via
-  ``flip_quiescent_to_pending``, restoring the operator-recovery contract.
+- A fresh user message lifts ``errored → pending`` via ``append_event``
+  itself, restoring the operator-recovery contract.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Two UPDATEs on the `sessions` row collapse to one: appending a user message used to require a seq-allocator UPDATE plus a separate `flip_quiescent_to_pending` UPDATE (both in the same transaction). The seq UPDATE now widens its SET list with two `CASE WHEN $3 AND status IN ('idle', 'errored') THEN ... ELSE ... END` clauses keyed off `is_user_message = (kind == "message" and role == "user")`, computed once before entering the transaction.
- The `flip_quiescent_to_pending` helper and its two call sites in `services/sessions.py:append_user_message` and `services/inbound.py:_append_with_dedup` disappear. The rollback contract in `_append_with_dedup` is preserved — the flip lives inside the same transaction that `try_record_inbound_ack` rolls back via `_DedupRollback`.
- Stale references to the deleted helper in `harness/loop.py:931`, `tests/e2e/test_errored_session_sweep.py:7-8`, and the docstring on migration 0040 are updated to point at the new mechanism. The `role` derivation block is hoisted to the top of `append_event` so it's in scope for the `is_user_message` predicate, and the pre-existing 4-line "Pure promotions" comment is condensed to a one-liner per the `/simplify` pass.

Pure structural refactor — same status transitions land on the row, just in one SQL statement instead of two. Aligns with the project's stated "correct-by-construction over multi-stage corrective pipelines" principle.

## Test plan

- [x] `uv run mypy src` — clean (153 files)
- [x] `uv run ruff check src tests` + format check — clean
- [x] `uv run pytest tests/unit -q` — 1250 passed
- [ ] CI e2e suite (covers the `errored → pending` operator-recovery contract via `tests/e2e/test_errored_session_sweep.py`)

## Code review notes

`/simplify` and the `pr-review-toolkit:code-reviewer` agent both: **ship as-is**.

Sub-30 nits, all addressed in-place per the broken-windows policy:

- Sev 30 — original condensed comment said "role and the three derived columns *below*" but `role` was the only one hoisted up; the others (`tool_name`, `is_error`, `sender_name`) are still computed ~45 lines later. Rephrased to "role/tool_name/is_error/sender_name: indexed-column promotions for events_search" — accurate without claiming adjacency.
- Sev 25 — migration 0040's docstring referenced the now-deleted helper by name. Updated to describe the mechanism without naming the helper, per CLAUDE.md "after refactors, grep exhaustively."
- The reviewer's exhaustive semantic-equivalence trace (every event kind × every session status) confirmed identical row state, identical rollback semantics, and one fewer UPDATE per user-message append. No regression on tuple-version churn (the seq UPDATE was already creating a new row version on every append).

🤖 Generated with [Claude Code](https://claude.com/claude-code)