### PR TITLE
fix(tools/glob): enable pipefail so rg failure surfaces

### DIFF
--- a/src/aios/tools/glob.py
+++ b/src/aios/tools/glob.py
@@ -67,7 +67,16 @@ async def glob_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     sandbox = runtime.require_sandbox_registry()
     handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
-    cmd = f"rg --files --glob {shlex.quote(pattern)} {shlex.quote(path)} 2>/dev/null | head -500"
+    # ``set -o pipefail`` so a failing ``rg`` (invalid glob pattern,
+    # missing path) propagates through the ``| head -500`` to the
+    # overall pipe exit code; without it ``head`` happily consumes
+    # empty input and exits 0, masking the error as "no matches".
+    # Same shape as the grep pipefail fix in PR #546.
+    cmd = (
+        "set -o pipefail; "
+        f"rg --files --glob {shlex.quote(pattern)} {shlex.quote(path)} 2>/dev/null "
+        "| head -500"
+    )
 
     result = await sandbox.exec(
         handle,

--- a/tests/unit/test_glob_handler.py
+++ b/tests/unit/test_glob_handler.py
@@ -130,3 +130,29 @@ class TestErrorPath:
         result = await glob_handler("sess_01TEST", {"pattern": "*.py"})
         assert "error" in result
         assert "some error" in result["error"]
+
+    async def test_cmd_uses_pipefail_so_rg_failure_propagates(
+        self, stub_registry: Any, stub_handle: SandboxHandle
+    ) -> None:
+        """Same shape as the grep pipefail fix (PR #546): ``rg --files
+        --glob <pattern> <path> 2>/dev/null | head -500`` is a pipe
+        whose final exit code is ``head``'s — which is 0 even when
+        ``rg`` failed (invalid glob pattern, missing path), because
+        ``head`` happily consumes empty input and exits 0.  Without
+        ``set -o pipefail`` the result returned to the model is
+        ``{"matches": []}`` — looking like "no matches" rather than
+        the actual rg error.  The model chases red herrings: tries
+        different patterns, different paths, never realizing rg
+        itself rejected its input.
+
+        PR #546's commit body named this as the next-up sibling
+        ("Sibling bug exists in tools/glob.py").
+        """
+        await glob_handler("sess_01TEST", {"pattern": "*.py"})
+        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        assert "pipefail" in cmd, (
+            f"cmd must enable ``pipefail`` so a failing ``rg`` (e.g., "
+            f"invalid glob pattern, missing path) propagates through the "
+            f"``| head -N`` to the overall pipe exit code; without it, "
+            f"rg errors silently return empty matches. Got: {cmd!r}"
+        )


### PR DESCRIPTION
## Summary

- ``tools/glob.py`` builds ``rg --files --glob <pattern> <path> 2>/dev/null | head -500``.  Without ``set -o pipefail``, ``head``'s exit code wins on a failing ``rg`` (invalid glob, missing path) → exit 0 → ``{"matches": []}`` returned to the model, indistinguishable from "no matches".  The model chases red herrings: tries different patterns, different paths, never realizing rg itself rejected its input.
- Mirrors the grep pipefail fix from PR #546 line-for-line; PR #546's commit body explicitly named glob.py as the next-up sibling ("Sibling bug exists in tools/glob.py").

## Test plan

- [x] ``tests/unit/test_glob_handler.py::test_cmd_uses_pipefail_so_rg_failure_propagates`` asserts ``pipefail`` is in the cmd — same pattern as the grep test that PR #546 added.
- [x] Type-checker — clean (155 source files)
- [x] Linter + format-check — clean
- [x] Unit suite — 1405 passed
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)