### PR TITLE
fix(harness/completion): extend prompt_cache_key gate to OpenRouter→OpenAI and Azure routes

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -112,6 +112,10 @@ def _supports_anthropic_cache_control(model: str) -> bool:
     return False
 
 
+_OPENAI_NATIVE_PROVIDERS = frozenset({"openai", "azure"})
+_OPENAI_PROXY_PROVIDERS = frozenset({"openrouter"})
+
+
 @cache
 def _supports_openai_prompt_cache_key(model: str) -> bool:
     """True when ``model`` accepts OpenAI's ``prompt_cache_key`` field.
@@ -120,9 +124,15 @@ def _supports_openai_prompt_cache_key(model: str) -> bool:
     explicit ``prompt_cache_key`` for cache eligibility. Anthropic uses
     ``cache_control`` content-block markers instead, so the two cache
     channels are mutually exclusive — the gate here mirrors
-    :func:`_supports_anthropic_cache_control`, returning True for the
-    openai provider (and only the openai provider) so the two paths
-    can't accidentally both fire.
+    :func:`_supports_anthropic_cache_control`, scoped to the OpenAI
+    side: native OpenAI (direct ``openai`` plus Azure OpenAI, which is
+    the same Responses / Chat Completions API on Microsoft infra and
+    [documents the field](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/prompt-caching)
+    natively) plus OpenAI-backed routes through OpenRouter (which
+    forwards unknown ``extra_body`` params to the backing provider).
+    Non-OpenAI models on OpenRouter stay gated out — the field is
+    silently dropped by OpenRouter for non-OpenAI backends and could
+    trip parameter validation on some adapter versions.
 
     Unknown model strings return False (safe no-op) — same posture as
     the Anthropic gate.
@@ -131,10 +141,15 @@ def _supports_openai_prompt_cache_key(model: str) -> bool:
     function of the model string, low cardinality.
     """
     try:
-        _, provider, _, _ = litellm.get_llm_provider(model)
+        model_name, provider, _, _ = litellm.get_llm_provider(model)
     except Exception:
         return False
-    return bool(provider == "openai")
+    if provider in _OPENAI_NATIVE_PROVIDERS:
+        return True
+    if provider in _OPENAI_PROXY_PROVIDERS:
+        lower = (model_name or model).lower()
+        return lower.startswith("openai/")
+    return False
 
 
 def _apply_provider_cache_hints(

--- a/tests/unit/test_completion_prompt_cache_key.py
+++ b/tests/unit/test_completion_prompt_cache_key.py
@@ -123,6 +123,103 @@ async def test_stream_litellm_openai_path_sends_prompt_cache_key(
 
 
 @pytest.mark.asyncio
+async def test_call_litellm_openrouter_openai_route_sends_prompt_cache_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenRouter routes that target an OpenAI backend
+    (``openrouter/openai/...``) must carry ``prompt_cache_key``.
+
+    OpenRouter forwards unknown params via ``extra_body`` to the
+    backing provider; for an OpenAI backend the cache key threads
+    through and OpenAI groups requests by it.  Pre-fix the provider
+    gate accepted only literal ``provider == "openai"``, so OpenRouter
+    routes dropped the key silently — reproducing the low-cache-hit
+    symptom PR #559 / #556 set out to fix, just for OpenRouter
+    users.
+    """
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> _DictResponse:
+        captured.update(kwargs)
+        return _ok_response()
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+
+    await completion.call_litellm(
+        model="openrouter/openai/gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        session_id="sess_openrouter",
+    )
+
+    extra_body = captured.get("extra_body")
+    assert isinstance(extra_body, dict)
+    assert extra_body.get("prompt_cache_key") == "sess_openrouter"
+
+
+@pytest.mark.asyncio
+async def test_call_litellm_azure_path_sends_prompt_cache_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Azure OpenAI is the same Responses / Chat Completions API on
+    Microsoft infra and natively supports ``prompt_cache_key``.
+
+    Pre-fix the provider gate accepted only literal ``provider ==
+    "openai"``, so Azure-deployed aios users dropped the key silently
+    — same low-cache-hit symptom as the direct-OpenAI and
+    OpenRouter-OpenAI cases."""
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> _DictResponse:
+        captured.update(kwargs)
+        return _ok_response()
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+
+    await completion.call_litellm(
+        model="azure/gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        session_id="sess_azure",
+    )
+
+    extra_body = captured.get("extra_body")
+    assert isinstance(extra_body, dict)
+    assert extra_body.get("prompt_cache_key") == "sess_azure"
+
+
+@pytest.mark.asyncio
+async def test_call_litellm_openrouter_non_openai_route_omits_prompt_cache_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenRouter routes that target a non-OpenAI backend must NOT
+    carry ``prompt_cache_key``.
+
+    Adding the field to an Anthropic / Llama / Mistral / Gemini
+    backend either gets silently discarded or trips parameter
+    validation, depending on the provider's adapter version.  The
+    gate stays scoped to the openai-backend subset of OpenRouter
+    routes."""
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> _DictResponse:
+        captured.update(kwargs)
+        return _ok_response()
+
+    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+
+    await completion.call_litellm(
+        model="openrouter/anthropic/claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "hi"}],
+        session_id="sess_openrouter_claude",
+    )
+
+    assert "prompt_cache_key" not in captured
+    extra_body = captured.get("extra_body")
+    if extra_body is not None:
+        assert isinstance(extra_body, dict)
+        assert extra_body.get("prompt_cache_key") is None
+
+
+@pytest.mark.asyncio
 async def test_call_litellm_anthropic_path_omits_prompt_cache_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- ``_supports_openai_prompt_cache_key`` accepted only literal ``provider == "openai"``, so two real OpenAI-API surfaces dropped the cache key silently:
    * ``openrouter/openai/gpt-4o`` → ``provider="openrouter"`` → gate returns False, yet OpenRouter [documents](https://openrouter.ai/docs/api/reference/parameters) that it forwards unknown ``extra_body`` params straight to the backing provider — so prompt_cache_key threads through to OpenAI.
    * ``azure/gpt-4o`` → ``provider="azure"`` → gate returns False, yet Azure OpenAI [documents](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/prompt-caching) ``prompt_cache_key`` as a native field on the same Responses / Chat Completions API.
- Both manifestations reproduce the low-cache-hit symptom that PR #559 / #556 set out to fix, just for OpenRouter- and Azure-deployed aios users.  Same defect (gate too narrow), two manifestations — bundled in one PR by analogy with PR #580's bundling of ``session_memory_stores`` + ``session_github_repositories`` clone-copy gaps.
- Fix mirrors ``_supports_anthropic_cache_control``: native-providers set + proxy-providers set + model-name discriminator.  Native: ``{"openai", "azure"}``. Proxy: ``{"openrouter"}`` with ``model_name.startswith("openai/")`` discriminator (so ``openrouter/openai/*`` matches but ``openrouter/anthropic/*`` / Llama / Mistral / Gemini stay gated out — the field is silently dropped at best on those backends and trips parameter validation at worst).

## Out-of-scope siblings deliberately not folded in

- **Bedrock / Vertex** aren't currently OpenAI-proxy providers (they host Anthropic / Google / Meta / Cohere / AI21 / Mistral but not OpenAI's GPT line), so adding them to ``_OPENAI_PROXY_PROVIDERS`` would be dead code today.  If a future LiteLLM version adds an OpenAI-proxied backend on those, revisit then with empirical validation that the wire body carries ``extra_body``.

## Test plan

- [x] Type-checker — clean (155 source files)
- [x] Linter + format-check — clean
- [x] Unit suite — 1404 passed (7 existing ``prompt_cache_key`` tests + 3 new: openrouter-openai positive, azure positive, openrouter-non-openai negative)
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)