### PR TITLE
fix(harness/sweep): serialize concurrent ghost repair on the same tool_call

### DIFF
--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -270,19 +270,24 @@ async def find_and_repair_ghosts(
         # cross-session sweeper (session_id=None) doesn't stamp empty
         # account_id onto repair events for real tenants.
         sid_account_id = await sessions_service.load_session_account_id(pool, sid)
-        await sessions_service.append_event(
-            pool,
-            sid,
-            "message",
-            {
-                "role": "tool",
-                "tool_call_id": tcid,
-                "name": name,
-                "content": content,
-                "is_error": True,
-            },
-            account_id=sid_account_id,
-        )
+        # Route through ``append_tool_result`` (services/sessions.py) rather
+        # than a bare ``append_event``: the FOR UPDATE session lock +
+        # ``find_tool_result_event`` check inside that function serialise
+        # concurrent repairs. The bare-append path had a TOCTOU window
+        # between the result-rows read above and the write here that
+        # admitted two duplicate synthetic results for the same
+        # ``tool_call_id`` under concurrent sweep invocation (periodic
+        # all-sessions sweep racing the per-tool tail sweep), violating
+        # invariant #4 (tool-always-appends-EXACTLY-one result).
+        async with pool.acquire() as conn:
+            await sessions_service.append_tool_result(
+                conn,
+                account_id=sid_account_id,
+                session_id=sid,
+                tool_call_id=tcid,
+                content=content,
+                is_error=True,
+            )
         log.info("sweep.ghost_repaired", session_id=sid, tool_call_id=tcid, tool_name=name)
 
     return [(sid, tcid) for sid, tcid, _ in ghosts]

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -353,11 +353,15 @@ class Harness:
 
     async def simulate_sigkill(self, session_id: str) -> None:
         """Simulate SIGKILL: cancel all in-flight tasks for a session
-        without letting their CancelledError handlers append results.
+        without letting any cancel-path code append events.
 
-        Mocks ``append_event`` to suppress writes during cancellation
-        cleanup, then restores it. After this call, the tasks are gone
-        and no tool results were appended.
+        Mocks the lowest-level ``queries.append_event`` so every write
+        path — the cancellation handler's tool_result, the finally
+        block's ``tool_execute_end`` span, and the tail
+        ``_trigger_sweep``'s ghost-repair via ``append_tool_result`` —
+        is suppressed during cancellation cleanup, then restores it.
+        After this call, the tasks are gone and the log shows what a
+        real SIGKILL would leave: no events from the cancelled tasks.
         """
         from unittest import mock
 
@@ -366,8 +370,11 @@ class Harness:
         # Remove from registry first so shutdown won't find them.
         self._task_registry._tasks.pop(session_id, None)
         if raw_tasks:
-            # Suppress DB writes during cancellation cleanup.
-            with mock.patch("aios.services.sessions.append_event"):
+            # Suppress DB writes during cancellation cleanup. Patch at the
+            # queries layer rather than the service layer so both
+            # ``services.append_event`` and ``services.append_tool_result``
+            # (used by the sweep's ghost-repair path) are covered.
+            with mock.patch("aios.db.queries.append_event"):
                 for t in raw_tasks:
                     if not t.done():
                         t.cancel()

--- a/tests/e2e/test_sweep.py
+++ b/tests/e2e/test_sweep.py
@@ -147,6 +147,75 @@ class TestGhostRecovery:
         )
         await harness.run_step(session.id)
 
+    async def test_concurrent_ghost_repair_emits_single_result(self, harness: Harness) -> None:
+        """Two concurrent ``find_and_repair_ghosts`` calls must produce
+        exactly one synthetic tool_result per ghost — not two.
+
+        Pre-fix the ghost-repair append goes through ``append_event``
+        directly (sweep.py:273), bypassing the session row-lock +
+        ``find_tool_result_event`` idempotency check that
+        ``append_tool_result`` enforces (services/sessions.py:233-282).
+        There is a TOCTOU window between the read of ``result_rows``
+        (line 200) and the append (line 273) — both sweeps can pass
+        the "no result yet" check before either writes, then both
+        write. The duplicate violates CLAUDE.md invariant #4
+        (tool-always-appends-EXACTLY-one result) and pollutes the
+        monotonic-context log.
+
+        In production the two sweeps that race here are the periodic
+        all-sessions sweep on the worker (`worker.py`) and the tail
+        sweep fired by each tool task's ``_trigger_sweep``
+        (`tool_dispatch.py`) — both share the worker event loop and
+        interleave at any ``await`` between the read and the append.
+        """
+        account_id = "acc_test_stub"
+        session = await harness.start("do something", tools=[])
+
+        async def dummy_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+            return {"result": "done"}
+
+        harness.register_tool("my_tool", dummy_handler)
+
+        call_x = tool_call("my_tool", {}, call_id="call_x")
+        await sessions_service.append_event(
+            harness._pool,
+            session.id,
+            "message",
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [call_x],
+                "reacting_to": 1,
+            },
+            account_id=account_id,
+        )
+
+        # Two concurrent repairs. asyncio.gather starts both immediately;
+        # they interleave at every ``await`` inside find_and_repair_ghosts
+        # (pool.acquire, fetch result_rows, fetch lifecycle_rows, fetch
+        # agent_rows, load_session_account_id, append_event), so at least
+        # one scheduling order will leave both sweeps believing the ghost
+        # is unresolved when they reach the append.
+        await asyncio.gather(
+            harness.run_ghost_repair(session.id),
+            harness.run_ghost_repair(session.id),
+        )
+
+        events = await harness.events(session.id)
+        tool_results_for_call_x = [
+            e
+            for e in events
+            if e.kind == "message"
+            and e.data.get("role") == "tool"
+            and e.data.get("tool_call_id") == "call_x"
+        ]
+        assert len(tool_results_for_call_x) == 1, (
+            f"got {len(tool_results_for_call_x)} synthetic tool_result events "
+            f"for call_x; only one is permitted by invariant #4. Pre-fix "
+            f"symptom: the unlocked read-then-append in find_and_repair_ghosts "
+            f"admits both concurrent sweeps to write."
+        )
+
     async def test_ghost_in_earlier_batch(self, harness: Harness) -> None:
         """Multi-batch conversation. Tool lost from first batch.
 


### PR DESCRIPTION
## Summary

- `find_and_repair_ghosts` had a TOCTOU window between the read of existing tool-result rows (sweep.py:200) and the synthetic-error append (sweep.py:273): the periodic all-sessions sweep on the worker (`worker.py:348`) and the per-tool tail sweep fired by `_trigger_sweep` at every tool task's finally block (`tool_dispatch.py:145`) share the worker event loop and interleave at every `await` between read and write. Two concurrent sweeps for the same session could both pass the "no result yet" check before either appended, then both write — two synthetic error events per ghost, violating CLAUDE.md invariant #4 (tool-always-appends-EXACTLY-one result) and polluting the monotonic-context log.
- Route the synthetic-error append through `append_tool_result` (services/sessions.py:233) rather than the bare `append_event` the function used previously. `append_tool_result` already serialises concurrent retried writes by locking the session row `FOR UPDATE` and short-circuiting on an existing `find_tool_result_event`, all in one transaction (the idempotency machinery that #445 introduced for the client-posted custom-tool result path). Routing ghost repair through the same function reuses that machinery for free.
- Update `tests/e2e/harness.py::simulate_sigkill` to mock at the queries layer (`aios.db.queries.append_event`) instead of the service layer (`aios.services.sessions.append_event`). The old mock was narrow enough to silence the bare-append in the buggy sweep path but not the `append_tool_result` path the fix uses; the new lower-level target covers both writes the docstring says it should ("Simulate SIGKILL: cancel without letting any cancel-path code append events").

## Test plan

- [x] New `test_concurrent_ghost_repair_emits_single_result` builds a ghost via the same manual-append shape as `test_crash_before_tool_launch`, then runs two `find_and_repair_ghosts` calls via `asyncio.gather`. Pre-fix it fails with two synthetic tool_result events for the same `tool_call_id` (seqs 3 and 4, identical content); post-fix it passes with exactly one.
- [x] All 11 e2e sweep tests still green.
- [x] mypy — clean (153 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1254 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)