### PR TITLE
fix(tools/http_request): reject '.'/'..' path segments to close route-allowlist traversal bypass

### DIFF
--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -107,6 +107,37 @@ def _match_route(server: HttpServerSpec, path: str) -> HttpRouteSpec | None:
     return None
 
 
+_DOT_SEGMENTS = frozenset({".", ".."})
+
+
+def _path_is_dispatchable(path: str) -> bool:
+    """True iff ``path`` is safe to feed through the route allowlist.
+
+    Filters paths whose textual shape lets the upstream URL diverge from
+    what ``match_glob`` checked:
+
+    * ``?`` / ``#`` — httpx parses these off as query / fragment, so the
+      upstream sees a different path than the gate validated.
+    * ``.`` / ``..`` segments — httpx applies RFC 3986 §5.2.4 dot-segment
+      removal: ``base_url/lights/..`` collapses to ``base_url/`` (reaching
+      the server root despite a ``/lights/*`` allowlist), and
+      ``base_url/lights/./state`` collapses to ``base_url/lights/state``
+      (escaping a ``/lights/*/state`` allowlist that expected a real id
+      segment between). ``*`` matches the literal ``.`` / ``..`` segment,
+      so without this filter the glob accepts what the wire then rewrites
+      past the gate.
+
+    Same posture as the ``?`` / ``#`` filters: reject before dispatch
+    so the gate's intent is the gate's effect.
+    """
+    if "?" in path or "#" in path:
+        return False
+    # Split on ``/`` to inspect each segment; ``.`` / ``..`` only trigger
+    # httpx's normalization when they're whole segments, not when they
+    # appear inside one (e.g. ``/foo..bar`` is a literal path component).
+    return not any(seg in _DOT_SEGMENTS for seg in path.split("/"))
+
+
 def _classify_permission(
     args: dict[str, Any], agent: Agent | AgentVersion
 ) -> PermissionPolicy | None:
@@ -115,14 +146,15 @@ def _classify_permission(
     Returns the matched route's ``permission_policy`` so the harness can
     park the call in ``requires_action`` if the operator marked it
     ``always_ask``. Returns ``None`` for missing server / no route match
-    / bad args / query-or-fragment-bearing path — the handler then runs
-    and emits a typed error the model can self-correct from.
+    / bad args / non-dispatchable path (see :func:`_path_is_dispatchable`)
+    — the handler then runs and emits a typed error the model can
+    self-correct from.
     """
     server_ref = args.get("server_ref")
     path = args.get("path")
     if not isinstance(server_ref, str) or not isinstance(path, str):
         return None
-    if "?" in path or "#" in path:
+    if not _path_is_dispatchable(path):
         return None
     server = _find_server(agent, server_ref)
     if server is None:
@@ -170,19 +202,19 @@ async def http_request_handler(session_id: str, arguments: dict[str, Any]) -> di
     caller_headers: dict[str, str] = arguments.get("headers") or {}
     body = arguments.get("body")
 
-    # Route allowlists are path-only gates. A ``?`` or ``#`` in ``path``
-    # would be matched as literal segment characters by ``match_glob``
-    # and then parsed by httpx as a query/fragment on the wire — letting
-    # ``/lights/1?action=delete`` slip past an `/lights/*` read-only route
-    # because the upstream sees the query string and treats it as a
-    # state-change request. Reject up front so the gate's intent is the
-    # gate's effect.
-    if "?" in path or "#" in path:
+    # Route allowlists are path-only gates. Filter paths whose textual
+    # shape lets the upstream URL diverge from what ``match_glob`` would
+    # check — ``?`` / ``#`` (parsed off as query / fragment), and
+    # ``.`` / ``..`` path segments (RFC 3986 §5.2.4 dot-segment removal:
+    # httpx normalizes ``base_url/lights/..`` to ``base_url/`` post-glob).
+    # Reject up front so the gate's intent is the gate's effect.
+    if not _path_is_dispatchable(path):
         return {
             "error": (
-                f"path {path!r} contains a query string or fragment, which is "
-                "not allowed — pass only the path portion. Route allowlists "
-                "do not extend across query parameters."
+                f"path {path!r} contains a query string, fragment, or "
+                "'.'/'..' segment, which is not allowed — pass only a "
+                "normalized path portion. Route allowlists do not extend "
+                "across query parameters or dot-segment normalization."
             )
         }
 

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -463,3 +463,135 @@ class TestHttpRequestHandler:
             )
         assert "error" in result
         assert "timed out" in result["error"].lower()
+
+    async def test_path_with_dot_dot_segment_rejected(self, _stub_runtime: Any) -> None:
+        """Path-traversal bypass of the route allowlist via ``..`` segments.
+
+        The route gate uses ``match_glob``, where ``*`` matches any single
+        path segment — including a literal ``..``. The constructed URL
+        ``base_url/lights/..`` is then normalized by httpx (per RFC 3986
+        section 5.2.4) into ``base_url/``, reaching the server root despite
+        the operator's intent to scope the agent to ``/lights/*``.
+
+        Same shape as the ``?`` and ``#`` rejection tests: a path the route
+        allowlist accepts produces, after httpx normalization, an upstream
+        request to a path the allowlist does NOT cover. Reject ``..`` at
+        the same site so the gate's intent is the gate's effect.
+
+        Pre-fix symptom: the request dispatches and the upstream sees the
+        root path, bypassing the allowlist that scoped to ``/lights/*``.
+        """
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(
+            response=httpx.Response(200, content=b""),
+            capture=captured,
+        )
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/..", "method": "GET"},
+            )
+        assert "error" in result, (
+            f"path with '..' segment must be rejected at the route gate; "
+            f"got success {result!r}. Pre-fix symptom: glob '/lights/*' "
+            f"matches 'lights/..' (the '*' eats the '..' segment), httpx "
+            f"normalizes 'base_url/lights/..' to 'base_url/', and the "
+            f"upstream receives a root-path request the allowlist never "
+            f"approved."
+        )
+        # And the request must not have been dispatched.
+        assert "url" not in captured, (
+            f"upstream request was dispatched despite path containing '..' "
+            f"traversal; captured={captured!r}"
+        )
+
+    async def test_path_with_single_dot_segment_rejected(self, _stub_runtime: Any) -> None:
+        """Same shape as ``..`` but for single-``.`` segments.
+
+        RFC 3986 §5.2.4 also strips ``.`` segments: ``base_url/lights/./state``
+        normalizes to ``base_url/lights/state``. Against a
+        ``/lights/*/state`` allowlist (operator's intent: only routes that
+        include a real id segment between ``lights`` and ``state``), the
+        agent can send ``/lights/./state``: ``*`` matches the literal ``.``
+        and the glob accepts, but the upstream then receives ``/lights/state``
+        — a path the allowlist does NOT cover.
+
+        Same root cause as ``..``; both are dot-segment normalization
+        artefacts. The fix at :func:`_path_is_dispatchable` covers both.
+        """
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*/state")])])
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(
+            response=httpx.Response(200, content=b""),
+            capture=captured,
+        )
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/./state", "method": "GET"},
+            )
+        assert "error" in result, (
+            f"path with single '.' segment must be rejected at the route "
+            f"gate; got success {result!r}. Pre-fix symptom: glob "
+            f"'/lights/*/state' matches 'lights/./state', httpx normalizes "
+            f"to 'base_url/lights/state', and the upstream receives a path "
+            f"the allowlist's *-segment scoping did not cover."
+        )
+        assert "url" not in captured, (
+            f"upstream request was dispatched despite '.' segment; captured={captured!r}"
+        )
+
+    async def test_path_with_embedded_dot_dot_rejected(self, _stub_runtime: Any) -> None:
+        """``..`` segments embedded mid-path also escape the allowlist.
+
+        With a ``/lights/**`` (multi-segment) allowlist, an agent can send
+        ``/lights/../admin/delete``: the glob matches because ``**`` accepts
+        any segments, but httpx normalizes the URL to ``base_url/admin/delete``
+        — reaching an admin endpoint the operator never granted.
+
+        Distinct from the single-segment case because ``**`` is the only
+        glob form that admits the embedded variant. Worth a separate test
+        so a fix that only handles the single-``*`` case still goes red here.
+        """
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/**")])])
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(
+            response=httpx.Response(200, content=b""),
+            capture=captured,
+        )
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {
+                    "server_ref": "hue",
+                    "path": "/lights/../admin/delete",
+                    "method": "GET",
+                },
+            )
+        assert "error" in result, (
+            f"path with embedded '..' must be rejected at the route gate; "
+            f"got success {result!r}. Pre-fix symptom: glob '/lights/**' "
+            f"matches 'lights/../admin/delete', httpx normalizes the URL "
+            f"to 'base_url/admin/delete', and the upstream receives an "
+            f"admin-path request the allowlist never approved."
+        )
+        assert "url" not in captured, (
+            f"upstream request was dispatched despite embedded '..' "
+            f"traversal; captured={captured!r}"
+        )


### PR DESCRIPTION
## Summary

- `_classify_permission` and `http_request_handler` only filtered `?` and `#` from `path` before feeding it to `match_glob`. A `*`-segment in the allowlist matches a literal `.` or `..`, and httpx then applies RFC 3986 §5.2.4 dot-segment removal to the constructed URL — so `base_url/lights/..` collapses to `base_url/` (server root despite a `/lights/*` allowlist), and `base_url/lights/./state` collapses to `base_url/lights/state` (escaping a `/lights/*/state` allowlist that expected an id segment).
- Net effect: an agent can reach endpoints the operator never granted via the route gate, by sending paths whose textual shape passes the glob check but whose normalized form bypasses it. The bypass landed on every `http_request` call site (immediate-dispatch gate AND runtime guard), so even `always_ask` routes could be pre-approved at a benign-looking path and then reach a sensitive endpoint via `..`.
- Fix: extract `_path_is_dispatchable` and reject paths containing `.` or `..` as whole segments alongside the existing `?` / `#` filter. Both call sites now share the helper. Embedded variants (`foo..bar`, `..bar`) are left alone — httpx doesn't normalize those.

Same posture as the existing `?` / `#` rejection (#485 shape): reject before dispatch so the gate's intent is the gate's effect.

## Test plan

- [x] Type-checker — clean
- [x] Linter + format-check — clean
- [x] Unit suite — 1351 passed (3 new tests; pre-fix red on the dispatch assertion, post-fix green)
- [x] New `test_path_with_dot_dot_segment_rejected` — `/lights/*` allowlist with `path="/lights/.."` (single `*` glob)
- [x] New `test_path_with_embedded_dot_dot_rejected` — `/lights/**` allowlist with `path="/lights/../admin/delete"` (covers the multi-segment `**` glob variant)
- [x] New `test_path_with_single_dot_segment_rejected` — `/lights/*/state` allowlist with `path="/lights/./state"` (covers the single-`.` variant)
- [ ] CI runs full e2e + integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)