### PR TITLE
refactor(ids): drop dead AGENT_VERSION + CONNECTOR_TOKEN prefixes

### DIFF
--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -24,12 +24,10 @@ ENVIRONMENT: Final = "env"
 SESSION: Final = "sess"
 EVENT: Final = "evt"
 CREDENTIAL: Final = "cred"
-AGENT_VERSION: Final = "agver"  # reserved for phase 4
 VAULT: Final = "vlt"
 VAULT_CREDENTIAL: Final = "vcr"
 SKILL: Final = "skl"
 CONNECTION: Final = "conn"
-CONNECTOR_TOKEN: Final = "ctok"
 SESSION_TEMPLATE: Final = "stpl"
 # Connector subsystem (#328 PR 2+). The aios_connectors module uses
 # these prefixes to mint ids via ``make_id``; the PR 2 migration
@@ -58,12 +56,10 @@ _PREFIXES: Final = frozenset(
         SESSION,
         EVENT,
         CREDENTIAL,
-        AGENT_VERSION,
         VAULT,
         VAULT_CREDENTIAL,
         SKILL,
         CONNECTION,
-        CONNECTOR_TOKEN,
         SESSION_TEMPLATE,
         MEMORY_STORE,
         MEMORY,


### PR DESCRIPTION
## Summary

Two id prefix constants in `src/aios/ids.py` were defined but never minted via `make_id`:

- `AGENT_VERSION = "agver"  # reserved for phase 4` — the `agent_versions` table uses compound `(agent_id, version)` keys, not ULIDs. Phase 4 came and went without needing this prefix.
- `CONNECTOR_TOKEN = "ctok"` — superseded by `RUNTIME_TOKEN` (which IS actively used and minted). Speculative scaffolding from an earlier connector-substrate design that was never realized.

Grep across `src/`, `tests/`, and `migrations/` confirms **zero** `agver_*` / `ctok_*` literal ids and zero references to the constants outside this file. Removed from both the declarations and the `_PREFIXES` frozenset (which `make_id` and `split_id` use for validation).

Net **-4 LOC**, single file. Mirrors PR #494 / #500 / #492 — pure dead-scaffolding delete per CLAUDE.md "Don't deprecate, delete."

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1318 passed
- [x] Grep-verified: no `agver_*` / `ctok_*` literal ids, no `AGENT_VERSION` / `CONNECTOR_TOKEN` references outside `ids.py` itself
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer`: **no concerns ≥ 30**. Verified the deletion is correct-by-construction: removing constants and their `_PREFIXES` entries in the same change keeps validation consistent (no orphaned prefix accepted, no minted id rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)