### PR TITLE
refactor(models/memory_stores): drop unused MEMORY_PATH_RE compiled regex

### DIFF
--- a/src/aios/models/github_repositories.py
+++ b/src/aios/models/github_repositories.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 MAX_REPOS_PER_SESSION = 8
 
 # Mount path pattern: absolute path, segments may not be empty/contain NUL.
-# Same shape as MEMORY_PATH_RE in models/memory_stores.py.
+# Same shape as ``_MEMORY_PATH_PATTERN`` in models/memory_stores.py.
 _MOUNT_PATH_PATTERN = r"^(/[^/\x00]+)+$"
 
 

--- a/src/aios/models/memory_stores.py
+++ b/src/aios/models/memory_stores.py
@@ -14,14 +14,12 @@ instructions cap 4096 chars.
 
 from __future__ import annotations
 
-import re
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 _MEMORY_PATH_PATTERN = r"^(/[^/\x00]+)+$"
-MEMORY_PATH_RE = re.compile(_MEMORY_PATH_PATTERN)
 MAX_CONTENT_BYTES = 102400
 MAX_STORES_PER_SESSION = 8
 MAX_INSTRUCTIONS_CHARS = 4096


### PR DESCRIPTION
## Summary

`MEMORY_PATH_RE = re.compile(_MEMORY_PATH_PATTERN)` was defined as a public-name module constant in `models/memory_stores.py` but is imported from nowhere in `src/`, `tests/`, or `packages/`. Pydantic's `MemoryPath` annotated type at line 73 consumes the **string** `_MEMORY_PATH_PATTERN` directly via `Field(pattern=...)` — the compiled-regex object is never read.

Removing it also lets `import re` go (only consumer in the file).

Updated the cross-reference comment in `models/github_repositories.py` to point at the surviving `_MEMORY_PATH_PATTERN` symbol.

Net **-2 LOC** across 2 files. Same shape as recent dead-symbol deletes (PR #503 / #509 / #512 / #515 / #516).

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1342 passed
- [x] Grep-verified: no `MEMORY_PATH_RE` references anywhere; `_MEMORY_PATH_PATTERN` still in active use
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer`: **no concerns ≥ 30**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)