### PR TITLE
refactor(harness/runtime): consolidate require_* helpers via _require[T]

### DIFF
--- a/src/aios/harness/runtime.py
+++ b/src/aios/harness/runtime.py
@@ -6,7 +6,7 @@ workaround is a small module that holds module-level globals — set once at
 worker startup, read by every task invocation.
 
 The values are ``None`` between import and ``worker_main`` initialization, so
-task bodies must check / call :func:`require` to fail loudly if a task fires
+task bodies use the ``require_*`` family to fail loudly if a task fires
 before the worker has finished setting up. The api process never sets these;
 attempting to read them from inside an api request handler will raise.
 
@@ -94,73 +94,42 @@ def clear_session_read_shas(session_id: str) -> None:
     _session_read_shas.pop(session_id, None)
 
 
-def require_pool() -> asyncpg.Pool[Any]:
-    if pool is None:
+def _require[T](name: str, value: T | None) -> T:
+    if value is None:
         raise RuntimeError(
-            "aios.harness.runtime.pool is not initialized; "
-            "this code is running outside a worker_main context"
+            f"aios.harness.runtime.{name} is not initialized; "
+            f"this code is running outside a worker_main context"
         )
-    return pool
+    return value
+
+
+def require_pool() -> asyncpg.Pool[Any]:
+    return _require("pool", pool)
 
 
 def require_crypto_box() -> CryptoBox:
-    if crypto_box is None:
-        raise RuntimeError(
-            "aios.harness.runtime.crypto_box is not initialized; "
-            "this code is running outside a worker_main context"
-        )
-    return crypto_box
+    return _require("crypto_box", crypto_box)
 
 
 def require_worker_id() -> str:
-    if worker_id is None:
-        raise RuntimeError(
-            "aios.harness.runtime.worker_id is not initialized; "
-            "this code is running outside a worker_main context"
-        )
-    return worker_id
+    return _require("worker_id", worker_id)
 
 
 def require_sandbox_registry() -> SandboxRegistry:
-    if sandbox_registry is None:
-        raise RuntimeError(
-            "aios.harness.runtime.sandbox_registry is not initialized; "
-            "this code is running outside a worker_main context"
-        )
-    return sandbox_registry
+    return _require("sandbox_registry", sandbox_registry)
 
 
 def require_task_registry() -> TaskRegistry:
-    if task_registry is None:
-        raise RuntimeError(
-            "aios.harness.runtime.task_registry is not initialized; "
-            "this code is running outside a worker_main context"
-        )
-    return task_registry
+    return _require("task_registry", task_registry)
 
 
 def require_mcp_session_pool() -> McpSessionPool:
-    if mcp_session_pool is None:
-        raise RuntimeError(
-            "aios.harness.runtime.mcp_session_pool is not initialized; "
-            "this code is running outside a worker_main context"
-        )
-    return mcp_session_pool
+    return _require("mcp_session_pool", mcp_session_pool)
 
 
 def require_mcp_broker() -> McpBroker:
-    if mcp_broker is None:
-        raise RuntimeError(
-            "aios.harness.runtime.mcp_broker is not initialized; "
-            "this code is running outside a worker_main context"
-        )
-    return mcp_broker
+    return _require("mcp_broker", mcp_broker)
 
 
 def require_tool_provider() -> ToolProvider:
-    if tool_provider is None:
-        raise RuntimeError(
-            "aios.harness.runtime.tool_provider is not initialized; "
-            "this code is running outside a worker_main context"
-        )
-    return tool_provider
+    return _require("tool_provider", tool_provider)


### PR DESCRIPTION
## Summary

- Eight `require_*` functions in `aios.harness.runtime` carried near-identical bodies — each `if X is None: raise RuntimeError(...); return X` with the same two-clause error message varying only in the symbol name. This PR extracts a single PEP 695 generic helper `_require[T](name: str, value: T | None) -> T` that either returns `T` or raises the parameterized error.
- Each public `require_*` wrapper (`require_pool`, `require_crypto_box`, `require_worker_id`, `require_sandbox_registry`, `require_task_registry`, `require_mcp_session_pool`, `require_mcp_broker`, `require_tool_provider`) survives with its signature unchanged. The 117 external call sites across `src/` and `tests/` see no change; observable behavior (return type and error string) is byte-identical pre/post.
- Also fixes a pre-existing stale Sphinx cross-ref in the module docstring (`:func:\`require\`` → `the \`\`require_*\`\` family`) — broken-windows policy applied to the touched file.

Net **-31 LOC** (+17/-48). Eight 7-line copies become eight 2-line wrappers + one 8-line generic helper.

## Test plan

- [x] `uv run mypy src` — clean (155 files; PEP 695 generic accepted)
- [x] `uv run ruff check src tests` + format check — clean
- [x] `uv run pytest tests/unit -q` — 1296 passed
- [ ] CI e2e suite (exercises every `require_*` wrapper on every worker step)

## Code review notes

`pr-review-toolkit:code-reviewer` agent verified:
- Error-message byte-equivalence (pre/post strings hash-match for `pool`, `crypto_box`, `tool_provider`)
- PEP 695 generic correctness — `T` narrows correctly at each call site
- Call site count: 117 external (125 incl. in-file definitions); all preserved unchanged

Verdict: **ship**. No findings ≥ 80. One sub-30 stylistic observation (the two adjacent f-string literals could be one) — purely cosmetic, matches existing convention in the same file.

This is exactly the case CLAUDE.md's "three similar lines is still better than one over-engineered helper" rule reserves for extraction: 8 copies past the threshold, zero behavioral degrees of freedom in the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)