### PR TITLE
fix(services/sessions): reject deny when tool already succeeded

### DIFF
--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -16,7 +16,7 @@ import asyncpg
 
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
-from aios.errors import NotFoundError, PayloadTooLargeError
+from aios.errors import ConflictError, NotFoundError, PayloadTooLargeError
 from aios.models.events import Event, EventKind
 from aios.models.sessions import (
     MAX_USER_MESSAGE_CHARS,
@@ -277,7 +277,31 @@ async def append_tool_result(
             conn, session_id, tool_call_id, account_id=account_id
         )
         if existing is not None:
-            return existing
+            # Idempotent retry: a prior call with matching intent
+            # (same ``is_error`` outcome) — return the original event.
+            # Intent-mismatch is a CONFLICT, not a retry: e.g., a deny
+            # arriving after the tool already produced a success result
+            # (two-tab race; always_allow tool; bogus pre-confirm
+            # pre-#533). Returning the success event would lie to the
+            # operator ("you denied successfully") while the model's
+            # context still carries the success result. Raise so the
+            # operator learns the deny is too late.
+            existing_is_error = bool(existing.data.get("is_error", False))
+            if existing_is_error == is_error:
+                return existing
+            raise ConflictError(
+                f"tool_call_id {tool_call_id!r} already has a "
+                f"{'error' if existing_is_error else 'success'} "
+                f"result; cannot append a "
+                f"{'error' if is_error else 'success'} result with "
+                f"the same tool_call_id",
+                detail={
+                    "session_id": session_id,
+                    "tool_call_id": tool_call_id,
+                    "existing_is_error": existing_is_error,
+                    "requested_is_error": is_error,
+                },
+            )
 
         name = await queries.lookup_tool_name_by_call_id(
             conn, session_id, tool_call_id, account_id=account_id

--- a/tests/integration/test_confirm_tool_deny_after_success.py
+++ b/tests/integration/test_confirm_tool_deny_after_success.py
@@ -1,0 +1,239 @@
+"""Integration test: ``confirm_tool_deny`` must distinguish a
+genuine retry of a prior deny from a deny that arrives AFTER the
+tool already produced a success result.
+
+Pre-fix ``append_tool_result``'s idempotency check uses
+``find_tool_result_event`` which matches ANY tool-role event for
+``tool_call_id``, success OR error. So:
+
+  1. Tool fires (e.g., always_allow agent, or pre-#533 bogus allow,
+     or two-tab race where one allow landed before the other deny).
+  2. The successful tool result event lands on the event log.
+  3. Operator clicks deny. ``confirm_tool_deny`` →
+     ``append_tool_result(is_error=True)`` → finds the success event,
+     treats the deny as an idempotent retry, returns the SUCCESS event.
+
+The HTTP response is 201 with ``data.content`` = the tool's output.
+The model's context still carries the success result. The deny had
+no effect: tool DID run, model sees the result, user believed they
+denied.
+
+The dedup-by-tool_call_id contract is broken when the existing
+event's intent differs from the new request's intent. Correct
+behavior: idempotent retry requires matching ``is_error``; an
+attempted deny against an already-succeeded tool is a CONFLICT,
+not a retry. Surface as ``ConflictError`` (router → 409); operator
+learns "too late, tool ran" rather than silent success.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import ConflictError
+from aios.models.agents import ToolSpec
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def session_with_tool_already_succeeded(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str]]:
+    """Yield ``(pool, account_id, session_id, tool_call_id)`` for a
+    session whose event log contains: assistant message with a
+    tool_calls entry, followed by a SUCCESSFUL tool-role result
+    event for that same tool_call_id."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_deny_race', NULL, TRUE, 'deny-after-success-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_deny_race",
+            name="deny-race-test",
+            model="openrouter/test",
+            system="",
+            tools=[ToolSpec(type="bash")],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_deny_race", name="deny-race-env"
+        )
+        async with pool.acquire() as conn:
+            session = await queries.insert_session(
+                conn,
+                account_id="acc_deny_race",
+                agent_id=agent.id,
+                environment_id=env.id,
+                agent_version=agent.version,
+                title=None,
+                metadata={},
+            )
+            # Parent assistant message with the tool_call.
+            await queries.append_event(
+                conn,
+                account_id="acc_deny_race",
+                session_id=session.id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tc_already_ran",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        }
+                    ],
+                },
+            )
+            # The tool ran successfully (some path bypassed the
+            # always_ask gate — two-tab race, always_allow tool,
+            # bogus pre-confirm pre-#533, etc.) and produced a
+            # success result event.
+            await queries.append_event(
+                conn,
+                account_id="acc_deny_race",
+                session_id=session.id,
+                kind="message",
+                data={
+                    "role": "tool",
+                    "tool_call_id": "tc_already_ran",
+                    "content": "the-tool-actually-executed",
+                    "name": "bash",
+                    # NOTE: no is_error key → success result.
+                },
+            )
+        yield pool, "acc_deny_race", session.id, "tc_already_ran"
+    finally:
+        await pool.close()
+
+
+class TestConfirmToolDenyAfterSuccess:
+    async def test_deny_after_success_raises_conflict_not_returns_success(
+        self,
+        session_with_tool_already_succeeded: tuple[asyncpg.Pool[Any], str, str, str],
+    ) -> None:
+        """A deny for a tool_call_id whose tool already produced a
+        successful result must NOT be treated as an idempotent retry —
+        the existing event's intent doesn't match the new request's
+        intent. Surface as ``ConflictError`` so the operator learns
+        the deny is too late rather than silently receiving the
+        success event back."""
+        pool, account_id, session_id, tool_call_id = session_with_tool_already_succeeded
+
+        with pytest.raises(ConflictError):
+            await sessions_service.confirm_tool_deny(
+                pool,
+                session_id,
+                tool_call_id,
+                "operator intended to deny",
+                account_id=account_id,
+            )
+
+        # And no second tool-role event for this tool_call_id should have
+        # been appended (we still want the single, true success event in
+        # the log — the conflict refused to write, not to coexist).
+        async with pool.acquire() as conn:
+            count = await conn.fetchval(
+                """
+                SELECT COUNT(*) FROM events
+                 WHERE session_id = $1
+                   AND data->>'role' = 'tool'
+                   AND data->>'tool_call_id' = $2
+                """,
+                session_id,
+                tool_call_id,
+            )
+        assert count == 1, (
+            f"deny-after-success must not append a duplicate tool-role event; current count={count}"
+        )
+
+    async def test_deny_idempotent_when_prior_deny_exists(
+        self,
+        migrated_db_url: str,
+        _reset_db_state: None,
+    ) -> None:
+        """Regression: a deny retry for an already-denied tool_call still
+        returns the original deny event (idempotency contract from #447
+        preserved). The conflict guard only fires for intent mismatch,
+        not same-intent retries."""
+        pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+        try:
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                    VALUES ('acc_deny_retry', NULL, TRUE, 'deny-retry-test')
+                    """
+                )
+            agent = await agents_service.create_agent(
+                pool,
+                account_id="acc_deny_retry",
+                name="deny-retry-test",
+                model="openrouter/test",
+                system="",
+                tools=[ToolSpec(type="bash")],
+                description=None,
+                metadata={},
+                window_min=50_000,
+                window_max=150_000,
+            )
+            env = await environments_service.create_environment(
+                pool, account_id="acc_deny_retry", name="deny-retry-env"
+            )
+            async with pool.acquire() as conn:
+                session = await queries.insert_session(
+                    conn,
+                    account_id="acc_deny_retry",
+                    agent_id=agent.id,
+                    environment_id=env.id,
+                    agent_version=agent.version,
+                    title=None,
+                    metadata={},
+                )
+                await queries.append_event(
+                    conn,
+                    account_id="acc_deny_retry",
+                    session_id=session.id,
+                    kind="message",
+                    data={
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "tc_to_deny",
+                                "type": "function",
+                                "function": {"name": "bash", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                )
+
+            first = await sessions_service.confirm_tool_deny(
+                pool, session.id, "tc_to_deny", "no", account_id="acc_deny_retry"
+            )
+            second = await sessions_service.confirm_tool_deny(
+                pool, session.id, "tc_to_deny", "no", account_id="acc_deny_retry"
+            )
+            assert first.id == second.id, "same-intent retry must return original event"
+        finally:
+            await pool.close()


### PR DESCRIPTION
## Summary

- ``append_tool_result``'s idempotency check dedups by ``tool_call_id`` alone, matching success OR error tool-role events. So a deny arriving AFTER the tool produced a success result (two-tab race; always_allow tool; bogus pre-confirm bypass pre-#533) is silently treated as a duplicate and the **success** event is returned to the operator (HTTP 201 with the tool's output as ``data.content``).
- The model's context still carries the success result unchanged. The deny had no effect — the tool ran, the model saw the result, the operator believed they denied. A textbook silent-failure: confirming bool returns success while the underlying intent was rejected.
- Fix: idempotent retry requires matching intent (same ``is_error`` outcome). Intent mismatch raises ``ConflictError`` (router → 409). The operator learns "too late, tool ran" instead of receiving a false success.

This is the symmetric twin to #533 (validate tool_call_id in confirm_tool_allow) — both targeted the "confirm endpoints silently accept impossible inputs" pattern. Same-intent retry idempotency from #447 preserved by the regression test.

## Test plan

- [x] Type-checker — clean
- [x] Linter + format-check — clean
- [x] Unit suite — 1345 passed
- [x] Integration: ``test_deny_after_success_raises_conflict_not_returns_success`` — fails red pre-fix with ``DID NOT RAISE <class 'aios.errors.ConflictError'>``; passes post-fix
- [x] Integration: ``test_deny_idempotent_when_prior_deny_exists`` — regression that same-intent retry still returns the original event
- [x] Existing tool-confirm idempotency tests (``test_tool_deny_idempotency``, ``test_tool_allow_idempotency``, ``test_tool_result_idempotency``) — still green
- [ ] CI runs full e2e + integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)