### PR TITLE
refactor(cli): centralize PayloadError handling in run_or_die

### DIFF
--- a/src/aios/cli/commands/agents.py
+++ b/src/aios/cli/commands/agents.py
@@ -8,8 +8,8 @@ from typing import Annotated
 import typer
 
 from aios.cli.commands._shared import call_single, render_paginated, unwrap
-from aios.cli.files import PayloadError, load_payload
-from aios.cli.output import print_error, print_success
+from aios.cli.files import load_payload
+from aios.cli.output import print_success
 from aios.cli.runtime import get_state, run_or_die
 from aios_sdk._generated.api.agents import (
     archive_agent,
@@ -68,11 +68,7 @@ def create(
     data: Annotated[str | None, typer.Option("--data", help="Inline JSON body.")] = None,
 ) -> None:
     def _run() -> int | None:
-        try:
-            payload = load_payload(file, stdin, data)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+        payload = load_payload(file, stdin, data)
         body = AgentCreate.from_dict(payload)
         call_single(ctx, create_agent.sync_detailed, body=body)
         return None
@@ -89,11 +85,7 @@ def update(
     data: Annotated[str | None, typer.Option("--data")] = None,
 ) -> None:
     def _run() -> int | None:
-        try:
-            payload = load_payload(file, stdin, data)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+        payload = load_payload(file, stdin, data)
         body = AgentUpdate.from_dict(payload)
         call_single(ctx, update_agent.sync_detailed, agent_id=agent_id, body=body)
         return None

--- a/src/aios/cli/commands/connections.py
+++ b/src/aios/cli/commands/connections.py
@@ -158,22 +158,10 @@ def create(
                 return 64
             ergonomic = {"connector": connector, "external_account_id": external_account_id}
             if metadata_json is not None:
-                try:
-                    ergonomic["metadata"] = load_json_object(metadata_json, "--metadata-json")
-                except PayloadError as exc:
-                    print_error(str(exc))
-                    return 64
+                ergonomic["metadata"] = load_json_object(metadata_json, "--metadata-json")
             if secret:
-                try:
-                    ergonomic["secrets"] = _parse_secret_kvs(secret)
-                except PayloadError as exc:
-                    print_error(str(exc))
-                    return 64
-        try:
-            payload = resolve_payload(ergonomic, file, stdin, data)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+                ergonomic["secrets"] = _parse_secret_kvs(secret)
+        payload = resolve_payload(ergonomic, file, stdin, data)
         body = ConnectionCreate.from_dict(payload)
         call_single(ctx, create_connection.sync_detailed, body=body)
         return None
@@ -202,11 +190,7 @@ def set_secrets(
     ] = None,
 ) -> None:
     def _run() -> int | None:
-        try:
-            kvs = _parse_secret_kvs(secret or [])
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+        kvs = _parse_secret_kvs(secret or [])
         body = ConnectionSetSecrets(secrets=ConnectionSetSecretsSecrets.from_dict(kvs))
         call_single(
             ctx, set_connection_secrets.sync_detailed, connection_id=connection_id, body=body

--- a/src/aios/cli/commands/envs.py
+++ b/src/aios/cli/commands/envs.py
@@ -8,8 +8,8 @@ from typing import Annotated
 import typer
 
 from aios.cli.commands._shared import call_single, render_paginated, unwrap
-from aios.cli.files import PayloadError, load_payload
-from aios.cli.output import print_error, print_success
+from aios.cli.files import load_payload
+from aios.cli.output import print_success
 from aios.cli.runtime import get_state, run_or_die
 from aios_sdk._generated.api.environments import (
     archive_environment,
@@ -62,11 +62,7 @@ def create(
     data: Annotated[str | None, typer.Option("--data")] = None,
 ) -> None:
     def _run() -> int | None:
-        try:
-            payload = load_payload(file, stdin, data)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+        payload = load_payload(file, stdin, data)
         body = EnvironmentCreate.from_dict(payload)
         call_single(ctx, create_environment.sync_detailed, body=body)
         return None
@@ -83,11 +79,7 @@ def update(
     data: Annotated[str | None, typer.Option("--data")] = None,
 ) -> None:
     def _run() -> int | None:
-        try:
-            payload = load_payload(file, stdin, data)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+        payload = load_payload(file, stdin, data)
         body = EnvironmentUpdate.from_dict(payload)
         call_single(ctx, update_environment.sync_detailed, env_id=env_id, body=body)
         return None

--- a/src/aios/cli/commands/session_templates.py
+++ b/src/aios/cli/commands/session_templates.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 import typer
 
 from aios.cli.commands._shared import call_single, render_paginated, unwrap
-from aios.cli.files import PayloadError, load_json_object, load_payload, resolve_payload
+from aios.cli.files import load_json_object, load_payload, resolve_payload
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
 from aios_sdk._generated.api.session_templates import (
@@ -98,16 +98,8 @@ def create(
             if agent_version is not None:
                 ergonomic["agent_version"] = agent_version
             if metadata_json is not None:
-                try:
-                    ergonomic["metadata"] = load_json_object(metadata_json, "--metadata-json")
-                except PayloadError as exc:
-                    print_error(str(exc))
-                    return 64
-        try:
-            payload = resolve_payload(ergonomic, file, stdin, data)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+                ergonomic["metadata"] = load_json_object(metadata_json, "--metadata-json")
+        payload = resolve_payload(ergonomic, file, stdin, data)
         body = SessionTemplateCreate.from_dict(payload)
         call_single(ctx, create_session_template.sync_detailed, body=body)
         return None
@@ -124,11 +116,7 @@ def update(
     data: Annotated[str | None, typer.Option("--data")] = None,
 ) -> None:
     def _run() -> int | None:
-        try:
-            payload = load_payload(file, stdin, data)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+        payload = load_payload(file, stdin, data)
         body = SessionTemplateUpdate.from_dict(payload)
         call_single(ctx, update_session_template.sync_detailed, template_id=template_id, body=body)
         return None

--- a/src/aios/cli/commands/sessions.py
+++ b/src/aios/cli/commands/sessions.py
@@ -17,7 +17,7 @@ from aios.cli.commands._shared import (
     render_single,
     with_client,
 )
-from aios.cli.files import PayloadError, load_json_object, load_payload
+from aios.cli.files import load_json_object, load_payload
 from aios.cli.output import cyan, dim, print_error, print_json, print_success
 from aios.cli.profile import compute_profile, profile_to_dict, render_profile
 from aios.cli.runtime import get_state, run_or_die
@@ -85,11 +85,7 @@ def create(
 ) -> None:
     def _run() -> int | None:
         if any([file, stdin, data]):
-            try:
-                payload = load_payload(file, stdin, data)
-            except PayloadError as exc:
-                print_error(str(exc))
-                return 64
+            payload = load_payload(file, stdin, data)
         else:
             if agent_id is None or environment_id is None:
                 print_error(
@@ -120,11 +116,7 @@ def update(
     data: Annotated[str | None, typer.Option("--data")] = None,
 ) -> None:
     def _run() -> int | None:
-        try:
-            payload = load_payload(file, stdin, data)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+        payload = load_payload(file, stdin, data)
         client = just_client(ctx)
         with client:
             obj = client.request("PUT", f"/v1/sessions/{session_id}", json_body=payload)
@@ -231,11 +223,7 @@ def send(
     def _run() -> int | None:
         body: dict[str, Any] = {"content": message}
         if metadata is not None:
-            try:
-                body["metadata"] = load_json_object(metadata, "--metadata")
-            except PayloadError as exc:
-                print_error(str(exc))
-                return 64
+            body["metadata"] = load_json_object(metadata, "--metadata")
         client = just_client(ctx)
         with client:
             event = client.request("POST", f"/v1/sessions/{session_id}/messages", json_body=body)

--- a/src/aios/cli/commands/skills.py
+++ b/src/aios/cli/commands/skills.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 import typer
 
 from aios.cli.commands._shared import call_single, render_paginated, unwrap
-from aios.cli.files import PayloadError, load_payload, walk_skill_dir
+from aios.cli.files import load_payload, walk_skill_dir
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
 from aios_sdk._generated.api.skills import (
@@ -136,18 +136,10 @@ def version_create(
 ) -> None:
     def _run() -> int | None:
         if dir_ is not None:
-            try:
-                files = walk_skill_dir(dir_)
-            except PayloadError as exc:
-                print_error(str(exc))
-                return 64
+            files = walk_skill_dir(dir_)
             payload: dict[str, Any] = {"files": files}
         else:
-            try:
-                payload = load_payload(file, stdin, data)
-            except PayloadError as exc:
-                print_error(str(exc))
-                return 64
+            payload = load_payload(file, stdin, data)
         body = SkillVersionCreate.from_dict(payload)
         call_single(ctx, create_skill_version.sync_detailed, skill_id=skill_id, body=body)
         return None
@@ -168,14 +160,6 @@ def _build_skill_payload(
         if title is None:
             print_error("--title is required when creating a skill from --dir")
             return 64
-        try:
-            files = walk_skill_dir(dir_)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+        files = walk_skill_dir(dir_)
         return {"display_title": title, "files": files}
-    try:
-        return load_payload(file, stdin, data)
-    except PayloadError as exc:
-        print_error(str(exc))
-        return 64
+    return load_payload(file, stdin, data)

--- a/src/aios/cli/commands/vaults.py
+++ b/src/aios/cli/commands/vaults.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 import typer
 
 from aios.cli.commands._shared import call_single, render_paginated, unwrap
-from aios.cli.files import PayloadError, load_json_object, load_payload, resolve_payload
+from aios.cli.files import load_json_object, load_payload, resolve_payload
 from aios.cli.output import print_error, print_success
 from aios.cli.runtime import get_state, run_or_die
 from aios_sdk._generated.api.vaults import (
@@ -96,16 +96,8 @@ def create(
                 return 64
             ergonomic = {"display_name": display_name}
             if metadata_json is not None:
-                try:
-                    ergonomic["metadata"] = load_json_object(metadata_json, "--metadata-json")
-                except PayloadError as exc:
-                    print_error(str(exc))
-                    return 64
-        try:
-            payload = resolve_payload(ergonomic, file, stdin, data)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+                ergonomic["metadata"] = load_json_object(metadata_json, "--metadata-json")
+        payload = resolve_payload(ergonomic, file, stdin, data)
         body = VaultCreate.from_dict(payload)
         call_single(ctx, create_vault.sync_detailed, body=body)
         return None
@@ -122,11 +114,7 @@ def update(
     data: Annotated[str | None, typer.Option("--data")] = None,
 ) -> None:
     def _run() -> int | None:
-        try:
-            payload = load_payload(file, stdin, data)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+        payload = load_payload(file, stdin, data)
         body = VaultUpdate.from_dict(payload)
         call_single(ctx, update_vault.sync_detailed, vault_id=vault_id, body=body)
         return None
@@ -225,11 +213,7 @@ def cred_create(
 ) -> None:
     def _run() -> int | None:
         source = body_file or file
-        try:
-            payload = load_payload(source, stdin, data)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+        payload = load_payload(source, stdin, data)
         body = VaultCredentialCreate.from_dict(payload)
         call_single(ctx, create_vault_credential.sync_detailed, vault_id=vault_id, body=body)
         return None
@@ -247,11 +231,7 @@ def cred_update(
     data: Annotated[str | None, typer.Option("--data")] = None,
 ) -> None:
     def _run() -> int | None:
-        try:
-            payload = load_payload(file, stdin, data)
-        except PayloadError as exc:
-            print_error(str(exc))
-            return 64
+        payload = load_payload(file, stdin, data)
         body = VaultCredentialUpdate.from_dict(payload)
         call_single(
             ctx,

--- a/src/aios/cli/runtime.py
+++ b/src/aios/cli/runtime.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 import typer
 
 from aios.cli.client import AiosApiError, AiosClient
+from aios.cli.files import PayloadError
 from aios.cli.output import OutputFormat, print_error
 
 if TYPE_CHECKING:
@@ -80,6 +81,9 @@ def run_or_die(fn: Callable[[], int | None]) -> None:
             print_error(f"detail: {exc.detail}")
         exit_code = 2 if exc.status_code == 401 else 1
         raise typer.Exit(exit_code) from exc
+    except PayloadError as exc:
+        print_error(str(exc))
+        raise typer.Exit(64) from exc
     except BrokenPipeError:
         _silence_stdout()
         raise typer.Exit(0) from None


### PR DESCRIPTION
## Summary

- 23 CLI commands across 7 files paid the same 4-line tax: \`try → PayloadError → print_error → return 64\`. \`run_or_die\` is already the CLI's error-handling boundary (\`AiosApiError\`, \`BrokenPipeError\`, \`KeyboardInterrupt\`) — added one more clause for \`PayloadError\`.
- Deleted all 23 site-level try/except blocks. Each load/parse call now propagates PayloadError to \`run_or_die\` and lands the same exit-64 with the same stderr message.
- Imports cleaned: \`PayloadError\` dropped where only caught (retained on \`connections.py\` which still raises from \`_parse_secret_kvs\`). \`print_error\` dropped from \`agents.py\`/\`envs.py\` (only used in deleted catches).

Net **+35 / -123 = -88 LOC** across 8 files.

## Why this matters

Canonical \"centralize at the boundary, not at every callsite\" kaizen. \`run_or_die\` was already the CLI's structured-exception handler for everything else; \`PayloadError\` was conspicuously the one CLI-input exception still handled per-callsite. 23-site deletion compresses to a 3-line addition. Future commands that load payloads no longer need to remember the try/except boilerplate.

## Test plan

- [x] \`uv run mypy src\` — clean (155 files)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1405 passed
- [ ] CI: full e2e/integration matrix

## Review notes

Code review (\`pr-review-toolkit:code-reviewer\`) returned **no findings** — \"Ship it. Behavior is bit-identical (same exit code 64, same stderr message).\" Verified:
- Exit code: was \`return 64\` (translated by \`run_or_die\`'s \`if rc: raise typer.Exit(rc)\`); now \`raise typer.Exit(64) from exc\` — same exit path.
- Message: identical \`print_error(str(exc))\` formatting; once in \`run_or_die\` instead of 23 sites.
- Except ordering safe (\`AiosApiError\` → \`PayloadError\` → \`BrokenPipeError\` → \`KeyboardInterrupt\`; no inheritance relationships).
- Non-PayloadError validation paths (\`--connector required\`, \`--title required\`, etc.) untouched — they correctly continue using in-function \`print_error → return 64\`.
- \`_parse_secret_kvs\` in \`connections.py\` still raises PayloadError; the import is retained as a raise-only consumer.
- \`_build_skill_payload\` annotation \`-> dict[str, Any] | int\` correctly retained (the int branch is the \`--title required\` check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)