### PR TITLE
fix(tools/edit): refuse to edit when cat read was truncated (silent file truncation)

### DIFF
--- a/src/aios/tools/edit.py
+++ b/src/aios/tools/edit.py
@@ -160,6 +160,23 @@ async def edit_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
                 "error": read_result.stderr.strip() or f"could not read {path}",
                 "path": path,
             }
+        # ``cat -- path`` stdout is capped at ``bash_max_output_bytes`` and the
+        # backend appends a literal ``[output truncated]`` marker. Treating the
+        # truncated bytes as the full file would (a) match ``old_string`` only
+        # within the prefix the model can see and (b) write the truncated bytes
+        # plus the marker text back via the heredoc — silently dropping every
+        # byte past the cap and embedding the marker into the file. Refuse the
+        # operation so the model picks a different tool (e.g. ``read`` with
+        # explicit ranges to locate and apply the edit out-of-band).
+        if read_result.truncated:
+            return {
+                "error": (
+                    f"file at {path} exceeds the {settings.bash_max_output_bytes}-byte "
+                    f"tool-output cap; edit cannot safely operate on the truncated read. "
+                    f"Use the read tool with explicit ranges to locate and apply your edit."
+                ),
+                "path": path,
+            }
         original = read_result.stdout
         precondition_sha = None
         memory_id = ""

--- a/tests/unit/test_edit_handler.py
+++ b/tests/unit/test_edit_handler.py
@@ -242,3 +242,49 @@ class TestErrorPaths:
         )
         assert "error" in result
         assert "Permission denied" in result["error"]
+
+    async def test_truncated_cat_aborts_write_back(
+        self, stub_registry: Any, stub_handle: SandboxHandle
+    ) -> None:
+        """``cat -- path`` is capped at ``bash_max_output_bytes`` (100 KiB by
+        default). For a non-memory file larger than that, the docker backend
+        sets ``CommandResult.truncated=True`` and appends the literal
+        ``"\\n\\n[output truncated]"`` marker to ``stdout``. Edit previously
+        ignored the flag, treated the truncated bytes as the full file, ran
+        ``original.replace(old, new)``, and write-back replaced the entire
+        file with the truncated content (plus the marker text) — silent
+        data loss for every model edit on any non-trivial file.
+
+        Failing pre-fix because edit accepted the truncated read and wrote
+        back; post-fix because edit now returns a typed error referencing
+        truncation, never reaching the second exec.
+        """
+        truncated_stdout = "A" * 95000 + "TARGET\n" + "rest..." + "\n\n[output truncated]"
+        truncated_result = CommandResult(
+            exit_code=0,
+            stdout=truncated_stdout,
+            stderr="",
+            timed_out=False,
+            truncated=True,
+        )
+        stub_registry.exec = _script_responses(truncated_result, _ok(""))  # type: ignore[method-assign]
+        result = await edit_handler(
+            "sess_01TEST",
+            {
+                "path": "/workspace/big.txt",
+                "old_string": "TARGET",
+                "new_string": "REPLACED",
+            },
+        )
+        assert "error" in result, (
+            f"edit must refuse to write back when the read was truncated "
+            f"(otherwise the bytes past the truncation point are silently "
+            f"lost on write); got success {result!r}."
+        )
+        assert "truncat" in result["error"].lower(), (
+            f"error must reference truncation so the model can use a "
+            f"different tool (e.g., read with explicit ranges); got "
+            f"{result['error']!r}."
+        )
+        # Critically, no write-back was attempted.
+        assert stub_registry.exec.await_count == 1  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- `edit` reads the target file via `cat -- path` through the sandbox exec backend, which caps stdout at `bash_max_output_bytes` (100 KiB by default) and appends the literal `"\n\n[output truncated]"` marker to the captured stdout. Edit previously checked only the exit code, not `CommandResult.truncated`, so for any non-memory file >100 KiB it treated the truncated bytes as the full file: the match-and-replace landed only within the visible prefix, then the base64 heredoc wrote that prefix (with the literal marker appended) back as the entire new file — silently dropping every byte past 100 KiB and embedding the `[output truncated]` text into the file as durable content.
- Two failure shapes for the model: silent data loss (bytes past the cap are gone) AND a misleading no-match error when `old_string` happens to live past the cap (model thinks the string isn't in the file, even though `read` with explicit ranges would find it).
- Per CLAUDE.md "fail hard, no fallbacks" + "model sees raw errors and retries through the session log": surface a typed error pointing at the size cap and direct the model to `read` with explicit ranges (which doesn't truncate the way `cat` does — it uses `sed -n A,Bp` on a range the model picks). The model can then locate the target and apply the edit out-of-band, or abort and tell the user. The fix is the minimal correct-by-construction guard at the input boundary; no client-side truncation handling needed.

## Test plan

- [x] New `TestErrorPaths::test_truncated_cat_aborts_write_back` builds a stub backend exec response with `truncated=True` and the literal "[output truncated]" suffix on stdout, calls `edit_handler` for a target string within the visible prefix, asserts the result contains `"error"` with "truncat" in the message, AND asserts `stub_registry.exec.await_count == 1` — proving no write-back was attempted. Pre-fix it fails: edit returns `{replaced: 1, diff: ...}` with no error and the write-back exec was queued.
- [x] Existing 11 `TestErrorPaths` / `TestStrictMatching` / `TestArguments` tests still green — the new guard is a strict superset that fires only when `truncated=True` (all existing tests use `truncated=False` via the `_ok` / `_err` helpers).
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1333 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)