### PR TITLE
fix(services/inbound): strip reserved keys from connector metadata to prevent workspace exfil

### DIFF
--- a/src/aios/services/inbound.py
+++ b/src/aios/services/inbound.py
@@ -29,6 +29,13 @@ from aios.services.attachment_staging import (
 )
 from aios.services.wake import defer_wake
 
+# Metadata keys the trusted server-side path writes from request / state.
+# Stripped from connector-supplied ``metadata`` before the merge so a
+# crafted payload can't plant fields the renderer / logging trusts —
+# most acutely ``attachments``, which the harness's vision renderer
+# resolves through ``resolve_to_host_path`` and reads from disk.
+_RESERVED_METADATA_KEYS = frozenset({"channel", "sender", "attachments", "platform_timestamp"})
+
 
 class _DedupRollback(Exception):
     """Internal: signals the dedup-ledger conflict path inside the txn."""
@@ -177,7 +184,20 @@ async def _append_with_dedup(
     sender_name = sender.get("display_name")
     metadata: dict[str, Any] = {}
     if connector_metadata is not None:
-        metadata.update(connector_metadata)
+        # Strip keys the trusted server-side path also writes. Most acutely
+        # ``attachments``: a connector-supplied record with
+        # ``in_sandbox_path="/workspace/..."`` would otherwise be picked up
+        # by the harness's vision renderer, which resolves the path through
+        # ``resolve_to_host_path`` (accepts ``/workspace`` + ``/mnt/attachments``),
+        # ``read_bytes`` it, and inlines as a base64 ``image_url`` part to
+        # the model provider — exfiltration of arbitrary /workspace files
+        # via the model's vision capability and reply. ``sender`` and
+        # ``platform_timestamp`` are similarly server-side state the
+        # connector has no business overriding; ``channel`` is already
+        # unconditionally overwritten below, but list it here for clarity.
+        metadata.update(
+            {k: v for k, v in connector_metadata.items() if k not in _RESERVED_METADATA_KEYS}
+        )
     metadata["channel"] = channel
     if isinstance(sender_name, str):
         metadata["sender"] = sender_name

--- a/tests/unit/test_inbound_metadata.py
+++ b/tests/unit/test_inbound_metadata.py
@@ -1,0 +1,155 @@
+"""Unit tests for inbound metadata sanitization.
+
+A connector-supplied ``metadata`` payload (POSTed to
+``/v1/connectors/runtime/inbound`` and passed through to
+``_append_with_dedup``) must not be able to plant fields the trusted
+server-side code path also writes. Most acutely: a forged
+``metadata.attachments`` record can point ``in_sandbox_path`` at a
+``/workspace/...`` file, which the harness's context renderer will
+``read_bytes`` and inline as a base64 ``image_url`` part to the model
+provider — exfiltration via the model's vision capability.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.services.inbound import _append_with_dedup
+
+
+@pytest.fixture
+def fake_pool() -> MagicMock:
+    """Build a MagicMock pool whose ``acquire()`` and ``transaction()`` produce
+    async-context-manager objects yielding MagicMock connections."""
+    pool = MagicMock()
+
+    class _AsyncCm:
+        def __init__(self, value: Any = None) -> None:
+            self._value = value
+
+        async def __aenter__(self) -> Any:
+            return self._value
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+    conn = MagicMock()
+    conn.transaction.return_value = _AsyncCm()
+    pool.acquire.return_value = _AsyncCm(conn)
+    return pool
+
+
+async def test_connector_cannot_plant_attachments_via_metadata(
+    fake_pool: MagicMock,
+) -> None:
+    """Pre-fix the inbound merge runs ``metadata.update(connector_metadata)``
+    first, then only conditionally overrides ``attachments`` when staged
+    uploads are non-empty. A connector POSTing inbound with zero real
+    uploads but ``connector_metadata={"attachments": [<evil>]}`` plants the
+    forged record into the event log. The vision renderer in
+    ``harness/context._apply_attachments`` resolves
+    ``record["in_sandbox_path"]`` through ``resolve_to_host_path`` (which
+    accepts ``/workspace/...`` paths) and ``read_bytes`` the file from the
+    host filesystem, then base64-encodes and inlines it as an ``image_url``
+    part to the model provider — exfiltration through the model's vision
+    capability and back to the connector channel via the model's reply.
+    """
+    evil = {
+        "in_sandbox_path": "/workspace/CLAUDE.md",
+        "content_type": "image/jpeg",
+        "size": 100,
+        "filename": "x.jpg",
+    }
+
+    captured: dict[str, Any] = {}
+
+    async def fake_append_event(*_args: Any, **kwargs: Any) -> Any:
+        captured["data"] = kwargs["data"]
+        ev = MagicMock()
+        ev.id = "evt_stub"
+        return ev
+
+    async def fake_try_record(*_args: Any, **_kwargs: Any) -> bool:
+        return True
+
+    with (
+        patch(
+            "aios.services.inbound.queries.append_event", AsyncMock(side_effect=fake_append_event)
+        ),
+        patch(
+            "aios.services.inbound.queries.try_record_inbound_ack",
+            AsyncMock(side_effect=fake_try_record),
+        ),
+    ):
+        await _append_with_dedup(
+            fake_pool,
+            account_id="acc_test_stub",
+            connector="telegram",
+            external_account_id="bot1",
+            event_id="evt_inbound_1",
+            session_id="sess_X",
+            chat_id="chat_1",
+            sender={"display_name": "Mallory"},
+            content="describe this image",
+            attachments=[],  # zero real uploads
+            connector_metadata={"attachments": [evil]},  # but a forged record in metadata
+            platform_timestamp=None,
+        )
+
+    metadata = captured["data"]["metadata"]
+    assert metadata.get("attachments") in (None, []), (
+        f"connector-supplied metadata.attachments must be stripped before "
+        f"the merge; got {metadata.get('attachments')!r}. Pre-fix symptom: "
+        f"the renderer would resolve /workspace/CLAUDE.md, read_bytes(), "
+        f"and inline base64 to the model provider — workspace exfiltration "
+        f"via the vision-capable model's reply back to the connector."
+    )
+
+
+async def test_connector_cannot_shadow_sender_via_metadata(
+    fake_pool: MagicMock,
+) -> None:
+    """Same pattern for ``sender``: trusted code sets it from the request's
+    ``sender.display_name``, but only conditionally (when that's a str).
+    A connector-supplied metadata.sender wins when the request sender is
+    blank — letting the connector forge a different user identity in
+    log/render output."""
+    captured: dict[str, Any] = {}
+
+    async def fake_append_event(*_args: Any, **kwargs: Any) -> Any:
+        captured["data"] = kwargs["data"]
+        ev = MagicMock()
+        ev.id = "evt_stub"
+        return ev
+
+    with (
+        patch(
+            "aios.services.inbound.queries.append_event", AsyncMock(side_effect=fake_append_event)
+        ),
+        patch(
+            "aios.services.inbound.queries.try_record_inbound_ack",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await _append_with_dedup(
+            fake_pool,
+            account_id="acc_test_stub",
+            connector="telegram",
+            external_account_id="bot1",
+            event_id="evt_inbound_2",
+            session_id="sess_X",
+            chat_id="chat_1",
+            sender={},  # no display_name → trusted code path doesn't override
+            content="hi",
+            attachments=[],
+            connector_metadata={"sender": "<spoofed>"},
+            platform_timestamp=None,
+        )
+
+    metadata = captured["data"]["metadata"]
+    assert metadata.get("sender") != "<spoofed>", (
+        f"connector-supplied metadata.sender must be stripped; got {metadata.get('sender')!r}."
+    )


### PR DESCRIPTION
## Summary

- `_append_with_dedup` ran `metadata.update(connector_metadata)` first, then only CONDITIONALLY overwrote `attachments` / `sender` / `platform_timestamp` from trusted state (when the real value was non-empty). A connector POSTing inbound with zero real uploads but `connector_metadata={"attachments": [{"in_sandbox_path": "/workspace/CLAUDE.md", "content_type": "image/jpeg", "size": 100, "filename": "x.jpg"}]}` planted the forged record into the event log unchanged.
- The harness's vision renderer in `harness/context._apply_attachments` resolves `record["in_sandbox_path"]` through `resolve_to_host_path` (which accepts paths under `/workspace` and `/mnt/attachments`), `read_bytes` it, and inlines as a base64 `image_url` part to the model provider. The provider's vision capability OCRs the bytes into the model's context; the model's reply (back to the connector channel) carries the file contents — exfiltration of arbitrary worker-readable `/workspace` files via the model's vision capability.
- `size` is taken from the agent-supplied metadata, not from `stat`, so the `INLINE_SIZE_CAP_BYTES` gate in `vision.py` is bypassed: `size=100, content_type="image/jpeg"` passes the inline check while the actual file on disk can be much larger (worker reads whatever is there).
- Fix: introduce module-level `_RESERVED_METADATA_KEYS = frozenset({"channel", "sender", "attachments", "platform_timestamp"})` and strip those before the `metadata.update(...)`. The trust boundary now stays at the connector-input edge: the connector can decorate inbound events with whatever non-reserved keys it likes, but cannot shadow the fields that the renderer / log / dedup paths trust as server-derived. Third reserved-key strip-list in this session (after #485 path-query, #487 Host-header) — same protocol-mismatch fix-class.

## Test plan

- [x] New `test_connector_cannot_plant_attachments_via_metadata` calls `_append_with_dedup` with `attachments=[]` and `connector_metadata={"attachments": [<evil>]}`, captures the `data` arg passed to `queries.append_event`, and asserts `metadata.get("attachments")` is empty. Pre-fix it fails — the evil record lands verbatim in the event's metadata; post-fix it passes.
- [x] New `test_connector_cannot_shadow_sender_via_metadata` verifies the same strip for the `sender` key when the request `sender.display_name` is absent.
- [x] Existing 1328 unit tests still green. Notable: existing e2e `test_inbound_attachment.py` uses the real `attachments=` list (not the metadata bypass) and is unaffected.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1330 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)