### PR TITLE
fix(db/queries): preserve focal_locked on session clone

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1163,8 +1163,13 @@ async def clone_session(
 
     The clone inherits ``agent_id``, ``environment_id``, ``agent_version``,
     ``title``, ``metadata``, ``env``, vault bindings, ``last_event_seq``,
-    ``status``, ``stop_reason``, and ``focal_channel`` so its next forward
-    step sees a context byte-identical to the parent's at clone time.
+    ``status``, ``stop_reason``, ``focal_channel``, and ``focal_locked``
+    so its next forward step sees a context byte-identical to the
+    parent's at clone time.  ``focal_locked`` MUST follow ``focal_channel``
+    on the clone path: a per_chat parent (``focal_locked=True``) cloned
+    without its lock would inherit the bound channel but bypass the
+    ``is_session_focal_locked`` gate on ``switch_channel``, letting the
+    clone escape per_chat isolation.
 
     Cumulative ``input_tokens`` / ``output_tokens`` start at 0 — those were
     paid on the parent and shouldn't be double-counted.
@@ -1212,11 +1217,11 @@ async def clone_session(
             INSERT INTO sessions (
                 id, agent_id, environment_id, agent_version, title, metadata,
                 status, stop_reason, workspace_volume_path, env, last_event_seq,
-                focal_channel, account_id
+                focal_channel, focal_locked, account_id
             )
             SELECT $1, agent_id, environment_id, agent_version, title, metadata,
                    status, stop_reason, $2, env, last_event_seq, focal_channel,
-                   account_id
+                   focal_locked, account_id
               FROM sessions WHERE id = $3
             RETURNING *
             """,

--- a/tests/integration/test_clone_preserves_focal_locked.py
+++ b/tests/integration/test_clone_preserves_focal_locked.py
@@ -1,0 +1,96 @@
+"""Integration test: ``clone_session`` must preserve ``focal_locked``.
+
+A clone that inherits ``focal_channel`` without ``focal_locked``
+gives the clone's model a chat binding without the lock that the
+parent's ``switch_channel`` gate relies on — the clone can call
+``switch_channel`` to escape the per_chat isolation the resolver
+established on the parent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(params=["telegram/bot/chat1", None], ids=["with-channel", "no-channel"])
+async def focal_locked_parent(
+    request: pytest.FixtureRequest, migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str | None]]:
+    """Yield ``(pool, account_id, parent_session_id, parent_focal_channel)``
+    for an idle parent created with ``focal_locked=True``.
+
+    Parametrized over channel presence so the test pins the invariant
+    that lock propagation is by the boolean alone, decoupled from
+    whether ``focal_channel`` is set.
+    """
+    parent_focal_channel: str | None = request.param
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_clone_focal', NULL, TRUE, 'clone-focal-locked-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_clone_focal",
+            name="clone-focal-test",
+            model="openrouter/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_clone_focal", name="clone-focal-env"
+        )
+        parent = await sessions_service.create_session(
+            pool,
+            account_id="acc_clone_focal",
+            agent_id=agent.id,
+            environment_id=env.id,
+            agent_version=agent.version,
+            title="per-chat-parent",
+            metadata={},
+            focal_channel=parent_focal_channel,
+            focal_locked=True,
+        )
+        # Pin the fixture so a green test cannot be due to the parent
+        # itself never being locked in the first place.
+        assert parent.focal_locked is True
+        assert parent.focal_channel == parent_focal_channel
+        yield pool, "acc_clone_focal", parent.id, parent_focal_channel
+    finally:
+        await pool.close()
+
+
+async def test_clone_preserves_focal_locked(
+    focal_locked_parent: tuple[asyncpg.Pool[Any], str, str, str | None],
+) -> None:
+    """A clone of a focal-locked parent must itself be focal-locked.
+
+    Otherwise the clone inherits the bound channel without the lock,
+    and its first ``switch_channel`` call escapes the per_chat
+    isolation the operator (or the resolver) set on the parent.
+    """
+    pool, account_id, parent_id, parent_focal_channel = focal_locked_parent
+
+    clone = await sessions_service.clone_session(pool, parent_id, account_id=account_id)
+
+    assert clone.focal_channel == parent_focal_channel
+    assert clone.focal_locked is True


### PR DESCRIPTION
## Summary

- ``clone_session``'s ``INSERT INTO sessions ... SELECT FROM sessions`` carried every focal-related column EXCEPT ``focal_locked`` — the new row's ``focal_locked`` defaulted to FALSE.  Cloning a per_chat session (``focal_locked=TRUE``, ``focal_channel='telegram/...'``) produced a clone that inherited the bound channel but DROPPED the lock.  The clone's model then bypassed the ``switch_channel`` gate (``tools/switch_channel.py:121`` calls ``is_session_focal_locked``, which returns FALSE for the unlocked clone) and could escape its bound chat — a per-chat-session isolation bypass.
- The lock has no UPDATE path anywhere in the codebase (only INSERTs and SELECTs reference ``focal_locked``); the clone propagation was the only code path through which a focal_locked-True parent could yield a focal_locked-False session, so the fix is complete for this defect class.
- Fix: add ``focal_locked`` to the INSERT column list and the SELECT clause; symmetric with ``insert_session``, which already writes the column.  Docstring expanded to spell out why the column is load-bearing for the security gate.

## Out-of-scope sibling defects (file follow-ups before next clone-shape PR)

- ``clone_session`` does not copy ``session_memory_stores`` or ``session_github_repositories`` — both tables predate the clone primitive but the INSERT/SELECT was never extended to them; clones of sessions with memory or github resources start with empty resource sets and the response reports ``resources: []`` instead of mirroring the parent.  Reviewer-discovered correctness gap of larger scope than focal_locked; honoring one-bug-per-PR per /bughunt skill rules.
- ``clone_session`` accepts archived parents (status-only refusal at ``queries.py:1208``; no ``archived_at IS NULL`` check); same archive-rejection family as PR #573 / #554 / #547.
- Clone of a per_chat session retains write access to the parent's ``focal_channel`` (outbound message can target the same chat), enabling one-way impersonation even with the lock now preserved.  Acceptable per current clone semantics but worth documenting.

## Test plan

- [x] Type-checker — clean (155 source files)
- [x] Linter + format-check — clean
- [x] Unit suite — 1401 passed
- [x] Integration suite — 55 passed, plus new ``test_clone_preserves_focal_locked`` parametrized over ``with-channel`` / ``no-channel`` to pin that lock propagation is by the boolean alone, decoupled from channel value.
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)