### PR TITLE
refactor(services/sessions): extract _lock_session_or_raise helper

### DIFF
--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -233,6 +233,27 @@ async def append_event(
         )
 
 
+async def _lock_session_or_raise(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+) -> None:
+    """``SELECT FOR UPDATE`` the session row; raise NotFoundError on miss.
+
+    Called inside an outer ``async with conn.transaction()`` block to
+    serialize concurrent retries on the same session. The presence check
+    is a free side effect — the primary purpose is the row lock.
+    """
+    locked = await conn.fetchval(
+        "SELECT id FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
+        session_id,
+        account_id,
+    )
+    if locked is None:
+        raise NotFoundError(
+            f"session {session_id} not found",
+            detail={"session_id": session_id},
+        )
+
+
 async def append_tool_result(
     conn: asyncpg.Connection[Any],
     *,
@@ -262,20 +283,7 @@ async def append_tool_result(
     deferring the wake afterwards.
     """
     async with conn.transaction():
-        # Lock the session row up-front so a concurrent retry serializes
-        # behind us and observes the appended event on its check. The
-        # ``WHERE … RETURNING`` shape gives us the row-presence check
-        # as a free side effect — the primary purpose is the lock.
-        locked = await conn.fetchval(
-            "SELECT id FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
-            session_id,
-            account_id,
-        )
-        if locked is None:
-            raise NotFoundError(
-                f"session {session_id} not found",
-                detail={"session_id": session_id},
-            )
+        await _lock_session_or_raise(conn, session_id, account_id=account_id)
         existing = await queries.find_tool_result_event(
             conn, session_id, tool_call_id, account_id=account_id
         )
@@ -549,16 +557,7 @@ async def confirm_tool_allow(
     silently accept impossible inputs.
     """
     async with pool.acquire() as conn, conn.transaction():
-        locked = await conn.fetchval(
-            "SELECT id FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
-            session_id,
-            account_id,
-        )
-        if locked is None:
-            raise NotFoundError(
-                f"session {session_id} not found",
-                detail={"session_id": session_id},
-            )
+        await _lock_session_or_raise(conn, session_id, account_id=account_id)
         existing = await queries.find_tool_confirmed_event(
             conn, session_id, tool_call_id, account_id=account_id
         )


### PR DESCRIPTION
## Summary

- \`append_tool_result\` (#533) and \`confirm_tool_allow\` (#535) added the same 10-line prelude — \`SELECT FOR UPDATE\` on the session row + \`NotFoundError\` on miss — without seeing each other's prior art. Two PRs, one pattern, two copies.
- Lift into \`_lock_session_or_raise(conn, session_id, *, account_id)\` placed beside the existing service helpers. Both call sites collapse to one line.
- Helper is called inside the existing \`conn.transaction()\` block at each site; it does NOT open its own transaction (\`SELECT FOR UPDATE\` requires the caller's tx context).

Net **-1 LOC**. Won't drift if a third lock-or-404 site lands.

## Why this matters

The duplication was fresh — both raise sites were introduced AFTER iter 2's services audit. Surfaced by iter 12's fresh services audit (9 PRs of churn since the last fresh services pass). Classic broken-windows territory: two near-simultaneous PRs added the same prelude without coordination, and a third PR would have done the same.

## Test plan

- [x] \`uv run mypy src\` — clean (155 files)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1405 passed
- [ ] CI: full e2e/integration matrix

## Review notes

Code review returned **no findings ≥ 80** — \"Approve as-is.\" Verified:
- **SQL byte-identical** to original; **NotFoundError shape preserved** (same message format, same \`detail\` dict).
- **No new transaction**: helper calls \`conn.fetchval\` directly; \`SELECT FOR UPDATE\` requires the caller's tx context (both call sites already in \`conn.transaction()\` blocks).
- **Helper module-private** (\`_\` prefix); placed between \`append_event\` and \`append_tool_result\` to preserve definition-before-use.
- **Docstring corrects a wording bug** in the deleted comment: original said \"WHERE … RETURNING shape\" but the query has \`FOR UPDATE\` not \`RETURNING\` — helper docstring uses the accurate term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)