### PR TITLE
refactor(models/common): consolidate cursor pagination via ListResponse.paginate

### DIFF
--- a/src/aios/api/routers/agents.py
+++ b/src/aios/api/routers/agents.py
@@ -58,11 +58,7 @@ async def list_(
     items = await service.list_agents(
         pool, limit=limit, after=after, name=name, account_id=account_id
     )
-    return ListResponse[Agent](
-        data=items,
-        has_more=len(items) == limit,
-        next_after=items[-1].id if items else None,
-    )
+    return ListResponse[Agent].paginate(items, limit, cursor=lambda x: x.id)
 
 
 @router.get("/{agent_id}", operation_id="get_agent")
@@ -132,11 +128,7 @@ async def list_versions(
     items = await service.list_agent_versions(
         pool, agent_id, limit=limit, after=after, account_id=account_id
     )
-    return ListResponse[AgentVersion](
-        data=items,
-        has_more=len(items) == limit,
-        next_after=str(items[-1].version) if items else None,
-    )
+    return ListResponse[AgentVersion].paginate(items, limit, cursor=lambda x: str(x.version))
 
 
 @router.get("/{agent_id}/versions/{version}", operation_id="get_agent_version")

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -121,11 +121,7 @@ async def list_(
         after=after,
         account_id=account_id,
     )
-    return ListResponse[Connection](
-        data=items,
-        has_more=len(items) == limit,
-        next_after=items[-1].id if items else None,
-    )
+    return ListResponse[Connection].paginate(items, limit, cursor=lambda x: x.id)
 
 
 @router.get("/{connection_id}", operation_id="get_connection")

--- a/src/aios/api/routers/environments.py
+++ b/src/aios/api/routers/environments.py
@@ -42,11 +42,7 @@ async def list_(
     """
     account_id, _, _ = _auth
     items = await service.list_environments(pool, limit=limit, after=after, account_id=account_id)
-    return ListResponse[Environment](
-        data=items,
-        has_more=len(items) == limit,
-        next_after=items[-1].id if items else None,
-    )
+    return ListResponse[Environment].paginate(items, limit, cursor=lambda x: x.id)
 
 
 @router.get("/{env_id}", operation_id="get_environment")

--- a/src/aios/api/routers/memory_stores.py
+++ b/src/aios/api/routers/memory_stores.py
@@ -67,11 +67,7 @@ async def list_stores(
         after=after,
         account_id=account_id,
     )
-    return ListResponse[MemoryStore](
-        data=items,
-        has_more=len(items) == limit,
-        next_after=items[-1].id if items else None,
-    )
+    return ListResponse[MemoryStore].paginate(items, limit, cursor=lambda x: x.id)
 
 
 @router.get("/{store_id}", operation_id="get_memory_store")

--- a/src/aios/api/routers/session_templates.py
+++ b/src/aios/api/routers/session_templates.py
@@ -64,11 +64,7 @@ async def list_(
     items = await service.list_session_templates(
         pool, limit=limit, after=after, account_id=account_id
     )
-    return ListResponse[SessionTemplate](
-        data=items,
-        has_more=len(items) == limit,
-        next_after=items[-1].id if items else None,
-    )
+    return ListResponse[SessionTemplate].paginate(items, limit, cursor=lambda x: x.id)
 
 
 @router.get("/{template_id}", operation_id="get_session_template")

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -111,11 +111,7 @@ async def list_(
         after=after,
         account_id=account_id,
     )
-    return ListResponse[Session](
-        data=items,
-        has_more=len(items) == limit,
-        next_after=items[-1].id if items else None,
-    )
+    return ListResponse[Session].paginate(items, limit, cursor=lambda x: x.id)
 
 
 @router.get("/{session_id}", operation_id="get_session")
@@ -480,11 +476,7 @@ async def list_events(
         error_only=error_only,
         account_id=account_id,
     )
-    return ListResponse[Event](
-        data=items,
-        has_more=len(items) == limit,
-        next_after=str(items[-1].seq) if items else None,
-    )
+    return ListResponse[Event].paginate(items, limit, cursor=lambda x: str(x.seq))
 
 
 @router.get("/{session_id}/context", operation_id="get_session_context")

--- a/src/aios/api/routers/skills.py
+++ b/src/aios/api/routers/skills.py
@@ -46,11 +46,7 @@ async def list_(
     """
     account_id, _, _ = _auth
     items = await service.list_skills(pool, limit=limit, after=after, account_id=account_id)
-    return ListResponse[Skill](
-        data=items,
-        has_more=len(items) == limit,
-        next_after=items[-1].id if items else None,
-    )
+    return ListResponse[Skill].paginate(items, limit, cursor=lambda x: x.id)
 
 
 @router.get("/{skill_id}", operation_id="get_skill")
@@ -114,11 +110,7 @@ async def list_versions(
     items = await service.list_skill_versions(
         pool, skill_id, limit=limit, after=after, account_id=account_id
     )
-    return ListResponse[SkillVersion](
-        data=items,
-        has_more=len(items) == limit,
-        next_after=str(items[-1].version) if items else None,
-    )
+    return ListResponse[SkillVersion].paginate(items, limit, cursor=lambda x: str(x.version))
 
 
 @router.get("/{skill_id}/versions/{version}", operation_id="get_skill_version")

--- a/src/aios/api/routers/vaults.py
+++ b/src/aios/api/routers/vaults.py
@@ -50,11 +50,7 @@ async def list_(
     """
     account_id, _, _ = _auth
     items = await service.list_vaults(pool, limit=limit, after=after, account_id=account_id)
-    return ListResponse[Vault](
-        data=items,
-        has_more=len(items) == limit,
-        next_after=items[-1].id if items else None,
-    )
+    return ListResponse[Vault].paginate(items, limit, cursor=lambda x: x.id)
 
 
 @router.get("/{vault_id}", operation_id="get_vault")
@@ -159,11 +155,7 @@ async def list_credentials(
     items = await service.list_vault_credentials(
         pool, vault_id, limit=limit, after=after, account_id=account_id
     )
-    return ListResponse[VaultCredential](
-        data=items,
-        has_more=len(items) == limit,
-        next_after=items[-1].id if items else None,
-    )
+    return ListResponse[VaultCredential].paginate(items, limit, cursor=lambda x: x.id)
 
 
 @router.get("/{vault_id}/credentials/{credential_id}", operation_id="get_vault_credential")

--- a/src/aios/models/common.py
+++ b/src/aios/models/common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from pydantic import BaseModel
@@ -13,6 +14,21 @@ class ListResponse[T](BaseModel):
     data: list[T]
     has_more: bool = False
     next_after: str | None = None
+
+    @classmethod
+    def paginate(
+        cls,
+        items: list[T],
+        limit: int,
+        *,
+        cursor: Callable[[T], str],
+    ) -> ListResponse[T]:
+        """Wrap a windowed query result in the pagination envelope."""
+        return cls(
+            data=items,
+            has_more=len(items) == limit,
+            next_after=cursor(items[-1]) if items else None,
+        )
 
 
 class ErrorBody(BaseModel):

--- a/tests/unit/test_list_response.py
+++ b/tests/unit/test_list_response.py
@@ -1,0 +1,37 @@
+"""Tests for ``ListResponse.paginate`` — the cursor-pagination envelope helper."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from aios.models.common import ListResponse
+
+
+class _Item(BaseModel):
+    id: str
+    seq: int
+
+
+def test_paginate_empty() -> None:
+    """Empty items: ``next_after`` is None and ``has_more`` is False."""
+    resp = ListResponse[_Item].paginate([], limit=10, cursor=lambda x: x.id)
+    assert resp.data == []
+    assert resp.has_more is False
+    assert resp.next_after is None
+
+
+def test_paginate_partial_page() -> None:
+    """Result smaller than ``limit``: ``has_more`` is False, cursor on last item."""
+    items = [_Item(id="a", seq=1), _Item(id="b", seq=2)]
+    resp = ListResponse[_Item].paginate(items, limit=10, cursor=lambda x: x.id)
+    assert resp.data == items
+    assert resp.has_more is False
+    assert resp.next_after == "b"
+
+
+def test_paginate_full_page() -> None:
+    """Result fills the page (``len == limit``): ``has_more`` is True."""
+    items = [_Item(id="a", seq=1), _Item(id="b", seq=2)]
+    resp = ListResponse[_Item].paginate(items, limit=2, cursor=lambda x: x.id)
+    assert resp.has_more is True
+    assert resp.next_after == "b"


### PR DESCRIPTION
## Summary

- Twelve cursor-pagination call sites across `aios.api.routers.*` carried the same 4-line block — build `ListResponse[T]`, compute `has_more = len(items) == limit`, derive `next_after` from the last item's cursor field. This PR extracts a single PEP 695 classmethod `ListResponse[T].paginate(items, limit, *, cursor)` and collapses each site to a one-liner whose only varying piece is the cursor extractor (`.id` for 9 sites; `str(.version)` / `str(.seq)` for the three non-id sites).
- The classmethod reuses the class's outer `T` parameter rather than introducing a fresh one — under PEP 695, `cls` binds to the parameterized class at call time (`ListResponse[Agent]`), the cursor's input type narrows correctly, and `cls(...)` yields a properly-parameterized instance with no schema regression risk.
- Net **-28 LOC** of production code (`+32/-60`). Adds one ~33-LOC test file. Mirrors PR #484's `_require[T]` consolidation in shape and scope discipline.

## Migration boundary

Six existing `ListResponse[...]` constructions remain inline — verified intentional:
- `memory_stores.py:197` (custom `has_more` from raw-row count vs. collapsed prefixes)
- `runtime_tokens.py:56` (unpaginated wrap, `has_more=False`)
- `connections.py:272,290`, `memory_stores.py:283`, `sessions.py:164` (unpaginated wraps)

None match the `(items, limit, cursor)` shape; forcing them through `paginate()` would harm clarity.

## Test plan

- [x] `uv run mypy src` — clean (155 source files; PEP 695 generic + outer-T classmethod accepted)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1301 passed (was 1298; +3 new pagination tests)
- [x] OpenAPI / SDK snapshot tests pass — JSON shape byte-identical (verified by `tests/unit/test_openapi_snapshot.py` and `test_sdk_snapshot.py`)
- [ ] CI e2e suite

## Code-review notes

Both `/simplify` and `pr-review-toolkit:code-reviewer` agents verified:
- Wire byte-identity for all 12 endpoints (`type(...).model_json_schema()` resolves `data: list[Item]` correctly)
- Type narrowing at every call site (cursor lambdas correctly typed for `Agent`/`AgentVersion`/`Event`/etc.)
- No prior pagination helper duplicated; the migration boundary is clean
- Pydantic v2 caches the parameterized generic class via `__class_getitem__`, so the new shape has no measurable per-call overhead

Verdict: **no findings ≥ 30**. Two minor `/simplify` findings (verbose docstring, redundant lambda-flexibility test) applied before opening the PR — broken-windows policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)