### PR TITLE
refactor(config): delete unreferenced connectors_auto_create setting

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -178,21 +178,6 @@ class Settings(BaseSettings):
         description="Tavily API key for web_fetch and web_search tools.",
     )
 
-    connectors_auto_create: dict[str, bool] = Field(
-        default_factory=dict,
-        description="Per-connector ``auto_create_connections`` knob (plan §13). "
-        "Inbound for an unknown ``(connector, account)`` pair auto-creates a "
-        "detached connection row by default; setting ``{name: false}`` disables "
-        "that for ``name``, dropping such inbounds with a ``no_connection`` "
-        "counter increment instead.  Names not present in the dict default to "
-        "``True``.\n\n"
-        "Shape note: the plan documented this as nested "
-        "``connectors.<name>.auto_create_connections``, but pydantic-settings "
-        "doesn't compose well with that shape under the ``AIOS_`` env prefix; "
-        "a flat ``AIOS_CONNECTORS_AUTO_CREATE='{\"signal\":false}'`` is "
-        "operationally equivalent and easier to override from systemd / env.",
-    )
-
     default_mcp_permission_policy: Literal["always_allow", "always_ask"] | None = Field(
         default=None,
         description="Fallback permission policy for MCP tools whose server "


### PR DESCRIPTION
## Summary

- Delete `Settings.connectors_auto_create` from `src/aios/config.py`. The field was a Pydantic settings entry with a 14-line docstring describing a per-connector "auto_create_connections" feature ("plan §13") that drops inbounds for unknown `(connector, account)` pairs with a `no_connection` counter increment. **The behavior was never implemented** — no code references `connectors_auto_create` outside its own definition; the `no_connection` drop branch the docstring promises doesn't exist anywhere in `src/`, `tests/`, `docs/`, `migrations/`, `connectors/`, or `packages/`.
- An operator who pinned `AIOS_CONNECTORS_AUTO_CREATE='{"signal":false}'` would silently get a no-op pre-deletion and continues to post-deletion (the `Settings` model uses `extra="ignore"`), so the change removes a footgun rather than functionality.
- Same "Don't deprecate, delete" pattern as PRs #478 (`AccountDriftError`, `NoRouteError`, `default_window_min/max`, empty TYPE_CHECKING blocks).

Net: -15 LOC pure deletion.

## Test plan

- [x] `uv run mypy src` — clean (153 files)
- [x] `uv run ruff check src tests` + format check — clean
- [x] `uv run pytest tests/unit -q` — 1254 passed
- [ ] CI e2e suite

## Verification

`pr-review-toolkit:code-reviewer` ran an exhaustive cross-tree scan and verified zero references for `connectors_auto_create`, `AIOS_CONNECTORS_AUTO_CREATE`, `auto_create_connections`, and `no_connection` (in this docstring's sense) anywhere in the codebase. `extra="ignore"` confirmed at `config.py:36` so still-configured env vars degrade silently. No in-flight issues or branches reuse the symbol.

Reviewer verdict: ship. No findings ≥ 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)