### PR TITLE
fix(db/queries): propagate memory + github attachments on session clone

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1162,14 +1162,17 @@ async def clone_session(
     """Clone a session into a new one with the same prefix of events.
 
     The clone inherits ``agent_id``, ``environment_id``, ``agent_version``,
-    ``title``, ``metadata``, ``env``, vault bindings, ``last_event_seq``,
+    ``title``, ``metadata``, ``env``, vault bindings, memory-store
+    attachments, github-repository attachments, ``last_event_seq``,
     ``status``, ``stop_reason``, ``focal_channel``, and ``focal_locked``
     so its next forward step sees a context byte-identical to the
     parent's at clone time.  ``focal_locked`` MUST follow ``focal_channel``
     on the clone path: a per_chat parent (``focal_locked=True``) cloned
     without its lock would inherit the bound channel but bypass the
     ``is_session_focal_locked`` gate on ``switch_channel``, letting the
-    clone escape per_chat isolation.
+    clone escape per_chat isolation.  github-repository ``id`` is a
+    global PK so each clone's row is minted fresh; everything else
+    on the attachment rows propagates verbatim.
 
     Cumulative ``input_tokens`` / ``output_tokens`` start at 0 — those were
     paid on the parent and shouldn't be double-counted.
@@ -1236,6 +1239,54 @@ async def clone_session(
             "SELECT $1, vault_id, rank, account_id FROM session_vaults WHERE session_id = $2",
             new_id,
             parent_session_id,
+        )
+
+        # Resource attachments.  ``session_memory_stores`` has a
+        # composite PK so a direct INSERT/SELECT works.
+        # ``session_github_repositories.id`` is a global PK, so each
+        # row needs a fresh ULID minted via the same ordinal-join
+        # pattern the events copy below uses.  Direct INSERT/SELECT
+        # bypasses the archival check the normal attach path enforces
+        # — by design: a clone snapshots the parent's attachment
+        # state at clone time, including references to stores
+        # archived after the parent attached them.
+        await conn.execute(
+            """
+            INSERT INTO session_memory_stores (
+                session_id, memory_store_id, rank, access, instructions,
+                name_at_attach, description_at_attach, account_id
+            )
+            SELECT $1, memory_store_id, rank, access, instructions,
+                   name_at_attach, description_at_attach, account_id
+              FROM session_memory_stores WHERE session_id = $2
+            """,
+            new_id,
+            parent_session_id,
+        )
+        gh_count: int = await conn.fetchval(
+            "SELECT COUNT(*) FROM session_github_repositories WHERE session_id = $1",
+            parent_session_id,
+        )
+        new_gh_ids = [make_id(GITHUB_REPOSITORY) for _ in range(gh_count)]
+        await conn.execute(
+            """
+            INSERT INTO session_github_repositories (
+                id, session_id, rank, repo_url, mount_path,
+                ciphertext, nonce, created_at, updated_at,
+                git_user_name, git_user_email, account_id
+            )
+            SELECT i.id, $2, s.rank, s.repo_url, s.mount_path,
+                   s.ciphertext, s.nonce, s.created_at, s.updated_at,
+                   s.git_user_name, s.git_user_email, s.account_id
+              FROM (
+                SELECT *, row_number() OVER (ORDER BY rank) AS rn
+                  FROM session_github_repositories WHERE session_id = $1
+              ) s
+              JOIN unnest($3::text[]) WITH ORDINALITY AS i(id, rn) USING (rn)
+            """,
+            parent_session_id,
+            new_id,
+            new_gh_ids,
         )
 
         # Events are gapless 1..last_event_seq per session, so we pre-generate

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -436,7 +436,8 @@ async def clone_session(
             conn, parent_session_id, workspace_path=workspace_path, account_id=account_id
         )
         vault_ids = await queries.get_session_vault_ids(conn, session.id, account_id=account_id)
-        return session.model_copy(update={"vault_ids": vault_ids})
+        echoes = await _list_all_echoes(conn, session.id, account_id=account_id)
+        return session.model_copy(update={"vault_ids": vault_ids, "resources": echoes})
 
 
 async def delete_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: str) -> None:

--- a/tests/integration/test_clone_preserves_resources.py
+++ b/tests/integration/test_clone_preserves_resources.py
@@ -1,0 +1,149 @@
+"""Integration test: ``clone_session`` must preserve attached memory
+stores and github repositories.
+
+Mirrored resources are what makes the clone's next sandbox provision
+mount the same shape the parent had at clone time, and what makes
+the API response stop lying ``resources: []`` to the caller.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+from pydantic import SecretStr
+
+from aios.crypto.vault import CryptoBox
+from aios.db.pool import create_pool
+from aios.models.github_repositories import GithubRepositoryResource
+from aios.models.memory_stores import MemoryStoreResource
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import memory_stores as memory_stores_service
+from aios.services import sessions as sessions_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def parent_with_resources(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, CryptoBox]]:
+    """Yield ``(pool, account_id, parent_id, crypto_box)`` for an idle
+    parent that has one memory store and one github repo attached."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    crypto_box = CryptoBox(os.urandom(32))
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_clone_res', NULL, TRUE, 'clone-resources-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_clone_res",
+            name="clone-res-test",
+            model="openrouter/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_clone_res", name="clone-res-env"
+        )
+        store = await memory_stores_service.create_store(
+            pool,
+            account_id="acc_clone_res",
+            name="notes",
+            description="parent's memory store",
+            metadata={},
+        )
+        parent = await sessions_service.create_session(
+            pool,
+            account_id="acc_clone_res",
+            agent_id=agent.id,
+            environment_id=env.id,
+            agent_version=agent.version,
+            title="parent-with-resources",
+            metadata={},
+            resources=[
+                MemoryStoreResource(
+                    type="memory_store",
+                    memory_store_id=store.id,
+                    access="read_write",
+                    instructions="parent attachment",
+                ),
+                # Two github repos so the ordinal-join's
+                # ``ORDER BY rank`` is actually exercised — with one
+                # row the ordering is trivial and a rank-scrambling
+                # regression would pass silently.
+                GithubRepositoryResource(
+                    type="github_repository",
+                    url="https://github.com/example/first.git",
+                    mount_path="/mnt/first",
+                    authorization_token=SecretStr("ghp_fake_test_token_1"),
+                    git_user_name="test-user",
+                    git_user_email="test@example.com",
+                ),
+                GithubRepositoryResource(
+                    type="github_repository",
+                    url="https://github.com/example/second.git",
+                    mount_path="/mnt/second",
+                    authorization_token=SecretStr("ghp_fake_test_token_2"),
+                    git_user_name="test-user",
+                    git_user_email="test@example.com",
+                ),
+            ],
+            crypto_box=crypto_box,
+        )
+        # Pin the fixture so a green test can't be due to the parent
+        # never having had resources attached.
+        assert len(parent.resources) == 3
+        memory_echo = next(r for r in parent.resources if r.type == "memory_store")
+        assert memory_echo.memory_store_id == store.id
+        yield pool, "acc_clone_res", parent.id, crypto_box
+    finally:
+        await pool.close()
+
+
+async def test_clone_preserves_memory_and_github_resources(
+    parent_with_resources: tuple[asyncpg.Pool[Any], str, str, CryptoBox],
+) -> None:
+    """Clones of a session with memory + github resources must mirror
+    those resources in their own ``Session.resources`` and in the
+    underlying ``session_memory_stores`` / ``session_github_repositories``
+    tables, so the clone's next sandbox provision mounts what the
+    parent had at clone time."""
+    pool, account_id, parent_id, _crypto_box = parent_with_resources
+
+    clone = await sessions_service.clone_session(pool, parent_id, account_id=account_id)
+    parent = await sessions_service.get_session(pool, parent_id, account_id=account_id)
+
+    clone_memory = [r for r in clone.resources if r.type == "memory_store"]
+    clone_github = [r for r in clone.resources if r.type == "github_repository"]
+    parent_github = [r for r in parent.resources if r.type == "github_repository"]
+
+    assert len(clone_memory) == 1
+    assert clone_memory[0].name == "notes"
+    assert clone_memory[0].instructions == "parent attachment"
+
+    # Mount-path order must match the parent's — the ordinal-join in
+    # ``clone_session`` keys on ``ORDER BY rank``; a regression that
+    # changes the ORDER BY would swap mount paths.
+    assert [r.mount_path for r in clone_github] == [r.mount_path for r in parent_github]
+    assert [r.url for r in clone_github] == [r.url for r in parent_github]
+
+    # ``session_github_repositories.id`` is a global PK so the clone
+    # must mint a fresh ULID per row, not reuse the parent's.
+    parent_github_ids = {r.id for r in parent_github}
+    for r in clone_github:
+        assert r.id.startswith("ghrepo_")
+        assert r.id not in parent_github_ids


### PR DESCRIPTION
## Summary

- ``clone_session`` copied ``sessions``, ``session_vaults``, and ``events`` but neither ``session_memory_stores`` nor ``session_github_repositories``.  Both tables predate the clone primitive but the INSERT/SELECT was never extended to them, so cloning a session with memory or github resources produced a clone with empty resource sets — the API response reported ``resources: []`` instead of mirroring the parent, and the clone's first sandbox provision would not mount any of the parent's resources.  Flagged as the next-up sibling in PR #576's code review at sev 85.
- The service-layer ``clone_session`` further compounded the gap: it only re-fetched ``vault_ids`` from the new row, so even with the DB rows in place the response would still report ``resources: []`` from the model default.  Both layers are fixed.
- Fix: add INSERT/SELECT into ``session_memory_stores`` (composite PK, direct INSERT/SELECT) and into ``session_github_repositories`` (global per-row id PK, ordinal-join with Python-minted ULIDs matching the existing events-copy pattern).  Service-layer fix calls ``_list_all_echoes`` on the cloned session.  By design the clone bypasses the archival validation the normal attach paths enforce — a clone snapshots the parent's attachment state at clone time including references to stores archived after the parent attached them.

## Out-of-scope sibling defect (file follow-up before next clone-shape PR)

- ``files`` table (session-attached uploads, migration 0032) is **also** not copied on clone.  Different defect class — the clone doesn't only need DB rows but also has to choose a disk-side approach (hardlink, duplicate, or share read-only).  One-bug-per-PR rule applies; not folding in.

## Test plan

- [x] Type-checker — clean (155 source files)
- [x] Linter + format-check — clean
- [x] Unit suite — 1401 passed
- [x] Integration suite — 57 passed, plus new ``test_clone_preserves_resources`` whose fixture pins a parent with one memory_store + **two** github repos to exercise the ``ORDER BY rank`` ordinal-join's order-preservation alongside the basic copy assertion.
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)