### PR TITLE
fix(tools/write): refresh read_sha cache after memory write so consecutive writes don't false-fail precondition

### DIFF
--- a/src/aios/tools/write.py
+++ b/src/aios/tools/write.py
@@ -29,6 +29,7 @@ On failure, returns ``{"error": "...", "path": path}``.
 from __future__ import annotations
 
 import base64
+import hashlib
 import shlex
 from typing import Any
 
@@ -157,6 +158,18 @@ async def write_handler(session_id: str, arguments: dict[str, Any]) -> dict[str,
             }
         except MemoryStoreArchivedError as exc:
             return {"error": exc.message, "path": path}
+
+        # Refresh the read-sha cache so a subsequent write tool call against
+        # this same path doesn't fail its precondition with the now-stale
+        # pre-write sha. Mirrors ``edit.py``'s post-update refresh; without
+        # this the model gets a misleading "file changed since your last
+        # read" error on its OWN second write.
+        runtime.set_read_sha(
+            session_id,
+            target.store_id,
+            target.store_path,
+            hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        )
 
     content_bytes = content.encode("utf-8")
     b64 = base64.b64encode(content_bytes).decode("ascii")

--- a/tests/unit/test_write_handler.py
+++ b/tests/unit/test_write_handler.py
@@ -157,3 +157,100 @@ class TestErrorPath:
         assert "error" in result
         assert "Permission denied" in result["error"]
         assert result["path"] == "/readonly/a.txt"
+
+
+class TestMemoryReadShaCacheRefresh:
+    """A successful write to a memory-mount target must refresh the per-
+    session ``read_sha`` cache so a subsequent write doesn't fail its
+    precondition check with the now-stale pre-write sha.
+
+    Edit already does this (`tools/edit.py` after `update_memory` /
+    `create_memory`); write skipped it. Without the refresh, a model that
+    writes the same memory file twice in a row sees its second write
+    fail with "the file at X changed since your last read; re-read it
+    and retry the write" — but nothing changed externally, the model
+    wrote both times itself. The error message is also misleading,
+    blaming an external change when the cache is the actual source of
+    the staleness.
+    """
+
+    @pytest.fixture
+    def memory_session(self, stub_registry: Any) -> Any:
+        """Attach a memory mount and seed the read_sha cache as if the
+        session had read the file once before."""
+        import hashlib
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from aios.models.memory_stores import MemoryStoreResourceEcho
+        from aios.services import memory_stores as memory_service
+
+        SESSION = "sess_01TEST"
+        STORE = "memstore_01STORE0000000000000000001"
+        PATH = "/notes/x.md"
+        MOUNT = "/mnt/memory/notes"
+
+        runtime.set_session_memory_mounts(
+            SESSION,
+            [
+                MemoryStoreResourceEcho(
+                    memory_store_id=STORE,
+                    access="read_write",
+                    instructions="",
+                    name="notes",
+                    description="",
+                    mount_path=MOUNT,
+                )
+            ],
+        )
+
+        seed_content = "first body\n"
+        seed_sha = hashlib.sha256(seed_content.encode("utf-8")).hexdigest()
+        runtime.set_read_sha(SESSION, STORE, PATH, seed_sha)
+
+        existing = MagicMock()
+        existing.id = "mem_01EXISTING000000000000000001"
+        existing.content_sha256 = seed_sha
+        existing.content = seed_content
+
+        with (
+            patch.object(
+                memory_service,
+                "get_memory_by_path",
+                AsyncMock(return_value=existing),
+            ),
+            patch.object(
+                memory_service,
+                "update_memory",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            yield SESSION, STORE, PATH, MOUNT
+
+        runtime.clear_session_memory_mounts(SESSION)
+        runtime.clear_session_read_shas(SESSION)
+
+    async def test_write_refreshes_read_sha_to_new_content(
+        self, memory_session: tuple[str, str, str, str]
+    ) -> None:
+        import hashlib
+
+        session, store, store_path, mount_path = memory_session
+        new_content = "second body — completely different\n"
+
+        result = await write_handler(
+            session,
+            {"path": f"{mount_path}{store_path}", "content": new_content},
+        )
+        assert "error" not in result, result
+
+        expected_sha = hashlib.sha256(new_content.encode("utf-8")).hexdigest()
+        actual_sha = runtime.get_read_sha(session, store, store_path)
+        assert actual_sha == expected_sha, (
+            f"write must refresh read_sha to the new content's sha so a "
+            f"subsequent write doesn't false-fail its precondition; got "
+            f"cached sha {actual_sha!r}, expected {expected_sha!r}. Pre-fix "
+            f"the cache still holds the pre-write sha, so the next "
+            f"`update_memory(precondition_sha256=stale_sha)` would raise "
+            f"MemoryPreconditionFailedError and the handler would return "
+            f"the misleading 'file changed since your last read' error."
+        )


### PR DESCRIPTION
## Summary

- A successful `create_memory` or `update_memory` from `write_handler` left the per-session `runtime.read_sha` cache holding the PRE-write content's sha. The next write from the same session against the same memory path would then read that stale sha as its `precondition_sha256`, and the DB-side check at `insert_memory_with_version` would fire `MemoryPreconditionFailedError` because the stored content sha is now the freshly-written value. The handler converts this to "the file at X changed since your last read; re-read it and retry the write" — but nothing changed externally, the model wrote both times itself. The model burns a tool round-trip re-reading its own work just to refresh the cache, and the operator log carries a "phantom-race" entry that doesn't correspond to any real concurrent write.
- Two-tool symmetry violation: `tools/edit.py` already refreshes `read_sha` after its `update_memory` (with the comment "so a subsequent write tool call against this same path doesn't fail its precondition with the now-stale pre-edit sha") and has e2e coverage for the edit→write sequence. Write just forgot the symmetric refresh. Adding it mirrors edit's exact post-update sha computation.

## Test plan

- [x] New `TestMemoryReadShaCacheRefresh::test_write_refreshes_read_sha_to_new_content` attaches a memory mount, seeds `read_sha` to the pre-write content's sha, patches `get_memory_by_path` to return an existing record and `update_memory` as a no-op, calls `write_handler`, and asserts `runtime.get_read_sha(...)` now returns the sha of the new content. Pre-fix the cache holds the stale seed sha; post-fix it holds the fresh sha and a subsequent write would pass its precondition check without bouncing through the user.
- [x] Existing 10 `TestArguments`/`TestHappyPath`/`TestErrorPath` tests still green (they all use non-memory paths and don't touch the read_sha cache).
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1337 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)