### PR TITLE
refactor(db/pool): drop dead singleton scaffold

### DIFF
--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -31,7 +31,7 @@ from aios.api.routers import (
 )
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
-from aios.db.pool import close_pool, create_pool
+from aios.db.pool import create_pool
 from aios.errors import install_exception_handlers
 from aios.harness import runtime
 from aios.harness.procrastinate_app import app as procrastinate_app
@@ -74,7 +74,6 @@ def create_app() -> FastAPI:
             runtime.tool_provider = prev_tool_provider
             await procrastinate_app.close_async()
             await pool.close()
-            await close_pool()
 
     app = FastAPI(
         title="aios",

--- a/src/aios/db/pool.py
+++ b/src/aios/db/pool.py
@@ -1,8 +1,8 @@
-"""asyncpg connection pool singleton.
+"""asyncpg connection pool helpers.
 
-The pool is created on first call to :func:`get_pool` and lives for the
-process lifetime. Tests construct their own pools via :func:`create_pool`
-and bypass the singleton.
+The API and worker processes each construct their own pool via
+:func:`create_pool` at startup and stash it on their own state
+(``app.state.pool`` / ``runtime.pool``).  Tests do the same.
 """
 
 from __future__ import annotations
@@ -10,10 +10,6 @@ from __future__ import annotations
 from typing import Any
 
 import asyncpg
-
-from aios.config import get_settings
-
-_pool: asyncpg.Pool[Any] | None = None
 
 
 def normalize_dsn(db_url: str) -> str:
@@ -32,20 +28,3 @@ async def create_pool(db_url: str, *, min_size: int = 1, max_size: int = 16) -> 
     if pool is None:
         raise RuntimeError(f"asyncpg.create_pool returned None for {db_url}")
     return pool
-
-
-async def get_pool() -> asyncpg.Pool[Any]:
-    """Return the process-wide pool, creating it on first call."""
-    global _pool
-    if _pool is None:
-        settings = get_settings()
-        _pool = await create_pool(settings.db_url, max_size=settings.db_pool_max_size)
-    return _pool
-
-
-async def close_pool() -> None:
-    """Close the process-wide pool. Idempotent."""
-    global _pool
-    if _pool is not None:
-        await _pool.close()
-        _pool = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,13 +228,10 @@ def aios_env_minimal(
     }
     with mock.patch.dict(os.environ, env_vars):
         from aios.config import get_settings
-        from aios.db import pool
 
         get_settings.cache_clear()
-        pool._pool = None
         yield env_vars
         get_settings.cache_clear()
-        pool._pool = None
 
 
 @pytest.fixture

--- a/tests/e2e/test_memory_cross_session_sync.py
+++ b/tests/e2e/test_memory_cross_session_sync.py
@@ -73,7 +73,6 @@ async def shared_docker_harness(
     import aios.tools  # noqa: F401  — register built-in tools
     from aios.config import get_settings
     from aios.crypto.vault import CryptoBox
-    from aios.db import pool as pool_module
     from aios.db.pool import create_pool
     from aios.harness.task_registry import TaskRegistry
     from aios.sandbox.backends import make_backend
@@ -93,7 +92,6 @@ async def shared_docker_harness(
 
     with mock.patch.dict(os.environ, env_vars):
         get_settings.cache_clear()
-        pool_module._pool = None
 
         # Seed acc_test_stub once.  Cleaner than the conftest aios_env
         # path since this fixture runs at module scope: a fresh asyncpg
@@ -174,7 +172,6 @@ async def shared_docker_harness(
         await mcp_broker.stop()
         await pool.close()
         get_settings.cache_clear()
-        pool_module._pool = None
 
 
 @pytest_asyncio.fixture(autouse=True, loop_scope="module")


### PR DESCRIPTION
## Summary

`src/aios/db/pool.py` defined a process-wide singleton pattern (`_pool` global + `get_pool()` + `close_pool()`) that **nothing adopted**. Production code (API + worker) always uses `create_pool()` directly and stashes the pool on its own state (`app.state.pool` / `runtime.pool`); tests do the same.

Concretely:
- `get_pool` is never imported anywhere in `src/`, `tests/`, or `packages/`.
- `close_pool()` was called from `api/app.py`'s lifespan but is a guaranteed no-op because `_pool` is never set.
- `pool._pool = None` resets in `tests/conftest.py` and `tests/e2e/test_memory_cross_session_sync.py` were defensive cleanup for a global that was never set.

The retained `create_pool` and `normalize_dsn` helpers are the actually-used surface (40+ call sites). Module docstring rewritten — the previous one claimed a singleton pattern that didn't exist.

Net **-28 LOC** across 4 files. Same shape as recent dead-scaffolding deletes (#494, #500, #503, #504, #509).

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1332 passed
- [x] Grep-verified: no remaining `pool_module` / `get_pool` / `close_pool` / dead-`_pool` references
- [ ] CI e2e suite (this PR also touches `test_memory_cross_session_sync.py` — the e2e suite will exercise it)

## Code-review notes

`pr-review-toolkit:code-reviewer` initially flagged a sev-85 issue: I'd missed the stale `pool_module._pool = None` reference in `tests/e2e/test_memory_cross_session_sync.py` (twice). Both fixed in this PR — broken-windows policy. Verdict after fix: **no concerns ≥ 30**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)