### PR TITLE
refactor(cli): consolidate 35 SDK call+render sites via call_single helper

### DIFF
--- a/src/aios/cli/commands/_shared.py
+++ b/src/aios/cli/commands/_shared.py
@@ -35,6 +35,23 @@ def render_single(obj: Any) -> None:
     print_json(obj)
 
 
+def call_single(
+    ctx: typer.Context,
+    fn: Callable[..., Response[Any]],
+    **kwargs: Any,
+) -> None:
+    """Open an SDK client, call an endpoint returning a single resource,
+    and render the result through :func:`render_single`.
+
+    The single-resource counterpart to :func:`render_paginated`: every
+    ``get`` / ``create`` / ``update`` / ``archive`` body that ends in
+    ``render_single(obj.to_dict())`` collapses to one line.
+    """
+    with get_state(ctx).sdk_client() as client:
+        obj = unwrap(fn(client=client, **kwargs))
+    render_single(obj.to_dict())
+
+
 def render_list(
     output_format: OutputFormat,
     envelope: dict[str, Any],

--- a/src/aios/cli/commands/accounts.py
+++ b/src/aios/cli/commands/accounts.py
@@ -23,7 +23,7 @@ from typing import Annotated
 
 import typer
 
-from aios.cli.commands._shared import render_list, render_single, unwrap
+from aios.cli.commands._shared import call_single, render_list, render_single, unwrap
 from aios.cli.output import print_json, print_note
 from aios.cli.runtime import get_state, run_or_die
 from aios_sdk._generated.api.accounts import (
@@ -75,9 +75,7 @@ def me(ctx: typer.Context) -> None:
     """Print the caller's account row."""
 
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(get_my_account.sync_detailed(client=client))
-        render_single(obj.to_dict())
+        call_single(ctx, get_my_account.sync_detailed)
 
     run_or_die(_run)
 
@@ -100,9 +98,7 @@ def get(ctx: typer.Context, target_id: str) -> None:
     """Read a caller-or-direct-child account."""
 
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(get_account.sync_detailed(client=client, target_id=target_id))
-        render_single(obj.to_dict())
+        call_single(ctx, get_account.sync_detailed, target_id=target_id)
 
     run_or_die(_run)
 
@@ -142,9 +138,7 @@ def mint(
 @app.command("archive", help="Archive a direct child account.")
 def archive(ctx: typer.Context, target_id: str) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(archive_account.sync_detailed(client=client, target_id=target_id))
-        render_single(obj.to_dict())
+        call_single(ctx, archive_account.sync_detailed, target_id=target_id)
 
     run_or_die(_run)
 
@@ -172,11 +166,7 @@ def update(
             display_name=display_name if display_name is not None else UNSET,
             can_mint_children=can_mint_children if can_mint_children is not None else UNSET,
         )
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                update_account.sync_detailed(client=client, target_id=target_id, body=body)
-            )
-        render_single(obj.to_dict())
+        call_single(ctx, update_account.sync_detailed, target_id=target_id, body=body)
 
     run_or_die(_run)
 
@@ -193,9 +183,7 @@ def by_path(
     ] = "",
 ) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(resolve_account_by_path.sync_detailed(client=client, path=path))
-        render_single(obj.to_dict())
+        call_single(ctx, resolve_account_by_path.sync_detailed, path=path)
 
     run_or_die(_run)
 

--- a/src/aios/cli/commands/agents.py
+++ b/src/aios/cli/commands/agents.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated
 
 import typer
 
-from aios.cli.commands._shared import render_paginated, render_single, unwrap
+from aios.cli.commands._shared import call_single, render_paginated, unwrap
 from aios.cli.files import PayloadError, load_payload
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
@@ -55,9 +55,7 @@ def list_(
 @app.command("get", help="Fetch a single agent by id.")
 def get(ctx: typer.Context, agent_id: str) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            agent = unwrap(get_agent.sync_detailed(client=client, agent_id=agent_id))
-        render_single(agent.to_dict())
+        call_single(ctx, get_agent.sync_detailed, agent_id=agent_id)
 
     run_or_die(_run)
 
@@ -76,9 +74,7 @@ def create(
             print_error(str(exc))
             return 64
         body = AgentCreate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            agent = unwrap(create_agent.sync_detailed(client=client, body=body))
-        render_single(agent.to_dict())
+        call_single(ctx, create_agent.sync_detailed, body=body)
         return None
 
     run_or_die(_run)
@@ -99,9 +95,7 @@ def update(
             print_error(str(exc))
             return 64
         body = AgentUpdate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            agent = unwrap(update_agent.sync_detailed(client=client, agent_id=agent_id, body=body))
-        render_single(agent.to_dict())
+        call_single(ctx, update_agent.sync_detailed, agent_id=agent_id, body=body)
         return None
 
     run_or_die(_run)
@@ -143,10 +137,6 @@ def versions(
 @app.command("version", help="Fetch a specific agent version.")
 def version(ctx: typer.Context, agent_id: str, version: int) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj: Any = unwrap(
-                get_agent_version.sync_detailed(client=client, agent_id=agent_id, version=version)
-            )
-        render_single(obj.to_dict())
+        call_single(ctx, get_agent_version.sync_detailed, agent_id=agent_id, version=version)
 
     run_or_die(_run)

--- a/src/aios/cli/commands/connections.py
+++ b/src/aios/cli/commands/connections.py
@@ -13,7 +13,12 @@ from typing import Annotated, Any
 
 import typer
 
-from aios.cli.commands._shared import render_list, render_paginated, render_single, unwrap
+from aios.cli.commands._shared import (
+    call_single,
+    render_list,
+    render_paginated,
+    unwrap,
+)
 from aios.cli.files import PayloadError, load_json_object, resolve_payload
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
@@ -91,9 +96,7 @@ def list_(
 @app.command("get")
 def get(ctx: typer.Context, connection_id: str) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(get_connection.sync_detailed(client=client, connection_id=connection_id))
-        render_single(obj.to_dict())
+        call_single(ctx, get_connection.sync_detailed, connection_id=connection_id)
 
     run_or_die(_run)
 
@@ -172,9 +175,7 @@ def create(
             print_error(str(exc))
             return 64
         body = ConnectionCreate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(create_connection.sync_detailed(client=client, body=body))
-        render_single(obj.to_dict())
+        call_single(ctx, create_connection.sync_detailed, body=body)
         return None
 
     run_or_die(_run)
@@ -207,13 +208,9 @@ def set_secrets(
             print_error(str(exc))
             return 64
         body = ConnectionSetSecrets(secrets=ConnectionSetSecretsSecrets.from_dict(kvs))
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                set_connection_secrets.sync_detailed(
-                    client=client, connection_id=connection_id, body=body
-                )
-            )
-        render_single(obj.to_dict())
+        call_single(
+            ctx, set_connection_secrets.sync_detailed, connection_id=connection_id, body=body
+        )
         print_success("secrets updated on", connection_id)
         return None
 
@@ -228,13 +225,7 @@ def attach(
 ) -> None:
     def _run() -> None:
         body = ConnectionAttach(session_id=session_id)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                attach_connection.sync_detailed(
-                    client=client, connection_id=connection_id, body=body
-                )
-            )
-        render_single(obj.to_dict())
+        call_single(ctx, attach_connection.sync_detailed, connection_id=connection_id, body=body)
 
     run_or_die(_run)
 
@@ -242,11 +233,7 @@ def attach(
 @app.command("detach", help="Drop the single_session binding, leaving the connection detached.")
 def detach(ctx: typer.Context, connection_id: str) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                detach_connection.sync_detailed(client=client, connection_id=connection_id)
-            )
-        render_single(obj.to_dict())
+        call_single(ctx, detach_connection.sync_detailed, connection_id=connection_id)
 
     run_or_die(_run)
 
@@ -259,13 +246,9 @@ def configure_per_chat(
 ) -> None:
     def _run() -> None:
         body = ConnectionConfigurePerChat(session_template_id=template)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                configure_connection_per_chat.sync_detailed(
-                    client=client, connection_id=connection_id, body=body
-                )
-            )
-        render_single(obj.to_dict())
+        call_single(
+            ctx, configure_connection_per_chat.sync_detailed, connection_id=connection_id, body=body
+        )
 
     run_or_die(_run)
 
@@ -275,11 +258,7 @@ def configure_per_chat(
 )
 def unconfigure(ctx: typer.Context, connection_id: str) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                unconfigure_connection.sync_detailed(client=client, connection_id=connection_id)
-            )
-        render_single(obj.to_dict())
+        call_single(ctx, unconfigure_connection.sync_detailed, connection_id=connection_id)
 
     run_or_die(_run)
 
@@ -296,11 +275,7 @@ def bind_chat_cmd(
 ) -> None:
     def _run() -> None:
         body = BindChatRequest(chat_id=chat_id, session_id=session_id)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                bind_chat.sync_detailed(client=client, connection_id=connection_id, body=body)
-            )
-        render_single(obj.to_dict())
+        call_single(ctx, bind_chat.sync_detailed, connection_id=connection_id, body=body)
 
     run_or_die(_run)
 

--- a/src/aios/cli/commands/envs.py
+++ b/src/aios/cli/commands/envs.py
@@ -7,7 +7,7 @@ from typing import Annotated
 
 import typer
 
-from aios.cli.commands._shared import render_paginated, render_single, unwrap
+from aios.cli.commands._shared import call_single, render_paginated, unwrap
 from aios.cli.files import PayloadError, load_payload
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
@@ -49,9 +49,7 @@ def list_(
 @app.command("get")
 def get(ctx: typer.Context, env_id: str) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(get_environment.sync_detailed(client=client, env_id=env_id))
-        render_single(obj.to_dict())
+        call_single(ctx, get_environment.sync_detailed, env_id=env_id)
 
     run_or_die(_run)
 
@@ -70,9 +68,7 @@ def create(
             print_error(str(exc))
             return 64
         body = EnvironmentCreate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(create_environment.sync_detailed(client=client, body=body))
-        render_single(obj.to_dict())
+        call_single(ctx, create_environment.sync_detailed, body=body)
         return None
 
     run_or_die(_run)
@@ -93,9 +89,7 @@ def update(
             print_error(str(exc))
             return 64
         body = EnvironmentUpdate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(update_environment.sync_detailed(client=client, env_id=env_id, body=body))
-        render_single(obj.to_dict())
+        call_single(ctx, update_environment.sync_detailed, env_id=env_id, body=body)
         return None
 
     run_or_die(_run)

--- a/src/aios/cli/commands/session_templates.py
+++ b/src/aios/cli/commands/session_templates.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any
 
 import typer
 
-from aios.cli.commands._shared import render_paginated, render_single, unwrap
+from aios.cli.commands._shared import call_single, render_paginated, unwrap
 from aios.cli.files import PayloadError, load_json_object, load_payload, resolve_payload
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
@@ -55,9 +55,7 @@ def list_(
 @app.command("get")
 def get(ctx: typer.Context, template_id: str) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(get_session_template.sync_detailed(client=client, template_id=template_id))
-        render_single(obj.to_dict())
+        call_single(ctx, get_session_template.sync_detailed, template_id=template_id)
 
     run_or_die(_run)
 
@@ -111,9 +109,7 @@ def create(
             print_error(str(exc))
             return 64
         body = SessionTemplateCreate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(create_session_template.sync_detailed(client=client, body=body))
-        render_single(obj.to_dict())
+        call_single(ctx, create_session_template.sync_detailed, body=body)
         return None
 
     run_or_die(_run)
@@ -134,13 +130,7 @@ def update(
             print_error(str(exc))
             return 64
         body = SessionTemplateUpdate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                update_session_template.sync_detailed(
-                    client=client, template_id=template_id, body=body
-                )
-            )
-        render_single(obj.to_dict())
+        call_single(ctx, update_session_template.sync_detailed, template_id=template_id, body=body)
         return None
 
     run_or_die(_run)

--- a/src/aios/cli/commands/skills.py
+++ b/src/aios/cli/commands/skills.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any
 
 import typer
 
-from aios.cli.commands._shared import render_paginated, render_single, unwrap
+from aios.cli.commands._shared import call_single, render_paginated, unwrap
 from aios.cli.files import PayloadError, load_payload, walk_skill_dir
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
@@ -51,9 +51,7 @@ def list_(
 @app.command("get", help="Fetch a skill.")
 def get(ctx: typer.Context, skill_id: str) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(get_skill.sync_detailed(client=client, skill_id=skill_id))
-        render_single(obj.to_dict())
+        call_single(ctx, get_skill.sync_detailed, skill_id=skill_id)
 
     run_or_die(_run)
 
@@ -80,9 +78,7 @@ def create(
         if isinstance(payload, int):
             return payload
         body = SkillCreate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(create_skill.sync_detailed(client=client, body=body))
-        render_single(obj.to_dict())
+        call_single(ctx, create_skill.sync_detailed, body=body)
         return None
 
     run_or_die(_run)
@@ -124,11 +120,7 @@ def versions(
 @app.command("version", help="Fetch a specific skill version.")
 def version(ctx: typer.Context, skill_id: str, version: int) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                get_skill_version.sync_detailed(client=client, skill_id=skill_id, version=version)
-            )
-        render_single(obj.to_dict())
+        call_single(ctx, get_skill_version.sync_detailed, skill_id=skill_id, version=version)
 
     run_or_die(_run)
 
@@ -157,11 +149,7 @@ def version_create(
                 print_error(str(exc))
                 return 64
         body = SkillVersionCreate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                create_skill_version.sync_detailed(client=client, skill_id=skill_id, body=body)
-            )
-        render_single(obj.to_dict())
+        call_single(ctx, create_skill_version.sync_detailed, skill_id=skill_id, body=body)
         return None
 
     run_or_die(_run)

--- a/src/aios/cli/commands/vaults.py
+++ b/src/aios/cli/commands/vaults.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any
 
 import typer
 
-from aios.cli.commands._shared import render_paginated, render_single, unwrap
+from aios.cli.commands._shared import call_single, render_paginated, unwrap
 from aios.cli.files import PayloadError, load_json_object, load_payload, resolve_payload
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
@@ -68,9 +68,7 @@ def list_(
 @app.command("get")
 def get(ctx: typer.Context, vault_id: str) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(get_vault.sync_detailed(client=client, vault_id=vault_id))
-        render_single(obj.to_dict())
+        call_single(ctx, get_vault.sync_detailed, vault_id=vault_id)
 
     run_or_die(_run)
 
@@ -109,9 +107,7 @@ def create(
             print_error(str(exc))
             return 64
         body = VaultCreate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(create_vault.sync_detailed(client=client, body=body))
-        render_single(obj.to_dict())
+        call_single(ctx, create_vault.sync_detailed, body=body)
         return None
 
     run_or_die(_run)
@@ -132,9 +128,7 @@ def update(
             print_error(str(exc))
             return 64
         body = VaultUpdate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(update_vault.sync_detailed(client=client, vault_id=vault_id, body=body))
-        render_single(obj.to_dict())
+        call_single(ctx, update_vault.sync_detailed, vault_id=vault_id, body=body)
         return None
 
     run_or_die(_run)
@@ -143,9 +137,7 @@ def update(
 @app.command("archive")
 def archive(ctx: typer.Context, vault_id: str) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(archive_vault.sync_detailed(client=client, vault_id=vault_id))
-        render_single(obj.to_dict())
+        call_single(ctx, archive_vault.sync_detailed, vault_id=vault_id)
 
     run_or_die(_run)
 
@@ -205,13 +197,9 @@ def cred_list(
 @credentials.command("get")
 def cred_get(ctx: typer.Context, vault_id: str, credential_id: str) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                get_vault_credential.sync_detailed(
-                    client=client, vault_id=vault_id, credential_id=credential_id
-                )
-            )
-        render_single(obj.to_dict())
+        call_single(
+            ctx, get_vault_credential.sync_detailed, vault_id=vault_id, credential_id=credential_id
+        )
 
     run_or_die(_run)
 
@@ -243,11 +231,7 @@ def cred_create(
             print_error(str(exc))
             return 64
         body = VaultCredentialCreate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                create_vault_credential.sync_detailed(client=client, vault_id=vault_id, body=body)
-            )
-        render_single(obj.to_dict())
+        call_single(ctx, create_vault_credential.sync_detailed, vault_id=vault_id, body=body)
         return None
 
     run_or_die(_run)
@@ -269,13 +253,13 @@ def cred_update(
             print_error(str(exc))
             return 64
         body = VaultCredentialUpdate.from_dict(payload)
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                update_vault_credential.sync_detailed(
-                    client=client, vault_id=vault_id, credential_id=credential_id, body=body
-                )
-            )
-        render_single(obj.to_dict())
+        call_single(
+            ctx,
+            update_vault_credential.sync_detailed,
+            vault_id=vault_id,
+            credential_id=credential_id,
+            body=body,
+        )
         return None
 
     run_or_die(_run)
@@ -284,13 +268,12 @@ def cred_update(
 @credentials.command("archive")
 def cred_archive(ctx: typer.Context, vault_id: str, credential_id: str) -> None:
     def _run() -> None:
-        with get_state(ctx).sdk_client() as client:
-            obj = unwrap(
-                archive_vault_credential.sync_detailed(
-                    client=client, vault_id=vault_id, credential_id=credential_id
-                )
-            )
-        render_single(obj.to_dict())
+        call_single(
+            ctx,
+            archive_vault_credential.sync_detailed,
+            vault_id=vault_id,
+            credential_id=credential_id,
+        )
 
     run_or_die(_run)
 


### PR DESCRIPTION
## Summary

- Across 7 CLI command files, `get` / `create` / `update` / `archive` bodies repeated the same 3-5 line block: `with state.sdk_client(): obj = unwrap(fn(client=client, **kwargs)); render_single(obj.to_dict())`. This PR adds `call_single(ctx, fn, **kwargs)` to `_shared.py` — the single-resource counterpart to the existing `render_paginated` sibling — and collapses every matching site to one call.
- Both single-line and multi-line `unwrap` shapes covered; **35 sites total** across `accounts.py`, `agents.py`, `connections.py`, `envs.py`, `session_templates.py`, `skills.py`, `vaults.py`.
- Sites with post-processing between `unwrap` and `render_single` (e.g., `signal.py` with `print_note(...)`, `accounts.mint` with `output_format` branching, sessions/dev which use the legacy `AiosClient` not the SDK) intentionally left alone.
- Net **-75 LOC** (`+82/-157`). Mirrors the consolidation shape of PR #484 (`require_*`), PR #489 (`ListResponse.paginate`), and the existing `render_paginated` helper.

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1308 passed
- [x] Grep-verified: remaining `render_single(obj.to_dict())` sites all have legitimate post-processing
- [ ] CI e2e suite

## Code-review notes

`/simplify` agents flagged that my initial regex missed 14 multi-line `unwrap(...)` sites; per broken-windows policy, those were swept up in the same PR (taking the total from 20 → 35 sites and -17 → -75 LOC).

`pr-review-toolkit:code-reviewer` agent verified:
- All 35 conversions byte-faithful (same fn, same kwargs, same render)
- Skipped sites have documented post-processing (none are call_single candidates)
- Import sweeps correct (e.g., `envs.py` drops `render_single`)
- mypy / ruff / tests all clean

Verdict: **no concerns ≥ 30**. Ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)