### PR TITLE
fix(db/pool): halve default pool size and warn near max_connections

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -155,7 +155,7 @@ class Settings(BaseSettings):
 
     # ── database pool ──────────────────────────────────────────────────────
     db_pool_max_size: int = Field(
-        default=16,
+        default=8,
         ge=1,
         description="Maximum asyncpg pool size. Should comfortably exceed "
         "worker_concurrency * ~3 connections per turn.",

--- a/src/aios/db/pool.py
+++ b/src/aios/db/pool.py
@@ -11,6 +11,11 @@ from typing import Any
 
 import asyncpg
 
+from aios.logging import get_logger
+
+_KNOWN_POOL_COUNT = 2  # API pool + worker pool (production call sites)
+log = get_logger("aios.db.pool")
+
 
 def normalize_dsn(db_url: str) -> str:
     """Strip SQLAlchemy/alembic driver prefixes; asyncpg wants bare ``postgresql://``."""
@@ -20,11 +25,22 @@ def normalize_dsn(db_url: str) -> str:
     return db_url
 
 
-async def create_pool(db_url: str, *, min_size: int = 1, max_size: int = 16) -> asyncpg.Pool[Any]:
+async def create_pool(db_url: str, *, min_size: int = 1, max_size: int = 8) -> asyncpg.Pool[Any]:
     """Create a new asyncpg pool against ``db_url``."""
     pool = await asyncpg.create_pool(
         dsn=normalize_dsn(db_url), min_size=min_size, max_size=max_size
     )
     if pool is None:
         raise RuntimeError(f"asyncpg.create_pool returned None for {db_url}")
+    async with pool.acquire() as conn:
+        pg_max_connections = int(await conn.fetchval("SHOW max_connections"))
+    total_pool_capacity = max_size * _KNOWN_POOL_COUNT
+    if total_pool_capacity >= pg_max_connections:
+        log.warning(
+            "db.pool.unsafe_max_size",
+            max_size=max_size,
+            known_pool_count=_KNOWN_POOL_COUNT,
+            total_pool_capacity=total_pool_capacity,
+            pg_max_connections=pg_max_connections,
+        )
     return pool

--- a/tests/unit/test_db_pool.py
+++ b/tests/unit/test_db_pool.py
@@ -1,0 +1,96 @@
+"""Unit tests for aios.db.pool."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import structlog
+
+from aios.db.pool import create_pool, normalize_dsn
+
+
+def _make_fake_pool(pg_max_connections: str) -> MagicMock:
+    """Build a fake asyncpg pool whose acquire() yields a conn with fetchval."""
+    fake_conn = AsyncMock()
+    fake_conn.fetchval = AsyncMock(return_value=pg_max_connections)
+
+    fake_pool = MagicMock()
+
+    @asynccontextmanager
+    async def _acquire() -> Any:
+        yield fake_conn
+
+    fake_pool.acquire = _acquire
+    return fake_pool
+
+
+@pytest.fixture
+def capture_logs() -> Iterator[structlog.testing.LogCapture]:
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    try:
+        yield cap
+    finally:
+        structlog.reset_defaults()
+
+
+@pytest.mark.asyncio
+async def test_default_max_size_is_8() -> None:
+    fake_pool = _make_fake_pool("200")
+    with patch(
+        "aios.db.pool.asyncpg.create_pool", new=AsyncMock(return_value=fake_pool)
+    ) as mock_create:
+        await create_pool("postgresql://stub/db")
+        mock_create.assert_called_once()
+        _, kwargs = mock_create.call_args
+        assert kwargs["max_size"] == 8
+
+
+@pytest.mark.asyncio
+async def test_warning_emitted_when_capacity_reaches_pg_max(
+    capture_logs: structlog.testing.LogCapture,
+) -> None:
+    # 8 (max_size) * 2 (known pool count) == 16 >= 16 (pg_max_connections) → warning
+    fake_pool = _make_fake_pool("16")
+    with patch("aios.db.pool.asyncpg.create_pool", new=AsyncMock(return_value=fake_pool)):
+        await create_pool("postgresql://stub/db")
+
+    matches = [e for e in capture_logs.entries if e.get("event") == "db.pool.unsafe_max_size"]
+    assert len(matches) == 1
+    entry = matches[0]
+    assert entry["log_level"] == "warning"
+    assert entry["total_pool_capacity"] == 16
+    assert entry["pg_max_connections"] == 16
+
+
+@pytest.mark.asyncio
+async def test_no_warning_when_capacity_is_safe(
+    capture_logs: structlog.testing.LogCapture,
+) -> None:
+    fake_pool = _make_fake_pool("100")
+    with patch("aios.db.pool.asyncpg.create_pool", new=AsyncMock(return_value=fake_pool)):
+        await create_pool("postgresql://stub/db")
+
+    matches = [e for e in capture_logs.entries if e.get("event") == "db.pool.unsafe_max_size"]
+    assert len(matches) == 0
+
+
+def test_normalize_dsn_strips_asyncpg_prefix() -> None:
+    assert normalize_dsn("postgresql+asyncpg://u:p@host/db") == "postgresql://u:p@host/db"
+
+
+def test_normalize_dsn_strips_psycopg_prefix() -> None:
+    assert normalize_dsn("postgresql+psycopg://u:p@host/db") == "postgresql://u:p@host/db"
+
+
+@pytest.mark.asyncio
+async def test_raises_when_asyncpg_returns_none() -> None:
+    with (
+        patch("aios.db.pool.asyncpg.create_pool", new=AsyncMock(return_value=None)),
+        pytest.raises(RuntimeError),
+    ):
+        await create_pool("postgresql://stub/db")


### PR DESCRIPTION
Closes #557

The API process was exhausting Postgres `max_connections=100` over time — two pools (API + worker) at `max_size=16` each, plus listen connections, left no headroom for `aios migrate` during rolling deploys.

**Changes**

- `src/aios/db/pool.py`: lower default `max_size` from 16 → 8; after the pool opens, `SHOW max_connections` is fetched and a structlog warning is emitted if `max_size * 2 >= pg_max_connections`, giving early notice before the next deploy deadlocks
- `src/aios/config.py`: align `db_pool_max_size` default to 8
- `tests/unit/test_db_pool.py`: 6 new unit tests covering the warning threshold logic

The `* 2` factor in the guard accounts for both the API and worker pools sharing the same Postgres instance; operators running a single process can raise the cap via `AIOS_DB_POOL_MAX_SIZE`.