### PR TITLE
fix(cli/chat): seed SSE cursor from joined session's last_event_seq

### DIFF
--- a/src/aios/cli/commands/chat.py
+++ b/src/aios/cli/commands/chat.py
@@ -74,14 +74,14 @@ def register(app: typer.Typer) -> None:
             state = get_state(ctx)
             client = state.client()
             try:
-                session_id = _resolve_session(
+                session_id, last_seq = _resolve_session(
                     client,
                     agent=agent,
                     environment_id=environment_id,
                     session=session,
                     title=title,
                 )
-                _run_repl(client, session_id, initial=initial, verbose=state.verbose)
+                _run_repl(client, session_id, last_seq, initial=initial, verbose=state.verbose)
             finally:
                 client.close()
             return None
@@ -96,13 +96,22 @@ def _resolve_session(
     environment_id: str | None,
     session: str | None,
     title: str | None,
-) -> str:
+) -> tuple[str, int]:
+    """Return ``(session_id, last_event_seq)`` for the join or create path.
+
+    ``last_event_seq`` becomes the SSE backfill cursor: passing it as the
+    first ``stream_session(after_seq=...)`` argument means a join of an
+    existing long-running session doesn't replay its entire event log
+    into the REPL before the user can type. For a freshly-created
+    session ``last_event_seq`` will be the seq of the initial user/system
+    events — backfill is small, no UX impact.
+    """
     if session is not None:
         obj = client.request("GET", f"/v1/sessions/{session}")
         sys.stdout.write(
             f"joined session {cyan(obj['id'])} (agent={obj['agent_id']}, status={obj['status']})\n"
         )
-        return str(obj["id"])
+        return str(obj["id"]), int(obj["last_event_seq"])
 
     assert agent is not None
     if environment_id is None:
@@ -119,23 +128,27 @@ def _resolve_session(
         f"created session {cyan(obj['id'])} (agent={obj['agent_id']}, "
         f"version={obj.get('agent_version')})\n"
     )
-    return str(obj["id"])
+    return str(obj["id"]), int(obj["last_event_seq"])
 
 
 def _run_repl(
     client: AiosClient,
     session_id: str,
+    last_seq: int,
     *,
     initial: str | None,
     verbose: bool,
 ) -> None:
+    """Run the chat REPL. ``last_seq`` is the SSE backfill cursor — pass
+    the joined session's current ``last_event_seq`` so a rejoin doesn't
+    replay the entire event history before the first live event.
+    """
     sys.stdout.write(
         dim(
             "type a message and press Enter. /exit quits, /interrupt cancels an in-flight turn, "
             "/help shows commands.\n"
         )
     )
-    last_seq = 0
 
     # One-shot initial message: send, stream, then exit without prompting.
     if initial is not None:

--- a/tests/unit/cli/test_cli_chat.py
+++ b/tests/unit/cli/test_cli_chat.py
@@ -7,9 +7,12 @@ newline). The ``turn_state`` dict threads that flag through the loop.
 
 from __future__ import annotations
 
+from typing import Any
+from unittest.mock import MagicMock
+
 import pytest
 
-from aios.cli.commands.chat import _render_chat_event, _write_delta
+from aios.cli.commands.chat import _render_chat_event, _resolve_session, _write_delta
 
 
 def test_write_delta_reports_true_when_chunk_written(capsys: pytest.CaptureFixture[str]) -> None:
@@ -62,3 +65,44 @@ def test_final_assistant_message_only_newline_when_deltas_streamed(
     assert capsys.readouterr().out == "\n"
     # Flag resets so a subsequent assistant message in the same turn starts fresh.
     assert turn_state["streamed_any_delta"] is False
+
+
+def test_resolve_session_join_returns_last_event_seq(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``aios chat --session ID`` must thread the joined session's current
+    ``last_event_seq`` into the SSE backfill cursor; otherwise the very
+    first ``stream_session(after_seq=0)`` replays the entire event log
+    of the joined session before the user can send a message. For a
+    long-running session (thousands of events) this floods stdout and
+    blocks interaction for many seconds.
+
+    The fix is to read ``last_event_seq`` off the GET response (the
+    field is already on ``Session``) and return it from
+    ``_resolve_session``. Same after-seq footgun class as the standing
+    ``aios sessions stream`` lesson."""
+    client: Any = MagicMock()
+    client.request.return_value = {
+        "id": "sess_X",
+        "agent_id": "agt_A",
+        "status": "running",
+        "last_event_seq": 1234,
+    }
+
+    result = _resolve_session(
+        client,
+        agent=None,
+        environment_id=None,
+        session="sess_X",
+        title=None,
+    )
+
+    # Post-fix the function returns (session_id, last_event_seq) so the
+    # REPL initialises its SSE cursor from the joined session's tail
+    # rather than backfilling from 0.
+    assert result == ("sess_X", 1234), (
+        f"expected ('sess_X', 1234); got {result!r}. Pre-fix only the "
+        f"session id was returned and the REPL hardcoded last_seq=0, "
+        f"causing the first stream call to backfill the entire session "
+        f"history before live events arrive."
+    )


### PR DESCRIPTION
## Summary

- `aios chat --session ID` opened the SSE stream with a hardcoded `last_seq = 0` for the first `stream_session(after_seq=...)` call. The server then backfilled the entire joined session's event log to stdout before any live event arrived — for a long-running session this floods the terminal with hundreds-to-thousands of historical messages and tool-calls and blocks the user from typing the first new prompt for many seconds.
- `Session.last_event_seq` is already on the GET response (`src/aios/models/sessions.py:190`); `_resolve_session` was discarding it and returning only the id. Thread the seq through: `_resolve_session` now returns `(session_id, last_event_seq)`, `chat()` unpacks the tuple, and `_run_repl` takes `last_seq` as a positional and drops the hardcoded `= 0`.
- Same after-seq footgun class as the standing "aios sessions stream needs --after-seq" lesson — two distinct CLI surfaces (the REPL and the standalone stream command) both want the same cursor-init contract.

## Test plan

- [x] New `test_resolve_session_join_returns_last_event_seq` mocks `client.request` to return a Session dict with `last_event_seq=1234` and asserts the function returns the tuple `("sess_X", 1234)`. Pre-fix it fails with the function returning just `"sess_X"`; post-fix it passes.
- [x] Existing 6 chat-related unit tests still green.
- [x] mypy — clean (155 source files); the `_run_repl` signature update is well-typed end-to-end.
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1306 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)