### PR TITLE
refactor(tests): consolidate e2e helpers into tests/helpers/connections.py

### DIFF
--- a/tests/e2e/test_connection_discovery_sse.py
+++ b/tests/e2e/test_connection_discovery_sse.py
@@ -23,26 +23,12 @@ import socket
 from collections.abc import AsyncIterator
 from unittest import mock
 
-import httpx
 import pytest
 import uvicorn
 
 from aios_sdk import Client, stream_connection_discovery
 from tests.conftest import needs_docker
-from tests.helpers.connections import authed_client
-
-
-async def _wait_for_health(url: str, *, deadline_s: float = 5.0) -> None:
-    deadline = asyncio.get_running_loop().time() + deadline_s
-    async with httpx.AsyncClient() as client:
-        while True:
-            with contextlib.suppress(httpx.HTTPError):
-                r = await client.get(f"{url}/v1/health", timeout=0.5)
-                if r.status_code < 500:
-                    return
-            if asyncio.get_running_loop().time() >= deadline:
-                raise TimeoutError(f"server at {url} not ready in {deadline_s}s")
-            await asyncio.sleep(0.05)
+from tests.helpers.connections import authed_client, create_connection, wait_for_health
 
 
 @pytest.fixture
@@ -84,7 +70,7 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
         serve_task = asyncio.create_task(_serve())
         try:
             url = f"http://127.0.0.1:{port}"
-            await _wait_for_health(url)
+            await wait_for_health(url)
             yield url
         finally:
             # See test_signal_registration.py for why ``should_exit`` alone
@@ -94,15 +80,6 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
             with contextlib.suppress(asyncio.CancelledError):
                 await serve_task
             await pool.close()
-
-
-async def _create_connection(api_key: str, base_url: str, account: str) -> str:
-    async with authed_client(base_url, api_key) as c:
-        r = await c.post(
-            "/v1/connections", json={"connector": "echo", "external_account_id": account}
-        )
-        r.raise_for_status()
-        return str(r.json()["id"])
 
 
 async def _issue_runtime_token(api_key: str, base_url: str, connector: str) -> str:
@@ -128,7 +105,7 @@ class TestConnectionDiscoverySse:
         api_key = aios_env["AIOS_API_KEY"]
 
         # Pre-existing connection that should show up in backfill.
-        pre_id = await _create_connection(api_key, live_server, "acct-disc-pre")
+        pre_id = await create_connection(api_key, live_server, "acct-disc-pre")
 
         token = await _issue_runtime_token(api_key, live_server, "echo")
 
@@ -177,7 +154,7 @@ class TestConnectionDiscoverySse:
             from aios.services import environments as env_svc
             from aios.services import sessions as sess_svc
 
-            new_id = await _create_connection(api_key, live_server, "acct-disc-new")
+            new_id = await create_connection(api_key, live_server, "acct-disc-new")
             added_id["new_id"] = new_id
 
             from aios.config import get_settings

--- a/tests/e2e/test_echo_http_connector.py
+++ b/tests/e2e/test_echo_http_connector.py
@@ -28,7 +28,7 @@ from aios_echo_http import EchoConnector
 
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness, assistant, last_assistant_content, tool_call
-from tests.helpers.connections import authed_client, issue_runtime_token, wait_for_health
+from tests.helpers.connections import create_connection, issue_runtime_token, wait_for_health
 
 
 @pytest.fixture
@@ -87,15 +87,6 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
             with contextlib.suppress(asyncio.CancelledError):
                 await serve_task
             await pool.close()
-
-
-async def _create_connection(api_key: str, base_url: str, account: str) -> str:
-    async with authed_client(base_url, api_key) as c:
-        r = await c.post(
-            "/v1/connections", json={"connector": "echo", "external_account_id": account}
-        )
-        r.raise_for_status()
-        return str(r.json()["id"])
 
 
 async def _publish_echo_tools_schema(harness: Harness) -> None:
@@ -190,7 +181,7 @@ class TestSdkAgainstLiveServer:
         )
 
         api_key = aios_env["AIOS_API_KEY"]
-        connection_id = await _create_connection(api_key, live_server, f"acct-sse-{id(self)}")
+        connection_id = await create_connection(api_key, live_server, f"acct-sse-{id(self)}")
         await connections_service.attach_connection(
             harness._pool, connection_id, session_id=session.id, account_id=account_id
         )
@@ -283,7 +274,7 @@ class TestEchoHttpConnectorEndToEnd:
         )
 
         api_key = aios_env["AIOS_API_KEY"]
-        connection_id = await _create_connection(api_key, live_server, f"acct-{id(self)}")
+        connection_id = await create_connection(api_key, live_server, f"acct-{id(self)}")
         await connections_service.attach_connection(
             harness._pool, connection_id, session_id=session.id, account_id=account_id
         )
@@ -389,7 +380,7 @@ class TestEchoHttpConnectorEndToEnd:
         )
 
         api_key = aios_env["AIOS_API_KEY"]
-        connection_id = await _create_connection(api_key, live_server, f"acct-i-{id(self)}")
+        connection_id = await create_connection(api_key, live_server, f"acct-i-{id(self)}")
         await connections_service.attach_connection(
             harness._pool, connection_id, session_id=session.id, account_id=account_id
         )

--- a/tests/e2e/test_runtime_token_connection_scope.py
+++ b/tests/e2e/test_runtime_token_connection_scope.py
@@ -19,26 +19,12 @@ import socket
 from collections.abc import AsyncIterator
 from unittest import mock
 
-import httpx
 import pytest
 import uvicorn
 
 from aios_sdk import Client, stream_connection_discovery
 from tests.conftest import needs_docker
-from tests.helpers.connections import authed_client, bearer
-
-
-async def _wait_for_health(url: str, *, deadline_s: float = 5.0) -> None:
-    deadline = asyncio.get_running_loop().time() + deadline_s
-    async with httpx.AsyncClient() as client:
-        while True:
-            with contextlib.suppress(httpx.HTTPError):
-                r = await client.get(f"{url}/v1/health", timeout=0.5)
-                if r.status_code < 500:
-                    return
-            if asyncio.get_running_loop().time() >= deadline:
-                raise TimeoutError(f"server at {url} not ready in {deadline_s}s")
-            await asyncio.sleep(0.05)
+from tests.helpers.connections import authed_client, bearer, create_connection, wait_for_health
 
 
 @pytest.fixture
@@ -82,7 +68,7 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
         serve_task = asyncio.create_task(_serve())
         try:
             url = f"http://127.0.0.1:{port}"
-            await _wait_for_health(url)
+            await wait_for_health(url)
             yield url
         finally:
             await server.shutdown()
@@ -90,15 +76,6 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
             with contextlib.suppress(asyncio.CancelledError):
                 await serve_task
             await pool.close()
-
-
-async def _create_connection(api_key: str, base_url: str, account: str) -> str:
-    async with authed_client(base_url, api_key) as c:
-        r = await c.post(
-            "/v1/connections", json={"connector": "echo", "external_account_id": account}
-        )
-        r.raise_for_status()
-        return str(r.json()["id"])
 
 
 async def _issue_runtime_token(
@@ -168,9 +145,9 @@ class TestRuntimeTokenConnectionScope:
         """Three echo connections A/B/C; scope to [A, B]; backfill must
         emit A and B (in any order) and must NOT emit C."""
         api_key = aios_env["AIOS_API_KEY"]
-        a = await _create_connection(api_key, live_server, "acct-scope-a")
-        b = await _create_connection(api_key, live_server, "acct-scope-b")
-        c = await _create_connection(api_key, live_server, "acct-scope-c")
+        a = await create_connection(api_key, live_server, "acct-scope-a")
+        b = await create_connection(api_key, live_server, "acct-scope-b")
+        c = await create_connection(api_key, live_server, "acct-scope-c")
 
         token = await _issue_runtime_token(api_key, live_server, "echo", connection_ids=[a, b])
 
@@ -188,9 +165,9 @@ class TestRuntimeTokenConnectionScope:
         behaviour: every active connection of the bearer's type is
         emitted in backfill."""
         api_key = aios_env["AIOS_API_KEY"]
-        a = await _create_connection(api_key, live_server, "acct-unscoped-a")
-        b = await _create_connection(api_key, live_server, "acct-unscoped-b")
-        c = await _create_connection(api_key, live_server, "acct-unscoped-c")
+        a = await create_connection(api_key, live_server, "acct-unscoped-a")
+        b = await create_connection(api_key, live_server, "acct-unscoped-b")
+        c = await create_connection(api_key, live_server, "acct-unscoped-c")
 
         token = await _issue_runtime_token(api_key, live_server, "echo")
 

--- a/tests/helpers/connections.py
+++ b/tests/helpers/connections.py
@@ -58,6 +58,20 @@ async def issue_runtime_token(api_key: str, base_url: str, connector: str) -> st
         return str(r.json()["plaintext"])
 
 
+async def create_connection(api_key: str, base_url: str, account: str) -> str:
+    """Create a detached ``echo`` connection scoped to ``account`` (the external_account_id).
+
+    Used by e2e tests that need a fresh connection_id without going
+    through the auto-create-on-first-inbound supervisor path.
+    """
+    async with authed_client(base_url, api_key) as c:
+        r = await c.post(
+            "/v1/connections", json={"connector": "echo", "external_account_id": account}
+        )
+        r.raise_for_status()
+        return str(r.json()["id"])
+
+
 @contextlib.asynccontextmanager
 async def asgi_client(pool: Any) -> AsyncIterator[httpx.AsyncClient]:
     """In-process ``httpx.AsyncClient`` wired to a fresh FastAPI app.


### PR DESCRIPTION
## Summary

- Three e2e files (\`test_connection_discovery_sse.py\`, \`test_runtime_token_connection_scope.py\`, \`test_echo_http_connector.py\`) each had a private byte-identical \`_create_connection(api_key, base_url, account)\`. Two of them re-derived \`_wait_for_health\` from scratch despite a canonical \`wait_for_health\` already living at \`tests/helpers/connections.py:88\`.
- Add \`create_connection\` to the helpers module (next to the existing \`issue_runtime_token\`); replace all five private copies with imports.
- Drop now-unused \`httpx\` and \`authed_client\` imports left over from the private helpers.

Net **+30 / -71 = -41 LOC** across 4 files. Pure consolidation, zero behavior change.

## Why this matters

3 byte-identical \`_create_connection\` definitions clears the "three similar lines is better than premature abstraction" threshold; 2 byte-identical re-derivations of an *existing* helper is textbook broken-windows territory. The fix is small and aligned with the in-codebase pattern (helpers/connections.py already groups by API operation).

## Test plan

- [x] \`uv run mypy src\` — clean (155 files)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1401 passed
- [ ] CI: full e2e matrix (the only suite that exercises these helpers)

## Review notes

Code review (\`pr-review-toolkit:code-reviewer\`) returned **no findings** — explicit "ship as-is" recommendation. Verifications:
- \`wait_for_health\` body in helpers (hoists \`loop = asyncio.get_running_loop()\` once) is functionally identical to the inlined copies (which re-resolved \`asyncio.get_running_loop().time()\` per iteration). \`get_running_loop()\` returns the same loop for the fixture lifetime.
- \`create_connection\` hardcodes \`"connector": "echo"\` to match all 3 call sites byte-for-byte; per the project stance against speculative kwarg surface area.
- All removed imports verified unused after the private-helper removals.

## Deferred (separate iterations)

- \`_issue_runtime_token\` in \`test_runtime_token_connection_scope.py\` has an extra \`connection_ids\` kwarg that the canonical lacks — would need an extension to the helper API.
- \`live_server\` fixture is duplicated across 5 e2e files (~50 LOC each) with a defer_wake-patch-set divergence — bigger lift.
- \`_StubRegistry\` duplicated across 7 unit tests — separate \`tests/helpers/sandbox.py\` move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)