### PR TITLE
fix(aios_connectors/resolver): treat stale ledger entry pointing at archived session as DETACHED

### DIFF
--- a/src/aios_connectors/resolver.py
+++ b/src/aios_connectors/resolver.py
@@ -50,6 +50,25 @@ class ResolveResult(NamedTuple):
     drop: ResolveDrop | None
 
 
+async def _session_is_archived(
+    pool: asyncpg.Pool[Any], session_id: str, *, account_id: str
+) -> bool:
+    """Return ``True`` iff ``session_id`` exists for ``account_id`` and is archived.
+
+    Shared by the tier-1 ledger and tier-3 single_session checks so both
+    surfaces refuse to route inbounds to a session ``append_event``
+    (post-#523) would reject — see the call sites for the full
+    ``DETACHED`` → 422 cascade rationale.
+    """
+    async with pool.acquire() as conn:
+        archived_at = await conn.fetchval(
+            "SELECT archived_at FROM sessions WHERE id = $1 AND account_id = $2",
+            session_id,
+            account_id,
+        )
+    return archived_at is not None
+
+
 async def resolve_target_session(
     pool: asyncpg.Pool[Any], *, account_id: str, connection: Connection, chat_id: str
 ) -> ResolveResult:
@@ -64,6 +83,18 @@ async def resolve_target_session(
             conn, connection.id, chat_id, account_id=account_id
         )
     if existing is not None:
+        # The ledger entry was stamped at spawn (tier-3) or operator-bind
+        # time (when the session was live), but the operator may have
+        # archived the bound session since.  Without this check the
+        # resolver returns the archived id with ``drop=None``,
+        # ``handle_inbound`` proceeds to ``append_event`` which (post-
+        # #523) raises NotFoundError, the inbound surfaces as
+        # ``SESSION_MISSING`` → HTTP 500, and well-behaved connectors
+        # retry-forever on 5xx (same retry-loop pathology PR #526 closed
+        # for tier-3 single_session).  ``DETACHED`` (→ 422) is the
+        # terminal signal that tells the connector to stop retrying.
+        if await _session_is_archived(pool, existing, account_id=account_id):
+            return ResolveResult(session_id=None, drop=ResolveDrop.DETACHED)
         return ResolveResult(session_id=existing, drop=None)
 
     # Tier 2: routing_rules prefix demux on the active binding.
@@ -101,13 +132,7 @@ async def resolve_target_session(
         # ledger stamp here so the next inbound goes through the same
         # check (no poisoning), and if the operator detaches+rebinds
         # to a live session the resolver picks it up immediately.
-        async with pool.acquire() as conn:
-            session_archived_at = await conn.fetchval(
-                "SELECT archived_at FROM sessions WHERE id = $1 AND account_id = $2",
-                binding.session_id,
-                account_id,
-            )
-        if session_archived_at is not None:
+        if await _session_is_archived(pool, binding.session_id, account_id=account_id):
             return ResolveResult(session_id=None, drop=ResolveDrop.DETACHED)
         # No ledger insert — operators opt into per-chat overrides explicitly.
         return ResolveResult(session_id=binding.session_id, drop=None)

--- a/tests/integration/test_resolver_archived_session.py
+++ b/tests/integration/test_resolver_archived_session.py
@@ -17,12 +17,15 @@ already returns ``DETACHED``/``ARCHIVED_TEMPLATE`` for permanent-config
 failures upstream of the append, and archived single_session targets
 deserve the same treatment.
 
-This iteration fixes the most-reachable case: tier-3 ``single_session``
-binding pointing at an archived session. Tier-2 ``target_type='session'``
-+ tier-1 stale-ledger entries are adjacent and could be a follow-up,
-but tier-2 routing rules have no operator-facing API today and tier-1
-lookup only fires after a successful tier-2/3 stamp (which we now
-refuse).
+PR #526 covered tier-3 ``single_session``.  Tier-1 (stale ledger entry
+pointing at an archived session) is the routine variant: any per_chat
+session spawned by tier-3 and stamped into the ledger becomes a stale
+entry the moment the operator archives the session.  Subsequent
+inbounds short-circuit tier-1's ``lookup_chat_session`` and land in the
+archived id, where ``append_event`` (post-#523) raises NotFoundError →
+``SESSION_MISSING`` → 500 → connector retry-forever.  Stamp-then-
+archive is exactly the lifecycle every per_chat session goes through,
+so the ledger is the most-reachable leak surface, not the least.
 """
 
 from __future__ import annotations
@@ -129,5 +132,113 @@ async def test_resolver_returns_detached_for_archived_single_session_target(
         f"{result!r}. Pre-fix the resolver returns the archived session_id "
         f"with drop=None; post-fix it returns drop=DETACHED with session_id "
         f"None."
+    )
+    assert result.session_id is None
+
+
+@pytest.fixture
+async def chat_sessions_ledger_with_archived_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str]]:
+    """Yield ``(pool, account_id, connection_id, chat_id)`` for a
+    ``chat_sessions`` ledger row whose target session has been archived.
+
+    Models the routine per_chat lifecycle: tier-3 spawned a session and
+    stamped the ledger, then the operator archived that session.  The
+    ledger now points at an archived id; tier-1 lookup must not return
+    it (or future inbounds 500-retry-forever — see module docstring)."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    chat_id = "stale-ledger-chat"
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_ledger_arch', NULL, TRUE, 'ledger-archived-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_ledger_arch",
+            name="ledger-arch-test",
+            model="openrouter/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_ledger_arch", name="ledger-arch-env"
+        )
+        async with pool.acquire() as conn:
+            session = await queries.insert_session(
+                conn,
+                account_id="acc_ledger_arch",
+                agent_id=agent.id,
+                environment_id=env.id,
+                agent_version=agent.version,
+                title=None,
+                metadata={},
+            )
+            connection = await queries.insert_connection(
+                conn,
+                connector="echo",
+                external_account_id="test-account",
+                metadata={},
+                account_id="acc_ledger_arch",
+            )
+            # Stamp the ledger BEFORE archiving — mirrors the order
+            # produced by a real per_chat spawn followed by an operator
+            # archive of the spawned session.
+            await queries.insert_chat_session(
+                conn,
+                connection_id=connection.id,
+                chat_id=chat_id,
+                session_id=session.id,
+                account_id="acc_ledger_arch",
+            )
+            await queries.archive_session(conn, session.id, account_id="acc_ledger_arch")
+        yield pool, "acc_ledger_arch", connection.id, chat_id
+    finally:
+        await pool.close()
+
+
+async def test_resolver_returns_detached_for_stale_ledger_archived_session(
+    chat_sessions_ledger_with_archived_session: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    """Tier-1 ``lookup_chat_session`` short-circuits on the stamped
+    ledger row without checking the bound session's ``archived_at``.
+
+    Routine per_chat lifecycle: tier-3 stamps the ledger at spawn time
+    (session live), operator later archives the session.  The ledger
+    row is now stale; the next inbound's tier-1 lookup returns the
+    archived id with ``drop=None``; ``handle_inbound`` proceeds to
+    ``append_event`` which (post-#523) raises NotFoundError; the
+    inbound surfaces as ``SESSION_MISSING`` → HTTP 500; connectors
+    retry-forever on 5xx.  The resolver must return ``DETACHED``
+    instead so the connector sees a 422 terminal signal.
+
+    Same defect class PR #526 closed for tier-3 single_session.  Tier-1
+    is the more reachable surface because every per_chat-spawned
+    session that the operator later archives produces a stale ledger
+    entry — and per_chat is the common case."""
+    from aios_connectors.resolver import ResolveDrop, resolve_target_session
+
+    pool, account_id, connection_id, chat_id = chat_sessions_ledger_with_archived_session
+    async with pool.acquire() as conn:
+        connection = await queries.get_connection(conn, connection_id, account_id=account_id)
+
+    result = await resolve_target_session(
+        pool, connection=connection, chat_id=chat_id, account_id=account_id
+    )
+
+    assert result.drop == ResolveDrop.DETACHED, (
+        f"tier-1 lookup must filter archived sessions out of the ledger so "
+        f"connectors get a 422 terminal signal instead of 500-retry-forever "
+        f"from the downstream append_event NotFoundError. Got {result!r}. "
+        f"Pre-fix the resolver returns the archived session_id with "
+        f"drop=None; post-fix it returns drop=DETACHED with session_id None."
     )
     assert result.session_id is None


### PR DESCRIPTION
## Summary

- The tier-1 `chat_sessions` ledger lookup short-circuits on the
  stamped `session_id` without checking `archived_at`. Routine per_chat
  lifecycle: tier-3 stamps the ledger at spawn time (session live),
  the operator later archives the session. The ledger is now stale;
  the next inbound's tier-1 lookup returns the archived id with
  `drop=None`; `handle_inbound` proceeds to `append_event` which
  (post-#523) raises `NotFoundError`; the inbound surfaces as
  `SESSION_MISSING` → HTTP 500; well-behaved connectors retry-forever
  on 5xx (Telegram retry-with-backoff, Signal SDK at-least-once,
  HTTP-pollers). Reachability is high: every per_chat-spawned session
  the operator later archives produces a stale ledger entry, and
  per_chat is the common case.
- Same defect class PR #526 closed for tier-3 single_session — same
  retry-loop pathology, same fix shape. Tier-1 is the more reachable
  surface, not the least (the prior PR's docstring deferred it on the
  reasoning that "tier-1 lookup only fires after a successful tier-2/3
  stamp" — true, but the stamp + later archive is the dominant
  lifecycle pattern that produces stale entries).
- Fix: after tier-1 lookup, refuse archived sessions and return
  `ResolveDrop.DETACHED` (router → 422 terminal "operator config
  issue" that tells the connector to stop retrying). Extracted the
  inline `SELECT archived_at` into a shared `_session_is_archived`
  helper so the tier-3 single_session check (PR #526) and this new
  tier-1 check use one definition.
- Tier-2 `target_type='session'` routing rules have an identical gap
  but no operator-facing CRUD today; left for a follow-up iteration.

## Test plan

- [x] Type-checker — clean (155 source files)
- [x] Linter + format-check — clean
- [x] Unit suite — 1348 passed
- [x] Integration: `test_resolver_returns_detached_for_stale_ledger_archived_session`
  — fails red pre-fix with `ResolveResult(session_id='sess_…', drop=None)`;
  passes post-fix with `drop=DETACHED, session_id=None`
- [x] Integration: existing `test_resolver_returns_detached_for_archived_single_session_target`
  (PR #526 regression) — still green after the helper extraction
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)