### PR TITLE
fix(ci): restore environment: stable for secret scoping (no reviewer gate)

### DIFF
--- a/.github/workflows/promote-api.yml
+++ b/.github/workflows/promote-api.yml
@@ -28,6 +28,7 @@ on:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    environment: stable  # scopes EUMEMIC_OPS_DISPATCH_TOKEN; no protection rules configured
     permissions:
       contents: read
     steps:

--- a/.github/workflows/promote-sandbox.yml
+++ b/.github/workflows/promote-sandbox.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    environment: stable  # scopes EUMEMIC_OPS_DISPATCH_TOKEN; no protection rules configured
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/promote-worker.yml
+++ b/.github/workflows/promote-worker.yml
@@ -28,6 +28,7 @@ on:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    environment: stable  # scopes EUMEMIC_OPS_DISPATCH_TOKEN; no protection rules configured
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

#534 removed \`environment: stable\` from the three promote workflows to drop the reviewer-approval gate. Side effect: workflows lost access to env-scoped secrets, in particular \`EUMEMIC_OPS_DISPATCH_TOKEN\` — which lives only on the stable environment, not at repo level.

v3 of \`peter-evans/repository-dispatch\` silently fell back to \`GITHUB_TOKEN\` on missing token; v4 (bumped in #532) requires an explicit token and fails loudly. Both landed together, and the failure first surfaced when promotes ran on the new code.

## Why this doesn't reintroduce the gate

The reviewer-approval requirement was on the **environment** itself (the \`protection_rules\` list, where required-reviewers entries live), not on the \`environment: stable\` declaration in the workflow. \`gh api repos/eumemic/aios/environments/stable\` currently returns \`protection_rules: []\` — there are no reviewers configured at the env level. So claiming the environment in the workflow gets us secret scope without re-introducing approval prompts.

## Changes

- \`.github/workflows/promote-sandbox.yml\` — re-add \`environment: stable\` with inline comment explaining why
- \`.github/workflows/promote-api.yml\` — same
- \`.github/workflows/promote-worker.yml\` — same

## Verification after merge

\`gh workflow run promote-api.yml --repo eumemic/aios\` should fire and complete without prompting for approval. If a prompt does appear (i.e. env-level reviewer rules are reinstated), the fix is at https://github.com/eumemic/aios/settings/environments/15351588657/edit — remove "Required reviewers" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)