### PR TITLE
refactor(services/connections): collapse two-acquire NOTIFY to one

### DIFF
--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -181,6 +181,10 @@ async def attach_connection(
     only point where the operator can correct the action that caused
     the misconfiguration.
     """
+    # pool.acquire() yields an autocommit connection; the INSERT commits
+    # before the NOTIFY fires.  Do NOT wrap these in
+    # ``async with conn.transaction()`` — see db/listen.py for why
+    # NOTIFY-after-commit is load-bearing for subscribers.
     async with pool.acquire() as conn:
         session = await queries.get_session(conn, session_id, account_id=account_id)
         if session.archived_at is not None:
@@ -196,10 +200,6 @@ async def attach_connection(
             account_id=account_id,
         )
         connection = await queries.get_connection(conn, connection_id, account_id=account_id)
-    # Second acquire so the NOTIFY fires OUTSIDE the insert's implicit
-    # transaction — subscribers must never see a payload for an
-    # uncommitted row.
-    async with pool.acquire() as conn:
         await queries.notify_connection_change(
             conn,
             connector=connection.connector,
@@ -413,6 +413,9 @@ async def archive_connection(
     live single_session, or from stranding the template a per_chat
     binding spawns from.
     """
+    # pool.acquire() yields an autocommit connection; the archive UPDATE
+    # commits before the NOTIFY fires.  See ``attach_connection`` and
+    # ``services/management_calls.py`` for the same pattern + rationale.
     async with pool.acquire() as conn:
         connection = await queries.get_connection(conn, connection_id, account_id=account_id)
         if connection.archived_at is not None:
@@ -425,7 +428,6 @@ async def archive_connection(
                 detail={"id": connection_id, "mode": binding.mode},
             )
         archived = await queries.archive_connection(conn, connection_id, account_id=account_id)
-    async with pool.acquire() as conn:
         await queries.notify_connection_change(
             conn,
             connector=archived.connector,


### PR DESCRIPTION
## Summary

- \`services/connections.py:attach_connection\` and \`archive_connection\` each opened TWO \`pool.acquire()\` blocks — one for INSERT/archive, a second for \`notify_connection_change\`. The justifying comment claimed the split was needed so the NOTIFY fires \"OUTSIDE the insert's implicit transaction\" — but \`pool.acquire()\` yields an autocommit connection; there is no implicit transaction.
- Collapsed both to single acquires matching the canonical pattern in \`services/management_calls.py:42-58\`, which explicitly documents: \"pool.acquire() yields an autocommit connection; the INSERT commits before the NOTIFY fires.\"
- \`notify_connection_change\`'s own docstring (\`db/queries.py:5229-5231\`) already requires \"pool-acquired (autocommit) connection OUTSIDE any transaction\" — the new shape satisfies this by construction.

Net **+7 / -5 = +2 LOC** (yellow flag — justified). The deletions remove two redundant \`async with pool.acquire() as conn:\` blocks; the additions are corrected multi-line comments. Win is **one fewer pool round-trip per attach/archive** + comment-matches-reality + alignment across all three INSERT-then-NOTIFY sites in the codebase.

## Why this matters

The misleading comment was propagating a wrong mental model — \"NOTIFY needs a second acquire because the first one is in a transaction.\" Future maintainers reading either function would either copy the pattern (perpetuating it) or feel pressure to wrap things in transactions (breaking the autocommit invariant). Aligning with \`management_calls.py\` makes the right pattern obvious.

## Test plan

- [x] \`uv run mypy src\` — clean (155 files)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1404 passed
- [ ] CI: full e2e matrix (where the attach/archive paths get exercised)

## Review notes

Code review (\`pr-review-toolkit:code-reviewer\`) returned **no findings ≥ 80**. Verified:
- Autocommit semantics — each statement self-commits; NOTIFY runs after INSERT has committed.
- No \`conn.transaction()\` introduced (verified via grep; only pre-existing unrelated occurrence remains).
- Error paths: raises from \`get_session\`, archived-session check, \`insert_binding\`, etc. all exit the \`async with\` before NOTIFY would fire — identical control-flow guarantee to the two-acquire shape.
- Archived-row idempotent early-return in \`archive_connection\` still returns before NOTIFY would fire — no re-emission of \`removed\` events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)