### PR TITLE
refactor(sandbox/github_clone): drop dead SandboxBackendError re-export

### DIFF
--- a/src/aios/sandbox/github_clone.py
+++ b/src/aios/sandbox/github_clone.py
@@ -36,7 +36,6 @@ from pathlib import Path
 
 from aios.logging import get_logger
 from aios.sandbox._subprocess import run_subprocess_with_timeout
-from aios.sandbox.backends.base import SandboxBackendError
 from aios.sandbox.volumes import (
     github_repo_cache_dir,
     github_repo_cache_lock_path,
@@ -312,10 +311,8 @@ def _redact_token_from_message(msg: str, token: str) -> str:
     return msg.replace(token, "<redacted>")
 
 
-# Re-export for callers that catch backend/git errors uniformly.
 __all__ = [
     "GithubCloneError",
-    "SandboxBackendError",
     "ensure_cache_clone",
     "ensure_session_working_tree",
     "remove_session_working_tree",


### PR DESCRIPTION
## Summary

`SandboxBackendError` was imported at the top of `github_clone.py` solely to re-export it via `__all__` for *"callers that catch backend/git errors uniformly"* (per the now-deleted line-315 comment). **No caller imports it via this path** — grep finds zero `from aios.sandbox.github_clone import ... SandboxBackendError` or `github_clone.SandboxBackendError` references. All 7 in-tree consumers of `SandboxBackendError` import it from `aios.sandbox.backends.base` directly.

The class is also not used internally in `github_clone.py`.

Net **-3 LOC**, single file. Same shape as PR #524 (drop dead package-level re-exports in `sandbox.backends.__init__`).

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1343 passed
- [x] Grep-verified: zero callers via `github_clone` path; not used internally
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer`: **no concerns ≥ 30**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)