### PR TITLE
chore(ci): drop stable-env reviewer-approval gate on promote workflows

### DIFF
--- a/.github/workflows/promote-api.yml
+++ b/.github/workflows/promote-api.yml
@@ -4,8 +4,9 @@ name: Promote aios-api → Coolify
 #
 # Replaces Coolify's "auto-deploy from master push" with an explicit
 # operator-triggered promote. Master merges remain candidates-for-promotion;
-# this workflow fires only on workflow_dispatch and requires reviewer approval
-# via the ``stable`` GitHub environment before the dispatch is sent.
+# this workflow fires only on workflow_dispatch — the dispatch invocation
+# itself is the gate. Repo-write access is the access barrier; promotes are
+# not auto-fired on merge.
 #
 # This workflow fires a repository_dispatch event into eumemic/eumemic-ops,
 # which runs ``./scripts/deploy aios-api``, polls Coolify for deploy
@@ -27,7 +28,6 @@ on:
 jobs:
   promote:
     runs-on: ubuntu-latest
-    environment: stable  # requires reviewer approval
     permissions:
       contents: read
     steps:

--- a/.github/workflows/promote-sandbox.yml
+++ b/.github/workflows/promote-sandbox.yml
@@ -1,9 +1,9 @@
 name: Promote aios-sandbox :smoked → :stable
 
 # Manifest-level retag: promotes the already-smoked image to :stable.
-# Requires explicit reviewer approval via the ``stable`` GitHub environment
-# before the retag executes, so no untested image can reach :stable
-# without a human sign-off.
+# The gate is the explicit workflow_dispatch invocation — :stable is never
+# touched by an automatic process; only an intentional operator (or trusted
+# bot) action retags. Repo-write access is the access barrier.
 #
 # After promoting, fires a repository-dispatch event to eumemic-ops so the
 # deploy ledger can record the new :stable digest.
@@ -19,7 +19,6 @@ on:
 jobs:
   promote:
     runs-on: ubuntu-latest
-    environment: stable  # requires reviewer approval
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/promote-worker.yml
+++ b/.github/workflows/promote-worker.yml
@@ -4,8 +4,9 @@ name: Promote aios-worker → Coolify
 #
 # Replaces Coolify's "auto-deploy from master push" with an explicit
 # operator-triggered promote. Master merges remain candidates-for-promotion;
-# this workflow fires only on workflow_dispatch and requires reviewer approval
-# via the ``stable`` GitHub environment before the dispatch is sent.
+# this workflow fires only on workflow_dispatch — the dispatch invocation
+# itself is the gate. Repo-write access is the access barrier; promotes are
+# not auto-fired on merge.
 #
 # This workflow fires a repository_dispatch event into eumemic/eumemic-ops,
 # which runs ``./scripts/deploy aios-worker``, polls Coolify for deploy
@@ -27,7 +28,6 @@ on:
 jobs:
   promote:
     runs-on: ubuntu-latest
-    environment: stable  # requires reviewer approval
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

Removes the `environment: stable` reviewer-approval requirement from all three promote workflows. The explicit `workflow_dispatch` invocation is the gate; repo-write access is the access barrier. Auto-deploy on merge is still off (that's the structural guarantee), so this only removes the per-promote manual approval click.

Why now: per operator request — the per-run approval friction was high enough that it created the worse outcome of "production drift accumulates until somebody finds time to click through approvals." Removing the click brings promote latency down to one CLI invocation.

## Changes

- `.github/workflows/promote-sandbox.yml` — drop `environment: stable`; rewrite header comment
- `.github/workflows/promote-api.yml` — drop `environment: stable`; rewrite header comment  
- `.github/workflows/promote-worker.yml` — drop `environment: stable`; rewrite header comment

## Security posture after this lands

- Auto-deploy on master push: **still off** (Coolify flag `is_auto_deploy_enabled=false`, asserted by `audit/checks/auto-deploy-disabled.sh`)
- Promotes still require: explicit `workflow_dispatch` invocation → fires `repository_dispatch` into eumemic-ops receiver → receiver runs `./scripts/deploy`, polls for completion, writes ledger row
- Trigger barrier: repo-write on `eumemic/aios` (today: Tom + trusted bots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)