### PR TITLE
fix(aios_connectors/resolver): surface archived single_session target as DETACHED

### DIFF
--- a/src/aios_connectors/resolver.py
+++ b/src/aios_connectors/resolver.py
@@ -90,6 +90,25 @@ async def resolve_target_session(
         return ResolveResult(session_id=None, drop=ResolveDrop.DETACHED)
     if binding.mode == "single_session":
         assert binding.session_id is not None
+        # Check whether the bound session was archived after this
+        # binding was created. Without this, the resolver would return
+        # the archived id, ``handle_inbound`` would fail at
+        # ``append_event`` (post-#523) with ``SESSION_MISSING`` (mapped
+        # to 500), and well-behaved connectors would retry forever
+        # because 5xx looks transient. ``DETACHED`` (→ 422) is the
+        # correct terminal signal — same shape the resolver already
+        # uses for ``ARCHIVED_TEMPLATE`` upstream of the append. No
+        # ledger stamp here so the next inbound goes through the same
+        # check (no poisoning), and if the operator detaches+rebinds
+        # to a live session the resolver picks it up immediately.
+        async with pool.acquire() as conn:
+            session_archived_at = await conn.fetchval(
+                "SELECT archived_at FROM sessions WHERE id = $1 AND account_id = $2",
+                binding.session_id,
+                account_id,
+            )
+        if session_archived_at is not None:
+            return ResolveResult(session_id=None, drop=ResolveDrop.DETACHED)
         # No ledger insert — operators opt into per-chat overrides explicitly.
         return ResolveResult(session_id=binding.session_id, drop=None)
     assert binding.mode == "per_chat"

--- a/tests/integration/test_resolver_archived_session.py
+++ b/tests/integration/test_resolver_archived_session.py
@@ -1,0 +1,133 @@
+"""Integration test: the connector resolver must not return an
+archived session_id from any of its three tiers.
+
+After PR #523 (``append_event`` refuses archived sessions), an inbound
+that flowed through the resolver pointing at an archived target would
+fail downstream with ``InboundDrop.SESSION_MISSING`` — the inbound
+router translates that to a 500-class status because semantically
+"session vanished mid-flight" is a transient error. Well-behaved
+connectors treat 5xx as retry-with-backoff, so every queued post-archive
+inbound becomes a permanent retry loop hammering the API.
+
+The CORRECT terminal signal is ``InboundDrop.DETACHED`` (router maps to
+422 "operator config issue"), which tells the connector "stop retrying,
+the operator must reconfigure." This is the same shape as
+``InboundDrop.ARCHIVED_TEMPLATE`` for the per_chat path — the resolver
+already returns ``DETACHED``/``ARCHIVED_TEMPLATE`` for permanent-config
+failures upstream of the append, and archived single_session targets
+deserve the same treatment.
+
+This iteration fixes the most-reachable case: tier-3 ``single_session``
+binding pointing at an archived session. Tier-2 ``target_type='session'``
++ tier-1 stale-ledger entries are adjacent and could be a follow-up,
+but tier-2 routing rules have no operator-facing API today and tier-1
+lookup only fires after a successful tier-2/3 stamp (which we now
+refuse).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.services import agents as agents_service
+from aios.services import connections as connections_service
+from aios.services import environments as environments_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def archived_session_bound_to_connection(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str]]:
+    """Yield ``(pool, account_id, connection_id, session_id)`` for a
+    single_session binding whose target session has been archived."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_resolver_arch', NULL, TRUE, 'resolver-archived-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_resolver_arch",
+            name="resolver-arch-test",
+            model="openrouter/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_resolver_arch", name="resolver-arch-env"
+        )
+        async with pool.acquire() as conn:
+            session = await queries.insert_session(
+                conn,
+                account_id="acc_resolver_arch",
+                agent_id=agent.id,
+                environment_id=env.id,
+                agent_version=agent.version,
+                title=None,
+                metadata={},
+            )
+            # Insert a connection directly via the DB (the public
+            # ``create_connection`` API requires a richer fixture set).
+            connection = await queries.insert_connection(
+                conn,
+                connector="echo",
+                external_account_id="test-account",
+                metadata={},
+                account_id="acc_resolver_arch",
+            )
+        # Bind single_session, then archive the target session.
+        await connections_service.attach_connection(
+            pool,
+            connection.id,
+            account_id="acc_resolver_arch",
+            session_id=session.id,
+        )
+        async with pool.acquire() as conn:
+            await queries.archive_session(conn, session.id, account_id="acc_resolver_arch")
+        yield pool, "acc_resolver_arch", connection.id, session.id
+    finally:
+        await pool.close()
+
+
+async def test_resolver_returns_detached_for_archived_single_session_target(
+    archived_session_bound_to_connection: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    """Tier-3 ``single_session`` resolution must treat an archived
+    target as DETACHED so connectors get a 422 terminal signal instead
+    of a 500-class retry-forever ``SESSION_MISSING`` from the
+    downstream ``append_event`` failure."""
+    from aios_connectors.resolver import ResolveDrop, resolve_target_session
+
+    pool, account_id, connection_id, _archived_session_id = archived_session_bound_to_connection
+    async with pool.acquire() as conn:
+        connection = await queries.get_connection(conn, connection_id, account_id=account_id)
+
+    result = await resolve_target_session(
+        pool, connection=connection, chat_id="any-chat", account_id=account_id
+    )
+
+    assert result.drop == ResolveDrop.DETACHED, (
+        f"resolver must return DETACHED (→ router 422) for archived "
+        f"single_session targets, not pass through the archived id and let "
+        f"the inbound retry-loop on append_event NotFoundError. Got "
+        f"{result!r}. Pre-fix the resolver returns the archived session_id "
+        f"with drop=None; post-fix it returns drop=DETACHED with session_id "
+        f"None."
+    )
+    assert result.session_id is None


### PR DESCRIPTION
## Summary

- `resolve_target_session`'s tier-3 `single_session` branch returned `binding.session_id` without checking the bound session's `archived_at`. After PR #523 (`append_event` refuses archived sessions), the inbound now fails downstream with `InboundDrop.SESSION_MISSING` — the inbound router translates that to a 500-class status because semantically "session vanished mid-flight" is a transient error. Well-behaved connectors (Telegram retry-with-backoff, Signal SDK at-least-once, HTTP-pollers) interpret 5xx as transient and retry, so every queued post-archive inbound becomes a permanent retry loop hammering the API endpoint.
- The correct terminal signal is `InboundDrop.DETACHED` (router maps to 422 "operator config issue"), telling the connector "stop retrying, the operator must reconfigure." Same shape the resolver already uses for `ARCHIVED_TEMPLATE` upstream of the append (per_chat path); archived single_session targets deserve the same.
- Single SELECT before returning the binding's session_id: if `archived_at IS NOT NULL` → `DETACHED`. No ledger stamp (consistent with the existing tier-3 single_session contract — no per-chat poisoning).
- Together with PR #521 (archived connection → DETACHED at handle_inbound) and PR #523 (archived session → NotFoundError at append_event SQL), this closes the third leg of the "archived resource accepts work" defect class. The three layers are complementary: #523 is the safety net (covers ANY caller path bypassing the resolver, e.g., direct API `post_message`); this PR is the early-rejection that returns a better status code for the inbound-via-resolver path.

## Test plan

- [x] New integration test `test_resolver_returns_detached_for_archived_single_session_target` creates a single_session binding pointing at a session, archives the session, then calls `resolve_target_session`. Pre-fix: `ResolveResult(session_id=<archived>, drop=None)`. Post-fix: `ResolveResult(session_id=None, drop=DETACHED)`. Verified locally against testcontainer Postgres.
- [x] Full unit suite — 1342 passed.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [ ] CI runs full e2e suite to confirm tier-3 happy-paths still work (archived check fires only when `archived_at IS NOT NULL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)