### PR TITLE
refactor(sandbox/backends): drop dead package-level re-exports

### DIFF
--- a/src/aios/sandbox/backends/__init__.py
+++ b/src/aios/sandbox/backends/__init__.py
@@ -13,18 +13,7 @@ caller's perspective — all per-session state lives on the
 
 from __future__ import annotations
 
-from aios.sandbox.backends.base import (
-    CommandResult,
-    Limited,
-    ManagedSandboxRef,
-    Mount,
-    NetworkPolicy,
-    SandboxBackend,
-    SandboxBackendError,
-    SandboxHandle,
-    SandboxSpec,
-    Unrestricted,
-)
+from aios.sandbox.backends.base import SandboxBackend
 
 
 def make_backend(name: str) -> SandboxBackend:
@@ -36,16 +25,4 @@ def make_backend(name: str) -> SandboxBackend:
     raise ValueError(f"unknown sandbox backend: {name!r}. Supported: 'docker'.")
 
 
-__all__ = [
-    "CommandResult",
-    "Limited",
-    "ManagedSandboxRef",
-    "Mount",
-    "NetworkPolicy",
-    "SandboxBackend",
-    "SandboxBackendError",
-    "SandboxHandle",
-    "SandboxSpec",
-    "Unrestricted",
-    "make_backend",
-]
+__all__ = ["make_backend"]


### PR DESCRIPTION
## Summary

The `aios.sandbox.backends` package's `__init__.py` re-exported ten symbols from `aios.sandbox.backends.base`, but every consumer imports those symbols directly from `.base`. Only `make_backend` is ever imported via the package form (`harness/worker.py` + 3 e2e fixtures).

Removed re-exports + their `__all__` entries: `CommandResult`, `Limited`, `ManagedSandboxRef`, `Mount`, `NetworkPolicy`, `SandboxBackendError`, `SandboxHandle`, `SandboxSpec`, `Unrestricted`.

**Retained**: `SandboxBackend` import (it's the return-type annotation on `make_backend`).

The module docstring already points at `aios.sandbox.backends.base.SandboxBackend` as the canonical location, confirming design intent: `.base` is the public surface for backend types, the package only exports the factory.

Net **-23 LOC**, single file.

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1342 passed
- [x] Grep-verified: all 4 package-level imports use only `make_backend`; all other consumers import via `.base`
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer`: **no concerns ≥ 30**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)