### PR TITLE
feat(runtime-tokens): connection-id allowlist scope for connectors

### DIFF
--- a/migrations/versions/0054_runtime_tokens_connection_ids.py
+++ b/migrations/versions/0054_runtime_tokens_connection_ids.py
@@ -1,0 +1,35 @@
+"""Add nullable ``connection_ids text[]`` to ``runtime_tokens`` (#350).
+
+The optional allowlist scope: when ``connection_ids`` is non-NULL on
+a runtime token, the bearer can only see / operate on the listed
+connection IDs.  ``NULL`` means "unscoped" — pre-#350 behaviour where
+the token sees every connection of its connector type.
+
+Precedent for ``text[]`` (vs. jsonb): ``session_templates.vault_ids``
+and ``session_templates.memory_store_ids``.  Backwards-safe because
+the column is nullable and has no default — pre-migration rows
+become ``NULL`` (unscoped).
+
+Revision ID: 0054
+Revises: 0053
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0054"
+down_revision: str = "0053"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE runtime_tokens ADD COLUMN connection_ids text[]")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE runtime_tokens DROP COLUMN IF EXISTS connection_ids")

--- a/openapi.json
+++ b/openapi.json
@@ -6116,7 +6116,7 @@
           "runtime-tokens"
         ],
         "summary": "Issue",
-        "description": "Mint a new bearer token scoped to ``body.connector``.\n\nThe plaintext is included in the response and CANNOT be recovered\nlater \u2014 operators must save it at issue time.",
+        "description": "Mint a new bearer token scoped to ``body.connector``.\n\nThe plaintext is included in the response and CANNOT be recovered\nlater \u2014 operators must save it at issue time.\n\nOptional ``body.connection_ids`` (#350) restricts the issued token\nto that allowlist of connection IDs; omit to leave the token\nunscoped (sees every connection of ``body.connector`` type).",
         "operationId": "issue_runtime_token",
         "parameters": [
           {
@@ -6292,7 +6292,7 @@
           "connectors"
         ],
         "summary": "Put Tools Schema",
-        "description": "Publish the runtime container's tool catalog for a connector type.\n\nThe runtime container is the source of truth for what tools it\nserves \u2014 it knows their names, parameter shapes, and docstrings.\nThe SDK derives JSON Schemas from ``@tool``-decorated methods at\nstartup and calls this once, replacing whatever was on the\n``connectors.tools_schema`` row wholesale.  Operators don't\nhand-write the schema.\n\nAuthorization: the runtime bearer's ``connector`` must match the\npath's ``connector``.",
+        "description": "Publish the runtime container's tool catalog for a connector type.\n\nThe runtime container is the source of truth for what tools it\nserves \u2014 it knows their names, parameter shapes, and docstrings.\nThe SDK derives JSON Schemas from ``@tool``-decorated methods at\nstartup and calls this once, replacing whatever was on the\n``connectors.tools_schema`` row wholesale.  Operators don't\nhand-write the schema.\n\nAuthorization: the runtime bearer's ``connector`` must match the\npath's ``connector``.  ``connection_ids`` allowlist is NOT enforced\nhere \u2014 the tools schema is a connector-type-wide registration, not\na per-connection operation.",
         "operationId": "put_connector_tools_schema",
         "parameters": [
           {
@@ -6359,7 +6359,7 @@
           "connectors"
         ],
         "summary": "Get Connection Discovery",
-        "description": "SSE stream of ``added`` / ``removed`` connection events for the\nruntime container's connector type (#328 PR 5).\n\nBackfills every active connection of the caller's ``connector``\ntype at subscribe time as ``added`` events, then tails the\n``connections_<connector>`` NOTIFY channel.  Each event is keyed\n``connection`` with a JSON body shaped::\n\n    {\"event\": \"added\" | \"removed\",\n     \"connection_id\": \"...\",\n     \"external_account_id\": \"...\"}\n\nThe runtime container subscribes once per ``connector`` type and\nfans out to per-connection workers on ``added``; tears them down\non ``removed``.",
+        "description": "SSE stream of ``added`` / ``removed`` connection events for the\nruntime container's connector type (#328 PR 5).\n\nBackfills every active connection of the caller's ``connector``\ntype at subscribe time as ``added`` events, then tails the\n``connections_<connector>`` NOTIFY channel.  Each event is keyed\n``connection`` with a JSON body shaped::\n\n    {\"event\": \"added\" | \"removed\",\n     \"connection_id\": \"...\",\n     \"external_account_id\": \"...\"}\n\nThe runtime container subscribes once per ``connector`` type and\nfans out to per-connection workers on ``added``; tears them down\non ``removed``.\n\nWhen the bearer carries a ``connection_ids`` allowlist (#350), the\nbackfill and tail both filter to that set \u2014 out-of-scope IDs are\nsilently omitted (not 403'd) so the runtime container's discovery\nloop just doesn't see them.",
         "operationId": "get_connection_discovery_v1_connectors_connections_get",
         "parameters": [
           {
@@ -6410,7 +6410,7 @@
           "connectors"
         ],
         "summary": "Post Runtime Inbound",
-        "description": "Append an inbound user message to ``connection_id``'s session.\n\nThe bearer authenticates the caller as one connector *type*;\n``connection_id`` rides as a form field and must belong to that\ntype.  Idempotent on ``event_id``; drops surface as 4xx/5xx with\na body explaining the reason (operator-config issue vs server\nerror vs payload).",
+        "description": "Append an inbound user message to ``connection_id``'s session.\n\nThe bearer authenticates the caller as one connector *type*;\n``connection_id`` rides as a form field and must belong to that\ntype.  When the bearer carries a ``connection_ids`` allowlist\n(#350), the form field must also be on the list \u2014 otherwise 403.\nIdempotent on ``event_id``; drops surface as 4xx/5xx with\na body explaining the reason (operator-config issue vs server\nerror vs payload).",
         "operationId": "post_connector_runtime_inbound",
         "parameters": [
           {
@@ -6470,7 +6470,7 @@
           "connectors"
         ],
         "summary": "Post Runtime Tool Result",
-        "description": "Submit a custom tool result from a runtime container.\n\nAuthorization: the bearer's connector must match ``body.connection_id``'s\nconnector, and the session must be bound to that connection.",
+        "description": "Submit a custom tool result from a runtime container.\n\nAuthorization: the bearer's connector must match\n``body.connection_id``'s connector, the session must be bound to\nthat connection, and (when the bearer carries a ``connection_ids``\nallowlist) ``body.connection_id`` must be on the list (#350).",
         "operationId": "post_connector_runtime_tool_result",
         "parameters": [
           {
@@ -6530,7 +6530,7 @@
           "connectors"
         ],
         "summary": "Get Runtime Secrets",
-        "description": "Decrypted secrets for ``connection_id``.\n\nThe bearer's connector must match the connection's connector\ntype.  Returns ``{\"secrets\": {}}`` when none are configured \u2014\ncallers decide whether that's acceptable.",
+        "description": "Decrypted secrets for ``connection_id``.\n\nThe bearer's connector must match the connection's connector\ntype; when the bearer carries a ``connection_ids`` allowlist\n(#350), ``connection_id`` must be on the list.  Returns\n``{\"secrets\": {}}`` when none are configured \u2014 callers decide\nwhether that's acceptable.",
         "operationId": "get_connector_runtime_secrets",
         "parameters": [
           {
@@ -6589,7 +6589,7 @@
           "connectors"
         ],
         "summary": "Get Runtime Calls",
-        "description": "SSE stream of pending custom tool calls across every active\nconnection of the caller's connector type.\n\nBackfills at subscribe time, then tails ``connector_calls_<connector>``.\nEach event is keyed ``call`` with a JSON body shaped::\n\n    {\n        \"session_id\": \"...\",\n        \"tool_call_id\": \"...\",\n        \"name\": \"...\",\n        \"arguments\": \"...\",       // JSON string from the model\n        \"focal_channel\": \"...\",\n        \"connection_id\": \"...\"\n    }\n\nThe ``connection_id`` field lets the runtime container fan out to\nits per-connection workers client-side.",
+        "description": "SSE stream of pending custom tool calls across every active\nconnection of the caller's connector type.\n\nBackfills at subscribe time, then tails ``connector_calls_<connector>``.\nEach event is keyed ``call`` with a JSON body shaped::\n\n    {\n        \"session_id\": \"...\",\n        \"tool_call_id\": \"...\",\n        \"name\": \"...\",\n        \"arguments\": \"...\",       // JSON string from the model\n        \"focal_channel\": \"...\",\n        \"connection_id\": \"...\"\n    }\n\nThe ``connection_id`` field lets the runtime container fan out to\nits per-connection workers client-side.  When the bearer carries\na ``connection_ids`` allowlist (#350), backfill and tail both\nfilter to that set \u2014 out-of-scope calls are silently omitted.",
         "operationId": "get_runtime_calls_v1_connectors_runtime_calls_get",
         "parameters": [
           {
@@ -6640,7 +6640,7 @@
           "connectors"
         ],
         "summary": "Get Runtime Management Calls",
-        "description": "SSE stream of pending management calls for the caller's connector type.\n\nPer-connector-type only (no session/connection scope).  Each event is\nkeyed ``call`` with body ``{\"call_id\": \"mgmt_...\", \"method\": str, \"params\": dict}``.",
+        "description": "SSE stream of pending management calls for the caller's connector type.\n\nPer-connector-type only (no session/connection scope).  Each event is\nkeyed ``call`` with body ``{\"call_id\": \"mgmt_...\", \"method\": str, \"params\": dict}``.\n``connection_ids`` allowlist is NOT enforced here \u2014 management\ncalls are connector-type-wide, not per-connection.",
         "operationId": "get_runtime_management_calls_v1_connectors_runtime_management_calls_get",
         "parameters": [
           {
@@ -10311,6 +10311,20 @@
             ],
             "title": "Label"
           },
+          "connection_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Connection Ids"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -10348,7 +10362,7 @@
           "created_at"
         ],
         "title": "RuntimeToken",
-        "description": "Read view of a runtime token.  Never carries plaintext."
+        "description": "Read view of a runtime token.  Never carries plaintext.\n\n``connection_ids`` is the optional allowlist scope (#350).  ``None``\nmeans the token is unscoped \u2014 it sees every connection of its\n``connector`` type.  A non-``None`` list (including ``[]``) limits\nvisibility / operations to the listed IDs only."
       },
       "RuntimeTokenIssue": {
         "properties": {
@@ -10367,6 +10381,21 @@
               }
             ],
             "title": "Label"
+          },
+          "connection_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Connection Ids",
+            "description": "Optional allowlist of connection IDs the issued token is authorized for.  Omit (``None``) to leave the token unscoped \u2014 it sees every connection of ``connector`` type."
           }
         },
         "additionalProperties": false,
@@ -10397,6 +10426,20 @@
               }
             ],
             "title": "Label"
+          },
+          "connection_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Connection Ids"
           },
           "plaintext": {
             "type": "string",

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/get_connection_discovery_v1_connectors_connections_get.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/get_connection_discovery_v1_connectors_connections_get.py
@@ -78,6 +78,11 @@ def sync_detailed(
     fans out to per-connection workers on ``added``; tears them down
     on ``removed``.
 
+    When the bearer carries a ``connection_ids`` allowlist (#350), the
+    backfill and tail both filter to that set — out-of-scope IDs are
+    silently omitted (not 403'd) so the runtime container's discovery
+    loop just doesn't see them.
+
     Args:
         authorization (None | str | Unset):
 
@@ -123,6 +128,11 @@ def sync(
     fans out to per-connection workers on ``added``; tears them down
     on ``removed``.
 
+    When the bearer carries a ``connection_ids`` allowlist (#350), the
+    backfill and tail both filter to that set — out-of-scope IDs are
+    silently omitted (not 403'd) so the runtime container's discovery
+    loop just doesn't see them.
+
     Args:
         authorization (None | str | Unset):
 
@@ -162,6 +172,11 @@ async def asyncio_detailed(
     The runtime container subscribes once per ``connector`` type and
     fans out to per-connection workers on ``added``; tears them down
     on ``removed``.
+
+    When the bearer carries a ``connection_ids`` allowlist (#350), the
+    backfill and tail both filter to that set — out-of-scope IDs are
+    silently omitted (not 403'd) so the runtime container's discovery
+    loop just doesn't see them.
 
     Args:
         authorization (None | str | Unset):
@@ -205,6 +220,11 @@ async def asyncio(
     The runtime container subscribes once per ``connector`` type and
     fans out to per-connection workers on ``added``; tears them down
     on ``removed``.
+
+    When the bearer carries a ``connection_ids`` allowlist (#350), the
+    backfill and tail both filter to that set — out-of-scope IDs are
+    silently omitted (not 403'd) so the runtime container's discovery
+    loop just doesn't see them.
 
     Args:
         authorization (None | str | Unset):

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/get_connector_runtime_secrets.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/get_connector_runtime_secrets.py
@@ -76,8 +76,10 @@ def sync_detailed(
      Decrypted secrets for ``connection_id``.
 
     The bearer's connector must match the connection's connector
-    type.  Returns ``{\"secrets\": {}}`` when none are configured —
-    callers decide whether that's acceptable.
+    type; when the bearer carries a ``connection_ids`` allowlist
+    (#350), ``connection_id`` must be on the list.  Returns
+    ``{\"secrets\": {}}`` when none are configured — callers decide
+    whether that's acceptable.
 
     Args:
         connection_id (str):
@@ -114,8 +116,10 @@ def sync(
      Decrypted secrets for ``connection_id``.
 
     The bearer's connector must match the connection's connector
-    type.  Returns ``{\"secrets\": {}}`` when none are configured —
-    callers decide whether that's acceptable.
+    type; when the bearer carries a ``connection_ids`` allowlist
+    (#350), ``connection_id`` must be on the list.  Returns
+    ``{\"secrets\": {}}`` when none are configured — callers decide
+    whether that's acceptable.
 
     Args:
         connection_id (str):
@@ -147,8 +151,10 @@ async def asyncio_detailed(
      Decrypted secrets for ``connection_id``.
 
     The bearer's connector must match the connection's connector
-    type.  Returns ``{\"secrets\": {}}`` when none are configured —
-    callers decide whether that's acceptable.
+    type; when the bearer carries a ``connection_ids`` allowlist
+    (#350), ``connection_id`` must be on the list.  Returns
+    ``{\"secrets\": {}}`` when none are configured — callers decide
+    whether that's acceptable.
 
     Args:
         connection_id (str):
@@ -183,8 +189,10 @@ async def asyncio(
      Decrypted secrets for ``connection_id``.
 
     The bearer's connector must match the connection's connector
-    type.  Returns ``{\"secrets\": {}}`` when none are configured —
-    callers decide whether that's acceptable.
+    type; when the bearer carries a ``connection_ids`` allowlist
+    (#350), ``connection_id`` must be on the list.  Returns
+    ``{\"secrets\": {}}`` when none are configured — callers decide
+    whether that's acceptable.
 
     Args:
         connection_id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/get_runtime_calls_v1_connectors_runtime_calls_get.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/get_runtime_calls_v1_connectors_runtime_calls_get.py
@@ -78,7 +78,9 @@ def sync_detailed(
         }
 
     The ``connection_id`` field lets the runtime container fan out to
-    its per-connection workers client-side.
+    its per-connection workers client-side.  When the bearer carries
+    a ``connection_ids`` allowlist (#350), backfill and tail both
+    filter to that set — out-of-scope calls are silently omitted.
 
     Args:
         authorization (None | str | Unset):
@@ -125,7 +127,9 @@ def sync(
         }
 
     The ``connection_id`` field lets the runtime container fan out to
-    its per-connection workers client-side.
+    its per-connection workers client-side.  When the bearer carries
+    a ``connection_ids`` allowlist (#350), backfill and tail both
+    filter to that set — out-of-scope calls are silently omitted.
 
     Args:
         authorization (None | str | Unset):
@@ -167,7 +171,9 @@ async def asyncio_detailed(
         }
 
     The ``connection_id`` field lets the runtime container fan out to
-    its per-connection workers client-side.
+    its per-connection workers client-side.  When the bearer carries
+    a ``connection_ids`` allowlist (#350), backfill and tail both
+    filter to that set — out-of-scope calls are silently omitted.
 
     Args:
         authorization (None | str | Unset):
@@ -212,7 +218,9 @@ async def asyncio(
         }
 
     The ``connection_id`` field lets the runtime container fan out to
-    its per-connection workers client-side.
+    its per-connection workers client-side.  When the bearer carries
+    a ``connection_ids`` allowlist (#350), backfill and tail both
+    filter to that set — out-of-scope calls are silently omitted.
 
     Args:
         authorization (None | str | Unset):

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/get_runtime_management_calls_v1_connectors_runtime_management_calls_get.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/get_runtime_management_calls_v1_connectors_runtime_management_calls_get.py
@@ -66,6 +66,8 @@ def sync_detailed(
 
     Per-connector-type only (no session/connection scope).  Each event is
     keyed ``call`` with body ``{\"call_id\": \"mgmt_...\", \"method\": str, \"params\": dict}``.
+    ``connection_ids`` allowlist is NOT enforced here — management
+    calls are connector-type-wide, not per-connection.
 
     Args:
         authorization (None | str | Unset):
@@ -100,6 +102,8 @@ def sync(
 
     Per-connector-type only (no session/connection scope).  Each event is
     keyed ``call`` with body ``{\"call_id\": \"mgmt_...\", \"method\": str, \"params\": dict}``.
+    ``connection_ids`` allowlist is NOT enforced here — management
+    calls are connector-type-wide, not per-connection.
 
     Args:
         authorization (None | str | Unset):
@@ -129,6 +133,8 @@ async def asyncio_detailed(
 
     Per-connector-type only (no session/connection scope).  Each event is
     keyed ``call`` with body ``{\"call_id\": \"mgmt_...\", \"method\": str, \"params\": dict}``.
+    ``connection_ids`` allowlist is NOT enforced here — management
+    calls are connector-type-wide, not per-connection.
 
     Args:
         authorization (None | str | Unset):
@@ -161,6 +167,8 @@ async def asyncio(
 
     Per-connector-type only (no session/connection scope).  Each event is
     keyed ``call`` with body ``{\"call_id\": \"mgmt_...\", \"method\": str, \"params\": dict}``.
+    ``connection_ids`` allowlist is NOT enforced here — management
+    calls are connector-type-wide, not per-connection.
 
     Args:
         authorization (None | str | Unset):

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/post_connector_runtime_inbound.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/post_connector_runtime_inbound.py
@@ -75,7 +75,9 @@ def sync_detailed(
 
     The bearer authenticates the caller as one connector *type*;
     ``connection_id`` rides as a form field and must belong to that
-    type.  Idempotent on ``event_id``; drops surface as 4xx/5xx with
+    type.  When the bearer carries a ``connection_ids`` allowlist
+    (#350), the form field must also be on the list — otherwise 403.
+    Idempotent on ``event_id``; drops surface as 4xx/5xx with
     a body explaining the reason (operator-config issue vs server
     error vs payload).
 
@@ -115,7 +117,9 @@ def sync(
 
     The bearer authenticates the caller as one connector *type*;
     ``connection_id`` rides as a form field and must belong to that
-    type.  Idempotent on ``event_id``; drops surface as 4xx/5xx with
+    type.  When the bearer carries a ``connection_ids`` allowlist
+    (#350), the form field must also be on the list — otherwise 403.
+    Idempotent on ``event_id``; drops surface as 4xx/5xx with
     a body explaining the reason (operator-config issue vs server
     error vs payload).
 
@@ -150,7 +154,9 @@ async def asyncio_detailed(
 
     The bearer authenticates the caller as one connector *type*;
     ``connection_id`` rides as a form field and must belong to that
-    type.  Idempotent on ``event_id``; drops surface as 4xx/5xx with
+    type.  When the bearer carries a ``connection_ids`` allowlist
+    (#350), the form field must also be on the list — otherwise 403.
+    Idempotent on ``event_id``; drops surface as 4xx/5xx with
     a body explaining the reason (operator-config issue vs server
     error vs payload).
 
@@ -188,7 +194,9 @@ async def asyncio(
 
     The bearer authenticates the caller as one connector *type*;
     ``connection_id`` rides as a form field and must belong to that
-    type.  Idempotent on ``event_id``; drops surface as 4xx/5xx with
+    type.  When the bearer carries a ``connection_ids`` allowlist
+    (#350), the form field must also be on the list — otherwise 403.
+    Idempotent on ``event_id``; drops surface as 4xx/5xx with
     a body explaining the reason (operator-config issue vs server
     error vs payload).
 

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/post_connector_runtime_tool_result.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/post_connector_runtime_tool_result.py
@@ -71,8 +71,10 @@ def sync_detailed(
 
      Submit a custom tool result from a runtime container.
 
-    Authorization: the bearer's connector must match ``body.connection_id``'s
-    connector, and the session must be bound to that connection.
+    Authorization: the bearer's connector must match
+    ``body.connection_id``'s connector, the session must be bound to
+    that connection, and (when the bearer carries a ``connection_ids``
+    allowlist) ``body.connection_id`` must be on the list (#350).
 
     Args:
         authorization (None | str | Unset):
@@ -112,8 +114,10 @@ def sync(
 
      Submit a custom tool result from a runtime container.
 
-    Authorization: the bearer's connector must match ``body.connection_id``'s
-    connector, and the session must be bound to that connection.
+    Authorization: the bearer's connector must match
+    ``body.connection_id``'s connector, the session must be bound to
+    that connection, and (when the bearer carries a ``connection_ids``
+    allowlist) ``body.connection_id`` must be on the list (#350).
 
     Args:
         authorization (None | str | Unset):
@@ -148,8 +152,10 @@ async def asyncio_detailed(
 
      Submit a custom tool result from a runtime container.
 
-    Authorization: the bearer's connector must match ``body.connection_id``'s
-    connector, and the session must be bound to that connection.
+    Authorization: the bearer's connector must match
+    ``body.connection_id``'s connector, the session must be bound to
+    that connection, and (when the bearer carries a ``connection_ids``
+    allowlist) ``body.connection_id`` must be on the list (#350).
 
     Args:
         authorization (None | str | Unset):
@@ -187,8 +193,10 @@ async def asyncio(
 
      Submit a custom tool result from a runtime container.
 
-    Authorization: the bearer's connector must match ``body.connection_id``'s
-    connector, and the session must be bound to that connection.
+    Authorization: the bearer's connector must match
+    ``body.connection_id``'s connector, the session must be bound to
+    that connection, and (when the bearer carries a ``connection_ids``
+    allowlist) ``body.connection_id`` must be on the list (#350).
 
     Args:
         authorization (None | str | Unset):

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/put_connector_tools_schema.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/put_connector_tools_schema.py
@@ -84,7 +84,9 @@ def sync_detailed(
     hand-write the schema.
 
     Authorization: the runtime bearer's ``connector`` must match the
-    path's ``connector``.
+    path's ``connector``.  ``connection_ids`` allowlist is NOT enforced
+    here — the tools schema is a connector-type-wide registration, not
+    a per-connection operation.
 
     Args:
         connector (str):
@@ -131,7 +133,9 @@ def sync(
     hand-write the schema.
 
     Authorization: the runtime bearer's ``connector`` must match the
-    path's ``connector``.
+    path's ``connector``.  ``connection_ids`` allowlist is NOT enforced
+    here — the tools schema is a connector-type-wide registration, not
+    a per-connection operation.
 
     Args:
         connector (str):
@@ -173,7 +177,9 @@ async def asyncio_detailed(
     hand-write the schema.
 
     Authorization: the runtime bearer's ``connector`` must match the
-    path's ``connector``.
+    path's ``connector``.  ``connection_ids`` allowlist is NOT enforced
+    here — the tools schema is a connector-type-wide registration, not
+    a per-connection operation.
 
     Args:
         connector (str):
@@ -218,7 +224,9 @@ async def asyncio(
     hand-write the schema.
 
     Authorization: the runtime bearer's ``connector`` must match the
-    path's ``connector``.
+    path's ``connector``.  ``connection_ids`` allowlist is NOT enforced
+    here — the tools schema is a connector-type-wide registration, not
+    a per-connection operation.
 
     Args:
         connector (str):

--- a/packages/aios-sdk/aios_sdk/_generated/api/runtime_tokens/issue_runtime_token.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runtime_tokens/issue_runtime_token.py
@@ -76,6 +76,10 @@ def sync_detailed(
     The plaintext is included in the response and CANNOT be recovered
     later — operators must save it at issue time.
 
+    Optional ``body.connection_ids`` (#350) restricts the issued token
+    to that allowlist of connection IDs; omit to leave the token
+    unscoped (sees every connection of ``body.connector`` type).
+
     Args:
         authorization (None | str | Unset):
         body (RuntimeTokenIssue): Request body for ``POST /v1/runtime-tokens``.
@@ -113,6 +117,10 @@ def sync(
     The plaintext is included in the response and CANNOT be recovered
     later — operators must save it at issue time.
 
+    Optional ``body.connection_ids`` (#350) restricts the issued token
+    to that allowlist of connection IDs; omit to leave the token
+    unscoped (sees every connection of ``body.connector`` type).
+
     Args:
         authorization (None | str | Unset):
         body (RuntimeTokenIssue): Request body for ``POST /v1/runtime-tokens``.
@@ -144,6 +152,10 @@ async def asyncio_detailed(
 
     The plaintext is included in the response and CANNOT be recovered
     later — operators must save it at issue time.
+
+    Optional ``body.connection_ids`` (#350) restricts the issued token
+    to that allowlist of connection IDs; omit to leave the token
+    unscoped (sees every connection of ``body.connector`` type).
 
     Args:
         authorization (None | str | Unset):
@@ -179,6 +191,10 @@ async def asyncio(
 
     The plaintext is included in the response and CANNOT be recovered
     later — operators must save it at issue time.
+
+    Optional ``body.connection_ids`` (#350) restricts the issued token
+    to that allowlist of connection IDs; omit to leave the token
+    unscoped (sees every connection of ``body.connector`` type).
 
     Args:
         authorization (None | str | Unset):

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_token.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_token.py
@@ -17,19 +17,26 @@ T = TypeVar("T", bound="RuntimeToken")
 class RuntimeToken:
     """Read view of a runtime token.  Never carries plaintext.
 
-    Attributes:
-        id (str):
-        connector (str):
-        created_at (datetime.datetime):
-        label (None | str | Unset):
-        last_used_at (datetime.datetime | None | Unset):
-        revoked_at (datetime.datetime | None | Unset):
+    ``connection_ids`` is the optional allowlist scope (#350).  ``None``
+    means the token is unscoped — it sees every connection of its
+    ``connector`` type.  A non-``None`` list (including ``[]``) limits
+    visibility / operations to the listed IDs only.
+
+        Attributes:
+            id (str):
+            connector (str):
+            created_at (datetime.datetime):
+            label (None | str | Unset):
+            connection_ids (list[str] | None | Unset):
+            last_used_at (datetime.datetime | None | Unset):
+            revoked_at (datetime.datetime | None | Unset):
     """
 
     id: str
     connector: str
     created_at: datetime.datetime
     label: None | str | Unset = UNSET
+    connection_ids: list[str] | None | Unset = UNSET
     last_used_at: datetime.datetime | None | Unset = UNSET
     revoked_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -46,6 +53,15 @@ class RuntimeToken:
             label = UNSET
         else:
             label = self.label
+
+        connection_ids: list[str] | None | Unset
+        if isinstance(self.connection_ids, Unset):
+            connection_ids = UNSET
+        elif isinstance(self.connection_ids, list):
+            connection_ids = self.connection_ids
+
+        else:
+            connection_ids = self.connection_ids
 
         last_used_at: None | str | Unset
         if isinstance(self.last_used_at, Unset):
@@ -74,6 +90,8 @@ class RuntimeToken:
         )
         if label is not UNSET:
             field_dict["label"] = label
+        if connection_ids is not UNSET:
+            field_dict["connection_ids"] = connection_ids
         if last_used_at is not UNSET:
             field_dict["last_used_at"] = last_used_at
         if revoked_at is not UNSET:
@@ -98,6 +116,23 @@ class RuntimeToken:
             return cast(None | str | Unset, data)
 
         label = _parse_label(d.pop("label", UNSET))
+
+        def _parse_connection_ids(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                connection_ids_type_0 = cast(list[str], data)
+
+                return connection_ids_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        connection_ids = _parse_connection_ids(d.pop("connection_ids", UNSET))
 
         def _parse_last_used_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -138,6 +173,7 @@ class RuntimeToken:
             connector=connector,
             created_at=created_at,
             label=label,
+            connection_ids=connection_ids,
             last_used_at=last_used_at,
             revoked_at=revoked_at,
         )

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_token_issue.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_token_issue.py
@@ -17,10 +17,13 @@ class RuntimeTokenIssue:
     Attributes:
         connector (str):
         label (None | str | Unset):
+        connection_ids (list[str] | None | Unset): Optional allowlist of connection IDs the issued token is authorized
+            for.  Omit (``None``) to leave the token unscoped — it sees every connection of ``connector`` type.
     """
 
     connector: str
     label: None | str | Unset = UNSET
+    connection_ids: list[str] | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         connector = self.connector
@@ -31,6 +34,15 @@ class RuntimeTokenIssue:
         else:
             label = self.label
 
+        connection_ids: list[str] | None | Unset
+        if isinstance(self.connection_ids, Unset):
+            connection_ids = UNSET
+        elif isinstance(self.connection_ids, list):
+            connection_ids = self.connection_ids
+
+        else:
+            connection_ids = self.connection_ids
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -40,6 +52,8 @@ class RuntimeTokenIssue:
         )
         if label is not UNSET:
             field_dict["label"] = label
+        if connection_ids is not UNSET:
+            field_dict["connection_ids"] = connection_ids
 
         return field_dict
 
@@ -57,9 +71,27 @@ class RuntimeTokenIssue:
 
         label = _parse_label(d.pop("label", UNSET))
 
+        def _parse_connection_ids(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                connection_ids_type_0 = cast(list[str], data)
+
+                return connection_ids_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        connection_ids = _parse_connection_ids(d.pop("connection_ids", UNSET))
+
         runtime_token_issue = cls(
             connector=connector,
             label=label,
+            connection_ids=connection_ids,
         )
 
         return runtime_token_issue

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_token_issued.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_token_issued.py
@@ -8,6 +8,8 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 from dateutil.parser import isoparse
 
+from ..types import UNSET, Unset
+
 T = TypeVar("T", bound="RuntimeTokenIssued")
 
 
@@ -24,6 +26,7 @@ class RuntimeTokenIssued:
             label (None | str):
             plaintext (str): The bearer token value.  Save this — it cannot be recovered.
             created_at (datetime.datetime):
+            connection_ids (list[str] | None | Unset):
     """
 
     id: str
@@ -31,6 +34,7 @@ class RuntimeTokenIssued:
     label: None | str
     plaintext: str
     created_at: datetime.datetime
+    connection_ids: list[str] | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -45,6 +49,15 @@ class RuntimeTokenIssued:
 
         created_at = self.created_at.isoformat()
 
+        connection_ids: list[str] | None | Unset
+        if isinstance(self.connection_ids, Unset):
+            connection_ids = UNSET
+        elif isinstance(self.connection_ids, list):
+            connection_ids = self.connection_ids
+
+        else:
+            connection_ids = self.connection_ids
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -56,6 +69,8 @@ class RuntimeTokenIssued:
                 "created_at": created_at,
             }
         )
+        if connection_ids is not UNSET:
+            field_dict["connection_ids"] = connection_ids
 
         return field_dict
 
@@ -77,12 +92,30 @@ class RuntimeTokenIssued:
 
         created_at = isoparse(d.pop("created_at"))
 
+        def _parse_connection_ids(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                connection_ids_type_0 = cast(list[str], data)
+
+                return connection_ids_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        connection_ids = _parse_connection_ids(d.pop("connection_ids", UNSET))
+
         runtime_token_issued = cls(
             id=id,
             connector=connector,
             label=label,
             plaintext=plaintext,
             created_at=created_at,
+            connection_ids=connection_ids,
         )
 
         runtime_token_issued.additional_properties = d

--- a/src/aios/api/deps.py
+++ b/src/aios/api/deps.py
@@ -80,20 +80,29 @@ async def require_bearer_auth(
 async def require_runtime_auth(
     pool: Annotated[asyncpg.Pool, Depends(get_pool)],
     authorization: Annotated[str | None, Header(alias="Authorization")] = None,
-) -> tuple[str, str, str]:
-    """Resolve a bearer runtime token to ``(token_id, connector, account_id)``.
+) -> tuple[str, str, str, list[str] | None]:
+    """Resolve a bearer runtime token to
+    ``(token_id, connector, account_id, connection_ids)``.
 
     Accepts only tokens issued via ``POST /v1/runtime-tokens``. Routes
     that take ``RuntimeAuthDep`` receive the resolved tuple — the
     ``connector`` half is used to scope the runtime-facing routes
     (``/connectors/runtime/...`` family) to one connector type;
-    ``account_id`` scopes resource queries to the token's tenant.
+    ``account_id`` scopes resource queries to the token's tenant;
+    ``connection_ids`` is the optional allowlist scope (#350):
+    ``None`` means the token is unscoped, a non-``None`` list limits
+    the bearer to those connection IDs.
     """
     token = _extract_bearer_token(authorization)
     resolved = await runtime_tokens_service.resolve(pool, token)
     if resolved is None:
         raise UnauthorizedError("invalid or revoked runtime token")
-    return (resolved.token_id, resolved.connector, resolved.account_id)
+    return (
+        resolved.token_id,
+        resolved.connector,
+        resolved.account_id,
+        resolved.connection_ids,
+    )
 
 
 # Type aliases for clarity at the route definitions.
@@ -104,4 +113,4 @@ CryptoBoxDep = Annotated[CryptoBox, Depends(get_crypto_box)]
 ProcrastinateDep = Annotated[ProcrastinateApp, Depends(get_procrastinate)]
 DbUrlDep = Annotated[str, Depends(get_db_url)]
 AuthDep = Annotated[AccountAuthResult, Depends(require_bearer_auth)]
-RuntimeAuthDep = Annotated[tuple[str, str, str], Depends(require_runtime_auth)]
+RuntimeAuthDep = Annotated[tuple[str, str, str, list[str] | None], Depends(require_runtime_auth)]

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -236,10 +236,7 @@ def _check_runtime_connection_scope(
     if target_connection_id not in auth_connection_ids:
         raise ForbiddenError(
             "runtime token not authorized for this connection",
-            detail={
-                "auth_connection_ids": auth_connection_ids,
-                "target_connection_id": target_connection_id,
-            },
+            detail={"target_connection_id": target_connection_id},
         )
 
 

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -220,6 +220,29 @@ def _check_runtime_scope(auth_connector: str, target_connector: str) -> None:
         )
 
 
+def _check_runtime_connection_scope(
+    auth_connection_ids: list[str] | None,
+    target_connection_id: str,
+) -> None:
+    """Raise 403 if a runtime bearer with a non-``None`` allowlist reaches
+    outside its ``connection_ids`` scope (#350).
+
+    ``None`` means the token is unscoped — no check is performed.
+    A non-``None`` list (including ``[]``) restricts the bearer to
+    its listed IDs only; anything else 403s.
+    """
+    if auth_connection_ids is None:
+        return
+    if target_connection_id not in auth_connection_ids:
+        raise ForbiddenError(
+            "runtime token not authorized for this connection",
+            detail={
+                "auth_connection_ids": auth_connection_ids,
+                "target_connection_id": target_connection_id,
+            },
+        )
+
+
 @router.put(
     "/{connector}/tools_schema",
     operation_id="put_connector_tools_schema",
@@ -240,9 +263,11 @@ async def put_tools_schema(
     hand-write the schema.
 
     Authorization: the runtime bearer's ``connector`` must match the
-    path's ``connector``.
+    path's ``connector``.  ``connection_ids`` allowlist is NOT enforced
+    here — the tools schema is a connector-type-wide registration, not
+    a per-connection operation.
     """
-    _, auth_connector, account_id = auth
+    _, auth_connector, account_id, _scope = auth
     _check_runtime_scope(auth_connector, connector)
     async with pool.acquire() as conn:
         await queries.update_connector_tools_schema(
@@ -274,10 +299,21 @@ async def get_connection_discovery(
     The runtime container subscribes once per ``connector`` type and
     fans out to per-connection workers on ``added``; tears them down
     on ``removed``.
+
+    When the bearer carries a ``connection_ids`` allowlist (#350), the
+    backfill and tail both filter to that set — out-of-scope IDs are
+    silently omitted (not 403'd) so the runtime container's discovery
+    loop just doesn't see them.
     """
-    _, connector, account_id = auth
+    _, connector, account_id, auth_connection_ids = auth
     return EventSourceResponse(
-        connection_discovery_stream(db_url, pool, connector, account_id=account_id),
+        connection_discovery_stream(
+            db_url,
+            pool,
+            connector,
+            account_id=account_id,
+            connection_ids=auth_connection_ids,
+        ),
         ping=15,
     )
 
@@ -320,14 +356,17 @@ async def post_runtime_inbound(
 
     The bearer authenticates the caller as one connector *type*;
     ``connection_id`` rides as a form field and must belong to that
-    type.  Idempotent on ``event_id``; drops surface as 4xx/5xx with
+    type.  When the bearer carries a ``connection_ids`` allowlist
+    (#350), the form field must also be on the list — otherwise 403.
+    Idempotent on ``event_id``; drops surface as 4xx/5xx with
     a body explaining the reason (operator-config issue vs server
     error vs payload).
     """
-    _, auth_connector, account_id = auth
+    _, auth_connector, account_id, auth_connection_ids = auth
     async with pool.acquire() as conn:
         connection = await queries.get_connection(conn, connection_id, account_id=account_id)
     _check_runtime_scope(auth_connector, connection.connector)
+    _check_runtime_connection_scope(auth_connection_ids, connection_id)
     return await _do_inbound(
         pool,
         account_id=account_id,
@@ -354,13 +393,16 @@ async def post_runtime_tool_result(
 ) -> Any:
     """Submit a custom tool result from a runtime container.
 
-    Authorization: the bearer's connector must match ``body.connection_id``'s
-    connector, and the session must be bound to that connection.
+    Authorization: the bearer's connector must match
+    ``body.connection_id``'s connector, the session must be bound to
+    that connection, and (when the bearer carries a ``connection_ids``
+    allowlist) ``body.connection_id`` must be on the list (#350).
     """
-    _, auth_connector, account_id = auth
+    _, auth_connector, account_id, auth_connection_ids = auth
     async with pool.acquire() as conn:
         connection = await queries.get_connection(conn, body.connection_id, account_id=account_id)
         _check_runtime_scope(auth_connector, connection.connector)
+        _check_runtime_connection_scope(auth_connection_ids, body.connection_id)
         if not await queries.is_session_bound_to_connection(
             conn,
             connection_id=body.connection_id,
@@ -399,13 +441,16 @@ async def get_runtime_secrets(
     """Decrypted secrets for ``connection_id``.
 
     The bearer's connector must match the connection's connector
-    type.  Returns ``{"secrets": {}}`` when none are configured —
-    callers decide whether that's acceptable.
+    type; when the bearer carries a ``connection_ids`` allowlist
+    (#350), ``connection_id`` must be on the list.  Returns
+    ``{"secrets": {}}`` when none are configured — callers decide
+    whether that's acceptable.
     """
-    _, auth_connector, account_id = auth
+    _, auth_connector, account_id, auth_connection_ids = auth
     async with pool.acquire() as conn:
         connection = await queries.get_connection(conn, connection_id, account_id=account_id)
     _check_runtime_scope(auth_connector, connection.connector)
+    _check_runtime_connection_scope(auth_connection_ids, connection_id)
     secrets = await connections_service.get_connection_secrets(
         pool, connection_id, crypto_box=crypto_box, account_id=account_id
     )
@@ -437,11 +482,19 @@ async def get_runtime_calls(
         }
 
     The ``connection_id`` field lets the runtime container fan out to
-    its per-connection workers client-side.
+    its per-connection workers client-side.  When the bearer carries
+    a ``connection_ids`` allowlist (#350), backfill and tail both
+    filter to that set — out-of-scope calls are silently omitted.
     """
-    _, connector, account_id = auth
+    _, connector, account_id, auth_connection_ids = auth
     return EventSourceResponse(
-        runtime_connector_calls_stream(db_url, pool, connector, account_id=account_id),
+        runtime_connector_calls_stream(
+            db_url,
+            pool,
+            connector,
+            account_id=account_id,
+            connection_ids=auth_connection_ids,
+        ),
         ping=15,
     )
 
@@ -459,8 +512,10 @@ async def get_runtime_management_calls(
 
     Per-connector-type only (no session/connection scope).  Each event is
     keyed ``call`` with body ``{"call_id": "mgmt_...", "method": str, "params": dict}``.
+    ``connection_ids`` allowlist is NOT enforced here — management
+    calls are connector-type-wide, not per-connection.
     """
-    _, connector, account_id = auth
+    _, connector, account_id, _scope = auth
     return EventSourceResponse(
         management_calls_stream(db_url, pool, connector, account_id=account_id),
         ping=15,
@@ -655,7 +710,11 @@ async def post_runtime_management_call_result(
     pool: PoolDep,
     auth: RuntimeAuthDep,
 ) -> None:
-    _, auth_connector, account_id = auth
+    _, auth_connector, account_id, _scope = auth
+    # ``connection_ids`` allowlist is NOT enforced — management calls
+    # are connector-type-wide; the result intake is the matching peer
+    # of ``get_runtime_management_calls`` which also doesn't filter.
+    #
     # Autocommit conn (no ``async with conn.transaction()``): the UPDATE
     # commits before the NOTIFY fires.  Don't wrap these in a
     # transaction — subscribers would see uncommitted state.  See

--- a/src/aios/api/routers/runtime_tokens.py
+++ b/src/aios/api/routers/runtime_tokens.py
@@ -30,15 +30,24 @@ async def issue(body: RuntimeTokenIssue, pool: PoolDep, _auth: AuthDep) -> Runti
 
     The plaintext is included in the response and CANNOT be recovered
     later — operators must save it at issue time.
+
+    Optional ``body.connection_ids`` (#350) restricts the issued token
+    to that allowlist of connection IDs; omit to leave the token
+    unscoped (sees every connection of ``body.connector`` type).
     """
     account_id, _, _ = _auth
     token, plaintext = await service.issue(
-        pool, connector=body.connector, label=body.label, account_id=account_id
+        pool,
+        connector=body.connector,
+        label=body.label,
+        account_id=account_id,
+        connection_ids=body.connection_ids,
     )
     return RuntimeTokenIssued(
         id=token.id,
         connector=token.connector,
         label=token.label,
+        connection_ids=token.connection_ids,
         plaintext=plaintext,
         created_at=token.created_at,
     )

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -142,6 +142,7 @@ async def runtime_connector_calls_stream(
     connector: str,
     *,
     account_id: str,
+    connection_ids: list[str] | None = None,
 ) -> AsyncIterator[ServerSentEvent]:
     """Yield SSE events for pending custom tool calls across every active
     connection of ``connector`` type (#328 PR 5).
@@ -152,7 +153,13 @@ async def runtime_connector_calls_stream(
 
     Backfills any pending calls at subscribe time, then tails the
     ``connector_calls_<connector>`` NOTIFY channel.
+
+    When ``connection_ids`` is non-``None`` (#350), backfill and tail
+    both filter to that allowlist — out-of-scope calls are silently
+    omitted.  The tail-side check parses the NOTIFY payload directly
+    so the per-connection fetch is skipped for out-of-scope IDs.
     """
+    allowlist = set(connection_ids) if connection_ids is not None else None
     async with listen_for_connector_calls_by_type(db_url, connector) as queue:
         emitted: set[str] = set()
 
@@ -161,6 +168,8 @@ async def runtime_connector_calls_stream(
                 conn, connector, account_id=account_id
             )
         for call in backfill:
+            if allowlist is not None and call.get("connection_id") not in allowlist:
+                continue
             emitted.add(call["tool_call_id"])
             yield ServerSentEvent(data=json.dumps(call), event="call")
 
@@ -171,6 +180,9 @@ async def runtime_connector_calls_stream(
             if not connection_id:
                 log.warning("sse.runtime_calls.malformed_payload", payload=payload)
                 continue
+            # Skip the per-connection fetch for out-of-scope IDs.
+            if allowlist is not None and connection_id not in allowlist:
+                continue
             async with pool.acquire() as conn:
                 pending = await queries.list_pending_calls_for_session_and_connection(
                     conn,
@@ -180,6 +192,10 @@ async def runtime_connector_calls_stream(
                 )
             for call in pending:
                 if call["tool_call_id"] in emitted:
+                    continue
+                # Defensive post-fetch check — keeps the emit honest even
+                # if a future refactor changes the partition logic.
+                if allowlist is not None and connection_id not in allowlist:
                     continue
                 emitted.add(call["tool_call_id"])
                 call["connection_id"] = connection_id
@@ -237,6 +253,7 @@ async def connection_discovery_stream(
     connector: str,
     *,
     account_id: str,
+    connection_ids: list[str] | None = None,
 ) -> AsyncIterator[ServerSentEvent]:
     """Yield ``added`` SSE events backfilling every active connection of
     ``connector`` type, then ``added`` / ``removed`` events as connections
@@ -247,7 +264,13 @@ async def connection_discovery_stream(
     workers, and tears workers down on ``removed`` events.  The emit
     side lives in :mod:`aios.services.connections.attach_connection` /
     ``archive_connection``.
+
+    When ``connection_ids`` is non-``None`` (#350), the backfill and
+    tail both filter to that allowlist — out-of-scope IDs are silently
+    skipped in either phase so the runtime container's discovery loop
+    just doesn't see them.
     """
+    allowlist = set(connection_ids) if connection_ids is not None else None
     async with listen_for_connection_discovery(db_url, connector) as queue:
         emitted_added: set[str] = set()
 
@@ -261,6 +284,8 @@ async def connection_discovery_stream(
                     conn, connector=connector, limit=200, after=cursor, account_id=account_id
                 )
             for connection in page:
+                if allowlist is not None and connection.id not in allowlist:
+                    continue
                 emitted_added.add(connection.id)
                 yield ServerSentEvent(
                     data=json.dumps(
@@ -289,6 +314,8 @@ async def connection_discovery_stream(
             # existence-leak (sibling account_ids would otherwise surface
             # via the tail).
             if event_account_id != account_id:
+                continue
+            if allowlist is not None and connection_id not in allowlist:
                 continue
             if event == "added" and connection_id in emitted_added:
                 continue

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -5401,6 +5401,7 @@ def _row_to_runtime_token(row: asyncpg.Record) -> RuntimeToken:
         id=row["id"],
         connector=row["connector"],
         label=row["label"],
+        connection_ids=(list(row["connection_ids"]) if row["connection_ids"] is not None else None),
         created_at=row["created_at"],
         last_used_at=row["last_used_at"],
         revoked_at=row["revoked_at"],
@@ -5414,6 +5415,7 @@ async def insert_runtime_token(
     connector: str,
     label: str | None,
     token_hash: str,
+    connection_ids: list[str] | None = None,
 ) -> RuntimeToken:
     """Insert a new (unrevoked) token scoping a runtime container to ``connector``.
 
@@ -5421,6 +5423,10 @@ async def insert_runtime_token(
     runtime token for a connector type before any connection of that
     type exists (the FK on ``runtime_tokens.connector`` would otherwise
     block first-token-on-fresh-type).
+
+    ``connection_ids`` is the optional allowlist scope (#350): ``None``
+    leaves the column NULL (unscoped); a list (including ``[]``) is
+    persisted verbatim.
     """
     await conn.execute(
         "INSERT INTO connectors (connector) VALUES ($1) ON CONFLICT DO NOTHING",
@@ -5428,8 +5434,9 @@ async def insert_runtime_token(
     )
     row = await conn.fetchrow(
         """
-        INSERT INTO runtime_tokens (id, connector, label, token_hash, account_id)
-        VALUES ($1, $2, $3, $4, $5)
+        INSERT INTO runtime_tokens
+            (id, connector, label, token_hash, account_id, connection_ids)
+        VALUES ($1, $2, $3, $4, $5, $6::text[])
         RETURNING *
         """,
         make_id(RUNTIME_TOKEN),
@@ -5437,6 +5444,7 @@ async def insert_runtime_token(
         label,
         token_hash,
         account_id,
+        connection_ids,
     )
     assert row is not None
     return _row_to_runtime_token(row)
@@ -5490,14 +5498,19 @@ async def revoke_runtime_token(
 async def resolve_runtime_token(
     conn: asyncpg.Connection[Any],
     token_hash: str,
-) -> tuple[str, str, str] | None:
+) -> tuple[str, str, str, list[str] | None] | None:
     """Look up an unrevoked token by hash; touch ``last_used_at`` in one round-trip.
 
-    Returns ``(token_id, connector, account_id)`` on hit, ``None`` on
-    miss / revoked token / archived account.  The token hash is
-    globally unique (one row owns the secret), so the lookup does not
-    filter by account; account_id is read off the matched row and
-    becomes the authenticated scope for the request.
+    Returns ``(token_id, connector, account_id, connection_ids)`` on
+    hit, ``None`` on miss / revoked token / archived account.  The
+    token hash is globally unique (one row owns the secret), so the
+    lookup does not filter by account; account_id is read off the
+    matched row and becomes the authenticated scope for the request.
+
+    ``connection_ids`` is the optional allowlist scope (#350):
+    ``None`` means the token is unscoped — every connection of
+    ``connector`` type is reachable; a non-``None`` list (including
+    ``[]``) limits the bearer to those connection IDs.
 
     Refuses tokens on archived accounts via the EXISTS subquery — same
     asymmetry-closing intent as :func:`lookup_account_by_key_hash`'s
@@ -5516,13 +5529,14 @@ async def resolve_runtime_token(
            AND EXISTS (SELECT 1 FROM accounts
                         WHERE accounts.id = runtime_tokens.account_id
                           AND accounts.archived_at IS NULL)
-        RETURNING id, connector, account_id
+        RETURNING id, connector, account_id, connection_ids
         """,
         token_hash,
     )
     if row is None:
         return None
-    return (row["id"], row["connector"], row["account_id"])
+    connection_ids = list(row["connection_ids"]) if row["connection_ids"] is not None else None
+    return (row["id"], row["connector"], row["account_id"], connection_ids)
 
 
 # ─── files ───────────────────────────────────────────────────────────────────

--- a/src/aios/models/runtime_tokens.py
+++ b/src/aios/models/runtime_tokens.py
@@ -23,11 +23,18 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class RuntimeToken(BaseModel):
-    """Read view of a runtime token.  Never carries plaintext."""
+    """Read view of a runtime token.  Never carries plaintext.
+
+    ``connection_ids`` is the optional allowlist scope (#350).  ``None``
+    means the token is unscoped — it sees every connection of its
+    ``connector`` type.  A non-``None`` list (including ``[]``) limits
+    visibility / operations to the listed IDs only.
+    """
 
     id: str
     connector: str
     label: str | None = None
+    connection_ids: list[str] | None = None
     created_at: datetime
     last_used_at: datetime | None = None
     revoked_at: datetime | None = None
@@ -40,6 +47,14 @@ class RuntimeTokenIssue(BaseModel):
 
     connector: str
     label: str | None = Field(default=None, max_length=128)
+    connection_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "Optional allowlist of connection IDs the issued token is "
+            "authorized for.  Omit (``None``) to leave the token "
+            "unscoped — it sees every connection of ``connector`` type."
+        ),
+    )
 
 
 class RuntimeTokenIssued(BaseModel):
@@ -52,6 +67,7 @@ class RuntimeTokenIssued(BaseModel):
     id: str
     connector: str
     label: str | None
+    connection_ids: list[str] | None = None
     plaintext: str = Field(
         description="The bearer token value.  Save this — it cannot be recovered.",
     )

--- a/src/aios/services/runtime_tokens.py
+++ b/src/aios/services/runtime_tokens.py
@@ -23,11 +23,18 @@ from aios.models.runtime_tokens import RuntimeToken
 
 
 class ResolvedRuntimeToken(NamedTuple):
-    """The handful of fields auth needs after a successful token lookup."""
+    """The handful of fields auth needs after a successful token lookup.
+
+    ``connection_ids`` is the optional allowlist scope (#350): ``None``
+    means the token is unscoped (sees every connection of its
+    ``connector`` type); a non-``None`` list — including ``[]`` —
+    limits the bearer to those connection IDs.
+    """
 
     token_id: str
     connector: str
     account_id: str
+    connection_ids: list[str] | None
 
 
 _TOKEN_PREFIX = "aios_runtime_"
@@ -44,11 +51,16 @@ async def issue(
     account_id: str,
     connector: str,
     label: str | None,
+    connection_ids: list[str] | None = None,
 ) -> tuple[RuntimeToken, str]:
     """Issue a fresh runtime token scoped to ``connector``.
 
     Returns ``(record, plaintext)``.  Plaintext is the bearer the
     runtime container will use; never persisted.
+
+    ``connection_ids`` is the optional allowlist scope (#350): ``None``
+    leaves the token unscoped; a list (including ``[]``) restricts the
+    bearer to the listed connection IDs.
     """
     plaintext = _TOKEN_PREFIX + secrets.token_urlsafe(_TOKEN_BYTES)
     async with pool.acquire() as conn:
@@ -58,6 +70,7 @@ async def issue(
             label=label,
             token_hash=_hash(plaintext),
             account_id=account_id,
+            connection_ids=connection_ids,
         )
     return token, plaintext
 
@@ -90,5 +103,10 @@ async def resolve(pool: asyncpg.Pool[Any], plaintext: str) -> ResolvedRuntimeTok
         row = await queries.resolve_runtime_token(conn, _hash(plaintext))
     if row is None:
         return None
-    token_id, connector, account_id = row
-    return ResolvedRuntimeToken(token_id=token_id, connector=connector, account_id=account_id)
+    token_id, connector, account_id, connection_ids = row
+    return ResolvedRuntimeToken(
+        token_id=token_id,
+        connector=connector,
+        account_id=account_id,
+        connection_ids=connection_ids,
+    )

--- a/tests/e2e/test_runtime_token_connection_scope.py
+++ b/tests/e2e/test_runtime_token_connection_scope.py
@@ -1,0 +1,368 @@
+"""End-to-end tests for runtime-token ``connection_ids`` allowlist scope (#350).
+
+A runtime token issued with ``connection_ids=[...]`` is authorized only
+on the listed connection IDs:
+* the connection-discovery SSE backfill emits only the allowlisted set;
+* runtime-scoped routes that name an out-of-scope ``connection_id``
+  return 403.
+
+Tokens issued without ``connection_ids`` retain the pre-#350 behaviour
+— they see every connection of the bearer's connector type.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import socket
+from collections.abc import AsyncIterator
+from unittest import mock
+
+import httpx
+import pytest
+import uvicorn
+
+from aios_sdk import Client, stream_connection_discovery
+from tests.conftest import needs_docker
+from tests.helpers.connections import authed_client, bearer
+
+
+async def _wait_for_health(url: str, *, deadline_s: float = 5.0) -> None:
+    deadline = asyncio.get_running_loop().time() + deadline_s
+    async with httpx.AsyncClient() as client:
+        while True:
+            with contextlib.suppress(httpx.HTTPError):
+                r = await client.get(f"{url}/v1/health", timeout=0.5)
+                if r.status_code < 500:
+                    return
+            if asyncio.get_running_loop().time() >= deadline:
+                raise TimeoutError(f"server at {url} not ready in {deadline_s}s")
+            await asyncio.sleep(0.05)
+
+
+@pytest.fixture
+async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
+    """Real-uvicorn aios so SSE chunked-transfer streaming works end-to-end.
+
+    Mirrors ``test_connection_discovery_sse.live_server`` — extracted-
+    but-not-shared because per-file pytest fixtures keep the setup
+    local to the assertions that depend on them.
+    """
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    pool = await create_pool(settings.db_url, min_size=1, max_size=4)
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", lifespan="off")
+    server = uvicorn.Server(config)
+    server.config.load()
+    server.lifespan = server.config.lifespan_class(server.config)
+
+    async def _serve() -> None:
+        sock.setblocking(False)
+        await server.serve(sockets=[sock])
+
+    with (
+        mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock),
+        mock.patch("aios.services.inbound.defer_wake", new_callable=mock.AsyncMock),
+    ):
+        serve_task = asyncio.create_task(_serve())
+        try:
+            url = f"http://127.0.0.1:{port}"
+            await _wait_for_health(url)
+            yield url
+        finally:
+            await server.shutdown()
+            serve_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await serve_task
+            await pool.close()
+
+
+async def _create_connection(api_key: str, base_url: str, account: str) -> str:
+    async with authed_client(base_url, api_key) as c:
+        r = await c.post(
+            "/v1/connections", json={"connector": "echo", "external_account_id": account}
+        )
+        r.raise_for_status()
+        return str(r.json()["id"])
+
+
+async def _issue_runtime_token(
+    api_key: str,
+    base_url: str,
+    connector: str,
+    *,
+    connection_ids: list[str] | None = None,
+) -> str:
+    """Mint a runtime token; optionally bind it to a connection allowlist."""
+    body: dict[str, object] = {"connector": connector}
+    if connection_ids is not None:
+        body["connection_ids"] = connection_ids
+    async with authed_client(base_url, api_key) as c:
+        r = await c.post("/v1/runtime-tokens", json=body)
+        r.raise_for_status()
+        return str(r.json()["plaintext"])
+
+
+async def _collect_backfill_ids(
+    base_url: str,
+    token: str,
+    *,
+    expected_ids: set[str],
+    timeout_s: float = 5.0,
+) -> set[str]:
+    """Open the discovery SSE stream and collect ``added`` IDs until
+    ``expected_ids`` is a subset of what we've seen — then cancel.
+
+    Discovery backfill emits one ``added`` per active connection of the
+    bearer's type before tailing NOTIFY; once we've seen every ID we
+    expect, anything still streaming is the tail, which we don't care
+    about for the backfill assertion.
+    """
+    seen: set[str] = set()
+    done = asyncio.Event()
+
+    async def _consume() -> None:
+        async with Client(base_url=base_url, token=token) as client:
+            async for msg in stream_connection_discovery(client.get_async_httpx_client(), "echo"):
+                if msg.event != "connection":
+                    continue
+                payload = json.loads(msg.data)
+                if payload["event"] == "added":
+                    seen.add(payload["connection_id"])
+                    if expected_ids.issubset(seen):
+                        done.set()
+
+    task = asyncio.create_task(_consume())
+    try:
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(done.wait(), timeout=timeout_s)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    return seen
+
+
+@needs_docker
+class TestRuntimeTokenConnectionScope:
+    async def test_scoped_token_discovery_emits_only_allowlisted(
+        self,
+        live_server: str,
+        aios_env: dict[str, str],
+    ) -> None:
+        """Three echo connections A/B/C; scope to [A, B]; backfill must
+        emit A and B (in any order) and must NOT emit C."""
+        api_key = aios_env["AIOS_API_KEY"]
+        a = await _create_connection(api_key, live_server, "acct-scope-a")
+        b = await _create_connection(api_key, live_server, "acct-scope-b")
+        c = await _create_connection(api_key, live_server, "acct-scope-c")
+
+        token = await _issue_runtime_token(api_key, live_server, "echo", connection_ids=[a, b])
+
+        seen = await _collect_backfill_ids(live_server, token, expected_ids={a, b}, timeout_s=5.0)
+        assert a in seen
+        assert b in seen
+        assert c not in seen
+
+    async def test_unscoped_token_sees_all_connections(
+        self,
+        live_server: str,
+        aios_env: dict[str, str],
+    ) -> None:
+        """Token issued without ``connection_ids`` retains pre-#350
+        behaviour: every active connection of the bearer's type is
+        emitted in backfill."""
+        api_key = aios_env["AIOS_API_KEY"]
+        a = await _create_connection(api_key, live_server, "acct-unscoped-a")
+        b = await _create_connection(api_key, live_server, "acct-unscoped-b")
+        c = await _create_connection(api_key, live_server, "acct-unscoped-c")
+
+        token = await _issue_runtime_token(api_key, live_server, "echo")
+
+        seen = await _collect_backfill_ids(
+            live_server, token, expected_ids={a, b, c}, timeout_s=5.0
+        )
+        assert {a, b, c}.issubset(seen)
+
+
+@needs_docker
+class TestRuntimeTokenConnectionScopeRoutes:
+    """403 / 200 boundary checks on the runtime-scoped routes when the
+    bearer's allowlist excludes (or includes) the target connection.
+
+    These don't need live SSE streaming, so the in-process
+    ``http_client`` ASGI transport is enough.
+    """
+
+    async def test_scoped_token_403_on_inbound_for_out_of_scope(
+        self,
+        http_client: object,
+        aios_env: dict[str, str],
+    ) -> None:
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/connections", json={"connector": "echo", "external_account_id": "acct-in-a"}
+        )
+        r.raise_for_status()
+        a_id = r.json()["id"]
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/connections", json={"connector": "echo", "external_account_id": "acct-in-b"}
+        )
+        r.raise_for_status()
+        b_id = r.json()["id"]
+
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/runtime-tokens",
+            json={"connector": "echo", "connection_ids": [a_id]},
+        )
+        r.raise_for_status()
+        plaintext = r.json()["plaintext"]
+
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/connectors/runtime/inbound",
+            data={
+                "connection_id": b_id,
+                "event_id": "evt-out-of-scope-1",
+                "chat_id": "chat-1",
+                "content": "hi",
+            },
+            headers=bearer(plaintext),
+        )
+        assert r.status_code == 403
+
+    async def test_scoped_token_403_on_tool_results_for_out_of_scope(
+        self,
+        http_client: object,
+        aios_env: dict[str, str],
+    ) -> None:
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/connections", json={"connector": "echo", "external_account_id": "acct-tr-a"}
+        )
+        r.raise_for_status()
+        a_id = r.json()["id"]
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/connections", json={"connector": "echo", "external_account_id": "acct-tr-b"}
+        )
+        r.raise_for_status()
+        b_id = r.json()["id"]
+
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/runtime-tokens",
+            json={"connector": "echo", "connection_ids": [a_id]},
+        )
+        r.raise_for_status()
+        plaintext = r.json()["plaintext"]
+
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/connectors/runtime/tool-results",
+            json={
+                "connection_id": b_id,
+                "session_id": "sess_nope",
+                "tool_call_id": "tcid_nope",
+                "content": "{}",
+            },
+            headers=bearer(plaintext),
+        )
+        assert r.status_code == 403
+
+    async def test_scoped_token_403_on_secrets_for_out_of_scope(
+        self,
+        http_client: object,
+        aios_env: dict[str, str],
+    ) -> None:
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/connections", json={"connector": "echo", "external_account_id": "acct-sec-a"}
+        )
+        r.raise_for_status()
+        a_id = r.json()["id"]
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/connections", json={"connector": "echo", "external_account_id": "acct-sec-b"}
+        )
+        r.raise_for_status()
+        b_id = r.json()["id"]
+
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/runtime-tokens",
+            json={"connector": "echo", "connection_ids": [a_id]},
+        )
+        r.raise_for_status()
+        plaintext = r.json()["plaintext"]
+
+        r = await http_client.get(  # type: ignore[attr-defined]
+            "/v1/connectors/runtime/secrets",
+            params={"connection_id": b_id},
+            headers=bearer(plaintext),
+        )
+        assert r.status_code == 403
+
+    async def test_scoped_token_200_on_secrets_for_in_scope(
+        self,
+        http_client: object,
+        aios_env: dict[str, str],
+    ) -> None:
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/connections", json={"connector": "echo", "external_account_id": "acct-sec-ok"}
+        )
+        r.raise_for_status()
+        a_id = r.json()["id"]
+
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/runtime-tokens",
+            json={"connector": "echo", "connection_ids": [a_id]},
+        )
+        r.raise_for_status()
+        plaintext = r.json()["plaintext"]
+
+        r = await http_client.get(  # type: ignore[attr-defined]
+            "/v1/connectors/runtime/secrets",
+            params={"connection_id": a_id},
+            headers=bearer(plaintext),
+        )
+        assert r.status_code == 200
+
+    async def test_unscoped_token_inbound_succeeds_for_any_connection(
+        self,
+        http_client: object,
+        aios_env: dict[str, str],
+    ) -> None:
+        """Pre-#350 behaviour preserved when ``connection_ids`` is omitted:
+        the inbound route does not 403 on connection-scope (it may
+        still fail later in the pipeline — we assert ``!= 403`` rather
+        than ``== 201``)."""
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/connections", json={"connector": "echo", "external_account_id": "acct-un-any"}
+        )
+        r.raise_for_status()
+        a_id = r.json()["id"]
+
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/runtime-tokens", json={"connector": "echo"}
+        )
+        r.raise_for_status()
+        plaintext = r.json()["plaintext"]
+
+        r = await http_client.post(  # type: ignore[attr-defined]
+            "/v1/connectors/runtime/inbound",
+            data={
+                "connection_id": a_id,
+                "event_id": "evt-un-any-1",
+                "chat_id": "chat-1",
+                "content": "hi",
+            },
+            headers=bearer(plaintext),
+        )
+        assert r.status_code != 403

--- a/tests/integration/test_runtime_token_connection_ids_scope.py
+++ b/tests/integration/test_runtime_token_connection_ids_scope.py
@@ -1,0 +1,132 @@
+"""Integration tests for the runtime-token ``connection_ids`` allowlist scope (#350).
+
+Issuing a runtime token with ``connection_ids=[...]`` produces a token
+that can only see / operate on the listed connections. Omitting the
+field (or storing ``NULL``) leaves the token unscoped — the
+pre-#350 behaviour. The migration must be backwards-safe: a row
+written before the migration (or by a caller that didn't set the
+column) resolves with ``connection_ids=None``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.ids import RUNTIME_TOKEN, make_id
+from aios.services import runtime_tokens as runtime_tokens_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def pool_with_account(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str]]:
+    """Yield ``(pool, account_id)`` for a non-archived account."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_rt_scope', NULL, TRUE, 'rt-scope-test')
+                """
+            )
+            # Insert connector catalog row so runtime_tokens FK is satisfied.
+            await conn.execute(
+                "INSERT INTO connectors (connector) VALUES ('echo') ON CONFLICT DO NOTHING",
+            )
+        yield pool, "acc_rt_scope"
+    finally:
+        await pool.close()
+
+
+async def test_issue_with_connection_ids_returns_scope(
+    pool_with_account: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """``service.issue(connection_ids=[...])`` round-trips the allowlist
+    onto the ``RuntimeToken`` read view."""
+    pool, account_id = pool_with_account
+    token, _plaintext = await runtime_tokens_service.issue(
+        pool,
+        account_id=account_id,
+        connector="echo",
+        label="scoped",
+        connection_ids=["c1", "c2"],
+    )
+    assert token.connection_ids == ["c1", "c2"]
+
+
+async def test_resolve_returns_connection_ids_scope(
+    pool_with_account: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """``service.resolve()`` surfaces the allowlist on a ``ResolvedRuntimeToken``."""
+    pool, account_id = pool_with_account
+    _token, plaintext = await runtime_tokens_service.issue(
+        pool,
+        account_id=account_id,
+        connector="echo",
+        label="scoped",
+        connection_ids=["c1", "c2"],
+    )
+    resolved = await runtime_tokens_service.resolve(pool, plaintext)
+    assert resolved is not None
+    assert resolved.connection_ids == ["c1", "c2"]
+
+
+async def test_resolve_unscoped_token_returns_none_for_connection_ids(
+    pool_with_account: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """Issuing without ``connection_ids`` leaves ``connection_ids=None``
+    on resolve. ``None`` is the "unscoped" sentinel; ``[]`` would mean
+    "zero connections accessible" — distinct semantics."""
+    pool, account_id = pool_with_account
+    _token, plaintext = await runtime_tokens_service.issue(
+        pool,
+        account_id=account_id,
+        connector="echo",
+        label="unscoped",
+    )
+    resolved = await runtime_tokens_service.resolve(pool, plaintext)
+    assert resolved is not None
+    assert resolved.connection_ids is None
+
+
+async def test_existing_db_row_with_null_connection_ids_resolves(
+    pool_with_account: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """Insert a token row directly without setting ``connection_ids`` —
+    simulates a pre-migration row. ``resolve()`` must succeed and
+    return ``connection_ids=None``. This is the backwards-compatibility
+    contract: the migration adds the column nullable, and existing
+    rows resolve as unscoped."""
+    pool, account_id = pool_with_account
+    plaintext = "aios_runtime_" + secrets.token_urlsafe(32)
+    token_hash = hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
+    token_id = make_id(RUNTIME_TOKEN)
+    async with pool.acquire() as conn:
+        # Explicitly omit ``connection_ids`` from the INSERT so the
+        # column stays at its (NULL) default — same as a row that
+        # existed before the migration.
+        await conn.execute(
+            """
+            INSERT INTO runtime_tokens (id, connector, label, token_hash, account_id)
+            VALUES ($1, $2, $3, $4, $5)
+            """,
+            token_id,
+            "echo",
+            "pre-migration",
+            token_hash,
+            account_id,
+        )
+    resolved = await runtime_tokens_service.resolve(pool, plaintext)
+    assert resolved is not None
+    assert resolved.token_id == token_id
+    assert resolved.connection_ids is None

--- a/tests/unit/test_runtime_tokens_router_validation.py
+++ b/tests/unit/test_runtime_tokens_router_validation.py
@@ -1,0 +1,29 @@
+"""Unit tests for ``RuntimeTokenIssue`` wire validation — connection_ids scope (#350).
+
+The ``connection_ids`` field is the optional allowlist scope: when set
+on issue, the resulting runtime token can only see/operate on the
+listed connection IDs. When omitted, the token behaves as before
+(``None`` => unscoped, sees all connections of its connector type).
+"""
+
+from __future__ import annotations
+
+from aios.models.runtime_tokens import RuntimeTokenIssue
+
+
+class TestRuntimeTokenIssueConnectionIds:
+    def test_accepts_connection_ids_allowlist(self) -> None:
+        body = RuntimeTokenIssue.model_validate(
+            {"connector": "echo", "connection_ids": ["c1", "c2"]}
+        )
+        assert body.connection_ids == ["c1", "c2"]
+
+    def test_defaults_to_none_when_omitted(self) -> None:
+        body = RuntimeTokenIssue.model_validate({"connector": "echo"})
+        assert body.connection_ids is None
+
+    def test_accepts_empty_list(self) -> None:
+        """``[]`` is a valid empty allowlist (zero connections accessible)
+        — distinct from ``None`` (unscoped). Don't coerce."""
+        body = RuntimeTokenIssue.model_validate({"connector": "echo", "connection_ids": []})
+        assert body.connection_ids == []


### PR DESCRIPTION
## Summary

Adds an optional `connection_ids` scope field to runtime tokens, letting operators mint a token that can only see and interact with a specific subset of connections. A token without the field behaves exactly as before.

## What changed

**Database**: migration `0054_runtime_tokens_connection_ids.py` adds a nullable `text[]` column to `runtime_tokens`. Existing tokens are unaffected (NULL = unscoped).

**Models and queries**: `RuntimeToken`, `RuntimeTokenIssue`, and `RuntimeTokenIssued` gain `connection_ids: list[str] | None`. The insert/resolve/row-mapping helpers thread the new field through.

**Auth dependency**: `require_runtime_auth` now returns a 4-tuple that includes the resolved scope; `RuntimeAuthDep` updated accordingly.

**Enforcement**: a new `_check_runtime_connection_scope` helper raises 403 if the accessed connection isn't in the token's allowlist. Wired into `post_runtime_inbound`, `post_runtime_tool_result`, and `get_runtime_secrets`.

**Discovery and call streams**: `connection_discovery_stream` filters both backfill and NOTIFY tail to the scoped set. `runtime_connector_calls_stream` filters at NOTIFY-parse time and again after the post-fetch re-read.

**Token minting**: `POST /v1/runtime-tokens` accepts the new body field and passes it through. No CLI changes — there's no `aios` subcommand for minting runtime tokens.

**OpenAPI / SDK snapshots** regenerated to match the new schema (required by existing snapshot tests).

## Design notes worth reviewing

- Column type is `text[]`, not jsonb — consistent with `connections.vault_ids`. asyncpg returns `list[str]` natively.
- `NULL` means unscoped (today's behavior). An explicit empty `[]` is a zero-connection allowlist; it is not coerced to NULL.
- `resolve_runtime_token` does not JOIN to verify scoped connection IDs still exist. Archival of a target connection surfaces as a 404 or SSE omission rather than silently invalidating the token.
- `PUT /v1/connectors/tools-schema` is not restricted for scoped tokens — the tools schema is global per connector type, so a scoped container writing it affects siblings. Left as-is for now; a `_check_unscoped_only` guard can be added in a follow-up if operators need the stricter policy.

## Test coverage

- 10 new e2e tests (scoped discovery, 403 on out-of-scope connections, unscoped tokens unaffected)
- 14 related regression-check tests pass
- 1371 unit + 51 integration tests pass; mypy and ruff clean

Closes #350