### PR TITLE
chore(ci): bump peter-evans/repository-dispatch v3 → v4

### DIFF
--- a/.github/workflows/promote-api.yml
+++ b/.github/workflows/promote-api.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
     steps:
       - name: Trigger eumemic-ops deploy receiver
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.EUMEMIC_OPS_DISPATCH_TOKEN }}
           repository: eumemic/eumemic-ops

--- a/.github/workflows/promote-sandbox.yml
+++ b/.github/workflows/promote-sandbox.yml
@@ -49,7 +49,7 @@ jobs:
             ghcr.io/eumemic/aios-sandbox@${{ steps.digest.outputs.digest }}
       - name: Trigger ledger append
         if: success()
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.EUMEMIC_OPS_DISPATCH_TOKEN }}
           repository: eumemic/eumemic-ops

--- a/.github/workflows/promote-worker.yml
+++ b/.github/workflows/promote-worker.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
     steps:
       - name: Trigger eumemic-ops deploy receiver
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.EUMEMIC_OPS_DISPATCH_TOKEN }}
           repository: eumemic/eumemic-ops


### PR DESCRIPTION
## Summary

v3 ships on Node 20, which GitHub Actions deprecates on **2026-06-02** (default flip to Node 24) and removes on **2026-09-16**. Each promote workflow currently emits a `Node.js 20 actions are deprecated` warning.

v4 (released 2025-10-01) is a pure runtime bump for Node 24 — no API surface changes; same inputs/outputs. GitHub-hosted runners (which we use) satisfy the Actions Runner ≥v2.327.1 requirement.

## Changes

- `.github/workflows/promote-sandbox.yml` — v3 → v4 (Track R)
- `.github/workflows/promote-api.yml` — v3 → v4 (Track G)
- `.github/workflows/promote-worker.yml` — v3 → v4 (Track G)

## Verification

Mechanical version bump; runtime behaviour confirmed in v4 release notes. The dispatch payload + auth pattern are identical between v3 and v4, so an end-to-end promote round-trip is the existing smoke (already exercised today for promote-api and promote-worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)