### PR TITLE
fix(api): pass proxy_headers to uvicorn so scheme reflects HTTPS

### DIFF
--- a/src/aios/cli/commands/ops.py
+++ b/src/aios/cli/commands/ops.py
@@ -23,6 +23,8 @@ def _run_api() -> int:
         host=settings.api_host,
         port=settings.api_port,
         log_config=None,  # we configure structlog ourselves
+        proxy_headers=True,
+        forwarded_allow_ips="*",
     )
     return 0
 

--- a/tests/unit/cli/test_ops.py
+++ b/tests/unit/cli/test_ops.py
@@ -1,0 +1,29 @@
+"""Tests for operator subcommands (api, worker, migrate)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from aios.cli.app import app
+
+runner = CliRunner()
+
+
+def test_api_command_passes_proxy_headers_to_uvicorn(monkeypatch):
+    """The `api` command must pass proxy_headers=True and forwarded_allow_ips="*"
+    to uvicorn.run so that X-Forwarded-For headers are trusted when running
+    behind a reverse proxy."""
+    monkeypatch.setenv("AIOS_API_KEY", "test")
+    monkeypatch.setenv("AIOS_DB_URL", "postgresql://localhost/test")
+
+    with patch("uvicorn.run") as mock_run:
+        runner.invoke(app, ["api"])
+
+    mock_run.assert_called_once()
+    _, kwargs = mock_run.call_args
+    assert kwargs.get("proxy_headers") is True, "uvicorn.run must be called with proxy_headers=True"
+    assert kwargs.get("forwarded_allow_ips") == "*", (
+        'uvicorn.run must be called with forwarded_allow_ips="*"'
+    )


### PR DESCRIPTION
Without `proxy_headers=True` and `forwarded_allow_ips="*"`, uvicorn ignores `X-Forwarded-Proto` from Traefik and `request.url.scheme` always reads `"http"` even when the client connected over HTTPS. This breaks `url_for`, signed URLs, and OAuth redirects.

`forwarded_allow_ips="*"` is required because Traefik runs as a sibling container, not loopback — uvicorn's default only trusts 127.0.0.1.

Adds both kwargs to `uvicorn.run()` in `ops.py` and a unit test that patches `uvicorn.run` and asserts both are passed.

Closes #570