### PR TITLE
fix(harness/loop): accept dict-form function.arguments in _classify_tool_call

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -23,7 +23,6 @@ watermark and proceeds.
 from __future__ import annotations
 
 import asyncio
-import json
 from typing import TYPE_CHECKING, Any, Literal
 
 from aios.db.sse_lock import has_subscriber
@@ -719,7 +718,7 @@ def _classify_tool_call(
       registered.  Routed to immediate tool-error so the model can
       self-correct rather than parking in ``requires_action``.
     """
-    from aios.harness.tool_dispatch import _parse_mcp_tool_name
+    from aios.harness.tool_dispatch import _parse_arguments, _parse_mcp_tool_name
     from aios.tools.registry import registry as tool_registry
 
     function = tool_call.get("function") or {}
@@ -759,13 +758,8 @@ def _classify_tool_call(
         # ``agent.http_servers``).  Malformed args fall through to
         # dispatch so the schema validator emits a typed error the
         # model can self-correct from.
-        function = tool_call.get("function") or {}
-        args_str = function.get("arguments") or "{}"
-        try:
-            args = json.loads(args_str)
-        except json.JSONDecodeError:
-            args = None
-        if isinstance(args, dict):
+        args = _parse_arguments(function.get("arguments"))
+        if args is not None:
             perm_route = tool_def.classify_permission(args, agent)
 
     if perm_tool == "always_ask" or perm_route == "always_ask":

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from aios.models.agents import HttpPermissionPolicy, HttpRouteSpec, HttpServerSpec
+from aios.models.agents import HttpPermissionPolicy, HttpRouteSpec, HttpServerSpec, ToolSpec
 from aios.tools.http_request import (
     _classify_permission,
     _decode_body,
@@ -23,8 +23,10 @@ from aios.tools.http_request import (
 _REAL_ASYNC_CLIENT = httpx.AsyncClient
 
 
-def _agent(*, http_servers: list[HttpServerSpec]) -> SimpleNamespace:
-    return SimpleNamespace(http_servers=http_servers)
+def _agent(
+    *, http_servers: list[HttpServerSpec], tools: list[ToolSpec] | None = None
+) -> SimpleNamespace:
+    return SimpleNamespace(http_servers=http_servers, tools=tools or [])
 
 
 def _server(
@@ -106,6 +108,47 @@ class TestClassifyPermission:
         agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
         assert _classify_permission({"server_ref": "hue"}, agent) is None
         assert _classify_permission({"server_ref": 123, "path": "/lights/1"}, agent) is None
+
+
+# ── _classify_tool_call (loop.py) over http_request ──────────────────────────
+
+
+class TestClassifyToolCallArguments:
+    """``_classify_tool_call`` must accept both string- and dict-form
+    ``function.arguments`` (providers differ on which shape they emit)."""
+
+    @staticmethod
+    def _make_agent() -> SimpleNamespace:
+        return _agent(
+            http_servers=[_server(routes=[_route("/lights/*", policy="always_allow")])],
+            tools=[ToolSpec(type="http_request")],
+        )
+
+    def test_string_arguments_classify_as_immediate(self) -> None:
+        from aios.harness.loop import _classify_tool_call
+
+        tc = {
+            "id": "c1",
+            "type": "function",
+            "function": {
+                "name": "http_request",
+                "arguments": '{"server_ref": "hue", "path": "/lights/1", "method": "GET"}',
+            },
+        }
+        assert _classify_tool_call(tc, self._make_agent(), {}) == "immediate"
+
+    def test_dict_arguments_classify_as_immediate(self) -> None:
+        from aios.harness.loop import _classify_tool_call
+
+        tc = {
+            "id": "c1",
+            "type": "function",
+            "function": {
+                "name": "http_request",
+                "arguments": {"server_ref": "hue", "path": "/lights/1", "method": "GET"},
+            },
+        }
+        assert _classify_tool_call(tc, self._make_agent(), {}) == "immediate"
 
 
 # ── _decode_body ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `_classify_tool_call`'s inline argument parser did `json.loads(args_str)` with only `JSONDecodeError` caught (`loop.py:763-767`). When a provider (Anthropic via OpenRouter, some direct Anthropic routes) returns `function.arguments` as a parsed dict instead of a JSON string, `json.loads(<dict>)` raises `TypeError`. The uncaught exception propagates out of `run_session_step`, killing the session step on every `http_request` tool call from that provider.
- `tool_dispatch._parse_arguments` already handles both shapes — `isinstance(raw_args, dict)` short-circuit + `(JSONDecodeError, TypeError)` catch. Routing classify through the same helper makes dispatch and classify see the same argument shape.
- The bug only surfaces today because `http_request` is currently the only tool with `classify_permission` set, and its agent-route permission refinement runs in the classify path. PR #472 added `http_request`; this is the matching dict-arg-shape regression.

## Test plan

- [x] New `TestClassifyToolCallArguments::test_string_arguments_classify_as_immediate` — regression catch on the existing string-arg path.
- [x] New `TestClassifyToolCallArguments::test_dict_arguments_classify_as_immediate` — pre-fix raises `TypeError: the JSON object must be str, bytes or bytearray, not dict`; post-fix returns `\"immediate\"`.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1309 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)