### PR TITLE
fix(sessions): make confirm_tool_allow idempotent on (session_id, tool_call_id)

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1553,6 +1553,39 @@ async def find_tool_result_event(
     return _row_to_event(row) if row is not None else None
 
 
+async def find_tool_confirmed_event(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    tool_call_id: str,
+    *,
+    account_id: str,
+) -> Event | None:
+    """Return the existing ``lifecycle/tool_confirmed`` event for
+    ``tool_call_id``, or ``None``.
+
+    Used by ``services.confirm_tool_allow`` to make the intake
+    idempotent on ``(session_id, tool_call_id)``: a retried POST returns
+    the original event instead of appending a duplicate. Mirrors the
+    same-shape sibling :func:`find_tool_result_event` (used by the deny
+    twin's idempotency).
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT * FROM events
+         WHERE session_id = $1
+           AND account_id = $2
+           AND kind = 'lifecycle'
+           AND data->>'event' = 'tool_confirmed'
+           AND data->>'tool_call_id' = $3
+         LIMIT 1
+        """,
+        session_id,
+        account_id,
+        tool_call_id,
+    )
+    return _row_to_event(row) if row is not None else None
+
+
 async def lookup_tool_name_by_call_id(
     conn: asyncpg.Connection[Any],
     session_id: str,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -15,7 +15,7 @@ import asyncpg
 
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
-from aios.errors import PayloadTooLargeError
+from aios.errors import NotFoundError, PayloadTooLargeError
 from aios.models.events import Event, EventKind
 from aios.models.sessions import (
     MAX_USER_MESSAGE_CHARS,
@@ -263,8 +263,6 @@ async def append_tool_result(
     in the connector-facing endpoint).  The caller is responsible for
     deferring the wake afterwards.
     """
-    from aios.errors import NotFoundError
-
     async with conn.transaction():
         # Lock the session row up-front so a concurrent retry serializes
         # behind us and observes the appended event on its check. The
@@ -506,16 +504,39 @@ async def confirm_tool_allow(
 ) -> Event:
     """Record an allow confirmation for an ``always_ask`` tool call.
 
-    Appends a lifecycle event. The worker's step function will see this
-    and dispatch the tool call.
+    Appends a ``lifecycle/tool_confirmed`` event. The worker's step
+    function will see this and dispatch the tool call.
+
+    Idempotent on ``(session_id, tool_call_id)``: a retried POST
+    (network blip, 502, mid-flight client disconnect, double-click)
+    returns the original event instead of appending a duplicate. Mirrors
+    the deny twin's same-event-shape dedup (#447); ``_dispatch_confirmed_tools``
+    further set-deduplicates so the tool dispatches once even pre-fix,
+    but the lifecycle event log must not accumulate duplicate rows.
     """
-    return await append_event(
-        pool,
-        session_id,
-        "lifecycle",
-        {"event": "tool_confirmed", "tool_call_id": tool_call_id, "result": "allow"},
-        account_id=account_id,
-    )
+    async with pool.acquire() as conn, conn.transaction():
+        locked = await conn.fetchval(
+            "SELECT id FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
+            session_id,
+            account_id,
+        )
+        if locked is None:
+            raise NotFoundError(
+                f"session {session_id} not found",
+                detail={"session_id": session_id},
+            )
+        existing = await queries.find_tool_confirmed_event(
+            conn, session_id, tool_call_id, account_id=account_id
+        )
+        if existing is not None:
+            return existing
+        return await queries.append_event(
+            conn,
+            session_id=session_id,
+            kind="lifecycle",
+            data={"event": "tool_confirmed", "tool_call_id": tool_call_id, "result": "allow"},
+            account_id=account_id,
+        )
 
 
 async def confirm_tool_deny(

--- a/tests/integration/test_tool_allow_idempotency.py
+++ b/tests/integration/test_tool_allow_idempotency.py
@@ -1,0 +1,160 @@
+"""Integration tests: ``services.confirm_tool_allow`` is idempotent on
+``(session_id, tool_call_id)``.
+
+The allow path appends a ``lifecycle/tool_confirmed`` event that the
+worker's step function picks up to dispatch the tool call. Pre-fix it
+forwarded straight to ``append_event``, so a retried POST
+``/v1/sessions/{id}/tool-confirmations`` with ``decision="allow"`` (a
+double-click, an SSE-disconnect retry, a network blip) appended a
+*second* ``lifecycle/tool_confirmed`` event with the same
+``tool_call_id`` — the unfixed sibling of the deny twin's #447 fix.
+
+Mitigated downstream by ``_dispatch_confirmed_tools`` collecting into a
+set (so the tool dispatches once), but the lifecycle event log
+accumulates duplicate rows — and the deny twin's own docstring spells
+out the contract this asymmetry violates ("Idempotent on
+``(session_id, tool_call_id)``: a retried POST returns the original
+event").
+
+This file pins the same idempotency contract for ``confirm_tool_allow``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.models.agents import ToolSpec
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def session_with_parent_tool_call(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str]]:
+    """Yield ``(pool, account_id, session_id, tool_call_id)`` for an
+    initialized session with one assistant event carrying a ``tool_calls``
+    entry."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_test', NULL, TRUE, 'tenant-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_test",
+            name="allow-test",
+            model="openrouter/test",
+            system="",
+            tools=[ToolSpec(type="bash")],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_test", name="allow-test-env"
+        )
+        async with pool.acquire() as conn:
+            session = await queries.insert_session(
+                conn,
+                account_id="acc_test",
+                agent_id=agent.id,
+                environment_id=env.id,
+                agent_version=agent.version,
+                title=None,
+                metadata={},
+            )
+            await queries.append_event(
+                conn,
+                account_id="acc_test",
+                session_id=session.id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tc_allow_test",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        }
+                    ],
+                },
+            )
+        yield pool, "acc_test", session.id, "tc_allow_test"
+    finally:
+        await pool.close()
+
+
+async def _count_tool_confirmed_events(
+    pool: asyncpg.Pool[Any], session_id: str, tool_call_id: str
+) -> int:
+    async with pool.acquire() as conn:
+        return (
+            await conn.fetchval(
+                """
+                SELECT COUNT(*) FROM events
+                 WHERE session_id = $1
+                   AND kind = 'lifecycle'
+                   AND data->>'event' = 'tool_confirmed'
+                   AND data->>'tool_call_id' = $2
+                """,
+                session_id,
+                tool_call_id,
+            )
+            or 0
+        )
+
+
+class TestConfirmToolAllowIdempotency:
+    async def test_duplicate_allow_does_not_create_second_event(
+        self,
+        session_with_parent_tool_call: tuple[asyncpg.Pool[Any], str, str, str],
+    ) -> None:
+        """Two allows on the same ``tool_call_id`` must produce ONE event."""
+        pool, account_id, session_id, tool_call_id = session_with_parent_tool_call
+
+        await sessions_service.confirm_tool_allow(
+            pool, session_id, tool_call_id, account_id=account_id
+        )
+        await sessions_service.confirm_tool_allow(
+            pool, session_id, tool_call_id, account_id=account_id
+        )
+
+        count = await _count_tool_confirmed_events(pool, session_id, tool_call_id)
+        assert count == 1, (
+            f"duplicate allow appended a second lifecycle/tool_confirmed event "
+            f"(count={count}); asymmetric with the deny twin's idempotency contract"
+        )
+
+    async def test_duplicate_allow_returns_original_event(
+        self,
+        session_with_parent_tool_call: tuple[asyncpg.Pool[Any], str, str, str],
+    ) -> None:
+        """The idempotent return must be the *first* call's event — same
+        id, same seq — so a retried POST gives the caller a stable handle."""
+        pool, account_id, session_id, tool_call_id = session_with_parent_tool_call
+
+        first = await sessions_service.confirm_tool_allow(
+            pool, session_id, tool_call_id, account_id=account_id
+        )
+        second = await sessions_service.confirm_tool_allow(
+            pool, session_id, tool_call_id, account_id=account_id
+        )
+
+        assert second.id == first.id
+        assert second.seq == first.seq


### PR DESCRIPTION
## Summary

- **Sibling of #447.** `services.confirm_tool_allow` did a bare `append_event` for the `lifecycle/tool_confirmed` event — a retried POST `/v1/sessions/:id/tool-confirmations` with `decision="allow"` appended duplicate rows. The deny twin has been idempotent since #447 via `find_tool_result_event`; the asymmetry was explicit (deny's docstring spelled out the contract this path violated). Mitigated downstream by `_dispatch_confirmed_tools` collecting into a set (so the tool dispatches once), but the lifecycle event log accumulated duplicate rows.
- **Fix mirrors the deny dedup.** New `queries.find_tool_confirmed_event` (sibling of `find_tool_result_event`, same shape, lifecycle-kind variant). `confirm_tool_allow` rewritten to `SELECT FOR UPDATE` → `find_existing` → return-or-append, matching `append_tool_result`'s structure in the same file.
- **Broken-windows lift.** `NotFoundError` moved from two inline imports (the existing one inside `append_tool_result` + the new one in the rewritten allow path) to the module-top import.

## TDD

`tests/integration/test_tool_allow_idempotency.py` — mirror of `test_tool_deny_idempotency.py`. Verified **red on pre-fix**: `count=2`. Post-fix: `count=1`, second-call returns the first event (same id + seq).

## Test plan

- [x] mypy clean (153 files)
- [x] ruff + format clean
- [x] Unit suite — 1248 passed
- [x] Integration tests (allow + deny idempotency) — 4 passed locally
- [ ] CI runs full e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)