### PR TITLE
fix(mcp/client): don't retry call_mcp_tool on timeout to avoid duplicate side effects

### DIFF
--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -278,6 +278,17 @@ async def call_mcp_tool(
                     session.call_tool(tool_name, arguments, meta=meta),
                     timeout=_TOOL_CALL_TIMEOUT_S,
                 )
+            except TimeoutError:
+                # Don't retry on timeout: the wait_for fires while we
+                # wait for the response, but the request may already
+                # have reached the server and been processed. A retry
+                # would duplicate the side effect — e.g. ``signal_send``
+                # / ``telegram_send`` delivering the same message twice.
+                # Evict so the next caller doesn't reuse the same
+                # session; surface the error so the model can decide
+                # whether to retry.
+                _pool.evict(url, vault_id)
+                raise
             except Exception:
                 _pool.evict(url, vault_id)
                 session, _ = await _pool.get_or_connect(url, vault_id, headers)

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -487,3 +487,38 @@ class TestCallMcpToolWithPool:
         assert result == {"content": ""}
         assert s_a.initialize.await_count == 1
         assert s_b.initialize.await_count == 1
+
+    async def test_does_not_retry_call_tool_on_timeout(
+        self, restore_runtime_pool: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A timeout in ``call_tool`` may mean the request reached the server
+        and was processed; retrying would duplicate the side effect. For
+        connector-provided tools like ``signal_send``/``telegram_send``
+        that's a duplicate user-visible message. The wrapper must NOT
+        retry on ``asyncio.TimeoutError`` — evict + surface the error
+        so the model decides whether to retry."""
+        from aios.mcp import client as mcp_client
+        from aios.mcp.client import call_mcp_tool
+
+        # Shrink the timeout so the test runs fast.
+        monkeypatch.setattr(mcp_client, "_TOOL_CALL_TIMEOUT_S", 0.05)
+
+        s_a = _make_mock_session()
+
+        async def _hang(*_args: object, **_kwargs: object) -> object:
+            await asyncio.sleep(60)
+            return None
+
+        s_a.call_tool = AsyncMock(side_effect=_hang)
+
+        runtime.mcp_session_pool = McpSessionPool()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(s_a)),
+        ):
+            result = await call_mcp_tool("https://m.example/", "v", {}, "do_thing", {})
+
+        # The wrapper returns a transport-error envelope on timeout.
+        assert result.get("code") == "transport_error"
+        # And crucially, ``call_tool`` was invoked EXACTLY ONCE — no retry.
+        assert s_a.call_tool.await_count == 1


### PR DESCRIPTION
## Summary

- `call_mcp_tool` (`src/aios/mcp/client.py:269-287`) wrapped both `get_or_connect` and `call_tool` in a single `except Exception: evict + retry` block. `asyncio.wait_for` raises `TimeoutError` when the response hasn't arrived within `_TOOL_CALL_TIMEOUT_S` (120s), but the request may already have reached the server and been processed — the timeout fires while we wait for the response, not while we wait to send. Retrying re-issues the same request, so the server processes it twice.
- For connector-provided tools like `signal_send` (`connectors/signal/src/aios_signal/connector.py:292`) and `telegram_send` — neither has client-side replay dedup — that's a duplicate user-visible message every time an outbound tool call races a slow or hung server.
- Surgical fix: catch `TimeoutError` specifically, evict the pool entry (so the next caller doesn't reuse it), and surface the error to the model — which can choose whether to retry. Generic exceptions still go through the original evict-and-retry path so the existing `test_evicts_and_retries_on_call_tool_failure` contract holds for the stale-pool-entry case.

## Test plan

- [x] New `test_does_not_retry_call_tool_on_timeout` — monkey-patches `_TOOL_CALL_TIMEOUT_S=0.05`, hangs the session's `call_tool`, asserts `call_tool.await_count == 1` and the result is a `transport_error` envelope. Pre-fix: `await_count == 2`; post-fix: `await_count == 1`.
- [x] Existing `test_evicts_and_retries_on_call_tool_failure` (RuntimeError path) still passes — the surgical split preserves the stale-pool-recovery contract.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1330 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)