### PR TITLE
fix(harness/completion): raise typed error when litellm returns None for an empty chunk stream

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -374,6 +374,21 @@ async def stream_litellm(
             await _notify_delta(pool, session_id, content)
 
     assembled: Any = litellm.stream_chunk_builder(chunks=chunks)
+    # ``litellm.stream_chunk_builder(chunks=[])`` returns ``None`` rather
+    # than raising, so a provider that closes the connection without
+    # emitting any chunks (Bedrock cold start, OpenRouter mid-handshake
+    # disconnect, vLLM under load) would otherwise crash at the
+    # ``assembled.get("usage")`` below with an opaque
+    # ``AttributeError: 'NoneType' object has no attribute 'get'``.
+    # Surface a typed error so operators see the actual failure mode in
+    # ``step.litellm_failed`` logs and the retry path's reason is
+    # meaningful.
+    if assembled is None:
+        raise RuntimeError(
+            f"litellm returned an empty completion (zero chunks) for model "
+            f"{model!r}; the provider closed the connection without emitting "
+            f"any data"
+        )
     usage_obj = assembled.get("usage")
     usage = _normalize_usage(
         usage_obj.model_dump() if hasattr(usage_obj, "model_dump") else usage_obj or {}

--- a/tests/unit/test_completion_timeouts.py
+++ b/tests/unit/test_completion_timeouts.py
@@ -271,3 +271,60 @@ async def test_stream_litellm_tolerates_empty_choices_chunk(
     # isn't dropped — the guard skips notify, not collection.
     assert len(captured["chunks"]) == 2
     assert captured["chunks"][-1].choices == []  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_stream_litellm_raises_typed_error_on_zero_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the provider closes the connection without emitting any chunks
+    (Bedrock cold start, OpenRouter mid-handshake disconnect, vLLM under
+    load), ``chunks=[]`` reaches ``litellm.stream_chunk_builder`` — which
+    returns ``None`` rather than raising. The current code then calls
+    ``assembled.get("usage")`` which crashes with a generic
+    ``AttributeError: 'NoneType' object has no attribute 'get'`` — an
+    opaque Python implementation detail in operator logs that doesn't
+    name the actual failure mode.
+
+    Per CLAUDE.md ``fail hard, no fallbacks`` plus ``model sees raw
+    errors``: surface a typed, descriptive error so operators see
+    "provider returned empty stream" rather than a NoneType crash and
+    the harness retry path logs a meaningful ``step.litellm_failed``
+    reason.
+    """
+
+    class _EmptyResponse:
+        def __aiter__(self) -> _EmptyResponse:
+            return self
+
+        async def __anext__(self) -> object:
+            raise StopAsyncIteration
+
+    async def fake_acompletion(**_kwargs: object) -> _EmptyResponse:
+        return _EmptyResponse()
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    # Intentionally do NOT patch ``stream_chunk_builder`` — we want the
+    # real-world behavior where it returns ``None`` for an empty chunk list.
+    # (Verified: ``litellm.stream_chunk_builder(chunks=[])`` returns None.)
+
+    with pytest.raises(Exception) as excinfo:
+        await completion.stream_litellm(
+            model="anthropic/claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "ping"}],
+            pool=_StubPool(),  # type: ignore[arg-type]
+            session_id="sess_test",
+        )
+
+    # Pre-fix: AttributeError("'NoneType' object has no attribute 'get'").
+    # Post-fix: a typed error whose message names "empty" so it's grep-able
+    # in operator logs.
+    msg = str(excinfo.value)
+    assert "NoneType" not in msg, (
+        f"completion must surface a typed error for empty streams, not a "
+        f"NoneType implementation detail; got {type(excinfo.value).__name__}: {msg!r}"
+    )
+    assert "empty" in msg.lower() or "no chunks" in msg.lower() or "zero" in msg.lower(), (
+        f"error message must name the failure mode (empty/no-chunks/zero); "
+        f"got {type(excinfo.value).__name__}: {msg!r}"
+    )


### PR DESCRIPTION
## Summary

- `stream_litellm` collects streaming chunks into a list, then calls `litellm.stream_chunk_builder(chunks=chunks)` to assemble the final message dict. When the provider closes the connection without emitting ANY chunks (Bedrock cold start, OpenRouter mid-handshake disconnect, vLLM under load), `chunks==[]` and `stream_chunk_builder` returns `None` (verified empirically: `litellm.stream_chunk_builder(chunks=[])` prints `None` in the LiteLLM version pinned in this repo).
- The next line is `assembled.get("usage")`, which then crashes with `AttributeError: 'NoneType' object has no attribute 'get'`. The outer `except Exception` in `run_session_step` catches it, logs `step.litellm_failed`, and triggers the retry path — so no permanent damage, but every operator who looks at `step.litellm_failed` sees a Python implementation detail (NoneType traceback) instead of the actual failure mode (empty stream from provider). The retry loop then hits the same crash three more times before giving up, each producing the same useless traceback.
- Per CLAUDE.md "fail hard, no fallbacks" + "model sees raw errors and retries through the session log": this isn't adding a fallback (no fake completion, no skip-and-pretend-success), it's adding the boundary check that LiteLLM's API should provide but doesn't. Operators looking at `step.litellm_failed` reasons can now grep for "empty completion" instead of guessing from "NoneType has no attribute 'get'."

## Test plan

- [x] New `test_stream_litellm_raises_typed_error_on_zero_chunks` mocks `litellm.acompletion` to return an iterator that immediately `raise StopAsyncIteration` on first `__anext__` (the production shape of an immediate-close stream), does NOT patch `stream_chunk_builder` (so the real None-on-empty behavior fires), and asserts the raised error message names the failure mode ("empty"/"no chunks"/"zero") AND does NOT mention "NoneType". Pre-fix it fails with the exact predicted `AttributeError("'NoneType' object has no attribute 'get'")`; post-fix it passes with the typed RuntimeError naming the model and the failure shape.
- [x] Existing 5 `test_completion_timeouts` tests still green — they all patch `stream_chunk_builder` to return a valid dict, so the new `assembled is None` guard never fires for them.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1335 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)