### PR TITLE
fix(services/vaults): serialize update_vault_credential to close cross-call lost-update race

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2487,14 +2487,28 @@ async def get_vault_credential_with_blob(
     credential_id: str,
     *,
     account_id: str,
+    for_update: bool = False,
 ) -> tuple[VaultCredential, EncryptedBlob]:
     """Fetch the credential metadata and decrypted-blob inputs in one round-trip.
 
     Excludes archived credentials — the blob is meaningless once archived
     (and gets zeroed out at archive time).
+
+    Pass ``for_update=True`` to take a row-level lock for the duration
+    of the surrounding transaction. Callers that follow the
+    decrypt-merge-encrypt-update pattern (e.g.
+    :func:`aios.services.vaults.update_vault_credential`) need this to
+    serialize the cross-call read-modify-write so two concurrent PUTs
+    don't both read the same pre-race blob.
     """
+    sql = (
+        "SELECT * FROM vault_credentials "
+        "WHERE id = $1 AND vault_id = $2 AND archived_at IS NULL AND account_id = $3"
+    )
+    if for_update:
+        sql += " FOR UPDATE"
     row = await conn.fetchrow(
-        "SELECT * FROM vault_credentials WHERE id = $1 AND vault_id = $2 AND archived_at IS NULL AND account_id = $3",
+        sql,
         credential_id,
         vault_id,
         account_id,

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -483,10 +483,16 @@ async def update_vault_credential(
     credential_id: str,
     body: VaultCredentialUpdate,
 ) -> VaultCredential:
-    async with pool.acquire() as conn:
-        # Decrypt existing payload, merge provided fields, re-encrypt.
+    # Serialize the decrypt-merge-encrypt-update sequence against the row
+    # so two concurrent PUTs each modifying a different field (e.g. token
+    # via auth-payload, display_name via column) don't both read the same
+    # pre-race blob and have the second commit clobber the first's edit.
+    # PR #496 fixed the in-call merge (None-unset); this transaction +
+    # FOR UPDATE closes the cross-call read-modify-write race that #496
+    # left uncovered. Mirrors the pattern in ``refresh_credential`` above.
+    async with pool.acquire() as conn, conn.transaction():
         cred, existing_blob = await queries.get_vault_credential_with_blob(
-            conn, vault_id, credential_id, account_id=account_id
+            conn, vault_id, credential_id, account_id=account_id, for_update=True
         )
         subkey = crypto_box.derive_account_subkey(account_id)
         existing_payload = subkey.decrypt_dict(existing_blob)

--- a/tests/e2e/test_vaults.py
+++ b/tests/e2e/test_vaults.py
@@ -345,6 +345,131 @@ class TestVaultCredentialCRUD:
         for f in failures:
             assert "maximum" in str(f)
 
+    async def test_concurrent_update_does_not_lose_writes(self, pool: Any, crypto_box: Any) -> None:
+        """Two concurrent ``PUT /v1/vaults/:vid/credentials/:cid`` requests
+        each modifying a DIFFERENT field of the same credential must both
+        win their respective edit. Pre-fix ``update_vault_credential``
+        opens a connection without a transaction or row lock; the
+        ``decrypt → merge → re-encrypt → UPDATE`` sequence is read-modify-
+        write across an unbounded gap, so the second commit clobbers the
+        first invocation's blob field. PR #496 fixed the merge-logic
+        for ``None``-unset within ONE call; this PR fixes the cross-call
+        race that ``#496`` left uncovered.
+
+        Pre-fix: token=A1 + display_name=A2 (call A) races with
+        token=B1 + display_name=B2 (call B). One field from one call
+        is silently lost (depending on commit order). Post-fix:
+        ``SELECT … FOR UPDATE`` serializes the read-decrypt-encrypt
+        critical section so both fields land.
+        """
+        account_id = "acc_test_stub"  # PR 3 scaffolding
+        from aios.services import vaults as svc
+
+        vault = await svc.create_vault(
+            pool, display_name="lost-update-test", metadata={}, account_id=account_id
+        )
+        cred = await svc.create_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=vault.id,
+            body=VaultCredentialCreate(
+                target_url="https://lost-update.example.com",
+                auth_type="bearer_header",
+                token=SecretStr("initial"),
+                display_name="initial",
+            ),
+            account_id=account_id,
+        )
+
+        # Force the race window deterministically: both invocations must
+        # complete the SELECT before either reaches the UPDATE. With
+        # plain ``asyncio.gather`` the asyncpg pool would generally let
+        # the first invocation run get → update before the second's
+        # get starts, masking the bug. Patch the UPDATE query to wait
+        # until BOTH invocations have arrived — this reconstructs the
+        # exact race that webhook-retry / dual-CLI / parallel-agent
+        # production traffic creates intermittently. The release event
+        # is set from a separate coroutine so neither update releases
+        # its own wait; FIFO wake order then preserves arrival order
+        # for the underlying ``original_update`` call into Postgres.
+        from unittest.mock import patch
+
+        from aios.db import queries as queries_mod
+
+        original_update = queries_mod.update_vault_credential
+        release_updates = asyncio.Event()
+        both_arrived = asyncio.Event()
+        reached_update = 0
+
+        async def gated_update(*args: Any, **kwargs: Any) -> Any:
+            nonlocal reached_update
+            reached_update += 1
+            if reached_update == 2:
+                both_arrived.set()
+            await release_updates.wait()
+            return await original_update(*args, **kwargs)
+
+        async def release_barrier() -> None:
+            # Pre-fix: both invocations reach ``gated_update`` (no row
+            # lock from get) and ``both_arrived`` fires fast.
+            # Post-fix: the second invocation blocks on ``FOR UPDATE``
+            # before ever reaching ``gated_update`` — ``both_arrived``
+            # times out. Either way, release ``release_updates`` so
+            # the first invocation commits; the second then proceeds
+            # naturally (immediately pre-fix, after row-lock release
+            # post-fix).
+            import contextlib as _contextlib
+
+            with _contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(both_arrived.wait(), timeout=0.5)
+            release_updates.set()
+
+        async def update_token() -> Any:
+            return await svc.update_vault_credential(
+                pool,
+                crypto_box,
+                vault_id=vault.id,
+                credential_id=cred.id,
+                body=VaultCredentialUpdate(token=SecretStr("token-A")),
+                account_id=account_id,
+            )
+
+        async def update_display_name() -> Any:
+            return await svc.update_vault_credential(
+                pool,
+                crypto_box,
+                vault_id=vault.id,
+                credential_id=cred.id,
+                body=VaultCredentialUpdate(display_name="display-B"),
+                account_id=account_id,
+            )
+
+        with patch.object(queries_mod, "update_vault_credential", gated_update):
+            await asyncio.gather(update_token(), update_display_name(), release_barrier())
+
+        # Read back via the get-with-blob query and decrypt to verify the
+        # actual stored secrets — the public ``VaultCredential`` strips
+        # them. Both invocations should have committed their field.
+        async with pool.acquire() as conn:
+            from aios.db import queries
+
+            final_cred, final_blob = await queries.get_vault_credential_with_blob(
+                conn, vault.id, cred.id, account_id=account_id
+            )
+
+        subkey = crypto_box.derive_account_subkey(account_id)
+        payload = subkey.decrypt_dict(final_blob)
+
+        assert final_cred.display_name == "display-B", (
+            f"display_name update was lost — pre-fix the token-update's "
+            f"earlier read decrypted the pre-race blob, merged token-A, and "
+            f"re-encrypted, clobbering the display_name field that was about "
+            f"to land. Final display_name: {final_cred.display_name!r}"
+        )
+        assert payload.get("token") == "token-A", (
+            f"token update was lost — symmetric race; final token in blob: {payload.get('token')!r}"
+        )
+
     async def test_credential_inserts_across_vaults_do_not_block(
         self, pool: Any, crypto_box: Any
     ) -> None:


### PR DESCRIPTION
## Summary

- `update_vault_credential` decrypted the stored blob, merged the provided field, re-encrypted, and UPDATE'd — across an unbounded asyncio yield window with no surrounding transaction and no row lock. Two concurrent `PUT /vaults/:vid/credentials/:cid` requests each modifying a DIFFERENT field of the same credential (one updates `token` via auth-payload encryption, the other updates `display_name` via column) would each read the same pre-race blob; whichever UPDATE commits LAST wins for the blob column, silently losing the other's edit. PR #496 fixed the IN-CALL merge semantics (None-unset of required fields); this PR fixes the CROSS-CALL concurrency that #496 left uncovered.
- Production reachability: webhook-retry sequences in connector integrations (Telegram, Signal SDK at-least-once) can fire two concurrent updates on the same OAuth credential; parallel CLI flows (`aios vaults credentials rotate` in two terminals); a multi-agent fan-out that touches the same shared vault. Pre-fix the second-to-commit silently overwrites the blob, leading to an inscrutable "token I just rotated isn't working" follow-up ticket.
- Fix: wrap the service body in `async with pool.acquire() as conn, conn.transaction():` and add a `for_update=True` kwarg to `queries.get_vault_credential_with_blob` that appends `FOR UPDATE` to the SELECT. The second concurrent invocation blocks on the row lock until the first commits, then proceeds with the freshly-committed state — both fields land in arrival order. Mirrors the `refresh_credential` / `lock_oauth_credential_for_refresh` pattern already used for OAuth refresh flows.

## Test plan

- [x] New e2e test `TestVaultCredentialCRUD::test_concurrent_update_does_not_lose_writes` patches `queries.update_vault_credential` with a barrier that forces both invocations to reach the UPDATE before either commits — deterministically reproducing the race. Pre-fix it fails with `token: 'initial'` (the token update was silently clobbered by the display_name update's stale-blob re-encryption). Post-fix the second invocation blocks on the row lock BEFORE reaching the barrier; the barrier's `wait_for` times out, the first commits, the second naturally proceeds with the post-A state, and both fields land correctly.
- [x] Verified both directions locally against testcontainer Postgres (with-fix passes; without-fix fails with exact predicted symptom).
- [x] Existing 31 vault e2e tests still green.
- [x] Full unit suite — 1342 passed.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [ ] CI runs full e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)