### PR TITLE
fix(sandbox): hold session lock during idle reaper eviction

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -486,7 +486,8 @@ class SandboxRegistry:
                         to_release.append(sid)
                 for sid in to_release:
                     log.info("sandbox.idle_release", session_id=sid)
-                    await self.release(sid)
+                    async with self._lock_for(sid):
+                        await self.release(sid)
             except Exception:
                 log.exception("sandbox.reap_idle_loop_failed")
 

--- a/tests/unit/test_sandbox_reaper.py
+++ b/tests/unit/test_sandbox_reaper.py
@@ -12,6 +12,10 @@ lifetime. Containers accumulated silently until process exit.
 Same anti-pattern as ``_run_interrupt_listener`` (fixed in PR #443).
 ``_periodic_sweep`` (``worker.py:343``) demonstrates the correct
 template: nest try/except INSIDE the ``while True``.
+
+Additional coverage: the reaper must hold the per-session lock while
+calling ``release()``. Without the lock, a concurrent fast-path caller
+can grab a handle that the reaper is about to destroy (issue #566).
 """
 
 from __future__ import annotations
@@ -129,6 +133,93 @@ async def test_reaper_processes_sandboxes_added_after_initial_failure() -> None:
                 f"exception={reaper.exception() if reaper.done() else None})"
             ) from exc
     finally:
+        reaper.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await reaper
+
+
+async def test_idle_release_evicts_cache_before_destroy() -> None:
+    """``_handles`` must be cleared before ``backend.destroy`` is awaited.
+
+    ``release()`` pops from ``_handles`` synchronously before calling
+    ``backend.destroy``, so any concurrent caller that checks the cache
+    after the pop will see a cache miss and provision fresh — even
+    though the destroy hasn't completed yet.
+
+    This documents the ordering invariant that makes the per-session
+    lock in the reaper sufficient to prevent issue #566.
+    """
+    handles_at_destroy: dict[str, bool] = {}
+    destroy_done = asyncio.Event()
+
+    async def destroy(handle: SandboxHandle) -> None:
+        # Record whether the session is still in _handles at this point.
+        handles_at_destroy[handle.session_id] = handle.session_id in registry._handles
+        destroy_done.set()
+
+    registry = SandboxRegistry(_backend_with_destroy(AsyncMock(side_effect=destroy)))
+    registry._handles["sess_x"] = _handle("sess_x")
+    registry._last_used["sess_x"] = 0.0
+
+    reaper = asyncio.create_task(registry._reap_idle_loop(idle_timeout=0.0, interval=0.01))
+    try:
+        await asyncio.wait_for(destroy_done.wait(), timeout=1.0)
+    finally:
+        reaper.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await reaper
+
+    # The handle must have been evicted from the cache BEFORE destroy ran.
+    assert handles_at_destroy.get("sess_x") is False, (
+        "release() called backend.destroy before popping _handles; "
+        "a concurrent get_or_provision could return a stale handle"
+    )
+
+
+async def test_idle_release_holds_per_session_lock() -> None:
+    """The reaper must hold the per-session lock for the full ``release()`` call.
+
+    Without ``async with self._lock_for(sid)`` in ``_reap_idle_loop``,
+    the lock is NOT held during ``backend.destroy`` — the per-session
+    lock object will report ``locked() == False`` while destroy runs.
+
+    With the fix, the reaper acquires the lock before calling
+    ``release()``, so the lock is held through the entire call including
+    the async ``backend.destroy`` step.
+
+    We capture a reference to the lock object BEFORE the reaper starts
+    so that ``_locks.pop()`` inside ``release()`` doesn't matter —
+    Python keeps the object alive as long as we hold a reference.
+    """
+    destroy_started = asyncio.Event()
+    destroy_continue = asyncio.Event()
+    lock_state_during_destroy: dict[str, bool] = {}
+
+    async def destroy(handle: SandboxHandle) -> None:
+        lock_state_during_destroy["locked"] = captured_lock.locked()
+        destroy_started.set()
+        await destroy_continue.wait()
+
+    registry = SandboxRegistry(_backend_with_destroy(AsyncMock(side_effect=destroy)))
+    registry._handles["sess_x"] = _handle("sess_x")
+    registry._last_used["sess_x"] = 0.0
+
+    # Capture the lock object BEFORE the reaper touches it.
+    # _lock_for() creates and stores it in _locks; the reaper will find
+    # the same object via _lock_for() and acquire it.
+    captured_lock = registry._lock_for("sess_x")
+
+    reaper = asyncio.create_task(registry._reap_idle_loop(idle_timeout=0.0, interval=0.01))
+    try:
+        await asyncio.wait_for(destroy_started.wait(), timeout=1.0)
+
+        assert lock_state_during_destroy.get("locked") is True, (
+            "per-session lock was NOT held by the reaper during backend.destroy; "
+            "fix _reap_idle_loop to wrap release() with "
+            "async with self._lock_for(sid)"
+        )
+    finally:
+        destroy_continue.set()
         reaper.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await reaper


### PR DESCRIPTION
The idle reaper in `SandboxRegistry._reap_idle_loop` called `release(sid)` without holding the per-session lock, creating a race with the fast-path in `get_or_provision`. The fast-path returns a cached handle without acquiring the lock; if the reaper destroys the container between that return and the next `await` in the caller, the tool call fails with "No such container".

Fix: wrap `release(sid)` in the reaper with `async with self._lock_for(sid)`. Since `release()` already pops from `_handles` synchronously before `await backend.destroy()`, any concurrent `get_or_provision` that misses the fast-path and then acquires the lock will see an empty cache and provision fresh.

Tests cover eviction ordering and lock-hold duration. The test captures the lock reference before `release()` pops `_locks[sid]`, since `_lock_for()` after the pop returns a fresh unlocked object.

Closes #566