### PR TITLE
refactor: delete unreferenced symbols across errors/config/imports

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -211,10 +211,6 @@ class Settings(BaseSettings):
     # ── observability ──────────────────────────────────────────────────────
     log_level: str = Field(default="INFO")
 
-    # ── windowing defaults (per-agent overrides live on the agent record) ──
-    default_window_min: int = Field(default=50_000, ge=1)
-    default_window_max: int = Field(default=150_000, ge=1)
-
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -65,20 +65,6 @@ class ConflictError(AiosError):
     status_code = 409
 
 
-class AccountDriftError(ConflictError):
-    """Operator tried to attach a connection for an identity the connector no longer serves.
-
-    Raised by :func:`aios.services.connections.attach_connection` when
-    the supervisor's current account snapshot doesn't include the
-    connection's ``external_account_id``.  Without this guard the
-    attach would succeed silently and inbound for that identity would
-    drop forever with the ``account_drift`` reason — operator pain
-    that's better surfaced at attach time than discovered hours later.
-    """
-
-    error_type = "account_drift"
-
-
 class PayloadTooLargeError(AiosError):
     error_type = "payload_too_large"
     status_code = 413
@@ -92,17 +78,6 @@ class UnauthorizedError(AiosError):
 class ForbiddenError(AiosError):
     error_type = "forbidden"
     status_code = 403
-
-
-class NoRouteError(AiosError):
-    """Raised when a channel address has no matching binding or routing rule.
-
-    Translates to 404 with envelope ``type="no_route"`` so callers (the
-    inbound-message endpoint, connectors) can branch on the type.
-    """
-
-    error_type = "no_route"
-    status_code = 404
 
 
 class CryptoDecryptError(AiosError):

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -26,14 +26,11 @@ import contextlib
 import sys
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import asyncpg
 
 import aios.tools  # noqa: F401  — side-effect: register built-in tools
-
-if TYPE_CHECKING:
-    pass
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
 from aios.db import queries

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -25,15 +25,11 @@ the registry and the orchestrator backend-agnostic.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
 
 from aios.config import get_settings
 from aios.logging import get_logger
 from aios.models.environments import EnvironmentConfig, LimitedNetworking
 from aios.sandbox.backends.base import SandboxBackend, SandboxHandle
-
-if TYPE_CHECKING:
-    pass
 
 log = get_logger("aios.sandbox.setup")
 


### PR DESCRIPTION
## Summary

- Four independently-verified dead-code deletions bundled under one "delete what nothing references" theme:
  1. `AccountDriftError` + `NoRouteError` from `aios.errors` — both classes defined and documented but never raised, imported, or referenced anywhere in `src/`, `tests/`, `docs/`, `migrations/`, `connectors/`, `packages/aios-sdk/`, the OpenAPI spec, or `.env.example`. Their `error_type` strings only existed inside their own definitions; the HTTP contract never observed them because the classes were never raised.
  2. `default_window_min` / `default_window_max` from `aios.config` — `Settings` fields never read. Per-agent `window_min`/`window_max` live on the agent record and are consumed directly by `harness/loop.py`; the settings-level defaults were dead surface and an operator setting `AIOS_DEFAULT_WINDOW_MIN` would silently get a no-op.
  3. Empty `if TYPE_CHECKING: pass` blocks in `sandbox/setup.py` and `harness/worker.py`, plus the now-unused `TYPE_CHECKING` symbol from each file's `typing` import. Left over from prior refactors that removed the type-only imports they once gated.
- Net: 4 files, +1/-37 = **-36 LOC pure deletion**. The `aios.tools` side-effect import in `worker.py` retains its leading position so the tool registry still populates before downstream imports.

## Test plan

- [x] `uv run mypy src` — clean (153 files)
- [x] `uv run ruff check src tests` + format check — clean
- [x] `uv run pytest tests/unit -q` — 1251 passed
- [ ] CI e2e suite

## Verification notes

The `pr-review-toolkit:code-reviewer` agent ran an exhaustive scrutiny pass and verified:
- Zero `AccountDriftError` / `account_drift` hits across `src`, `tests`, `connectors`, `packages/aios-sdk`, `migrations`, `docs`, `README.md`, `.env.example`, `openapi.json`, `compose.yml`, `pyproject.toml`. No `__all__` in `errors.py`.
- Zero `NoRouteError` / `no_route` hits, same scope.
- Zero `default_window_*` / `AIOS_DEFAULT_WINDOW_*` hits.
- Both `TYPE_CHECKING: pass` blocks confirmed empty; no hidden circular-import workaround.

Verdict: ship. No findings ≥ 80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)