### PR TITLE
fix: paginate() false-positive has_more and session stats hot path

### DIFF
--- a/src/aios/api/routers/agents.py
+++ b/src/aios/api/routers/agents.py
@@ -54,7 +54,7 @@ async def list_(
     exactly.
     """
     items = await service.list_agents(
-        pool, limit=limit, after=after, name=name, account_id=account_id
+        pool, limit=limit + 1, after=after, name=name, account_id=account_id
     )
     return ListResponse[Agent].paginate(items, limit, cursor=lambda x: x.id)
 
@@ -122,7 +122,7 @@ async def list_versions(
     complete snapshot of the agent's config at the time it was created.
     """
     items = await service.list_agent_versions(
-        pool, agent_id, limit=limit, after=after, account_id=account_id
+        pool, agent_id, limit=limit + 1, after=after, account_id=account_id
     )
     return ListResponse[AgentVersion].paginate(items, limit, cursor=lambda x: str(x.version))
 

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -114,7 +114,7 @@ async def list_(
         connector=connector,
         session_id=session_id,
         mode=mode,
-        limit=limit,
+        limit=limit + 1,
         after=after,
         account_id=account_id,
     )

--- a/src/aios/api/routers/environments.py
+++ b/src/aios/api/routers/environments.py
@@ -39,7 +39,9 @@ async def list_(
 
     Cursor pagination via ``after``.
     """
-    items = await service.list_environments(pool, limit=limit, after=after, account_id=account_id)
+    items = await service.list_environments(
+        pool, limit=limit + 1, after=after, account_id=account_id
+    )
     return ListResponse[Environment].paginate(items, limit, cursor=lambda x: x.id)
 
 

--- a/src/aios/api/routers/memory_stores.py
+++ b/src/aios/api/routers/memory_stores.py
@@ -63,7 +63,7 @@ async def list_stores(
     items = await service.list_stores(
         pool,
         include_archived=include_archived,
-        limit=limit,
+        limit=limit + 1,
         after=after,
         account_id=account_id,
     )

--- a/src/aios/api/routers/session_templates.py
+++ b/src/aios/api/routers/session_templates.py
@@ -62,7 +62,7 @@ async def list_(
     Cursor pagination via ``after``.
     """
     items = await service.list_session_templates(
-        pool, limit=limit, after=after, account_id=account_id
+        pool, limit=limit + 1, after=after, account_id=account_id
     )
     return ListResponse[SessionTemplate].paginate(items, limit, cursor=lambda x: x.id)
 

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -105,7 +105,7 @@ async def list_(
         pool,
         agent_id=agent_id,
         status=status_filter,
-        limit=limit,
+        limit=limit + 1,
         after=after,
         account_id=account_id,
     )
@@ -114,7 +114,11 @@ async def list_(
 
 @router.get("/{session_id}", operation_id="get_session")
 async def get(session_id: str, pool: PoolDep, account_id: AccountIdDep) -> Session:
-    return await service.get_session(pool, session_id, account_id=account_id)
+    session = await service.get_session(pool, session_id, account_id=account_id)
+    total_events, last_event_at = await service.get_session_event_stats(
+        pool, session_id, account_id=account_id
+    )
+    return session.model_copy(update={"total_events": total_events, "last_event_at": last_event_at})
 
 
 @router.put("/{session_id}", operation_id="update_session")
@@ -429,7 +433,7 @@ async def list_events(
     account_id: AccountIdDep,
     after: int = 0,
     # after_seq is the legacy name; prefer after. Both are accepted.
-    after_seq: Annotated[int | None, Query(alias="after_seq")] = None,
+    after_seq: int | None = None,
     kind: EventKind | None = None,
     # Higher cap than the standard 200: operators paginate through full
     # session event logs via ``aios sessions events`` (one page per
@@ -469,13 +473,7 @@ async def list_events(
         error_only=error_only,
         account_id=account_id,
     )
-    has_more = len(rows) > limit
-    items = rows[:limit]
-    return ListResponse[Event](
-        data=items,
-        has_more=has_more,
-        next_after=str(items[-1].seq) if items else None,
-    )
+    return ListResponse[Event].paginate(rows, limit, cursor=lambda x: str(x.seq))
 
 
 @router.get("/{session_id}/events/{event_id}", operation_id="get_session_event")

--- a/src/aios/api/routers/skills.py
+++ b/src/aios/api/routers/skills.py
@@ -43,7 +43,7 @@ async def list_(
 
     Cursor pagination via ``after``.
     """
-    items = await service.list_skills(pool, limit=limit, after=after, account_id=account_id)
+    items = await service.list_skills(pool, limit=limit + 1, after=after, account_id=account_id)
     return ListResponse[Skill].paginate(items, limit, cursor=lambda x: x.id)
 
 
@@ -102,7 +102,7 @@ async def list_versions(
     complete file-bundle snapshot at the time it was created.
     """
     items = await service.list_skill_versions(
-        pool, skill_id, limit=limit, after=after, account_id=account_id
+        pool, skill_id, limit=limit + 1, after=after, account_id=account_id
     )
     return ListResponse[SkillVersion].paginate(items, limit, cursor=lambda x: str(x.version))
 

--- a/src/aios/api/routers/vaults.py
+++ b/src/aios/api/routers/vaults.py
@@ -47,7 +47,7 @@ async def list_(
     Cursor pagination: pass ``after`` from a previous response's
     ``next_after`` to get the next page.
     """
-    items = await service.list_vaults(pool, limit=limit, after=after, account_id=account_id)
+    items = await service.list_vaults(pool, limit=limit + 1, after=after, account_id=account_id)
     return ListResponse[Vault].paginate(items, limit, cursor=lambda x: x.id)
 
 
@@ -147,7 +147,7 @@ async def list_credentials(
     only metadata (display name, target_url, auth_type, timestamps).
     """
     items = await service.list_vault_credentials(
-        pool, vault_id, limit=limit, after=after, account_id=account_id
+        pool, vault_id, limit=limit + 1, after=after, account_id=account_id
     )
     return ListResponse[VaultCredential].paginate(items, limit, cursor=lambda x: x.id)
 

--- a/src/aios/models/common.py
+++ b/src/aios/models/common.py
@@ -23,11 +23,18 @@ class ListResponse[T](BaseModel):
         *,
         cursor: Callable[[T], str],
     ) -> ListResponse[T]:
-        """Wrap a windowed query result in the pagination envelope."""
+        """Wrap a windowed query result in the pagination envelope.
+
+        Callers must fetch ``limit + 1`` rows and pass them here.  The extra
+        row is used to detect whether more pages exist without a separate COUNT
+        query; it is stripped before the response is built.
+        """
+        has_more = len(items) > limit
+        data = items[:limit]
         return cls(
-            data=items,
-            has_more=len(items) == limit,
-            next_after=cursor(items[-1]) if items else None,
+            data=data,
+            has_more=has_more,
+            next_after=cursor(data[-1]) if data else None,
         )
 
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -9,6 +9,7 @@ and inject environment variables at container provisioning time.
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from types import EllipsisType
 from typing import Any
 
@@ -137,17 +138,14 @@ async def get_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: s
         session = await queries.get_session(conn, session_id, account_id=account_id)
         vault_ids = await queries.get_session_vault_ids(conn, session_id, account_id=account_id)
         echoes = await _list_all_echoes(conn, session_id, account_id=account_id)
-        total_events, last_event_at = await queries.get_session_event_stats(
-            conn, session_id, account_id=account_id
-        )
-        return session.model_copy(
-            update={
-                "vault_ids": vault_ids,
-                "resources": echoes,
-                "total_events": total_events,
-                "last_event_at": last_event_at,
-            }
-        )
+        return session.model_copy(update={"vault_ids": vault_ids, "resources": echoes})
+
+
+async def get_session_event_stats(
+    pool: asyncpg.Pool[Any], session_id: str, *, account_id: str
+) -> tuple[int, datetime | None]:
+    async with pool.acquire() as conn:
+        return await queries.get_session_event_stats(conn, session_id, account_id=account_id)
 
 
 async def get_session_model(pool: asyncpg.Pool[Any], session_id: str, *, account_id: str) -> str:

--- a/tests/unit/test_list_response.py
+++ b/tests/unit/test_list_response.py
@@ -29,9 +29,19 @@ def test_paginate_partial_page() -> None:
     assert resp.next_after == "b"
 
 
-def test_paginate_full_page() -> None:
-    """Result fills the page (``len == limit``): ``has_more`` is True."""
+def test_paginate_full_page_no_more() -> None:
+    """Exactly ``limit`` items returned (caller fetched limit+1, got limit): ``has_more`` False."""
     items = [_Item(id="a", seq=1), _Item(id="b", seq=2)]
     resp = ListResponse[_Item].paginate(items, limit=2, cursor=lambda x: x.id)
+    assert resp.data == items
+    assert resp.has_more is False
+    assert resp.next_after == "b"
+
+
+def test_paginate_has_more() -> None:
+    """Caller fetched ``limit+1`` rows and got ``limit+1`` back: ``has_more`` True, data trimmed."""
+    items = [_Item(id="a", seq=1), _Item(id="b", seq=2), _Item(id="c", seq=3)]
+    resp = ListResponse[_Item].paginate(items, limit=2, cursor=lambda x: x.id)
+    assert resp.data == [_Item(id="a", seq=1), _Item(id="b", seq=2)]
     assert resp.has_more is True
     assert resp.next_after == "b"


### PR DESCRIPTION
Follow-up to #598 addressing three code review issues that didn't land in the squash merge.

## Changes

**`ListResponse.paginate()` false-positive `has_more` (9 endpoints affected)**

`has_more = len(items) == limit` cannot distinguish "page is full and there are more" from "page is full and this is the last page." All list endpoints (agents, sessions, environments, skills, connections, vaults, memory_stores, session_templates, and events) had this bug. Fixed `paginate()` to use `len(items) > limit` with an `items[:limit]` slice, and updated all 11 call sites to fetch `limit + 1` rows from the DB. Tests updated to verify both cases.

**Session stats off the inference hot path**

`get_session_event_stats` (COUNT + MAX query) was added inside `service.get_session()`, which the harness inference loop calls on every wake step. Moved the stats fetch into the API `get` handler only — the only caller that needs it for the response payload.

**Redundant `Query(alias="after_seq")` removed**

The alias was identical to the parameter name; removed the annotation.