### PR TITLE
refactor(sandbox/registry): drop unused SandboxRegistry.backend property

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -79,10 +79,6 @@ class SandboxRegistry:
         # client and bound TCP port.
         self._evict_proxy_stop_tasks: set[asyncio.Task[None]] = set()
 
-    @property
-    def backend(self) -> SandboxBackend:
-        return self._backend
-
     def _lock_for(self, session_id: str) -> asyncio.Lock:
         lock = self._locks.get(session_id)
         if lock is None:


### PR DESCRIPTION
## Summary

The `backend` `@property` on `SandboxRegistry` was a 3-line wrapper around `self._backend` with zero external readers — `grep -rn "registry\.backend\|sandbox_registry\.backend" src/ tests/` shows no caller reads `.backend` on any `SandboxRegistry` instance. The class uses `self._backend` directly throughout.

Per CLAUDE.md's "Don't deprecate, delete" stance, the property is removed. The `SandboxBackend` import remains needed for the constructor parameter type (line 69) and docstring references.

Net **-4 LOC**, single file. Same shape as recent dead-scaffolding deletes (PR #494, #500, #503).

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1326 passed
- [x] Grep-verified: no external `.backend` readers
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer`: **no concerns ≥ 30**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)