### PR TITLE
fix(db/listen): close conn on add_listener failure across 5 listener context managers

### DIFF
--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -89,27 +89,29 @@ async def listen_for_connector_result(
     per-session) channel and a tighter queue bound.
     """
     conn = await asyncpg.connect(normalize_dsn(db_url))
-    queue: asyncio.Queue[str] = asyncio.Queue(maxsize=8)
-    channel = f"connector_result_{call_id}"
-
-    def _callback(
-        _conn: asyncpg.Connection[object],
-        _pid: int,
-        _channel: str,
-        payload: str,
-    ) -> None:
-        # See ``listen_for_events`` for why this MUST be synchronous.
-        try:
-            queue.put_nowait(payload)
-        except asyncio.QueueFull:
-            log.warning("listen.connector_result_queue_full", call_id=call_id)
-
-    await conn.add_listener(channel, _callback)
     try:
-        yield queue
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=8)
+        channel = f"connector_result_{call_id}"
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            # See ``listen_for_events`` for why this MUST be synchronous.
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning("listen.connector_result_queue_full", call_id=call_id)
+
+        await conn.add_listener(channel, _callback)
+        try:
+            yield queue
+        finally:
+            with contextlib.suppress(Exception):
+                await conn.remove_listener(channel, _callback)
     finally:
-        with contextlib.suppress(Exception):
-            await conn.remove_listener(channel, _callback)
         with contextlib.suppress(Exception):
             await conn.close()
 
@@ -141,43 +143,45 @@ async def listen_for_events(
         that a slow consumer can fall behind by ~1000 events before drops.
     """
     conn = await asyncpg.connect(normalize_dsn(db_url))
-    queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-    channel = f"events_{session_id}"
-
-    def _callback(
-        _conn: asyncpg.Connection[object],
-        _pid: int,
-        _channel: str,
-        payload: str,
-    ) -> None:
-        # CRITICAL: this callback is invoked on asyncpg's connection read
-        # loop. It MUST be synchronous. No await calls allowed here.
-        try:
-            queue.put_nowait(payload)
-        except asyncio.QueueFull:
-            log.warning(
-                "listen.queue_full_drop",
-                session_id=session_id,
-                queue_max=queue_max,
-            )
-            # Drop oldest to make room. The SSE consumer can recover by
-            # reconnecting with `?after_seq=`.
-            try:
-                queue.get_nowait()
-                queue.put_nowait(payload)
-            except (asyncio.QueueEmpty, asyncio.QueueFull):
-                pass
-
-    await conn.add_listener(channel, _callback)
-    # Hold a shared advisory lock on this dedicated connection so the
-    # worker can detect that an SSE subscriber exists (issue #81).
-    # pg_locks releases automatically on connection close — no cleanup.
-    await acquire_subscriber_lock(conn, session_id)
     try:
-        yield queue
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
+        channel = f"events_{session_id}"
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            # CRITICAL: this callback is invoked on asyncpg's connection read
+            # loop. It MUST be synchronous. No await calls allowed here.
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning(
+                    "listen.queue_full_drop",
+                    session_id=session_id,
+                    queue_max=queue_max,
+                )
+                # Drop oldest to make room. The SSE consumer can recover by
+                # reconnecting with `?after_seq=`.
+                try:
+                    queue.get_nowait()
+                    queue.put_nowait(payload)
+                except (asyncio.QueueEmpty, asyncio.QueueFull):
+                    pass
+
+        await conn.add_listener(channel, _callback)
+        # Hold a shared advisory lock on this dedicated connection so the
+        # worker can detect that an SSE subscriber exists (issue #81).
+        # pg_locks releases automatically on connection close — no cleanup.
+        await acquire_subscriber_lock(conn, session_id)
+        try:
+            yield queue
+        finally:
+            with contextlib.suppress(Exception):
+                await conn.remove_listener(channel, _callback)
     finally:
-        with contextlib.suppress(Exception):
-            await conn.remove_listener(channel, _callback)
         with contextlib.suppress(Exception):
             await conn.close()
 
@@ -197,35 +201,37 @@ async def listen_for_connector_calls_by_type(
     half of the payload.
     """
     conn = await asyncpg.connect(normalize_dsn(db_url))
-    queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-    channel = f"connector_calls_{connector}"
-
-    def _callback(
-        _conn: asyncpg.Connection[object],
-        _pid: int,
-        _channel: str,
-        payload: str,
-    ) -> None:
-        try:
-            queue.put_nowait(payload)
-        except asyncio.QueueFull:
-            log.warning(
-                "listen.connector_calls_type_queue_full_drop",
-                connector=connector,
-                queue_max=queue_max,
-            )
-            try:
-                queue.get_nowait()
-                queue.put_nowait(payload)
-            except (asyncio.QueueEmpty, asyncio.QueueFull):
-                pass
-
-    await conn.add_listener(channel, _callback)
     try:
-        yield queue
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
+        channel = f"connector_calls_{connector}"
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning(
+                    "listen.connector_calls_type_queue_full_drop",
+                    connector=connector,
+                    queue_max=queue_max,
+                )
+                try:
+                    queue.get_nowait()
+                    queue.put_nowait(payload)
+                except (asyncio.QueueEmpty, asyncio.QueueFull):
+                    pass
+
+        await conn.add_listener(channel, _callback)
+        try:
+            yield queue
+        finally:
+            with contextlib.suppress(Exception):
+                await conn.remove_listener(channel, _callback)
     finally:
-        with contextlib.suppress(Exception):
-            await conn.remove_listener(channel, _callback)
         with contextlib.suppress(Exception):
             await conn.close()
 
@@ -239,35 +245,37 @@ async def listen_for_management_calls(
 ) -> AsyncIterator[asyncio.Queue[str]]:
     """LISTEN ``connector_management_calls_<connector>``; yield a queue of ``call_id`` payloads."""
     conn = await asyncpg.connect(normalize_dsn(db_url))
-    queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-    channel = f"connector_management_calls_{connector}"
-
-    def _callback(
-        _conn: asyncpg.Connection[object],
-        _pid: int,
-        _channel: str,
-        payload: str,
-    ) -> None:
-        try:
-            queue.put_nowait(payload)
-        except asyncio.QueueFull:
-            log.warning(
-                "listen.connector_management_calls_queue_full_drop",
-                connector=connector,
-                queue_max=queue_max,
-            )
-            try:
-                queue.get_nowait()
-                queue.put_nowait(payload)
-            except (asyncio.QueueEmpty, asyncio.QueueFull):
-                pass
-
-    await conn.add_listener(channel, _callback)
     try:
-        yield queue
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
+        channel = f"connector_management_calls_{connector}"
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning(
+                    "listen.connector_management_calls_queue_full_drop",
+                    connector=connector,
+                    queue_max=queue_max,
+                )
+                try:
+                    queue.get_nowait()
+                    queue.put_nowait(payload)
+                except (asyncio.QueueEmpty, asyncio.QueueFull):
+                    pass
+
+        await conn.add_listener(channel, _callback)
+        try:
+            yield queue
+        finally:
+            with contextlib.suppress(Exception):
+                await conn.remove_listener(channel, _callback)
     finally:
-        with contextlib.suppress(Exception):
-            await conn.remove_listener(channel, _callback)
         with contextlib.suppress(Exception):
             await conn.close()
 
@@ -286,35 +294,37 @@ async def listen_for_connection_discovery(
     ``archive_connection``.
     """
     conn = await asyncpg.connect(normalize_dsn(db_url))
-    queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-    channel = f"connections_{connector}"
-
-    def _callback(
-        _conn: asyncpg.Connection[object],
-        _pid: int,
-        _channel: str,
-        payload: str,
-    ) -> None:
-        try:
-            queue.put_nowait(payload)
-        except asyncio.QueueFull:
-            log.warning(
-                "listen.connection_discovery_queue_full_drop",
-                connector=connector,
-                queue_max=queue_max,
-            )
-            try:
-                queue.get_nowait()
-                queue.put_nowait(payload)
-            except (asyncio.QueueEmpty, asyncio.QueueFull):
-                pass
-
-    await conn.add_listener(channel, _callback)
     try:
-        yield queue
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
+        channel = f"connections_{connector}"
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning(
+                    "listen.connection_discovery_queue_full_drop",
+                    connector=connector,
+                    queue_max=queue_max,
+                )
+                try:
+                    queue.get_nowait()
+                    queue.put_nowait(payload)
+                except (asyncio.QueueEmpty, asyncio.QueueFull):
+                    pass
+
+        await conn.add_listener(channel, _callback)
+        try:
+            yield queue
+        finally:
+            with contextlib.suppress(Exception):
+                await conn.remove_listener(channel, _callback)
     finally:
-        with contextlib.suppress(Exception):
-            await conn.remove_listener(channel, _callback)
         with contextlib.suppress(Exception):
             await conn.close()
 

--- a/tests/unit/test_listen.py
+++ b/tests/unit/test_listen.py
@@ -1,0 +1,86 @@
+"""Unit coverage for the ``aios.db.listen`` context managers.
+
+Every listener allocates a dedicated asyncpg connection and runs
+``conn.add_listener`` (and, for :func:`listen_for_events`,
+``acquire_subscriber_lock``) before yielding. If any of those setup
+steps raise, the conn must still be closed — otherwise the dedicated
+asyncpg connection leaks for the worker / API process lifetime,
+slowly chewing through Postgres ``max_connections``.
+"""
+
+from __future__ import annotations
+
+from contextlib import AbstractAsyncContextManager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.db import listen
+
+
+def _mk_listener(name: str) -> AbstractAsyncContextManager[Any]:
+    """Build the listener context manager keyed by function name.
+
+    Each listener has a different signature; this hides that variance so
+    the test body can parametrize uniformly on the failure path.
+    """
+    db_url = "postgresql://stub/aios"
+    if name == "listen_for_connector_result":
+        return listen.listen_for_connector_result(db_url, "call_c1")
+    if name == "listen_for_events":
+        return listen.listen_for_events(db_url, "sess_X")
+    if name == "listen_for_connector_calls_by_type":
+        return listen.listen_for_connector_calls_by_type(db_url, "telegram")
+    if name == "listen_for_management_calls":
+        return listen.listen_for_management_calls(db_url, "telegram")
+    if name == "listen_for_connection_discovery":
+        return listen.listen_for_connection_discovery(db_url, "telegram")
+    raise ValueError(f"unknown listener: {name}")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "listen_for_connector_result",
+        "listen_for_events",
+        "listen_for_connector_calls_by_type",
+        "listen_for_management_calls",
+        "listen_for_connection_discovery",
+    ],
+)
+async def test_add_listener_failure_closes_conn(name: str) -> None:
+    """conn.close() must run if add_listener raises during setup."""
+    conn = MagicMock()
+    conn.add_listener = AsyncMock(side_effect=RuntimeError("simulated network blip"))
+    conn.close = AsyncMock()
+
+    with (
+        patch("aios.db.listen.asyncpg.connect", AsyncMock(return_value=conn)),
+        pytest.raises(RuntimeError, match="simulated network blip"),
+    ):
+        async with _mk_listener(name):
+            pytest.fail("context manager should not yield when setup raises")
+
+    conn.close.assert_awaited_once()
+
+
+async def test_listen_for_events_acquire_subscriber_lock_failure_closes_conn() -> None:
+    """conn.close() must run if acquire_subscriber_lock raises after add_listener."""
+    conn = MagicMock()
+    conn.add_listener = AsyncMock()
+    conn.remove_listener = AsyncMock()
+    conn.close = AsyncMock()
+
+    with (
+        patch("aios.db.listen.asyncpg.connect", AsyncMock(return_value=conn)),
+        patch(
+            "aios.db.listen.acquire_subscriber_lock",
+            AsyncMock(side_effect=RuntimeError("lock acquisition failed")),
+        ),
+        pytest.raises(RuntimeError, match="lock acquisition failed"),
+    ):
+        async with listen.listen_for_events("postgresql://stub/aios", "sess_X"):
+            pytest.fail("context manager should not yield when setup raises")
+
+    conn.close.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Five of the six listener context managers in `src/aios/db/listen.py` allocated their dedicated asyncpg connection *outside* any guarding `try:` block: `listen_for_connector_result`, `listen_for_events`, `listen_for_connector_calls_by_type`, `listen_for_management_calls`, and `listen_for_connection_discovery`. A failure in `conn.add_listener` (or, for `listen_for_events`, in `acquire_subscriber_lock`) propagated out of the context manager with the conn still open — leaked for the worker / API process lifetime. Long-running processes slowly chewed through Postgres `max_connections` on transient network blips.
- Mirror the correct shape already present in `listen_for_session_interrupts` (same file): nest the listener-registration `try/finally` inside an outer `try/finally` whose `finally` unconditionally closes the conn. The diff looks large because it re-indents the bodies; the actual change per listener is two added lines (`try:` after `conn = ...` and `finally: await conn.close()`).
- Identical-shape duplication ships across all five sites in one PR (precedent: #426 account_id sweep, #490 _locks dict cleanup) — the fix shape is structurally identical at each site and a multi-PR split would just be churn.

## Test plan

- [x] New `test_add_listener_failure_closes_conn` — parametrized across all 5 listeners. Mocks `asyncpg.connect` to return a stub conn whose `add_listener` raises; asserts `conn.close()` was awaited.
- [x] New `test_listen_for_events_acquire_subscriber_lock_failure_closes_conn` — covers the second failure path unique to `listen_for_events`.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1324 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)