### PR TITLE
fix(tools/bash_memory_reconcile): skip symlinks to block worker-fs exfiltration via bash ln -s

### DIFF
--- a/src/aios/tools/bash_memory_reconcile.py
+++ b/src/aios/tools/bash_memory_reconcile.py
@@ -61,12 +61,21 @@ def _bytes_map_to_sha_map(
 def _walk_store_files(host_dir: Path) -> list[tuple[Path, str]]:
     """Return (absolute_path, store_path) for all eligible files in host_dir.
 
-    Skips directories, the .materialized marker, and any hidden temp files
+    Skips directories, the .materialized marker, any hidden temp files
     starting with ``.tmp.`` (written by the atomic_mirror helper during
-    in-flight writes).
+    in-flight writes), and any symlinks. The symlink rejection mirrors
+    PR #497's policy for ``walk_skill_dir``: bash inside the sandbox can
+    ``ln -s <worker-side-path> /mnt/memory/<store>/leak``, and the
+    subsequent host-side ``read_bytes`` would resolve the symlink
+    against the worker's filesystem — exfiltrating any worker-readable
+    file (vault key material on disk, neighbour tenants' state, /etc,
+    OAuth refresh tokens, …) into a memory store that then persists
+    the bytes to DB and renders them to the model on every wake.
     """
     results: list[tuple[Path, str]] = []
     for fpath in host_dir.rglob("*"):
+        if fpath.is_symlink():
+            continue
         if fpath.is_dir():
             continue
         name = fpath.name

--- a/tests/unit/test_bash_memory_reconcile.py
+++ b/tests/unit/test_bash_memory_reconcile.py
@@ -155,6 +155,60 @@ class TestSnapshot:
         assert result == {}
 
 
+class TestSymlinkRejection:
+    """Bash inside the sandbox can ``ln -s <worker-side-path> /mnt/memory/<store>/leak``.
+    The host_dir read happens on the WORKER side, so ``read_bytes`` on the
+    symlinked file resolves the link against the worker's filesystem — which
+    exposes any file the worker process can read (vault key material on disk,
+    other tenants' state, /etc, etc.) to a memory store that subsequently
+    persists the bytes to the DB and renders them to the model. Reject
+    symlinks at the walk site, matching #497's policy for
+    ``walk_skill_dir`` (same confused-deputy threat class)."""
+
+    def test_snapshot_skips_symlinks_to_host_files(self, tmp_path: Path) -> None:
+        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
+
+        sensitive = tmp_path / "host_secret.txt"
+        sensitive.write_text("HOST-ONLY SECRET")
+
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        (host_dir / ".materialized").touch()
+        # Bash inside the sandbox would create this symlink; the target is
+        # resolved against the worker's filesystem at read time.
+        (host_dir / "leak.txt").symlink_to(sensitive)
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
+            result = snapshot_memory_mounts(SESSION_ID)
+
+        assert (STORE_A, "/leak.txt") not in result, (
+            f"snapshot must skip symlinks; got entries for symlinked paths: "
+            f"{[k for k in result if k[1] == '/leak.txt']!r}. Pre-fix the "
+            f"file_sha would be the sha256 of the symlink target's bytes "
+            f"(HOST-ONLY SECRET) — confused-deputy exfiltration through the "
+            f"reconcile path."
+        )
+
+    def test_snapshot_skips_symlinks_to_in_tree_files(self, tmp_path: Path) -> None:
+        """Strict rejection — even an in-tree symlink is skipped. Matches the
+        #497 policy for skill files: copy the file, don't link it."""
+        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
+
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        (host_dir / ".materialized").touch()
+        (host_dir / "real.md").write_text("real content")
+        (host_dir / "alias.md").symlink_to(host_dir / "real.md")
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
+            result = snapshot_memory_mounts(SESSION_ID)
+
+        assert (STORE_A, "/real.md") in result
+        assert (STORE_A, "/alias.md") not in result
+
+
 # ── TestReconcile ─────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- `_walk_store_files` in the bash post-exec reconcile walks a memory store's host_dir with `Path.rglob("*")` and skips only directories (`fpath.is_dir()` — which itself follows symlinks). Bash inside the sandbox can `ln -s <worker-side-path> /mnt/memory/<store>/leak`, and the subsequent host-side `read_bytes` resolves the symlink against the WORKER's filesystem at line 110. Any file the worker process can read (vault key material on disk, neighbour tenants' state, /etc/passwd, OAuth refresh tokens, …) gets exfiltrated into the memory store, persisted to the DB, and rendered to the model on every wake of every session attached to that store.
- Symmetric threat to PR #497 (`walk_skill_dir`): same confused-deputy pattern, different blast direction. #497 was operator-→-registry; this one is model-→-worker-filesystem AND durable (stored in DB across sessions), making it strictly worse. Skip `fpath.is_symlink()` at the walk site, fail-closed. Authors who need to share content can copy the file.
- `Path.rglob` in 3.13 defaults to `recurse_symlinks=False`, so directory symlinks aren't traversed; this PR closes the file-symlink gap that `is_dir()` left open.

## Test plan

- [x] New `TestSymlinkRejection::test_snapshot_skips_symlinks_to_host_files` plants a worker-side `host_secret.txt` outside any sandbox mount, creates `leak.txt` symlink inside the store's host_dir pointing at it, and asserts the snapshot does NOT include `/leak.txt`. Pre-fix it fails with the snapshot containing the sha256 of `HOST-ONLY SECRET`; post-fix it passes.
- [x] New `test_snapshot_skips_symlinks_to_in_tree_files` verifies the rejection is strict even for in-tree symlinks (matching #497's policy).
- [x] Existing 17 `TestSnapshot` + `TestReconcile` tests still green — the new guard is a strict superset of the existing `is_dir()` skip and doesn't change any happy-path behavior.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1328 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)