### PR TITLE
refactor(harness/runtime): drop unused require_mcp_session_pool() wrapper

### DIFF
--- a/src/aios/harness/runtime.py
+++ b/src/aios/harness/runtime.py
@@ -119,10 +119,6 @@ def require_task_registry() -> TaskRegistry:
     return _require("task_registry", task_registry)
 
 
-def require_mcp_session_pool() -> McpSessionPool:
-    return _require("mcp_session_pool", mcp_session_pool)
-
-
 def require_mcp_broker() -> McpBroker:
     return _require("mcp_broker", mcp_broker)
 


### PR DESCRIPTION
## Summary

Same shape as PR #515 (`require_worker_id`). PR #484 consolidated eight `require_*` wrappers via `_require[T]`, but `require_mcp_session_pool()` has **zero callers**. Consumers read `runtime.mcp_session_pool` directly:

- `mcp/client.py:190, 272` read the global directly
- `harness/worker.py:132` writes the global directly
- `tests/unit/test_mcp_pool.py` (5 sites) read/write directly

`grep -rn "require_mcp_session_pool"` returns zero hits outside the definition. `McpSessionPool` import remains needed for the module-level `mcp_session_pool: McpSessionPool | None = None` global.

Net **-4 LOC**, single file.

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1335 passed
- [x] Grep-verified: no callers anywhere
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer`: **no concerns ≥ 30**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)