### PR TITLE
fix(mcp): surface discovery failures only where the model consciously initiated them

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -830,15 +830,31 @@ async def discover_session_mcp_tools(
         )
         return await discover_mcp_tools(url, vault_id, headers, name)
 
-    results = await asyncio.gather(*[_discover_one(n, u) for n, u in servers])
-    tools: list[dict[str, Any]] = [
-        tool for (tool_list, _instructions) in results for tool in tool_list
-    ]
-    instructions_by_server: dict[str, str] = {
-        name: instructions
-        for (name, _url), (_tools, instructions) in zip(servers, results, strict=True)
-        if instructions
-    }
+    # Discovery runs as part of the step prelude — a process the model
+    # didn't consciously initiate — so a single server's transport
+    # failure is logged at WARN for ops visibility but does NOT surface
+    # as a model-visible event. The failed server contributes neither
+    # tools nor an instructions entry, so the system prompt's
+    # mcp_servers_block reflects only servers the model can actually
+    # use. Healthy servers' discoveries proceed unaffected.
+    raw_results = await asyncio.gather(
+        *[_discover_one(n, u) for n, u in servers], return_exceptions=True
+    )
+    tools: list[dict[str, Any]] = []
+    instructions_by_server: dict[str, str] = {}
+    for (name, url), result in zip(servers, raw_results, strict=True):
+        if isinstance(result, BaseException):
+            log.warning(
+                "mcp.discovery_failed",
+                server_name=name,
+                url=url,
+                error=f"{type(result).__name__}: {result}",
+            )
+            continue
+        tool_list, instructions = result
+        tools.extend(tool_list)
+        if instructions:
+            instructions_by_server[name] = instructions
     return tools, instructions_by_server
 
 

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -181,51 +181,45 @@ async def discover_mcp_tools(
       any. Used by the harness to compose per-connector affordance prose
       into the system prompt.
 
-    On any error, logs a warning and returns ``([], None)`` — the model
-    simply doesn't see those tools (or that connector's instructions).
+    Raises on transport / protocol / auth failure. Callers decide how to
+    surface the error: the step prelude (``discover_session_mcp_tools``)
+    logs at WARN and filters the failed server out of the tools and
+    instructions it returns, since the model didn't consciously initiate
+    that discovery. The broker HTTP handlers translate it into a 502
+    response because the sandboxed model DID initiate the call.
     """
-    try:
-        from aios.harness import runtime
+    from aios.harness import runtime
 
-        _pool = runtime.mcp_session_pool
+    _pool = runtime.mcp_session_pool
 
-        if _pool is not None:
-            # Pool path: reuse cached session; on failure evict + retry once.
-            try:
-                session, init_result = await _pool.get_or_connect(url, vault_id, headers)
-                result = await session.list_tools()
-            except Exception:
-                _pool.evict(url, vault_id)
-                session, init_result = await _pool.get_or_connect(url, vault_id, headers)
-                result = await session.list_tools()
-        else:
-            # Fallback: fresh connection per call (API process, tests).
-            async with AsyncExitStack() as stack:
-                session, init_result = await _open_session(url, headers, stack)
-                result = await session.list_tools()
+    if _pool is not None:
+        # Pool path: reuse cached session; on failure evict + retry once.
+        try:
+            session, init_result = await _pool.get_or_connect(url, vault_id, headers)
+            result = await session.list_tools()
+        except Exception:
+            _pool.evict(url, vault_id)
+            session, init_result = await _pool.get_or_connect(url, vault_id, headers)
+            result = await session.list_tools()
+    else:
+        # Fallback: fresh connection per call (API process, tests).
+        async with AsyncExitStack() as stack:
+            session, init_result = await _open_session(url, headers, stack)
+            result = await session.list_tools()
 
-        if len(result.tools) > MAX_TOOLS_PER_SERVER:
-            log.warning(
-                "mcp.tools_truncated",
-                server_name=server_name,
-                total=len(result.tools),
-                limit=MAX_TOOLS_PER_SERVER,
-            )
-
-        tools: list[dict[str, Any]] = [
-            make_function_tool(f"mcp__{server_name}__{tool.name}", tool)
-            for tool in result.tools[:MAX_TOOLS_PER_SERVER]
-        ]
-        return tools, init_result.instructions
-
-    except Exception:
+    if len(result.tools) > MAX_TOOLS_PER_SERVER:
         log.warning(
-            "mcp.discovery_failed",
+            "mcp.tools_truncated",
             server_name=server_name,
-            url=url,
-            exc_info=True,
+            total=len(result.tools),
+            limit=MAX_TOOLS_PER_SERVER,
         )
-        return [], None
+
+    tools: list[dict[str, Any]] = [
+        make_function_tool(f"mcp__{server_name}__{tool.name}", tool)
+        for tool in result.tools[:MAX_TOOLS_PER_SERVER]
+    ]
+    return tools, init_result.instructions
 
 
 def shape_call_result(result: Any) -> dict[str, Any]:

--- a/src/aios/sandbox/mcp_proxy.py
+++ b/src/aios/sandbox/mcp_proxy.py
@@ -86,6 +86,24 @@ def _err(status: int, message: str) -> JSONResponse:
     return JSONResponse({"error": message}, status_code=status)
 
 
+def _transport_err(server_name: str, exc: BaseException) -> JSONResponse:
+    """502 response shape for an upstream MCP discovery failure.
+
+    Mirrors :func:`aios.mcp.client.call_mcp_tool`'s error envelope
+    (``{"error": ..., "code": "transport_error"}``) so the sandboxed
+    model sees the same shape whether discovery or invocation hit the
+    upstream blip — and so its CLI wrapper can branch on ``code``
+    rather than substring-matching the human-readable message.
+    """
+    return JSONResponse(
+        {
+            "error": f"MCP server '{server_name}' error: {type(exc).__name__}: {exc}",
+            "code": "transport_error",
+        },
+        status_code=502,
+    )
+
+
 class McpBroker:
     """One shared HTTP broker per worker.
 
@@ -288,9 +306,18 @@ class McpBroker:
         vault_id, headers = await resolve_auth_for_target_url(
             pool, crypto_box, session_id, server.url, account_id=account_id
         )
-        tool_dicts, _instructions = await discover_mcp_tools(
-            server.url, vault_id, headers, server_name
-        )
+        try:
+            tool_dicts, _instructions = await discover_mcp_tools(
+                server.url, vault_id, headers, server_name
+            )
+        except Exception as exc:
+            log.warning(
+                "mcp_broker.discovery_failed",
+                server_name=server_name,
+                url=server.url,
+                exc_info=True,
+            )
+            return _transport_err(server_name, exc)
 
         out: list[dict[str, Any]] = []
         for td in tool_dicts:
@@ -321,7 +348,16 @@ class McpBroker:
         vault_id, headers = await resolve_auth_for_target_url(
             pool, crypto_box, session_id, server.url, account_id=account_id
         )
-        tool_dicts, _ = await discover_mcp_tools(server.url, vault_id, headers, server.name)
+        try:
+            tool_dicts, _ = await discover_mcp_tools(server.url, vault_id, headers, server.name)
+        except Exception as exc:
+            log.warning(
+                "mcp_broker.discovery_failed",
+                server_name=server.name,
+                url=server.url,
+                exc_info=True,
+            )
+            return _transport_err(server.name, exc)
         qualified = f"mcp__{server.name}__{tool_name}"
         for td in tool_dicts:
             fn = td.get("function", {})

--- a/tests/unit/sandbox/test_mcp_proxy.py
+++ b/tests/unit/sandbox/test_mcp_proxy.py
@@ -203,6 +203,31 @@ class TestListTools:
             resp = await client.get(f"{base_url}/v1/s/servers/nope/tools")
         assert resp.status_code == 404
 
+    async def test_discovery_failure_returns_502(
+        self, broker: McpBroker, base_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the model runs ``mcp list-tools <server>`` and the upstream
+        server is unreachable, the broker must surface the transport
+        failure as a 502 so the sandboxed model sees that its conscious
+        action failed — not a 200 with an empty tools list, which would
+        be indistinguishable from a server that genuinely has no tools.
+        """
+        agent = _agent(
+            mcp_servers=[_server()], tools=[_toolset("tav", default_policy="always_allow")]
+        )
+        broker.register_session("sess_X", "s")
+        monkeypatch.setattr(broker, "_load_agent", _async_returning(agent))
+
+        async def _discover(*_args: object, **_kwargs: object) -> object:
+            raise ConnectionError("simulated upstream down")
+
+        monkeypatch.setattr("aios.sandbox.mcp_proxy.discover_mcp_tools", _discover)
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{base_url}/v1/s/servers/tav/tools")
+        assert resp.status_code == 502
+        assert resp.json().get("code") == "transport_error"
+
 
 class TestToolHelp:
     async def test_returns_schema_for_always_allow_tool(
@@ -276,6 +301,28 @@ class TestToolHelp:
             resp = await client.get(f"{base_url}/v1/s/servers/tav/tools/dangerous")
         assert resp.status_code == 403
         assert "disabled" in resp.json()["error"]
+
+    async def test_discovery_failure_returns_502(
+        self, broker: McpBroker, base_url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``mcp tool-help <server> <tool>`` is a conscious model action;
+        a discovery transport failure must surface as 502, not silently
+        masquerade as 'tool not found'."""
+        agent = _agent(
+            mcp_servers=[_server()], tools=[_toolset("tav", default_policy="always_allow")]
+        )
+        broker.register_session("sess_X", "s")
+        monkeypatch.setattr(broker, "_load_agent", _async_returning(agent))
+
+        async def _discover(*_args: object, **_kwargs: object) -> object:
+            raise ConnectionError("simulated upstream down")
+
+        monkeypatch.setattr("aios.sandbox.mcp_proxy.discover_mcp_tools", _discover)
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{base_url}/v1/s/servers/tav/tools/web_search")
+        assert resp.status_code == 502
+        assert resp.json().get("code") == "transport_error"
 
 
 class TestInvoke:

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -202,3 +202,55 @@ class TestDiscoverSessionMcpTools:
                 account_id="acc_test_stub",
             )
         assert instructions == {}
+
+    async def test_failed_server_filtered_from_tools_and_instructions(self) -> None:
+        """When one server's discovery raises, the others still succeed:
+        partial-success preserved, the failed server contributes neither
+        tools nor an instructions entry. The discovery failure happens in
+        the step prelude — a process the model didn't consciously initiate —
+        so it's logged at WARN for ops, not surfaced as a model-visible
+        event. The model sees a consistent view: only servers that are
+        actually usable appear in its tools list and instructions block.
+        """
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[
+                McpServerSpec(name="gh", url="https://mcp.github"),
+                McpServerSpec(name="broken", url="https://mcp.broken"),
+                McpServerSpec(name="ln", url="https://mcp.linear"),
+            ],
+            tools=[
+                ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh"),
+                ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="broken"),
+                ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="ln"),
+            ],
+        )
+
+        async def _discover(
+            _url: str, _vault_id: str | None, _headers: dict[str, str], name: str
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            if name == "broken":
+                raise ConnectionError("simulated discovery failure")
+            return [{"name": f"mcp__{name}__t"}], f"{name}-instructions"
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_target_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = (None, {})
+            tools, instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+                account_id="acc_test_stub",
+            )
+
+        tool_names = {t["name"] for t in tools}
+        assert tool_names == {"mcp__gh__t", "mcp__ln__t"}, (
+            "Failed server's tools must be omitted; healthy servers must still appear"
+        )
+        assert set(instructions) == {"gh", "ln"}, (
+            "Failed server must NOT appear in the instructions dict — the system "
+            "prompt would otherwise list a server the model can't actually use"
+        )

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -321,14 +321,19 @@ class TestDiscoverMcpTools:
         assert tools[0]["function"]["name"] == "mcp__myserver__tool_a"
         assert tools[1]["function"]["name"] == "mcp__myserver__tool_b"
 
-    async def test_discovery_failure_returns_empty(self) -> None:
+    async def test_discovery_raises_on_transport_failure(self) -> None:
+        """Discovery propagates the underlying transport exception so the
+        caller can decide how to surface it. The previous silent
+        ``([], None)`` fallback hid server-down failures from the model:
+        the system prompt listed the server but no tools were callable,
+        leaving the model unable to self-correct.
+        """
         with patch("aios.mcp.client.streamable_http_client") as mock_transport:
             mock_transport.return_value.__aenter__ = AsyncMock(side_effect=ConnectionError("down"))
             mock_transport.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            result = await discover_mcp_tools("https://bad.example.com/", None, {}, "bad")
-
-        assert result == ([], None)
+            with pytest.raises(ConnectionError, match="down"):
+                await discover_mcp_tools("https://bad.example.com/", None, {}, "bad")
 
     async def test_discovery_propagates_server_instructions(self) -> None:
         """``InitializeResult.instructions`` is the standard MCP transport


### PR DESCRIPTION
## Summary

- `discover_mcp_tools` silently caught all exceptions and returned `([], None)`. The model saw the server's name in `mcp_servers_block` (from `agent.mcp_servers` config) but no callable tools and no error signal — semantically indistinguishable from a correctly-configured server that happens to have no tools. The model couldn't self-correct because there was nothing to react to.
- The fix splits behaviour across the three call sites by whether the model **consciously initiated** the action:
  - `discover_mcp_tools` itself (`mcp/client.py`) — raises instead of swallowing. The decision about how to surface failure moves to callers, where context is known.
  - `discover_session_mcp_tools` (`harness/loop.py`) — the step prelude. Background discovery the model didn't ask for. Switches to `gather(return_exceptions=True)`, logs failed servers at WARN, and filters them out of **both** the tools list **and** the instructions dict feeding `mcp_servers_block`. Healthy servers proceed unaffected; the model sees only servers it can actually use.
  - Broker `_list_tools` / `_tool_help` (`sandbox/mcp_proxy.py`) — invoked by the sandboxed model via `mcp list-tools <server>` / `mcp tool-help <server> <tool>`. Wraps the discover call with try/except and returns 502 with a `transport_error` envelope, mirroring `call_mcp_tool`'s error shape so the CLI wrapper can branch on `.code` rather than substring-matching the message.

The shared heuristic: the model should see errors for processes it consciously initiated; bowels-of-the-system failures stay in the ops log unless they directly affect what the model can do, in which case the model just sees a smaller available set, not a noisy error event.

## Test plan

- [x] Rewrote `test_discovery_failure_returns_empty` → `test_discovery_raises_on_transport_failure` — encodes the new raise contract.
- [x] New `test_failed_server_filtered_from_tools_and_instructions` — three servers, one raises; verifies the failed server is omitted from BOTH the returned tools and the instructions dict, while healthy servers' tools survive.
- [x] New `TestListTools.test_discovery_failure_returns_502` and `TestToolHelp.test_discovery_failure_returns_502` — broker routes return 502 with `code: "transport_error"`.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1348 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)