### PR TITLE
refactor(models/vaults): extract _VaultCredentialSecrets mixin

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -12022,6 +12022,180 @@
       },
       "VaultCredentialCreate": {
         "properties": {
+          "access_token": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Access Token"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "refresh_token": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Token"
+          },
+          "token_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token Endpoint"
+          },
+          "token_endpoint_auth": {
+            "anyOf": [
+              {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/TokenEndpointAuthNone"
+                  },
+                  {
+                    "$ref": "#/components/schemas/TokenEndpointAuthBasic"
+                  },
+                  {
+                    "$ref": "#/components/schemas/TokenEndpointAuthPost"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "method",
+                  "mapping": {
+                    "client_secret_basic": "#/components/schemas/TokenEndpointAuthBasic",
+                    "client_secret_post": "#/components/schemas/TokenEndpointAuthPost",
+                    "none": "#/components/schemas/TokenEndpointAuthNone"
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token Endpoint Auth"
+          },
+          "scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scope"
+          },
+          "resource": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource"
+          },
+          "token": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Password"
+          },
+          "header_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Header Name"
+          },
+          "header_value": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Header Value"
+          },
           "display_name": {
             "anyOf": [
               {
@@ -12053,7 +12227,19 @@
             "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
-          },
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "target_url",
+          "auth_type"
+        ],
+        "title": "VaultCredentialCreate",
+        "description": "Request body for ``POST /v1/vaults/{vault_id}/credentials``.\n\nAll secret fields are write-only. The ``target_url`` is immutable\nafter creation. The service layer validates required fields per\n``auth_type``."
+      },
+      "VaultCredentialUpdate": {
+        "properties": {
           "access_token": {
             "anyOf": [
               {
@@ -12227,19 +12413,7 @@
               }
             ],
             "title": "Header Value"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "target_url",
-          "auth_type"
-        ],
-        "title": "VaultCredentialCreate",
-        "description": "Request body for ``POST /v1/vaults/{vault_id}/credentials``.\n\nAll secret fields are write-only. The ``target_url`` is immutable\nafter creation. The service layer validates required fields per\n``auth_type``."
-      },
-      "VaultCredentialUpdate": {
-        "properties": {
+          },
           "display_name": {
             "anyOf": [
               {
@@ -12263,180 +12437,6 @@
               }
             ],
             "title": "Metadata"
-          },
-          "access_token": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "password",
-                "writeOnly": true
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Access Token"
-          },
-          "expires_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expires At"
-          },
-          "client_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Client Id"
-          },
-          "refresh_token": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "password",
-                "writeOnly": true
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Refresh Token"
-          },
-          "token_endpoint": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Token Endpoint"
-          },
-          "token_endpoint_auth": {
-            "anyOf": [
-              {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/TokenEndpointAuthNone"
-                  },
-                  {
-                    "$ref": "#/components/schemas/TokenEndpointAuthBasic"
-                  },
-                  {
-                    "$ref": "#/components/schemas/TokenEndpointAuthPost"
-                  }
-                ],
-                "discriminator": {
-                  "propertyName": "method",
-                  "mapping": {
-                    "client_secret_basic": "#/components/schemas/TokenEndpointAuthBasic",
-                    "client_secret_post": "#/components/schemas/TokenEndpointAuthPost",
-                    "none": "#/components/schemas/TokenEndpointAuthNone"
-                  }
-                }
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Token Endpoint Auth"
-          },
-          "scope": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scope"
-          },
-          "resource": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Resource"
-          },
-          "token": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "password",
-                "writeOnly": true
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Token"
-          },
-          "username": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "password",
-                "writeOnly": true
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Username"
-          },
-          "password": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "password",
-                "writeOnly": true
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Password"
-          },
-          "header_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Header Name"
-          },
-          "header_value": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "password",
-                "writeOnly": true
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Header Value"
           }
         },
         "additionalProperties": false,

--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_create.py
@@ -31,8 +31,6 @@ class VaultCredentialCreate:
         Attributes:
             target_url (str):
             auth_type (VaultCredentialCreateAuthType):
-            display_name (None | str | Unset):
-            metadata (VaultCredentialCreateMetadata | Unset):
             access_token (None | str | Unset):
             expires_at (datetime.datetime | None | Unset):
             client_id (None | str | Unset):
@@ -46,12 +44,12 @@ class VaultCredentialCreate:
             password (None | str | Unset):
             header_name (None | str | Unset):
             header_value (None | str | Unset):
+            display_name (None | str | Unset):
+            metadata (VaultCredentialCreateMetadata | Unset):
     """
 
     target_url: str
     auth_type: VaultCredentialCreateAuthType
-    display_name: None | str | Unset = UNSET
-    metadata: VaultCredentialCreateMetadata | Unset = UNSET
     access_token: None | str | Unset = UNSET
     expires_at: datetime.datetime | None | Unset = UNSET
     client_id: None | str | Unset = UNSET
@@ -71,6 +69,8 @@ class VaultCredentialCreate:
     password: None | str | Unset = UNSET
     header_name: None | str | Unset = UNSET
     header_value: None | str | Unset = UNSET
+    display_name: None | str | Unset = UNSET
+    metadata: VaultCredentialCreateMetadata | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.token_endpoint_auth_basic import TokenEndpointAuthBasic
@@ -80,16 +80,6 @@ class VaultCredentialCreate:
         target_url = self.target_url
 
         auth_type = self.auth_type.value
-
-        display_name: None | str | Unset
-        if isinstance(self.display_name, Unset):
-            display_name = UNSET
-        else:
-            display_name = self.display_name
-
-        metadata: dict[str, Any] | Unset = UNSET
-        if not isinstance(self.metadata, Unset):
-            metadata = self.metadata.to_dict()
 
         access_token: None | str | Unset
         if isinstance(self.access_token, Unset):
@@ -177,6 +167,16 @@ class VaultCredentialCreate:
         else:
             header_value = self.header_value
 
+        display_name: None | str | Unset
+        if isinstance(self.display_name, Unset):
+            display_name = UNSET
+        else:
+            display_name = self.display_name
+
+        metadata: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -185,10 +185,6 @@ class VaultCredentialCreate:
                 "auth_type": auth_type,
             }
         )
-        if display_name is not UNSET:
-            field_dict["display_name"] = display_name
-        if metadata is not UNSET:
-            field_dict["metadata"] = metadata
         if access_token is not UNSET:
             field_dict["access_token"] = access_token
         if expires_at is not UNSET:
@@ -215,6 +211,10 @@ class VaultCredentialCreate:
             field_dict["header_name"] = header_name
         if header_value is not UNSET:
             field_dict["header_value"] = header_value
+        if display_name is not UNSET:
+            field_dict["display_name"] = display_name
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
 
         return field_dict
 
@@ -231,22 +231,6 @@ class VaultCredentialCreate:
         target_url = d.pop("target_url")
 
         auth_type = VaultCredentialCreateAuthType(d.pop("auth_type"))
-
-        def _parse_display_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        display_name = _parse_display_name(d.pop("display_name", UNSET))
-
-        _metadata = d.pop("metadata", UNSET)
-        metadata: VaultCredentialCreateMetadata | Unset
-        if isinstance(_metadata, Unset):
-            metadata = UNSET
-        else:
-            metadata = VaultCredentialCreateMetadata.from_dict(_metadata)
 
         def _parse_access_token(data: object) -> None | str | Unset:
             if data is None:
@@ -420,11 +404,25 @@ class VaultCredentialCreate:
 
         header_value = _parse_header_value(d.pop("header_value", UNSET))
 
+        def _parse_display_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        display_name = _parse_display_name(d.pop("display_name", UNSET))
+
+        _metadata = d.pop("metadata", UNSET)
+        metadata: VaultCredentialCreateMetadata | Unset
+        if isinstance(_metadata, Unset):
+            metadata = UNSET
+        else:
+            metadata = VaultCredentialCreateMetadata.from_dict(_metadata)
+
         vault_credential_create = cls(
             target_url=target_url,
             auth_type=auth_type,
-            display_name=display_name,
-            metadata=metadata,
             access_token=access_token,
             expires_at=expires_at,
             client_id=client_id,
@@ -438,6 +436,8 @@ class VaultCredentialCreate:
             password=password,
             header_name=header_name,
             header_value=header_value,
+            display_name=display_name,
+            metadata=metadata,
         )
 
         return vault_credential_create

--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_update.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_update.py
@@ -29,8 +29,6 @@ class VaultCredentialUpdate:
     Omitted secret fields are preserved (decrypt-merge-encrypt).
 
         Attributes:
-            display_name (None | str | Unset):
-            metadata (None | Unset | VaultCredentialUpdateMetadataType0):
             access_token (None | str | Unset):
             expires_at (datetime.datetime | None | Unset):
             client_id (None | str | Unset):
@@ -44,10 +42,10 @@ class VaultCredentialUpdate:
             password (None | str | Unset):
             header_name (None | str | Unset):
             header_value (None | str | Unset):
+            display_name (None | str | Unset):
+            metadata (None | Unset | VaultCredentialUpdateMetadataType0):
     """
 
-    display_name: None | str | Unset = UNSET
-    metadata: None | Unset | VaultCredentialUpdateMetadataType0 = UNSET
     access_token: None | str | Unset = UNSET
     expires_at: datetime.datetime | None | Unset = UNSET
     client_id: None | str | Unset = UNSET
@@ -67,6 +65,8 @@ class VaultCredentialUpdate:
     password: None | str | Unset = UNSET
     header_name: None | str | Unset = UNSET
     header_value: None | str | Unset = UNSET
+    display_name: None | str | Unset = UNSET
+    metadata: None | Unset | VaultCredentialUpdateMetadataType0 = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.token_endpoint_auth_basic import TokenEndpointAuthBasic
@@ -75,20 +75,6 @@ class VaultCredentialUpdate:
         from ..models.vault_credential_update_metadata_type_0 import (
             VaultCredentialUpdateMetadataType0,
         )
-
-        display_name: None | str | Unset
-        if isinstance(self.display_name, Unset):
-            display_name = UNSET
-        else:
-            display_name = self.display_name
-
-        metadata: dict[str, Any] | None | Unset
-        if isinstance(self.metadata, Unset):
-            metadata = UNSET
-        elif isinstance(self.metadata, VaultCredentialUpdateMetadataType0):
-            metadata = self.metadata.to_dict()
-        else:
-            metadata = self.metadata
 
         access_token: None | str | Unset
         if isinstance(self.access_token, Unset):
@@ -176,13 +162,23 @@ class VaultCredentialUpdate:
         else:
             header_value = self.header_value
 
+        display_name: None | str | Unset
+        if isinstance(self.display_name, Unset):
+            display_name = UNSET
+        else:
+            display_name = self.display_name
+
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, VaultCredentialUpdateMetadataType0):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update({})
-        if display_name is not UNSET:
-            field_dict["display_name"] = display_name
-        if metadata is not UNSET:
-            field_dict["metadata"] = metadata
         if access_token is not UNSET:
             field_dict["access_token"] = access_token
         if expires_at is not UNSET:
@@ -209,6 +205,10 @@ class VaultCredentialUpdate:
             field_dict["header_name"] = header_name
         if header_value is not UNSET:
             field_dict["header_value"] = header_value
+        if display_name is not UNSET:
+            field_dict["display_name"] = display_name
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
 
         return field_dict
 
@@ -222,34 +222,6 @@ class VaultCredentialUpdate:
         )
 
         d = dict(src_dict)
-
-        def _parse_display_name(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        display_name = _parse_display_name(d.pop("display_name", UNSET))
-
-        def _parse_metadata(
-            data: object,
-        ) -> None | Unset | VaultCredentialUpdateMetadataType0:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, dict):
-                    raise TypeError()
-                metadata_type_0 = VaultCredentialUpdateMetadataType0.from_dict(data)
-
-                return metadata_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(None | Unset | VaultCredentialUpdateMetadataType0, data)
-
-        metadata = _parse_metadata(d.pop("metadata", UNSET))
 
         def _parse_access_token(data: object) -> None | str | Unset:
             if data is None:
@@ -423,9 +395,35 @@ class VaultCredentialUpdate:
 
         header_value = _parse_header_value(d.pop("header_value", UNSET))
 
+        def _parse_display_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        display_name = _parse_display_name(d.pop("display_name", UNSET))
+
+        def _parse_metadata(
+            data: object,
+        ) -> None | Unset | VaultCredentialUpdateMetadataType0:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = VaultCredentialUpdateMetadataType0.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | VaultCredentialUpdateMetadataType0, data)
+
+        metadata = _parse_metadata(d.pop("metadata", UNSET))
+
         vault_credential_update = cls(
-            display_name=display_name,
-            metadata=metadata,
             access_token=access_token,
             expires_at=expires_at,
             client_id=client_id,
@@ -439,6 +437,8 @@ class VaultCredentialUpdate:
             password=password,
             header_name=header_name,
             header_value=header_value,
+            display_name=display_name,
+            metadata=metadata,
         )
 
         return vault_credential_update

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -87,56 +87,19 @@ class Vault(BaseModel):
 # ── Vault Credential ────────────────────────────────────────────────────────
 
 
-class VaultCredentialCreate(BaseModel):
-    """Request body for ``POST /v1/vaults/{vault_id}/credentials``.
+class _VaultCredentialSecrets(BaseModel):
+    """Shared secret-bearing fields for ``VaultCredentialCreate`` /
+    ``VaultCredentialUpdate``.
 
-    All secret fields are write-only. The ``target_url`` is immutable
-    after creation. The service layer validates required fields per
+    All fields are optional on both bodies: omitted on Create means
+    "not configured", omitted on Update means "preserve existing".
+    The service layer validates which fields are required per
     ``auth_type``.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    display_name: str | None = Field(default=None, max_length=128)
-    target_url: str = Field(min_length=1)
-    auth_type: AuthType
-    metadata: dict[str, Any] = Field(default_factory=dict)
-
     # oauth2_refresh fields
-    access_token: SecretStr | None = None
-    expires_at: datetime | None = None
-    client_id: str | None = None
-    refresh_token: SecretStr | None = None
-    token_endpoint: str | None = None
-    token_endpoint_auth: TokenEndpointAuth | None = None
-    scope: str | None = None
-    resource: str | None = None
-
-    # bearer_header fields
-    token: SecretStr | None = None
-
-    # basic fields
-    username: SecretStr | None = None
-    password: SecretStr | None = None
-
-    # custom_header fields
-    header_name: str | None = None
-    header_value: SecretStr | None = None
-
-
-class VaultCredentialUpdate(BaseModel):
-    """Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.
-
-    ``target_url`` and ``auth_type`` are immutable — not accepted here.
-    Omitted secret fields are preserved (decrypt-merge-encrypt).
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    display_name: str | None = Field(default=None, max_length=128)
-    metadata: dict[str, Any] | None = None
-
-    # oauth2_refresh fields (all optional — omitted = preserve)
     access_token: SecretStr | None = None
     expires_at: datetime | None = None
     client_id: str | None = None
@@ -156,6 +119,31 @@ class VaultCredentialUpdate(BaseModel):
     # custom_header
     header_name: str | None = None
     header_value: SecretStr | None = None
+
+
+class VaultCredentialCreate(_VaultCredentialSecrets):
+    """Request body for ``POST /v1/vaults/{vault_id}/credentials``.
+
+    All secret fields are write-only. The ``target_url`` is immutable
+    after creation. The service layer validates required fields per
+    ``auth_type``.
+    """
+
+    display_name: str | None = Field(default=None, max_length=128)
+    target_url: str = Field(min_length=1)
+    auth_type: AuthType
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class VaultCredentialUpdate(_VaultCredentialSecrets):
+    """Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.
+
+    ``target_url`` and ``auth_type`` are immutable — not accepted here.
+    Omitted secret fields are preserved (decrypt-merge-encrypt).
+    """
+
+    display_name: str | None = Field(default=None, max_length=128)
+    metadata: dict[str, Any] | None = None
 
 
 class VaultCredential(BaseModel):


### PR DESCRIPTION
## Summary

- \`VaultCredentialCreate\` and \`VaultCredentialUpdate\` both declared the same 13 optional secret fields (oauth2_refresh / bearer_header / basic / custom_header). Lifted into a private \`_VaultCredentialSecrets\` base.
- Subclasses keep only their own shape-distinct fields: Create has required immutable \`target_url\` / \`auth_type\` plus factory-default \`metadata\`; Update has preserve-existing \`metadata: dict | None\`.
- \`model_config = ConfigDict(extra=\"forbid\")\` lives on the base, inherited by both subclasses.

Net **-12 LOC** in \`models/vaults.py\`. \`openapi.json\` + the two generated SDK models regenerated — diffs are pure reordering (Pydantic 2 places inherited fields before subclass fields in \`model_fields\`); no field counts, types, defaults, or \`required\` arrays change.

## Why this matters

13 fields duplicated across two classes was clear DRY territory and the project's pattern for shared shape is Pydantic inheritance. Verified that no source code iterates \`model_fields\` (field-order is invisible to consumers).

## Test plan

- [x] \`uv run mypy src\` — clean (155 files)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1404 passed (incl. SDK/client snapshot tests post-regen)
- [ ] CI: full e2e/integration matrix

## Review notes

Code review caught a sev-95 blocker: regenerating \`openapi.json\` was necessary but not sufficient — the SDK/client generators encode field order from the spec, so \`scripts/regen-client.sh\` had to run too. Fixed in the same commit. Both \`test_sdk_snapshot.py\` and \`test_client_snapshot.py\` now pass.

Other verifications:
- Field counts: Create = 17 (13 inherited + 4 own), Update = 15 (13 + 2). Matches original.
- \`extra=\"forbid\"\` propagates to both subclasses (verified via \`additionalProperties: false\` on both schemas in \`openapi.json\`).
- \`metadata\` semantic asymmetry preserved (Create=factory dict, Update=None for preserve-existing).
- \`target_url\`/\`auth_type\` immutability on Update preserved (still absent from \`VaultCredentialUpdate.model_fields\`).
- Mixin uses leading underscore — clearly internal-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)