### PR TITLE
fix(sandbox/registry): don't pop _locks entry mid-cleanup

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -302,7 +302,20 @@ class SandboxRegistry:
 
         handle = self._handles.pop(session_id, None)
         self._last_used.pop(session_id, None)
-        self._locks.pop(session_id, None)
+        # NOTE: do NOT pop self._locks[session_id] here.  The two
+        # release()-callers (``release_if_mounts_changed`` and the
+        # idle reaper) wrap this call in ``async with
+        # self._lock_for(session_id)``; popping the entry mid-release
+        # would leave the caller holding a lock that's no longer
+        # findable in the dict, so a concurrent ``get_or_provision``
+        # would call ``_lock_for()``, see no entry, create a new
+        # lock, and race with the in-progress release.  The race
+        # leaks: ``_release_mcp_broker_secret`` below would
+        # unregister the new provision's broker secret, wedging the
+        # new sandbox.  The accumulation of one ``asyncio.Lock`` per
+        # ever-touched session is a bounded leak that the worker's
+        # eventual restart clears; the race is unacceptable.
+        # ``release_all()`` clears the whole dict at teardown.
         proxy = self._git_proxies.pop(session_id, None)
 
         if proxy is not None:
@@ -369,7 +382,15 @@ class SandboxRegistry:
         from aios.harness import runtime
 
         self._last_used.pop(session_id, None)
-        self._locks.pop(session_id, None)
+        # NOTE: do NOT pop self._locks[session_id] here either — same
+        # reason as ``release()``.  A concurrent ``get_or_provision``
+        # that is already inside ``async with self._lock_for(sid)``
+        # (awaiting ``_provision``) would have its lock disappear
+        # from the dict; a subsequent third task arriving via
+        # ``_lock_for(sid)`` would see no entry, create a new lock,
+        # and race with the in-flight provision.  ``_release_mcp_broker_secret``
+        # below would then unregister that in-flight provision's
+        # broker secret, wedging the new sandbox.
         if self._handles.pop(session_id, None) is not None:
             log.info("sandbox.evicted", session_id=session_id)
         # Drop the proxy too — a fresh sandbox will get a fresh proxy

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -185,40 +185,16 @@ class TestReleaseIfMountsChanged:
 
 
 class TestLocksDictCleanup:
-    """``SandboxRegistry._locks`` must release its per-session entries on
-    teardown. Pre-fix the dict was only ever populated (by
-    ``_lock_for``) and never popped — every session that ever provisioned
-    a sandbox left a permanent ``asyncio.Lock`` entry, slow unbounded
-    growth across long-running workers handling many sessions. Companion
-    leak class to #451 (runtime per-session caches not cleared on
-    ``release``) and #475 (mcp pool evict strands owner task)."""
-
-    async def test_release_clears_lock(self) -> None:
-        backend = FakeBackend()
-        registry = SandboxRegistry(backend=backend)
-        _seed(registry, "sess_X")
-        # Touch the lock so it lands in ``_locks``.
-        _ = registry._lock_for("sess_X")
-        assert "sess_X" in registry._locks
-
-        await registry.release("sess_X")
-
-        assert "sess_X" not in registry._locks, (
-            f"_locks still contains 'sess_X' after release; got "
-            f"{list(registry._locks)!r}. Slow unbounded growth across the "
-            f"worker's lifetime as sessions are released."
-        )
-
-    async def test_evict_clears_lock(self) -> None:
-        backend = FakeBackend()
-        registry = SandboxRegistry(backend=backend)
-        _seed(registry, "sess_X")
-        _ = registry._lock_for("sess_X")
-        assert "sess_X" in registry._locks
-
-        registry.evict("sess_X")
-
-        assert "sess_X" not in registry._locks
+    """``SandboxRegistry._locks`` is reclaimed at registry teardown
+    (``release_all``) only.  Both ``release()`` and ``evict()``
+    deliberately keep the per-session entry so a concurrent
+    ``get_or_provision`` (or one already in-flight) serializes via
+    the same lock instance — popping while another task is mid-
+    provision would let it run unprotected against the cleanup's
+    broker-secret unregistration, wedging the new sandbox.  One
+    ``asyncio.Lock`` per ever-touched session_id is a bounded leak
+    that the worker's eventual restart clears; the race is
+    unacceptable."""
 
     async def test_release_all_clears_locks(self) -> None:
         backend = FakeBackend()
@@ -232,6 +208,73 @@ class TestLocksDictCleanup:
         await registry.release_all()
 
         assert registry._locks == {}
+
+    async def test_evict_does_not_pop_lock_entry(self) -> None:
+        """``evict()`` must also keep ``_locks[sid]`` so an in-flight
+        ``get_or_provision`` that already acquired the lock isn't left
+        holding an instance that's no longer findable — a third caller
+        arriving via ``_lock_for(sid)`` would then create a new lock
+        and race with the in-flight provision."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        _seed(registry, "sess_X")
+        original_lock = registry._lock_for("sess_X")
+
+        registry.evict("sess_X")
+
+        assert registry._lock_for("sess_X") is original_lock
+
+    async def test_release_does_not_pop_lock_entry_mid_release(self) -> None:
+        """``release()`` must NOT pop ``_locks[sid]`` mid-release.
+
+        ``release_if_mounts_changed`` and the idle reaper both wrap
+        ``release()`` in ``async with self._lock_for(sid)`` so that a
+        concurrent ``get_or_provision`` serializes behind them.  If
+        ``release()`` pops ``_locks[sid]`` while its awaits (proxy
+        stop, ``backend.destroy``) are still in flight, the lock the
+        caller holds is no longer findable in the dict — a concurrent
+        ``get_or_provision`` would call ``_lock_for()``, see no entry,
+        and create a NEW lock.  Both tasks then run unprotected, and
+        ``release()``'s subsequent ``_release_mcp_broker_secret`` call
+        unregisters the new provision's broker secret, wedging the
+        new sandbox with no MCP authentication until the next eviction
+        cycle.
+        """
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        _seed(registry, "sess_X")
+
+        destroy_started = asyncio.Event()
+        destroy_unblock = asyncio.Event()
+
+        async def blocking_destroy(handle: SandboxHandle) -> None:
+            destroy_started.set()
+            await destroy_unblock.wait()
+
+        backend.destroy = blocking_destroy  # type: ignore[method-assign]
+
+        original_lock = registry._lock_for("sess_X")
+
+        async def release_task() -> None:
+            async with registry._lock_for("sess_X"):
+                await registry.release("sess_X")
+
+        task = asyncio.create_task(release_task())
+        try:
+            await destroy_started.wait()
+
+            # While release() is in progress, ``_lock_for`` MUST return
+            # the same lock instance the caller is holding.  Otherwise a
+            # concurrent provision creates a new lock and races.
+            lock_during_release = registry._lock_for("sess_X")
+            assert lock_during_release is original_lock, (
+                "release() popped _locks[sid] mid-release; a concurrent "
+                "get_or_provision would create a new lock and race with "
+                "the still-running release."
+            )
+        finally:
+            destroy_unblock.set()
+            await task
 
 
 class TestEvictReclamation:


### PR DESCRIPTION
## Summary

- ``SandboxRegistry.release()`` popped ``self._locks[session_id]`` BEFORE its awaits (``_stop_proxy_silently``, ``backend.destroy``) completed.  ``release_if_mounts_changed`` and the idle reaper wrap ``release()`` in ``async with self._lock_for(sid)`` for mutual exclusion vs ``get_or_provision``.  With the pop mid-release, the lock the caller holds was no longer findable in the dict — a concurrent ``get_or_provision`` would see no entry, create a NEW lock, and proceed in parallel.  ``release()``'s subsequent ``_release_mcp_broker_secret`` then unregistered the new provision's broker secret, wedging the new sandbox with no MCP authentication.  Silent 401s on every MCP tool call until the next eviction cycle.
- ``evict()`` had the same shape (per code review).  An in-flight ``get_or_provision`` already inside ``async with self._lock_for(sid)`` would have its lock popped from the dict; a third task arriving via ``_lock_for(sid)`` would create a new lock and race with the in-flight provision while evict's ``_release_mcp_broker_secret`` unregistered the in-flight provision's secret.
- Fix: remove ``self._locks.pop(session_id, None)`` from both ``release()`` and ``evict()``.  ``release_all()`` still clears the dict at registry teardown.  One ``asyncio.Lock`` (~120 bytes) per ever-touched session_id is a bounded leak that the worker's eventual restart clears; the race is unacceptable.  The decision-rationale lives in inline comments at both sites so a future refactor doesn't re-introduce the pop.

## Test changes

- Deleted ``test_release_clears_lock`` and ``test_evict_clears_lock`` (they asserted the now-buggy behavior).
- Added ``test_release_does_not_pop_lock_entry_mid_release`` — blocks ``backend.destroy`` on an event, asserts that during the suspension ``_lock_for`` returns the same lock instance the caller holds (pre-fix: a new unlocked lock).
- Added symmetric ``test_evict_does_not_pop_lock_entry`` for the evict() path.
- ``test_release_all_clears_locks`` unchanged — teardown still clears the dict.
- Class docstring rewritten to reflect the new "bounded leak < race" design.

## Test plan

- [x] Type-checker — clean (155 source files)
- [x] Linter + format-check — clean
- [x] Unit suite — 1405 passed
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)