### PR TITLE
refactor(harness/runtime): drop unused require_worker_id() wrapper

### DIFF
--- a/src/aios/harness/runtime.py
+++ b/src/aios/harness/runtime.py
@@ -111,10 +111,6 @@ def require_crypto_box() -> CryptoBox:
     return _require("crypto_box", crypto_box)
 
 
-def require_worker_id() -> str:
-    return _require("worker_id", worker_id)
-
-
 def require_sandbox_registry() -> SandboxRegistry:
     return _require("sandbox_registry", sandbox_registry)
 


### PR DESCRIPTION
## Summary

PR #484 consolidated eight `require_*` wrappers via the generic `_require[T]` helper, but `require_worker_id()` was preserved alongside the others. In practice every consumer of the `worker_id` global reads `runtime.worker_id` **directly as a plain attribute** — `worker.py:129` sets it; `worker.py:150` and the e2e conftests read it. `grep -rn "require_worker_id"` returns zero hits outside the definition.

Per CLAUDE.md's "Don't deprecate, delete" stance, the wrapper is removed. Sibling `require_pool` / `require_crypto_box` / etc. are untouched and remain actively used.

Net **-4 LOC**, single file. Same shape as PR #494 / #504 — pure dead-scaffolding delete.

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1334 passed
- [x] Grep-verified: no callers of `require_worker_id` anywhere in `src/`, `tests/`, or `packages/`
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer`: **no concerns ≥ 30**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)