### PR TITLE
refactor(ids): drop dead RUNTIME id prefix

### DIFF
--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -37,7 +37,6 @@ SESSION_TEMPLATE: Final = "stpl"
 # does that on a binding id; if one is added later, generate ULIDs
 # in the migration or relax ``split_id``.
 BINDING: Final = "bnd"
-RUNTIME: Final = "rt"
 RUNTIME_TOKEN: Final = "rtk"
 MEMORY_STORE: Final = "memstore"
 MEMORY: Final = "mem"
@@ -66,7 +65,6 @@ _PREFIXES: Final = frozenset(
         GITHUB_REPOSITORY,
         FILE,
         BINDING,
-        RUNTIME,
         RUNTIME_TOKEN,
         MANAGEMENT_CALL,
         ACCOUNT,


### PR DESCRIPTION
## Summary

`RUNTIME: Final = "rt"` in `src/aios/ids.py` was defined and added to `_PREFIXES` but never minted: no `make_id("rt")` call sites, no `rt_*` literal id references anywhere in `src/`, `tests/`, or `migrations/`.

The active `RUNTIME_TOKEN` constant (prefix `"rtk"`) is unaffected — different name, different prefix, still actively used by `make_id(RUNTIME_TOKEN)`.

Net **-2 LOC**, single file. Same shape as PR #503 (`AGENT_VERSION` + `CONNECTOR_TOKEN`) and PR #509 (`ROUTING_RULE`) — pure dead-scaffolding delete per CLAUDE.md "Don't deprecate, delete."

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1333 passed
- [x] Grep-verified: no `rt_*` literal ids, no `RUNTIME` references outside ids.py
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer`: **no concerns ≥ 30**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)