### PR TITLE
fix(services/skills): reject absolute / .. path keys in skill upload to block worker-host write escape

### DIFF
--- a/src/aios/services/skills.py
+++ b/src/aios/services/skills.py
@@ -125,6 +125,34 @@ def _extract_skill_metadata(
             detail={"path": skill_md_path},
         )
 
+    # Reject absolute paths and ``..`` traversal at the upload boundary.
+    # ``provision_skill_files`` later does
+    # ``Path(<workspace>/sess/skills/<dir>) / key``; Python's ``Path``
+    # operator ``/`` discards the left operand for absolute right sides
+    # (so ``/etc/aios_pwned`` → writes to ``/etc/aios_pwned`` directly)
+    # and the OS resolves ``..`` segments at ``open(2)`` time (so a key
+    # like ``../../../etc/aios_pwned`` escapes the per-session skills
+    # subtree). Either path lets an authenticated ``POST /v1/skills``
+    # caller write attacker-controlled bytes to attacker-chosen worker-
+    # host paths — sandbox escape via the management plane. Same threat
+    # class as PR #497 / #505 (symlink follow), different mechanism.
+    for path in files:
+        if path.startswith("/"):
+            raise ValidationError(
+                f"skill file keys must be relative; got absolute path {path!r}",
+                detail={"path": path},
+            )
+        if ".." in path.split("/"):
+            raise ValidationError(
+                f"skill file keys must not contain '..' traversal segments; got {path!r}",
+                detail={"path": path},
+            )
+    if directory == ".." or directory == "" or "\x00" in directory:
+        raise ValidationError(
+            f"skill directory must be a single safe path segment; got {directory!r}",
+            detail={"directory": directory},
+        )
+
     name, description = parse_skill_md(files[skill_md_path])
 
     normalized: dict[str, str] = {}

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -209,6 +209,40 @@ class TestExtractSkillMetadata:
                 }
             )
 
+    def test_rejects_path_traversal_key(self) -> None:
+        """A skill upload with a key containing ``..`` segments would,
+        when ``provision_skill_files`` does
+        ``Path(<workspace>/skills/<dir>) / key``, resolve to a host-side
+        path outside the workspace at ``write_text`` time (the OS
+        normalizes ``..`` in ``open(2)``). Worker writes attacker-chosen
+        bytes to attacker-chosen worker-host paths — sandbox escape via
+        the management plane.
+
+        Reject at the server boundary. Same threat-class as #497 / #505
+        (symlink-follow exfiltration) but for the path-construction-side
+        of the symlink-vs-traversal duality.
+        """
+        files = {
+            "my-skill/SKILL.md": "---\nname: my-skill\ndescription: x\n---\n",
+            "../../../etc/aios_pwned": "EVIL",
+        }
+        with pytest.raises(ValidationError, match=r"\.\.|traversal|escape|relative"):
+            _extract_skill_metadata(files)
+
+    def test_rejects_absolute_path_key(self) -> None:
+        """An absolute-path key (``/etc/aios_rooted``) is even worse:
+        Python's ``Path("/a/b") / "/c"`` discards the left operand
+        entirely and returns ``Path("/c")``. ``write_text`` then writes
+        directly to the absolute path with worker-process privileges.
+        Reject at the boundary.
+        """
+        files = {
+            "my-skill/SKILL.md": "---\nname: my-skill\ndescription: x\n---\n",
+            "/etc/aios_rooted": "EVIL",
+        }
+        with pytest.raises(ValidationError, match=r"absolute|relative|escape"):
+            _extract_skill_metadata(files)
+
 
 # ── TestSkillModels ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `POST /v1/skills` accepts a JSON `files: dict[str, str]` payload that flows through `_extract_skill_metadata` → DB row → `provision_skill_files`, which writes each `(key, value)` to disk on the WORKER host (not inside the sandbox container) via `Path(<workspace>/<sess>/skills/<dir>) / key).write_text(content)`.
- Two Python `pathlib` footguns compose into sandbox escape via the management plane:
  - `Path("/a/b") / "/c/d"` returns `Path("/c/d")` — absolute right side discards the left operand entirely. A key like `/etc/aios_pwned` writes directly to `/etc/aios_pwned`.
  - `Path("/a/b") / "../../x"` returns `Path("/a/b/../../x")`; `write_text` calls `open(2)` which resolves `..` segments at kernel level. A key like `../../../etc/aios_pwned` escapes the per-session skills subtree.
- The CLI's `walk_skill_dir` was fixed for symlinks in #497 (and `bash_memory_reconcile` for the same reason in #505), but the server boundary was the last untrusted-input layer before `write_text` and accepted these traversal/absolute keys unconditionally — anyone who can authenticate to `POST /v1/skills` (authenticated, but per-account in a multi-tenant deployment) can write attacker-controlled bytes to attacker-chosen worker-host paths with worker-process privileges.
- Same threat class as #497 / #505 (operator/model → host fs), but the entry point is the management API rather than the runtime container, so the existing symlink rejection doesn't catch it. Fix at the boundary in `_extract_skill_metadata`: reject keys that `startswith("/")` (absolute), contain `..` as a path segment (traversal), AND reject a derived `directory` that is itself `..` / empty / contains NUL.

## Test plan

- [x] New `TestExtractSkillMetadata::test_rejects_path_traversal_key` asserts `ValidationError` for a payload containing `"../../../etc/aios_pwned": "EVIL"` alongside the valid SKILL.md. Pre-fix it fails with `DID NOT RAISE`; post-fix it passes.
- [x] New `test_rejects_absolute_path_key` asserts the same for `"/etc/aios_rooted": "EVIL"`. Pre-fix fails; post-fix passes.
- [x] Existing 34 `TestParseSkillMd` / `TestValidateSkillName` / `TestExtractSkillMetadata` / `TestBuildSkillsSystemBlock` etc. tests still green — the new validation rejects strictly more inputs than before, and no existing test uses a payload with `..` or absolute paths.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1339 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)