### PR TITLE
fix(tools/search_events): reject queries that escape the events_search view

### DIFF
--- a/src/aios/tools/search_events.py
+++ b/src/aios/tools/search_events.py
@@ -35,17 +35,77 @@ _FORBIDDEN_KEYWORDS = re.compile(
     re.IGNORECASE,
 )
 
+# Identifiers that, if referenced, mean the query is reaching outside the
+# per-session ``events_search`` view.  Stamping the events table directly
+# bypasses the view's ``session_id = current_setting('app.session_id', true)``
+# scoping; querying any other application table leaks rows that belong to
+# other sessions and other accounts (multi-tenancy).  ``pg_*`` /
+# ``information_schema`` are the schema-introspection surfaces that would
+# enumerate the rest of the catalogue.  The check runs on the *literal-stripped*
+# SQL so a substring inside an ILIKE pattern (e.g. ``'%events%'``) doesn't
+# false-positive.
+_FORBIDDEN_REFERENCES = re.compile(
+    r"\b("
+    r"events|sessions|accounts|account_keys|agents|agent_versions|environments|"
+    r"connections|connectors|vaults|vault_credentials|memory_stores|memories|"
+    r"memory_versions|session_vaults|session_resources|session_memory_stores|"
+    r"session_github_repositories|session_templates|github_repositories|"
+    r"pending_management_calls|attachments|files|skills|skill_versions|"
+    r"procrastinate_\w+|pg_\w+|information_schema|pg_catalog"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Strip SQL string literals (single-quote and dollar-quoted) and comments so
+# the identifier check above runs against the structural SQL only.  Double-
+# quoted identifiers are NOT stripped — ``"events"`` is the events table,
+# not a string — and the structural regex's ``\b`` boundaries still match
+# inside them.
+_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_SINGLE_QUOTE_RE = re.compile(r"'(?:''|[^'])*'")
+_DOLLAR_QUOTE_RE = re.compile(r"\$(\w*)\$.*?\$\1\$", re.DOTALL)
+
+
+def _strip_string_literals(sql: str) -> str:
+    """Replace SQL string literals and comments with empty placeholders.
+
+    Double-quoted identifiers are intentionally preserved — they are how
+    Postgres references tables/columns with reserved-word or mixed-case
+    names, and ``\\b`` word boundaries still match identifiers inside
+    quotes.
+    """
+    sql = _LINE_COMMENT_RE.sub("", sql)
+    sql = _BLOCK_COMMENT_RE.sub("", sql)
+    sql = _SINGLE_QUOTE_RE.sub("''", sql)
+    sql = _DOLLAR_QUOTE_RE.sub("$$$$", sql)
+    return sql
+
 
 def _validate_sql(sql: str) -> str | None:
-    """Validate SQL is a safe SELECT query. Returns an error string or None."""
+    """Validate SQL is a safe SELECT query. Returns an error string or None.
+
+    The agent's SQL surface is exclusively the per-session ``events_search``
+    view.  Direct access to any other table — including the underlying
+    ``events`` table — bypasses the view's per-session scoping and leaks
+    rows belonging to other sessions and (post multi-tenancy v1) other
+    accounts.  The structural check runs on the literal-stripped SQL so
+    substring matches inside ``ILIKE`` patterns don't false-positive.
+    """
     stripped = sql.strip()
     if not stripped.upper().startswith("SELECT"):
         return "Only SELECT queries are allowed"
     if ";" in stripped:
         return "Multiple statements (semicolons) are not allowed"
-    m = _FORBIDDEN_KEYWORDS.search(stripped)
-    if m:
-        return f"Forbidden keyword '{m.group()}' is not allowed in queries"
+    kw_match = _FORBIDDEN_KEYWORDS.search(stripped)
+    if kw_match:
+        return f"Forbidden keyword '{kw_match.group()}' is not allowed in queries"
+    structural = _strip_string_literals(stripped)
+    ref_match = _FORBIDDEN_REFERENCES.search(structural)
+    if ref_match:
+        return (
+            f"Identifier {ref_match.group()!r} is not allowed; query the events_search view instead"
+        )
     return None
 
 

--- a/tests/e2e/test_search_events.py
+++ b/tests/e2e/test_search_events.py
@@ -147,6 +147,37 @@ class TestSearchEvents:
         assert "error" in result
         assert "SELECT" in result["error"]
 
+    async def test_rejects_cross_session_via_events_table(self, harness: Harness) -> None:
+        """Reaching the raw ``events`` table bypasses per-session scoping.
+
+        The ``events_search`` view filters by ``current_setting('app.session_id')``;
+        the underlying ``events`` table does not.  A naive scanner would only
+        forbid writes — but a SELECT against ``events`` happily returns rows
+        from any session in the database (and post multi-tenancy, any account).
+        Verify that the validator blocks the bypass before the query reaches
+        Postgres, so the cross-tenant leak surface is closed at the tool boundary.
+        """
+        session_id_a = await self._setup_session(harness)
+
+        harness.script_model([assistant("Kubernetes is great!")])
+        session_b = await harness.start("Tell me about Kubernetes", tools=["search_events"])
+        await harness.run_until_idle(session_b.id)
+
+        # Session A tries to read session B's events via the raw table.
+        result = await search_events_handler(
+            session_id_a,
+            {
+                "query": (
+                    f"SELECT data FROM events WHERE session_id = '{session_b.id}' "
+                    f"AND data->>'role' = 'user'"
+                ),
+            },
+        )
+        assert "error" in result, (
+            f"validator must reject direct events-table access; got: {result!r}"
+        )
+        assert "events_search" in result["error"]
+
     async def test_read_only_enforcement(self, harness: Harness) -> None:
         """The READ ONLY transaction used by _execute_query blocks writes.
 

--- a/tests/unit/test_search_events_handler.py
+++ b/tests/unit/test_search_events_handler.py
@@ -80,6 +80,84 @@ class TestValidateSql:
         assert err is not None
         assert "SELECT" in err
 
+    def test_rejects_direct_events_table_query(self) -> None:
+        """The agent's SQL surface is the per-session ``events_search`` view.
+
+        Allowing direct access to the ``events`` table bypasses the view's
+        ``session_id = current_setting('app.session_id', true)`` filter and
+        returns events from any session in the database (cross-tenant leak,
+        since the table holds rows for every account).
+        """
+        err = _validate_sql("SELECT data FROM events")
+        assert err is not None
+
+    def test_rejects_query_against_other_table(self) -> None:
+        """Tables other than ``events_search`` are out of scope for the agent.
+
+        A read-only SELECT against ``vault_credentials`` / ``accounts`` /
+        ``sessions`` / etc. still leaks cross-tenant rows; the view scoping
+        only works when the agent is forced to use the view.
+        """
+        for table in ("vault_credentials", "accounts", "sessions", "connections"):
+            err = _validate_sql(f"SELECT * FROM {table}")
+            assert err is not None, f"validator allowed access to {table!r}"
+
+    def test_rejects_events_table_via_cte(self) -> None:
+        """CTEs that reference ``events`` directly are the same defect class."""
+        err = _validate_sql(
+            "WITH peek AS (SELECT data FROM events WHERE session_id = 'sess_OTHER') "
+            "SELECT * FROM peek"
+        )
+        assert err is not None
+
+    def test_rejects_events_via_quoted_identifier(self) -> None:
+        """Postgres double-quoted identifiers must not bypass the check."""
+        err = _validate_sql("SELECT * FROM \"events\" WHERE session_id = 'sess_OTHER'")
+        assert err is not None
+
+    def test_rejects_pg_catalog_introspection(self) -> None:
+        """Postgres catalog tables enumerate the whole schema and must be blocked."""
+        for q in (
+            "SELECT * FROM pg_catalog.pg_tables",
+            "SELECT * FROM pg_class",
+            "SELECT * FROM information_schema.tables",
+        ):
+            err = _validate_sql(q)
+            assert err is not None, f"validator allowed {q!r}"
+
+    def test_allows_ilike_substring_with_table_name(self) -> None:
+        """ILIKE patterns containing a forbidden token must not false-positive.
+
+        ``content_text ILIKE '%events%'`` is a legitimate substring search
+        on the agent's own messages; the literal-stripping pass strips
+        the quoted string so the structural regex doesn't see it.
+        """
+        assert (
+            _validate_sql("SELECT * FROM events_search WHERE content_text ILIKE '%events%'") is None
+        )
+        assert (
+            _validate_sql("SELECT * FROM events_search WHERE content_text ILIKE '%sessions%'")
+            is None
+        )
+
+    def test_rejects_events_via_dollar_quoted_evasion(self) -> None:
+        """Dollar-quoted strings (Postgres-specific) must be stripped before the check.
+
+        Without dollar-quote stripping, a model could write
+        ``'%' || $$evil events$$ || '%'`` to confuse a naïve scanner; we want
+        to make sure the dollar-quoted body doesn't seed false positives
+        (i.e. that legitimate dollar-quoted strings containing forbidden
+        words still validate cleanly).
+        """
+        # Dollar-quoted string with forbidden word inside the literal — legit.
+        assert (
+            _validate_sql("SELECT * FROM events_search WHERE content_text ILIKE $$%events table%$$")
+            is None
+        )
+        # Dollar-quoted around a real FROM events bypass attempt — must reject.
+        err = _validate_sql("SELECT * FROM events_search UNION SELECT * FROM events")
+        assert err is not None
+
     def test_rejects_empty_string(self) -> None:
         err = _validate_sql("")
         assert err is not None


### PR DESCRIPTION
## Summary

- The ``search_events`` validator only forbade DML/DDL keywords; it did not constrain which tables a SELECT could reference. The ``events_search`` view scopes to ``current_setting('app.session_id')``, but ``SELECT data FROM events`` (or any other application table) bypassed the view and returned rows from every session in the database and — post multi-tenancy v1 (#367) — every account.
- Add a structural-identifier denylist over the literal-stripped SQL: strips single-quote, dollar-quoted strings, and SQL comments so ``content_text ILIKE '%events%'`` still passes; preserves double-quoted identifiers so ``FROM \"events\"`` is still caught.
- Bug discovered by ``/bughunt``; no upstream tracking issue.

## Test plan

- [x] ``mypy src`` — clean
- [x] ``ruff check`` + ``ruff format --check`` — clean
- [x] ``pytest tests/unit`` — 1355 passed
- [x] ``pytest tests/e2e/test_search_events.py`` — 12 passed (includes new ``test_rejects_cross_session_via_events_table``)
- [ ] CI runs full e2e suite

## Notes

The denylist names the current set of sensitive tables verbatim. A new application table added to the schema would not be auto-protected; the long-term fix is a proper SQL parser (sqlglot) or a Postgres ROLE that only has ``SELECT`` on ``events_search``. Both are larger lifts; this PR closes the active leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)