### PR TITLE
fix(sandbox): strong-ref GitProxy stop task in evict() to survive GC

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -73,6 +73,11 @@ class SandboxRegistry:
         self._last_used: dict[str, float] = {}
         self._locks: dict[str, asyncio.Lock] = {}
         self._reaper_task: asyncio.Task[None] | None = None
+        # Strong refs for evict()'s fire-and-forget proxy-stop tasks.
+        # asyncio only weak-refs tasks, so without this the task can be
+        # GC'd before stop() unwinds the proxy's uvicorn server, httpx
+        # client and bound TCP port.
+        self._evict_proxy_stop_tasks: set[asyncio.Task[None]] = set()
 
     @property
     def backend(self) -> SandboxBackend:
@@ -357,6 +362,13 @@ class SandboxRegistry:
         Used by tool_dispatch when it detects a sandbox-side failure that
         suggests the sandbox itself is unhealthy; the next tool call will
         cold-start a fresh one.
+
+        The per-session :class:`GitProxy` is stopped in the background:
+        the caller is on a retry path and can't block on stop()'s up-to-5s
+        graceful drain. Skipping stop() entirely would strand the proxy's
+        uvicorn server, httpx client and bound TCP port — ``release_all``
+        only sees ``_git_proxies`` (which we've popped here), so without
+        the background stop the proxy leaks for the worker's lifetime.
         """
         from aios.harness import runtime
 
@@ -368,9 +380,12 @@ class SandboxRegistry:
         # from the next provision pass.
         proxy = self._git_proxies.pop(session_id, None)
         if proxy is not None:
-            # Fire-and-forget — eviction is best-effort cleanup; worker
-            # shutdown's ``release_all`` is the authoritative final stop.
-            asyncio.create_task(self._stop_proxy_silently(proxy, session_id))  # noqa: RUF006
+            task = asyncio.create_task(
+                self._stop_proxy_silently(proxy, session_id),
+                name=f"sandbox-evict-proxy-stop:{session_id}",
+            )
+            self._evict_proxy_stop_tasks.add(task)
+            task.add_done_callback(self._evict_proxy_stop_tasks.discard)
         # Same story for the MCP broker secret: drop it immediately; a
         # fresh sandbox will get a fresh secret from the next provision.
         self._release_mcp_broker_secret(session_id)

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -1,14 +1,17 @@
-"""Unit tests for ``SandboxRegistry.release_if_mounts_changed`` (issue #198).
+"""Unit tests for ``SandboxRegistry`` worker-side cleanup paths.
 
-Exercises the worker-side mount-drift detector that recycles a cached
-sandbox when the session's attached memory stores have changed since
-the sandbox was provisioned. The check fires once per step at the top
-of ``loop._run_session_step_body``.
+``TestReleaseIfMountsChanged`` covers the mount-drift detector that
+recycles a cached sandbox when the session's attached memory stores
+have changed since provisioning (issue #198). ``TestEvictReclamation``
+covers the ``evict`` fast path used by ``tool_dispatch`` when a
+sandbox-side failure suggests the sandbox itself is unhealthy.
 """
 
 from __future__ import annotations
 
 import asyncio
+import gc
+from typing import Any, cast
 
 import pytest
 
@@ -229,3 +232,53 @@ class TestLocksDictCleanup:
         await registry.release_all()
 
         assert registry._locks == {}
+
+
+class TestEvictReclamation:
+    """``evict`` reclaims the per-session ``GitProxy`` through ``stop()``."""
+
+    async def test_evict_records_stop_task_in_strong_ref_set(self) -> None:
+        """evict() must strongly reference its fire-and-forget stop task
+        while it runs and discard it once the task completes."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+
+        class _StubProxy:
+            async def stop(self) -> None: ...
+
+        registry._git_proxies["sess_X"] = cast(Any, _StubProxy())
+        registry._handles["sess_X"] = make_handle(session_id="sess_X")
+        registry._last_used["sess_X"] = 0.0
+
+        registry.evict("sess_X")
+        # set.add runs synchronously inside evict — the loop hasn't yielded
+        # yet, so the new task is still in flight.
+        assert len(registry._evict_proxy_stop_tasks) == 1
+
+        for _ in range(3):
+            await asyncio.sleep(0)
+        # add_done_callback(discard) reclaims the slot — otherwise the
+        # set grows unboundedly across the worker's lifetime.
+        assert len(registry._evict_proxy_stop_tasks) == 0
+
+    async def test_evict_proxy_actually_stops_under_gc(self) -> None:
+        """GC between evict() and the loop's first yield must not lose the
+        stop task — asyncio only weak-refs tasks, so without the strong-ref
+        set the freshly created task is eligible for collection here."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+
+        proxy_stopped = asyncio.Event()
+
+        class _StubProxy:
+            async def stop(self) -> None:
+                proxy_stopped.set()
+
+        registry._git_proxies["sess_X"] = cast(Any, _StubProxy())
+        registry._handles["sess_X"] = make_handle(session_id="sess_X")
+        registry._last_used["sess_X"] = 0.0
+
+        registry.evict("sess_X")
+        gc.collect()
+
+        await asyncio.wait_for(proxy_stopped.wait(), timeout=1.0)


### PR DESCRIPTION
## Summary

- `SandboxRegistry.evict()` fired the per-session `GitProxy.stop()` as a bare `asyncio.create_task` without holding a reference. `asyncio._all_tasks` is a `WeakSet`, so the freshly-created task could be GC'd before its coroutine ran, stranding the proxy's uvicorn server, httpx client and bound TCP port.
- The leak is on a hot path — every transient sandbox-side tool failure routes through `evict()` (`tool_dispatch.py:178, 324-328`) — and `release_all` only iterates `_git_proxies` (which `evict` already popped), so a missed stop survives the worker's lifetime.
- Mirror the fix from #475 (the exact same shape in `McpSessionPool.evict`): hold the task in a `set[asyncio.Task[None]]` field on the registry and discard it via `add_done_callback(set.discard)` so the strong reference dies exactly when the coroutine completes.

## Sibling lineage

This closes the third leg of the recent sandbox/MCP eviction-leak audit:
- #463 / #464 / #457 — `GitProxy.start()` / subprocess give-up FD release on bind / cancel paths.
- #475 — `McpSessionPool.evict` close-with-strong-ref (the structural twin of this PR).
- This PR — `SandboxRegistry.evict` strong-ref for the proxy-stop task.

## Test plan

- [x] New `test_evict_records_stop_task_in_strong_ref_set` — structural: the set must be populated synchronously inside `evict()` and emptied by the done-callback once the stop coroutine completes. Pre-fix the field doesn't exist (`AttributeError`); post-fix passes.
- [x] New `test_evict_proxy_actually_stops_under_gc` — behavioural: forcing `gc.collect()` between `evict()` and the first event-loop yield must not lose the task. Without the strong-ref the task object is eligible for collection here.
- [x] All 11 `TestReleaseIfMountsChanged` + `TestEvictReclamation` tests pass.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1301 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)