### PR TITLE
refactor(harness/tool_dispatch): collapse bail-outs onto _ToolBail

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -537,11 +537,10 @@ async def _run_session_step_body(
         # Unknown-MCP tools route through the regular MCP dispatcher,
         # bypassing the permission gate.  ``_execute_mcp_tool_async``
         # already detects unknown servers and appends a tool_error
-        # event (``mcp_tool.server_not_found``); the prior code path
-        # parked the session in ``requires_action`` and dispatched
-        # only after a confirmation, which never came.  Routing them
-        # to immediate dispatch lets the model see the error in the
-        # next step and self-correct.
+        # event for them; the prior code path parked the session in
+        # ``requires_action`` and dispatched only after a confirmation,
+        # which never came.  Routing them to immediate dispatch lets
+        # the model see the error in the next step and self-correct.
         immediate_mcp = mcp_immediate + unknown_mcp
         if immediate_mcp:
             launch_mcp_tool_calls(
@@ -688,8 +687,8 @@ def _is_known_mcp_server(server_name: str, mcp_server_map: dict[str, str]) -> bo
     Used by :func:`_classify_tool_call` to short-circuit hallucinated
     tool names before the permission gate, so the model gets a tool
     error in one turn instead of parking in ``requires_action`` forever
-    waiting on a confirmation that would dispatch into
-    ``mcp_tool.server_not_found`` anyway.
+    waiting on a confirmation that would surface as an unknown-server
+    tool error anyway.
     """
     return server_name in mcp_server_map
 

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -74,6 +74,13 @@ class _ToolCall:
     is_error: bool = False
 
 
+class _ToolBail(Exception):
+    """Intentional bail from a tool body: the lifecycle treats it as a
+    clean model-visible error, not a handler crash (no type prefix on
+    the message, no ``on_exception`` callback).
+    """
+
+
 @asynccontextmanager
 async def _tool_lifecycle(
     pool: asyncpg.Pool[Any],
@@ -114,6 +121,12 @@ async def _tool_lifecycle(
         tc.is_error = True
         await _append_tool_result(
             pool, session_id, call_id, name, account_id=account_id, error="cancelled"
+        )
+    except _ToolBail as err:
+        bound_log.info(f"{log_prefix}.bail", error=str(err))
+        tc.is_error = True
+        await _append_tool_result(
+            pool, session_id, call_id, name, account_id=account_id, error=str(err)
         )
     except Exception as err:
         bound_log.exception(f"{log_prefix}.handler_failed")
@@ -179,27 +192,12 @@ async def _execute_tool_async(
     ) as tc:
         arguments = _parse_arguments(tc.raw_args)
         if arguments is None:
-            tc.bound_log.warning("tool.bad_arguments")
-            tc.is_error = True
-            await _append_tool_result(
-                pool,
-                session_id,
-                tc.call_id,
-                tc.name,
-                account_id=account_id,
-                error="arguments were not valid JSON",
-            )
-            return
+            raise _ToolBail("arguments were not valid JSON")
 
         try:
             tool = registry.get(tc.name)
         except ToolNotFoundError as err:
-            tc.bound_log.warning("tool.not_registered")
-            tc.is_error = True
-            await _append_tool_result(
-                pool, session_id, tc.call_id, tc.name, account_id=account_id, error=err.message
-            )
-            return
+            raise _ToolBail(err.message) from err
 
         # Validate arguments against the tool's parameters_schema before
         # dispatch.  Weaker models often emit tool calls with wrong
@@ -211,17 +209,7 @@ async def _execute_tool_async(
         # explicitly gives the model feedback to self-correct.
         schema_error = _validate_arguments(arguments, tool.parameters_schema)
         if schema_error is not None:
-            tc.bound_log.info("tool.schema_error", error=schema_error)
-            tc.is_error = True
-            await _append_tool_result(
-                pool,
-                session_id,
-                tc.call_id,
-                tc.name,
-                account_id=account_id,
-                error=schema_error,
-            )
-            return
+            raise _ToolBail(schema_error)
 
         # Invoke handler.  Handlers return either a plain dict (JSON-
         # encoded into the tool message's content) or a ToolResult
@@ -439,19 +427,12 @@ async def _execute_mcp_tool_async(
     ) as tc:
         arguments = _parse_arguments(tc.raw_args)
         if arguments is None:
-            tc.bound_log.warning("mcp_tool.bad_arguments")
-            tc.is_error = True
-            await _append_tool_result(
-                pool,
-                session_id,
-                tc.call_id,
-                tc.name,
-                account_id=account_id,
-                error="arguments were not valid JSON",
-            )
-            return
+            raise _ToolBail("arguments were not valid JSON")
 
-        server_name, tool_name = _parse_mcp_tool_name(tc.name)
+        try:
+            server_name, tool_name = _parse_mcp_tool_name(tc.name)
+        except ValueError as err:
+            raise _ToolBail(str(err)) from err
 
         from aios.harness.channels import (
             FOCAL_CHANNEL_META_KEY,
@@ -466,17 +447,7 @@ async def _execute_mcp_tool_async(
 
         url = mcp_server_map.get(server_name)
         if url is None:
-            tc.bound_log.warning("mcp_tool.server_not_found", server_name=server_name)
-            tc.is_error = True
-            await _append_tool_result(
-                pool,
-                session_id,
-                tc.call_id,
-                tc.name,
-                account_id=account_id,
-                error=f"MCP server {server_name!r} not found",
-            )
-            return
+            raise _ToolBail(f"MCP server {server_name!r} not found")
 
         from aios.mcp.client import call_mcp_tool, resolve_auth_for_target_url
 


### PR DESCRIPTION
## Summary

- `_execute_tool_async` and `_execute_mcp_tool_async` shared five almost-identical bail-out blocks — each manually building a `tool_result` error event, setting `tc.is_error`, logging, and `return`-ing. The lifecycle already had exception → `tool_result` machinery; bail-outs were reinventing it to avoid the generic handler's `"ValueError: …"` type prefix.
- Introduce a private `_ToolBail(Exception)` sentinel; the lifecycle catches it ahead of generic `Exception` and appends a clean tool_result whose body is the error string verbatim (no type prefix, no `on_exception` callback). Each bail collapses from ~10 lines to one `raise _ToolBail("…")`.
- Mirrors the existing `_DedupRollback` pattern in `services/inbound.py`. Net: **-30 LOC**.

Invariant #4 (tool-always-appends-result) preserved correct-by-construction — every `_ToolBail` flows through the single `_append_tool_result` call in the lifecycle, exactly once.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1349 passed
- [ ] CI runs the full suite

## Reviewer notes

Code-review pass surfaced three sub-80 observations (posted per project memory: score triages, doesn't suppress):

**F1 (sev 70) — Model-visible MCP malformed-name error shape changed.** Before: `"ValueError: malformed MCP tool name: 'foo'"` (caught by generic Exception handler). After: `"malformed MCP tool name: 'foo'"` (caught by `_ToolBail` via explicit wrap). Intentional: the `ValueError:` prefix was noise the model doesn't act on. Consistent with `_ToolBail`'s "clean model-visible error" stance.

**F2 (sev 68) — `server_name` no longer a structured log key.** Was `bound_log.warning("mcp_tool.server_not_found", server_name=server_name)`; now lives inside the `error=` string in `{prefix}.bail`. Recoverable: `tc.name` (full `mcp__<server>__<tool>`) is already bound on `bound_log`, so operators can still filter by name. Not worth special-casing in the unified handler.

**F3 (sev 62) — `loop.py` comments less specific after log rename.** The two stale references to `mcp_tool.server_not_found` were rewritten to "an unknown-server tool error" — necessary trade-off, the dispatch decision is still well-explained.

Plus: five distinct log events (`tool.bad_arguments`, `tool.not_registered`, `tool.schema_error`, `mcp_tool.bad_arguments`, `mcp_tool.server_not_found`) unify into `{prefix}.bail` with the error in extras. Grep across the worktree found no consumers of the old names. Log levels also unify on `info` — these are model-correctable mistakes, matching the level `schema_error` already used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)