### PR TITLE
fix(db/queries): reject update_memory_store on archived rows

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -4356,6 +4356,19 @@ async def update_memory_store(
     description: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> MemoryStore:
+    # Refuse updates to archived stores: the read path filters
+    # ``archived_at IS NULL``, so a rewrite of an archived row has
+    # no observable effect — but the bare UPDATE below would still
+    # commit the new values and the RETURNING-built response would
+    # lie back to the caller as if the update took.  Same shape as
+    # ``update_agent`` / ``update_environment`` / ``update_session``
+    # (PR #573) / ``update_session_template`` (PR #547) /
+    # ``update_vault`` (PR #554).  Defense-in-depth for callers
+    # that bypass the service layer (services/memory_stores.py
+    # already pre-checks via the equivalent ``allow_archived=False``
+    # shape).
+    current = await get_memory_store(conn, store_id, allow_archived=False, account_id=account_id)
+
     sets: list[str] = []
     args: list[Any] = [store_id]
     if name is not None:
@@ -4368,7 +4381,7 @@ async def update_memory_store(
         args.append(json.dumps(metadata))
         sets.append(f"metadata = ${len(args)}::jsonb")
     if not sets:
-        return await get_memory_store(conn, store_id, account_id=account_id)
+        return current
     sets.append("updated_at = now()")
     args.append(account_id)
     sql = (

--- a/tests/integration/test_update_memory_store_archived.py
+++ b/tests/integration/test_update_memory_store_archived.py
@@ -1,0 +1,80 @@
+"""Integration test: ``queries.update_memory_store`` must refuse to
+rewrite an archived store.
+
+The service-layer ``update_store`` (services/memory_stores.py:134)
+already pre-fetches and raises ``MemoryStoreArchivedError`` on
+archived rows, but the query-layer ``update_memory_store`` has no
+guard.  Same defect-class as PR #547 (update_session_template), PR
+#554 (update_vault), PR #573 (update_session) — silent-write-on-
+archived-row family.  Closes the last named sibling from PR #554's
+commit body.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import MemoryStoreArchivedError
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def archived_memory_store(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, store_id)`` for a memory store that
+    has been archived after creation."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_mem_arch', NULL, TRUE, 'memstore-archived-test')
+                """
+            )
+            store = await queries.insert_memory_store(
+                conn,
+                name="pre-archive",
+                description="the parent description",
+                metadata={},
+                account_id="acc_mem_arch",
+            )
+            archived = await queries.archive_memory_store(conn, store.id, account_id="acc_mem_arch")
+        assert archived.archived_at is not None
+        yield pool, "acc_mem_arch", store.id
+    finally:
+        await pool.close()
+
+
+async def test_update_memory_store_refuses_archived(
+    archived_memory_store: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """A direct call to ``queries.update_memory_store`` on an archived
+    row must raise ``MemoryStoreArchivedError`` rather than silently
+    rewriting the row.  The service layer already guards this; the
+    query layer is the defense-in-depth backstop for any future
+    caller that bypasses the service."""
+    pool, account_id, store_id = archived_memory_store
+
+    async with pool.acquire() as conn:
+        with pytest.raises(MemoryStoreArchivedError) as excinfo:
+            await queries.update_memory_store(
+                conn, store_id, name="post-archive", account_id=account_id
+            )
+
+    detail = excinfo.value.detail
+    assert detail is not None
+    assert detail.get("id") == store_id
+
+    # The row's name must not have been rewritten.
+    async with pool.acquire() as conn:
+        actual_name = await conn.fetchval("SELECT name FROM memory_stores WHERE id = $1", store_id)
+    assert actual_name == "pre-archive"


### PR DESCRIPTION
## Summary

- ``queries.update_memory_store``'s UPDATE WHERE clause filtered only ``id = $1 AND account_id = $N``.  Archived rows still matched, so a direct caller (e.g. an admin script bypassing the service) could rewrite columns on an archived row; the read path filters ``archived_at IS NULL``, so the rewritten fields are invisible to subsequent reads — but the RETURNING-built response would lie back to the caller as if the update took.
- The service-layer ``services/memory_stores.py:134`` already pre-checks and raises ``MemoryStoreArchivedError`` on archived rows.  This fix brings the query layer into parity so the invariant is enforced regardless of which caller path is used.
- Closes the last named sibling from PR #554's commit body (``Sibling write paths in the same family still open: update_session, update_memory_store``).  Same defect class as PR #523 / #547 (update_session_template) / #554 (update_vault) / #573 (update_session).

## Test plan

- [x] New ``tests/integration/test_update_memory_store_archived.py`` calls ``queries.update_memory_store`` directly on an archived row and asserts ``MemoryStoreArchivedError``; follow-up SELECT confirms the row's name was NOT rewritten.
- [x] Type-checker — clean (155 source files)
- [x] Linter + format-check — clean
- [x] Unit suite — 1405 passed
- [x] Integration suite — 58 passed
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)