### PR TITLE
refactor(services/runtime_tokens): inline single-caller _generate_plaintext

### DIFF
--- a/src/aios/services/runtime_tokens.py
+++ b/src/aios/services/runtime_tokens.py
@@ -34,10 +34,6 @@ _TOKEN_PREFIX = "aios_runtime_"
 _TOKEN_BYTES = 32  # 256 bits of entropy
 
 
-def _generate_plaintext() -> str:
-    return _TOKEN_PREFIX + secrets.token_urlsafe(_TOKEN_BYTES)
-
-
 def _hash(plaintext: str) -> str:
     return hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
 
@@ -54,7 +50,7 @@ async def issue(
     Returns ``(record, plaintext)``.  Plaintext is the bearer the
     runtime container will use; never persisted.
     """
-    plaintext = _generate_plaintext()
+    plaintext = _TOKEN_PREFIX + secrets.token_urlsafe(_TOKEN_BYTES)
     async with pool.acquire() as conn:
         token = await queries.insert_runtime_token(
             conn,


### PR DESCRIPTION
## Summary

`_generate_plaintext()` was a 1-line helper with **exactly one caller** in the same file:

```python
def _generate_plaintext() -> str:
    return _TOKEN_PREFIX + secrets.token_urlsafe(_TOKEN_BYTES)
...
plaintext = _generate_plaintext()  # only call site
```

Per CLAUDE.md "three similar lines is better than premature abstraction" — and the inverse, one caller doesn't need a helper. The inline form `plaintext = _TOKEN_PREFIX + secrets.token_urlsafe(_TOKEN_BYTES)` is equally readable; the assignment target already names the semantic role.

Companion `_hash()` (2 callers — `issue` + `resolve`) is correctly kept unchanged.

Net **-4 LOC**, single file.

## Test plan

- [x] `uv run mypy src` — clean (155 source files)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean
- [x] `uv run pytest tests/unit -q` — 1345 passed
- [x] Grep-verified: zero remaining references to `_generate_plaintext`
- [ ] CI e2e suite

## Code-review notes

`pr-review-toolkit:code-reviewer`: **no concerns ≥ 30**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)