### PR TITLE
fix(services/sessions): jail workspace_path to per-account subdir [security]

### DIFF
--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -269,11 +269,18 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     lifetime.
     """
     from aios.harness import runtime
-    from aios.sandbox.volumes import ensure_workspace_path
+    from aios.sandbox.volumes import ensure_workspace_path, validate_workspace_path
 
     settings = get_settings()
     account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     raw_path, session_env = await _load_session_provisioning(session_id, account_id=account_id)
+    # Re-validate at the bind-mount boundary: ``validate_workspace_path``
+    # also runs at session-create time, but a symlink swap on any
+    # directory component of ``raw_path`` between then and now would
+    # let ``ensure_workspace_path``'s ``Path.resolve()`` dereference
+    # to an out-of-jail target.  Re-running the check immediately
+    # before the bind-mount closes that TOCTOU window.
+    validate_workspace_path(raw_path, account_id)
     workspace_path = ensure_workspace_path(raw_path)
     env_config = await _load_environment_config(session_id, account_id=account_id)
     memory_echoes = await _materialize_memory_mounts(session_id, account_id=account_id)

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -19,6 +19,7 @@ import re
 from pathlib import Path
 
 from aios.config import get_settings
+from aios.errors import ForbiddenError
 
 _UNSAFE_FILENAME_CHARS = re.compile(r"[^\w.\-]")
 _MAX_FILENAME_LEN = 200
@@ -78,6 +79,50 @@ def ensure_workspace_path(raw_path: str) -> Path:
     path = Path(raw_path).resolve()
     path.mkdir(parents=True, exist_ok=True)
     return path
+
+
+def validate_workspace_path(raw_path: str, account_id: str) -> None:
+    """Refuse ``raw_path`` if it resolves outside the account's
+    workspace subdirectory.
+
+    Without this check an authenticated client could POST
+    ``/v1/sessions`` with e.g. ``workspace_path="/etc"`` and the
+    sandbox would bind-mount the host's ``/etc`` read-write at
+    ``/workspace`` — arbitrary host filesystem read/write via any
+    bash / write / edit tool call.  A path under another account's
+    subdir (``workspace_root/{other_account_id}/...``) would defeat
+    the per-account-subdir isolation ``insert_session`` enforces by
+    default.
+
+    ``Path.resolve()`` collapses ``..`` traversal and dereferences
+    symlinks on the supplied path before the ``is_relative_to``
+    check, so create-time inputs that already point outside the jail
+    are rejected — including ``/etc``, ``..``-traversal back up to
+    ``workspace_root/{other_account_id}``, and symlinks under the
+    account's subdir that point outward at validate time.
+
+    Limitations: this is the create-time + bind-mount-time check on
+    the workspace_path argument.  Symlinks WRITTEN inside the
+    mounted ``/workspace`` after the bind-mount is live still resolve
+    on the host filesystem at access time (Docker bind-mount semantic),
+    so a tool ``ln -s /etc /workspace/sneaky`` followed by
+    ``cat /workspace/sneaky/passwd`` still reads host ``/etc/passwd``.
+    Fencing that surface requires kernel-level mount options
+    (``nosymfollow``) or container-level MAC; out of scope for this
+    fix.
+
+    Raises ``ForbiddenError`` (403, not 422): semantically this is an
+    attempted privilege escalation per the project's "fail hard" stance,
+    and surfacing it under the auth-tier error family makes it visible
+    in audit logs as such.
+    """
+    path = Path(raw_path).resolve()
+    account_root = (get_settings().workspace_root / account_id).resolve()
+    if not path.is_relative_to(account_root):
+        raise ForbiddenError(
+            "workspace_path must resolve to within the account's workspace subdirectory",
+            detail={"workspace_path": raw_path},
+        )
 
 
 _MEMORY_STORES_ROOT = "_memory_stores"

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -26,6 +26,7 @@ from aios.models.sessions import (
     SessionStatus,
     split_resources_by_type,
 )
+from aios.sandbox.volumes import validate_workspace_path
 from aios.services import github_repositories as github_repo_service
 from aios.services import memory_stores as memory_service
 
@@ -94,6 +95,8 @@ async def create_session(
     ``github_repository`` entries (their auth tokens are encrypted on
     insert). Memory-store-only attachments don't need it.
     """
+    if workspace_path is not None:
+        validate_workspace_path(workspace_path, account_id)
     async with pool.acquire() as conn, conn.transaction():
         session = await queries.insert_session(
             conn,
@@ -431,6 +434,8 @@ async def clone_session(
     workspace_path: str | None = None,
 ) -> Session:
     """Clone a session — see :func:`queries.clone_session`."""
+    if workspace_path is not None:
+        validate_workspace_path(workspace_path, account_id)
     async with pool.acquire() as conn:
         session = await queries.clone_session(
             conn, parent_session_id, workspace_path=workspace_path, account_id=account_id

--- a/tests/integration/test_workspace_path_jail.py
+++ b/tests/integration/test_workspace_path_jail.py
@@ -1,0 +1,166 @@
+"""Integration test: ``workspace_path`` must be jailed within the
+account's workspace subdirectory.
+
+Pre-fix the ``SessionCreate.workspace_path`` validator only checked
+``is_absolute()``.  ``ensure_workspace_path`` then ``mkdir(parents=True,
+exist_ok=True)``'d any existing host path, and the sandbox spec
+bind-mounted it read-write at ``/workspace``.  Any authenticated
+client could:
+
+- Set ``workspace_path="/etc"`` (or ``/var/log``, ``/Users/tom/...``)
+  and read/write arbitrary host files through bash / write / edit
+  tools.
+- Set ``workspace_path=str(workspace_root / other_account_id /
+  some_session)`` and cross into another tenant's session files,
+  defeating the per-account-subdir isolation that ``insert_session``
+  enforces by default.
+
+The fix validates that the resolved ``workspace_path`` is within
+``workspace_root/{account_id}/``.  ``Path.resolve()`` collapses
+``..`` traversal and dereferences symlinks before the
+``is_relative_to`` check, so neither escape vector slips through.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.config import get_settings
+from aios.db.pool import create_pool
+from aios.errors import ForbiddenError
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def two_accounts_with_agent_env(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str, str]]:
+    """Yield ``(pool, acc_a, acc_b, agent_a_id, env_a_id)`` —
+    two child accounts plus an agent + env owned by acc_a so we can
+    build a sibling test that tenant A can't mount tenant B's path."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_root',  NULL,      TRUE,  'tenant-root'),
+                       ('acc_a',     'acc_root', FALSE, 'tenant-a'),
+                       ('acc_b',     'acc_root', FALSE, 'tenant-b')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_a",
+            name="ws-jail-test",
+            model="openrouter/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_a", name="ws-jail-env"
+        )
+        yield pool, "acc_a", "acc_b", agent.id, env.id
+    finally:
+        await pool.close()
+
+
+async def test_create_session_rejects_arbitrary_host_path(
+    two_accounts_with_agent_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    """``workspace_path="/etc"`` (or any host path outside the
+    workspace root) must be rejected before the row lands in the DB
+    and before the sandbox provisioner gets a chance to bind-mount
+    it."""
+    pool, acc_a, _acc_b, agent_id, env_id = two_accounts_with_agent_env
+
+    with pytest.raises(ForbiddenError):
+        await sessions_service.create_session(
+            pool,
+            account_id=acc_a,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            workspace_path="/etc",
+        )
+
+
+async def test_create_session_rejects_cross_tenant_workspace_path(
+    two_accounts_with_agent_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    """A workspace_path that resolves into another account's
+    subdirectory must be rejected.  Closes the per-account-subdir
+    invariant ``insert_session`` enforces by default."""
+    pool, acc_a, acc_b, agent_id, env_id = two_accounts_with_agent_env
+    other_account_dir = str(get_settings().workspace_root / acc_b / "any_session")
+
+    with pytest.raises(ForbiddenError):
+        await sessions_service.create_session(
+            pool,
+            account_id=acc_a,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            workspace_path=other_account_dir,
+        )
+
+
+async def test_create_session_rejects_dotdot_traversal_back_to_other_tenant(
+    two_accounts_with_agent_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    """A ``..``-laced path that resolves into another account's subdir
+    must be rejected.  ``Path.resolve()`` collapses ``..`` segments
+    before the ``is_relative_to`` check; pinning this case ensures a
+    future refactor swapping ``.resolve()`` for ``.absolute()`` (which
+    preserves ``..``) is caught by the suite."""
+    pool, acc_a, acc_b, agent_id, env_id = two_accounts_with_agent_env
+    traversed = str(get_settings().workspace_root / acc_a / ".." / acc_b / "sneaky")
+
+    with pytest.raises(ForbiddenError):
+        await sessions_service.create_session(
+            pool,
+            account_id=acc_a,
+            agent_id=agent_id,
+            environment_id=env_id,
+            title=None,
+            metadata={},
+            workspace_path=traversed,
+        )
+
+
+async def test_create_session_accepts_within_account_subdir(
+    two_accounts_with_agent_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    """Operators legitimately override ``workspace_path`` to share a
+    workspace between sessions of the same account (per the
+    ``clone_session`` docstring's "share a read-only volume between
+    clones" example).  Paths within ``workspace_root/{account_id}/``
+    must still pass."""
+    pool, acc_a, _acc_b, agent_id, env_id = two_accounts_with_agent_env
+    own_account_dir = str(get_settings().workspace_root / acc_a / "shared")
+
+    session = await sessions_service.create_session(
+        pool,
+        account_id=acc_a,
+        agent_id=agent_id,
+        environment_id=env_id,
+        title=None,
+        metadata={},
+        workspace_path=own_account_dir,
+    )
+
+    assert session.id.startswith("sess_")


### PR DESCRIPTION
## Summary (security-critical)

- Pre-fix any authenticated client could POST ``/v1/sessions`` (or ``POST /v1/sessions/:id/clone``) with ``workspace_path="/etc"`` or any host path — the sandbox would bind-mount the target read-write at ``/workspace``, giving the model's bash / write / edit tool calls arbitrary host filesystem read/write.  Cross-tenant: tenant A could supply ``workspace_root/{B}/...`` to mount tenant B's session files.
- The ``SessionCreate.workspace_path`` and ``SessionCloneRequest.workspace_path`` validators only checked ``is_absolute()``.  ``ensure_workspace_path`` then ``mkdir(parents=True, exist_ok=True)``'d any path and ``spec.py`` bind-mounted it rw at ``/workspace``.

## Fix

- New ``validate_workspace_path(raw_path, account_id)`` in ``sandbox/volumes.py`` rejects paths that don't resolve into ``workspace_root/{account_id}/``.  ``Path.resolve()`` collapses ``..`` traversal and dereferences create-time symlinks before the ``is_relative_to`` check.  Raises ``ForbiddenError`` (403) — substrate framing is attempted privilege escalation per the project's "fail hard" stance, surfacing the rejection as an auth-tier failure in audit logs rather than a generic validation 422.
- Called from ``services.create_session`` and ``services.clone_session`` before passing through.
- **Re-called at the bind-mount boundary** in ``spec.py`` immediately before ``ensure_workspace_path`` so a symlink swap on any directory component between session-create and first-provision can't escape the jail (TOCTOU close, per code-reviewer finding).

## Out-of-scope follow-up (security-relevant, deserves its own iteration)

Symlinks **WRITTEN inside** the mounted ``/workspace`` after the bind-mount is live still resolve on the host filesystem at access time (Docker bind-mount semantic) — a tool ``ln -s /etc /workspace/sneaky`` followed by ``cat /workspace/sneaky/passwd`` still reads host ``/etc/passwd``.  Fencing that surface requires kernel-level mount options (``nosymfollow``) or container-level MAC.  Documented as a known limitation in ``validate_workspace_path``'s docstring; addressing it deserves operator input on the container-hardening approach.

## Test plan

- [x] ``tests/integration/test_workspace_path_jail.py`` covers four cases:
  - host path (``"/etc"``) rejected
  - cross-tenant path (``workspace_root/{B}/...``) rejected
  - ``..``-traversal back to another tenant rejected
  - within-account path accepted (legitimate clone-share use case)
- [x] Type-checker — clean (155 source files)
- [x] Linter + format-check — clean
- [x] Unit suite — 1405 passed
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)