### PR TITLE
fix(api/memory_stores): accept ?after= cursor in list_memory_stores

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4284,7 +4284,7 @@
           "memory-stores"
         ],
         "summary": "List Stores",
-        "description": "List memory stores, newest first.\n\nUnlike most resources, archived stores can be included via\n``include_archived=true`` (default false). No cursor pagination \u2014 bumps\nthe default limit to 100 since stores are typically few.",
+        "description": "List memory stores, newest first.\n\nUnlike most resources, archived stores can be included via\n``include_archived=true`` (default false). Cursor pagination: pass\n``after`` from a previous response's ``next_after`` to get the next\npage. The default limit is 100 since stores are typically few.",
         "operationId": "list_memory_stores",
         "parameters": [
           {
@@ -4307,6 +4307,22 @@
               "minimum": 1,
               "default": 100,
               "title": "Limit"
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "After"
             }
           },
           {

--- a/packages/aios-sdk/aios_sdk/_generated/api/memory_stores/list_memory_stores.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/memory_stores/list_memory_stores.py
@@ -14,6 +14,7 @@ def _get_kwargs(
     *,
     include_archived: bool | Unset = False,
     limit: int | Unset = 100,
+    after: None | str | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
@@ -25,6 +26,13 @@ def _get_kwargs(
     params["include_archived"] = include_archived
 
     params["limit"] = limit
+
+    json_after: None | str | Unset
+    if isinstance(after, Unset):
+        json_after = UNSET
+    else:
+        json_after = after
+    params["after"] = json_after
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -73,6 +81,7 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     include_archived: bool | Unset = False,
     limit: int | Unset = 100,
+    after: None | str | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseMemoryStore]:
     """List Stores
@@ -80,12 +89,14 @@ def sync_detailed(
      List memory stores, newest first.
 
     Unlike most resources, archived stores can be included via
-    ``include_archived=true`` (default false). No cursor pagination — bumps
-    the default limit to 100 since stores are typically few.
+    ``include_archived=true`` (default false). Cursor pagination: pass
+    ``after`` from a previous response's ``next_after`` to get the next
+    page. The default limit is 100 since stores are typically few.
 
     Args:
         include_archived (bool | Unset):  Default: False.
         limit (int | Unset):  Default: 100.
+        after (None | str | Unset):
         authorization (None | str | Unset):
 
     Raises:
@@ -99,6 +110,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         include_archived=include_archived,
         limit=limit,
+        after=after,
         authorization=authorization,
     )
 
@@ -114,6 +126,7 @@ def sync(
     client: AuthenticatedClient | Client,
     include_archived: bool | Unset = False,
     limit: int | Unset = 100,
+    after: None | str | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseMemoryStore | None:
     """List Stores
@@ -121,12 +134,14 @@ def sync(
      List memory stores, newest first.
 
     Unlike most resources, archived stores can be included via
-    ``include_archived=true`` (default false). No cursor pagination — bumps
-    the default limit to 100 since stores are typically few.
+    ``include_archived=true`` (default false). Cursor pagination: pass
+    ``after`` from a previous response's ``next_after`` to get the next
+    page. The default limit is 100 since stores are typically few.
 
     Args:
         include_archived (bool | Unset):  Default: False.
         limit (int | Unset):  Default: 100.
+        after (None | str | Unset):
         authorization (None | str | Unset):
 
     Raises:
@@ -141,6 +156,7 @@ def sync(
         client=client,
         include_archived=include_archived,
         limit=limit,
+        after=after,
         authorization=authorization,
     ).parsed
 
@@ -150,6 +166,7 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     include_archived: bool | Unset = False,
     limit: int | Unset = 100,
+    after: None | str | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseMemoryStore]:
     """List Stores
@@ -157,12 +174,14 @@ async def asyncio_detailed(
      List memory stores, newest first.
 
     Unlike most resources, archived stores can be included via
-    ``include_archived=true`` (default false). No cursor pagination — bumps
-    the default limit to 100 since stores are typically few.
+    ``include_archived=true`` (default false). Cursor pagination: pass
+    ``after`` from a previous response's ``next_after`` to get the next
+    page. The default limit is 100 since stores are typically few.
 
     Args:
         include_archived (bool | Unset):  Default: False.
         limit (int | Unset):  Default: 100.
+        after (None | str | Unset):
         authorization (None | str | Unset):
 
     Raises:
@@ -176,6 +195,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         include_archived=include_archived,
         limit=limit,
+        after=after,
         authorization=authorization,
     )
 
@@ -189,6 +209,7 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     include_archived: bool | Unset = False,
     limit: int | Unset = 100,
+    after: None | str | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseMemoryStore | None:
     """List Stores
@@ -196,12 +217,14 @@ async def asyncio(
      List memory stores, newest first.
 
     Unlike most resources, archived stores can be included via
-    ``include_archived=true`` (default false). No cursor pagination — bumps
-    the default limit to 100 since stores are typically few.
+    ``include_archived=true`` (default false). Cursor pagination: pass
+    ``after`` from a previous response's ``next_after`` to get the next
+    page. The default limit is 100 since stores are typically few.
 
     Args:
         include_archived (bool | Unset):  Default: False.
         limit (int | Unset):  Default: 100.
+        after (None | str | Unset):
         authorization (None | str | Unset):
 
     Raises:
@@ -217,6 +240,7 @@ async def asyncio(
             client=client,
             include_archived=include_archived,
             limit=limit,
+            after=after,
             authorization=authorization,
         )
     ).parsed

--- a/src/aios/api/routers/memory_stores.py
+++ b/src/aios/api/routers/memory_stores.py
@@ -50,16 +50,22 @@ async def list_stores(
     _auth: AuthDep,
     include_archived: bool = False,
     limit: Annotated[int, Query(ge=1, le=200)] = 100,
+    after: str | None = None,
 ) -> ListResponse[MemoryStore]:
     """List memory stores, newest first.
 
     Unlike most resources, archived stores can be included via
-    ``include_archived=true`` (default false). No cursor pagination — bumps
-    the default limit to 100 since stores are typically few.
+    ``include_archived=true`` (default false). Cursor pagination: pass
+    ``after`` from a previous response's ``next_after`` to get the next
+    page. The default limit is 100 since stores are typically few.
     """
     account_id, _, _ = _auth
     items = await service.list_stores(
-        pool, include_archived=include_archived, limit=limit, account_id=account_id
+        pool,
+        include_archived=include_archived,
+        limit=limit,
+        after=after,
+        account_id=account_id,
     )
     return ListResponse[MemoryStore](
         data=items,

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -4164,20 +4164,21 @@ async def list_memory_stores(
     account_id: str,
     include_archived: bool = False,
     limit: int = 100,
+    after: str | None = None,
 ) -> list[MemoryStore]:
-    if include_archived:
-        rows = await conn.fetch(
-            "SELECT * FROM memory_stores WHERE account_id = $1 ORDER BY id DESC LIMIT $2",
-            account_id,
-            limit,
-        )
-    else:
-        rows = await conn.fetch(
-            "SELECT * FROM memory_stores WHERE archived_at IS NULL AND account_id = $1 "
-            "ORDER BY id DESC LIMIT $2",
-            account_id,
-            limit,
-        )
+    args: list[Any] = [account_id]
+    where = ["account_id = $1"]
+    if not include_archived:
+        where.append("archived_at IS NULL")
+    if after is not None:
+        args.append(after)
+        where.append(f"id < ${len(args)}")
+    args.append(limit)
+    sql = (
+        f"SELECT * FROM memory_stores WHERE {' AND '.join(where)} "
+        f"ORDER BY id DESC LIMIT ${len(args)}"
+    )
+    rows = await conn.fetch(sql, *args)
     return [_row_to_memory_store(r) for r in rows]
 
 

--- a/src/aios/services/memory_stores.py
+++ b/src/aios/services/memory_stores.py
@@ -103,11 +103,20 @@ async def get_store(pool: asyncpg.Pool[Any], store_id: str, *, account_id: str) 
 
 
 async def list_stores(
-    pool: asyncpg.Pool[Any], *, account_id: str, include_archived: bool = False, limit: int = 100
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    include_archived: bool = False,
+    limit: int = 100,
+    after: str | None = None,
 ) -> list[MemoryStore]:
     async with pool.acquire() as conn:
         return await queries.list_memory_stores(
-            conn, include_archived=include_archived, limit=limit, account_id=account_id
+            conn,
+            include_archived=include_archived,
+            limit=limit,
+            after=after,
+            account_id=account_id,
         )
 
 

--- a/tests/e2e/test_memory_stores_api.py
+++ b/tests/e2e/test_memory_stores_api.py
@@ -114,6 +114,44 @@ class TestStoreCrud:
         assert r.status_code == 404, r.text
 
 
+class TestStoreListPagination:
+    """The ``next_after`` cursor returned by ``GET /v1/memory-stores`` must be
+    acceptable as ``?after=`` on the next call. Pre-fix the router accepted
+    no ``after`` parameter, so FastAPI silently dropped it and the caller
+    following the documented cursor pattern saw the same page back —
+    isomorphic to the events-pagination break that #389 fixed."""
+
+    async def test_after_advances_pagination(self, http_client: httpx.AsyncClient) -> None:
+        # Create 5 stores so a limit=2 walk takes 3 pages.
+        ids: list[str] = []
+        for _ in range(5):
+            store = await _create_store(http_client)
+            ids.append(store["id"])
+
+        r1 = await http_client.get("/v1/memory-stores", params={"limit": 2})
+        assert r1.status_code == 200, r1.text
+        page1 = r1.json()
+        assert len(page1["data"]) == 2
+        assert page1["has_more"] is True
+        assert page1["next_after"] == page1["data"][-1]["id"]
+
+        # Second page, ?after=<page1.next_after> → ids MUST be disjoint from page1.
+        # Pre-fix this returned page1 again because the router signature ignored ``after``.
+        r2 = await http_client.get(
+            "/v1/memory-stores", params={"limit": 2, "after": page1["next_after"]}
+        )
+        assert r2.status_code == 200, r2.text
+        page2 = r2.json()
+        assert len(page2["data"]) == 2
+        page1_ids = {row["id"] for row in page1["data"]}
+        page2_ids = {row["id"] for row in page2["data"]}
+        assert page1_ids.isdisjoint(page2_ids), (
+            f"page 2 must advance past page 1's cursor; got overlap "
+            f"{page1_ids & page2_ids}. Pre-fix symptom: `?after=` was silently "
+            f"ignored and the same page came back."
+        )
+
+
 class TestMemoryCrud:
     async def test_create_retrieve_round_trip(self, http_client: httpx.AsyncClient) -> None:
         store = await _create_store(http_client)


### PR DESCRIPTION
## Summary

- The `GET /v1/memory-stores` response always carried a `next_after` field (the canonical paginated-list envelope), but the router signature lacked an `after` query parameter. FastAPI silently drops unknown query params, so a client following the documented cursor pattern (`pass response.next_after as ?after= on the next call`) got the same first page back forever, and an operator with more than 100 memory stores had no way to walk past the first page.
- The router's docstring claimed "No cursor pagination" — accurate to the absent signature but inconsistent with the envelope it produced and with the documented client protocol. Same shape as #389 (`?after_seq=` vs `next_after` on `/sessions/:id/events`): the fix is to honor the cursor the response advertises.
- Thread `after: str | None` through the three layers (`api/routers/memory_stores.py` → `services/memory_stores.py` → `db/queries.py::list_memory_stores`), mirroring the canonical `list_agents` cursor pattern: `WHERE id < $after` on the existing `ORDER BY id DESC`. Updates the docstring to describe the cursor protocol and regenerates the OpenAPI / SDK snapshots.

## Test plan

- [x] New `TestStoreListPagination::test_after_advances_pagination` in `tests/e2e/test_memory_stores_api.py` creates 5 stores, walks two pages with `limit=2`, and asserts the page-2 ids are disjoint from page-1. Pre-fix it fails with the exact overlap predicted by the hypothesis (page 2 = page 1, because `?after=` was silently ignored); post-fix it passes.
- [x] Existing `TestStoreCrud` tests in the same file still green.
- [x] OpenAPI snapshot regenerated via `scripts/regen-openapi.sh`; SDK regenerated via `scripts/regen-client.sh`. Both snapshot tests pass.
- [x] mypy — clean (153 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1254 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)