### PR TITLE
fix(db/queries): reject append_event to archived sessions so messages don't 201-then-vanish

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1706,12 +1706,22 @@ async def append_event(
             "                  THEN 'pending' ELSE status END, "
             "    updated_at = CASE WHEN $3 AND status IN ('idle', 'errored') "
             "                      THEN now() ELSE updated_at END "
-            "WHERE id = $1 AND account_id = $2 RETURNING last_event_seq, focal_channel",
+            "WHERE id = $1 AND account_id = $2 AND archived_at IS NULL "
+            "RETURNING last_event_seq, focal_channel",
             session_id,
             account_id,
             is_user_message,
         )
         if seq_row is None:
+            # Treat archived as "session no longer exists for write purposes."
+            # ``find_sessions_needing_inference`` (harness/sweep.py) already
+            # filters ``archived_at IS NULL``, so without this guard a
+            # POST to an archived session would return 201 + silently
+            # vanish: the row's ``last_event_seq`` increments, the event
+            # INSERTs, but the wake-sweep never picks it up. Surfacing as
+            # ``NotFoundError`` (→ 404 at the router) gives the caller an
+            # honest signal that the post is dropped. Same defect class
+            # as PR #521 (archived-connection inbound), one layer deeper.
             raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
         seq = seq_row["last_event_seq"]
         focal_at_arrival: str | None = seq_row["focal_channel"]

--- a/tests/integration/test_append_event_archived.py
+++ b/tests/integration/test_append_event_archived.py
@@ -1,0 +1,105 @@
+"""Integration test: ``queries.append_event`` must refuse to append
+events to archived sessions.
+
+Pre-fix the UPDATE WHERE clause in ``append_event`` only filtered
+``id = $1 AND account_id = $2`` — archived rows still match, so the
+session row's ``last_event_seq`` is incremented and the event INSERT
+succeeds. The wake-sweep (``find_sessions_needing_inference`` in
+``harness/sweep.py``) DOES filter ``archived_at IS NULL``, so the model
+never wakes. Result: ``POST /v1/sessions/{id}/messages`` returns 201
+Created, ``defer_wake`` enqueues, but the message vanishes into the
+archived session — no inference, no error, no operator-visible signal
+that the post was lost.
+
+Same defect class as PR #521 (archived-connection inbound), one layer
+deeper: the SESSION itself is archived, not the connection. The
+root-cause fix is at the deepest layer — ``append_event``'s UPDATE
+WHERE — so it covers EVERY caller path (direct API ``post_message``,
+connector inbound via resolver tier-2/3 ``single_session`` and
+``target_type='session'``, internal tool result handling, etc.) in one
+guard rather than gating each call site individually.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import NotFoundError
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def archived_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for a session that has
+    been archived after creation."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_archived', NULL, TRUE, 'archived-session-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_archived",
+            name="archived-test",
+            model="openrouter/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_archived", name="archived-test-env"
+        )
+        async with pool.acquire() as conn:
+            session = await queries.insert_session(
+                conn,
+                account_id="acc_archived",
+                agent_id=agent.id,
+                environment_id=env.id,
+                agent_version=agent.version,
+                title=None,
+                metadata={},
+            )
+            await queries.archive_session(conn, session.id, account_id="acc_archived")
+        yield pool, "acc_archived", session.id
+    finally:
+        await pool.close()
+
+
+class TestAppendEventArchivedSession:
+    async def test_append_event_refuses_archived_session(
+        self,
+        archived_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """The UPDATE in ``append_event`` must filter
+        ``archived_at IS NULL`` so an attempt to append to an archived
+        session raises ``NotFoundError`` instead of silently
+        succeeding with no downstream wake."""
+        pool, account_id, session_id = archived_session
+
+        async with pool.acquire() as conn:
+            with pytest.raises(NotFoundError):
+                await queries.append_event(
+                    conn,
+                    account_id=account_id,
+                    session_id=session_id,
+                    kind="message",
+                    data={"role": "user", "content": "should be refused"},
+                )


### PR DESCRIPTION
## Summary

- `append_event`'s session-row UPDATE filtered only `id = $1 AND account_id = $2`, leaving archived rows still matchable. The row's `last_event_seq` got incremented and the event INSERT succeeded; the API returned 201 Created and `defer_wake` enqueued the job. But the wake-sweep (`find_sessions_needing_inference` in `harness/sweep.py:99`) DID filter `WHERE s.archived_at IS NULL`, so the model never woke. Result: `POST /v1/sessions/{id}/messages` to an archived session silently dropped the message — no inference, no error, no operator-visible signal.
- Same defect class as PR #521 (archived-connection inbound), one layer deeper: the SESSION itself is archived, not the connection. Fixing at the deepest layer (`append_event`'s WHERE clause) instead of gating each call site means ONE guard covers every upstream caller path: direct API `post_message`, connector inbound via resolver tier-3 `single_session` binding pointing at an archived session, resolver tier-2 routing-rule with `target_type='session'` pointing at an archived session, and internal lifecycle (tool_confirmed, etc.) appending to a session archived mid-step.
- The write side now matches the read side's invariant: both `find_sessions_needing_inference` and `append_event` agree that archived sessions are out of scope. NotFoundError surfaces through the existing router translation as 404, matching the "session resource no longer active" semantic.

## Test plan

- [x] New integration test `TestAppendEventArchivedSession::test_append_event_refuses_archived_session` creates a session, archives it, then attempts `append_event` against it. Pre-fix: `DID NOT RAISE` — the event was silently appended. Post-fix: raises `NotFoundError` as expected. Verified locally against testcontainer Postgres.
- [x] Full unit suite — 1342 passed (no regressions; no existing unit tests touch the archived-session append path).
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [ ] CI runs the new integration test plus full e2e suite to confirm the change doesn't break any existing legitimate-append flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)