### PR TITLE
fix(db/queries): reject update_session on archived rows

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1046,6 +1046,29 @@ async def update_session(
     title: str | None | EllipsisType = ...,
     metadata: dict[str, Any] | None = None,
 ) -> Session:
+    # Refuse updates to archived sessions: read paths
+    # (``list_sessions``, the worker, the resolver) all filter
+    # ``archived_at IS NULL``, so a rewrite of an archived row has no
+    # observable effect — but the bare UPDATE below would still commit
+    # the new values and the RETURNING-built response would lie back
+    # to the caller as if the update took.  Mirrors the symmetric
+    # raise on archived rows in ``update_agent`` / ``update_environment``
+    # / ``update_session_template`` (PR #547) / ``update_vault``
+    # (PR #554).
+    #
+    # Load-bearing for the resource-attachment writes inside
+    # ``service.update_session`` (vault_ids / memory / github
+    # resources): those callers run in the same transaction but their
+    # query-layer functions don't independently check ``archived_at``,
+    # so this raise is the only synchronous barrier against rewriting
+    # attachments on an archived session.
+    current = await get_session(conn, session_id, account_id=account_id)
+    if current.archived_at is not None:
+        raise ConflictError(
+            f"session {session_id} is archived",
+            detail={"id": session_id},
+        )
+
     sets: list[str] = []
     args: list[Any] = [session_id]  # $1 = session_id
 
@@ -1063,7 +1086,7 @@ async def update_session(
         sets.append(f"metadata = ${len(args)}::jsonb")
 
     if not sets:
-        return await get_session(conn, session_id, account_id=account_id)
+        return current
 
     sets.append("updated_at = now()")
     args.append(account_id)

--- a/tests/integration/test_update_session_archived.py
+++ b/tests/integration/test_update_session_archived.py
@@ -1,0 +1,129 @@
+"""Integration test: updating an archived session must fail fast
+instead of silently committing edits that have no observable effect.
+
+Pre-fix the UPDATE WHERE clause in ``update_session`` filters only
+``id = $1 AND account_id = $N`` — archived rows still match, so the
+row's ``title`` / ``metadata`` / ``agent_id`` columns get rewritten
+and the RETURNING-built response reports the new values back to the
+caller as if the update succeeded.  The read paths that operators and
+the worker rely on (``list_sessions`` filters ``archived_at IS NULL``;
+the resolver and ``append_event`` refuse archived targets) never see
+the rewritten fields — but the API has returned 200 OK with the
+post-update payload, lying to the operator.
+
+Same defect class as PR #523 (archived-session ``append_event``), PR
+#547 (``update_session_template`` archived rewrite), and PR #554
+(``update_vault`` archived rewrite — explicitly enumerated
+``update_session`` as the still-open sibling).  The fix is symmetric
+with the ``update_agent`` / ``update_environment`` / ``update_vault``
+path that already raises ``ConflictError`` on archived rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import ConflictError
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def archived_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for a session that has
+    been archived after creation."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_sess_arch', NULL, TRUE, 'session-archived-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_sess_arch",
+            name="sess-arch-test",
+            model="openrouter/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_sess_arch", name="sess-arch-env"
+        )
+        session = await sessions_service.create_session(
+            pool,
+            account_id="acc_sess_arch",
+            agent_id=agent.id,
+            environment_id=env.id,
+            agent_version=agent.version,
+            title="pre-archive",
+            metadata={},
+        )
+        async with pool.acquire() as conn:
+            archived = await queries.archive_session(conn, session.id, account_id="acc_sess_arch")
+        assert archived.archived_at is not None
+        yield pool, "acc_sess_arch", session.id
+    finally:
+        await pool.close()
+
+
+@pytest.mark.parametrize(
+    "update_kwargs",
+    [
+        pytest.param({"title": "post-archive"}, id="title-only"),
+        pytest.param({"metadata": {"k": "v"}}, id="metadata-only"),
+        # No settable fields exercises the ``return current`` branch
+        # in ``queries.update_session`` (post-archive-check, pre-UPDATE),
+        # distinct from the path the other parametrize cases route
+        # through.  A refactor that re-introduced ``get_session(...)``
+        # there without re-checking ``archived_at`` would silently
+        # regress; this case is the canary.
+        pytest.param({}, id="no-fields"),
+    ],
+)
+async def test_update_session_refuses_archived(
+    archived_session: tuple[asyncpg.Pool[Any], str, str],
+    update_kwargs: dict[str, Any],
+) -> None:
+    """Pre-fix: ``service.update_session`` returns 200 with the
+    post-update session payload; a follow-up SELECT shows the row's
+    ``title`` was actually rewritten on the archived row.  Post-fix:
+    raises ``ConflictError`` carrying the session id, and the row's
+    ``title`` remains unchanged."""
+    pool, account_id, session_id = archived_session
+
+    with pytest.raises(ConflictError) as excinfo:
+        await sessions_service.update_session(
+            pool, session_id, account_id=account_id, **update_kwargs
+        )
+
+    detail = excinfo.value.detail
+    assert detail is not None
+    assert detail.get("id") == session_id
+
+    # Defense-in-depth pin: the row's title must not have been
+    # rewritten (the bare UPDATE would have matched and committed the
+    # new value even on the archived row).
+    async with pool.acquire() as conn:
+        actual_title = await conn.fetchval("SELECT title FROM sessions WHERE id = $1", session_id)
+    assert actual_title == "pre-archive", (
+        f"archived session row was rewritten despite the refusal: "
+        f"title is {actual_title!r}, expected 'pre-archive'."
+    )


### PR DESCRIPTION
## Summary

- ``update_session``'s UPDATE WHERE clause filtered only ``id = $1 AND account_id = $N``.  Archived rows still matched, so the row's ``title`` / ``metadata`` / ``agent_id`` columns were rewritten and the RETURNING-built response reported the new values back to the caller as if the update succeeded.  The read paths operators and the worker rely on (``list_sessions`` filters ``archived_at IS NULL``; the resolver / ``append_event`` refuse archived targets) never see the rewritten fields — but the API returned 200 OK with the post-update payload, silently lying to the operator.
- Closes the next-up sibling enumerated in PR #554's commit body (``Sibling write paths in the same family still open: update_session, update_memory_store ...``).  Same defect class as PR #523 (archived-session ``append_event``), PR #547 (``update_session_template``), and PR #554 (``update_vault``).
- Fix: pre-fetch via ``get_session``; if ``archived_at IS NOT NULL`` raise ``ConflictError``.  Mirrors ``update_vault`` line-for-line, including reusing the pre-fetched ``current`` in the no-sets fast path so a no-op PUT doesn't re-read the same row twice.  The new raise is also load-bearing for the resource-attach writes inside ``service.update_session`` (``vault_ids`` / memory / github resources): their query-layer functions don't independently check ``archived_at`` but share the outer transaction, so the early raise rolls them back.

## Follow-ups (called out by reviewer, deliberately out of scope per one-bug-per-PR)

- ``update_memory_store`` query-layer archived guard missing (service-layer guard exists).  Last remaining direct sibling.
- Pre-fetch→UPDATE race window across all five archive-rejecting updates (``update_session``, ``update_vault``, ``update_session_template``, ``update_agent``, ``update_environment``): a concurrent ``archive_X`` can land between the check and the UPDATE.  Closable with one ``AND archived_at IS NULL`` clause per UPDATE.
- Worker-internal writers (``set_session_focal_channel``, ``set_session_status``, ``increment_session_usage``) write to ``sessions`` rows without ``archived_at`` filters.  Different model-consciousness layer (per memory ``feedback_model_consciousness_heuristic.md``); separate fix shape.

## Test plan

- [x] Type-checker — clean (155 source files)
- [x] Linter + format-check — clean
- [x] Unit suite — 1400 passed
- [x] Integration suite — 52 passed, including new ``test_update_session_archived.py`` parametrized over ``title-only`` / ``metadata-only`` / ``no-fields``.  The ``no-fields`` case exercises the ``return current`` fast path distinct from the ``RETURNING *`` UPDATE path so a refactor that re-introduces ``get_session(...)`` there without re-checking ``archived_at`` would not silently regress.
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)