### PR TITLE
fix(harness/completion): use extra_body so prompt_cache_key reaches OpenAI

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -149,26 +149,35 @@ def _apply_provider_cache_hints(
     * **Anthropic** — content-block ``cache_control`` markers, set by
       :func:`inject_cache_breakpoints` directly on the messages list.
       Nothing to do here.
-    * **OpenAI** — explicit ``prompt_cache_key`` kwarg, set here.
-      OpenAI's Responses / Chat Completions APIs group requests by this
-      key for cache eligibility. The natural per-session scope keeps
-      successive turns of the same session in the same bucket while
-      distinct sessions don't collide.
+    * **OpenAI** — explicit ``prompt_cache_key`` field, nested under
+      ``extra_body`` so it survives the litellm boundary. litellm 1.83.4
+      strips unknown top-level kwargs from the outbound OpenAI HTTP body;
+      ``extra_body`` is the documented pass-through that the OpenAI
+      Python SDK merges into the request JSON. OpenAI's Responses / Chat
+      Completions APIs group requests by ``prompt_cache_key`` for cache
+      eligibility. The natural per-session scope keeps successive turns
+      of the same session in the same bucket while distinct sessions
+      don't collide.
 
     Skips when ``session_id`` is unset — a caller that doesn't know the
     session (rare; only the harness's two call sites invoke these
     wrappers, and both have it) gets the safe no-op rather than a
     synthetic key that would re-bucket every call.
 
-    The caller's ``extra`` mapping (typically the agent's
-    ``litellm_extra``) is merged AFTER this helper, so an agent can
-    override ``prompt_cache_key`` with a custom scope — e.g. to share a
-    bucket across multiple sessions of the same conversation.
+    **Merge order:** this helper runs AFTER the caller's ``extra``
+    mapping (typically the agent's ``litellm_extra``) is merged into
+    ``kwargs``, so agent-provided ``extra_body`` siblings (e.g.,
+    OpenRouter ``provider.order``) are preserved alongside the cache
+    key. The inner ``setdefault`` preserves an agent-provided explicit
+    ``extra_body["prompt_cache_key"]`` override — agents may want a
+    custom scope, e.g. to share a bucket across multiple sessions of
+    the same conversation.
     """
     if session_id is None:
         return
     if _supports_openai_prompt_cache_key(model):
-        kwargs["prompt_cache_key"] = session_id
+        extra_body = kwargs.setdefault("extra_body", {})
+        extra_body.setdefault("prompt_cache_key", session_id)
 
 
 def inject_cache_breakpoints(
@@ -353,9 +362,9 @@ async def call_litellm(
         kwargs["tools"] = tools
     if api_base is not None:
         kwargs["api_base"] = api_base
-    _apply_provider_cache_hints(kwargs, model, session_id)
     if extra:
         kwargs.update(extra)
+    _apply_provider_cache_hints(kwargs, model, session_id)
 
     response = await litellm.acompletion(**kwargs)
     usage_obj = response.get("usage")
@@ -404,9 +413,9 @@ async def stream_litellm(
         kwargs["tools"] = tools
     if api_base is not None:
         kwargs["api_base"] = api_base
-    _apply_provider_cache_hints(kwargs, model, session_id)
     if extra:
         kwargs.update(extra)
+    _apply_provider_cache_hints(kwargs, model, session_id)
 
     response = await litellm.acompletion(**kwargs)
 

--- a/tests/unit/test_completion_prompt_cache_key.py
+++ b/tests/unit/test_completion_prompt_cache_key.py
@@ -70,7 +70,10 @@ async def test_call_litellm_openai_path_sends_prompt_cache_key(
         session_id="sess_abc123",
     )
 
-    assert captured.get("prompt_cache_key") == "sess_abc123"
+    extra_body = captured.get("extra_body")
+    assert isinstance(extra_body, dict)
+    assert extra_body.get("prompt_cache_key") == "sess_abc123"
+    assert "prompt_cache_key" not in captured  # NOT at top level
 
 
 @pytest.mark.asyncio
@@ -113,7 +116,10 @@ async def test_stream_litellm_openai_path_sends_prompt_cache_key(
         session_id="sess_xyz789",
     )
 
-    assert captured.get("prompt_cache_key") == "sess_xyz789"
+    extra_body = captured.get("extra_body")
+    assert isinstance(extra_body, dict)
+    assert extra_body.get("prompt_cache_key") == "sess_xyz789"
+    assert "prompt_cache_key" not in captured  # NOT at top level
 
 
 @pytest.mark.asyncio
@@ -142,6 +148,10 @@ async def test_call_litellm_anthropic_path_omits_prompt_cache_key(
     )
 
     assert "prompt_cache_key" not in captured
+    extra_body = captured.get("extra_body")
+    if extra_body is not None:
+        assert isinstance(extra_body, dict)
+        assert extra_body.get("prompt_cache_key") is None
 
 
 @pytest.mark.asyncio
@@ -165,6 +175,10 @@ async def test_call_litellm_openai_path_session_id_optional(
     )
 
     assert "prompt_cache_key" not in captured
+    extra_body = captured.get("extra_body")
+    if extra_body is not None:
+        assert isinstance(extra_body, dict)
+        assert extra_body.get("prompt_cache_key") is None
 
 
 @pytest.mark.asyncio
@@ -189,7 +203,98 @@ async def test_call_litellm_extra_overrides_prompt_cache_key(
         model="openai/gpt-5.5",
         messages=[{"role": "user", "content": "hi"}],
         session_id="sess_default",
-        extra={"prompt_cache_key": "shared-bucket"},
+        extra={"extra_body": {"prompt_cache_key": "shared-bucket"}},
     )
 
-    assert captured.get("prompt_cache_key") == "shared-bucket"
+    extra_body = captured.get("extra_body")
+    assert isinstance(extra_body, dict)
+    assert extra_body.get("prompt_cache_key") == "shared-bucket"
+
+
+@pytest.mark.asyncio
+async def test_call_litellm_openai_preserves_agent_extra_body_siblings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the agent provides ``extra_body`` for unrelated reasons (e.g.
+    OpenRouter ``provider.order`` pinning), ``prompt_cache_key`` must be
+    merged alongside, not clobber and not get clobbered.
+
+    Naive ``setdefault("extra_body", {})`` BEFORE the agent's
+    ``kwargs.update(extra)`` would let the agent's ``extra_body`` wholesale
+    replace the harness's, dropping ``prompt_cache_key``. The fix is to
+    merge AFTER the agent's update.
+    """
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> _DictResponse:
+        captured.update(kwargs)
+        return _ok_response()
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+
+    await completion.call_litellm(
+        model="openai/gpt-5.5",
+        messages=[{"role": "user", "content": "hi"}],
+        session_id="sess_merge",
+        extra={"extra_body": {"provider": {"order": ["anthropic"]}}},
+    )
+
+    extra_body = captured.get("extra_body")
+    assert isinstance(extra_body, dict)
+    assert extra_body.get("prompt_cache_key") == "sess_merge"
+    assert extra_body.get("provider") == {"order": ["anthropic"]}
+
+
+@pytest.mark.asyncio
+async def test_call_litellm_openai_path_prompt_cache_key_reaches_http_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wire-level guard: ``prompt_cache_key`` must land in the outbound HTTP
+    JSON body, not just in kwargs passed to ``litellm.acompletion``.
+
+    The previous fix (PR #556) failed this because top-level kwargs are
+    stripped by litellm 1.83.4 before the OpenAI HTTP request is built;
+    ``extra_body`` is the pass-through that the OpenAI Python SDK merges
+    into the request JSON.
+    """
+    import json
+
+    import httpx
+    from openai import AsyncOpenAI
+
+    captured_body: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_body.update(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "gpt-5.5",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {"role": "assistant", "content": ""},
+                    }
+                ],
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            },
+        )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    mock_client = AsyncOpenAI(
+        api_key="test-key",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    await completion.call_litellm(
+        model="openai/gpt-5.5",
+        messages=[{"role": "user", "content": "hi"}],
+        session_id="sess_wire",
+        extra={"client": mock_client},
+    )
+
+    assert captured_body.get("prompt_cache_key") == "sess_wire"


### PR DESCRIPTION
Closes #558.

PR #556 set `kwargs["prompt_cache_key"] = session_id` to enable OpenAI prefix
caching, but litellm 1.83.4 silently filters unknown top-level kwargs out of
the outbound HTTP body. Verified via oai-proxy dumps: the key never reached
`/v1/chat/completions`, and post-deploy measurement showed 0
`cache_read_input_tokens` across 5 same-session requests (5125 input tokens).
The documented pass-through mechanism is `extra_body`.

## Fix (two parts)

1. **Nest under `extra_body`.** `_apply_provider_cache_hints` now does
   `kwargs.setdefault("extra_body", {}).setdefault("prompt_cache_key", session_id)`.
   Outer setdefault preserves any pre-existing `extra_body`; inner setdefault
   preserves any explicit agent override.

2. **Reorder: apply hints AFTER `kwargs.update(extra)`** in both `call_litellm`
   and `stream_litellm`. Without this, an agent passing `extra_body` for an
   unrelated reason (e.g., OpenRouter `provider.order` pinning via
   `Agent.litellm_extra`) would wholesale replace our freshly-created
   `extra_body` and silently drop `prompt_cache_key`.

## Tests

- Updated existing kwargs-boundary tests in
  `tests/unit/test_completion_prompt_cache_key.py` to assert the new nested
  shape, and the agent-override test to use `extra_body["prompt_cache_key"]`.
- Added a merge-order defense test: agent supplies `extra_body` (provider
  pinning) alongside session_id; both keys must survive in captured kwargs.
- Added a wire-level integration test that injects an `AsyncOpenAI` client
  with `httpx.MockTransport` via litellm's `client=` pass-through, captures
  the actual outbound HTTP JSON body, and asserts `body["prompt_cache_key"]`
  is present. This is the test layer #556 missed — asserting at the kwargs
  boundary couldn't have caught litellm's downstream filtering; only the HTTP
  wire can.

## Behavior break (small, operator-trusted)

Agents previously overriding the default via
`litellm_extra={"prompt_cache_key": "..."}` will silently stop overriding.
The new override location is
`litellm_extra={"extra_body": {"prompt_cache_key": "..."}}`. `litellm_extra`
is operator-trusted, so blast radius is bounded.

## Validation

- 1368 unit tests pass; mypy clean; ruff clean.
- End-to-end `cache_read_input_tokens > 0` on turn 2+ to be verified
  post-deploy via oai-proxy dumps.