### PR TITLE
refactor(models): share mount-path validator across resource modules

### DIFF
--- a/src/aios/models/_paths.py
+++ b/src/aios/models/_paths.py
@@ -1,10 +1,21 @@
-"""Shared validator for channel-path-like strings.
+"""Shared validators for path-shaped strings.
 
-Used by both inbound-message ``path`` (must be non-empty) and routing-rule
-``prefix`` (may be empty — the per-connection catch-all).
+Two distinct concepts live here:
+
+* :func:`validate_path_segments` — channel-path strings (inbound-message
+  ``path``, routing-rule ``prefix``). May be empty for the per-connection
+  catch-all; rejects ``..`` segments.
+* :data:`ABSOLUTE_PATH_PATTERN` + :func:`check_no_traversal_segments` —
+  absolute mount/memory paths (``MemoryPath``, ``GithubRepositoryResource.
+  mount_path``). Must match the pattern AND have no ``.``/``..`` segments
+  so ``host_dir / path.lstrip("/")`` can't escape the per-resource dir.
 """
 
 from __future__ import annotations
+
+# Absolute, slash-separated path with non-empty non-NUL segments.
+# Used as the Pydantic ``Field(pattern=...)`` for mount-like paths.
+ABSOLUTE_PATH_PATTERN = r"^(/[^/\x00]+)+$"
 
 
 def validate_path_segments(s: str, *, allow_empty: bool) -> None:
@@ -18,3 +29,14 @@ def validate_path_segments(s: str, *, allow_empty: bool) -> None:
             raise ValueError("must not contain empty segments (leading/trailing/doubled '/')")
         if seg == "..":
             raise ValueError("must not contain '..' segments")
+
+
+def check_no_traversal_segments(path: str) -> None:
+    """Reject ``.`` and ``..`` segments in an absolute path.
+
+    Path-traversal guard at the input boundary — without this,
+    ``host_dir / path.lstrip("/")`` could escape the per-resource dir.
+    """
+    for segment in path.lstrip("/").split("/"):
+        if segment in (".", ".."):
+            raise ValueError(f"path segment {segment!r} is not allowed (would enable traversal)")

--- a/src/aios/models/github_repositories.py
+++ b/src/aios/models/github_repositories.py
@@ -19,21 +19,17 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 
+from aios.models._paths import ABSOLUTE_PATH_PATTERN, check_no_traversal_segments
+
 # Cap mirrors memory_stores' MAX_STORES_PER_SESSION. There's no hard
 # resource constraint forcing a low cap; this is a sanity bound that
 # matches the existing aios convention for per-session mountable resources.
 MAX_REPOS_PER_SESSION = 8
 
-# Mount path pattern: absolute path, segments may not be empty/contain NUL.
-# Same shape as ``_MEMORY_PATH_PATTERN`` in models/memory_stores.py.
-_MOUNT_PATH_PATTERN = r"^(/[^/\x00]+)+$"
-
 
 def _check_mount_path(path: str) -> None:
     """Block path-traversal segments and reserved-mount overlaps."""
-    for segment in path.lstrip("/").split("/"):
-        if segment in (".", ".."):
-            raise ValueError(f"path segment {segment!r} is not allowed (would enable traversal)")
+    check_no_traversal_segments(path)
     if path == "/mnt/memory" or path.startswith("/mnt/memory/"):
         raise ValueError("mount_path may not overlap with the /mnt/memory tree (memory stores)")
     if path == "/workspace":
@@ -60,7 +56,7 @@ class GithubRepositoryResource(BaseModel):
 
     type: Literal["github_repository"]
     url: str = Field(min_length=1)
-    mount_path: str = Field(min_length=2, max_length=4096, pattern=_MOUNT_PATH_PATTERN)
+    mount_path: str = Field(min_length=2, max_length=4096, pattern=ABSOLUTE_PATH_PATTERN)
     authorization_token: SecretStr
     git_user_name: str | None = Field(default=None, max_length=256)
     git_user_email: str | None = Field(default=None, max_length=256)

--- a/src/aios/models/memory_stores.py
+++ b/src/aios/models/memory_stores.py
@@ -19,7 +19,8 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-_MEMORY_PATH_PATTERN = r"^(/[^/\x00]+)+$"
+from aios.models._paths import ABSOLUTE_PATH_PATTERN, check_no_traversal_segments
+
 MAX_CONTENT_BYTES = 102400
 MAX_STORES_PER_SESSION = 8
 MAX_INSTRUCTIONS_CHARS = 4096
@@ -73,21 +74,13 @@ MemoryPath = Annotated[
     Field(
         min_length=2,
         max_length=4096,
-        pattern=_MEMORY_PATH_PATTERN,
+        pattern=ABSOLUTE_PATH_PATTERN,
         description=(
             "Absolute, slash-separated path. Segments may not contain / or NUL, "
             "and `.` and `..` are not allowed as segments."
         ),
     ),
 ]
-
-
-def _check_memory_path(path: str) -> None:
-    """Reject `.` and `..` segments. Path-traversal guard at the input boundary —
-    without this, ``host_dir / path.lstrip("/")`` could escape the per-store dir."""
-    for segment in path.lstrip("/").split("/"):
-        if segment in (".", ".."):
-            raise ValueError(f"path segment {segment!r} is not allowed (would enable traversal)")
 
 
 class MemoryCreate(BaseModel):
@@ -100,7 +93,7 @@ class MemoryCreate(BaseModel):
 
     @model_validator(mode="after")
     def _check(self) -> MemoryCreate:
-        _check_memory_path(self.path)
+        check_no_traversal_segments(self.path)
         if len(self.content.encode("utf-8")) > MAX_CONTENT_BYTES:
             raise ValueError(f"content exceeds {MAX_CONTENT_BYTES}-byte cap")
         return self
@@ -136,7 +129,7 @@ class MemoryUpdate(BaseModel):
         if self.content is not None and len(self.content.encode("utf-8")) > MAX_CONTENT_BYTES:
             raise ValueError(f"content exceeds {MAX_CONTENT_BYTES}-byte cap")
         if self.path is not None:
-            _check_memory_path(self.path)
+            check_no_traversal_segments(self.path)
         return self
 
 


### PR DESCRIPTION
## Summary

- \`models/memory_stores.py\` and \`models/github_repositories.py\` each defined the same \`^(/[^/\x00]+)+$\` regex and a near-identical \`_check_*_path\` validator rejecting \`.\`/\`..\` segments. The comment at \`github_repositories.py:28\` literally flagged it: \`# Same shape as _MEMORY_PATH_PATTERN in models/memory_stores.py.\`
- Lift \`ABSOLUTE_PATH_PATTERN\` and \`check_no_traversal_segments(path)\` into \`models/_paths.py\` (which already housed \`validate_path_segments\` for the channel-path family).
- \`github_repositories._check_mount_path\` now calls the shared check then layers its \`/mnt/memory\` / \`/workspace\` reserved-mount guards on top.

## Why this matters

The code itself was asking for this fix. Path-traversal validation is security-adjacent — having two slightly different versions across two resource modules is the kind of duplication that drifts dangerously (one gets an extra check, the other doesn't). Single source of truth removes the drift vector.

## Net LOC (yellow flag, justified)

Diff is **+34 / -23 = +11 LOC** — kaizen rules call net-positive a yellow flag. Justification:
- Additions: expanded module docstring on \`_paths.py\` (~10 LOC explaining the two now-coexisting validators) + the new \`check_no_traversal_segments\` function body.
- Deletions: 2 duplicate \`_*_PATTERN\` constants + 2 duplicate validator bodies + the in-code "Same shape as..." comment.

The "extra" lines are documentation for a security-adjacent module; the function body replaces fragmented inline logic. Net-positive in *value* even if not in raw line count.

## Test plan

- [x] \`uv run mypy src\` — clean (155 files)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1401 passed
- [ ] CI: full e2e matrix

## Review notes

Code review (\`pr-review-toolkit:code-reviewer\`) returned **no findings ≥ 80**. Byte-identical-body verification:
- \`check_no_traversal_segments\` body matches the old \`_check_memory_path\` body verbatim (same iteration, same predicate, same error message).
- \`_check_mount_path\` now calls the shared check first, then preserves both reserved-mount guards (\`/mnt/memory\` overlap and \`/workspace\`) in unchanged order — error precedence preserved.
- \`ABSOLUTE_PATH_PATTERN\` is byte-identical to both old \`_MEMORY_PATH_PATTERN\` and \`_MOUNT_PATH_PATTERN\`.
- Exhaustive grep confirmed zero stale references to the deleted constants/functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)