### PR TITLE
fix(harness/vision): strip RFC-7231 content-type parameters from data URI

### DIFF
--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -94,11 +94,21 @@ def make_image_url_part(*, content_type: str, data_b64: str) -> dict[str, Any]:
     occasionally lie, and Anthropic rejects mime-vs-magic mismatches.
     Centralising the sniff here means every caller is covered without
     having to remember to wire correction at the call site.
+
+    Also strips RFC-7231 parameters (anything after ``;``) from the mime
+    before building the data URI. A connector posting an attachment with
+    ``Content-Type: image/webp; charset=utf-8`` would otherwise produce
+    ``data:image/webp; charset=utf-8;base64,...``, which Anthropic and
+    most providers reject as malformed — bricking every wake of any
+    session whose context now includes that part. ``correct_image_mime_b64``
+    only rewrites for PNG/JPEG/GIF magic, so WEBP/SVG/HEIC/AVIF/BMP
+    declared values flow through unchanged unless stripped here.
     """
     content_type = correct_image_mime_b64(content_type, data_b64)
+    bare_mime = content_type.split(";", 1)[0].strip()
     return {
         "type": "image_url",
-        "image_url": {"url": f"data:{content_type};base64,{data_b64}"},
+        "image_url": {"url": f"data:{bare_mime};base64,{data_b64}"},
     }
 
 

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -140,6 +140,53 @@ class TestMakeImageUrlPart:
         part = vision.make_image_url_part(content_type="image/png", data_b64="ZmFrZQ==")
         assert part["image_url"]["url"].startswith("data:image/png;base64,")
 
+    def test_strips_content_type_parameters_from_data_uri(self) -> None:
+        """RFC-7231 content-types can carry parameters
+        (``image/jpeg; charset=utf-8``, ``image/webp ; foo=bar``). When a
+        connector POSTs an inbound attachment whose multipart
+        ``Content-Type`` header includes parameters, the staging layer
+        persists the value verbatim into ``metadata.attachments[i]
+        .content_type``. The renderer then calls ``make_image_url_part``
+        which only sniff-corrects for PNG/JPEG/GIF magic bytes — for
+        WEBP/SVG/HEIC/AVIF/BMP (and ANY other non-sniffable image type)
+        the declared value flows through unchanged into
+        ``data:image/webp; charset=utf-8;base64,...``.
+
+        Anthropic's ``/v1/messages`` and most other providers reject
+        non-canonical image mimes — the inference call 400s on every
+        wake of any session whose context includes such a part. Since
+        the renderer's monotonicity invariant means the part stays in
+        context once added, this bricks the session indefinitely.
+
+        Fix: strip the parameter portion in ``make_image_url_part``
+        (after sniff correction). Cheapest correct-by-construction
+        guard at the renderer boundary.
+        """
+        part = vision.make_image_url_part(
+            content_type="image/webp; charset=utf-8",
+            data_b64="UklGRg==",
+        )
+        url = part["image_url"]["url"]
+        assert url == "data:image/webp;base64,UklGRg==", (
+            f"data URI must carry only the bare mime (no RFC-7231 parameters); "
+            f"got {url!r}. Pre-fix the renderer would build "
+            f"``data:image/webp; charset=utf-8;base64,...`` which Anthropic "
+            f"and most other providers reject, bricking the session on every "
+            f"wake."
+        )
+
+    def test_strips_content_type_parameters_with_whitespace(self) -> None:
+        """Defensive: providers can send ``image/jpeg ; foo=bar`` with
+        a space before the semicolon. The strip must trim the surrounding
+        whitespace too."""
+        # Use bytes that don't match any sniffer table entry so the
+        # declared value survives through correct_image_mime_b64.
+        part = vision.make_image_url_part(
+            content_type="image/heic ; profile=main",
+            data_b64="ZmFrZQ==",
+        )
+        assert part["image_url"]["url"] == "data:image/heic;base64,ZmFrZQ=="
+
 
 class TestTextMarker:
     def test_image_with_path(self) -> None:


### PR DESCRIPTION
## Summary

- A connector that POSTs an inbound attachment whose multipart `Content-Type` header carries RFC-7231 parameters (`image/webp; charset=utf-8`, `image/heic ; profile=main`) gets that exact string persisted to `metadata.attachments[i].content_type` by `attachment_staging` without normalization. `harness/context._apply_attachments` then calls `make_image_url_part(content_type=..., data_b64=...)`, which delegates to `correct_image_mime_b64` (only sniff-corrects for PNG/JPEG/GIF — WEBP/SVG/HEIC/AVIF/BMP fall through declared unchanged) and builds `data:image/webp; charset=utf-8;base64,...`. Anthropic's `/v1/messages` and most providers reject this as a malformed data URI per RFC 2397 (which doesn't permit parameter portions in the mime slot) → 400 on inference.
- Combined with the monotonic-context invariant (`harness/context`), once this part lands in a session's context every subsequent wake re-renders the same malformed URI and re-fails inference. Session is bricked at the LiteLLM boundary indefinitely — recoverable only by deleting the event or manually editing the persisted attachment record.
- Fix: in `make_image_url_part`, after `correct_image_mime_b64`, split on `;` and strip surrounding whitespace before building the data URI. The renderer's output is now always a bare canonical mime regardless of what the connector / upload layer sent. Mirrors the "boundary-check the dependency contract" pattern of PR #514 (typed-error on litellm None) and PR #511 (refuse-edit on truncated read).

## Test plan

- [x] New `test_strips_content_type_parameters_from_data_uri` asserts `make_image_url_part(content_type="image/webp; charset=utf-8", ...)` returns `url == "data:image/webp;base64,..."`. Pre-fix the URL carries the `; charset=utf-8` mid-section; post-fix it's bare.
- [x] New `test_strips_content_type_parameters_with_whitespace` verifies `image/heic ; profile=main` (space-before-semicolon form some providers emit) also strips clean.
- [x] Existing 17 `TestSupportsVision` / `TestCanInlineImage` / `TestMakeImageUrlPart` / `TestTextMarker` tests still green — the new strip is a no-op on bare mimes (the test fixtures all use canonical mime strings).
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1341 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)