### PR TITLE
fix(tools/grep): enable pipefail so rg failure doesn't silently return empty matches

### DIFF
--- a/src/aios/tools/grep.py
+++ b/src/aios/tools/grep.py
@@ -150,7 +150,15 @@ async def grep_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     parts.append("2>/dev/null")
     parts.append(f"| head -{limit}")
 
-    cmd = " ".join(parts)
+    # ``set -o pipefail`` is load-bearing: without it the pipe's exit code is
+    # ``head``'s (0 even when ``rg`` failed because ``head`` happily consumes
+    # empty stdin), and the existing ``exit_code not in (0, 1)`` branch never
+    # fires for bad-regex / bad-path / other rg failures. The model gets
+    # ``{"matches": ""}`` and reads it as "no matches" — chasing red herrings
+    # (different paths, different patterns) instead of fixing its input.
+    # ``bash -c`` is the sandbox exec shell so the option is supported.
+    # Same defect class as PR #513 (read tool), one tool over.
+    cmd = "set -o pipefail; " + " ".join(parts)
 
     result = await sandbox.exec(
         handle,

--- a/tests/unit/test_grep_handler.py
+++ b/tests/unit/test_grep_handler.py
@@ -97,7 +97,7 @@ class TestHappyPath:
     async def test_default_path(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello"})
         cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
-        assert cmd.startswith("rg")
+        assert "rg " in cmd
         assert "/workspace" in cmd
 
     async def test_include_flag(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
@@ -198,3 +198,34 @@ class TestErrorPath:
         result = await grep_handler("sess_01TEST", {"pattern": "[invalid"})
         assert "error" in result
         assert "invalid regex" in result["error"]
+
+    async def test_cmd_uses_pipefail_so_rg_failure_propagates(
+        self, stub_registry: Any, stub_handle: SandboxHandle
+    ) -> None:
+        """``rg <pattern> <path> 2>/dev/null | head -N`` is a pipe whose final
+        exit code is ``head``'s — which is 0 even when ``rg`` failed (bad regex
+        ``rg`` exit 2, path traversal error, missing path) because ``head``
+        happily consumes empty input and exits 0. Without ``set -o pipefail``
+        the result returned to the model is ``{"matches": ""}`` — empty,
+        looking like "no matches" rather than the actual rg error. The model
+        chases red herrings: tries different paths, different patterns, never
+        realizing rg itself rejected its input.
+
+        Stderr is also swallowed via ``2>/dev/null`` so there's nothing to
+        surface even if the exit code were correct — but the existing
+        ``result.exit_code not in (0, 1)`` branch would convert it to an
+        error dict if the exit code propagated.
+
+        Mirrors the read-tool fix in PR #513: prepend ``set -o pipefail`` so
+        any non-zero exit anywhere in the pipe is surfaced as the overall exit
+        code, which the existing error-detection branch then turns into the
+        error dict the model can act on.
+        """
+        await grep_handler("sess_01TEST", {"pattern": "hello"})
+        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        assert "pipefail" in cmd, (
+            f"cmd must enable ``pipefail`` so a failing ``rg`` (e.g., invalid "
+            f"regex, missing path) propagates through the ``| head -N`` to "
+            f"the overall pipe exit code; without it, rg errors silently "
+            f"return empty matches. Got: {cmd!r}"
+        )


### PR DESCRIPTION
## Summary

- `grep` builds `rg <flags> <pattern> <path> 2>/dev/null | head -<limit>`. The pipe's final exit code is `head`'s — 0 even when `rg` failed (invalid regex exits 2, path traversal, missing path) because `head` happily consumes empty stdin and exits 0. The existing `result.exit_code not in (0, 1)` branch never fires; the model gets `{"matches": ""}` indistinguishable from "no matches", chases red herrings (different paths, different patterns) instead of fixing its invalid regex. `2>/dev/null` strips stderr so there's no signal at all.
- Same defect class as PR #513 (read tool), one tool over. Fix is identical: prepend `set -o pipefail` so any non-zero exit anywhere in the pipe becomes the overall exit code, which the existing error-detection branch then converts to the error dict the model can act on. The sandbox runs every exec through `bash -c` so the option is supported.
- Sibling bug exists in `tools/glob.py` (same shape: `rg --files --glob ... | head -500`); left for a follow-up to keep this PR scoped to one tool per project convention.

## Test plan

- [x] New `TestErrorPath::test_cmd_uses_pipefail_so_rg_failure_propagates` asserts the constructed command contains `pipefail`. Pre-fix it fails on `'rg -n --max-columns=500 hello /workspace 2>/dev/null | head -250'`; post-fix it passes.
- [x] Existing `test_default_path` loosened from `cmd.startswith(\"rg\")` to `\"rg \" in cmd` to accommodate the prefix; unrelated `test_grep_failure_returns_error_dict` still passes because it mocks the exec result directly (pipefail only matters at shell-execution time).
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1349 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)