### PR TITLE
refactor(ids): drop dead ROUTING_RULE prefix

### DIFF
--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -39,7 +39,6 @@ SESSION_TEMPLATE: Final = "stpl"
 BINDING: Final = "bnd"
 RUNTIME: Final = "rt"
 RUNTIME_TOKEN: Final = "rtk"
-ROUTING_RULE: Final = "rule"
 MEMORY_STORE: Final = "memstore"
 MEMORY: Final = "mem"
 MEMORY_VERSION: Final = "memver"
@@ -69,7 +68,6 @@ _PREFIXES: Final = frozenset(
         BINDING,
         RUNTIME,
         RUNTIME_TOKEN,
-        ROUTING_RULE,
         MANAGEMENT_CALL,
         ACCOUNT,
         ACCOUNT_KEY,


### PR DESCRIPTION
## Summary

`ROUTING_RULE = "rule"` in `src/aios/ids.py` was defined and added to `_PREFIXES` but never used: no Python code mints `routing_rules` ids via `make_id`. The `routing_rules` DB table exists and is **read** by `aios_connectors/resolver.py` (via `queries.list_routing_rules_for_connection`), but its `id` column is `text PRIMARY KEY` with no app-side mint path — whatever rows exist are produced by migrations or external tooling, not by this Python constant.

Grep across `src/`, `tests/`, and `migrations/` confirms zero references outside the two lines being deleted. Same shape as PR #503 (`AGENT_VERSION` + `CONNECTOR_TOKEN`) — pure dead-scaffolding delete per CLAUDE.md "Don't deprecate, delete."

Net **-2 LOC**, single file.

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1329 passed
- [x] Grep-verified: no `rule_*` literal ids, no `ROUTING_RULE` references outside ids.py
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer`: **no concerns ≥ 30** on the ids.py slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)