### PR TITLE
fix(sandbox/registry): clear _locks dict on release/evict/release_all

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -301,6 +301,7 @@ class SandboxRegistry:
 
         handle = self._handles.pop(session_id, None)
         self._last_used.pop(session_id, None)
+        self._locks.pop(session_id, None)
         proxy = self._git_proxies.pop(session_id, None)
 
         if proxy is not None:
@@ -360,6 +361,7 @@ class SandboxRegistry:
         from aios.harness import runtime
 
         self._last_used.pop(session_id, None)
+        self._locks.pop(session_id, None)
         if self._handles.pop(session_id, None) is not None:
             log.info("sandbox.evicted", session_id=session_id)
         # Drop the proxy too — a fresh sandbox will get a fresh proxy
@@ -386,6 +388,7 @@ class SandboxRegistry:
         proxies = list(self._git_proxies.values())
         self._handles.clear()
         self._last_used.clear()
+        self._locks.clear()
         self._git_proxies.clear()
 
         if proxies:

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -179,3 +179,53 @@ class TestReleaseIfMountsChanged:
         # New handle's snapshot matches current echoes → no release fired.
         destroys = [c for c in backend.calls if c[0] == "destroy"]
         assert destroys == []
+
+
+class TestLocksDictCleanup:
+    """``SandboxRegistry._locks`` must release its per-session entries on
+    teardown. Pre-fix the dict was only ever populated (by
+    ``_lock_for``) and never popped — every session that ever provisioned
+    a sandbox left a permanent ``asyncio.Lock`` entry, slow unbounded
+    growth across long-running workers handling many sessions. Companion
+    leak class to #451 (runtime per-session caches not cleared on
+    ``release``) and #475 (mcp pool evict strands owner task)."""
+
+    async def test_release_clears_lock(self) -> None:
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        _seed(registry, "sess_X")
+        # Touch the lock so it lands in ``_locks``.
+        _ = registry._lock_for("sess_X")
+        assert "sess_X" in registry._locks
+
+        await registry.release("sess_X")
+
+        assert "sess_X" not in registry._locks, (
+            f"_locks still contains 'sess_X' after release; got "
+            f"{list(registry._locks)!r}. Slow unbounded growth across the "
+            f"worker's lifetime as sessions are released."
+        )
+
+    async def test_evict_clears_lock(self) -> None:
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        _seed(registry, "sess_X")
+        _ = registry._lock_for("sess_X")
+        assert "sess_X" in registry._locks
+
+        registry.evict("sess_X")
+
+        assert "sess_X" not in registry._locks
+
+    async def test_release_all_clears_locks(self) -> None:
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        _seed(registry, "sess_X")
+        _seed(registry, "sess_Y")
+        _ = registry._lock_for("sess_X")
+        _ = registry._lock_for("sess_Y")
+        assert set(registry._locks) == {"sess_X", "sess_Y"}
+
+        await registry.release_all()
+
+        assert registry._locks == {}


### PR DESCRIPTION
## Summary

- `SandboxRegistry._locks` is populated by `_lock_for` on every session that ever provisions a sandbox but was never popped on any teardown path (`release`, `evict`, `release_all`). Each session left a permanent `asyncio.Lock` entry — slow unbounded growth across long-running workers handling many sessions.
- Companion to #451, which swept session-keyed runtime caches (`_session_memory_mounts`, `_session_read_shas`) into `release()` and added the cleanup hook. `_locks` is the same shape (`dict[session_id, T]` on the registry, same per-session lifecycle) but was missed in that sweep.
- Pop the entry alongside the existing `_handles` / `_last_used` / `_git_proxies` cleanup in all three teardown sites. Safe under concurrency: a task already holding the lock via `async with self._lock_for(sid):` has a strong reference on its own stack — popping the dict entry doesn't invalidate that reference, so `__aexit__` releases the same lock object correctly. New `_lock_for(sid)` callers get a fresh lock; in-flight waiters on the old lock complete against it. Single-instance semantics inside any outstanding `async with`; fresh instance for new callers.

## Test plan

- [x] New `TestLocksDictCleanup::test_release_clears_lock` / `test_evict_clears_lock` / `test_release_all_clears_locks` exercise each teardown site. Pre-fix the first fails with `_locks` still containing `"sess_X"` after `release`; post-fix all three pass.
- [x] Existing 9 `TestReleaseIfMountsChanged` tests still green — the new pops are additive to the existing per-session cleanup sequence and don't alter the in-lock release path (`release_if_mounts_changed` delegates to `release` after the lock acquire, then exits the `async with` which releases the local lock-object reference cleanly).
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1302 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)