### PR TITLE
fix(events API): pagination, silent failures, session-detail gaps (#596)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2627,7 +2627,7 @@
           "sessions"
         ],
         "summary": "List Events",
-        "description": "List events for a session, paginated by sequence number.\n\nPass the response's ``next_after`` field as ``?after=`` on the next call\nto walk forward through the stream. (The query param was previously\nnamed ``after_seq``, which didn't match the ``next_after`` response\nfield \u2014 clients following the natural roundtrip pattern sent\n``?after=`` and got it silently ignored, causing pagination to loop on\nthe first page. See issue #389.)",
+        "description": "List events for a session, paginated by sequence number.\n\nPass the response's ``next_after`` field as ``?after=`` on the next call\nto walk forward through the stream. (The query param was previously\nnamed ``after_seq``, which didn't match the ``next_after`` response\nfield \u2014 clients following the natural roundtrip pattern sent\n``?after=`` and got it silently ignored, causing pagination to loop on\nthe first page. See issue #389.)\n\n``?after_seq=N`` is accepted as an alias for ``?after=N`` for\nbackwards compatibility with older clients (issue #596).",
         "operationId": "list_session_events",
         "parameters": [
           {
@@ -2647,6 +2647,22 @@
               "type": "integer",
               "default": 0,
               "title": "After"
+            }
+          },
+          {
+            "name": "after_seq",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "After Seq"
             }
           },
           {
@@ -2717,6 +2733,74 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResponse_Event_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/sessions/{session_id}/events/{event_id}": {
+      "get": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Get Event",
+        "description": "Fetch a single event by its id.\n\nReturns 404 when the event does not exist or belongs to a different session.",
+        "operationId": "get_session_event",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "event_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Event Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
                 }
               }
             }
@@ -10648,6 +10732,23 @@
             "type": "boolean",
             "title": "Focal Locked",
             "default": false
+          },
+          "last_event_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Event At"
+          },
+          "total_events": {
+            "type": "integer",
+            "title": "Total Events",
+            "default": 0
           }
         },
         "type": "object",

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/get_session_event.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/get_session_event.py
@@ -1,0 +1,209 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.event import Event
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    event_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/sessions/{session_id}/events/{event_id}".format(
+            session_id=quote(str(session_id), safe=""),
+            event_id=quote(str(event_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Event | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = Event.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Event | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    event_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Event | HTTPValidationError]:
+    """Get Event
+
+     Fetch a single event by its id.
+
+    Returns 404 when the event does not exist or belongs to a different session.
+
+    Args:
+        session_id (str):
+        event_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Event | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        event_id=event_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    event_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Event | HTTPValidationError | None:
+    """Get Event
+
+     Fetch a single event by its id.
+
+    Returns 404 when the event does not exist or belongs to a different session.
+
+    Args:
+        session_id (str):
+        event_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Event | HTTPValidationError
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        event_id=event_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    event_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Event | HTTPValidationError]:
+    """Get Event
+
+     Fetch a single event by its id.
+
+    Returns 404 when the event does not exist or belongs to a different session.
+
+    Args:
+        session_id (str):
+        event_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Event | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        event_id=event_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    event_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Event | HTTPValidationError | None:
+    """Get Event
+
+     Fetch a single event by its id.
+
+    Returns 404 when the event does not exist or belongs to a different session.
+
+    Args:
+        session_id (str):
+        event_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Event | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            event_id=event_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/list_session_events.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/list_session_events.py
@@ -16,6 +16,7 @@ def _get_kwargs(
     session_id: str,
     *,
     after: int | Unset = 0,
+    after_seq: int | None | Unset = UNSET,
     kind: ListSessionEventsKindType0 | None | Unset = UNSET,
     limit: int | Unset = 200,
     error_only: bool | Unset = False,
@@ -28,6 +29,13 @@ def _get_kwargs(
     params: dict[str, Any] = {}
 
     params["after"] = after
+
+    json_after_seq: int | None | Unset
+    if isinstance(after_seq, Unset):
+        json_after_seq = UNSET
+    else:
+        json_after_seq = after_seq
+    params["after_seq"] = json_after_seq
 
     json_kind: None | str | Unset
     if isinstance(kind, Unset):
@@ -91,6 +99,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     after: int | Unset = 0,
+    after_seq: int | None | Unset = UNSET,
     kind: ListSessionEventsKindType0 | None | Unset = UNSET,
     limit: int | Unset = 200,
     error_only: bool | Unset = False,
@@ -107,9 +116,13 @@ def sync_detailed(
     ``?after=`` and got it silently ignored, causing pagination to loop on
     the first page. See issue #389.)
 
+    ``?after_seq=N`` is accepted as an alias for ``?after=N`` for
+    backwards compatibility with older clients (issue #596).
+
     Args:
         session_id (str):
         after (int | Unset):  Default: 0.
+        after_seq (int | None | Unset):
         kind (ListSessionEventsKindType0 | None | Unset):
         limit (int | Unset):  Default: 200.
         error_only (bool | Unset):  Default: False.
@@ -126,6 +139,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         session_id=session_id,
         after=after,
+        after_seq=after_seq,
         kind=kind,
         limit=limit,
         error_only=error_only,
@@ -144,6 +158,7 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     after: int | Unset = 0,
+    after_seq: int | None | Unset = UNSET,
     kind: ListSessionEventsKindType0 | None | Unset = UNSET,
     limit: int | Unset = 200,
     error_only: bool | Unset = False,
@@ -160,9 +175,13 @@ def sync(
     ``?after=`` and got it silently ignored, causing pagination to loop on
     the first page. See issue #389.)
 
+    ``?after_seq=N`` is accepted as an alias for ``?after=N`` for
+    backwards compatibility with older clients (issue #596).
+
     Args:
         session_id (str):
         after (int | Unset):  Default: 0.
+        after_seq (int | None | Unset):
         kind (ListSessionEventsKindType0 | None | Unset):
         limit (int | Unset):  Default: 200.
         error_only (bool | Unset):  Default: False.
@@ -180,6 +199,7 @@ def sync(
         session_id=session_id,
         client=client,
         after=after,
+        after_seq=after_seq,
         kind=kind,
         limit=limit,
         error_only=error_only,
@@ -192,6 +212,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     after: int | Unset = 0,
+    after_seq: int | None | Unset = UNSET,
     kind: ListSessionEventsKindType0 | None | Unset = UNSET,
     limit: int | Unset = 200,
     error_only: bool | Unset = False,
@@ -208,9 +229,13 @@ async def asyncio_detailed(
     ``?after=`` and got it silently ignored, causing pagination to loop on
     the first page. See issue #389.)
 
+    ``?after_seq=N`` is accepted as an alias for ``?after=N`` for
+    backwards compatibility with older clients (issue #596).
+
     Args:
         session_id (str):
         after (int | Unset):  Default: 0.
+        after_seq (int | None | Unset):
         kind (ListSessionEventsKindType0 | None | Unset):
         limit (int | Unset):  Default: 200.
         error_only (bool | Unset):  Default: False.
@@ -227,6 +252,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         session_id=session_id,
         after=after,
+        after_seq=after_seq,
         kind=kind,
         limit=limit,
         error_only=error_only,
@@ -243,6 +269,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     after: int | Unset = 0,
+    after_seq: int | None | Unset = UNSET,
     kind: ListSessionEventsKindType0 | None | Unset = UNSET,
     limit: int | Unset = 200,
     error_only: bool | Unset = False,
@@ -259,9 +286,13 @@ async def asyncio(
     ``?after=`` and got it silently ignored, causing pagination to loop on
     the first page. See issue #389.)
 
+    ``?after_seq=N`` is accepted as an alias for ``?after=N`` for
+    backwards compatibility with older clients (issue #596).
+
     Args:
         session_id (str):
         after (int | Unset):  Default: 0.
+        after_seq (int | None | Unset):
         kind (ListSessionEventsKindType0 | None | Unset):
         limit (int | Unset):  Default: 200.
         error_only (bool | Unset):  Default: False.
@@ -280,6 +311,7 @@ async def asyncio(
             session_id=session_id,
             client=client,
             after=after,
+            after_seq=after_seq,
             kind=kind,
             limit=limit,
             error_only=error_only,

--- a/packages/aios-sdk/aios_sdk/_generated/models/session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session.py
@@ -44,6 +44,8 @@ class Session:
         archived_at (datetime.datetime | None | Unset):
         focal_channel (None | str | Unset):
         focal_locked (bool | Unset):  Default: False.
+        last_event_at (datetime.datetime | None | Unset):
+        total_events (int | Unset):  Default: 0.
     """
 
     id: str
@@ -65,6 +67,8 @@ class Session:
     archived_at: datetime.datetime | None | Unset = UNSET
     focal_channel: None | str | Unset = UNSET
     focal_locked: bool | Unset = False
+    last_event_at: datetime.datetime | None | Unset = UNSET
+    total_events: int | Unset = 0
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -135,6 +139,16 @@ class Session:
 
         focal_locked = self.focal_locked
 
+        last_event_at: None | str | Unset
+        if isinstance(self.last_event_at, Unset):
+            last_event_at = UNSET
+        elif isinstance(self.last_event_at, datetime.datetime):
+            last_event_at = self.last_event_at.isoformat()
+        else:
+            last_event_at = self.last_event_at
+
+        total_events = self.total_events
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -164,6 +178,10 @@ class Session:
             field_dict["focal_channel"] = focal_channel
         if focal_locked is not UNSET:
             field_dict["focal_locked"] = focal_locked
+        if last_event_at is not UNSET:
+            field_dict["last_event_at"] = last_event_at
+        if total_events is not UNSET:
+            field_dict["total_events"] = total_events
 
         return field_dict
 
@@ -289,6 +307,25 @@ class Session:
 
         focal_locked = d.pop("focal_locked", UNSET)
 
+        def _parse_last_event_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                last_event_at_type_0 = isoparse(data)
+
+                return last_event_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        last_event_at = _parse_last_event_at(d.pop("last_event_at", UNSET))
+
+        total_events = d.pop("total_events", UNSET)
+
         session = cls(
             id=id,
             agent_id=agent_id,
@@ -307,6 +344,8 @@ class Session:
             archived_at=archived_at,
             focal_channel=focal_channel,
             focal_locked=focal_locked,
+            last_event_at=last_event_at,
+            total_events=total_events,
         )
 
         session.additional_properties = d

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -428,6 +428,8 @@ async def list_events(
     pool: PoolDep,
     account_id: AccountIdDep,
     after: int = 0,
+    # after_seq is the legacy name; prefer after. Both are accepted.
+    after_seq: Annotated[int | None, Query(alias="after_seq")] = None,
     kind: EventKind | None = None,
     # Higher cap than the standard 200: operators paginate through full
     # session event logs via ``aios sessions events`` (one page per
@@ -444,23 +446,50 @@ async def list_events(
     field — clients following the natural roundtrip pattern sent
     ``?after=`` and got it silently ignored, causing pagination to loop on
     the first page. See issue #389.)
+
+    ``?after_seq=N`` is accepted as an alias for ``?after=N`` for
+    backwards compatibility with older clients (issue #596).
     """
+    # Resolve after_seq alias: explicit after_seq overrides after.
+    effective_after = after_seq if after_seq is not None else after
     # Scope check: 404 cross-tenant probes before reading events. The
     # ``read_events`` query also filters by account_id, so this is
     # belt-and-suspenders against a future query that forgets the
     # filter — but ``get_session`` is what gives the caller a clean
     # 404 rather than an empty list for a cross-tenant session id.
     await service.get_session(pool, session_id, account_id=account_id)
-    items = await service.read_events(
+    # Fetch one extra row so we can tell whether more exist without a
+    # separate COUNT query — accurate has_more with no off-by-one.
+    rows = await service.read_events(
         pool,
         session_id,
-        after_seq=after,
+        after_seq=effective_after,
         kind=kind,
-        limit=limit,
+        limit=limit + 1,
         error_only=error_only,
         account_id=account_id,
     )
-    return ListResponse[Event].paginate(items, limit, cursor=lambda x: str(x.seq))
+    has_more = len(rows) > limit
+    items = rows[:limit]
+    return ListResponse[Event](
+        data=items,
+        has_more=has_more,
+        next_after=str(items[-1].seq) if items else None,
+    )
+
+
+@router.get("/{session_id}/events/{event_id}", operation_id="get_session_event")
+async def get_event(
+    session_id: str,
+    event_id: str,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+) -> Event:
+    """Fetch a single event by its id.
+
+    Returns 404 when the event does not exist or belongs to a different session.
+    """
+    return await service.get_event(pool, session_id, event_id, account_id=account_id)
 
 
 @router.get("/{session_id}/context", operation_id="get_session_context")

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2159,6 +2159,33 @@ async def read_events(
     return [_row_to_event(r) for r in rows]
 
 
+async def get_event(
+    conn: asyncpg.Connection[Any], session_id: str, event_id: str, *, account_id: str
+) -> Event:
+    row = await conn.fetchrow(
+        "SELECT * FROM events WHERE id = $1 AND session_id = $2 AND account_id = $3",
+        event_id,
+        session_id,
+        account_id,
+    )
+    if row is None:
+        raise NotFoundError(f"event {event_id} not found", detail={"id": event_id})
+    return _row_to_event(row)
+
+
+async def get_session_event_stats(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+) -> tuple[int, datetime | None]:
+    row = await conn.fetchrow(
+        "SELECT COUNT(*) AS total, MAX(created_at) AS last_at FROM events "
+        "WHERE session_id = $1 AND account_id = $2",
+        session_id,
+        account_id,
+    )
+    assert row is not None  # COUNT(*) always returns a row
+    return int(row["total"]), row["last_at"]
+
+
 async def read_message_events(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> list[Event]:

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -195,6 +195,8 @@ class Session(BaseModel):
     archived_at: datetime | None = None
     focal_channel: str | None = None
     focal_locked: bool = False
+    last_event_at: datetime | None = None
+    total_events: int = 0
 
 
 class SessionCloneRequest(BaseModel):

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -137,7 +137,17 @@ async def get_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: s
         session = await queries.get_session(conn, session_id, account_id=account_id)
         vault_ids = await queries.get_session_vault_ids(conn, session_id, account_id=account_id)
         echoes = await _list_all_echoes(conn, session_id, account_id=account_id)
-        return session.model_copy(update={"vault_ids": vault_ids, "resources": echoes})
+        total_events, last_event_at = await queries.get_session_event_stats(
+            conn, session_id, account_id=account_id
+        )
+        return session.model_copy(
+            update={
+                "vault_ids": vault_ids,
+                "resources": echoes,
+                "total_events": total_events,
+                "last_event_at": last_event_at,
+            }
+        )
 
 
 async def get_session_model(pool: asyncpg.Pool[Any], session_id: str, *, account_id: str) -> str:
@@ -361,6 +371,13 @@ async def read_events(
             account_id=account_id,
             error_only=error_only,
         )
+
+
+async def get_event(
+    pool: asyncpg.Pool[Any], session_id: str, event_id: str, *, account_id: str
+) -> Event:
+    async with pool.acquire() as conn:
+        return await queries.get_event(conn, session_id, event_id, account_id=account_id)
 
 
 async def read_message_events(

--- a/tests/e2e/test_events_pagination.py
+++ b/tests/e2e/test_events_pagination.py
@@ -56,16 +56,18 @@ async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[http
         yield client
 
 
-@pytest.fixture
-async def session_with_events(pool: Any) -> str:
+_ACCOUNT_ID = "acc_test_stub"
+
+
+async def _make_session_with_events(pool: Any, n_events: int = 5) -> str:
+    """Create a session with ``n_events`` user messages. Returns the session id."""
     from aios.db import queries
     from aios.services import agents as agents_svc
     from aios.services import sessions as sessions_svc
 
-    account_id = "acc_test_stub"
     async with pool.acquire() as conn:
         env = await queries.insert_environment(
-            conn, name=f"events-env-{_uniq()}", account_id=account_id
+            conn, name=f"events-env-{_uniq()}", account_id=_ACCOUNT_ID
         )
     agent = await agents_svc.create_agent(
         pool,
@@ -77,7 +79,7 @@ async def session_with_events(pool: Any) -> str:
         metadata={},
         window_min=50_000,
         window_max=150_000,
-        account_id=account_id,
+        account_id=_ACCOUNT_ID,
     )
     session = await sessions_svc.create_session(
         pool,
@@ -85,13 +87,18 @@ async def session_with_events(pool: Any) -> str:
         environment_id=env.id,
         title=None,
         metadata={},
-        account_id=account_id,
+        account_id=_ACCOUNT_ID,
     )
-    for i in range(5):
+    for i in range(n_events):
         await sessions_svc.append_user_message(
-            pool, session.id, f"message {i}", account_id=account_id
+            pool, session.id, f"message {i}", account_id=_ACCOUNT_ID
         )
     return session.id
+
+
+@pytest.fixture
+async def session_with_events(pool: Any) -> str:
+    return await _make_session_with_events(pool, n_events=5)
 
 
 class TestEventsPaginationRoundTrip:
@@ -160,3 +167,170 @@ class TestEventsPaginationRoundTrip:
             assert cursor is not None
         else:
             pytest.fail("Pagination did not terminate within 20 iterations")
+
+
+class TestLimitValidation:
+    """Gap 1: limit > 500 must return 422; limit = 500 must be accepted."""
+
+    async def test_limit_over_500_returns_422(
+        self, http_client: httpx.AsyncClient, session_with_events: str
+    ) -> None:
+        r = await http_client.get(
+            f"/v1/sessions/{session_with_events}/events",
+            params={"limit": 501},
+        )
+        assert r.status_code == 422, r.text
+
+    async def test_limit_500_accepted(
+        self, http_client: httpx.AsyncClient, session_with_events: str
+    ) -> None:
+        r = await http_client.get(
+            f"/v1/sessions/{session_with_events}/events",
+            params={"limit": 500},
+        )
+        assert r.status_code == 200, r.text
+
+
+class TestHasMoreAccuracy:
+    """Gap 2: has_more must be a true off-by-one-free signal."""
+
+    async def test_has_more_false_when_at_exact_boundary(
+        self, http_client: httpx.AsyncClient, session_with_events: str
+    ) -> None:
+        # session_with_events has exactly 5 events; requesting limit=5
+        # must return has_more=False (not True as the paginate() helper
+        # previously signalled when len==limit).
+        r = await http_client.get(
+            f"/v1/sessions/{session_with_events}/events",
+            params={"limit": 5},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert len(body["data"]) == 5
+        assert body["has_more"] is False, (
+            "has_more should be False when all events fit in exactly one page"
+        )
+
+    async def test_has_more_true_with_valid_next_after(
+        self, http_client: httpx.AsyncClient, session_with_events: str
+    ) -> None:
+        # 5 events, request limit=3 → has_more=True and next_after is set
+        r = await http_client.get(
+            f"/v1/sessions/{session_with_events}/events",
+            params={"limit": 3},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert len(body["data"]) == 3
+        assert body["has_more"] is True
+        assert body["next_after"] is not None
+
+
+class TestAfterSeqAlias:
+    """Gap 3: ?after_seq=N must work as an alias for ?after=N."""
+
+    async def test_after_seq_filters_events(
+        self, http_client: httpx.AsyncClient, session_with_events: str
+    ) -> None:
+        # Fetch first page to get a real seq value
+        r1 = await http_client.get(
+            f"/v1/sessions/{session_with_events}/events",
+            params={"limit": 2},
+        )
+        assert r1.status_code == 200, r1.text
+        page1 = r1.json()
+        boundary_seq = page1["data"][-1]["seq"]
+
+        # Use after_seq alias; all returned events must have seq > boundary_seq
+        r2 = await http_client.get(
+            f"/v1/sessions/{session_with_events}/events",
+            params={"after_seq": boundary_seq},
+        )
+        assert r2.status_code == 200, r2.text
+        page2 = r2.json()
+        assert len(page2["data"]) > 0, "Expected events after the boundary seq"
+        for event in page2["data"]:
+            assert event["seq"] > boundary_seq, (
+                f"after_seq={boundary_seq} was ignored; got seq {event['seq']}"
+            )
+
+
+class TestSessionEventStats:
+    """Gaps 4/5: last_event_at and total_events on the Session resource."""
+
+    async def test_last_event_at_populated(
+        self, http_client: httpx.AsyncClient, session_with_events: str
+    ) -> None:
+        r = await http_client.get(f"/v1/sessions/{session_with_events}")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["last_event_at"] is not None, (
+            "last_event_at should be non-null after events are appended"
+        )
+
+    async def test_total_events_count(
+        self, http_client: httpx.AsyncClient, session_with_events: str
+    ) -> None:
+        r = await http_client.get(f"/v1/sessions/{session_with_events}")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["total_events"] == 5, f"Expected total_events=5, got {body['total_events']}"
+
+    async def test_fresh_session_has_zero_total_events(
+        self, http_client: httpx.AsyncClient, pool: Any
+    ) -> None:
+        # Create a session with no messages
+        session_id = await _make_session_with_events(pool, n_events=0)
+        r = await http_client.get(f"/v1/sessions/{session_id}")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["total_events"] == 0, (
+            f"Expected total_events=0 for fresh session, got {body['total_events']}"
+        )
+        assert body["last_event_at"] is None, (
+            "last_event_at should be None for session with no events"
+        )
+
+
+class TestGetSingleEvent:
+    """Gap 6: GET /v1/sessions/{id}/events/{event_id} must be a real endpoint."""
+
+    async def test_get_event_by_id(
+        self, http_client: httpx.AsyncClient, session_with_events: str
+    ) -> None:
+        # List events to get a real event id
+        r_list = await http_client.get(
+            f"/v1/sessions/{session_with_events}/events",
+            params={"limit": 1},
+        )
+        assert r_list.status_code == 200, r_list.text
+        first_event = r_list.json()["data"][0]
+        event_id = first_event["id"]
+
+        r = await http_client.get(f"/v1/sessions/{session_with_events}/events/{event_id}")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["id"] == event_id
+        assert body["seq"] == first_event["seq"]
+
+    async def test_get_event_missing_returns_404(
+        self, http_client: httpx.AsyncClient, session_with_events: str
+    ) -> None:
+        r = await http_client.get(f"/v1/sessions/{session_with_events}/events/evt_notexist")
+        assert r.status_code == 404, r.text
+
+    async def test_get_event_wrong_session_returns_404(
+        self, http_client: httpx.AsyncClient, pool: Any, session_with_events: str
+    ) -> None:
+        # Get a real event id from session_with_events
+        r_list = await http_client.get(
+            f"/v1/sessions/{session_with_events}/events",
+            params={"limit": 1},
+        )
+        assert r_list.status_code == 200, r_list.text
+        event_id = r_list.json()["data"][0]["id"]
+
+        # Create a different session; use its id with the real event id
+        other_session_id = await _make_session_with_events(pool, n_events=0)
+        r = await http_client.get(f"/v1/sessions/{other_session_id}/events/{event_id}")
+        assert r.status_code == 404, r.text


### PR DESCRIPTION
Closes #596

The events API had several gaps that made pagination unreliable and session detail responses incomplete. This PR fixes all six of them.

## What was broken

**Pagination correctness (`list_events`):**
- `has_more` was a false positive — the query fetched exactly `limit` rows, so the last page always looked like there might be more.
- `after_seq` was accepted as a query param but silently ignored; only `after` worked.
- `next_after` could be null even when `has_more=True`, breaking cursor-based iteration.

**Session detail (`GET /v1/sessions/{id}`):**
- `last_event_at` and `total_events` were always missing — the service layer never fetched them.

**Single-event fetch:**
- `GET /v1/sessions/{id}/events/{event_id}` didn't exist at all, making it impossible to retrieve a specific event by ID without fetching a full page.

**Validation:**
- `limit > 500` was already rejected by FastAPI's `Query(le=500)`, but there were no tests pinning the contract.

## What was fixed

- `list_events` now fetches `limit + 1` rows, slices to `limit`, and derives `has_more` from whether the extra row was present. `next_after` is guaranteed non-null when `has_more=True`.
- `after_seq` is now an explicit alias for `after`, so both param names work.
- Added `get_session_event_stats` SQL query that returns `last_event_at` and `total_events`; wired into `service.get_session`.
- Implemented `GET /v1/sessions/{id}/events/{event_id}` with proper 404 for missing or wrong-session events.
- Added regression tests covering the `limit > 500` validation contract and the corrected `has_more` / `next_after` behavior.

## Implementation notes

The `has_more` fix was applied directly to the `list_events` router rather than to the shared `ListResponse.paginate` utility — other endpoints use that utility correctly under their own semantics, so touching it would have been unnecessarily risky. The OpenAPI snapshot and generated SDK client needed regeneration after the router changes; the pre-commit hook caught this automatically.