### PR TITLE
docs(ci): close #564 — promote-api/worker workflows already live

### DIFF
--- a/.github/workflows/promote-api.yml
+++ b/.github/workflows/promote-api.yml
@@ -14,7 +14,7 @@ name: Promote aios-api → Coolify
 # If anything in that chain fails, production stays on the prior known-good
 # build.
 #
-# Spec: eumemic/eumemic-ops#19 (deploy-gate v2 step 7).
+# Spec: eumemic/eumemic-ops#19 (deploy-gate v2 step 7). Issue: eumemic/aios#564.
 # Receiver: eumemic/eumemic-ops .github/workflows/deploy-app.yml.
 #
 # Security note: this workflow does not interpolate any untrusted input

--- a/.github/workflows/promote-worker.yml
+++ b/.github/workflows/promote-worker.yml
@@ -14,7 +14,7 @@ name: Promote aios-worker → Coolify
 # If anything in that chain fails, production stays on the prior known-good
 # build.
 #
-# Spec: eumemic/eumemic-ops#19 (deploy-gate v2 step 7).
+# Spec: eumemic/eumemic-ops#19 (deploy-gate v2 step 7). Issue: eumemic/aios#564.
 # Receiver: eumemic/eumemic-ops .github/workflows/deploy-app.yml.
 #
 # Security note: this workflow does not interpolate any untrusted input


### PR DESCRIPTION
## Context

Issue #564 requested adding `promote-api.yml` and `promote-worker.yml` for Track G v2. Both workflows were implemented in #488 and have been active on GitHub ever since — `gh workflow list` confirms `Promote aios-api → Coolify` and `Promote aios-worker → Coolify` as active workflows.

The issue was never closed after #488 merged.

## What this PR does

Adds the `eumemic/aios#564` back-reference to the `# Spec:` comment in both workflow files so the tracking history is navigable from the code. Nothing else changes.

## Acceptance criteria status (all satisfied on master)

| Criterion | Status |
|---|---|
| Both workflow files merged to master | ✅ since #488 |
| `gh workflow list` shows them | ✅ confirmed |
| `workflow_dispatch` trigger | ✅ |
| References `secrets.EUMEMIC_OPS_DISPATCH_TOKEN` via `environment: stable` | ✅ |
| Action version matches `promote-sandbox.yml` convention (`@v4`) | ✅ |
| Correct payload (`app`, `track`, `sha`, `promoted_by`) | ✅ |

Note on reviewer gate: the `environment: stable` protection rule was intentionally removed in #537 (the operator decided operator-triggered dispatch is the gate, not a required reviewer). The `environment:` block is retained to scope the `EUMEMIC_OPS_DISPATCH_TOKEN` secret.

Closes #564