### PR TITLE
feat(ci): Track G promote workflows for aios-api + aios-worker

### DIFF
--- a/.github/workflows/promote-api.yml
+++ b/.github/workflows/promote-api.yml
@@ -1,0 +1,46 @@
+name: Promote aios-api → Coolify
+
+# Track G: explicit, gated deploy of the aios-api service container.
+#
+# Replaces Coolify's "auto-deploy from master push" with an explicit
+# operator-triggered promote. Master merges remain candidates-for-promotion;
+# this workflow fires only on workflow_dispatch and requires reviewer approval
+# via the ``stable`` GitHub environment before the dispatch is sent.
+#
+# This workflow fires a repository_dispatch event into eumemic/eumemic-ops,
+# which runs ``./scripts/deploy aios-api``, polls Coolify for deploy
+# completion, runs the audit suite, and appends a row to deploy-ledger.jsonl.
+# If anything in that chain fails, production stays on the prior known-good
+# build.
+#
+# Spec: eumemic/eumemic-ops#19 (deploy-gate v2 step 7).
+# Receiver: eumemic/eumemic-ops .github/workflows/deploy-app.yml.
+#
+# Security note: this workflow does not interpolate any untrusted input
+# into ``run:`` commands (there are no run: commands). Only trusted contexts
+# (github.actor, github.sha, secrets.EUMEMIC_OPS_DISPATCH_TOKEN) are
+# referenced, all inside the client-payload of a pinned action.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment: stable  # requires reviewer approval
+    permissions:
+      contents: read
+    steps:
+      - name: Trigger eumemic-ops deploy receiver
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.EUMEMIC_OPS_DISPATCH_TOKEN }}
+          repository: eumemic/eumemic-ops
+          event-type: deploy-app
+          client-payload: |
+            {
+              "app": "aios-api",
+              "track": "G",
+              "sha": "${{ github.sha }}",
+              "promoted_by": "${{ github.actor }}"
+            }

--- a/.github/workflows/promote-worker.yml
+++ b/.github/workflows/promote-worker.yml
@@ -1,0 +1,46 @@
+name: Promote aios-worker → Coolify
+
+# Track G: explicit, gated deploy of the aios-worker service container.
+#
+# Replaces Coolify's "auto-deploy from master push" with an explicit
+# operator-triggered promote. Master merges remain candidates-for-promotion;
+# this workflow fires only on workflow_dispatch and requires reviewer approval
+# via the ``stable`` GitHub environment before the dispatch is sent.
+#
+# This workflow fires a repository_dispatch event into eumemic/eumemic-ops,
+# which runs ``./scripts/deploy aios-worker``, polls Coolify for deploy
+# completion, runs the audit suite, and appends a row to deploy-ledger.jsonl.
+# If anything in that chain fails, production stays on the prior known-good
+# build.
+#
+# Spec: eumemic/eumemic-ops#19 (deploy-gate v2 step 7).
+# Receiver: eumemic/eumemic-ops .github/workflows/deploy-app.yml.
+#
+# Security note: this workflow does not interpolate any untrusted input
+# into ``run:`` commands (there are no run: commands). Only trusted contexts
+# (github.actor, github.sha, secrets.EUMEMIC_OPS_DISPATCH_TOKEN) are
+# referenced, all inside the client-payload of a pinned action.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment: stable  # requires reviewer approval
+    permissions:
+      contents: read
+    steps:
+      - name: Trigger eumemic-ops deploy receiver
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.EUMEMIC_OPS_DISPATCH_TOKEN }}
+          repository: eumemic/eumemic-ops
+          event-type: deploy-app
+          client-payload: |
+            {
+              "app": "aios-worker",
+              "track": "G",
+              "sha": "${{ github.sha }}",
+              "promoted_by": "${{ github.actor }}"
+            }


### PR DESCRIPTION
## Summary

Adds two `workflow_dispatch` workflows that fire a `deploy-app` `repository_dispatch` into `eumemic/eumemic-ops`, gated on the `stable` environment's required-reviewer approval:

- `.github/workflows/promote-api.yml` — payload `{"app":"aios-api","track":"G",...}`
- `.github/workflows/promote-worker.yml` — payload `{"app":"aios-worker","track":"G",...}`

These are the aios-side half of Track G (deploy-gate v2 step 7). Mirrors the existing `promote-sandbox.yml` shape minus the image retag — Track G doesn't retag any image, it just signals the receiver to run `./scripts/deploy <app>` with audit + ledger append.

Spec: eumemic/eumemic-ops#19
**Counterpart to eumemic-ops#20** (the deploy receiver).

## Behavior change

Today: PR merge to aios master → Coolify auto-deploys aios-api/worker. If it fails, production is degraded until manual recovery (e.g. the 2026-05-15 multitenancy migration incident).

After: PR merge → CI runs full validation → image is candidate-for-promotion (no production change yet) → operator triggers `promote-api`/`promote-worker` `workflow_dispatch` → reviewer approves on the `stable` environment → eumemic-ops receiver deploys, polls Coolify, runs audit, appends ledger. On failure, production stays on the prior known-good build.

## Inertness

These workflows are inert until both of the following land:

1. The receiver workflow in eumemic-ops merges (eumemic-ops#20). Until then, the dispatch arrives at eumemic-ops but nothing handles it.
2. Coolify auto-deploy is flipped off on `aios-api` and `aios-worker` (operator action via `./scripts/coolify PATCH ...`, post-merge, per the sequencing in eumemic-ops#19).

Until step 2, both auto-deploy *and* the explicit promote will run for any given merge — harmless duplication, not a regression.

## Test plan

- [ ] CI passes on this PR (it's workflow-only — no code paths exercised).
- [ ] After merge: workflows appear in the Actions tab on `master`.
- [ ] After eumemic-ops#20 merges: trigger `promote-api` `workflow_dispatch` manually, approve the `stable` environment gate, verify receiver fires, deploy completes, ledger row lands. Repeat for `promote-worker`.
- [ ] After both promotes verified end-to-end: flip `is_auto_deploy_enabled=false` on aios-api + aios-worker via `./scripts/coolify PATCH`.
- [ ] Verify a subsequent master merge does NOT auto-deploy (deploy queue shows no new finished row from the merge).

Security: no `run:` steps; only trusted contexts (`github.actor`, `github.sha`, `secrets.EUMEMIC_OPS_DISPATCH_TOKEN`) referenced, all inside the `client-payload` of a pinned action (`peter-evans/repository-dispatch@v3`).