### PR TITLE
fix(harness/tool_dispatch): worker tool-result append clobbered operator deny when tool was in-flight

### DIFF
--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -245,10 +245,10 @@ async def _execute_tool_async(
         else:
             event_data["content"] = json.dumps(result, ensure_ascii=False)
         tc.bound_log.info("tool.completed")
-        await sessions_service.append_event(
+        await _append_tool_result_event(
             pool,
             session_id,
-            "message",
+            tc.call_id,
             event_data,
             account_id=account_id,
         )
@@ -295,6 +295,67 @@ def _validate_arguments(arguments: dict[str, Any], schema: dict[str, Any]) -> st
     return "\n".join(lines)
 
 
+async def _append_tool_result_event(
+    pool: asyncpg.Pool[Any],
+    session_id: str,
+    tool_call_id: str,
+    event_data: dict[str, Any],
+    *,
+    account_id: str,
+) -> None:
+    """Append a ``role:"tool"`` event, dedup-guarded on ``tool_call_id``.
+
+    The worker's tool task lifecycle (success-, error-, schema-,
+    cancel-paths) all funnel through here so a tool-role event that
+    already landed via the operator path (``confirm_tool_deny`` →
+    ``services.sessions.append_tool_result``) is not silently
+    overwritten by the late worker result.
+
+    Specifically: an ``always_allow`` builtin (or any tool the harness
+    dispatches without the always_ask confirmation gate) can have its
+    operator deny commit while the task is in-flight; without dedup
+    here, the worker's late append lands a SECOND tool-role event for
+    the same ``tool_call_id`` and the context builder's
+    ``real_results[tcid] = e.data`` keying clobbers the deny — the
+    next prompt carries the tool's successful output as if no deny had
+    happened (silent failure symmetric to PR #535).
+
+    Transaction + ``SELECT ... FOR UPDATE`` mirrors
+    :func:`services.sessions.append_tool_result` so the worker-vs-API
+    race serialises through the same session-row lock as the operator
+    path; "first commit wins, second commit no-ops" applies to either
+    ordering.
+    """
+    from aios.db import queries
+
+    async with pool.acquire() as conn, conn.transaction():
+        await conn.execute(
+            "SELECT 1 FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
+            session_id,
+            account_id,
+        )
+        existing = await queries.find_tool_result_event(
+            conn, session_id, tool_call_id, account_id=account_id
+        )
+        if existing is not None:
+            existing_is_error = bool(existing.data.get("is_error", False))
+            log.warning(
+                "tool.result_dedup_skip",
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                existing_is_error=existing_is_error,
+                attempted_is_error=bool(event_data.get("is_error", False)),
+            )
+            return
+        await queries.append_event(
+            conn,
+            session_id=session_id,
+            kind="message",
+            data=event_data,
+            account_id=account_id,
+        )
+
+
 async def _append_tool_result(
     pool: asyncpg.Pool[Any],
     session_id: str,
@@ -304,12 +365,13 @@ async def _append_tool_result(
     account_id: str,
     error: str,
 ) -> None:
-    """Append a tool-role error event."""
+    """Append a tool-role error event (dedup-guarded — see
+    :func:`_append_tool_result_event`)."""
     content = json.dumps({"error": error}, ensure_ascii=False)
-    await sessions_service.append_event(
+    await _append_tool_result_event(
         pool,
         session_id,
-        "message",
+        call_id,
         {
             "role": "tool",
             "tool_call_id": call_id,
@@ -498,6 +560,6 @@ async def _execute_mcp_tool_async(
             tc.is_error = True
 
         tc.bound_log.info("mcp_tool.completed", is_error=mcp_is_error)
-        await sessions_service.append_event(
-            pool, session_id, "message", event_data, account_id=account_id
+        await _append_tool_result_event(
+            pool, session_id, tc.call_id, event_data, account_id=account_id
         )

--- a/tests/integration/test_worker_result_after_deny.py
+++ b/tests/integration/test_worker_result_after_deny.py
@@ -1,0 +1,252 @@
+"""Integration test: a worker's late tool_result append for an in-flight
+tool whose deny already committed must NOT silently overwrite the deny.
+
+Scenario (the dual race to #535):
+
+  1. Model emits ``tool_call X`` as an ``always_allow`` builtin (or any
+     tool the harness dispatches without operator confirmation).
+  2. Worker fire-and-forgets the tool task; the tool starts running.
+  3. Operator POSTs ``decision=deny`` for ``X`` via
+     ``/v1/sessions/<id>/tool-confirmations``. The deny path appends a
+     ``role:"tool"`` event with ``is_error=True``.
+  4. Tool task completes a moment later. The worker's success-result
+     append (``aios.harness.tool_dispatch._execute_tool_async``) calls
+     ``sessions_service.append_event`` directly — no
+     ``tool_call_id`` dedup. A SECOND ``role:"tool"`` event for the
+     SAME ``tool_call_id`` lands.
+
+Effect at the model: the context builder
+(``aios.harness.context._build_messages``) keys ``real_results`` by
+``tool_call_id`` last-wins; the worker's late success event clobbers the
+operator's deny, and the next prompt carries the tool's successful
+output as if no deny had happened. Symmetric silent-failure to the bug
+PR #535 closed in the opposite direction.
+
+Per the same intent-mismatch posture #535 introduced for the API path,
+the worker's append should refuse when an opposite-intent tool-role
+event already exists. Same dedup-by-``tool_call_id`` machinery, just
+moved one layer up so BOTH commit paths (operator + worker) honor it.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.harness import runtime
+from aios.harness.task_registry import TaskRegistry
+from aios.harness.tool_dispatch import _execute_tool_async
+from aios.models.agents import ToolSpec
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+from aios.tools.registry import registry
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def runtime_for_dispatch() -> AsyncIterator[None]:
+    """Install minimum worker globals on ``aios.harness.runtime`` so
+    ``_execute_tool_async``'s ``runtime.require_task_registry()`` works.
+
+    Restores the previous globals on teardown.
+    """
+    prev_task_reg = runtime.task_registry
+    prev_worker_id = runtime.worker_id
+    runtime.task_registry = TaskRegistry()
+    runtime.worker_id = "worker_test_deny_race"
+    try:
+        yield
+    finally:
+        runtime.task_registry = prev_task_reg
+        runtime.worker_id = prev_worker_id
+
+
+@pytest.fixture
+def _register_test_tool() -> Any:
+    """Snapshot/restore the tool registry around a test-local tool.
+
+    Registers an ``echo_for_deny_race`` tool whose handler immediately
+    returns success. Drives ``_execute_tool_async`` end-to-end without
+    the bash-tool side effects.
+    """
+    snapshot = dict(registry._tools)
+
+    async def _handler(_session_id: str, _arguments: dict[str, Any]) -> dict[str, Any]:
+        return {"output": "tool actually ran successfully"}
+
+    registry.register(
+        name="echo_for_deny_race",
+        description="test-only tool that returns success immediately",
+        parameters_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        handler=_handler,
+    )
+    try:
+        yield
+    finally:
+        registry._tools = snapshot
+
+
+@pytest.fixture
+async def session_with_pending_tool_call(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str]]:
+    """Yield ``(pool, account_id, session_id, tool_call_id)`` for a
+    session whose event log contains an assistant message with a
+    tool_calls entry but NO tool-role result event yet (in-flight)."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_worker_race', NULL, TRUE, 'worker-deny-race-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_worker_race",
+            name="worker-deny-race-test",
+            model="openrouter/test",
+            system="",
+            # ``bash`` is a placeholder — the test invokes
+            # ``_execute_tool_async`` directly with a tool_call whose
+            # function.name targets the test-only registered tool, so
+            # the agent's declared tools list is not consulted.
+            tools=[ToolSpec(type="bash")],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_worker_race", name="worker-deny-race-env"
+        )
+        async with pool.acquire() as conn:
+            session = await queries.insert_session(
+                conn,
+                account_id="acc_worker_race",
+                agent_id=agent.id,
+                environment_id=env.id,
+                agent_version=agent.version,
+                title=None,
+                metadata={},
+            )
+            # Assistant message with one tool_call; no tool-role result
+            # event yet (the tool is in-flight in the simulated race).
+            await queries.append_event(
+                conn,
+                account_id="acc_worker_race",
+                session_id=session.id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tc_in_flight",
+                            "type": "function",
+                            "function": {
+                                "name": "echo_for_deny_race",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                },
+            )
+        yield pool, "acc_worker_race", session.id, "tc_in_flight"
+    finally:
+        await pool.close()
+
+
+class TestWorkerResultAfterDeny:
+    async def test_worker_success_after_deny_must_not_clobber_deny(
+        self,
+        session_with_pending_tool_call: tuple[asyncpg.Pool[Any], str, str, str],
+        runtime_for_dispatch: None,
+        _register_test_tool: None,
+    ) -> None:
+        """Race: operator deny commits while tool task is in-flight; the
+        task's late success append must not land a second tool-role
+        event that the context builder's last-wins keying would let
+        clobber the deny.
+
+        Concrete assertions:
+          * exactly ONE ``role:"tool"`` event exists for the tool_call_id
+            after both commit attempts
+          * that single event is the operator's deny (``is_error == True``)
+        """
+        pool, account_id, session_id, tool_call_id = session_with_pending_tool_call
+
+        # Step A: operator deny lands. Today this writes a tool-role
+        # event with is_error=True via append_tool_result's dedup-aware
+        # path.
+        await sessions_service.confirm_tool_deny(
+            pool,
+            session_id,
+            tool_call_id,
+            "operator denied while task was in-flight",
+            account_id=account_id,
+        )
+
+        # Step B: worker's tool task completes and tries to log its
+        # success. Drive the real production code path (``_execute_tool_async``)
+        # directly — the task body is the SQL-commit surface that
+        # races the operator deny in production. Awaiting it inline
+        # eliminates the asyncio-scheduling variable; the race
+        # ordering (deny first, worker second) is established by the
+        # explicit step order.
+        #
+        # ``_trigger_sweep`` (called from the lifecycle's ``finally``)
+        # depends on the procrastinate app being open; the SQL-commit
+        # surface under test happens BEFORE the sweep so a no-op
+        # patch is sufficient to keep the dispatch path intact.
+        async def _noop_sweep(*_a: Any, **_kw: Any) -> None:
+            return None
+
+        with mock.patch("aios.harness.tool_dispatch._trigger_sweep", _noop_sweep):
+            await _execute_tool_async(
+                pool,
+                session_id,
+                {
+                    "id": tool_call_id,
+                    "type": "function",
+                    "function": {"name": "echo_for_deny_race", "arguments": "{}"},
+                },
+                account_id=account_id,
+            )
+
+        # The bug: the deny silently lost. Two tool-role events exist
+        # for the same tool_call_id; the context builder's last-wins
+        # keying renders the worker's success in the prompt.
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT data FROM events
+                 WHERE session_id = $1
+                   AND data->>'role' = 'tool'
+                   AND data->>'tool_call_id' = $2
+                 ORDER BY seq
+                """,
+                session_id,
+                tool_call_id,
+            )
+
+        assert len(rows) == 1, (
+            f"deny must be the only tool-role event; the worker's late append "
+            f"clobbered the operator's intent (count={len(rows)})"
+        )
+        surviving = (
+            json.loads(rows[0]["data"]) if isinstance(rows[0]["data"], str) else rows[0]["data"]
+        )
+        assert surviving.get("is_error") is True, (
+            "the deny event must remain the authoritative tool-role event"
+        )


### PR DESCRIPTION
## Summary

- The worker's tool task lifecycle (success-, error-, schema-, cancel-paths) all funneled tool-role events through `sessions_service.append_event` directly — no `tool_call_id` dedup. An `always_allow` builtin (or any tool the harness dispatches without the always_ask confirmation gate) that's in-flight when the operator POSTs a deny lands TWO tool-role events for the same `tool_call_id`: the operator's deny first, then the worker's late result.
- The context builder's `real_results[tcid] = e.data` last-wins keying (`src/aios/harness/context.py:557-564`) clobbers the deny — the next prompt carries the tool's successful output as if no deny had happened. Symmetric silent-failure to the bug PR #535 closed in the opposite race direction.
- Fix: every tool-role append from `_execute_tool_async` / `_execute_mcp_tool_async` / `_append_tool_result` now funnels through `_append_tool_result_event`, which serialises against the session-row lock (mirroring `services.sessions.append_tool_result`) and refuses a second tool-role event for the same `tool_call_id` (logs `tool.result_dedup_skip` for ops visibility). First commit wins, second commit no-ops — same posture as the operator path's #535 fix.

## Substrate state changes

None — code-only change. The new dedup helper uses the existing `queries.find_tool_result_event` and `queries.append_event` primitives.

## Test plan

- [x] New integration test `test_worker_success_after_deny_must_not_clobber_deny` drives the actual `_execute_tool_async` worker path after an operator deny commits, asserts exactly ONE tool-role event survives and it's the deny. Pre-fix: count=2, asserts FAIL. Post-fix: dedup helper logs warning and skips; count=1, asserts pass.
- [x] mypy — clean (155 source files)
- [x] ruff check + format-check — clean
- [x] Full unit suite — 1349 passed
- [x] Integration suite — 39 passed
- [ ] CI runs e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>