### PR TITLE
refactor(sandbox): drop unused Disabled NetworkPolicy variant

### DIFF
--- a/src/aios/sandbox/backends/__init__.py
+++ b/src/aios/sandbox/backends/__init__.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 from aios.sandbox.backends.base import (
     CommandResult,
-    Disabled,
     Limited,
     ManagedSandboxRef,
     Mount,
@@ -39,7 +38,6 @@ def make_backend(name: str) -> SandboxBackend:
 
 __all__ = [
     "CommandResult",
-    "Disabled",
     "Limited",
     "ManagedSandboxRef",
     "Mount",

--- a/src/aios/sandbox/backends/base.py
+++ b/src/aios/sandbox/backends/base.py
@@ -55,12 +55,6 @@ class Unrestricted(NetworkPolicy):
 
 
 @dataclass(frozen=True, slots=True)
-class Disabled(NetworkPolicy):
-    """No network at all. Backends may translate to ``--network none``,
-    a network namespace with no interfaces, etc."""
-
-
-@dataclass(frozen=True, slots=True)
 class Limited(NetworkPolicy):
     """Allow outbound only to ``allowed_hosts`` (resolved at apply time).
 

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -28,7 +28,6 @@ from aios.sandbox.backends.base import (
     MANAGED_LABEL_VALUE,
     SESSION_LABEL_KEY,
     CommandResult,
-    Disabled,
     Limited,
     ManagedSandboxRef,
     SandboxBackendError,
@@ -83,10 +82,7 @@ class DockerBackend:
         for key, value in spec.labels.items():
             argv.extend(["--label", f"{key}={value}"])
 
-        if isinstance(spec.network_policy, Disabled):
-            argv.extend(["--network", "none"])
-        else:
-            argv.extend(["--network", SANDBOX_NETWORK_NAME])
+        argv.extend(["--network", SANDBOX_NETWORK_NAME])
 
         # Limited policy needs NET_ADMIN so the iptables script (applied
         # later by the registry via aios.sandbox.setup) can install rules.

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -244,8 +244,6 @@ def _network_policy_from_config(env_config: EnvironmentConfig | None) -> Network
     networking = env_config.networking if env_config else None
     if isinstance(networking, LimitedNetworking):
         return Limited(allowed_hosts=frozenset(networking.allowed_hosts))
-    # Today the only non-limited option is unrestricted; ``Disabled`` is
-    # reserved for future use (no current EnvironmentConfig produces it).
     return Unrestricted()
 
 


### PR DESCRIPTION
## Summary

- `Disabled` was a tagged-union variant of `NetworkPolicy` reserved for future use — no `EnvironmentConfig` ever produced it. The `spec.py` comment beside `_network_policy_from_config` admitted as much: *"Disabled is reserved for future use (no current EnvironmentConfig produces it)"*. Per CLAUDE.md's "Don't deprecate, delete" stance, this PR removes the variant outright.
- Deletion sites: the `Disabled` dataclass in `backends/base.py`; its import + the unreachable `--network none` branch in `backends/docker.py`; its re-export in `backends/__init__.py`; the obsolete justifying comment in `spec.py`.
- Behavior on the only reachable policies (`Limited`, `Unrestricted`) is provably preserved — both took the `else` arm of the deleted `if isinstance(..., Disabled)` branch.
- Net **-14 LOC** (`+1/-15`) across 4 files. Mirrors PR #482's dead-config delete pattern.

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1305 passed
- [x] Grep-verified: no remaining `Disabled` references in `src/` or `tests/` (the two unrelated matches — "Disabled tools" in `models/agents.py`, "Disabled per-tool overrides" in `test_step_context_mcp_hint.py` — refer to distinct concepts)
- [x] Grep-verified: no external consumer imports `Disabled` from `aios.sandbox.backends`
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer` agent verified:
- `--network` default collapse is faithful — pre-deletion, `Disabled` was the only branch emitting `--network none`; both reachable policies took the `else`.
- `_network_policy_from_config` semantics unchanged (only the comment was removed).
- No tests depended on `Disabled`; `tests/unit/test_networking.py` exercises only `LimitedNetworking` / `UnrestrictedNetworking`.

Verdict: **no concerns ≥ 30**. Ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)