### PR TITLE
fix(harness/completion): inject prompt_cache_key on openai-provider path

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -112,6 +112,65 @@ def _supports_anthropic_cache_control(model: str) -> bool:
     return False
 
 
+@cache
+def _supports_openai_prompt_cache_key(model: str) -> bool:
+    """True when ``model`` accepts OpenAI's ``prompt_cache_key`` field.
+
+    OpenAI's Responses / Chat Completions APIs group requests by an
+    explicit ``prompt_cache_key`` for cache eligibility. Anthropic uses
+    ``cache_control`` content-block markers instead, so the two cache
+    channels are mutually exclusive — the gate here mirrors
+    :func:`_supports_anthropic_cache_control`, returning True for the
+    openai provider (and only the openai provider) so the two paths
+    can't accidentally both fire.
+
+    Unknown model strings return False (safe no-op) — same posture as
+    the Anthropic gate.
+
+    Cached for the same reason as the Anthropic counterpart: pure
+    function of the model string, low cardinality.
+    """
+    try:
+        _, provider, _, _ = litellm.get_llm_provider(model)
+    except Exception:
+        return False
+    return bool(provider == "openai")
+
+
+def _apply_provider_cache_hints(
+    kwargs: dict[str, Any],
+    model: str,
+    session_id: str | None,
+) -> None:
+    """Inject the provider-appropriate cache hint into outbound kwargs.
+
+    Two cache channels exist, dispatched by provider:
+
+    * **Anthropic** — content-block ``cache_control`` markers, set by
+      :func:`inject_cache_breakpoints` directly on the messages list.
+      Nothing to do here.
+    * **OpenAI** — explicit ``prompt_cache_key`` kwarg, set here.
+      OpenAI's Responses / Chat Completions APIs group requests by this
+      key for cache eligibility. The natural per-session scope keeps
+      successive turns of the same session in the same bucket while
+      distinct sessions don't collide.
+
+    Skips when ``session_id`` is unset — a caller that doesn't know the
+    session (rare; only the harness's two call sites invoke these
+    wrappers, and both have it) gets the safe no-op rather than a
+    synthetic key that would re-bucket every call.
+
+    The caller's ``extra`` mapping (typically the agent's
+    ``litellm_extra``) is merged AFTER this helper, so an agent can
+    override ``prompt_cache_key`` with a custom scope — e.g. to share a
+    bucket across multiple sessions of the same conversation.
+    """
+    if session_id is None:
+        return
+    if _supports_openai_prompt_cache_key(model):
+        kwargs["prompt_cache_key"] = session_id
+
+
 def inject_cache_breakpoints(
     messages: list[dict[str, Any]],
     tools: list[dict[str, Any]] | None,
@@ -269,6 +328,7 @@ async def call_litellm(
     tools: list[dict[str, Any]] | None = None,
     api_base: str | None = None,
     extra: dict[str, Any] | None = None,
+    session_id: str | None = None,
 ) -> tuple[dict[str, Any], dict[str, int], float | None]:
     """Call ``litellm.acompletion`` and return ``(message, usage, cost)``.
 
@@ -277,6 +337,10 @@ async def call_litellm(
     ``thinking_blocks``. The harness stores the message dict opaquely.
     Usage is normalized to our canonical field names. Cost is LiteLLM's
     per-request USD figure, or ``None`` when the provider doesn't report it.
+
+    ``session_id`` (when provided on the openai provider path) is forwarded
+    as OpenAI's ``prompt_cache_key`` so successive turns of the same
+    session share a cache bucket. See ``_apply_provider_cache_hints``.
     """
     inject_cache_breakpoints(messages, tools, model)
 
@@ -289,6 +353,7 @@ async def call_litellm(
         kwargs["tools"] = tools
     if api_base is not None:
         kwargs["api_base"] = api_base
+    _apply_provider_cache_hints(kwargs, model, session_id)
     if extra:
         kwargs.update(extra)
 
@@ -339,6 +404,7 @@ async def stream_litellm(
         kwargs["tools"] = tools
     if api_base is not None:
         kwargs["api_base"] = api_base
+    _apply_provider_cache_hints(kwargs, model, session_id)
     if extra:
         kwargs.update(extra)
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -431,6 +431,7 @@ async def _run_session_step_body(
                 messages=messages,
                 tools=tools if tools else None,
                 extra=agent.litellm_extra or None,
+                session_id=session_id,
             )
     except Exception:
         log.exception("step.litellm_failed", session_id=session_id)

--- a/tests/unit/test_completion_prompt_cache_key.py
+++ b/tests/unit/test_completion_prompt_cache_key.py
@@ -1,0 +1,195 @@
+"""Outbound ``prompt_cache_key`` forwarding for the openai-provider path.
+
+Production observation: an aios session that hits Anthropic shows ~90%
+prompt-cache reads, while the same session against an OpenAI-compatible
+endpoint (oai-proxy → auth2api → Codex/ChatGPT) sits near 7%. The
+Anthropic path gets ``cache_control`` markers from
+:func:`inject_cache_breakpoints`; the openai path was getting nothing.
+
+OpenAI's Responses / Chat Completions APIs cache by the explicit
+``prompt_cache_key`` field — callers pass a stable identifier and the
+provider groups requests by that key for cache eligibility. The natural
+scope in aios is the session id: every turn in a session shares a
+prefix, and distinct sessions don't collide on cache lookups.
+
+These tests pin the wire-level behavior: the openai path *must* send
+``prompt_cache_key`` set to the session id, and the anthropic path
+*must not* (cache_control markers already do the job there, and adding
+the field would either be ignored or — worse — confuse a non-OpenAI
+adapter).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.harness import completion
+
+
+class _DictResponse(dict[str, object]):
+    """Subscriptable + ``.get`` + ``_hidden_params`` like a real LiteLLM response.
+
+    The wrapper's ``_extract_cost`` reads ``_hidden_params``; a bare dict
+    raises ``AttributeError`` on that lookup, which masks the kwarg we're
+    actually trying to assert on.
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self._hidden_params: dict[str, object] = {}
+
+
+def _ok_response() -> _DictResponse:
+    return _DictResponse(
+        choices=[{"message": {"role": "assistant", "content": ""}}],
+        usage={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_litellm_openai_path_sends_prompt_cache_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The non-streaming wrapper must forward a stable ``prompt_cache_key``
+    on the openai provider path, keyed on ``session_id``.
+
+    Without this, OpenAI's cache lookup can't group successive turns of
+    the same session — producing the 7%-reads anomaly observed in prod.
+    """
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> _DictResponse:
+        captured.update(kwargs)
+        return _ok_response()
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+
+    await completion.call_litellm(
+        model="openai/gpt-5.5",
+        messages=[{"role": "user", "content": "hi"}],
+        session_id="sess_abc123",
+    )
+
+    assert captured.get("prompt_cache_key") == "sess_abc123"
+
+
+@pytest.mark.asyncio
+async def test_stream_litellm_openai_path_sends_prompt_cache_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streaming path must forward the same ``prompt_cache_key`` it would
+    on the non-streaming path. The harness picks streaming vs. non-streaming
+    based on whether a subscriber is attached — caching must not depend on
+    that pick."""
+    captured: dict[str, object] = {}
+
+    class _EmptyResponse:
+        def __aiter__(self) -> _EmptyResponse:
+            return self
+
+        async def __anext__(self) -> object:
+            raise StopAsyncIteration
+
+    async def fake_acompletion(**kwargs: object) -> _EmptyResponse:
+        captured.update(kwargs)
+        return _EmptyResponse()
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(
+        completion.litellm,
+        "stream_chunk_builder",
+        lambda chunks: {
+            "usage": {},
+            "choices": [{"message": {"role": "assistant", "content": ""}}],
+        },
+    )
+
+    from tests.unit.test_completion_timeouts import _StubPool
+
+    await completion.stream_litellm(
+        model="openai/gpt-5.5",
+        messages=[{"role": "user", "content": "hi"}],
+        pool=_StubPool(),  # type: ignore[arg-type]
+        session_id="sess_xyz789",
+    )
+
+    assert captured.get("prompt_cache_key") == "sess_xyz789"
+
+
+@pytest.mark.asyncio
+async def test_call_litellm_anthropic_path_omits_prompt_cache_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anthropic-routed calls must NOT carry ``prompt_cache_key``.
+
+    Cache control on that path is driven by content-block markers
+    (:func:`inject_cache_breakpoints`). The OpenAI cache-key field has
+    no defined behavior for the Anthropic adapter and could trip
+    parameter validation in some LiteLLM versions; keep the channels
+    cleanly separated."""
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> _DictResponse:
+        captured.update(kwargs)
+        return _ok_response()
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+
+    await completion.call_litellm(
+        model="anthropic/claude-opus-4-6",
+        messages=[{"role": "user", "content": "hi"}],
+        session_id="sess_anthropic",
+    )
+
+    assert "prompt_cache_key" not in captured
+
+
+@pytest.mark.asyncio
+async def test_call_litellm_openai_path_session_id_optional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``session_id`` is optional — when omitted, no ``prompt_cache_key``
+    is sent (rather than e.g. a synthetic one that would create a
+    different cache bucket every call)."""
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> _DictResponse:
+        captured.update(kwargs)
+        return _ok_response()
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+
+    await completion.call_litellm(
+        model="openai/gpt-5.5",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert "prompt_cache_key" not in captured
+
+
+@pytest.mark.asyncio
+async def test_call_litellm_extra_overrides_prompt_cache_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``prompt_cache_key`` in ``extra`` (e.g. agent-level
+    override via ``litellm_extra``) wins over the harness default.
+
+    Agents may want a custom scope — e.g. share a cache bucket across
+    multiple sessions of the same conversation. The harness default is
+    the safe fallback, not a ceiling."""
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> _DictResponse:
+        captured.update(kwargs)
+        return _ok_response()
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+
+    await completion.call_litellm(
+        model="openai/gpt-5.5",
+        messages=[{"role": "user", "content": "hi"}],
+        session_id="sess_default",
+        extra={"prompt_cache_key": "shared-bucket"},
+    )
+
+    assert captured.get("prompt_cache_key") == "shared-bucket"


### PR DESCRIPTION
## Summary

Production observation: same aios session, same workload — the Anthropic route sits at ~90% prompt-cache reads, the OpenAI route (via oai-proxy → auth2api → Codex/ChatGPT) sits at ~7%. The Anthropic path gets `cache_control` content-block markers from `inject_cache_breakpoints`; the OpenAI path gets nothing — `_supports_anthropic_cache_control` gates that injection off for `provider="openai"` and there is no counterpart for OpenAI's cache machinery.

OpenAI's Responses / Chat Completions APIs group requests for cache eligibility by an explicit `prompt_cache_key` field. The natural per-session scope keeps successive turns of the same session in the same cache bucket while distinct sessions do not collide.

## Investigation evidence

- `src/aios/harness/completion.py:157` (pre-patch) — `inject_cache_breakpoints` early-returns when `_supports_anthropic_cache_control(model)` is False, which is the case for any model resolving via `litellm.get_llm_provider` to `provider="openai"`. Aios sent zero cache hints on the openai path.
- `litellm` 1.83.4 (pinned in `pyproject.toml`) lists `prompt_cache_key` in `get_supported_openai_params("openai/gpt-5.5")` — first-class openai-supported param, passes through directly as a top-level kwarg.
- `apps/oai-proxy/src/oai_proxy/proxy/handler.py:140` forwards `raw_body` verbatim to auth2api; no body field is stripped. Confirms oai-proxy is a transparent passthrough — the fix lives entirely in aios.

## The fix

Two-line dispatch by provider mirroring the Anthropic gate:

- `_supports_openai_prompt_cache_key(model)` — returns True iff litellm classifies `model` as `provider="openai"` (Anthropic-backed proxies through OpenRouter/Bedrock/Vertex stay on the cache_control path).
- `_apply_provider_cache_hints(kwargs, model, session_id)` — when `session_id` is set and the provider is openai, sets `kwargs["prompt_cache_key"] = session_id`. Anthropic-path messages keep using the existing content-block markers; OpenAI-path requests now carry an explicit, stable per-session cache key.

`call_litellm` gains an optional `session_id` kwarg (the streaming variant already had it). The single caller in `harness/loop.py` was already in scope of `session_id`; one-line plumbing.

Agent-level `litellm_extra={"prompt_cache_key": "..."}` still overrides — `_apply_provider_cache_hints` runs *before* `kwargs.update(extra)`. The harness default is the safe fallback, not a ceiling.

## Tests

`tests/unit/test_completion_prompt_cache_key.py` — five new tests, all initially RED:

1. `test_call_litellm_openai_path_sends_prompt_cache_key` — non-streaming wrapper forwards `prompt_cache_key=session_id` on the openai path.
2. `test_stream_litellm_openai_path_sends_prompt_cache_key` — same for the streaming wrapper (subscriber-attached path).
3. `test_call_litellm_anthropic_path_omits_prompt_cache_key` — Anthropic-routed calls must NOT carry the field (channels stay separate).
4. `test_call_litellm_openai_path_session_id_optional` — omitted `session_id` means no field (rather than a synthetic one that would re-bucket every call).
5. `test_call_litellm_extra_overrides_prompt_cache_key` — agent-level override via `extra` wins over the harness default.

Red → green trajectory verified: pre-fix run errored on `TypeError: call_litellm() got an unexpected keyword argument 'session_id'` at test 1; post-fix all five pass.

Full unit suite: 1366 pass (no regressions in the existing `test_usage.py::TestInjectCacheBreakpointsProviderGuard` or `test_completion_timeouts.py`).

mypy + ruff (check + format): clean.

## Acceptance criteria

- [x] Outbound openai-path requests carry `prompt_cache_key` set to a stable per-session value (verified via captured kwargs in unit tests).
- [x] Outbound anthropic-path requests do NOT carry `prompt_cache_key` (verified).
- [x] Existing `cache_control` injection on the Anthropic path is unchanged (existing `TestInjectCacheBreakpoints*` tests pass unchanged).
- [x] Agent-level override still works (verified).
- [x] `1366 passed` on `uv run pytest tests/unit -q`.

## Implementation

Files changed:
- `src/aios/harness/completion.py` — add `_supports_openai_prompt_cache_key`, `_apply_provider_cache_hints`; thread `session_id` through `call_litellm`; both wrappers call `_apply_provider_cache_hints` before merging `extra`.
- `src/aios/harness/loop.py` — pass `session_id=session_id` to `call_litellm` (the streaming path already had it).
- `tests/unit/test_completion_prompt_cache_key.py` — new test file.

### Followups (not bundled, per bug-per-PR)

- **Auto-prefix-cache stability audit on the openai path.** The Responses API also auto-caches stable prefixes ≥1024 tokens; if anything in the prefix mutates per turn (timestamps, sequence numbers injected high), explicit `prompt_cache_key` still helps but auto-prefix-caching would amplify it. The Anthropic side achieves 90% reads on the same prefix, which is strong evidence the prefix is stable enough — but worth a dedicated audit once the cache-key fix lands and we can read the reads-rate delta.
- **Chat Completions vs Responses API.** litellm's openai adapter defaults to `/v1/chat/completions`; the Responses API has somewhat stronger cache machinery. Both accept `prompt_cache_key`, so this fix works on either. Switching wire format is a separate change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>