### PR TITLE
refactor(sandbox/github_clone): consolidate token-redacted error envelopes

### DIFF
--- a/src/aios/sandbox/github_clone.py
+++ b/src/aios/sandbox/github_clone.py
@@ -104,6 +104,18 @@ async def _run_git(
     return rc, stdout, stderr
 
 
+def _raise_redacted_git_error(stderr: bytes, *, message: str, token: str) -> None:
+    """Raise :class:`GithubCloneError` with ``stderr`` decoded and
+    token-redacted appended to ``message``.
+
+    Used by every raise site whose preceding ``_run_git`` operation
+    carried the auth-embedded URL (clone, fetch, remote set-url) and
+    whose stderr could therefore leak the token if echoed verbatim.
+    """
+    redacted = _redact_token_from_message(stderr.decode("utf-8", errors="replace"), token)
+    raise GithubCloneError(f"{message}: {redacted}")
+
+
 async def ensure_cache_clone(repo_url: str, token: str) -> Path:
     """Ensure ``<cache_root>/<url_hash>`` is a populated bare clone.
 
@@ -152,9 +164,8 @@ async def ensure_cache_clone(repo_url: str, token: str) -> Path:
                 # Drop any partial dir so the next attempt re-clones from scratch.
                 if cache_dir.exists():
                     shutil.rmtree(cache_dir, ignore_errors=True)
-                raise GithubCloneError(
-                    f"git clone --bare failed for {repo_url!r}: "
-                    f"{_redact_token_from_message(stderr.decode('utf-8', errors='replace'), token)}"
+                _raise_redacted_git_error(
+                    stderr, message=f"git clone --bare failed for {repo_url!r}", token=token
                 )
             # Disable gc on the bare cache so it can't reap objects that
             # per-session working trees alternate against.
@@ -250,9 +261,10 @@ async def ensure_session_working_tree(
     if rc != 0:
         if work_dir.exists():
             shutil.rmtree(work_dir, ignore_errors=True)
-        raise GithubCloneError(
-            f"git clone --reference failed for session {session_id} repo {resource_id}: "
-            f"{_redact_token_from_message(stderr.decode('utf-8', errors='replace'), token)}"
+        _raise_redacted_git_error(
+            stderr,
+            message=f"git clone --reference failed for session {session_id} repo {resource_id}",
+            token=token,
         )
 
     # Replace the auth-embedded origin URL with the proxy URL. The bind
@@ -267,9 +279,10 @@ async def ensure_session_working_tree(
     if rc != 0:
         if work_dir.exists():
             shutil.rmtree(work_dir, ignore_errors=True)
-        raise GithubCloneError(
-            f"failed to scrub origin URL for session {session_id} repo {resource_id}: "
-            f"{_redact_token_from_message(stderr.decode('utf-8', errors='replace'), token)}"
+        _raise_redacted_git_error(
+            stderr,
+            message=f"failed to scrub origin URL for session {session_id} repo {resource_id}",
+            token=token,
         )
 
     for key, value in (("user.name", git_user_name), ("user.email", git_user_email)):


### PR DESCRIPTION
## Summary

- Three raise sites in \`src/aios/sandbox/github_clone.py\` (clone --bare, clone --reference, remote set-url) constructed the same multi-line error envelope: \`GithubCloneError(f\"<context>: {_redact_token_from_message(stderr.decode(...), token)}\")\`.
- Extracted \`_raise_redacted_git_error(stderr, *, message, token)\` helper that does decode → redact → raise. Call sites collapse the 4-line raise to a 3-line invocation.
- Fourth raise site (\`git config user.name/email\`) intentionally left as-is — its argv carries no auth URL so its stderr cannot leak the token; helper docstring scopes itself to operations that DID carry the auth-embedded URL.

Net **+13 LOC** (yellow flag — justified). The bulk is the helper's 5-line docstring pinning the security invariant.

## Why this matters

This was flagged in iter 4's sandbox audit. Future clone/fetch additions are pointed at the canonical helper rather than re-typing the pattern (which is exactly how the original duplication arose). Single point for token-redaction logic = single point for security audit, less risk of future contributors forgetting redaction.

## Test plan

- [x] \`uv run mypy src\` — clean (155 files)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1405 passed (incl. all 15 github_clone tests)
- [ ] CI: full e2e/integration matrix

## Review notes

Code review (\`pr-review-toolkit:code-reviewer\`) returned **no findings ≥ 80** — \"Code meets standards.\" Verified:
- Behavior preservation: error envelope strings are byte-identical (caller passes pre-colon prefix; helper appends \`\": \"\` then redacted stderr).
- Cleanup-before-raise: each site still runs \`shutil.rmtree(..., ignore_errors=True)\` BEFORE the helper call.
- Site 4 (git config user.name) correctly excluded — that command's argv contains no auth URL.
- mypy treats \`-> None\` on always-raising helper as well-typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)