### PR TITLE
refactor(sandbox/mcp_proxy): drop unused require_invoke parameter

### DIFF
--- a/src/aios/sandbox/mcp_proxy.py
+++ b/src/aios/sandbox/mcp_proxy.py
@@ -221,19 +221,13 @@ class McpBroker:
         return JSONResponse({"servers": servers})
 
     async def _resolve_for_tool(
-        self, request: Request, *, require_invoke: bool
+        self, request: Request
     ) -> tuple[str, McpServerSpec, ToolSpec, str] | Response:
         """Common prelude for tool routes: resolve session, agent,
         toolset, server, and authorize the tool. Returns
         ``(session_id, server_spec, toolset, tool_name)`` on success or
         a ``Response`` to return immediately on failure.
-
-        ``require_invoke`` selects between "browsing" semantics (--help
-        and listing accept any always_allow tool) and "invoke"
-        semantics (currently the same; kept for forward-compat with the
-        always_ask path that will need a different short-circuit).
         """
-        del require_invoke  # reserved for v2 always_ask path
         resolved = await self._resolve_session(request)
         if isinstance(resolved, Response):
             return resolved
@@ -300,7 +294,7 @@ class McpBroker:
         return JSONResponse({"tools": out})
 
     async def _tool_help(self, request: Request) -> Response:
-        resolved = await self._resolve_for_tool(request, require_invoke=False)
+        resolved = await self._resolve_for_tool(request)
         if isinstance(resolved, Response):
             return resolved
         session_id, server, _toolset, tool_name = resolved
@@ -337,7 +331,7 @@ class McpBroker:
         if not isinstance(arguments, dict):
             return _err(400, 'request body must contain {"arguments": <object>}')
 
-        resolved = await self._resolve_for_tool(request, require_invoke=True)
+        resolved = await self._resolve_for_tool(request)
         if isinstance(resolved, Response):
             return resolved
         session_id, server, _toolset, tool_name = resolved


### PR DESCRIPTION
## Summary

- `McpBroker._resolve_for_tool` took `require_invoke: bool` keyword-only, then immediately `del`'d it with the comment *"reserved for v2 always_ask path"*. The two internal callers (`_tool_help` and `_invoke`) passed `False` and `True` respectively, but neither value had any behavioral effect — the parameter was never read.
- Per CLAUDE.md's "Don't deprecate, delete" and "Don't speculate on future flexibility" stances, the parameter is removed now. When the v2 always_ask path actually lands, re-add what's actually needed.
- Net **-6 LOC** (`+3/-9`) in a single file. Mirrors the dead-scaffolding delete pattern of PR #482 (`connectors_auto_create`) and PR #492 (`Disabled` NetworkPolicy variant).

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1307 passed
- [x] Grep-verified: no external callers of `_resolve_for_tool` outside `mcp_proxy.py`
- [x] Grep-verified: no test references `require_invoke`
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer` agent verified:
- Zero behavioral effect (parameter was only `del`'d, never inspected)
- Call site equivalence (both `_tool_help` and `_invoke` reach the same code path)
- No external callers, no test references
- Docstring removal aligns with the no-speculation stance

Verdict: **no concerns ≥ 30**. Ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)