### PR TITLE
refactor(models): replace github_repositories token check with Field(min_length=1)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8659,6 +8659,7 @@
           },
           "authorization_token": {
             "type": "string",
+            "minLength": 1,
             "format": "password",
             "title": "Authorization Token",
             "writeOnly": true
@@ -8767,6 +8768,7 @@
         "properties": {
           "authorization_token": {
             "type": "string",
+            "minLength": 1,
             "format": "password",
             "title": "Authorization Token",
             "writeOnly": true

--- a/src/aios/models/github_repositories.py
+++ b/src/aios/models/github_repositories.py
@@ -57,15 +57,13 @@ class GithubRepositoryResource(BaseModel):
     type: Literal["github_repository"]
     url: str = Field(min_length=1)
     mount_path: str = Field(min_length=2, max_length=4096, pattern=ABSOLUTE_PATH_PATTERN)
-    authorization_token: SecretStr
+    authorization_token: SecretStr = Field(min_length=1)
     git_user_name: str | None = Field(default=None, max_length=256)
     git_user_email: str | None = Field(default=None, max_length=256)
 
     @model_validator(mode="after")
     def _check(self) -> GithubRepositoryResource:
         _check_mount_path(self.mount_path)
-        if not self.authorization_token.get_secret_value():
-            raise ValueError("authorization_token must be non-empty")
         return self
 
 
@@ -100,15 +98,9 @@ class GithubRepositoryUpdate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    authorization_token: SecretStr
+    authorization_token: SecretStr = Field(min_length=1)
     git_user_name: str | None = Field(default=None, max_length=256)
     git_user_email: str | None = Field(default=None, max_length=256)
-
-    @model_validator(mode="after")
-    def _check(self) -> GithubRepositoryUpdate:
-        if not self.authorization_token.get_secret_value():
-            raise ValueError("authorization_token must be non-empty")
-        return self
 
 
 def validate_resources(resources: list[GithubRepositoryResource]) -> None:

--- a/tests/unit/test_github_repositories_models.py
+++ b/tests/unit/test_github_repositories_models.py
@@ -49,7 +49,7 @@ class TestGithubRepositoryResourceCreate:
             )  # type: ignore[call-arg]
 
     def test_token_must_be_non_empty(self) -> None:
-        with pytest.raises(ValidationError, match="non-empty"):
+        with pytest.raises(ValidationError, match="authorization_token"):
             GithubRepositoryResource(
                 type="github_repository",
                 url="https://github.com/octocat/Hello-World",
@@ -133,7 +133,7 @@ class TestGithubRepositoryUpdate:
             GithubRepositoryUpdate()  # type: ignore[call-arg]
 
     def test_token_must_be_non_empty(self) -> None:
-        with pytest.raises(ValidationError, match="non-empty"):
+        with pytest.raises(ValidationError, match="authorization_token"):
             GithubRepositoryUpdate(authorization_token=SecretStr(""))
 
     def test_immutable_fields_rejected(self) -> None:


### PR DESCRIPTION
## Summary

- Two hand-rolled \`model_validator(mode=\"after\")\` methods existed on \`GithubRepositoryResource\` and \`GithubRepositoryUpdate\` solely to enforce \`authorization_token\` non-empty. Pydantic's \`Field(min_length=1)\` expresses the same rule declaratively against \`SecretStr.get_secret_value()\`.
- \`GithubRepositoryResource._check\`: keeps the \`_check_mount_path\` call (multi-rule logic Pydantic can't express); drops the token branch.
- \`GithubRepositoryUpdate._check\`: deleted entirely — its sole purpose was the token check, now subsumed by \`Field(min_length=1)\`.
- Tests updated to match on the field name (\`authorization_token\`) instead of the now-replaced custom message (\`\"non-empty\"\`).
- \`openapi.json\` regenerated — adds \`\"minLength\": 1\` to both \`authorization_token\` schemas, documenting an already-enforced constraint.

Net **+6 / -12 = -6 LOC**. Pure framework-builtin substitution.

## Why this matters

Canonical kaizen: replace hand-rolled validation with the framework's declarative form. Side benefit — the OpenAPI surface now honestly declares the constraint clients were already required to satisfy.

## Test plan

- [x] \`uv run mypy src\` — clean (155 files)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1401 passed (incl. all 28 \`test_github_repositories_models.py\`)
- [ ] CI: full e2e/integration matrix

## Review notes

Code review (\`pr-review-toolkit:code-reviewer\`) returned **no findings** — \"ship it\". Verified:
- Pydantic 2 enforces \`min_length=1\` against \`SecretStr.get_secret_value()\` (empty \`SecretStr(\"\")\` raises \`ValidationError\` with \`type=string_too_short\`, \`loc=(\"authorization_token\",)\`).
- All 28 model tests still pass; new \`match=\"authorization_token\"\` regex hits the field name in Pydantic's rendered error.
- No \`src/\` code reaches into the removed \`_check\` method.
- \`openapi.json\` change is additive — clients that regenerate against the new schema gain an honest constraint declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)