### PR TITLE
refactor(tests/integration): extract seed_agent_env_session fixture (big-win)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,58 @@ from typing import Any
 import asyncpg
 import pytest
 
+from aios.db import queries
+from aios.models.agents import Agent, ToolSpec
+from aios.models.environments import Environment
+from aios.models.sessions import Session
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+
+
+async def seed_agent_env_session(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    prefix: str,
+    tools: list[ToolSpec] | None = None,
+) -> tuple[Agent, Environment, Session]:
+    """Seed a default ``(agent, env, session)`` trio scoped to ``account_id``.
+
+    Used by integration tests that need a session-shaped scaffold but
+    don't care about the specifics of the agent / environment / session
+    rows. The agent name is ``{prefix}-agent``; the env name is
+    ``{prefix}-env``. Other agent settings (``model="openrouter/test"``,
+    ``window_min=50_000``, ``window_max=150_000``, empty system /
+    description / metadata) match the long-standing conventions across
+    the existing integration tests.
+    """
+    agent = await agents_service.create_agent(
+        pool,
+        account_id=account_id,
+        name=f"{prefix}-agent",
+        model="openrouter/test",
+        system="",
+        tools=tools or [],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    env = await environments_service.create_environment(
+        pool, account_id=account_id, name=f"{prefix}-env"
+    )
+    async with pool.acquire() as conn:
+        session = await queries.insert_session(
+            conn,
+            account_id=account_id,
+            agent_id=agent.id,
+            environment_id=env.id,
+            agent_version=agent.version,
+            title=None,
+            metadata={},
+        )
+    return agent, env, session
+
 
 @pytest.fixture
 async def conn_two_accounts(

--- a/tests/integration/test_append_event_archived.py
+++ b/tests/integration/test_append_event_archived.py
@@ -31,8 +31,7 @@ import pytest
 from aios.db import queries
 from aios.db.pool import create_pool
 from aios.errors import NotFoundError
-from aios.services import agents as agents_service
-from aios.services import environments as environments_service
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -52,31 +51,10 @@ async def archived_session(
                 VALUES ('acc_archived', NULL, TRUE, 'archived-session-test')
                 """
             )
-        agent = await agents_service.create_agent(
-            pool,
-            account_id="acc_archived",
-            name="archived-test",
-            model="openrouter/test",
-            system="",
-            tools=[],
-            description=None,
-            metadata={},
-            window_min=50_000,
-            window_max=150_000,
-        )
-        env = await environments_service.create_environment(
-            pool, account_id="acc_archived", name="archived-test-env"
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_archived", prefix="archived-test"
         )
         async with pool.acquire() as conn:
-            session = await queries.insert_session(
-                conn,
-                account_id="acc_archived",
-                agent_id=agent.id,
-                environment_id=env.id,
-                agent_version=agent.version,
-                title=None,
-                metadata={},
-            )
             await queries.archive_session(conn, session.id, account_id="acc_archived")
         yield pool, "acc_archived", session.id
     finally:

--- a/tests/integration/test_attach_connection_archived_session.py
+++ b/tests/integration/test_attach_connection_archived_session.py
@@ -30,9 +30,8 @@ import pytest
 from aios.db import queries
 from aios.db.pool import create_pool
 from aios.errors import ConflictError
-from aios.services import agents as agents_service
 from aios.services import connections as connections_service
-from aios.services import environments as environments_service
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -53,31 +52,10 @@ async def archived_session_and_detached_connection(
                 VALUES ('acc_attach_arch', NULL, TRUE, 'attach-archived-test')
                 """
             )
-        agent = await agents_service.create_agent(
-            pool,
-            account_id="acc_attach_arch",
-            name="attach-arch-test",
-            model="openrouter/test",
-            system="",
-            tools=[],
-            description=None,
-            metadata={},
-            window_min=50_000,
-            window_max=150_000,
-        )
-        env = await environments_service.create_environment(
-            pool, account_id="acc_attach_arch", name="attach-arch-env"
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_attach_arch", prefix="attach-arch"
         )
         async with pool.acquire() as conn:
-            session = await queries.insert_session(
-                conn,
-                account_id="acc_attach_arch",
-                agent_id=agent.id,
-                environment_id=env.id,
-                agent_version=agent.version,
-                title=None,
-                metadata={},
-            )
             connection = await queries.insert_connection(
                 conn,
                 connector="echo",

--- a/tests/integration/test_bind_chat_to_session_archived.py
+++ b/tests/integration/test_bind_chat_to_session_archived.py
@@ -27,9 +27,8 @@ import pytest
 from aios.db import queries
 from aios.db.pool import create_pool
 from aios.errors import ConflictError
-from aios.services import agents as agents_service
 from aios.services import connections as connections_service
-from aios.services import environments as environments_service
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -49,31 +48,10 @@ async def archived_session_and_connection(
                 VALUES ('acc_bind_arch', NULL, TRUE, 'bind-archived-test')
                 """
             )
-        agent = await agents_service.create_agent(
-            pool,
-            account_id="acc_bind_arch",
-            name="bind-arch-test",
-            model="openrouter/test",
-            system="",
-            tools=[],
-            description=None,
-            metadata={},
-            window_min=50_000,
-            window_max=150_000,
-        )
-        env = await environments_service.create_environment(
-            pool, account_id="acc_bind_arch", name="bind-arch-env"
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_bind_arch", prefix="bind-arch"
         )
         async with pool.acquire() as conn:
-            session = await queries.insert_session(
-                conn,
-                account_id="acc_bind_arch",
-                agent_id=agent.id,
-                environment_id=env.id,
-                agent_version=agent.version,
-                title=None,
-                metadata={},
-            )
             connection = await queries.insert_connection(
                 conn,
                 connector="echo",

--- a/tests/integration/test_confirm_tool_allow_after_resolved.py
+++ b/tests/integration/test_confirm_tool_allow_after_resolved.py
@@ -44,9 +44,8 @@ from aios.db import queries
 from aios.db.pool import create_pool
 from aios.errors import ConflictError
 from aios.models.agents import ToolSpec
-from aios.services import agents as agents_service
-from aios.services import environments as environments_service
 from aios.services import sessions as sessions_service
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -67,32 +66,14 @@ async def _seed_session_with_tool_call(
             account_id,
             f"allow-after-resolved-test-{suffix}",
         )
-    agent = await agents_service.create_agent(
+    _agent, _env, session = await seed_agent_env_session(
         pool,
         account_id=account_id,
-        name=f"allow-after-resolved-agent-{suffix}",
-        model="openrouter/test",
-        system="",
+        prefix=f"allow-after-resolved-{suffix}",
         tools=[ToolSpec(type="bash")],
-        description=None,
-        metadata={},
-        window_min=50_000,
-        window_max=150_000,
-    )
-    env = await environments_service.create_environment(
-        pool, account_id=account_id, name=f"allow-after-resolved-env-{suffix}"
     )
     tool_call_id = f"tc_resolved_{suffix}"
     async with pool.acquire() as conn:
-        session = await queries.insert_session(
-            conn,
-            account_id=account_id,
-            agent_id=agent.id,
-            environment_id=env.id,
-            agent_version=agent.version,
-            title=None,
-            metadata={},
-        )
         await queries.append_event(
             conn,
             account_id=account_id,

--- a/tests/integration/test_confirm_tool_allow_validates_call_id.py
+++ b/tests/integration/test_confirm_tool_allow_validates_call_id.py
@@ -40,9 +40,8 @@ from aios.db import queries
 from aios.db.pool import create_pool
 from aios.errors import NotFoundError
 from aios.models.agents import ToolSpec
-from aios.services import agents as agents_service
-from aios.services import environments as environments_service
 from aios.services import sessions as sessions_service
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -63,31 +62,10 @@ async def session_with_parent_tool_call(
                 VALUES ('acc_validate', NULL, TRUE, 'allow-validate-test')
                 """
             )
-        agent = await agents_service.create_agent(
-            pool,
-            account_id="acc_validate",
-            name="allow-validate-test",
-            model="openrouter/test",
-            system="",
-            tools=[ToolSpec(type="bash")],
-            description=None,
-            metadata={},
-            window_min=50_000,
-            window_max=150_000,
-        )
-        env = await environments_service.create_environment(
-            pool, account_id="acc_validate", name="allow-validate-env"
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_validate", prefix="allow-validate", tools=[ToolSpec(type="bash")]
         )
         async with pool.acquire() as conn:
-            session = await queries.insert_session(
-                conn,
-                account_id="acc_validate",
-                agent_id=agent.id,
-                environment_id=env.id,
-                agent_version=agent.version,
-                title=None,
-                metadata={},
-            )
             await queries.append_event(
                 conn,
                 account_id="acc_validate",

--- a/tests/integration/test_confirm_tool_deny_after_success.py
+++ b/tests/integration/test_confirm_tool_deny_after_success.py
@@ -38,9 +38,8 @@ from aios.db import queries
 from aios.db.pool import create_pool
 from aios.errors import ConflictError
 from aios.models.agents import ToolSpec
-from aios.services import agents as agents_service
-from aios.services import environments as environments_service
 from aios.services import sessions as sessions_service
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -62,31 +61,13 @@ async def session_with_tool_already_succeeded(
                 VALUES ('acc_deny_race', NULL, TRUE, 'deny-after-success-test')
                 """
             )
-        agent = await agents_service.create_agent(
+        _agent, _env, session = await seed_agent_env_session(
             pool,
             account_id="acc_deny_race",
-            name="deny-race-test",
-            model="openrouter/test",
-            system="",
+            prefix="deny-race",
             tools=[ToolSpec(type="bash")],
-            description=None,
-            metadata={},
-            window_min=50_000,
-            window_max=150_000,
-        )
-        env = await environments_service.create_environment(
-            pool, account_id="acc_deny_race", name="deny-race-env"
         )
         async with pool.acquire() as conn:
-            session = await queries.insert_session(
-                conn,
-                account_id="acc_deny_race",
-                agent_id=agent.id,
-                environment_id=env.id,
-                agent_version=agent.version,
-                title=None,
-                metadata={},
-            )
             # Parent assistant message with the tool_call.
             await queries.append_event(
                 conn,
@@ -185,31 +166,13 @@ class TestConfirmToolDenyAfterSuccess:
                     VALUES ('acc_deny_retry', NULL, TRUE, 'deny-retry-test')
                     """
                 )
-            agent = await agents_service.create_agent(
+            _agent, _env, session = await seed_agent_env_session(
                 pool,
                 account_id="acc_deny_retry",
-                name="deny-retry-test",
-                model="openrouter/test",
-                system="",
+                prefix="deny-retry",
                 tools=[ToolSpec(type="bash")],
-                description=None,
-                metadata={},
-                window_min=50_000,
-                window_max=150_000,
-            )
-            env = await environments_service.create_environment(
-                pool, account_id="acc_deny_retry", name="deny-retry-env"
             )
             async with pool.acquire() as conn:
-                session = await queries.insert_session(
-                    conn,
-                    account_id="acc_deny_retry",
-                    agent_id=agent.id,
-                    environment_id=env.id,
-                    agent_version=agent.version,
-                    title=None,
-                    metadata={},
-                )
                 await queries.append_event(
                     conn,
                     account_id="acc_deny_retry",

--- a/tests/integration/test_list_recent_chats_like.py
+++ b/tests/integration/test_list_recent_chats_like.py
@@ -36,8 +36,7 @@ from aios.db import queries
 from aios.db.pool import create_pool
 from aios.ids import make_id
 from aios.models.agents import ToolSpec
-from aios.services import agents as agents_service
-from aios.services import environments as environments_service
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -56,31 +55,9 @@ async def session_in_account(
                 VALUES ('acc_test', NULL, TRUE, 'tenant-test')
                 """
             )
-        agent = await agents_service.create_agent(
-            pool,
-            account_id="acc_test",
-            name="like-test",
-            model="openrouter/test",
-            system="",
-            tools=[ToolSpec(type="bash")],
-            description=None,
-            metadata={},
-            window_min=50_000,
-            window_max=150_000,
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_test", prefix="like-test", tools=[ToolSpec(type="bash")]
         )
-        env = await environments_service.create_environment(
-            pool, account_id="acc_test", name="like-test-env"
-        )
-        async with pool.acquire() as conn:
-            session = await queries.insert_session(
-                conn,
-                account_id="acc_test",
-                agent_id=agent.id,
-                environment_id=env.id,
-                agent_version=agent.version,
-                title=None,
-                metadata={},
-            )
         yield pool, "acc_test", session.id
     finally:
         await pool.close()

--- a/tests/integration/test_resolver_archived_session.py
+++ b/tests/integration/test_resolver_archived_session.py
@@ -38,9 +38,8 @@ import pytest
 
 from aios.db import queries
 from aios.db.pool import create_pool
-from aios.services import agents as agents_service
 from aios.services import connections as connections_service
-from aios.services import environments as environments_service
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -60,31 +59,10 @@ async def archived_session_bound_to_connection(
                 VALUES ('acc_resolver_arch', NULL, TRUE, 'resolver-archived-test')
                 """
             )
-        agent = await agents_service.create_agent(
-            pool,
-            account_id="acc_resolver_arch",
-            name="resolver-arch-test",
-            model="openrouter/test",
-            system="",
-            tools=[],
-            description=None,
-            metadata={},
-            window_min=50_000,
-            window_max=150_000,
-        )
-        env = await environments_service.create_environment(
-            pool, account_id="acc_resolver_arch", name="resolver-arch-env"
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_resolver_arch", prefix="resolver-arch"
         )
         async with pool.acquire() as conn:
-            session = await queries.insert_session(
-                conn,
-                account_id="acc_resolver_arch",
-                agent_id=agent.id,
-                environment_id=env.id,
-                agent_version=agent.version,
-                title=None,
-                metadata={},
-            )
             # Insert a connection directly via the DB (the public
             # ``create_connection`` API requires a richer fixture set).
             connection = await queries.insert_connection(
@@ -157,31 +135,10 @@ async def chat_sessions_ledger_with_archived_session(
                 VALUES ('acc_ledger_arch', NULL, TRUE, 'ledger-archived-test')
                 """
             )
-        agent = await agents_service.create_agent(
-            pool,
-            account_id="acc_ledger_arch",
-            name="ledger-arch-test",
-            model="openrouter/test",
-            system="",
-            tools=[],
-            description=None,
-            metadata={},
-            window_min=50_000,
-            window_max=150_000,
-        )
-        env = await environments_service.create_environment(
-            pool, account_id="acc_ledger_arch", name="ledger-arch-env"
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_ledger_arch", prefix="ledger-arch"
         )
         async with pool.acquire() as conn:
-            session = await queries.insert_session(
-                conn,
-                account_id="acc_ledger_arch",
-                agent_id=agent.id,
-                environment_id=env.id,
-                agent_version=agent.version,
-                title=None,
-                metadata={},
-            )
             connection = await queries.insert_connection(
                 conn,
                 connector="echo",

--- a/tests/integration/test_tool_allow_idempotency.py
+++ b/tests/integration/test_tool_allow_idempotency.py
@@ -30,9 +30,8 @@ import pytest
 from aios.db import queries
 from aios.db.pool import create_pool
 from aios.models.agents import ToolSpec
-from aios.services import agents as agents_service
-from aios.services import environments as environments_service
 from aios.services import sessions as sessions_service
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -53,31 +52,10 @@ async def session_with_parent_tool_call(
                 VALUES ('acc_test', NULL, TRUE, 'tenant-test')
                 """
             )
-        agent = await agents_service.create_agent(
-            pool,
-            account_id="acc_test",
-            name="allow-test",
-            model="openrouter/test",
-            system="",
-            tools=[ToolSpec(type="bash")],
-            description=None,
-            metadata={},
-            window_min=50_000,
-            window_max=150_000,
-        )
-        env = await environments_service.create_environment(
-            pool, account_id="acc_test", name="allow-test-env"
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_test", prefix="allow-test", tools=[ToolSpec(type="bash")]
         )
         async with pool.acquire() as conn:
-            session = await queries.insert_session(
-                conn,
-                account_id="acc_test",
-                agent_id=agent.id,
-                environment_id=env.id,
-                agent_version=agent.version,
-                title=None,
-                metadata={},
-            )
             await queries.append_event(
                 conn,
                 account_id="acc_test",

--- a/tests/integration/test_tool_deny_idempotency.py
+++ b/tests/integration/test_tool_deny_idempotency.py
@@ -30,9 +30,8 @@ import pytest
 from aios.db import queries
 from aios.db.pool import create_pool
 from aios.models.agents import ToolSpec
-from aios.services import agents as agents_service
-from aios.services import environments as environments_service
 from aios.services import sessions as sessions_service
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -54,31 +53,10 @@ async def session_with_parent_tool_call(
                 VALUES ('acc_test', NULL, TRUE, 'tenant-test')
                 """
             )
-        agent = await agents_service.create_agent(
-            pool,
-            account_id="acc_test",
-            name="deny-test",
-            model="openrouter/test",
-            system="",
-            tools=[ToolSpec(type="bash")],
-            description=None,
-            metadata={},
-            window_min=50_000,
-            window_max=150_000,
-        )
-        env = await environments_service.create_environment(
-            pool, account_id="acc_test", name="deny-test-env"
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_test", prefix="deny-test", tools=[ToolSpec(type="bash")]
         )
         async with pool.acquire() as conn:
-            session = await queries.insert_session(
-                conn,
-                account_id="acc_test",
-                agent_id=agent.id,
-                environment_id=env.id,
-                agent_version=agent.version,
-                title=None,
-                metadata={},
-            )
             await queries.append_event(
                 conn,
                 account_id="acc_test",

--- a/tests/integration/test_tool_result_idempotency.py
+++ b/tests/integration/test_tool_result_idempotency.py
@@ -37,9 +37,8 @@ import pytest
 from aios.db import queries
 from aios.db.pool import create_pool
 from aios.models.agents import ToolSpec
-from aios.services import agents as agents_service
-from aios.services import environments as environments_service
 from aios.services import sessions as sessions_service
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -61,31 +60,10 @@ async def session_with_parent_tool_call(
                 VALUES ('acc_test', NULL, TRUE, 'tenant-test')
                 """
             )
-        agent = await agents_service.create_agent(
-            pool,
-            account_id="acc_test",
-            name="dedup-test",
-            model="openrouter/test",
-            system="",
-            tools=[ToolSpec(type="bash")],
-            description=None,
-            metadata={},
-            window_min=50_000,
-            window_max=150_000,
-        )
-        env = await environments_service.create_environment(
-            pool, account_id="acc_test", name="dedup-test-env"
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_test", prefix="dedup-test", tools=[ToolSpec(type="bash")]
         )
         async with pool.acquire() as conn:
-            session = await queries.insert_session(
-                conn,
-                account_id="acc_test",
-                agent_id=agent.id,
-                environment_id=env.id,
-                agent_version=agent.version,
-                title=None,
-                metadata={},
-            )
             # Append the parent assistant event with a tool_calls entry.
             await queries.append_event(
                 conn,

--- a/tests/integration/test_worker_result_after_deny.py
+++ b/tests/integration/test_worker_result_after_deny.py
@@ -44,10 +44,9 @@ from aios.harness import runtime
 from aios.harness.task_registry import TaskRegistry
 from aios.harness.tool_dispatch import _execute_tool_async
 from aios.models.agents import ToolSpec
-from aios.services import agents as agents_service
-from aios.services import environments as environments_service
 from aios.services import sessions as sessions_service
 from aios.tools.registry import registry
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -111,35 +110,17 @@ async def session_with_pending_tool_call(
                 VALUES ('acc_worker_race', NULL, TRUE, 'worker-deny-race-test')
                 """
             )
-        agent = await agents_service.create_agent(
+        # ``bash`` is a placeholder — the test invokes
+        # ``_execute_tool_async`` directly with a tool_call whose
+        # function.name targets the test-only registered tool, so
+        # the agent's declared tools list is not consulted.
+        _agent, _env, session = await seed_agent_env_session(
             pool,
             account_id="acc_worker_race",
-            name="worker-deny-race-test",
-            model="openrouter/test",
-            system="",
-            # ``bash`` is a placeholder — the test invokes
-            # ``_execute_tool_async`` directly with a tool_call whose
-            # function.name targets the test-only registered tool, so
-            # the agent's declared tools list is not consulted.
+            prefix="worker-deny-race",
             tools=[ToolSpec(type="bash")],
-            description=None,
-            metadata={},
-            window_min=50_000,
-            window_max=150_000,
-        )
-        env = await environments_service.create_environment(
-            pool, account_id="acc_worker_race", name="worker-deny-race-env"
         )
         async with pool.acquire() as conn:
-            session = await queries.insert_session(
-                conn,
-                account_id="acc_worker_race",
-                agent_id=agent.id,
-                environment_id=env.id,
-                agent_version=agent.version,
-                title=None,
-                metadata={},
-            )
             # Assistant message with one tool_call; no tool-role result
             # event yet (the tool is in-flight in the simulated race).
             await queries.append_event(


### PR DESCRIPTION
## Summary (big-win iteration)

This is the first "thorough-search" iteration after 12 small kaizens. Targeted the biggest LOC win in the deferred queue.

- 12 integration test files repeated the same ~18-line \`create_agent\` + \`create_environment\` + \`insert_session\` seed boilerplate with only \`account_id\`, name prefix, and (sometimes) \`tools\` varying.
- Add \`seed_agent_env_session(pool, *, account_id, prefix, tools=None)\` to \`tests/integration/conftest.py\` (whose docstring already documents the home: *"Anything that seeds reusable account / tenant state belongs here so individual test modules don't re-roll the same scaffolding."*).
- Each call site collapses from ~22 lines to ~3 lines.

Net **+96 / -339 = -243 LOC** across 13 files (12 tests + 1 conftest).

## Why this matters

After 12 normal-cadence kaizen iterations (-185 net LOC across small wins), the deferred queue had this -200+ LOC pattern waiting. The blast radius (15+ files) is what kept previous iterations from picking it; "thorough big-win mode" exists exactly for these.

## What's NOT in this PR (intentional skips)

- \`test_workspace_path_jail.py\` — fixture creates only agent+env, no session
- \`test_clone_preserves_resources.py\` / \`test_clone_preserves_focal_locked.py\` — use \`sessions_service.create_session(..., resources=[...])\`
- Update/concurrent tests (\`test_update_agent_concurrent.py\`, etc.) — diverge on session creation

Per kaizen "don't expand scope mid-implementation," sticking to the 12 that cleanly fit.

## Test plan

- [x] \`uv run mypy src\` — clean (155 files)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1405 passed
- [ ] CI: integration suite (the converted tests; this is the real validator)

## Review notes

Code review (\`pr-review-toolkit:code-reviewer\`) returned **no findings ≥ 80** — \"Approve.\" Verified:
- Behavior preservation: same 3 operations (create_agent → create_environment → insert_session), same kwargs.
- No test asserts on \`agent.name\` or \`env.name\` of the refactored fixtures (grep-confirmed; only skipped files have such assertions).
- Suffix-ordering quirk in \`test_confirm_tool_allow_after_resolved.py\` (suffix position in name moved from last to middle): functionally equivalent, no assertion.
- Imports cleaned: \`agents_service\` / \`environments_service\` removed exclusively where they became dead.
- Helper placement: matches the \`tests/helpers/sandbox.py::make_handle\` pattern (module-level async function, not a pytest fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)