### PR TITLE
fix(cli/sessions): send ?after= not ?after_seq= so events pagination doesn't loop

### DIFF
--- a/src/aios/cli/commands/sessions.py
+++ b/src/aios/cli/commands/sessions.py
@@ -289,7 +289,7 @@ def events(
                 envelope = client.request(
                     "GET",
                     f"/v1/sessions/{session_id}/events",
-                    params={"after_seq": after_seq, "kind": kind, "limit": limit},
+                    params={"after": after_seq, "kind": kind, "limit": limit},
                 )
         render_list(
             state.output_format,

--- a/tests/unit/cli/test_cli_sessions.py
+++ b/tests/unit/cli/test_cli_sessions.py
@@ -138,3 +138,18 @@ def test_profile_empty_session_gracefully(mocked_cli):
     result = runner.invoke(app, ["sessions", "profile", "sess_empty"])
     assert result.exit_code == 0, result.output
     assert "no steps" in result.output
+
+
+def test_events_sends_after_param_not_after_seq(mocked_cli):
+    """The server renamed the events-pagination query param to ``after``
+    so it matches the ``next_after`` response field; ``?after_seq=`` is
+    silently ignored, which makes pagination loop from seq 0. The CLI
+    must send ``after``, not the pre-rename ``after_seq``."""
+    mocked_cli.queue_response(
+        httpx.Response(200, json={"data": [], "has_more": False, "next_after": None})
+    )
+    result = runner.invoke(app, ["sessions", "events", "sess_1", "--after-seq", "42"])
+    assert result.exit_code == 0, result.output
+    assert mocked_cli.captured.path == "/v1/sessions/sess_1/events"
+    assert mocked_cli.captured.query.get("after") == ["42"]
+    assert "after_seq" not in mocked_cli.captured.query


### PR DESCRIPTION
## Summary

- The server's `GET /v1/sessions/:id/events` endpoint renamed its pagination query parameter from `after_seq` to `after` so it matches the `next_after` field in the response envelope. The router has an explicit docstring (`src/aios/api/routers/sessions.py:456-460`) documenting the rename and the silent-ignore symptom it was meant to fix client-side.
- The CLI's `aios sessions events` command at `src/aios/cli/commands/sessions.py:292` was missed during the rename: it still sends `params={"after_seq": after_seq, ...}`. The server silently ignores the unknown query param, returning a fresh page from seq 0 on every call.
- The sibling `fetch_all_events` walker at `src/aios/cli/commands/_shared.py:210` was already updated to send `"after": cursor_seq`. The single-page CLI command was the one missed callsite.

## Test plan

- [x] New `test_events_sends_after_param_not_after_seq` asserts `mocked_cli.captured.query.get("after") == ["42"]` and `"after_seq" not in mocked_cli.captured.query`. Pre-fix the captured query is `{"after_seq": ["42"], "limit": ["200"]}`; post-fix `{"after": ["42"], "limit": ["200"]}`.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1327 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)