### PR TITLE
fix(services/vaults): reject PUT that nulls a required-by-auth-type credential field

### DIFF
--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -345,6 +345,13 @@ def _merge_auth_payload(
     """Merge update fields into the existing decrypted payload.
 
     Only fields present in model_fields_set replace existing values.
+    Fields explicitly set to ``None`` are unset from the merged payload
+    (the documented unset-via-null behavior). After the merge, the
+    payload is re-validated against ``auth_type``'s required-fields list:
+    a PUT that unsets a required-by-auth-type field (e.g. ``token`` for
+    ``bearer_header``) raises ``ValidationError`` rather than landing a
+    silently-broken credential whose downstream auth-header rendering
+    would emit an empty bearer.
     """
     fields = _fields_for(auth_type)
     merged = dict(existing)
@@ -362,7 +369,41 @@ def _merge_auth_payload(
             merged[field] = val.isoformat()
         else:
             merged[field] = val
+    _validate_required_in_payload(merged, auth_type)
     return merged
+
+
+def _validate_required_in_payload(payload: dict[str, Any], auth_type: AuthType) -> None:
+    """Raise ``ValidationError`` if any field required by ``auth_type`` is
+    missing or empty in ``payload``. Mirrors the create-side checks in
+    :func:`_extract_auth_payload`; the merge path delegates here so a
+    PUT can't land an incomplete credential under the unset-via-null
+    contract.
+    """
+    if auth_type == "bearer_header" and not payload.get("token"):
+        raise ValidationError(
+            "bearer_header credentials require 'token'",
+            detail={"auth_type": auth_type},
+        )
+    if auth_type == "basic":
+        missing = [f for f in _BASIC_FIELDS if not payload.get(f)]
+        if missing:
+            raise ValidationError(
+                f"basic credentials require {missing}",
+                detail={"auth_type": auth_type, "missing": missing},
+            )
+    if auth_type == "custom_header":
+        missing = [f for f in _CUSTOM_HEADER_FIELDS if not payload.get(f)]
+        if missing:
+            raise ValidationError(
+                f"custom_header credentials require {missing}",
+                detail={"auth_type": auth_type, "missing": missing},
+            )
+    if auth_type == "oauth2_refresh" and not payload.get("access_token"):
+        raise ValidationError(
+            "oauth2_refresh credentials require 'access_token'",
+            detail={"auth_type": auth_type},
+        )
 
 
 async def create_vault_credential(

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -290,6 +290,43 @@ class TestMergeAuthPayload:
         assert "client_id" not in merged
         assert merged["access_token"] == "at"
 
+    def test_unsetting_required_bearer_token_is_rejected(self) -> None:
+        """A PUT with ``{"token": null}`` on a bearer_header credential
+        previously silently dropped the token from the merged payload,
+        leaving an "active" credential with no token. Downstream
+        rendering produced ``Authorization`` headers with an empty bearer
+        token and the upstream reliably 401'd. Reject at the merge site
+        so the operator gets a clear ``ValidationError`` instead of a
+        silently-broken credential."""
+        existing = {"token": "secret"}
+        update = VaultCredentialUpdate(token=None)
+        with pytest.raises(ValidationError, match="bearer_header"):
+            _merge_auth_payload(existing, update, "bearer_header")
+
+    def test_unsetting_required_basic_username_is_rejected(self) -> None:
+        existing = {"username": "alice", "password": "secret"}
+        update = VaultCredentialUpdate(username=None)
+        with pytest.raises(ValidationError, match="basic"):
+            _merge_auth_payload(existing, update, "basic")
+
+    def test_unsetting_required_basic_password_is_rejected(self) -> None:
+        existing = {"username": "alice", "password": "secret"}
+        update = VaultCredentialUpdate(password=None)
+        with pytest.raises(ValidationError, match="basic"):
+            _merge_auth_payload(existing, update, "basic")
+
+    def test_unsetting_required_custom_header_value_is_rejected(self) -> None:
+        existing = {"header_name": "X-Api-Key", "header_value": "sekrit"}
+        update = VaultCredentialUpdate(header_value=None)
+        with pytest.raises(ValidationError, match="custom_header"):
+            _merge_auth_payload(existing, update, "custom_header")
+
+    def test_unsetting_required_oauth_access_token_is_rejected(self) -> None:
+        existing = {"access_token": "at", "client_id": "cid"}
+        update = VaultCredentialUpdate(access_token=None)
+        with pytest.raises(ValidationError, match="oauth2_refresh"):
+            _merge_auth_payload(existing, update, "oauth2_refresh")
+
 
 # ── update_vault_credential: no private sentinel leaks into queries ──────────
 


### PR DESCRIPTION
## Summary

- `_merge_auth_payload` honors the documented unset-via-null contract (`PUT {"field": null}` removes `field` from the merged payload — see `test_unsets_field_when_set_to_none`) without checking whether the field is required by the credential's `auth_type`. A PUT with `{"token": null}` on a `bearer_header` credential silently dropped the token; the credential row stayed "active" but downstream `_auth_header_from_payload` rendered an empty bearer (`Authorization: Bearer `) and the upstream reliably 401'd. The operator got no error at the API; the model self-recovers through retries but the credential is in an incoherent state until they notice and re-create it.
- Same shape across every auth_type's required fields: `token` (bearer_header), `username`/`password` (basic), `header_name`/`header_value` (custom_header), `access_token` (oauth2_refresh). Optional metadata fields (e.g. `client_id` for oauth2_refresh) remain unset-able via null — the existing `test_unsets_field_when_set_to_none` still passes.
- Introduce `_validate_required_in_payload(payload, auth_type)` that mirrors the create-side checks in `_extract_auth_payload` and call it at the end of `_merge_auth_payload`. The merge path now raises `ValidationError` instead of returning a broken credential. The check uses `not payload.get(f)` (truthy guard), so it also catches a future PUT that sets a required field to an empty SecretStr — closing the secondary find from a prior audit (empty creds accepted on update too).

## Test plan

- [x] Five new tests in `TestMergeAuthPayload` exercise each auth_type's required fields: bearer token, basic username, basic password, custom_header value, oauth2 access_token. All raise `ValidationError` with the expected auth_type marker. Pre-fix the bearer/oauth tests fail with no exception (silent corruption); post-fix they pass.
- [x] Existing `test_unsets_field_when_set_to_none` still green — `client_id` is not a required field for `oauth2_refresh`, so the new validation lets it through.
- [x] Other three `TestMergeAuthPayload` tests still green.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1313 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)