### PR TITLE
fix(cli/files): reject symlinks in walk_skill_dir to prevent confused-deputy file exfiltration

### DIFF
--- a/src/aios/cli/files.py
+++ b/src/aios/cli/files.py
@@ -121,6 +121,14 @@ def walk_skill_dir(root: Path) -> dict[str, str]:
 
     files: dict[str, str] = {}
     for path in sorted(root.rglob("*")):
+        # Reject symlinks before any operation that follows them
+        # (``is_file()``, ``read_text()`` both do). A planted symlink
+        # inside a skill dir pointing at ``~/.ssh/id_rsa`` would otherwise
+        # be silently read and uploaded — confused-deputy exfiltration of
+        # local files through whatever registry ``AIOS_URL`` points at.
+        # Authors who actually need duplication can copy the file.
+        if path.is_symlink():
+            raise PayloadError(f"skill files must not be symlinks: {path}")
         if not path.is_file():
             continue
         rel = path.relative_to(root).as_posix()

--- a/tests/unit/cli/test_files.py
+++ b/tests/unit/cli/test_files.py
@@ -110,3 +110,44 @@ def test_walk_skill_dir_not_a_directory(tmp_path: Path):
     f.write_text("x")
     with pytest.raises(PayloadError, match="not a directory"):
         walk_skill_dir(f)
+
+
+def test_walk_skill_dir_rejects_symlinked_file(tmp_path: Path):
+    """A symlink in a skill dir pointing OUTSIDE the dir must be
+    rejected. ``Path.is_file()`` and ``Path.read_text()`` both follow
+    symlinks by default; without an explicit guard a planted symlink
+    (e.g. ``ln -s ~/.ssh/id_rsa skill/notes.txt``) gets read and
+    uploaded to whatever ``AIOS_URL`` points at when the operator runs
+    ``aios skills create --dir skill``. Confused-deputy exfiltration of
+    arbitrary local files via misconfigured / hostile registry URL.
+
+    Reject at the walk site (``fail hard, no fallbacks``) — silently
+    skipping would let a planted symlink go unnoticed.
+    """
+    secret = tmp_path / "secret.txt"
+    secret.write_text("sensitive: aws_access_key_id=AKIA...")
+    skill = tmp_path / "my-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("# my skill")
+    (skill / "leak").symlink_to(secret)
+
+    with pytest.raises(PayloadError, match=r"symlink"):
+        walk_skill_dir(skill)
+
+
+def test_walk_skill_dir_rejects_symlinked_file_pointing_inside(
+    tmp_path: Path,
+) -> None:
+    """Even an in-tree symlink is rejected — the policy is strict at
+    the walk site rather than relying on ``resolve().is_relative_to``
+    containment checks (which are racy under TOCTOU on the workspace
+    directory). The author can simply duplicate the file content
+    instead of using a symlink."""
+    skill = tmp_path / "my-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("# my skill")
+    (skill / "helper.py").write_text("print('hi')")
+    (skill / "alias.py").symlink_to(skill / "helper.py")
+
+    with pytest.raises(PayloadError, match=r"symlink"):
+        walk_skill_dir(skill)


### PR DESCRIPTION
## Summary

- `walk_skill_dir` iterates `root.rglob("*")` and reads every file via `path.is_file()` + `path.read_text(...)`. Both calls follow symlinks by default, so a planted symlink inside a skill directory pointing OUTSIDE the directory (e.g. `ln -s ~/.ssh/id_rsa my-skill/notes.txt`) silently gets its target read and uploaded to whatever `AIOS_URL` resolves to when the operator runs `aios skills create --dir my-skill`. Combined with no registry allowlist this is a confused-deputy exfiltration of arbitrary reachable local files.
- The threat model isn't only adversarial — an author who symlinks shared assets across skill dirs would accidentally ship the symlinked targets' full contents under their identity.
- Reject `path.is_symlink()` at the walk site, fail-hard with a typed `PayloadError` rather than silently skipping. An author who needs to share content across skills can copy the file. Python 3.13's `Path.rglob` already defaults to `recurse_symlinks=False` so directory symlinks aren't traversed; this PR closes the file-symlink gap.

## Test plan

- [x] New `test_walk_skill_dir_rejects_symlinked_file` plants a symlink pointing OUTSIDE the skill dir and asserts `PayloadError` with "symlink" in the message. Pre-fix it fails ("did not raise"); post-fix it passes.
- [x] New `test_walk_skill_dir_rejects_symlinked_file_pointing_inside` verifies the rejection is strict — even an in-tree symlink raises. Documents the policy: copy the file, don't link it.
- [x] Existing 11 `walk_skill_dir` / `load_payload` tests still green — the new guard is a strict superset of the existing `is_file()` skip.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1317 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)