### PR TITLE
refactor(api/sse): drop dead "_ = queries" reference

### DIFF
--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -320,8 +320,3 @@ def _is_terminal(payload: dict[str, Any]) -> bool:
         and isinstance(payload["data"], dict)
         and payload["data"].get("status") == "terminated"
     )
-
-
-# Reference imports for static analysis: queries is reserved for future use
-# (e.g., per-session validation before opening the stream).
-_ = queries


### PR DESCRIPTION
## Summary

- The trailing `_ = queries` line in `src/aios/api/sse.py` plus its 2-line preceding comment claimed *"queries is reserved for future use,"* but `queries` is **already actively used six times** in the same file (lines 62, 160, 175, 206, 222, 260). The stub was stale residue from when the import was genuinely unused; current state makes it a noise comment that contradicts the code.
- Per CLAUDE.md's "Don't deprecate, delete" stance and rule against future-flexibility speculation, the stub is removed. Same shape as PR #494 / PR #492 — pure dead-scaffolding delete.
- Net **-5 LOC** (5 deletions, 0 insertions), single file.

## Test plan

- [x] `uv run mypy src` — clean (155 source files; no unused-import warning since `queries` is still actively used)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1317 passed
- [x] Grep-verified: no test references `_ = queries`
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer`: no concerns ≥ 30. Verified 6 active `queries` usages remain (lines 62, 160, 175, 206, 222, 260); removing the stub cannot break static analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)