### PR TITLE
refactor(api): introduce AccountIdDep; drop _auth tuple-discard across 10 routers

### DIFF
--- a/src/aios/api/deps.py
+++ b/src/aios/api/deps.py
@@ -77,6 +77,20 @@ async def require_bearer_auth(
     return (account.id, key_id, account.can_mint_children)
 
 
+async def get_account_id(
+    auth: Annotated[AccountAuthResult, Depends(require_bearer_auth)],
+) -> str:
+    """Return just the ``account_id`` from the bearer-token auth tuple.
+
+    Endpoints that don't need ``key_id`` or ``can_mint_children`` use
+    ``AccountIdDep`` to skip the tuple destructure. Endpoints that
+    audit-log the key_id or branch on can_mint (currently only the
+    ``accounts`` router) keep ``AuthDep``.
+    """
+    account_id, _, _ = auth
+    return account_id
+
+
 async def require_runtime_auth(
     pool: Annotated[asyncpg.Pool, Depends(get_pool)],
     authorization: Annotated[str | None, Header(alias="Authorization")] = None,
@@ -113,4 +127,5 @@ CryptoBoxDep = Annotated[CryptoBox, Depends(get_crypto_box)]
 ProcrastinateDep = Annotated[ProcrastinateApp, Depends(get_procrastinate)]
 DbUrlDep = Annotated[str, Depends(get_db_url)]
 AuthDep = Annotated[AccountAuthResult, Depends(require_bearer_auth)]
+AccountIdDep = Annotated[str, Depends(get_account_id)]
 RuntimeAuthDep = Annotated[tuple[str, str, str, list[str] | None], Depends(require_runtime_auth)]

--- a/src/aios/api/routers/agents.py
+++ b/src/aios/api/routers/agents.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Query, status
 
-from aios.api.deps import AuthDep, PoolDep
+from aios.api.deps import AccountIdDep, PoolDep
 from aios.models.agents import Agent, AgentCreate, AgentUpdate, AgentVersion
 from aios.models.common import ListResponse
 from aios.services import agents as service
@@ -15,13 +15,12 @@ router = APIRouter(prefix="/v1/agents", tags=["agents"])
 
 
 @router.post("", operation_id="create_agent", status_code=status.HTTP_201_CREATED)
-async def create(body: AgentCreate, pool: PoolDep, _auth: AuthDep) -> Agent:
+async def create(body: AgentCreate, pool: PoolDep, account_id: AccountIdDep) -> Agent:
     """Create a new agent at version 1.
 
     Subsequent updates produce new immutable versions in the history; see
     ``update_agent`` and ``list_agent_versions``.
     """
-    account_id, _, _ = _auth
     return await service.create_agent(
         pool,
         name=body.name,
@@ -43,7 +42,7 @@ async def create(body: AgentCreate, pool: PoolDep, _auth: AuthDep) -> Agent:
 @router.get("", operation_id="list_agents")
 async def list_(
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
     name: str | None = None,
@@ -54,7 +53,6 @@ async def list_(
     ``next_after`` to get the next page. Optional ``name`` filter matches
     exactly.
     """
-    account_id, _, _ = _auth
     items = await service.list_agents(
         pool, limit=limit, after=after, name=name, account_id=account_id
     )
@@ -62,14 +60,15 @@ async def list_(
 
 
 @router.get("/{agent_id}", operation_id="get_agent")
-async def get(agent_id: str, pool: PoolDep, _auth: AuthDep) -> Agent:
+async def get(agent_id: str, pool: PoolDep, account_id: AccountIdDep) -> Agent:
     """Fetch one agent by id, returning the latest version's config."""
-    account_id, _, _ = _auth
     return await service.get_agent(pool, agent_id, account_id=account_id)
 
 
 @router.put("/{agent_id}", operation_id="update_agent")
-async def update(agent_id: str, body: AgentUpdate, pool: PoolDep, _auth: AuthDep) -> Agent:
+async def update(
+    agent_id: str, body: AgentUpdate, pool: PoolDep, account_id: AccountIdDep
+) -> Agent:
     """Update an agent, creating a new immutable version.
 
     The ``version`` field on the body is required for optimistic concurrency
@@ -78,7 +77,6 @@ async def update(agent_id: str, body: AgentUpdate, pool: PoolDep, _auth: AuthDep
     to the current version, no new version is created and the existing one
     is returned unchanged (no-op).
     """
-    account_id, _, _ = _auth
     return await service.update_agent(
         pool,
         agent_id,
@@ -100,13 +98,12 @@ async def update(agent_id: str, body: AgentUpdate, pool: PoolDep, _auth: AuthDep
 
 
 @router.delete("/{agent_id}", operation_id="archive_agent", status_code=status.HTTP_204_NO_CONTENT)
-async def archive(agent_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+async def archive(agent_id: str, pool: PoolDep, account_id: AccountIdDep) -> None:
     """Archive an agent: sets ``archived_at`` and hides it from default lists.
 
     The row and all version history persist; sessions referencing the agent
     continue to function. There is no API surface to un-archive currently.
     """
-    account_id, _, _ = _auth
     await service.archive_agent(pool, agent_id, account_id=account_id)
 
 
@@ -114,7 +111,7 @@ async def archive(agent_id: str, pool: PoolDep, _auth: AuthDep) -> None:
 async def list_versions(
     agent_id: str,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: int | None = None,
 ) -> ListResponse[AgentVersion]:
@@ -124,7 +121,6 @@ async def list_versions(
     response's ``next_after`` to get the next page. Each version is a
     complete snapshot of the agent's config at the time it was created.
     """
-    account_id, _, _ = _auth
     items = await service.list_agent_versions(
         pool, agent_id, limit=limit, after=after, account_id=account_id
     )
@@ -132,11 +128,12 @@ async def list_versions(
 
 
 @router.get("/{agent_id}/versions/{version}", operation_id="get_agent_version")
-async def get_version(agent_id: str, version: int, pool: PoolDep, _auth: AuthDep) -> AgentVersion:
+async def get_version(
+    agent_id: str, version: int, pool: PoolDep, account_id: AccountIdDep
+) -> AgentVersion:
     """Fetch one historical version's config snapshot.
 
     The snapshot reflects the agent's config at the time the version was
     written and is unaffected by subsequent updates or archival.
     """
-    account_id, _, _ = _auth
     return await service.get_agent_version(pool, agent_id, version, account_id=account_id)

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -17,7 +17,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Query, status
 
-from aios.api.deps import AuthDep, CryptoBoxDep, PoolDep
+from aios.api.deps import AccountIdDep, CryptoBoxDep, PoolDep
 from aios.models.common import ListResponse
 from aios.models.connections import (
     BindChatRequest,
@@ -37,7 +37,7 @@ router = APIRouter(prefix="/v1/connections", tags=["connections"])
 
 @router.post("", operation_id="create_connection", status_code=status.HTTP_201_CREATED)
 async def create(
-    body: ConnectionCreate, pool: PoolDep, crypto_box: CryptoBoxDep, _auth: AuthDep
+    body: ConnectionCreate, pool: PoolDep, crypto_box: CryptoBoxDep, account_id: AccountIdDep
 ) -> Connection:
     """Create a detached connection, **idempotent on ``(connector, external_account_id)``**.
 
@@ -60,7 +60,6 @@ async def create(
     ``GET /v1/connectors/runtime/secrets`` route — operator-facing
     reads return ``secrets_set: bool`` instead of values.
     """
-    account_id, _, _ = _auth
     return await service.create_connection(
         pool,
         connector=body.connector,
@@ -78,7 +77,7 @@ async def set_secrets(
     body: ConnectionSetSecrets,
     pool: PoolDep,
     crypto_box: CryptoBoxDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> Connection:
     """Replace the connection's encrypted secrets dict, wholesale.
 
@@ -89,7 +88,6 @@ async def set_secrets(
     ``GET /v1/connectors/runtime/secrets`` route to a connector container
     holding a runtime token for this connector type.
     """
-    account_id, _, _ = _auth
     return await service.set_connection_secrets(
         pool, connection_id, secrets=body.secrets, crypto_box=crypto_box, account_id=account_id
     )
@@ -98,7 +96,7 @@ async def set_secrets(
 @router.get("", operation_id="list_connections")
 async def list_(
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     connector: str | None = None,
     session_id: str | None = None,
     mode: ConnectionMode | None = None,
@@ -111,7 +109,6 @@ async def list_(
     connections in single_session mode bound to that session), ``mode``
     (``detached`` / ``single_session`` / ``per_chat``). Filters compose.
     """
-    account_id, _, _ = _auth
     items = await service.list_connections(
         pool,
         connector=connector,
@@ -125,9 +122,8 @@ async def list_(
 
 
 @router.get("/{connection_id}", operation_id="get_connection")
-async def get(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Connection:
+async def get(connection_id: str, pool: PoolDep, account_id: AccountIdDep) -> Connection:
     """Fetch one connection by id."""
-    account_id, _, _ = _auth
     return await service.get_connection(pool, connection_id, account_id=account_id)
 
 
@@ -136,7 +132,7 @@ async def get(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Connection:
     operation_id="archive_connection",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def delete(connection_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+async def delete(connection_id: str, pool: PoolDep, account_id: AccountIdDep) -> None:
     """Archive a connection (DELETE soft-archives, only on detached connections).
 
     The service layer rejects archive attempts while an active binding
@@ -144,7 +140,6 @@ async def delete(connection_id: str, pool: PoolDep, _auth: AuthDep) -> None:
     live sessions or strand the template a per_chat binding spawns
     from. Detach or unconfigure first, then archive.
     """
-    account_id, _, _ = _auth
     await service.archive_connection(pool, connection_id, account_id=account_id)
 
 
@@ -153,7 +148,7 @@ async def attach(
     connection_id: str,
     body: ConnectionAttach,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> Connection:
     """Attach a connection to a session (single_session mode).
 
@@ -162,7 +157,6 @@ async def attach(
     an inbound referencing an unknown account simply drops at the
     inbound boundary.
     """
-    account_id, _, _ = _auth
     return await service.attach_connection(
         pool, connection_id, session_id=body.session_id, account_id=account_id
     )
@@ -173,14 +167,13 @@ async def attach(
     operation_id="detach_connection",
     openapi_extra={"x-codegen": {"mcp": {"destructiveHint": True}}},
 )
-async def detach(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Connection:
+async def detach(connection_id: str, pool: PoolDep, account_id: AccountIdDep) -> Connection:
     """Detach a single_session connection back to detached mode.
 
     The bound session is unaffected (continues to exist); only the
     connection's mode/binding changes. Inbound on this connection is
     paused until it's re-attached or configured for per_chat.
     """
-    account_id, _, _ = _auth
     return await service.detach_connection(pool, connection_id, account_id=account_id)
 
 
@@ -189,7 +182,7 @@ async def detach(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Connectio
     operation_id="configure_connection_per_chat",
 )
 async def configure_per_chat(
-    connection_id: str, body: ConnectionConfigurePerChat, pool: PoolDep, _auth: AuthDep
+    connection_id: str, body: ConnectionConfigurePerChat, pool: PoolDep, account_id: AccountIdDep
 ) -> Connection:
     """Move a detached connection into per_chat mode, pinned to a session template.
 
@@ -197,7 +190,6 @@ async def configure_per_chat(
     sessions using the named template (agent + environment + vaults +
     memory stores). Use ``unconfigure_connection`` to return to detached.
     """
-    account_id, _, _ = _auth
     return await service.configure_per_chat(
         pool, connection_id, session_template_id=body.session_template_id, account_id=account_id
     )
@@ -208,7 +200,7 @@ async def configure_per_chat(
     operation_id="unconfigure_connection",
     openapi_extra={"x-codegen": {"mcp": {"destructiveHint": True}}},
 )
-async def unconfigure(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Connection:
+async def unconfigure(connection_id: str, pool: PoolDep, account_id: AccountIdDep) -> Connection:
     """Return a per_chat connection to detached mode.
 
     Already-spawned sessions are unaffected and continue normally;
@@ -217,7 +209,6 @@ async def unconfigure(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Conn
     chats) is removed — inbound from new chat partners is paused until
     the connection is reconfigured.
     """
-    account_id, _, _ = _auth
     return await service.unconfigure_connection(pool, connection_id, account_id=account_id)
 
 
@@ -227,7 +218,7 @@ async def unconfigure(connection_id: str, pool: PoolDep, _auth: AuthDep) -> Conn
     status_code=status.HTTP_201_CREATED,
 )
 async def bind_chat(
-    connection_id: str, body: BindChatRequest, pool: PoolDep, _auth: AuthDep
+    connection_id: str, body: BindChatRequest, pool: PoolDep, account_id: AccountIdDep
 ) -> BoundChat:
     """Operator-curate a chat → session mapping (#215).
 
@@ -242,7 +233,6 @@ async def bind_chat(
     from the requested one if a concurrent writer landed first or the
     supervisor pre-populated it via per_chat spawn).
     """
-    account_id, _, _ = _auth
     return await service.bind_chat_to_session(
         pool, connection_id, chat_id=body.chat_id, session_id=body.session_id, account_id=account_id
     )
@@ -253,21 +243,23 @@ async def bind_chat(
     operation_id="unbind_chat",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def unbind_chat(connection_id: str, chat_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+async def unbind_chat(
+    connection_id: str, chat_id: str, pool: PoolDep, account_id: AccountIdDep
+) -> None:
     """Drop the operator-curated row.  Idempotent — repeat calls 204."""
-    account_id, _, _ = _auth
     await service.unbind_chat(pool, connection_id, chat_id, account_id=account_id)
 
 
 @router.get("/{connection_id}/bound-chats", operation_id="list_bound_chats")
-async def bound_chats(connection_id: str, pool: PoolDep, _auth: AuthDep) -> ListResponse[BoundChat]:
+async def bound_chats(
+    connection_id: str, pool: PoolDep, account_id: AccountIdDep
+) -> ListResponse[BoundChat]:
     """List operator-curated chat → session bindings on this connection.
 
     Includes both manually-bound rows (via ``bind_chat``) and per_chat
     auto-spawned rows (via the supervisor on first inbound from a new
     chat partner).
     """
-    account_id, _, _ = _auth
     items = await service.list_bound_chats(pool, connection_id, account_id=account_id)
     return ListResponse[BoundChat](data=items)
 
@@ -276,7 +268,7 @@ async def bound_chats(connection_id: str, pool: PoolDep, _auth: AuthDep) -> List
 async def recent_chats(
     connection_id: str,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
 ) -> ListResponse[RecentChat]:
     """List chats that recently sent inbound on this connection, newest first.
@@ -285,6 +277,5 @@ async def recent_chats(
     enumerates the conversational counterparts that the connector has
     delivered messages from.
     """
-    account_id, _, _ = _auth
     items = await service.list_recent_chats(pool, connection_id, limit=limit, account_id=account_id)
     return ListResponse[RecentChat](data=items)

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel, ConfigDict
 from sse_starlette import EventSourceResponse
 
 from aios.api.deps import (
-    AuthDep,
+    AccountIdDep,
     CryptoBoxDep,
     DbUrlDep,
     PoolDep,
@@ -600,7 +600,7 @@ async def post_signal_register(
     body: SignalRegisterRequest,
     db_url: DbUrlDep,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> SignalRegisterResponse:
     """Initiate signal-cli ``register`` for ``account``.
 
@@ -608,7 +608,6 @@ async def post_signal_register(
     browser, repost with ``captcha=<token>``.  On success: SMS (or voice
     call with ``voice=true``) carrying a 6-digit code for ``verify``.
     """
-    account_id, _, _ = _auth
     result = await _signal_management_call(
         db_url,
         pool,
@@ -637,7 +636,7 @@ async def post_signal_verify(
     body: SignalVerifyRequest,
     db_url: DbUrlDep,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> SignalVerifyResponse:
     """Submit the SMS / voice verification code.
 
@@ -645,7 +644,6 @@ async def post_signal_verify(
     running connector picks it up on the next ``verify_phone`` call
     without restart.
     """
-    account_id, _, _ = _auth
     result = await _signal_management_call(
         db_url,
         pool,
@@ -668,11 +666,10 @@ async def post_signal_profile(
     body: SignalProfileRequest,
     db_url: DbUrlDep,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> None:
     """Update ``given_name`` / ``family_name`` / ``about``.  Avatar bytes
     are not supported in v1 (no operator→container file staging surface)."""
-    account_id, _, _ = _auth
     await _signal_management_call(
         db_url,
         pool,

--- a/src/aios/api/routers/environments.py
+++ b/src/aios/api/routers/environments.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Query, status
 
-from aios.api.deps import AuthDep, PoolDep
+from aios.api.deps import AccountIdDep, PoolDep
 from aios.models.common import ListResponse
 from aios.models.environments import Environment, EnvironmentCreate, EnvironmentUpdate
 from aios.services import environments as service
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/v1/environments", tags=["environments"])
 
 
 @router.post("", operation_id="create_environment", status_code=status.HTTP_201_CREATED)
-async def create(body: EnvironmentCreate, pool: PoolDep, _auth: AuthDep) -> Environment:
+async def create(body: EnvironmentCreate, pool: PoolDep, account_id: AccountIdDep) -> Environment:
     """Create a new environment — a reusable sandbox configuration template.
 
     The ``config`` field describes the container the sessions running this
@@ -23,7 +23,6 @@ async def create(body: EnvironmentCreate, pool: PoolDep, _auth: AuthDep) -> Envi
     base image). Sessions reference environments by id; multiple sessions
     can share one environment.
     """
-    account_id, _, _ = _auth
     return await service.create_environment(
         pool, name=body.name, config=body.config, account_id=account_id
     )
@@ -32,7 +31,7 @@ async def create(body: EnvironmentCreate, pool: PoolDep, _auth: AuthDep) -> Envi
 @router.get("", operation_id="list_environments")
 async def list_(
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[Environment]:
@@ -40,21 +39,19 @@ async def list_(
 
     Cursor pagination via ``after``.
     """
-    account_id, _, _ = _auth
     items = await service.list_environments(pool, limit=limit, after=after, account_id=account_id)
     return ListResponse[Environment].paginate(items, limit, cursor=lambda x: x.id)
 
 
 @router.get("/{env_id}", operation_id="get_environment")
-async def get(env_id: str, pool: PoolDep, _auth: AuthDep) -> Environment:
+async def get(env_id: str, pool: PoolDep, account_id: AccountIdDep) -> Environment:
     """Fetch one environment by id."""
-    account_id, _, _ = _auth
     return await service.get_environment(pool, env_id, account_id=account_id)
 
 
 @router.put("/{env_id}", operation_id="update_environment")
 async def update(
-    env_id: str, body: EnvironmentUpdate, pool: PoolDep, _auth: AuthDep
+    env_id: str, body: EnvironmentUpdate, pool: PoolDep, account_id: AccountIdDep
 ) -> Environment:
     """Update an environment's ``name`` and/or ``config``.
 
@@ -63,7 +60,6 @@ async def update(
     container), so updates take effect for existing sessions on their next
     provision rather than at update time.
     """
-    account_id, _, _ = _auth
     return await service.update_environment(
         pool, env_id, name=body.name, config=body.config, account_id=account_id
     )
@@ -72,12 +68,11 @@ async def update(
 @router.delete(
     "/{env_id}", operation_id="archive_environment", status_code=status.HTTP_204_NO_CONTENT
 )
-async def archive(env_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+async def archive(env_id: str, pool: PoolDep, account_id: AccountIdDep) -> None:
     """Archive an environment: hides from default lists, leaves the row in place.
 
     Sessions referencing the archived environment continue to function — the
     sandbox provisioner reads the config by JOIN and does not filter by
     archive state. There is no API surface to un-archive currently.
     """
-    account_id, _, _ = _auth
     await service.archive_environment(pool, env_id, account_id=account_id)

--- a/src/aios/api/routers/memory_stores.py
+++ b/src/aios/api/routers/memory_stores.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Query, status
 
-from aios.api.deps import AuthDep, PoolDep
+from aios.api.deps import AccountIdDep, PoolDep
 from aios.models.common import ListResponse
 from aios.models.memory_stores import (
     Memory,
@@ -27,14 +27,15 @@ router = APIRouter(prefix="/v1/memory-stores", tags=["memory-stores"])
 
 
 @router.post("", operation_id="create_memory_store", status_code=status.HTTP_201_CREATED)
-async def create_store(body: MemoryStoreCreate, pool: PoolDep, _auth: AuthDep) -> MemoryStore:
+async def create_store(
+    body: MemoryStoreCreate, pool: PoolDep, account_id: AccountIdDep
+) -> MemoryStore:
     """Create a new memory store — a named collection of file-like memories.
 
     Memories created in this store are mirrored to a per-store host
     directory so that sessions referencing the store can read them through
     the sandbox filesystem.
     """
-    account_id, _, _ = _auth
     return await service.create_store(
         pool,
         name=body.name,
@@ -47,7 +48,7 @@ async def create_store(body: MemoryStoreCreate, pool: PoolDep, _auth: AuthDep) -
 @router.get("", operation_id="list_memory_stores")
 async def list_stores(
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     include_archived: bool = False,
     limit: Annotated[int, Query(ge=1, le=200)] = 100,
     after: str | None = None,
@@ -59,7 +60,6 @@ async def list_stores(
     ``after`` from a previous response's ``next_after`` to get the next
     page. The default limit is 100 since stores are typically few.
     """
-    account_id, _, _ = _auth
     items = await service.list_stores(
         pool,
         include_archived=include_archived,
@@ -71,15 +71,14 @@ async def list_stores(
 
 
 @router.get("/{store_id}", operation_id="get_memory_store")
-async def get_store(store_id: str, pool: PoolDep, _auth: AuthDep) -> MemoryStore:
+async def get_store(store_id: str, pool: PoolDep, account_id: AccountIdDep) -> MemoryStore:
     """Fetch one memory store by id."""
-    account_id, _, _ = _auth
     return await service.get_store(pool, store_id, account_id=account_id)
 
 
 @router.post("/{store_id}", operation_id="update_memory_store")
 async def update_store(
-    store_id: str, body: MemoryStoreUpdate, pool: PoolDep, _auth: AuthDep
+    store_id: str, body: MemoryStoreUpdate, pool: PoolDep, account_id: AccountIdDep
 ) -> MemoryStore:
     """Update a memory store's ``name``, ``description``, or ``metadata``.
 
@@ -87,7 +86,6 @@ async def update_store(
     archived stores are read-only. Treat as partial update on the listed
     fields.
     """
-    account_id, _, _ = _auth
     return await service.update_store(
         pool,
         store_id,
@@ -103,7 +101,7 @@ async def update_store(
     operation_id="archive_memory_store",
     openapi_extra={"x-codegen": {"mcp": {"destructiveHint": True}}},
 )
-async def archive_store(store_id: str, pool: PoolDep, _auth: AuthDep) -> MemoryStore:
+async def archive_store(store_id: str, pool: PoolDep, account_id: AccountIdDep) -> MemoryStore:
     """Archive a memory store: hides from default lists, makes it read-only.
 
     The store and its memories persist; sessions can still resolve memory
@@ -111,7 +109,6 @@ async def archive_store(store_id: str, pool: PoolDep, _auth: AuthDep) -> MemoryS
     un-archived (no API surface for that currently). Use
     ``delete_memory_store`` for full removal.
     """
-    account_id, _, _ = _auth
     return await service.archive_store(pool, store_id, account_id=account_id)
 
 
@@ -120,7 +117,7 @@ async def archive_store(store_id: str, pool: PoolDep, _auth: AuthDep) -> MemoryS
     operation_id="delete_memory_store",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def delete_store(store_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+async def delete_store(store_id: str, pool: PoolDep, account_id: AccountIdDep) -> None:
     """Hard-delete a memory store, all its memories, and its host mirror.
 
     Cascade-deletes memories and versions in the database. After the DB
@@ -128,7 +125,6 @@ async def delete_store(store_id: str, pool: PoolDep, _auth: AuthDep) -> None:
     (best-effort — a missing dir is fine, indicates no session ever
     provisioned for this store). Returns 204.
     """
-    account_id, _, _ = _auth
     await service.delete_store(pool, store_id, account_id=account_id)
 
 
@@ -140,14 +136,15 @@ async def delete_store(store_id: str, pool: PoolDep, _auth: AuthDep) -> None:
     operation_id="create_memory",
     status_code=status.HTTP_201_CREATED,
 )
-async def create_memory(store_id: str, body: MemoryCreate, pool: PoolDep, _auth: AuthDep) -> Memory:
+async def create_memory(
+    store_id: str, body: MemoryCreate, pool: PoolDep, account_id: AccountIdDep
+) -> Memory:
     """Create a memory at the given path within a store.
 
     The content is also mirrored to the store's host directory so that
     sandboxed sessions can read it through the filesystem. Creates an
     initial version (every memory mutation creates a version).
     """
-    account_id, _, _ = _auth
     return await service.create_memory(
         pool,
         store_id=store_id,
@@ -162,7 +159,7 @@ async def create_memory(store_id: str, body: MemoryCreate, pool: PoolDep, _auth:
 async def list_memories(
     store_id: str,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     path_prefix: str | None = None,
     order_by: str = "created_at",
     depth: int | None = None,
@@ -178,7 +175,6 @@ async def list_memories(
     fetch (cursor pagination not yet supported; use ``path_prefix`` to
     narrow scope when a store has thousands of memories).
     """
-    account_id, _, _ = _auth
     items = await service.list_memories(
         pool,
         store_id,
@@ -198,9 +194,10 @@ async def list_memories(
 
 
 @router.get("/{store_id}/memories/{memory_id}", operation_id="get_memory")
-async def get_memory(store_id: str, memory_id: str, pool: PoolDep, _auth: AuthDep) -> Memory:
+async def get_memory(
+    store_id: str, memory_id: str, pool: PoolDep, account_id: AccountIdDep
+) -> Memory:
     """Fetch one memory by id, including its current content."""
-    account_id, _, _ = _auth
     return await service.get_memory(
         pool, store_id, memory_id, include_content=True, account_id=account_id
     )
@@ -212,7 +209,7 @@ async def update_memory(
     memory_id: str,
     body: MemoryUpdate,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> Memory:
     """Update a memory's content and/or path. Creates a new version.
 
@@ -222,7 +219,6 @@ async def update_memory(
     mirror is updated to match: renames delete the old path and write the
     new one.
     """
-    account_id, _, _ = _auth
     return await service.update_memory(
         pool,
         store_id=store_id,
@@ -242,14 +238,15 @@ async def update_memory(
     operation_id="delete_memory",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def delete_memory(store_id: str, memory_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+async def delete_memory(
+    store_id: str, memory_id: str, pool: PoolDep, account_id: AccountIdDep
+) -> None:
     """Soft-delete a memory and remove it from the host mirror.
 
     Sets ``deleted_at`` on the memory and appends a ``deleted`` tombstone
     version. The row and version history persist; live reads filter on
     ``deleted_at IS NULL`` so the memory becomes invisible. Returns 204.
     """
-    account_id, _, _ = _auth
     await service.delete_memory(
         pool,
         store_id=store_id,
@@ -266,7 +263,7 @@ async def delete_memory(store_id: str, memory_id: str, pool: PoolDep, _auth: Aut
 async def list_versions(
     store_id: str,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     memory_id: str | None = None,
     limit: Annotated[int, Query(ge=1, le=200)] = 100,
 ) -> ListResponse[MemoryVersion]:
@@ -276,7 +273,6 @@ async def list_versions(
     Without the filter, returns versions across all memories in the store
     (useful for audit). No cursor pagination; bumps default limit to 100.
     """
-    account_id, _, _ = _auth
     items = await service.list_versions(
         pool, store_id, memory_id=memory_id, limit=limit, account_id=account_id
     )
@@ -285,10 +281,9 @@ async def list_versions(
 
 @router.get("/{store_id}/memory-versions/{version_id}", operation_id="get_memory_version")
 async def get_version(
-    store_id: str, version_id: str, pool: PoolDep, _auth: AuthDep
+    store_id: str, version_id: str, pool: PoolDep, account_id: AccountIdDep
 ) -> MemoryVersion:
     """Fetch one historical memory version by id."""
-    account_id, _, _ = _auth
     return await service.get_version(pool, store_id, version_id, account_id=account_id)
 
 
@@ -298,7 +293,7 @@ async def get_version(
     openapi_extra={"x-codegen": {"mcp": {"destructiveHint": True}}},
 )
 async def redact_version(
-    store_id: str, version_id: str, pool: PoolDep, _auth: AuthDep
+    store_id: str, version_id: str, pool: PoolDep, account_id: AccountIdDep
 ) -> MemoryVersion:
     """Redact the content of a historical memory version in place.
 
@@ -307,7 +302,6 @@ async def redact_version(
     previously written into a memory. Live memory content is unaffected
     (only this specific historical version is redacted).
     """
-    account_id, _, _ = _auth
     return await service.redact_version(
         pool,
         store_id=store_id,

--- a/src/aios/api/routers/runtime_tokens.py
+++ b/src/aios/api/routers/runtime_tokens.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, status
 
-from aios.api.deps import AuthDep, PoolDep
+from aios.api.deps import AccountIdDep, PoolDep
 from aios.models.common import ListResponse
 from aios.models.runtime_tokens import (
     RuntimeToken,
@@ -25,7 +25,9 @@ router = APIRouter(prefix="/v1/runtime-tokens", tags=["runtime-tokens"])
 
 
 @router.post("", operation_id="issue_runtime_token", status_code=status.HTTP_201_CREATED)
-async def issue(body: RuntimeTokenIssue, pool: PoolDep, _auth: AuthDep) -> RuntimeTokenIssued:
+async def issue(
+    body: RuntimeTokenIssue, pool: PoolDep, account_id: AccountIdDep
+) -> RuntimeTokenIssued:
     """Mint a new bearer token scoped to ``body.connector``.
 
     The plaintext is included in the response and CANNOT be recovered
@@ -35,7 +37,6 @@ async def issue(body: RuntimeTokenIssue, pool: PoolDep, _auth: AuthDep) -> Runti
     to that allowlist of connection IDs; omit to leave the token
     unscoped (sees every connection of ``body.connector`` type).
     """
-    account_id, _, _ = _auth
     token, plaintext = await service.issue(
         pool,
         connector=body.connector,
@@ -57,16 +58,14 @@ async def issue(body: RuntimeTokenIssue, pool: PoolDep, _auth: AuthDep) -> Runti
 async def list_(
     connector: str,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> ListResponse[RuntimeToken]:
     """All tokens (revoked included) for ``connector``, newest first."""
-    account_id, _, _ = _auth
     items = await service.list_tokens(pool, connector=connector, account_id=account_id)
     return ListResponse[RuntimeToken](data=items, has_more=False, next_after=None)
 
 
 @router.post("/{token_id}/revoke", operation_id="revoke_runtime_token")
-async def revoke(token_id: str, pool: PoolDep, _auth: AuthDep) -> RuntimeToken:
+async def revoke(token_id: str, pool: PoolDep, account_id: AccountIdDep) -> RuntimeToken:
     """Soft-delete a token.  Idempotent — re-revoking is a no-op."""
-    account_id, _, _ = _auth
     return await service.revoke(pool, token_id, account_id=account_id)

--- a/src/aios/api/routers/session_templates.py
+++ b/src/aios/api/routers/session_templates.py
@@ -14,7 +14,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Query, status
 
-from aios.api.deps import AuthDep, PoolDep
+from aios.api.deps import AccountIdDep, PoolDep
 from aios.models.common import ListResponse
 from aios.models.session_templates import (
     SessionTemplate,
@@ -27,7 +27,9 @@ router = APIRouter(prefix="/v1/session-templates", tags=["session-templates"])
 
 
 @router.post("", operation_id="create_session_template", status_code=status.HTTP_201_CREATED)
-async def create(body: SessionTemplateCreate, pool: PoolDep, _auth: AuthDep) -> SessionTemplate:
+async def create(
+    body: SessionTemplateCreate, pool: PoolDep, account_id: AccountIdDep
+) -> SessionTemplate:
     """Create a session template — a frozen recipe for per_chat session spawn.
 
     Captures the agent + environment + vaults + memory stores that a
@@ -35,7 +37,6 @@ async def create(body: SessionTemplateCreate, pool: PoolDep, _auth: AuthDep) -> 
     partner. Pin ``agent_version`` to a specific version for deterministic
     spawning, or leave unset to track the agent's latest.
     """
-    account_id, _, _ = _auth
     return await service.create_session_template(
         pool,
         name=body.name,
@@ -52,7 +53,7 @@ async def create(body: SessionTemplateCreate, pool: PoolDep, _auth: AuthDep) -> 
 @router.get("", operation_id="list_session_templates")
 async def list_(
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[SessionTemplate]:
@@ -60,7 +61,6 @@ async def list_(
 
     Cursor pagination via ``after``.
     """
-    account_id, _, _ = _auth
     items = await service.list_session_templates(
         pool, limit=limit, after=after, account_id=account_id
     )
@@ -68,15 +68,14 @@ async def list_(
 
 
 @router.get("/{template_id}", operation_id="get_session_template")
-async def get(template_id: str, pool: PoolDep, _auth: AuthDep) -> SessionTemplate:
+async def get(template_id: str, pool: PoolDep, account_id: AccountIdDep) -> SessionTemplate:
     """Fetch one session template by id."""
-    account_id, _, _ = _auth
     return await service.get_session_template(pool, template_id, account_id=account_id)
 
 
 @router.put("/{template_id}", operation_id="update_session_template")
 async def update(
-    template_id: str, body: SessionTemplateUpdate, pool: PoolDep, _auth: AuthDep
+    template_id: str, body: SessionTemplateUpdate, pool: PoolDep, account_id: AccountIdDep
 ) -> SessionTemplate:
     """Update a session template's recipe fields. Omitted fields are preserved.
 
@@ -85,7 +84,6 @@ async def update(
     pass null to switch to "track latest," pass a number to pin to that
     specific version. Already-spawned sessions are unaffected.
     """
-    account_id, _, _ = _auth
     return await service.update_session_template(
         pool,
         template_id,
@@ -105,7 +103,7 @@ async def update(
     operation_id="archive_session_template",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def delete(template_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+async def delete(template_id: str, pool: PoolDep, account_id: AccountIdDep) -> None:
     """Archive a session template (soft-delete via DELETE verb).
 
     Already-spawned sessions are unaffected and continue normally. Per-chat
@@ -114,5 +112,4 @@ async def delete(template_id: str, pool: PoolDep, _auth: AuthDep) -> None:
     handler until the connection is reconfigured to point at a different
     template. There is no API surface to un-archive currently.
     """
-    account_id, _, _ = _auth
     await service.archive_session_template(pool, template_id, account_id=account_id)

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, File, Query, UploadFile, status
 from sse_starlette import EventSourceResponse
 
 from aios.api.deps import (
-    AuthDep,
+    AccountIdDep,
     CryptoBoxDep,
     DbUrlDep,
     PoolDep,
@@ -64,9 +64,8 @@ async def create(
     pool: PoolDep,
     procrastinate: ProcrastinateDep,
     crypto_box: CryptoBoxDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> Session:
-    account_id, _, _ = _auth
     session = await service.create_session(
         pool,
         agent_id=body.agent_id,
@@ -93,7 +92,7 @@ async def create(
 @router.get("", operation_id="list_sessions")
 async def list_(
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     agent_id: str | None = None,
     status_filter: Annotated[
         SessionStatus | None,
@@ -102,7 +101,6 @@ async def list_(
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[Session]:
-    account_id, _, _ = _auth
     items = await service.list_sessions(
         pool,
         agent_id=agent_id,
@@ -115,8 +113,7 @@ async def list_(
 
 
 @router.get("/{session_id}", operation_id="get_session")
-async def get(session_id: str, pool: PoolDep, _auth: AuthDep) -> Session:
-    account_id, _, _ = _auth
+async def get(session_id: str, pool: PoolDep, account_id: AccountIdDep) -> Session:
     return await service.get_session(pool, session_id, account_id=account_id)
 
 
@@ -126,9 +123,8 @@ async def update(
     body: SessionUpdate,
     pool: PoolDep,
     crypto_box: CryptoBoxDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> Session:
-    account_id, _, _ = _auth
 
     # Use model_fields_set to distinguish "not provided" from "explicitly null".
     # agent_version=null means "latest" (auto-updating); omitted means "keep current".
@@ -148,7 +144,7 @@ async def update(
 
 @router.get("/{session_id}/resources", operation_id="list_session_resources")
 async def list_resources(
-    session_id: str, pool: PoolDep, _auth: AuthDep
+    session_id: str, pool: PoolDep, account_id: AccountIdDep
 ) -> ListResponse[SessionResourceEcho]:
     """List all resources attached to ``session_id``.
 
@@ -157,7 +153,6 @@ async def list_resources(
     Equivalent to reading the ``resources`` field on the full session
     record, but cheaper if you don't need anything else.
     """
-    account_id, _, _ = _auth
     # Reuse get_session for ordering + echo construction; resources are
     # already on the returned record.
     session = await service.get_session(pool, session_id, account_id=account_id)
@@ -166,7 +161,7 @@ async def list_resources(
 
 @router.get("/{session_id}/resources/{resource_id}", operation_id="get_session_resource")
 async def get_resource(
-    session_id: str, resource_id: str, pool: PoolDep, _auth: AuthDep
+    session_id: str, resource_id: str, pool: PoolDep, account_id: AccountIdDep
 ) -> GithubRepositoryResourceEcho:
     """Fetch a single resource attached to ``session_id`` by its id.
 
@@ -174,7 +169,6 @@ async def get_resource(
     memory store attachments are keyed by ``(session_id, memory_store_id)``
     and don't have a separate attachment id.
     """
-    account_id, _, _ = _auth
     _require_github_resource_id(resource_id)
     return await github_repo_service.get_resource(
         pool, session_id, resource_id, account_id=account_id
@@ -188,7 +182,7 @@ async def update_resource(
     body: GithubRepositoryUpdate,
     pool: PoolDep,
     crypto_box: CryptoBoxDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> GithubRepositoryResourceEcho:
     """Rotate the auth token on a github_repository attachment.
 
@@ -196,7 +190,6 @@ async def update_resource(
     the next sandbox provision recycles the container and re-clones the
     working tree with the new token.
     """
-    account_id, _, _ = _auth
     _require_github_resource_id(resource_id)
     # Identity is replaced atomically when the caller mentions either
     # field in the payload; absent means preserve the stored values
@@ -244,8 +237,7 @@ def _require_github_resource_id(resource_id: str) -> None:
     operation_id="archive_session",
     openapi_extra={"x-codegen": {"mcp": {"destructiveHint": True}}},
 )
-async def archive(session_id: str, pool: PoolDep, _auth: AuthDep) -> Session:
-    account_id, _, _ = _auth
+async def archive(session_id: str, pool: PoolDep, account_id: AccountIdDep) -> Session:
     return await service.archive_session(pool, session_id, account_id=account_id)
 
 
@@ -258,7 +250,7 @@ async def clone(
     session_id: str,
     body: SessionCloneRequest,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> Session:
     """Clone a session at its current state into a new session.
 
@@ -268,7 +260,6 @@ async def clone(
 
     Refuses if the parent isn't ``idle`` or ``terminated``.
     """
-    account_id, _, _ = _auth
     return await service.clone_session(
         pool, session_id, workspace_path=body.workspace_path, account_id=account_id
     )
@@ -279,8 +270,7 @@ async def clone(
     operation_id="delete_session",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def delete(session_id: str, pool: PoolDep, _auth: AuthDep) -> None:
-    account_id, _, _ = _auth
+async def delete(session_id: str, pool: PoolDep, account_id: AccountIdDep) -> None:
     await service.delete_session(pool, session_id, account_id=account_id)
 
 
@@ -294,9 +284,8 @@ async def post_message(
     body: SessionUserMessage,
     pool: PoolDep,
     procrastinate: ProcrastinateDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> Event:
-    account_id, _, _ = _auth
     metadata = body.metadata or None
     if metadata is not None:
         channel = metadata.get("channel")
@@ -321,10 +310,9 @@ async def interrupt(
     session_id: str,
     body: SessionInterruptRequest,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> Session:
     """Interrupt a running session: cancel all in-flight work and idle it."""
-    account_id, _, _ = _auth
     await service.append_event(
         pool, session_id, "interrupt", {"reason": body.reason}, account_id=account_id
     )
@@ -351,7 +339,7 @@ async def submit_tool_result(
     session_id: str,
     body: ToolResultRequest,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> Event:
     """Submit a custom tool result. Appends a tool-role message and wakes the session.
 
@@ -362,7 +350,6 @@ async def submit_tool_result(
     ``tool_call_id`` has no matching parent assistant tool call, since a
     result with no parent is a client bug that would leave an orphan row.
     """
-    account_id, _, _ = _auth
     async with pool.acquire() as conn:
         event = await service.append_tool_result(
             conn,
@@ -384,7 +371,7 @@ async def submit_tool_result(
 async def upload_file(
     session_id: str,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     file: Annotated[UploadFile, File(description="Bytes to upload into the session workspace.")],
 ) -> FileUploadResponse:
     """Upload a single file into the session's workspace (#324).
@@ -392,7 +379,6 @@ async def upload_file(
     Operator-authenticated.  Files land at a stable host path; the model
     sees them inside the sandbox at ``/mnt/uploads/<file_id>/<filename>``.
     """
-    account_id, _, _ = _auth
     record = await files_service.stage_upload(
         pool, session_id=session_id, upload=file, account_id=account_id
     )
@@ -415,7 +401,7 @@ async def submit_tool_confirmation(
     session_id: str,
     body: ToolConfirmationRequest,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> Event:
     """Confirm or deny an ``always_ask`` built-in tool call.
 
@@ -423,7 +409,6 @@ async def submit_tool_confirmation(
     its next step.  ``deny`` appends a tool-role error event; the model
     sees the denial message and can adapt.
     """
-    account_id, _, _ = _auth
     if body.result == "allow":
         event = await service.confirm_tool_allow(
             pool, session_id, body.tool_call_id, account_id=account_id
@@ -441,7 +426,7 @@ async def submit_tool_confirmation(
 async def list_events(
     session_id: str,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     after: int = 0,
     kind: EventKind | None = None,
     # Higher cap than the standard 200: operators paginate through full
@@ -460,7 +445,6 @@ async def list_events(
     ``?after=`` and got it silently ignored, causing pagination to loop on
     the first page. See issue #389.)
     """
-    account_id, _, _ = _auth
     # Scope check: 404 cross-tenant probes before reading events. The
     # ``read_events`` query also filters by account_id, so this is
     # belt-and-suspenders against a future query that forgets the
@@ -483,7 +467,7 @@ async def list_events(
 async def get_context(
     session_id: str,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> ContextResponse:
     """Return the chat-completions payload the worker would send next.
 
@@ -494,7 +478,6 @@ async def get_context(
     session-status bumps, event appends) are omitted; the endpoint is
     read-only.
     """
-    account_id, _, _ = _auth
     from aios.harness.step_context import compose_step_context, compute_step_prelude
     from aios.harness.tokens import approx_tokens
     from aios.models.agents import Agent, AgentVersion
@@ -567,11 +550,10 @@ async def stream_events(
     session_id: str,
     db_url: DbUrlDep,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     after_seq: int = 0,
 ) -> EventSourceResponse:
     """Stream session events as Server-Sent Events."""
-    account_id, _, _ = _auth
     await service.get_session(pool, session_id, account_id=account_id)
     return EventSourceResponse(
         sse_event_stream(db_url, pool, session_id, after_seq=after_seq),
@@ -584,7 +566,7 @@ async def wait_for_events(
     session_id: str,
     db_url: DbUrlDep,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     after: int = 0,
     timeout_seconds: Annotated[int, Query(alias="timeout", ge=0, le=60)] = 30,
 ) -> WaitResponse:
@@ -599,7 +581,6 @@ async def wait_for_events(
     resume from where you left off. (The query param was previously named
     ``after_seq``; see issue #389.)
     """
-    account_id, _, _ = _auth
     await service.get_session(pool, session_id, account_id=account_id)
 
     async with listen_for_events(db_url, session_id) as queue:

--- a/src/aios/api/routers/skills.py
+++ b/src/aios/api/routers/skills.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Query, status
 
-from aios.api.deps import AuthDep, PoolDep
+from aios.api.deps import AccountIdDep, PoolDep
 from aios.models.common import ListResponse
 from aios.models.skills import Skill, SkillCreate, SkillVersion, SkillVersionCreate
 from aios.services import skills as service
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/v1/skills", tags=["skills"])
 
 
 @router.post("", operation_id="create_skill", status_code=status.HTTP_201_CREATED)
-async def create(body: SkillCreate, pool: PoolDep, _auth: AuthDep) -> Skill:
+async def create(body: SkillCreate, pool: PoolDep, account_id: AccountIdDep) -> Skill:
     """Create a new skill from an uploaded file bundle.
 
     The bundle must include exactly one ``<directory>/SKILL.md`` file with
@@ -26,7 +26,6 @@ async def create(body: SkillCreate, pool: PoolDep, _auth: AuthDep) -> Skill:
     ``directory``, ``name``, and ``description`` are extracted from that
     frontmatter; subsequent versions reuse this extraction.
     """
-    account_id, _, _ = _auth
     skill, _version = await service.create_skill(
         pool, display_title=body.display_title, files=body.files, account_id=account_id
     )
@@ -36,7 +35,7 @@ async def create(body: SkillCreate, pool: PoolDep, _auth: AuthDep) -> Skill:
 @router.get("", operation_id="list_skills")
 async def list_(
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[Skill]:
@@ -44,27 +43,24 @@ async def list_(
 
     Cursor pagination via ``after``.
     """
-    account_id, _, _ = _auth
     items = await service.list_skills(pool, limit=limit, after=after, account_id=account_id)
     return ListResponse[Skill].paginate(items, limit, cursor=lambda x: x.id)
 
 
 @router.get("/{skill_id}", operation_id="get_skill")
-async def get(skill_id: str, pool: PoolDep, _auth: AuthDep) -> Skill:
+async def get(skill_id: str, pool: PoolDep, account_id: AccountIdDep) -> Skill:
     """Fetch one skill by id, returning the latest version's config."""
-    account_id, _, _ = _auth
     return await service.get_skill(pool, skill_id, account_id=account_id)
 
 
 @router.delete("/{skill_id}", operation_id="archive_skill", status_code=status.HTTP_204_NO_CONTENT)
-async def archive(skill_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+async def archive(skill_id: str, pool: PoolDep, account_id: AccountIdDep) -> None:
     """Archive a skill: sets ``archived_at`` and hides it from default lists.
 
     The row and version history persist; agents that reference this skill
     by id continue to resolve their pinned versions. There is no API
     surface to un-archive currently.
     """
-    account_id, _, _ = _auth
     await service.archive_skill(pool, skill_id, account_id=account_id)
 
 
@@ -77,7 +73,7 @@ async def archive(skill_id: str, pool: PoolDep, _auth: AuthDep) -> None:
     status_code=status.HTTP_201_CREATED,
 )
 async def create_version(
-    skill_id: str, body: SkillVersionCreate, pool: PoolDep, _auth: AuthDep
+    skill_id: str, body: SkillVersionCreate, pool: PoolDep, account_id: AccountIdDep
 ) -> SkillVersion:
     """Upload a new immutable version of a skill's file bundle.
 
@@ -86,7 +82,6 @@ async def create_version(
     a complete snapshot — files not present in the upload are not carried
     over from previous versions.
     """
-    account_id, _, _ = _auth
     return await service.create_skill_version(
         pool, skill_id, files=body.files, account_id=account_id
     )
@@ -96,7 +91,7 @@ async def create_version(
 async def list_versions(
     skill_id: str,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: int | None = None,
 ) -> ListResponse[SkillVersion]:
@@ -106,7 +101,6 @@ async def list_versions(
     response's ``next_after`` to get the next page. Each version is a
     complete file-bundle snapshot at the time it was created.
     """
-    account_id, _, _ = _auth
     items = await service.list_skill_versions(
         pool, skill_id, limit=limit, after=after, account_id=account_id
     )
@@ -114,11 +108,12 @@ async def list_versions(
 
 
 @router.get("/{skill_id}/versions/{version}", operation_id="get_skill_version")
-async def get_version(skill_id: str, version: int, pool: PoolDep, _auth: AuthDep) -> SkillVersion:
+async def get_version(
+    skill_id: str, version: int, pool: PoolDep, account_id: AccountIdDep
+) -> SkillVersion:
     """Fetch one historical version's file bundle.
 
     The bundle reflects the skill's state at the time the version was
     written and is unaffected by subsequent versions or archival.
     """
-    account_id, _, _ = _auth
     return await service.get_skill_version(pool, skill_id, version, account_id=account_id)

--- a/src/aios/api/routers/vaults.py
+++ b/src/aios/api/routers/vaults.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Query, status
 
-from aios.api.deps import AuthDep, CryptoBoxDep, PoolDep
+from aios.api.deps import AccountIdDep, CryptoBoxDep, PoolDep
 from aios.models.common import ListResponse
 from aios.models.vaults import (
     Vault,
@@ -25,12 +25,11 @@ router = APIRouter(prefix="/v1/vaults", tags=["vaults"])
 
 
 @router.post("", operation_id="create_vault", status_code=status.HTTP_201_CREATED)
-async def create(body: VaultCreate, pool: PoolDep, _auth: AuthDep) -> Vault:
+async def create(body: VaultCreate, pool: PoolDep, account_id: AccountIdDep) -> Vault:
     """Create a new vault — a named collection for MCP server credentials.
 
     Credentials are added separately via ``create_vault_credential``.
     """
-    account_id, _, _ = _auth
     return await service.create_vault(
         pool, display_name=body.display_name, metadata=body.metadata, account_id=account_id
     )
@@ -39,7 +38,7 @@ async def create(body: VaultCreate, pool: PoolDep, _auth: AuthDep) -> Vault:
 @router.get("", operation_id="list_vaults")
 async def list_(
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[Vault]:
@@ -48,25 +47,24 @@ async def list_(
     Cursor pagination: pass ``after`` from a previous response's
     ``next_after`` to get the next page.
     """
-    account_id, _, _ = _auth
     items = await service.list_vaults(pool, limit=limit, after=after, account_id=account_id)
     return ListResponse[Vault].paginate(items, limit, cursor=lambda x: x.id)
 
 
 @router.get("/{vault_id}", operation_id="get_vault")
-async def get(vault_id: str, pool: PoolDep, _auth: AuthDep) -> Vault:
+async def get(vault_id: str, pool: PoolDep, account_id: AccountIdDep) -> Vault:
     """Fetch one vault by id."""
-    account_id, _, _ = _auth
     return await service.get_vault(pool, vault_id, account_id=account_id)
 
 
 @router.put("/{vault_id}", operation_id="update_vault")
-async def update(vault_id: str, body: VaultUpdate, pool: PoolDep, _auth: AuthDep) -> Vault:
+async def update(
+    vault_id: str, body: VaultUpdate, pool: PoolDep, account_id: AccountIdDep
+) -> Vault:
     """Update a vault's ``display_name`` and/or ``metadata``.
 
     Omitted fields are preserved.
     """
-    account_id, _, _ = _auth
     return await service.update_vault(
         pool,
         vault_id,
@@ -81,7 +79,7 @@ async def update(vault_id: str, body: VaultUpdate, pool: PoolDep, _auth: AuthDep
     operation_id="archive_vault",
     openapi_extra={"x-codegen": {"mcp": {"destructiveHint": True}}},
 )
-async def archive(vault_id: str, pool: PoolDep, _auth: AuthDep) -> Vault:
+async def archive(vault_id: str, pool: PoolDep, account_id: AccountIdDep) -> Vault:
     """Archive a vault and **purge the encrypted secret material** of its credentials.
 
     Sets ``archived_at`` and hides the vault from default lists. In the same
@@ -92,19 +90,17 @@ async def archive(vault_id: str, pool: PoolDep, _auth: AuthDep) -> Vault:
 
     Use ``delete_vault`` instead if you want to remove the rows entirely.
     """
-    account_id, _, _ = _auth
     return await service.archive_vault(pool, vault_id, account_id=account_id)
 
 
 @router.delete("/{vault_id}", operation_id="delete_vault", status_code=status.HTTP_204_NO_CONTENT)
-async def delete(vault_id: str, pool: PoolDep, _auth: AuthDep) -> None:
+async def delete(vault_id: str, pool: PoolDep, account_id: AccountIdDep) -> None:
     """Hard-delete a vault and all its credentials (``ON DELETE CASCADE``).
 
     Returns 204. Unlike ``archive_vault``, this removes the rows entirely
     and leaves no audit trail. Prefer archive unless you specifically need
     the rows gone.
     """
-    account_id, _, _ = _auth
     await service.delete_vault(pool, vault_id, account_id=account_id)
 
 
@@ -121,7 +117,7 @@ async def create_credential(
     body: VaultCredentialCreate,
     pool: PoolDep,
     crypto_box: CryptoBoxDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> VaultCredential:
     """Add a credential to a vault. Secrets are encrypted at rest via the CryptoBox.
 
@@ -132,7 +128,6 @@ async def create_credential(
     ``target_url`` is immutable after creation — to retarget a credential,
     archive the existing one and create a new credential at the new URL.
     """
-    account_id, _, _ = _auth
     return await service.create_vault_credential(
         pool, crypto_box, vault_id=vault_id, body=body, account_id=account_id
     )
@@ -142,7 +137,7 @@ async def create_credential(
 async def list_credentials(
     vault_id: str,
     pool: PoolDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     after: str | None = None,
 ) -> ListResponse[VaultCredential]:
@@ -151,7 +146,6 @@ async def list_credentials(
     Cursor pagination via ``after``. Secret material is never returned —
     only metadata (display name, target_url, auth_type, timestamps).
     """
-    account_id, _, _ = _auth
     items = await service.list_vault_credentials(
         pool, vault_id, limit=limit, after=after, account_id=account_id
     )
@@ -160,14 +154,13 @@ async def list_credentials(
 
 @router.get("/{vault_id}/credentials/{credential_id}", operation_id="get_vault_credential")
 async def get_credential(
-    vault_id: str, credential_id: str, pool: PoolDep, _auth: AuthDep
+    vault_id: str, credential_id: str, pool: PoolDep, account_id: AccountIdDep
 ) -> VaultCredential:
     """Fetch one credential's metadata. Secrets are never returned.
 
     Internal MCP clients resolve the secret directly through the service
     layer (with OAuth refresh as needed); the HTTP API never exposes it.
     """
-    account_id, _, _ = _auth
     return await service.get_vault_credential(pool, vault_id, credential_id, account_id=account_id)
 
 
@@ -178,7 +171,7 @@ async def update_credential(
     body: VaultCredentialUpdate,
     pool: PoolDep,
     crypto_box: CryptoBoxDep,
-    _auth: AuthDep,
+    account_id: AccountIdDep,
 ) -> VaultCredential:
     """Update a credential's metadata and/or rotate its auth secrets.
 
@@ -188,7 +181,6 @@ async def update_credential(
     only the new ``refresh_token`` (and optional ``access_token`` /
     ``expires_at``); other auth fields stay intact.
     """
-    account_id, _, _ = _auth
     return await service.update_vault_credential(
         pool,
         crypto_box,
@@ -205,7 +197,7 @@ async def update_credential(
     openapi_extra={"x-codegen": {"mcp": {"destructiveHint": True}}},
 )
 async def archive_credential(
-    vault_id: str, credential_id: str, pool: PoolDep, _auth: AuthDep
+    vault_id: str, credential_id: str, pool: PoolDep, account_id: AccountIdDep
 ) -> VaultCredential:
     """Archive a credential and **zero its encrypted secret payload**.
 
@@ -213,7 +205,6 @@ async def archive_credential(
     encrypted blob is scrubbed at archive time so a future DB dump cannot
     leak the secret. Use ``delete_vault_credential`` for full removal.
     """
-    account_id, _, _ = _auth
     return await service.archive_vault_credential(
         pool, vault_id, credential_id, account_id=account_id
     )
@@ -225,7 +216,7 @@ async def archive_credential(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_credential(
-    vault_id: str, credential_id: str, pool: PoolDep, _auth: AuthDep
+    vault_id: str, credential_id: str, pool: PoolDep, account_id: AccountIdDep
 ) -> None:
     """Hard-delete a credential row. Returns 204.
 
@@ -233,5 +224,4 @@ async def delete_credential(
     leaves no audit trail. Prefer archive unless you specifically need the
     row gone.
     """
-    account_id, _, _ = _auth
     await service.delete_vault_credential(pool, vault_id, credential_id, account_id=account_id)


### PR DESCRIPTION
## Summary

- 10 non-accounts routers paid an `account_id, _, _ = _auth` tax on every endpoint, discarding `key_id` and `can_mint_children` they never used. **88 sites** carried this pattern.
- Introduce `AccountIdDep = Annotated[str, Depends(get_account_id)]` in `src/aios/api/deps.py`. The helper chains over `require_bearer_auth` and returns just the `account_id`; FastAPI per-request caches the upstream call so no auth work runs twice.
- Convert all 88 sites to `account_id: AccountIdDep`, deleting both the `_auth: AuthDep` parameter alias and the destructure line.
- `accounts.py` keeps `AuthDep` — it audit-logs `key_id` and branches on `can_mint_children`. `RuntimeAuthDep` untouched.

Net **+137 / -186 = -49 LOC**. Pure mechanical conversion; no behavior change.

## Why this matters

The discard `_, _` pattern was a small reading-tax at every endpoint, and the kind of thing that grows. 88 sites is well past the abstraction threshold; the new dep (1 helper + 1 alias = ~15 lines in `deps.py`) buys 88 site simplifications and signatures that name what they need.

Aligned with `feedback_phase_a_pile_onto_one_pr.md` — route hygiene piled into one substantial PR rather than per-router.

## Test plan

- [x] \`uv run mypy src\` — clean (155 files)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1401 passed
- [ ] CI: full test matrix (incl. e2e/integration)

## Review notes

Code review (\`pr-review-toolkit:code-reviewer\`) returned **no findings at or above sev 80, no findings at all**. Verifications:
- Auth semantics preserved: same \`require_bearer_auth\` upstream, same \`UnauthorizedError\` on missing/invalid/revoked, timing-uniform 401 message inherited.
- FastAPI per-request caching of \`Depends(require_bearer_auth)\` ensures no per-request auth work runs twice.
- \`accounts.py\` correctly keeps \`AuthDep\` (only legitimate full-tuple consumer).
- \`connectors.py\` runtime routes correctly keep \`RuntimeAuthDep\`.
- No Pydantic body model has an \`account_id\` field that could collide.
- No path/query param \`account_id\` in any converted route.
- No leftover \`_auth\` or \`account_id, _, _ = _auth\` references outside \`accounts.py\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)