### PR TITLE
fix(harness/attachment_gc): skip recently-staged files to avoid worker-startup race

### DIFF
--- a/src/aios/harness/attachment_gc.py
+++ b/src/aios/harness/attachment_gc.py
@@ -12,6 +12,7 @@ exists for the next provision.
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,16 @@ import asyncpg
 
 from aios.db import queries
 from aios.sandbox.volumes import attachments_root
+
+# Files staged within this many seconds of sweep time are considered
+# in-flight: ``stage_inbound_attachments`` writes to disk BEFORE the
+# ``_append_with_dedup`` transaction commits, so a sweep that runs in
+# the gap between rename and commit would otherwise race-delete the
+# file before the API's commit lands the referencing event. 300s is
+# generous compared to a healthy staging-txn latency (single-digit ms),
+# while still small enough that orphans get reaped promptly on the
+# next worker boot.
+_IN_FLIGHT_AGE_S = 300.0
 
 
 class AttachmentGcError(RuntimeError):
@@ -55,6 +66,15 @@ async def sweep_orphan_attachments(pool: asyncpg.Pool[Any]) -> int:
     if not root.exists():
         return 0
 
+    # Skip files staged within the in-flight window — they may be
+    # mid-transaction in another process, with their referencing
+    # event not yet committed. Without this guard, a worker restart
+    # that lands between ``stage_inbound_attachments`` rename and
+    # ``_append_with_dedup`` commit would silently delete the just-
+    # staged bytes, leaving the post-commit event pointing at a
+    # missing file (renderer ``FileNotFoundError`` on every wake).
+    in_flight_cutoff = time.time() - _IN_FLIGHT_AGE_S
+
     on_disk_by_session: dict[str, dict[str, Path]] = {}
     for session_dir in root.iterdir():
         if not session_dir.is_dir():
@@ -65,6 +85,8 @@ async def sweep_orphan_attachments(pool: asyncpg.Pool[Any]) -> int:
                 continue
             for file_path in connector_dir.iterdir():
                 if not file_path.is_file():
+                    continue
+                if file_path.stat().st_mtime > in_flight_cutoff:
                     continue
                 sandbox_path = f"/mnt/attachments/{connector_dir.name}/{file_path.name}"
                 session_files[sandbox_path] = file_path

--- a/tests/unit/test_attachment_gc.py
+++ b/tests/unit/test_attachment_gc.py
@@ -1,0 +1,132 @@
+"""Unit tests for ``aios.harness.attachment_gc``.
+
+The sweep must NOT delete files that were just staged by an
+in-flight inbound transaction. ``handle_inbound`` writes attachment
+bytes to disk BEFORE its ``append_event`` + ``try_record_inbound_ack``
+transaction commits. If a worker reboot (laptop sleep, redeploy, OOM)
+fires ``sweep_orphan_attachments`` between the rename and the commit,
+the sweep sees a file with no committed event row referencing it and
+classifies it as orphan. Without an age filter, it unlinks. The
+API's commit then succeeds but the persisted ``in_sandbox_path``
+points at a deleted file — the renderer's later read raises
+``FileNotFoundError`` and the attachment is silently lost.
+
+Same defect class as PR #517 (cleanup scope: don't unlink files this
+invocation doesn't own), one layer up: the sweep doesn't own ANY
+file it didn't write, so the conservative rule is to skip recently
+created files entirely.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.harness.attachment_gc import sweep_orphan_attachments
+
+
+@pytest.fixture
+def attachments_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Per-test attachments root pointed at a tmpdir."""
+    root = tmp_path / "_attachments"
+    root.mkdir()
+    monkeypatch.setattr(
+        "aios.harness.attachment_gc.attachments_root",
+        lambda: root,
+    )
+    return root
+
+
+def _seed_attachment(root: Path, session_id: str, connector: str, filename: str) -> Path:
+    """Create ``_attachments/<sid>/<conn>/<filename>`` and return its path."""
+    target = root / session_id / connector / filename
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"\x89PNG\r\n\x1a\nstaged-bytes-just-now")
+    return target
+
+
+@pytest.fixture
+def fake_pool() -> MagicMock:
+    """Pool whose ``acquire()`` returns a context-managed MagicMock conn."""
+    pool = MagicMock()
+
+    class _AsyncCm:
+        async def __aenter__(self) -> Any:
+            return MagicMock()
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+    pool.acquire.return_value = _AsyncCm()
+    return pool
+
+
+async def test_sweep_skips_recently_staged_file_with_no_event_yet(
+    attachments_root: Path,
+    fake_pool: MagicMock,
+) -> None:
+    """A file just placed on disk by ``stage_inbound_attachments`` —
+    whose ``append_event`` + dedup txn hasn't committed yet — must
+    NOT be unlinked by the sweep. Pre-fix the sweep had no age
+    filter and would race-delete the file before the API's commit;
+    post-fix it should skip files newer than the staging-txn
+    latency budget."""
+    session_id = "sess_01STAGING0000000000000001"
+    connector = "echo"
+    filename = "evt_inflight-photo.png"
+    file_path = _seed_attachment(attachments_root, session_id, connector, filename)
+    assert file_path.exists()
+
+    # The events table has NO row referencing this path — the txn is
+    # mid-flight on a different process. Mock the query to return empty.
+    with patch(
+        "aios.harness.attachment_gc.queries.list_attachment_paths_for_sessions",
+        AsyncMock(return_value={}),
+    ):
+        await sweep_orphan_attachments(fake_pool)
+
+    assert file_path.exists(), (
+        "sweep must skip recently-staged files (mtime within the staging-"
+        "txn latency window); pre-fix the sweep race-deletes any file "
+        "whose referencing event hasn't committed yet, which happens "
+        "deterministically on every worker restart that lands between "
+        "the stage_inbound_attachments rename and the _append_with_dedup "
+        "commit. Renderer would later FileNotFoundError on the in-sandbox "
+        "path the committed event ends up referencing."
+    )
+
+
+async def test_sweep_still_unlinks_genuinely_old_orphans(
+    attachments_root: Path,
+    fake_pool: MagicMock,
+) -> None:
+    """The fix mustn't disable the sweep entirely. A file old enough
+    that its inbound txn definitely either committed (and the events
+    table now references it) or rolled back (and it should be reaped)
+    must still be unlinked when no event references it. Set mtime
+    well in the past to simulate a long-completed-rolled-back txn."""
+    import os
+    import time
+
+    session_id = "sess_01STAGING0000000000000002"
+    file_path = _seed_attachment(attachments_root, session_id, "echo", "evt_old-img.png")
+    # Mtime 1 hour ago — far past any sane staging-txn latency.
+    old = time.time() - 3600
+    os.utime(file_path, (old, old))
+    assert file_path.exists()
+
+    with patch(
+        "aios.harness.attachment_gc.queries.list_attachment_paths_for_sessions",
+        AsyncMock(return_value={}),
+    ):
+        deleted = await sweep_orphan_attachments(fake_pool)
+
+    assert not file_path.exists(), (
+        "sweep must still reap genuinely-orphaned old files; the age "
+        "filter should be a small protect-in-flight-txn window, not a "
+        "disable-the-sweep refactor."
+    )
+    assert deleted == 1


### PR DESCRIPTION
## Summary

- `sweep_orphan_attachments` walks `<workspace>/_attachments/<sid>/<conn>/` and unlinks any file not present in the events table's referenced-paths set. The API process stages attachments in this order: (1) `stage_inbound_attachments` writes bytes + `os.rename` into the final path; (2) `_append_with_dedup` opens a txn, runs `append_event` + `try_record_inbound_ack`; (3) commit. A worker boot between (1) and (3) — laptop sleep, rolling deploy, OOM, manual restart — fires the sweep, which queries committed events, sees no row referencing the just-staged file, classifies as orphan, and `unlink`s it. The API's commit at (3) succeeds but the persisted `in_sandbox_path` points at a deleted file. The renderer's later `read_bytes` raises `FileNotFoundError`; the attachment is silently lost from the model's view.
- The `worker.py` comment claiming Postgres snapshot isolation governs this is wrong — snapshot isolation constrains visibility of *committed* rows; the sweep's snapshot cannot see the API's open txn. The race is reachable on every worker restart proportional to the staging-txn latency window.
- Fix: skip files whose `mtime` is within `_IN_FLIGHT_AGE_S` (300s). The window is generous compared to a healthy staging-txn latency (single-digit ms) but bounded so genuinely-orphaned files (rolled-back txns from N minutes ago) still get reaped on the next worker boot. Same defect class as PR #517 (cleanup scope: don't unlink files this invocation doesn't own), one layer up.

## Test plan

- [x] New `test_sweep_skips_recently_staged_file_with_no_event_yet` seeds a file with mtime=now, mocks `list_attachment_paths_for_sessions` to return empty, calls `sweep_orphan_attachments`, asserts the file still exists. Pre-fix: file deleted. Post-fix: file kept.
- [x] New `test_sweep_still_unlinks_genuinely_old_orphans` seeds a file with mtime=1hr-ago, runs the same sweep, asserts the file is gone AND `deleted == 1`. Guards against the fix becoming "disable the sweep".
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1345 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)