### PR TITLE
fix(mcp/client): don't retry call_mcp_tool on non-timeout exceptions

### DIFF
--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -272,24 +272,20 @@ async def call_mcp_tool(
                     session.call_tool(tool_name, arguments, meta=meta),
                     timeout=_TOOL_CALL_TIMEOUT_S,
                 )
-            except TimeoutError:
-                # Don't retry on timeout: the wait_for fires while we
-                # wait for the response, but the request may already
-                # have reached the server and been processed. A retry
-                # would duplicate the side effect — e.g. ``signal_send``
-                # / ``telegram_send`` delivering the same message twice.
-                # Evict so the next caller doesn't reuse the same
-                # session; surface the error so the model can decide
-                # whether to retry.
+            except Exception:
+                # Don't retry any call_tool failure: by the time the
+                # exception surfaces here, the request may already
+                # have reached the server and been processed —
+                # whether it was a timeout firing mid-response-read,
+                # a broken pipe, a TCP reset, or an HTTP/2 GOAWAY.
+                # A retry would duplicate the side effect — e.g.
+                # ``signal_send`` / ``telegram_send`` delivering the
+                # same message twice.  Evict so the next caller
+                # doesn't reuse the same session; surface the error
+                # so the model can decide whether to retry through
+                # the session log.
                 _pool.evict(url, vault_id)
                 raise
-            except Exception:
-                _pool.evict(url, vault_id)
-                session, _ = await _pool.get_or_connect(url, vault_id, headers)
-                result = await asyncio.wait_for(
-                    session.call_tool(tool_name, arguments, meta=meta),
-                    timeout=_TOOL_CALL_TIMEOUT_S,
-                )
         else:
             async with AsyncExitStack() as stack:
                 session, _ = await _open_session(url, headers, stack)

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -467,26 +467,26 @@ class TestCallMcpToolWithPool:
 
         session.initialize.assert_awaited_once()
 
-    async def test_evicts_and_retries_on_call_tool_failure(
-        self, restore_runtime_pool: None
-    ) -> None:
-        """First ``call_tool`` raises → pool evicts, second succeeds."""
+    async def test_does_not_retry_on_call_tool_failure(self, restore_runtime_pool: None) -> None:
+        """A non-timeout transport failure (broken pipe, TCP reset,
+        HTTP/2 GOAWAY) may have landed after the server already
+        processed the request — retrying would duplicate the side
+        effect, just like the timeout case.  The wrapper evicts and
+        surfaces the error; the model decides whether to retry."""
         from aios.mcp.client import call_mcp_tool
 
-        s_a, s_b = _make_mock_session(), _make_mock_session()
+        s_a = _make_mock_session()
         s_a.call_tool = AsyncMock(side_effect=RuntimeError("broken"))
-        s_b.call_tool = AsyncMock(return_value=MagicMock(content=[], isError=False))
 
         runtime.mcp_session_pool = McpSessionPool()
         with (
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
-            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(s_a)),
         ):
             result = await call_mcp_tool("https://m.example/", "v", {}, "do_thing", {})
 
-        assert result == {"content": ""}
-        assert s_a.initialize.await_count == 1
-        assert s_b.initialize.await_count == 1
+        assert result.get("code") == "transport_error"
+        assert s_a.call_tool.await_count == 1
 
     async def test_does_not_retry_call_tool_on_timeout(
         self, restore_runtime_pool: None, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

- ``call_mcp_tool``'s ``except Exception`` branch was evicting the session and retrying — same dangerous shape as the ``TimeoutError`` branch explicitly avoids.  A broken pipe / TCP reset / HTTP/2 GOAWAY mid-flight may have landed after the server already processed the request, so retrying duplicates the side effect — e.g. ``signal_send`` / ``telegram_send`` delivering the same message twice.
- Fix: collapse both branches into one ``except Exception`` that evicts and raises, with no retry.  The outer ``except Exception as err`` already wraps the raise as a ``transport_error`` envelope for the caller; the model decides whether to retry through the session log (the project's ``fail hard, no fallbacks`` stance).
- Cost: a stale pool entry (TCP RST after long idle, server restart) is no longer self-healed in-process — the first call after the drop now bills a model round-trip.  Trade-off is correct: side-effect safety dominates, and connection pre-flight health-checks aren't free either.

## Test plan

- [x] ``tests/unit/test_mcp_pool.py::test_does_not_retry_on_call_tool_failure`` (renamed + rewritten from the stale ``test_evicts_and_retries_on_call_tool_failure``) is the no-timeout sibling of the ``test_does_not_retry_call_tool_on_timeout`` already in this file.  Asserts ``call_tool`` runs exactly once and the result is a ``transport_error`` envelope.
- [x] Type-checker — clean (155 source files)
- [x] Linter + format-check — clean
- [x] Unit suite — 1404 passed
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)