### PR TITLE
fix(tools/http_request): reject '..' path segments — allowlist bypass via httpx URL normalisation

### DIFF
--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -107,6 +107,39 @@ def _match_route(server: HttpServerSpec, path: str) -> HttpRouteSpec | None:
     return None
 
 
+def _path_rejected_reason(path: str) -> str | None:
+    """Return the reason ``path`` must be rejected at the route gate, or
+    ``None`` when it's safe to glob-match.
+
+    The route allowlist is enforced by segment-glob matching on the
+    raw ``path`` string, but the final URL is composed and dispatched
+    via ``httpx``. Any element that ``httpx`` mutates between match
+    and wire is an allowlist bypass: ``?action=delete`` slips past
+    ``/lights/*`` because httpx parses it as a query string; ``..``
+    segments slip past ``/lights/**`` because httpx normalises
+    ``/v1/lights/../admin`` to ``/v1/admin`` on the wire. Reject up
+    front so the gate's check equals the gate's effect.
+    """
+    if "?" in path or "#" in path:
+        return (
+            f"path {path!r} contains a query string or fragment, which is "
+            "not allowed — pass only the path portion. Route allowlists "
+            "do not extend across query parameters."
+        )
+    # ``..`` as a literal segment: ``foo/../bar`` is normalised by httpx
+    # to ``bar``, escaping any allowlist that matched ``foo/*``. The
+    # check looks for the segment, not the substring, so paths like
+    # ``foo..bar`` (legal in many APIs) are left alone.
+    if ".." in path.split("/"):
+        return (
+            f"path {path!r} contains a '..' segment, which is not allowed — "
+            "the upstream URL would be normalised to a different path, "
+            "escaping the route allowlist's intent. Pass an absolute path "
+            "without traversal."
+        )
+    return None
+
+
 def _classify_permission(
     args: dict[str, Any], agent: Agent | AgentVersion
 ) -> PermissionPolicy | None:
@@ -115,14 +148,15 @@ def _classify_permission(
     Returns the matched route's ``permission_policy`` so the harness can
     park the call in ``requires_action`` if the operator marked it
     ``always_ask``. Returns ``None`` for missing server / no route match
-    / bad args / query-or-fragment-bearing path — the handler then runs
-    and emits a typed error the model can self-correct from.
+    / bad args / query-or-fragment-bearing / traversal-bearing path —
+    the handler then runs and emits a typed error the model can
+    self-correct from.
     """
     server_ref = args.get("server_ref")
     path = args.get("path")
     if not isinstance(server_ref, str) or not isinstance(path, str):
         return None
-    if "?" in path or "#" in path:
+    if _path_rejected_reason(path) is not None:
         return None
     server = _find_server(agent, server_ref)
     if server is None:
@@ -170,21 +204,13 @@ async def http_request_handler(session_id: str, arguments: dict[str, Any]) -> di
     caller_headers: dict[str, str] = arguments.get("headers") or {}
     body = arguments.get("body")
 
-    # Route allowlists are path-only gates. A ``?`` or ``#`` in ``path``
-    # would be matched as literal segment characters by ``match_glob``
-    # and then parsed by httpx as a query/fragment on the wire — letting
-    # ``/lights/1?action=delete`` slip past an `/lights/*` read-only route
-    # because the upstream sees the query string and treats it as a
-    # state-change request. Reject up front so the gate's intent is the
-    # gate's effect.
-    if "?" in path or "#" in path:
-        return {
-            "error": (
-                f"path {path!r} contains a query string or fragment, which is "
-                "not allowed — pass only the path portion. Route allowlists "
-                "do not extend across query parameters."
-            )
-        }
+    # Route allowlists are path-only gates. Reject any path element that
+    # ``httpx`` would mutate between match and wire (query/fragment, ``..``
+    # traversal) so the gate's check equals the gate's effect — see
+    # ``_path_rejected_reason``.
+    reason = _path_rejected_reason(path)
+    if reason is not None:
+        return {"error": reason}
 
     agent, account_id = await _load_session_agent(session_id)
     server = _find_server(agent, server_ref)

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -330,6 +330,54 @@ class TestHttpRequestHandler:
             )
         assert "error" in result
 
+    async def test_path_traversal_rejected(self, _stub_runtime: Any) -> None:
+        """A ``path`` containing ``..`` must be rejected at the route gate.
+
+        The route allowlist is a path-only gate enforced by segment-glob
+        matching. ``..`` is treated as a literal single segment by
+        :func:`match_glob` and thus matches the ``*`` wildcard — but
+        ``httpx`` normalises ``../`` traversal before sending, so the
+        upstream sees a path that escapes the allowlist's intent. An
+        allowlist of ``/lights/**`` plus ``path="lights/../admin/delete"``
+        passes the gate but lands at ``/admin/delete`` on the wire.
+
+        Same shape as #485 (query string in path): a worker-managed
+        URL element gets silently mutated between gate and wire,
+        breaking the operator's allowlist intent. Reject ``..``
+        segments at the gate so the allowlist's effect equals its
+        check.
+        """
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/**")])])
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(
+            response=httpx.Response(200, content=b""),
+            capture=captured,
+        )
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {
+                    "server_ref": "hue",
+                    "path": "lights/../admin/delete",
+                    "method": "GET",
+                },
+            )
+        assert "error" in result, (
+            f"path containing '..' must be rejected at the route gate; "
+            f"got success {result!r}. Pre-fix symptom: httpx normalises "
+            f"/v1/lights/../admin/delete to /v1/admin/delete on the wire, "
+            f"escaping the /lights/** allowlist's intent."
+        )
+        # And the request must not have been dispatched.
+        assert "url" not in captured, (
+            f"upstream request was dispatched despite path containing '..'; captured={captured!r}"
+        )
+
     async def test_successful_get(self, _stub_runtime: Any) -> None:
         agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
         response = httpx.Response(


### PR DESCRIPTION
## Summary

- The ``http_request`` tool's route allowlist is enforced by segment-glob matching on the raw ``path`` argument, but the final URL is composed via ``httpx``, which normalises ``../`` traversal **before sending**. ``..`` is a single segment (no slashes) so the ``*`` wildcard matches it — meaning an allowlist of ``/lights/**`` plus ``path="lights/../admin/delete"`` passed the gate while the upstream actually received ``/admin/delete``. The agent could escape any route scope by injecting a ``..`` segment.
- Refactors the existing query/fragment check at the entry point and inside ``_classify_permission`` into a shared ``_path_rejected_reason`` helper, then adds traversal detection alongside ``?`` / ``#``. The traversal check looks for literal segments (``".." in path.split("/")``), so paths like ``foo..bar`` (legal in many APIs) are left alone — only ``..`` between slashes is rejected.
- Same shape as #485 (query string in path) and the Host-header bypass already covered by ``test_caller_host_header_dropped``: a worker-managed URL element gets silently mutated between gate check and wire, breaking the operator's allowlist intent.

Demonstration with the pre-fix code:

```python
>>> import httpx
>>> r = httpx.Request("GET", "https://api.example.com/v1/lights/../admin/delete")
>>> r.url.path
'/v1/admin/delete'
>>> from aios.tools._glob_match import match_glob
>>> match_glob("/lights/**", "lights/../admin/delete")
True
```

The gate passed; the wire saw ``/admin/delete``.

## Test plan

- [x] New ``test_path_traversal_rejected`` — encodes the bypass and asserts both an error response and that the upstream stub never receives the request (no leakage past the gate).
- [x] Existing ``test_path_with_query_string_rejected`` and ``test_path_with_fragment_rejected`` still pass against the refactored helper.
- [x] ``uv run mypy src`` — clean (155 source files)
- [x] ``uv run ruff check src tests && uv run ruff format --check src tests`` — clean
- [x] Full unit suite — 1349 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)