### PR TITLE
fix(tools/http_request): reject query string in path so route allowlist isn't bypassed

### DIFF
--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -110,12 +110,14 @@ def _classify_permission(
     Returns the matched route's ``permission_policy`` so the harness can
     park the call in ``requires_action`` if the operator marked it
     ``always_ask``. Returns ``None`` for missing server / no route match
-    / bad args — the handler then runs and emits a typed error the
-    model can self-correct from.
+    / bad args / query-or-fragment-bearing path — the handler then runs
+    and emits a typed error the model can self-correct from.
     """
     server_ref = args.get("server_ref")
     path = args.get("path")
     if not isinstance(server_ref, str) or not isinstance(path, str):
+        return None
+    if "?" in path or "#" in path:
         return None
     server = _find_server(agent, server_ref)
     if server is None:
@@ -162,6 +164,22 @@ async def http_request_handler(session_id: str, arguments: dict[str, Any]) -> di
     method = arguments["method"]
     caller_headers: dict[str, str] = arguments.get("headers") or {}
     body = arguments.get("body")
+
+    # Route allowlists are path-only gates. A ``?`` or ``#`` in ``path``
+    # would be matched as literal segment characters by ``match_glob``
+    # and then parsed by httpx as a query/fragment on the wire — letting
+    # ``/lights/1?action=delete`` slip past an `/lights/*` read-only route
+    # because the upstream sees the query string and treats it as a
+    # state-change request. Reject up front so the gate's intent is the
+    # gate's effect.
+    if "?" in path or "#" in path:
+        return {
+            "error": (
+                f"path {path!r} contains a query string or fragment, which is "
+                "not allowed — pass only the path portion. Route allowlists "
+                "do not extend across query parameters."
+            )
+        }
 
     agent, account_id = await _load_session_agent(session_id)
     server = _find_server(agent, server_ref)

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -230,6 +230,63 @@ class TestHttpRequestHandler:
         assert "error" in result
         assert "does not match any enabled route" in result["error"]
 
+    async def test_path_with_query_string_rejected(self, _stub_runtime: Any) -> None:
+        """A ``path`` carrying a query string must be rejected even when the
+        path-portion matches an enabled route. The route allowlist is a
+        path-only gate; if a ``?`` segment slipped through, the operator's
+        intent (e.g. an `/lights/*` read-only allowlist) would be bypassed
+        because ``httpx`` parses the query off the constructed URL and sends
+        it upstream, where APIs routinely interpret ``?action=delete`` /
+        ``?force=true`` / ``?_method=DELETE`` as state-changing operations.
+
+        Pre-fix ``match_glob`` treats ``?action=delete`` as literal trailing
+        characters on the last segment, so ``/lights/1?action=delete`` matches
+        ``/lights/*`` and the upstream receives the query string verbatim."""
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(
+            response=httpx.Response(200, content=b""),
+            capture=captured,
+        )
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {
+                    "server_ref": "hue",
+                    "path": "/lights/1?action=delete",
+                    "method": "GET",
+                },
+            )
+        assert "error" in result, (
+            f"path with query string must be rejected at the route gate; "
+            f"got success {result!r}. Pre-fix symptom: the upstream URL "
+            f"carried ?action=delete past an allowlist intended for "
+            f"read-only operations."
+        )
+        # And the request must not have been dispatched.
+        assert "url" not in captured, (
+            f"upstream request was dispatched despite path containing a "
+            f"query string; captured={captured!r}"
+        )
+
+    async def test_path_with_fragment_rejected(self, _stub_runtime: Any) -> None:
+        """Same shape as query-string bypass for ``#fragment``. ``httpx``
+        strips the fragment over the wire but the glob-match silently accepts
+        it, leaving an inconsistency between what the route gate checks and
+        what the upstream sees. Reject for consistency with ``?``."""
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
+        with _patch_load_agent(agent):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/1#frag", "method": "GET"},
+            )
+        assert "error" in result
+
     async def test_successful_get(self, _stub_runtime: Any) -> None:
         agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
         response = httpx.Response(


### PR DESCRIPTION
## Summary

- The `http_request` route allowlist is a path-only gate, but `path` was not validated for `?` or `#` separators. ``match_glob`` treats the substring after a `?` as literal trailing characters on the last segment, so `/lights/1?action=delete` matches the route `/lights/*` and slips past the gate. The handler then concatenates `base_url + path` into the URL, and httpx parses the `?...` portion as a query string and sends it upstream verbatim.
- Real-world impact: an operator-declared read-only `/lights/*` route gives the agent unintended write reach because many APIs route mutations through query parameters (`?action=delete`, `?force=true`, `?_method=DELETE`, RESTish `_method` overrides). The gate's intent ("read-only") and the gate's effect ("any method-shape the upstream honors") diverge.
- Reject paths containing `?` or `#` at two sites: `http_request_handler` returns a typed error before route lookup (model self-corrects), and `_classify_permission` returns `None` (the same "unclassified" signal it uses for missing-server / no-match / bad-args) so the harness's per-route confirmation prompt doesn't fire on a path the handler will reject anyway — keeping operator-confirmed shape and dispatched shape in lockstep.
- Same protocol-mismatch shape as #477 (Telegram reaction emoji not rendered) and #479 (cursor pagination cursor not accepted): the envelope says X, the behavior delivered Y. Validating at the boundary keeps gate-intent and gate-effect aligned.

## Test plan

- [x] New `test_path_with_query_string_rejected` constructs an agent with a `/lights/*` route, calls `http_request_handler` with `path="/lights/1?action=delete"`. Pre-fix it fails: the mocked upstream is dispatched and returns 200. Post-fix passes: the handler returns an error and the mocked client's `request` is never called.
- [x] New `test_path_with_fragment_rejected` does the same for `path="/lights/1#frag"` — rejecting for parity with `?` even though httpx would strip fragments over the wire (the inconsistency between route check and upstream behavior is itself the bug-class).
- [x] Existing 17 `TestHttpRequestHandler` and `TestClassifyPermission` tests still green.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1298 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)