### PR TITLE
fix(sandbox/mcp_proxy): release serve task on McpBroker.start() bind timeout

### DIFF
--- a/src/aios/sandbox/mcp_proxy.py
+++ b/src/aios/sandbox/mcp_proxy.py
@@ -150,25 +150,38 @@ class McpBroker:
         self._server = uvicorn.Server(config)
         self._serve_task = asyncio.create_task(self._server.serve(), name="mcp-broker-serve")
 
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + _BIND_TIMEOUT_S
-        while loop.time() < deadline:
-            await asyncio.sleep(0.01)
-            if self._server.started and self._server.servers:
-                sockets = self._server.servers[0].sockets
-                if sockets:
-                    self._port = sockets[0].getsockname()[1]
-                    log.info("mcp_broker.started", port=self._port)
-                    return
-        raise RuntimeError(f"mcp broker failed to bind within {_BIND_TIMEOUT_S}s")
+        try:
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + _BIND_TIMEOUT_S
+            while loop.time() < deadline:
+                await asyncio.sleep(0.01)
+                if self._server.started and self._server.servers:
+                    sockets = self._server.servers[0].sockets
+                    if sockets:
+                        self._port = sockets[0].getsockname()[1]
+                        log.info("mcp_broker.started", port=self._port)
+                        return
+            raise RuntimeError(f"mcp broker failed to bind within {_BIND_TIMEOUT_S}s")
+        except BaseException:
+            # Bind never completed; the caller drops its reference, so
+            # nothing else will call stop() — without this the serve
+            # task and the half-bound socket leak for the worker's
+            # lifetime.
+            await self.stop()
+            raise
 
     async def stop(self) -> None:
-        if self._server is not None:
-            self._server.should_exit = True
         try:
-            if self._serve_task is not None:
-                with contextlib.suppress(TimeoutError, asyncio.CancelledError):
-                    await asyncio.wait_for(self._serve_task, timeout=5.0)
+            # Graceful drain only matters once the server actually
+            # bound — ``should_exit`` is checked inside the uvicorn
+            # main loop, which never runs on a failed-bind path, so
+            # without this gate the failed-bind cleanup pays a
+            # pointless 5s wait on every retry.
+            if self._server is not None and self._server.started:
+                self._server.should_exit = True
+                if self._serve_task is not None:
+                    with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+                        await asyncio.wait_for(self._serve_task, timeout=5.0)
         finally:
             if self._serve_task is not None and not self._serve_task.done():
                 self._serve_task.cancel()

--- a/tests/unit/sandbox/test_mcp_proxy.py
+++ b/tests/unit/sandbox/test_mcp_proxy.py
@@ -9,12 +9,14 @@ happy-path listing / --help / invocation flow.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import Any
 
 import httpx
 import pytest
+import uvicorn
 
 from aios.models.agents import (
     McpPermissionPolicy,
@@ -355,3 +357,20 @@ def _async_returning(value: Any) -> Any:
         return value
 
     return _impl
+
+
+class TestStartBindFailureCleanup:
+    async def test_bind_timeout_releases_serve_task(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # uvicorn.Server.serve that never starts — bind never completes.
+        async def _hang(_self: uvicorn.Server, *_a: object, **_k: object) -> None:
+            await asyncio.sleep(60)
+
+        monkeypatch.setattr(uvicorn.Server, "serve", _hang)
+        monkeypatch.setattr("aios.sandbox.mcp_proxy._BIND_TIMEOUT_S", 0.05)
+
+        b = McpBroker()
+        with pytest.raises(RuntimeError, match="mcp broker failed to bind"):
+            await b.start()
+
+        assert b._serve_task is not None
+        assert b._serve_task.done()


### PR DESCRIPTION
## Summary

- `McpBroker.start()` raised `RuntimeError` on bind timeout without calling `self.stop()`. The caller (worker_main) drops its reference at that point, so the uvicorn serve task lives on as an orphan — pending for the worker's lifetime — and the half-bound socket isn't released.
- Wrap the bind-poll loop in `try/except BaseException: await self.stop(); raise`, mirroring the fix landed in `GitProxy.start()` in #463. This is the third leg of the same eviction-leak family: #463 (GitProxy.start), #491 (SandboxRegistry.evict), this PR (McpBroker.start).
- **Broken-windows follow-on:** mirror #463's matching `stop()` change too — gate the 5s graceful `wait_for` on `self._server.started`. Without the gate, a failed-bind cleanup pays a pointless 5s wait per attempt because `should_exit` is checked inside the uvicorn main loop, which never runs on a failed-bind path. The asymmetry showed up empirically: the new test ran in 5.44s before the gate, 0.44s after.

## Test plan

- [x] New `TestStartBindFailureCleanup::test_bind_timeout_releases_serve_task` — monkey-patches `uvicorn.Server.serve` to hang and `_BIND_TIMEOUT_S=0.05`. Pre-fix: `RuntimeError` raised, `_serve_task` still pending (assertion fires). Post-fix: `_serve_task.done()` is True.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1316 passed, test takes 0.44s
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)