### PR TITLE
fix(services/attachment_staging): concurrent same-event_id staging deletes winner's file

### DIFF
--- a/src/aios/services/attachment_staging.py
+++ b/src/aios/services/attachment_staging.py
@@ -109,12 +109,18 @@ async def stage_inbound_attachments(
                 # re-reading the stream.
                 size = target.stat().st_size
             else:
-                # Register the destination path with the cleanup list
-                # *before* we touch the disk so a partial write
-                # (e.g. mid-stream cancellation) is still reachable for
-                # the compensating unlink.
-                newly_staged_paths.append(target)
+                # Register the destination AFTER ``_stream_to_disk``
+                # successfully renames our ``.part`` into place. If we
+                # registered before and ``_stream_to_disk`` raised mid-
+                # stream, the caller's cleanup would unlink ``target`` —
+                # but in the concurrent-same-event_id race (webhook
+                # retries) ``target`` may have just been atomically
+                # renamed into place by the winning invocation, so
+                # unlinking would DELETE the winner's bytes the renderer
+                # later expects. Post-rename is the only point where
+                # this invocation truly owns ``target``.
                 size = await _stream_to_disk(attachment.stream, target)
+                newly_staged_paths.append(target)
 
             staged_records.append(
                 {
@@ -155,9 +161,15 @@ async def _stream_to_disk(stream: UploadStream, target: Path) -> int:
         os.rename(temp_path, target)
     except BaseException:
         # BaseException so partial state is cleaned up under task cancellation.
-        # ASYNC240: tmpfs unlinks are sub-microsecond; threading them
-        # would cost more than the syscall.
+        # Only unlink ``temp_path`` — never ``target``. The ``target`` slot may
+        # have been atomically renamed into by a concurrent invocation
+        # (webhook retry with same event_id) that won the race past our
+        # ``target.exists()`` check; unlinking it would delete the winner's
+        # bytes the renderer later expects via the ``staged_records``
+        # ``in_sandbox_path``. Cleanup of ``target`` for the failure path
+        # in which THIS invocation owned it (rename succeeded, caller
+        # raised later) is the caller's job via ``newly_staged_paths``.
+        # tmpfs unlink is sub-microsecond; not worth threading.
         temp_path.unlink(missing_ok=True)
-        target.unlink(missing_ok=True)  # noqa: ASYNC240
         raise
     return size

--- a/tests/unit/test_attachment_staging.py
+++ b/tests/unit/test_attachment_staging.py
@@ -220,3 +220,87 @@ class TestStaging:
         sess_dir = temp_workspace_root / "_attachments" / "sess-1" / "echo"
         if sess_dir.exists():
             assert list(sess_dir.iterdir()) == []
+
+    async def test_concurrent_same_event_id_keeps_winners_file_on_disk(
+        self, temp_workspace_root: Path
+    ) -> None:
+        """Webhook retries (Telegram resend on 5xx, Signal at-least-once)
+        can deliver the same inbound twice concurrently. Both calls pass
+        ``target.exists()`` before either ``os.rename`` lands, both write
+        to the SAME ``.part`` sibling, one wins the rename, the other's
+        rename raises ``FileNotFoundError``. The loser's
+        ``except BaseException`` then unconditionally ran
+        ``target.unlink(missing_ok=True)`` — DELETING the winner's
+        freshly-renamed file. The winner's invocation returned a
+        ``staged_records`` entry pointing at the now-missing path; the
+        renderer would later fail to open it (or worse, the GC sweep
+        would race with the actual write).
+
+        To reproduce the race in a single asyncio event loop the stream
+        ``read`` is wrapped with an ``asyncio.sleep(0)`` yield so the
+        scheduler can interleave the two invocations between
+        ``target.exists()`` and ``os.rename`` — the same shape real
+        ``UploadFile`` streams produce when reading from a real socket.
+
+        Fix: don't unlink ``target`` in the loser's cleanup path —
+        nothing this invocation owns lives at ``target``.
+        """
+        import asyncio
+
+        class _SlowStream:
+            """Yield to the event loop after every chunk so two
+            concurrent ``stage_inbound_attachments`` calls actually
+            interleave between ``target.exists()`` and ``os.rename``."""
+
+            def __init__(self, payload: bytes) -> None:
+                self._payload = payload
+                self._pos = 0
+
+            async def read(self, size: int = -1) -> bytes:
+                await asyncio.sleep(0)
+                if self._pos >= len(self._payload):
+                    return b""
+                chunk = (
+                    self._payload[self._pos :]
+                    if size < 0
+                    else self._payload[self._pos : self._pos + size]
+                )
+                self._pos += len(chunk)
+                return chunk
+
+        a = InboundAttachment(
+            stream=_SlowStream(b"A" * 100), filename="img.jpg", content_type="image/jpeg"
+        )  # type: ignore[arg-type]
+        b = InboundAttachment(
+            stream=_SlowStream(b"B" * 100), filename="img.jpg", content_type="image/jpeg"
+        )  # type: ignore[arg-type]
+
+        results = await asyncio.gather(
+            stage_inbound_attachments(
+                session_id="sess-1",
+                connector_name="echo",
+                event_id="evt-1",
+                attachments=[a],
+            ),
+            stage_inbound_attachments(
+                session_id="sess-1",
+                connector_name="echo",
+                event_id="evt-1",
+                attachments=[b],
+            ),
+            return_exceptions=True,
+        )
+
+        # At least one invocation should have succeeded (the rename winner).
+        successes = [r for r in results if not isinstance(r, BaseException)]
+        assert len(successes) >= 1, f"at least one stage must succeed; got {results!r}"
+
+        target = temp_workspace_root / "_attachments" / "sess-1" / "echo" / "evt-1-img.jpg"
+        assert target.exists(), (
+            f"the rename winner's file must survive — pre-fix the loser's "
+            f"``except BaseException`` cleanup unlinked target, deleting the "
+            f"file the winner returned a ``staged_records`` reference to. "
+            f"Subsequent renderer reads (or attachment_gc orphan-sweep races) "
+            f"would then fail. Directory contents: "
+            f"{list((temp_workspace_root / '_attachments' / 'sess-1' / 'echo').iterdir()) if (temp_workspace_root / '_attachments' / 'sess-1' / 'echo').exists() else 'dir missing'}"
+        )


### PR DESCRIPTION
## Summary

- Webhook retries (Telegram resend on 5xx, Signal SDK at-least-once) can deliver the same inbound twice concurrently — same `session_id` + `connector` + `event_id` + `filename` → same `target` path. Both invocations pass the `target.exists()` check before either `os.rename` lands; both write to the SAME `.part` sibling; one wins the rename, the other's `os.rename(temp_path, target)` raises `FileNotFoundError` because the winner already moved the inode away.
- The loser's `except BaseException` in `_stream_to_disk` then unconditionally ran `target.unlink(missing_ok=True)` — DELETING the winner's freshly-renamed file. The winner had already returned a `staged_records` entry with an `in_sandbox_path` pointing at that path; the renderer would later open it, find nothing, and fall back to a text marker (silent attachment loss). Worse, on the inbound caller side, `newly_staged_paths.append(target)` was registered BEFORE `_stream_to_disk` returned, so the post-exception `except Exception` cleanup at the caller layer would ALSO unlink target — a second clobber pass for invocations that escape via `Exception` instead of `BaseException`.
- Fix two scope errors in the cleanup logic:
  1. `_stream_to_disk`: only unlink `temp_path` (always owned by this invocation), never `target` (uncertain ownership under concurrency; may be a peer's freshly-renamed inode).
  2. `stage_inbound_attachments`: move `newly_staged_paths.append(target)` to AFTER `_stream_to_disk` returns successfully, so the caller's rollback loop only touches files this invocation actually owns (post-rename). Pre-rename failures leave `newly_staged_paths` empty — the caller's cleanup is a no-op, the peer's file stays.

## Test plan

- [x] New `test_concurrent_same_event_id_keeps_winners_file_on_disk` uses a slow `_SlowStream` that yields to the event loop on each `read` (matching real `UploadFile` semantics over a socket), so two `asyncio.gather`'d `stage_inbound_attachments` calls actually interleave between `target.exists()` and `os.rename`. At least one call must succeed; the winner's `target` must remain on disk. Pre-fix the directory is empty (both files unlinked by the loser's cleanup); post-fix the winner's file survives.
- [x] Existing 13 `TestStaging` / `TestSafeFilename` tests still green — they cover non-racing paths where the cleanup-of-target behavior was incidentally never exercised.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1336 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)