### PR TITLE
fix(services/sessions): reject allow when tool_call has already resolved

### DIFF
--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -532,6 +532,15 @@ async def confirm_tool_allow(
     the deny twin's same-event-shape dedup (#447); ``_dispatch_confirmed_tools``
     further set-deduplicates so the tool dispatches once even pre-fix,
     but the lifecycle event log must not accumulate duplicate rows.
+
+    Rejects with :class:`ConflictError` when the tool call already has
+    a tool-role result event — a prior deny or a racing dispatch
+    pinned the model's view; appending a lifecycle ``allow`` here would
+    be a phantom no-op surfaced as 201 (operator UI shows "allow
+    accepted" while the model has moved on with the prior result).
+    Symmetric twin to #535 (``confirm_tool_deny`` rejected when tool
+    already succeeded); same defect class — confirm endpoints must not
+    silently accept impossible inputs.
     """
     async with pool.acquire() as conn, conn.transaction():
         locked = await conn.fetchval(
@@ -569,6 +578,30 @@ async def confirm_tool_allow(
             raise NotFoundError(
                 f"tool_call_id {tool_call_id!r} not found",
                 detail={"session_id": session_id, "tool_call_id": tool_call_id},
+            )
+        # Reject when the tool call has already resolved (deny error
+        # or successful dispatch).  Pinning the model's view is
+        # one-way; an allow appended after the result has no dispatch
+        # effect (``CONFIRMED_ROWS_SQL`` filters out sessions whose
+        # confirmed-and-not-resolved set is empty), yet returning the
+        # lifecycle event would lie to the operator ("allow
+        # accepted").  Surface as ``ConflictError`` (→ 409) so the
+        # operator learns "too late" — same shape as #535's
+        # deny-after-success.
+        prior_result = await queries.find_tool_result_event(
+            conn, session_id, tool_call_id, account_id=account_id
+        )
+        if prior_result is not None:
+            prior_is_error = bool(prior_result.data.get("is_error", False))
+            raise ConflictError(
+                f"tool_call_id {tool_call_id!r} already has a "
+                f"{'error' if prior_is_error else 'success'} "
+                f"result; cannot allow a tool call that has already resolved",
+                detail={
+                    "session_id": session_id,
+                    "tool_call_id": tool_call_id,
+                    "existing_is_error": prior_is_error,
+                },
             )
         return await queries.append_event(
             conn,

--- a/tests/integration/test_confirm_tool_allow_after_resolved.py
+++ b/tests/integration/test_confirm_tool_allow_after_resolved.py
@@ -1,0 +1,256 @@
+"""Integration test: ``confirm_tool_allow`` must reject when the
+referenced tool_call has already been resolved (a tool-role result
+already exists in the log).
+
+Pre-fix the allow path checks only for an existing
+``lifecycle/tool_confirmed`` event (idempotent retry guard).  It does
+NOT check whether a tool-role result already exists for the same
+``tool_call_id``.  So:
+
+  1. Tool fires (always_ask).  Session parks in ``requires_action``.
+  2. Operator denies in tab A → ``confirm_tool_deny`` →
+     ``append_tool_result(is_error=True)``.  A tool-role error event
+     lands on the log; no ``lifecycle/tool_confirmed`` event exists.
+  3. Operator clicks allow in tab B → ``confirm_tool_allow`` →
+     ``find_tool_confirmed_event`` returns ``None`` → the allow
+     appends a fresh ``lifecycle/tool_confirmed allow`` event.
+
+The HTTP response is 201 with the lifecycle event.  Operator UI
+displays "allow accepted."  But the model's context still carries the
+deny's error result, has reacted to it, and may have moved on.  The
+allow had no effect.  A textbook silent-failure: confirming bool
+returns success while the underlying intent is impossible.
+
+Symmetric twin to #535 (``confirm_tool_deny`` rejected when tool
+already succeeded).  Same defect class: "confirm endpoints silently
+accept impossible inputs."  The contract should be: idempotent retry
+requires no prior result; an attempted allow against an
+already-resolved tool is a CONFLICT, not a no-op.
+
+The same trap applies to allow-after-success (always_allow tool, or
+any path that produced a result before the allow arrived).  Both
+paths are covered.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import ConflictError
+from aios.models.agents import ToolSpec
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+
+pytestmark = pytest.mark.integration
+
+
+async def _seed_session_with_tool_call(
+    pool: asyncpg.Pool[Any], account_id: str, suffix: str
+) -> tuple[str, str]:
+    """Create an account, agent, env, session, and append one assistant
+    event carrying a single ``tool_calls`` entry.  Returns
+    ``(session_id, tool_call_id)``.
+    """
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+            VALUES ($1, NULL, TRUE, $2)
+            """,
+            account_id,
+            f"allow-after-resolved-test-{suffix}",
+        )
+    agent = await agents_service.create_agent(
+        pool,
+        account_id=account_id,
+        name=f"allow-after-resolved-agent-{suffix}",
+        model="openrouter/test",
+        system="",
+        tools=[ToolSpec(type="bash")],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    env = await environments_service.create_environment(
+        pool, account_id=account_id, name=f"allow-after-resolved-env-{suffix}"
+    )
+    tool_call_id = f"tc_resolved_{suffix}"
+    async with pool.acquire() as conn:
+        session = await queries.insert_session(
+            conn,
+            account_id=account_id,
+            agent_id=agent.id,
+            environment_id=env.id,
+            agent_version=agent.version,
+            title=None,
+            metadata={},
+        )
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session.id,
+            kind="message",
+            data={
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": tool_call_id,
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": "{}"},
+                    }
+                ],
+            },
+        )
+    return session.id, tool_call_id
+
+
+@pytest.fixture
+async def session_with_tool_already_denied(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str]]:
+    """Yield ``(pool, account_id, session_id, tool_call_id)`` for a
+    session whose event log contains: assistant message with a
+    ``tool_calls`` entry, followed by a tool-role ERROR result event
+    for that same ``tool_call_id`` (i.e. the deny twin already ran).
+    """
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        account_id = "acc_allow_after_deny"
+        session_id, tool_call_id = await _seed_session_with_tool_call(pool, account_id, "deny")
+        # Simulate a prior deny: appends a tool-role error event for
+        # the same ``tool_call_id`` (mirrors what
+        # ``confirm_tool_deny`` would write).
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "content": '{"error": "Permission denied by operator."}',
+                    "name": "bash",
+                    "is_error": True,
+                },
+            )
+        yield pool, account_id, session_id, tool_call_id
+    finally:
+        await pool.close()
+
+
+@pytest.fixture
+async def session_with_tool_already_succeeded(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str]]:
+    """Yield ``(pool, account_id, session_id, tool_call_id)`` for a
+    session whose event log contains: assistant message with a
+    ``tool_calls`` entry, followed by a SUCCESSFUL tool-role result
+    event for that same ``tool_call_id`` (always_allow tool or
+    pre-confirm bypass race produced a result before this allow).
+    """
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        account_id = "acc_allow_after_success"
+        session_id, tool_call_id = await _seed_session_with_tool_call(pool, account_id, "success")
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "content": "the-tool-actually-executed",
+                    "name": "bash",
+                    # NOTE: no is_error key → success result.
+                },
+            )
+        yield pool, account_id, session_id, tool_call_id
+    finally:
+        await pool.close()
+
+
+class TestConfirmToolAllowAfterResolved:
+    async def test_allow_after_deny_raises_conflict_not_silent_no_op(
+        self,
+        session_with_tool_already_denied: tuple[asyncpg.Pool[Any], str, str, str],
+    ) -> None:
+        """An allow for a tool_call_id that already has a deny error
+        result must NOT silently succeed — the lifecycle event would
+        have no dispatch effect (the result already pinned the model's
+        view) yet the operator sees 201, believing the allow took.
+
+        Surface as ``ConflictError`` so the operator learns "too late,
+        already denied" rather than receiving a phantom success.
+        """
+        pool, account_id, session_id, tool_call_id = session_with_tool_already_denied
+
+        with pytest.raises(ConflictError):
+            await sessions_service.confirm_tool_allow(
+                pool, session_id, tool_call_id, account_id=account_id
+            )
+
+        # No ``lifecycle/tool_confirmed`` event should have been written —
+        # the conflict refused the append, didn't merely coexist with it.
+        async with pool.acquire() as conn:
+            count = await conn.fetchval(
+                """
+                SELECT COUNT(*) FROM events
+                 WHERE session_id = $1
+                   AND kind = 'lifecycle'
+                   AND data->>'event' = 'tool_confirmed'
+                   AND data->>'tool_call_id' = $2
+                """,
+                session_id,
+                tool_call_id,
+            )
+        assert count == 0, (
+            f"allow-after-deny must not append a phantom lifecycle event; current count={count}"
+        )
+
+    async def test_allow_after_success_raises_conflict_not_silent_no_op(
+        self,
+        session_with_tool_already_succeeded: tuple[asyncpg.Pool[Any], str, str, str],
+    ) -> None:
+        """An allow for a tool_call_id that already produced a success
+        result must NOT silently succeed.  The tool already ran (e.g.
+        always_allow toolset, or any race where dispatch beat the
+        operator click); confirming "allow" can't go back in time.
+
+        Same defect shape as deny-after-success (#535) — confirm
+        endpoint must reject impossible inputs rather than return a
+        misleading 201.
+        """
+        pool, account_id, session_id, tool_call_id = session_with_tool_already_succeeded
+
+        with pytest.raises(ConflictError):
+            await sessions_service.confirm_tool_allow(
+                pool, session_id, tool_call_id, account_id=account_id
+            )
+
+        async with pool.acquire() as conn:
+            count = await conn.fetchval(
+                """
+                SELECT COUNT(*) FROM events
+                 WHERE session_id = $1
+                   AND kind = 'lifecycle'
+                   AND data->>'event' = 'tool_confirmed'
+                   AND data->>'tool_call_id' = $2
+                """,
+                session_id,
+                tool_call_id,
+            )
+        assert count == 0, (
+            f"allow-after-success must not append a phantom lifecycle event; current count={count}"
+        )


### PR DESCRIPTION
## Summary

- ``confirm_tool_allow``'s idempotent-retry guard checks only for an existing ``lifecycle/tool_confirmed`` event. It does NOT check whether a tool-role result already exists for the same ``tool_call_id``. A deny in tab A followed by an allow in tab B (or any allow arriving after a successful dispatch produced a result) appended a fresh lifecycle event and returned 201 — operator UI shows "allow accepted" while the model has already reacted to the prior result and moved on. The lifecycle event has no dispatch effect (``CONFIRMED_ROWS_SQL`` filters out sessions whose confirmed-and-not-resolved set is empty); the operator is misled.
- Fix: probe for a prior ``find_tool_result_event`` after the idempotent allow-retry guard. If one exists, raise ``ConflictError`` (router → 409) carrying the prior result's ``is_error`` so the operator learns "too late, already resolved" rather than receiving a phantom success.
- Symmetric twin to #535 (``confirm_tool_deny`` rejected when tool already succeeded). Same defect class — confirm endpoints must not silently accept impossible inputs.

## Test plan

- [x] Type-checker — clean
- [x] Linter + format-check — clean
- [x] Unit suite — 1348 passed
- [x] Integration: ``test_allow_after_deny_raises_conflict_not_silent_no_op`` — fails red pre-fix with ``DID NOT RAISE <class 'aios.errors.ConflictError'>``; passes post-fix
- [x] Integration: ``test_allow_after_success_raises_conflict_not_silent_no_op`` — covers the second reachable trigger path
- [x] Existing tool-confirm tests (``test_tool_allow_idempotency``, ``test_tool_deny_idempotency``, ``test_confirm_tool_deny_after_success``, ``test_confirm_tool_allow_validates_call_id``, ``test_tool_confirmation``) — all still green (20/20)
- [ ] CI runs full e2e + integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)