### PR TITLE
fix(services/inbound): trusted sender.display_name lost in render

### DIFF
--- a/src/aios/services/inbound.py
+++ b/src/aios/services/inbound.py
@@ -34,7 +34,13 @@ from aios.services.wake import defer_wake
 # crafted payload can't plant fields the renderer / logging trusts —
 # most acutely ``attachments``, which the harness's vision renderer
 # resolves through ``resolve_to_host_path`` and reads from disk.
-_RESERVED_METADATA_KEYS = frozenset({"channel", "sender", "attachments", "platform_timestamp"})
+#
+# ``sender_name`` is the key the renderer + ``events_search.sender_name``
+# derivation actually consume; reserving the historical ``sender`` key
+# instead left the security boundary off the consumed slot — a connector
+# could forge an arbitrary ``sender_name`` and the renderer would surface
+# it as the trusted ``from=`` clause.
+_RESERVED_METADATA_KEYS = frozenset({"channel", "sender_name", "attachments", "platform_timestamp"})
 
 
 class _DedupRollback(Exception):
@@ -215,7 +221,10 @@ async def _append_with_dedup(
         )
     metadata["channel"] = channel
     if isinstance(sender_name, str):
-        metadata["sender"] = sender_name
+        # See ``_RESERVED_METADATA_KEYS`` for why this writes under
+        # ``sender_name`` (the key the renderer + events_search column
+        # consume) rather than the pre-fix ``sender`` (a dead key).
+        metadata["sender_name"] = sender_name
     if isinstance(attachments, list) and attachments:
         metadata["attachments"] = attachments
     if platform_timestamp is not None:

--- a/tests/unit/test_inbound_metadata.py
+++ b/tests/unit/test_inbound_metadata.py
@@ -112,11 +112,13 @@ async def test_connector_cannot_plant_attachments_via_metadata(
 async def test_connector_cannot_shadow_sender_via_metadata(
     fake_pool: MagicMock,
 ) -> None:
-    """Same pattern for ``sender``: trusted code sets it from the request's
-    ``sender.display_name``, but only conditionally (when that's a str).
-    A connector-supplied metadata.sender wins when the request sender is
-    blank — letting the connector forge a different user identity in
-    log/render output."""
+    """Same pattern for the rendered sender identity: trusted code sets
+    ``metadata["sender_name"]`` from ``sender.display_name`` (the key
+    the harness renderer + ``events_search.sender_name`` derivation
+    consume), and a connector-supplied ``metadata["sender_name"]`` must
+    be stripped — otherwise the connector can forge a different user
+    identity in log/render output by passing it through the bytes-only
+    inbound POST while leaving ``sender.display_name`` blank."""
     captured: dict[str, Any] = {}
 
     async def fake_append_event(*_args: Any, **kwargs: Any) -> Any:
@@ -145,13 +147,103 @@ async def test_connector_cannot_shadow_sender_via_metadata(
             sender={},  # no display_name → trusted code path doesn't override
             content="hi",
             attachments=[],
-            connector_metadata={"sender": "<spoofed>"},
+            connector_metadata={"sender_name": "<spoofed>"},
             platform_timestamp=None,
         )
 
     metadata = captured["data"]["metadata"]
-    assert metadata.get("sender") != "<spoofed>", (
-        f"connector-supplied metadata.sender must be stripped; got {metadata.get('sender')!r}."
+    assert metadata.get("sender_name") != "<spoofed>", (
+        f"connector-supplied metadata.sender_name must be stripped; got "
+        f"{metadata.get('sender_name')!r}."
+    )
+
+
+async def test_inbound_sender_display_name_reaches_renderer(
+    fake_pool: MagicMock,
+) -> None:
+    """The trusted ``sender.display_name`` must land in the metadata key
+    that the harness renderer + ``events_search.sender_name`` derivation
+    actually consume — ``metadata["sender_name"]``.
+
+    Pre-fix the trusted code writes ``metadata["sender"] = display_name``
+    (the key in ``_RESERVED_METADATA_KEYS``) but every reader looks at
+    ``metadata["sender_name"]``:
+      - ``harness/context._format_channel_header`` (focal full-content)
+      - ``harness/context._format_notification_marker`` (non-focal)
+      - ``db/queries._derive_sender_name`` (search_events sender_name
+        column)
+    As a result an inbound from a connector that doesn't redundantly
+    stamp ``metadata["sender_name"]`` itself (the documented contract is
+    that ``sender.display_name`` carries the canonical identity — see
+    the echo-http reference connector) renders without sender attribution
+    and the search_events column is NULL.
+
+    Most-deployed connectors (telegram, signal) paper over this by also
+    writing ``metadata["sender_name"]`` directly from their own state,
+    so the symptom only surfaces on minimal/new connectors and on the
+    ``events_search.sender_name`` column even for telegram/signal when
+    the connector value differs from ``sender.display_name`` (the
+    promoted column reflects the wrong source of truth).
+    """
+    from aios.db.queries import _derive_sender_name
+    from aios.harness.context import render_user_event
+
+    captured: dict[str, Any] = {}
+
+    async def fake_append_event(*_args: Any, **kwargs: Any) -> Any:
+        captured["data"] = kwargs["data"]
+        ev = MagicMock()
+        ev.id = "evt_stub"
+        return ev
+
+    with (
+        patch(
+            "aios.services.inbound.queries.append_event", AsyncMock(side_effect=fake_append_event)
+        ),
+        patch(
+            "aios.services.inbound.queries.try_record_inbound_ack",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await _append_with_dedup(
+            fake_pool,
+            account_id="acc_test_stub",
+            connector="echo",
+            external_account_id="bot1",
+            event_id="evt_inbound_render",
+            session_id="sess_X",
+            chat_id="chat_1",
+            sender={"display_name": "Alice"},
+            content="hello",
+            attachments=[],
+            connector_metadata=None,  # minimal connector: only sender payload
+            platform_timestamp=None,
+        )
+
+    data = captured["data"]
+    metadata = data["metadata"]
+    channel = metadata["channel"]
+
+    # 1. Renderer's full-content header must include the sender clause.
+    rendered = render_user_event(
+        data,
+        orig_channel=channel,
+        focal_channel_at_arrival=channel,
+    )
+    assert "from=Alice" in rendered["content"], (
+        f"focal-render must include from=Alice; got content={rendered['content']!r}. "
+        f"Pre-fix the trusted ``sender.display_name`` is stored at "
+        f"metadata['sender'] which no reader consumes; "
+        f"metadata={metadata!r}."
+    )
+
+    # 2. Derived ``sender_name`` column must be populated so search_events
+    #    WHERE sender_name = 'Alice' returns the inbound row.
+    derived = _derive_sender_name("message", data)
+    assert derived == "Alice", (
+        f"events_search.sender_name derivation must yield 'Alice'; got "
+        f"{derived!r}. Pre-fix _derive_sender_name reads metadata['sender_name'] "
+        f"which the trusted code never writes; metadata={metadata!r}."
     )
 
 


### PR DESCRIPTION
## Summary

The inbound service writes `metadata[\"sender\"] = sender.display_name`, but every reader (renderer's `from=` clause, `_format_notification_marker`, `events_search.sender_name` derivation) consumes `metadata[\"sender_name\"]`. So an inbound from a connector that doesn't redundantly stamp `metadata[\"sender_name\"]` itself (the contract: `sender.display_name` is the canonical identity — see echo-http) renders without sender attribution and the search column is NULL.

The same typo split the security boundary off the consumed slot: `_RESERVED_METADATA_KEYS` reserved `\"sender\"` (dead), so a connector could forge an arbitrary `metadata[\"sender_name\"]` and the renderer would surface it as the trusted `from=` clause without any check.

Fix both halves together: write under `sender_name`; reserve `sender_name`. For telegram/signal, stripping the connector-supplied value is a no-op — their value matches `sender.display_name` (same `msg.sender_name` fallback chain). For echo-http and any future minimal connector, attribution now reaches the renderer + search column.

## Substrate state changes

None — code-only change.

## Test plan

- New unit test `test_inbound_sender_display_name_reaches_renderer` reproduces the bug (renderer omits `from=Alice`; `_derive_sender_name` returns None) pre-fix, passes post-fix.
- Updated `test_connector_cannot_shadow_sender_via_metadata` to spoof through `sender_name` (the now-reserved consumed key) instead of the now-passthrough `sender`.
- All 1349 unit tests pass.
- mypy clean (155 src files); ruff lint + format clean.

## Risk / rollback

Low. Mechanical key rename + matching strip-set update; semantically isolated to the inbound metadata merge. Telegram/signal users observe identical behavior (their connectors already stamp the right key). Echo-http and future minimal connectors gain working sender attribution.

Rollback: revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)