### PR TITLE
refactor(sandbox/mcp): extract McpBroker._load_auth_for helper

### DIFF
--- a/src/aios/sandbox/mcp_proxy.py
+++ b/src/aios/sandbox/mcp_proxy.py
@@ -309,6 +309,27 @@ class McpBroker:
             )
         return await agents_service.get_agent(pool, session.agent_id, account_id=account_id)
 
+    async def _load_auth_for(
+        self, session_id: str, server_url: str
+    ) -> tuple[str | None, dict[str, str]]:
+        """Resolve ``(vault_id, headers)`` for an MCP call out to ``server_url``.
+
+        Used by all three tool routes (``_list_tools`` / ``_tool_help`` /
+        ``_invoke``) to look up the session's vault binding for the server
+        and decrypt the auth headers. Deferred-imports
+        :mod:`aios.harness.runtime` and :mod:`aios.services.sessions` to
+        avoid an import cycle at module load.
+        """
+        from aios.harness import runtime
+        from aios.services import sessions as sessions_service
+
+        pool = runtime.require_pool()
+        crypto_box = runtime.require_crypto_box()
+        account_id = await sessions_service.load_session_account_id(pool, session_id)
+        return await resolve_auth_for_target_url(
+            pool, crypto_box, session_id, server_url, account_id=account_id
+        )
+
     async def _list_servers(self, request: Request) -> Response:
         resolved = await self._resolve_session(request)
         if isinstance(resolved, Response):
@@ -372,15 +393,7 @@ class McpBroker:
         if server is None:
             return _err(404, f"server '{server_name}' has no URL configured")
 
-        from aios.harness import runtime
-        from aios.services import sessions as sessions_service
-
-        pool = runtime.require_pool()
-        crypto_box = runtime.require_crypto_box()
-        account_id = await sessions_service.load_session_account_id(pool, session_id)
-        vault_id, headers = await resolve_auth_for_target_url(
-            pool, crypto_box, session_id, server.url, account_id=account_id
-        )
+        vault_id, headers = await self._load_auth_for(session_id, server.url)
         try:
             tool_dicts, _instructions = await discover_mcp_tools(
                 server.url, vault_id, headers, server_name
@@ -414,15 +427,7 @@ class McpBroker:
             return resolved
         session_id, server, _toolset, tool_name = resolved
 
-        from aios.harness import runtime
-        from aios.services import sessions as sessions_service
-
-        pool = runtime.require_pool()
-        crypto_box = runtime.require_crypto_box()
-        account_id = await sessions_service.load_session_account_id(pool, session_id)
-        vault_id, headers = await resolve_auth_for_target_url(
-            pool, crypto_box, session_id, server.url, account_id=account_id
-        )
+        vault_id, headers = await self._load_auth_for(session_id, server.url)
         try:
             tool_dicts, _ = await discover_mcp_tools(server.url, vault_id, headers, server.name)
         except Exception as exc:
@@ -460,15 +465,7 @@ class McpBroker:
             return resolved
         session_id, server, _toolset, tool_name = resolved
 
-        from aios.harness import runtime
-        from aios.services import sessions as sessions_service
-
-        pool = runtime.require_pool()
-        crypto_box = runtime.require_crypto_box()
-        account_id = await sessions_service.load_session_account_id(pool, session_id)
-        vault_id, headers = await resolve_auth_for_target_url(
-            pool, crypto_box, session_id, server.url, account_id=account_id
-        )
+        vault_id, headers = await self._load_auth_for(session_id, server.url)
         log.info(
             "mcp_broker.invoke",
             session_id=session_id,


### PR DESCRIPTION
## Summary

- \`McpBroker._list_tools\`, \`_tool_help\`, and \`_invoke\` each opened with the same 8-line auth-resolution prelude: deferred imports + \`require_pool → require_crypto_box → load_session_account_id → resolve_auth_for_target_url\`.
- Lift into \`_load_auth_for(session_id, server_url) -> (vault_id, headers)\` next to \`_load_agent\`, its existing sibling private helper. The deferred imports stay inside the function body — the \`harness.worker → mcp_proxy → harness.runtime\` cycle is real (verified by the reviewer).

Net **+24 / -27 = -3 LOC** in one file.

## Why this matters

Flagged independently by audits in kaizen iters 2 and 4 — second time the same duplication was identified. Three byte-identical 8-line blocks is clearly past the \"three similar lines is still better than premature abstraction\" threshold. The helper mirrors \`_load_agent\` in shape (purpose, deferred-import note, body structure), so the consolidation aligns with the existing in-file pattern.

## Test plan

- [x] \`uv run mypy src\` — clean (155 files)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1401 passed
- [ ] CI: full e2e/integration matrix

## Review notes

Code review (\`pr-review-toolkit:code-reviewer\`) returned **no findings**. Specifically verified:
- Helper body is line-for-line identical to the deleted blocks (same imports, same function calls, same kwargs).
- Import-cycle preservation is real: \`harness.worker\` (line 39) imports \`from aios.harness import runtime\`, then (line 51) \`from aios.sandbox.mcp_proxy import McpBroker\`. Module-load-time hoisting of \`runtime\` into \`mcp_proxy\` would close the cycle. Same reason \`_load_agent\` keeps its imports deferred today.
- Naming + placement match the \`_load_agent\` sibling style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)