### PR TITLE
fix(tools/http_request): strip caller Host header so vhost-routed upstreams honor base_url scope

### DIFF
--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -35,6 +35,11 @@ _MAX_RESPONSE_CHARS = 100_000
 _TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0)
 _ALLOWED_METHODS = ("GET", "POST", "PUT", "DELETE", "PATCH")
 
+# Headers the worker manages on the agent's behalf. Agent-supplied values
+# under any casing are stripped before dispatch so the route allowlist's
+# intent (path-only + base_url-scoped) isn't bypassed.
+_RESERVED_HEADERS = frozenset({"authorization", "host"})
+
 
 HTTP_REQUEST_DESCRIPTION = (
     "Make an authenticated HTTP request to one of the agent's declared "
@@ -202,7 +207,15 @@ async def http_request_handler(session_id: str, arguments: dict[str, Any]) -> di
         pool, crypto_box, session_id, server.base_url, account_id=account_id
     )
 
-    request_headers = {k: v for k, v in caller_headers.items() if k.lower() != "authorization"}
+    # Strip headers the worker manages on the agent's behalf. ``Authorization``
+    # is rendered from the session vault below. ``Host`` is derived from the
+    # request URL by httpx; an agent override would land the request on a
+    # different name-based virtual host than the operator's base_url scopes
+    # to (NGINX, Cloudflare, ALB, Ingress — all route by Host header), so
+    # leaving it caller-controlled effectively defeats the route allowlist.
+    request_headers = {
+        k: v for k, v in caller_headers.items() if k.lower() not in _RESERVED_HEADERS
+    }
     request_headers.update(auth_headers)
 
     try:

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -356,6 +356,55 @@ class TestHttpRequestHandler:
         assert sent["Authorization"] == "Bearer broker-token"
         assert sent["X-Other"] == "ok"
 
+    async def test_caller_host_header_dropped(self, _stub_runtime: Any) -> None:
+        """An agent-supplied ``Host`` header must not reach the dispatched
+        request. The route allowlist scopes by ``base_url`` — i.e. by the
+        TCP host the connection lands on — but with name-based virtual
+        hosting (a near-universal production HTTP pattern: NGINX, Cloudflare,
+        AWS ALB, Kubernetes Ingress) the upstream routes by the ``Host``
+        header, not by the destination IP. A caller_headers passthrough of
+        ``Host: admin.internal`` would land the request on an upstream
+        vhost the operator never approved, bypassing the route allowlist's
+        intent.
+
+        Same shape as #485 (query string in path) and #477 (Telegram
+        reaction emoji): a worker-managed protocol element (here: the
+        TCP host derived from base_url) gets silently overridden by an
+        agent-controlled field. Strip ``Host`` at the same site that
+        strips ``Authorization``.
+        """
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
+        captured: dict[str, Any] = {}
+        response = httpx.Response(200, content=b"ok")
+        stub = _make_stub_client(response=response, capture=captured)
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth({"Authorization": "Bearer broker-token"}),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            await http_request_handler(
+                "sess_x",
+                {
+                    "server_ref": "hue",
+                    "path": "/lights/1",
+                    "method": "GET",
+                    # Case-mixed to verify the strip is case-insensitive,
+                    # matching the ``Authorization`` filter's semantics.
+                    "headers": {"HoSt": "admin.internal", "X-Other": "ok"},
+                },
+            )
+        sent = captured["kwargs"]["headers"]
+        # The agent's Host (under any casing) must not be present.
+        assert all(k.lower() != "host" for k in sent), (
+            f"caller Host header must be stripped before dispatch; got {sent!r}. "
+            f"Pre-fix symptom: the only stripped header was Authorization, so "
+            f"a Host override slipped through to httpx and onto the wire — "
+            f"bypassing the operator's base_url scoping under name-based vhosting."
+        )
+        # Other agent-supplied headers should still pass through.
+        assert sent["X-Other"] == "ok"
+
     async def test_timeout_returns_error(self, _stub_runtime: Any) -> None:
         agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
         stub = _make_stub_client(exc=httpx.ReadTimeout("timed out"))


### PR DESCRIPTION
## Summary

- The dispatch path stripped only `Authorization` from `caller_headers`; an agent-supplied `Host` passed through to httpx and onto the wire verbatim. With name-based virtual hosting (NGINX, Cloudflare, AWS ALB, Kubernetes Ingress — universal in production HTTP infrastructure) the upstream dispatches by the `Host` header, not the connection's TCP destination, so a `headers={"Host": "admin.internal"}` could land the request on a vhost the operator's `base_url` never scoped to. The route allowlist's intent ("agent stays within this server's surface") diverges from the gate's effect ("agent can reach any vhost on the same IP").
- Introduce `_RESERVED_HEADERS = frozenset({"authorization", "host"})` and gate `caller_headers` against the case-folded membership check, replacing the inline `!= "authorization"` filter. `Host` joins `Authorization` as a worker-managed protocol element — both are derived from server state (`base_url` + vault credential) and the agent has no business overriding them.
- Sibling to #485 (query string in path slips past route allowlist): same protocol-mismatch shape, same fix-class (validate at the boundary so gate-intent matches gate-effect).

## Test plan

- [x] New `test_caller_host_header_dropped` constructs the `{"HoSt": "admin.internal", "X-Other": "ok"}` shape (mixed casing to verify the strip is case-insensitive) and asserts `Host` is absent from the dispatched `kwargs["headers"]` while `X-Other` passes through. Pre-fix it fails — `HoSt` lands verbatim. Post-fix passes.
- [x] Existing `test_caller_authorization_header_dropped` and the other 18 `TestHttpRequestHandler` / `TestClassifyPermission` / `TestDecodeBody` tests still green — the new strip is a strict superset of the old.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1299 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)