### PR TITLE
fix(services/inbound): refuse to route inbound for archived connection

### DIFF
--- a/src/aios/services/inbound.py
+++ b/src/aios/services/inbound.py
@@ -93,6 +93,21 @@ async def handle_inbound(
     async with pool.acquire() as conn:
         connection = await queries.get_connection(conn, connection_id, account_id=account_id)
 
+    # Refuse to route inbounds for archived connections. ``get_connection``
+    # doesn't filter ``archived_at IS NULL`` (other callers — listing,
+    # archive itself, audit views — legitimately need archived rows), and
+    # ``archive_connection`` doesn't cascade-delete the per-chat
+    # ``chat_sessions`` ledger rows, so the resolver's tier-1
+    # ``lookup_chat_session`` would short-circuit on the stale ledger entry
+    # and land the message in the session the operator believes is
+    # decommissioned. Surface ``DETACHED`` so the router returns the same
+    # 422 it would for any other "no live routing target" case — connector
+    # containers cache state and the NOTIFY-on-removal is best-effort, so
+    # post-archive inbounds during the propagation window are routine
+    # rather than exceptional.
+    if connection.archived_at is not None:
+        return InboundResult(None, None, InboundDrop.DETACHED, False)
+
     # Session resolution: three-tier resolver in the connector subsystem
     # (chat_sessions → routing_rules → bindings.mode). Imported inside the
     # function so the core service module stays import-clean against the

--- a/tests/unit/test_inbound_metadata.py
+++ b/tests/unit/test_inbound_metadata.py
@@ -153,3 +153,82 @@ async def test_connector_cannot_shadow_sender_via_metadata(
     assert metadata.get("sender") != "<spoofed>", (
         f"connector-supplied metadata.sender must be stripped; got {metadata.get('sender')!r}."
     )
+
+
+async def test_archived_connection_drops_inbound_without_routing(
+    fake_pool: MagicMock,
+) -> None:
+    """An inbound delivered for a connection whose ``archived_at`` is set
+    must NOT be routed into any session, even when a stale
+    ``chat_sessions`` ledger row still exists from before the archive.
+
+    Background: ``queries.get_connection`` does NOT filter
+    ``archived_at IS NULL`` and ``archive_connection`` doesn't cascade-
+    delete the per-chat ``chat_sessions`` ledger rows. The three-tier
+    resolver's tier-1 ``lookup_chat_session`` short-circuits on the
+    stale ledger row and returns the pre-archive session id, so a
+    misbehaving (or merely retrying) connector container that posts
+    after archive lands its messages in a session the operator believes
+    is decommissioned. Pre-fix ``handle_inbound`` happily proceeds with
+    the archived connection's metadata; post-fix it returns
+    ``drop_reason=DETACHED`` before touching the resolver.
+
+    Reachability: high — runtime connector containers cache state, the
+    connection_discovery_stream removal NOTIFY is at-most-once, and
+    network blips cause retry of inbounds queued just before archive.
+    """
+    from datetime import UTC, datetime
+    from unittest.mock import patch
+
+    from aios.models.connections import Connection
+    from aios.services.inbound import InboundDrop, handle_inbound
+
+    archived = Connection(
+        id="conn_01ARCHIVED000000000000000001",
+        connector="telegram",
+        external_account_id="bot1",
+        session_id=None,
+        session_template_id=None,
+        metadata={},
+        secrets_set=False,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        attached_at=None,
+        updated_at=datetime(2026, 1, 2, tzinfo=UTC),
+        archived_at=datetime(2026, 1, 3, tzinfo=UTC),  # ← archived
+    )
+
+    async def fake_get_connection(*_args: Any, **_kwargs: Any) -> Connection:
+        return archived
+
+    resolver_called = False
+
+    async def fake_resolver(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal resolver_called
+        resolver_called = True
+        raise AssertionError("resolver should not be invoked for archived connection")
+
+    with (
+        patch(
+            "aios.services.inbound.queries.get_connection",
+            AsyncMock(side_effect=fake_get_connection),
+        ),
+        patch("aios_connectors.resolver.resolve_target_session", fake_resolver),
+    ):
+        result = await handle_inbound(
+            fake_pool,
+            account_id="acc_test_stub",
+            connection_id=archived.id,
+            event_id="evt_should_drop",
+            chat_id="chat_1",
+            sender={},
+            content="hello",
+        )
+
+    assert result.drop_reason == InboundDrop.DETACHED, (
+        f"archived connection must short-circuit with a drop reason instead of "
+        f"flowing through the resolver to a stale ``chat_sessions`` row; got "
+        f"{result!r}. Pre-fix the resolver is invoked and would land the "
+        f"message in the pre-archive per_chat session — operator believes the "
+        f"connection is decommissioned but messages keep flowing."
+    )
+    assert not resolver_called, "resolver must be skipped entirely for archived connections"


### PR DESCRIPTION
## Summary

- `handle_inbound` calls `queries.get_connection` then hands the result to `resolve_target_session`. `get_connection` doesn't filter `archived_at IS NULL` (other callers — listing, archive itself, audit views — legitimately need archived rows), and `archive_connection` doesn't cascade-delete `chat_sessions` ledger rows (migration `0033_subsystem_tables.py` uses `ON DELETE NO ACTION`, and the migration in `0027` explicitly notes that `ON DELETE CASCADE` wouldn't fire for soft-archive anyway). The resolver's tier-1 `lookup_chat_session` then short-circuits on the stale ledger row and returns the pre-archive session id — messages keep landing in the session the operator believes is decommissioned.
- Reachability: high in real deployments. Runtime connector containers cache state; the `connection_discovery_stream` removal NOTIFY is best-effort/at-most-once; network blips cause retry of inbounds queued just before archive. Any of these lets a post-archive inbound win the race against the cache update.
- Fix at the inbound boundary: after `get_connection`, if `connection.archived_at is not None`, return `InboundResult(drop_reason=DETACHED)` before invoking the resolver. `DETACHED` is the semantically closest existing drop (both mean "no live routing target"), the router maps it to 422 ("operator config issue"), and downstream containers learn to stop posting via the same path they'd learn any other detach. The chat_sessions cascade-delete-on-archive is a separate defense-in-depth follow-up.

## Test plan

- [x] New `test_archived_connection_drops_inbound_without_routing` mocks `queries.get_connection` to return a `Connection` with `archived_at` set, mocks `resolve_target_session` to raise an `AssertionError` if invoked, and asserts `handle_inbound` returns `drop_reason=DETACHED` AND that the resolver is never called. Pre-fix the assertion in the resolver mock fires (`resolver should not be invoked for archived connection`); post-fix the test passes — the archived check short-circuits before the resolver and the drop reason matches.
- [x] Existing 2 `test_inbound_metadata` tests still green — they exercise `_append_with_dedup` directly and don't go through `handle_inbound`'s `get_connection` path.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1342 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)