### PR TITLE
fix(services/vaults): scope vault-row FOR UPDATE by account_id in create_vault_credential

### DIFF
--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -420,9 +420,21 @@ async def create_vault_credential(
         # Lock the parent vault row to serialize concurrent credential inserts
         # within this vault. Without it, two parallel inserts can both observe
         # ``count == MAX-1`` and overflow the cap.
+        #
+        # The ``account_id = $2`` filter is load-bearing for tenant isolation,
+        # not just the lock's correctness: ``insert_vault_credential`` trusts
+        # the caller's ``account_id`` (writes it verbatim) and the
+        # ``vault_credentials.vault_id`` FK enforces only existence, not
+        # account-matching. Without scoping the lock, tenant A can target
+        # tenant B's vault_id, land the lock, pass the (correctly scoped)
+        # quota check at count 0, and write a credential row at
+        # ``(account_id=A, vault_id=B-vault)``. Mirrors the sessions.py
+        # ``SELECT id FROM sessions … FOR UPDATE`` pattern, where the
+        # account_id is similarly load-bearing rather than redundant.
         locked = await conn.fetchrow(
-            "SELECT 1 FROM vaults WHERE id = $1 FOR UPDATE",
+            "SELECT 1 FROM vaults WHERE id = $1 AND account_id = $2 FOR UPDATE",
             vault_id,
+            account_id,
         )
         if locked is None:
             raise NotFoundError(

--- a/tests/e2e/test_tenant_isolation.py
+++ b/tests/e2e/test_tenant_isolation.py
@@ -219,6 +219,48 @@ class TestTwoTenantIsolation:
         cross = await http_client.get(f"/v1/session-templates/{b_id}", headers=_bearer(ka))
         assert cross.status_code == 404, cross.text
 
+    async def test_vault_credential_create_cross_tenant_404(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        """POST /v1/vaults/{B-vault}/credentials as tenant A must 404.
+
+        ``services.vaults.create_vault_credential`` row-locks the parent
+        vault with ``SELECT 1 FROM vaults WHERE id = $1 FOR UPDATE`` —
+        no ``account_id`` filter. Tenant A can target tenant B's
+        ``vault_id``, land the lock, then ``insert_vault_credential``
+        writes a row with ``(account_id=A, vault_id=B's vault)`` —
+        cross-tenant data placement. The credential is invisible to B
+        (B's reads scope by ``account_id``), but A has manufactured a
+        credential nested under a vault it doesn't own. Match the
+        established cross-tenant posture: NotFound, not silent success.
+        """
+        ka = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-vcred-a")
+        kb = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-vcred-b")
+
+        vault_b = await http_client.post(
+            "/v1/vaults", headers=_bearer(kb), json={"display_name": "b-vault"}
+        )
+        assert vault_b.status_code == 201, vault_b.text
+        b_vault_id = vault_b.json()["id"]
+
+        # Tenant A targets tenant B's vault_id; expected 404, not 201.
+        cross = await http_client.post(
+            f"/v1/vaults/{b_vault_id}/credentials",
+            headers=_bearer(ka),
+            json={
+                "display_name": "stolen",
+                "target_url": "https://example.com",
+                "auth_type": "bearer_header",
+                "token": "secret",
+            },
+        )
+        assert cross.status_code == 404, cross.text
+
+        # Confirm B's view of its own vault is uncontaminated.
+        list_b = await http_client.get(f"/v1/vaults/{b_vault_id}/credentials", headers=_bearer(kb))
+        assert list_b.status_code == 200
+        assert list_b.json()["data"] == []
+
     async def test_keys_isolated(
         self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
     ) -> None:


### PR DESCRIPTION
## Summary

- ``create_vault_credential`` row-locked the parent vault with ``SELECT 1 FROM vaults WHERE id = $1 FOR UPDATE`` — no ``account_id`` filter. Combined with ``insert_vault_credential`` trusting the caller's ``account_id`` verbatim and the FK enforcing only existence, tenant A could POST to ``/v1/vaults/{B-vault}/credentials`` and write a credential row at ``(account_id=A, vault_id=B-vault)`` — a cross-tenant data placement (no read leak; A manufactures their own credential nested under a vault they don't own).
- Add ``AND account_id = $2`` to the lock so a cross-tenant target 404s at the same gate that already rejects missing vault ids. Mirrors the existing ``sessions.py`` ``SELECT id FROM sessions … FOR UPDATE`` pattern where the account filter is similarly load-bearing.
- Adds an e2e regression in ``TestTwoTenantIsolation`` proving the symptom (201 pre-fix, 404 post-fix) and confirming B's view of its own vault stays uncontaminated.
- Continues the cross-tenant sweep from #426 into ``services/*`` inline SQL — the prior sweep covered only ``db/queries.py``.

## Test plan

- [x] ``uv run mypy src`` — clean
- [x] ``uv run ruff check src tests && uv run ruff format --check src tests`` — clean
- [x] ``uv run pytest tests/unit -q`` — 1348 passed
- [x] ``uv run pytest tests/e2e/test_vaults.py tests/e2e/test_tenant_isolation.py tests/unit/test_vault.py -q`` — 94 passed (new regression test green only post-fix)
- [ ] CI runs full e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)