### PR TITLE
fix(tools/read): enable pipefail so cat failure doesn't silently return empty content

### DIFF
--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -106,17 +106,26 @@ async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     end = offset + limit - 1
     quoted_path = shlex.quote(path)
     sed_arg = shlex.quote(f"{offset},{end}p")
-    # cat -n numbers lines (1-indexed) with the format `   N\tCONTENT`;
-    # sed -n 'START,ENDp' slices by line number against the already-
+    # ``cat -n`` numbers lines (1-indexed) with the format ``   N\tCONTENT``;
+    # ``sed -n 'START,ENDp'`` slices by line number against the already-
     # numbered output so the visible numbers are the file's actual line
     # numbers, not relative to the slice.
+    #
+    # ``set -o pipefail`` is load-bearing: without it the pipe's exit code
+    # is ``sed``'s (0) even when ``cat`` failed (e.g., missing path), and
+    # the existing ``exit_code != 0`` branch silently returns empty content
+    # to the model. For memory targets it's worse — the empty sha line gets
+    # cached into the read-sha map and poisons the next write-tool
+    # precondition. ``bash -c`` is the sandbox exec shell so the option is
+    # supported.
     if target is None:
-        cmd = f"cat -n -- {quoted_path} | sed -n {sed_arg}"
+        cmd = f"set -o pipefail; cat -n -- {quoted_path} | sed -n {sed_arg}"
     else:
         # Memory mounts: prepend the raw-file sha (one line, 64 hex chars)
         # so the write-tool precondition can be gated against the FS state
         # the model just observed. One docker-exec round-trip total.
         cmd = (
+            f"set -o pipefail; "
             f"sha256sum -- {quoted_path} | cut -d' ' -f1 && "
             f"cat -n -- {quoted_path} | sed -n {sed_arg}"
         )

--- a/tests/unit/test_read_handler.py
+++ b/tests/unit/test_read_handler.py
@@ -143,3 +143,30 @@ class TestErrorPath:
         assert "error" in result
         assert "No such file" in result["error"]
         assert result["path"] == "/nope"
+
+    async def test_cmd_uses_pipefail_so_cat_failure_propagates(
+        self, stub_registry: Any, stub_handle: SandboxHandle
+    ) -> None:
+        """``cat -n -- path | sed -n A,Bp`` is a pipe whose final exit code is
+        ``sed``'s — which is 0 even when ``cat`` failed (e.g., path doesn't
+        exist) because ``sed`` happily consumes empty input and exits 0. Without
+        ``set -o pipefail`` the result returned to the model is
+        ``{path: ..., content: ""}`` — empty content, no error — indistinguishable
+        from reading an empty file. For memory targets it's worse: the empty
+        sha line is then cached into the read-sha map (poisoning the next
+        write's precondition).
+
+        The fix prepends ``set -o pipefail`` to the bash invocation so any
+        non-zero exit anywhere in the pipe (or in either side of the ``&&``)
+        is surfaced as the overall exit code, which the existing
+        ``result.exit_code != 0`` branch then turns into the error dict the
+        previous test expects.
+        """
+        await read_handler("sess_01TEST", {"path": "/workspace/a.txt"})
+        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        assert "pipefail" in cmd, (
+            f"cmd must enable ``pipefail`` so a failing ``cat`` (e.g., missing "
+            f"file) propagates through the ``| sed -n ...`` to the overall "
+            f"pipe exit code; without it, missing files silently return empty "
+            f"content. Got: {cmd!r}"
+        )


### PR DESCRIPTION
## Summary

- `read` builds `cat -n -- {path} | sed -n A,Bp` (and for memory targets, `sha256sum ... | cut -d' ' -f1 && cat -n ... | sed -n ...`). The pipe's final exit code is `sed`'s — which is 0 even when `cat` failed (e.g., missing path) because `sed` happily consumes empty stdin and exits 0. The existing `result.exit_code != 0` branch never fires; the model gets `{path: ..., content: ""}` — indistinguishable from reading a real empty file.
- Memory-target case is worse: `sha256sum` failure also flows through `cut -d' ' -f1` (exits 0), so the empty sha line gets cached into the per-session `read_sha` map via `runtime.set_read_sha(..., "")`. The next `write` tool call gates its precondition against that cached empty string, which doesn't match anything real on disk — so the write fails with `MemoryPreconditionFailedError: file changed` that's impossible to diagnose without tracing back through the stale sha cache. One silent failure cascades into a confusing "impossible" downstream error.
- Fix: prepend `set -o pipefail` to the bash command in both branches. The sandbox runs every exec through `bash -c` (see `backends/docker.py:150-157`) so the option is supported. With pipefail, any failing command anywhere in the pipe (or in either side of the `&&`) becomes the overall exit code, which the existing `exit_code != 0` branch converts to the error dict the model sees.

## Test plan

- [x] New `TestErrorPath::test_cmd_uses_pipefail_so_cat_failure_propagates` calls `read_handler` and inspects the constructed command via `stub_registry.exec.await_args.args[1]`, asserting it contains "pipefail". Pre-fix it fails with the bare `cat -n -- /workspace/a.txt | sed -n 1,2000p` command; post-fix it passes.
- [x] Existing `test_cat_failure_returns_error_dict` (which assumes the underlying exec already returned `exit_code=1`) still passes because the new pipefail prefix only matters at shell-execution time; mocked exec calls aren't affected.
- [x] Existing 10 `TestArguments` / `TestHappyPath` / `TestErrorPath` tests still green.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1334 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)