### PR TITLE
refactor(db/queries): collapse list_* forks onto args/where builder

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -141,21 +141,17 @@ async def get_environment(
 async def list_environments(
     conn: asyncpg.Connection[Any], *, account_id: str, limit: int = 50, after: str | None = None
 ) -> list[Environment]:
-    if after is None:
-        rows = await conn.fetch(
-            "SELECT * FROM environments WHERE archived_at IS NULL AND account_id = $1 "
-            "ORDER BY id DESC LIMIT $2",
-            account_id,
-            limit,
-        )
-    else:
-        rows = await conn.fetch(
-            "SELECT * FROM environments WHERE archived_at IS NULL AND id < $1 "
-            "AND account_id = $2 ORDER BY id DESC LIMIT $3",
-            after,
-            account_id,
-            limit,
-        )
+    args: list[Any] = [account_id]
+    where = ["archived_at IS NULL", "account_id = $1"]
+    if after is not None:
+        args.append(after)
+        where.append(f"id < ${len(args)}")
+    args.append(limit)
+    sql = (
+        f"SELECT * FROM environments WHERE {' AND '.join(where)} "
+        f"ORDER BY id DESC LIMIT ${len(args)}"
+    )
+    rows = await conn.fetch(sql, *args)
     return [_row_to_environment(r) for r in rows]
 
 
@@ -2276,21 +2272,14 @@ async def get_vault(conn: asyncpg.Connection[Any], vault_id: str, *, account_id:
 async def list_vaults(
     conn: asyncpg.Connection[Any], *, account_id: str, limit: int = 50, after: str | None = None
 ) -> list[Vault]:
-    if after is None:
-        rows = await conn.fetch(
-            "SELECT * FROM vaults WHERE archived_at IS NULL AND account_id = $1 "
-            "ORDER BY id DESC LIMIT $2",
-            account_id,
-            limit,
-        )
-    else:
-        rows = await conn.fetch(
-            "SELECT * FROM vaults WHERE archived_at IS NULL AND id < $1 AND account_id = $2 "
-            "ORDER BY id DESC LIMIT $3",
-            after,
-            account_id,
-            limit,
-        )
+    args: list[Any] = [account_id]
+    where = ["archived_at IS NULL", "account_id = $1"]
+    if after is not None:
+        args.append(after)
+        where.append(f"id < ${len(args)}")
+    args.append(limit)
+    sql = f"SELECT * FROM vaults WHERE {' AND '.join(where)} ORDER BY id DESC LIMIT ${len(args)}"
+    rows = await conn.fetch(sql, *args)
     return [_row_to_vault(r) for r in rows]
 
 
@@ -2903,21 +2892,14 @@ async def get_skill(conn: asyncpg.Connection[Any], skill_id: str, *, account_id:
 async def list_skills(
     conn: asyncpg.Connection[Any], *, account_id: str, limit: int = 50, after: str | None = None
 ) -> list[Skill]:
-    if after is None:
-        rows = await conn.fetch(
-            "SELECT * FROM skills WHERE archived_at IS NULL AND account_id = $1 "
-            "ORDER BY id DESC LIMIT $2",
-            account_id,
-            limit,
-        )
-    else:
-        rows = await conn.fetch(
-            "SELECT * FROM skills WHERE archived_at IS NULL AND id < $1 AND account_id = $2 "
-            "ORDER BY id DESC LIMIT $3",
-            after,
-            account_id,
-            limit,
-        )
+    args: list[Any] = [account_id]
+    where = ["archived_at IS NULL", "account_id = $1"]
+    if after is not None:
+        args.append(after)
+        where.append(f"id < ${len(args)}")
+    args.append(limit)
+    sql = f"SELECT * FROM skills WHERE {' AND '.join(where)} ORDER BY id DESC LIMIT ${len(args)}"
+    rows = await conn.fetch(sql, *args)
     return [_row_to_skill(r) for r in rows]
 
 
@@ -4041,23 +4023,17 @@ async def get_session_template(
 async def list_session_templates(
     conn: asyncpg.Connection[Any], *, account_id: str, limit: int = 50, after: str | None = None
 ) -> list[SessionTemplate]:
-    if after is None:
-        rows = await conn.fetch(
-            "SELECT * FROM session_templates "
-            "WHERE archived_at IS NULL AND account_id = $2 "
-            "ORDER BY id DESC LIMIT $1",
-            limit,
-            account_id,
-        )
-    else:
-        rows = await conn.fetch(
-            "SELECT * FROM session_templates "
-            "WHERE archived_at IS NULL AND id < $1 AND account_id = $3 "
-            "ORDER BY id DESC LIMIT $2",
-            after,
-            limit,
-            account_id,
-        )
+    args: list[Any] = [account_id]
+    where = ["archived_at IS NULL", "account_id = $1"]
+    if after is not None:
+        args.append(after)
+        where.append(f"id < ${len(args)}")
+    args.append(limit)
+    sql = (
+        f"SELECT * FROM session_templates WHERE {' AND '.join(where)} "
+        f"ORDER BY id DESC LIMIT ${len(args)}"
+    )
+    rows = await conn.fetch(sql, *args)
     return [_row_to_session_template(r) for r in rows]
 
 


### PR DESCRIPTION
## Summary

- Four `list_*` functions (`list_environments`, `list_vaults`, `list_skills`, `list_session_templates`) shared a near-twin `if after is None: fetch(A) else fetch(B)` body. Replaced each with the inline `args/where` builder that `list_memory_stores` already uses in this file.
- Pure-mechanical refactor: no caller changes (kwargs identical), no behavior change, no new helper introduced. Net **-24 LOC** in one file.
- Side benefit: `list_session_templates` had a copy-paste wart in its original SQL (parameter ordering `limit=$1, account_id=$2/$3` cross-referenced). The builder pattern normalises that to the canonical ordering.

## Why this matters

The duplication had drifted: three sites used a clean two-branch fork, one (`session_templates`) had quietly developed a placeholder-ordering wart from successive edits. Aligning all four with the in-file precedent (`list_memory_stores`) eliminates the duplication signal and removes the copy-paste vector for future drift.

This is "use the pattern that already exists" rather than introducing a new abstraction — consistent with aios's stance on extreme simplicity and "three similar lines is better than premature abstraction." The 4-site duplication exceeds that threshold; the builder is small (5 LOC body) and already proven in `list_memory_stores`.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1400 passed
- [ ] CI: full test matrix (incl. e2e/integration)

## Review notes

Code review (`pr-review-toolkit:code-reviewer`) confirmed SQL semantic equivalence at 95+ confidence: WHERE-AND commutativity preserves result sets; parameter placeholders match args; per-table f-string templates produce equivalent text.

Sub-50 nits surfaced for transparency:
- **Sev 20**: ruff format produces single-line SQL for `list_vaults` / `list_skills` (table names fit under 100 chars) but multi-line for `list_environments` / `list_session_templates` (table names push over). Visually inconsistent within the four call sites; driven by line-length, not intent. Forcing 2-line form would fight ruff's autoformatter.
- **Sev 25**: The `where` list starts with literal `"account_id = $1"` rather than deriving the index. Matches the precedent at `list_memory_stores`; not a regression introduced by this PR.
- **Sev 15**: WHERE clause ordering changes (`account_id = $1 AND id < $2` vs original `id < $1 AND account_id = $2`) — commutative `AND` makes this semantically identical; pg_stat_statements buckets get new cache entries (negligible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)