### PR TITLE
refactor(tests/e2e): extract live_aios_server context manager (big-win)

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -15,15 +15,89 @@ Docker containers.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
+import socket
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 from unittest import mock
 
 import pytest
+import uvicorn
 
 from tests.e2e.harness import Harness
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wait_for_health
+
+_DEFAULT_DEFER_WAKE_PATCHES: tuple[str, ...] = (
+    "aios.api.routers.sessions.defer_wake",
+    "aios.api.routers.connectors.defer_wake",
+    "aios.services.inbound.defer_wake",
+)
+
+
+@contextlib.asynccontextmanager
+async def live_aios_server(
+    *,
+    defer_wake_patches: tuple[str, ...] = _DEFAULT_DEFER_WAKE_PATCHES,
+    pool_max_size: int = 4,
+) -> AsyncIterator[str]:
+    """Run uvicorn on a free port serving the aios app; yield base URL.
+
+    Used by e2e tests that need a real HTTP socket (SSE streaming,
+    chunked transfer, real-uvicorn behaviour) rather than the
+    ``ASGITransport`` shortcut. ``defer_wake_patches`` is mocked for
+    the context's lifetime — the tests drive session advancement
+    directly via the harness, so the production ``defer_wake`` would
+    queue jobs the test never executes. The default covers the three
+    production sites; SSE-only tests that never hit the connectors
+    router can pass a narrower tuple to keep the mock surface tight.
+
+    Uvicorn's ``should_exit`` is poll-based (500 ms tick); with an
+    open SSE stream the poll routinely loses the race and the test
+    eats the full ``wait_for`` timeout. ``server.shutdown()`` triggers
+    the graceful drain synchronously instead, then cancelling the
+    serve task frees the asyncio bookkeeping.
+    """
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    pool = await create_pool(settings.db_url, min_size=1, max_size=pool_max_size)
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", lifespan="off")
+    server = uvicorn.Server(config)
+    server.config.load()
+    server.lifespan = server.config.lifespan_class(server.config)
+
+    async def _serve() -> None:
+        sock.setblocking(False)
+        await server.serve(sockets=[sock])
+
+    with contextlib.ExitStack() as patches:
+        for target in defer_wake_patches:
+            patches.enter_context(mock.patch(target, new_callable=mock.AsyncMock))
+        serve_task = asyncio.create_task(_serve())
+        try:
+            url = f"http://127.0.0.1:{port}"
+            await wait_for_health(url)
+            yield url
+        finally:
+            await server.shutdown()
+            serve_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await serve_task
+            await pool.close()
 
 
 async def wait_for_predicate(

--- a/tests/e2e/test_connection_discovery_sse.py
+++ b/tests/e2e/test_connection_discovery_sse.py
@@ -19,67 +19,30 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
-import socket
 from collections.abc import AsyncIterator
-from unittest import mock
 
 import pytest
-import uvicorn
 
 from aios_sdk import Client, stream_connection_discovery
 from tests.conftest import needs_docker
-from tests.helpers.connections import authed_client, create_connection, wait_for_health
+from tests.e2e.conftest import live_aios_server
+from tests.helpers.connections import authed_client, create_connection
 
 
 @pytest.fixture
 async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
-    """Same shape as ``test_echo_http_connector.live_server`` —
-    extracted-but-not-shared because per-file pytest fixtures keep the
-    setup local to the assertions that depend on them.
+    """Real-uvicorn aios so SSE chunked-transfer streaming works end-to-end.
+
+    SSE-only paths: skip the ``routers.connectors.defer_wake`` patch
+    that the connector-driven e2e tests need.
     """
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    pool = await create_pool(settings.db_url, min_size=1, max_size=4)
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    port = sock.getsockname()[1]
-
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", lifespan="off")
-    server = uvicorn.Server(config)
-    server.config.load()
-    server.lifespan = server.config.lifespan_class(server.config)
-
-    async def _serve() -> None:
-        sock.setblocking(False)
-        await server.serve(sockets=[sock])
-
-    with (
-        mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock),
-        mock.patch("aios.services.inbound.defer_wake", new_callable=mock.AsyncMock),
-    ):
-        serve_task = asyncio.create_task(_serve())
-        try:
-            url = f"http://127.0.0.1:{port}"
-            await wait_for_health(url)
-            yield url
-        finally:
-            # See test_signal_registration.py for why ``should_exit`` alone
-            # loses the race against open SSE streams.
-            await server.shutdown()
-            serve_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await serve_task
-            await pool.close()
+    async with live_aios_server(
+        defer_wake_patches=(
+            "aios.api.routers.sessions.defer_wake",
+            "aios.services.inbound.defer_wake",
+        ),
+    ) as url:
+        yield url
 
 
 async def _issue_runtime_token(api_key: str, base_url: str, connector: str) -> str:

--- a/tests/e2e/test_echo_http_connector.py
+++ b/tests/e2e/test_echo_http_connector.py
@@ -23,70 +23,19 @@ import contextlib
 from collections.abc import AsyncIterator
 
 import pytest
-import uvicorn
 from aios_echo_http import EchoConnector
 
 from tests.conftest import needs_docker
+from tests.e2e.conftest import live_aios_server
 from tests.e2e.harness import Harness, assistant, last_assistant_content, tool_call
-from tests.helpers.connections import create_connection, issue_runtime_token, wait_for_health
+from tests.helpers.connections import create_connection, issue_runtime_token
 
 
 @pytest.fixture
 async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
-    """Run uvicorn on a free port, serving the aios app.
-
-    Returns the base URL.  Uses defer_wake mocking the same way the
-    in-process http_client fixture does — tests drive the harness
-    directly for any session advancement.
-    """
-    import socket
-    from unittest import mock
-
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    pool = await create_pool(settings.db_url, min_size=1, max_size=4)
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    port = sock.getsockname()[1]
-
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", lifespan="off")
-    server = uvicorn.Server(config)
-    server.config.load()
-    server.lifespan = server.config.lifespan_class(server.config)
-
-    async def _serve() -> None:
-        # Hand uvicorn the prebound socket so we don't race on port pick.
-        sock.setblocking(False)
-        await server.serve(sockets=[sock])
-
-    with (
-        mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock),
-        mock.patch("aios.api.routers.connectors.defer_wake", new_callable=mock.AsyncMock),
-        mock.patch("aios.services.inbound.defer_wake", new_callable=mock.AsyncMock),
-    ):
-        serve_task = asyncio.create_task(_serve())
-        try:
-            url = f"http://127.0.0.1:{port}"
-            await wait_for_health(url)
-            yield url
-        finally:
-            # See test_signal_registration.py for why ``should_exit`` alone
-            # loses the race against open SSE streams.
-            await server.shutdown()
-            serve_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await serve_task
-            await pool.close()
+    """Run uvicorn on a free port, serving the aios app."""
+    async with live_aios_server() as url:
+        yield url
 
 
 async def _publish_echo_tools_schema(harness: Harness) -> None:

--- a/tests/e2e/test_runtime_token_connection_scope.py
+++ b/tests/e2e/test_runtime_token_connection_scope.py
@@ -15,67 +15,30 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
-import socket
 from collections.abc import AsyncIterator
-from unittest import mock
 
 import pytest
-import uvicorn
 
 from aios_sdk import Client, stream_connection_discovery
 from tests.conftest import needs_docker
-from tests.helpers.connections import authed_client, bearer, create_connection, wait_for_health
+from tests.e2e.conftest import live_aios_server
+from tests.helpers.connections import authed_client, bearer, create_connection
 
 
 @pytest.fixture
 async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
     """Real-uvicorn aios so SSE chunked-transfer streaming works end-to-end.
 
-    Mirrors ``test_connection_discovery_sse.live_server`` — extracted-
-    but-not-shared because per-file pytest fixtures keep the setup
-    local to the assertions that depend on them.
+    SSE-only paths: skip the ``routers.connectors.defer_wake`` patch
+    that the connector-driven e2e tests need.
     """
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    pool = await create_pool(settings.db_url, min_size=1, max_size=4)
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    port = sock.getsockname()[1]
-
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", lifespan="off")
-    server = uvicorn.Server(config)
-    server.config.load()
-    server.lifespan = server.config.lifespan_class(server.config)
-
-    async def _serve() -> None:
-        sock.setblocking(False)
-        await server.serve(sockets=[sock])
-
-    with (
-        mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock),
-        mock.patch("aios.services.inbound.defer_wake", new_callable=mock.AsyncMock),
-    ):
-        serve_task = asyncio.create_task(_serve())
-        try:
-            url = f"http://127.0.0.1:{port}"
-            await wait_for_health(url)
-            yield url
-        finally:
-            await server.shutdown()
-            serve_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await serve_task
-            await pool.close()
+    async with live_aios_server(
+        defer_wake_patches=(
+            "aios.api.routers.sessions.defer_wake",
+            "aios.services.inbound.defer_wake",
+        ),
+    ) as url:
+        yield url
 
 
 async def _issue_runtime_token(

--- a/tests/e2e/test_signal_connector.py
+++ b/tests/e2e/test_signal_connector.py
@@ -17,19 +17,17 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import socket
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
-from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import uvicorn
 
 from tests.conftest import needs_docker
+from tests.e2e.conftest import live_aios_server
 from tests.e2e.harness import Harness, assistant, last_assistant_content, tool_call
-from tests.helpers.connections import authed_client, issue_runtime_token, wait_for_health
+from tests.helpers.connections import authed_client, issue_runtime_token
 
 # Two phones, two connections — the demux subjects.
 PHONE_A = "+15550000111"
@@ -42,50 +40,8 @@ ALICE_UUID = "cccccccc-3333-3333-3333-333333333333"
 @pytest.fixture
 async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
     """Uvicorn aios on a free port — same shape as the echo e2e fixture."""
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    pool = await create_pool(settings.db_url, min_size=1, max_size=8)
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    port = sock.getsockname()[1]
-
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", lifespan="off")
-    server = uvicorn.Server(config)
-    server.config.load()
-    server.lifespan = server.config.lifespan_class(server.config)
-
-    async def _serve() -> None:
-        sock.setblocking(False)
-        await server.serve(sockets=[sock])
-
-    with (
-        mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock),
-        mock.patch("aios.api.routers.connectors.defer_wake", new_callable=mock.AsyncMock),
-        mock.patch("aios.services.inbound.defer_wake", new_callable=mock.AsyncMock),
-    ):
-        serve_task = asyncio.create_task(_serve())
-        try:
-            url = f"http://127.0.0.1:{port}"
-            await wait_for_health(url)
-            yield url
-        finally:
-            # See test_signal_registration.py for why ``should_exit`` alone
-            # loses the race against open SSE streams.
-            await server.shutdown()
-            serve_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await serve_task
-            await pool.close()
+    async with live_aios_server(pool_max_size=8) as url:
+        yield url
 
 
 async def _create_signal_connection(

--- a/tests/e2e/test_signal_registration.py
+++ b/tests/e2e/test_signal_registration.py
@@ -7,16 +7,15 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import socket
 from collections.abc import AsyncIterator
 from unittest import mock
 
 import pytest
-import uvicorn
 
 from aios_connector_http import HttpConnector, ManagementHandlerError, management_handler
 from tests.conftest import needs_docker
-from tests.helpers.connections import authed_client, issue_runtime_token, wait_for_health
+from tests.e2e.conftest import live_aios_server
+from tests.helpers.connections import authed_client, issue_runtime_token
 
 
 class _FakeSignalConnector(HttpConnector):
@@ -97,53 +96,8 @@ class _FakeSignalConnector(HttpConnector):
 @pytest.fixture
 async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
     """Same uvicorn-in-process fixture pattern the other e2e tests use."""
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    pool = await create_pool(settings.db_url, min_size=1, max_size=8)
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    port = sock.getsockname()[1]
-
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", lifespan="off")
-    server = uvicorn.Server(config)
-    server.config.load()
-    server.lifespan = server.config.lifespan_class(server.config)
-
-    async def _serve() -> None:
-        sock.setblocking(False)
-        await server.serve(sockets=[sock])
-
-    with (
-        mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock),
-        mock.patch("aios.api.routers.connectors.defer_wake", new_callable=mock.AsyncMock),
-        mock.patch("aios.services.inbound.defer_wake", new_callable=mock.AsyncMock),
-    ):
-        serve_task = asyncio.create_task(_serve())
-        try:
-            url = f"http://127.0.0.1:{port}"
-            await wait_for_health(url)
-            yield url
-        finally:
-            # uvicorn's ``should_exit`` is poll-based (500 ms tick); with an
-            # open SSE stream the poll routinely loses the race and the test
-            # eats the full 5 s wait_for timeout.  ``shutdown()`` triggers
-            # the graceful drain synchronously instead, then cancel the
-            # serve task to free the asyncio bookkeeping.
-            await server.shutdown()
-            serve_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await serve_task
-            await pool.close()
+    async with live_aios_server(pool_max_size=8) as url:
+        yield url
 
 
 async def _run_connector(connector: _FakeSignalConnector) -> None:

--- a/tests/e2e/test_telegram_connector.py
+++ b/tests/e2e/test_telegram_connector.py
@@ -19,17 +19,15 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import socket
 from collections.abc import AsyncIterator
-from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import uvicorn
 
 from tests.conftest import needs_docker
+from tests.e2e.conftest import live_aios_server
 from tests.e2e.harness import Harness, assistant, last_assistant_content, tool_call
-from tests.helpers.connections import authed_client, issue_runtime_token, wait_for_health
+from tests.helpers.connections import authed_client, issue_runtime_token
 
 BOT_TOKEN_A = "11111:tokenA"
 BOT_TOKEN_B = "22222:tokenB"
@@ -40,50 +38,8 @@ BOT_ID_B = 222
 @pytest.fixture
 async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
     """Uvicorn aios on a free port — same shape as the echo e2e fixture."""
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    pool = await create_pool(settings.db_url, min_size=1, max_size=8)
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    port = sock.getsockname()[1]
-
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", lifespan="off")
-    server = uvicorn.Server(config)
-    server.config.load()
-    server.lifespan = server.config.lifespan_class(server.config)
-
-    async def _serve() -> None:
-        sock.setblocking(False)
-        await server.serve(sockets=[sock])
-
-    with (
-        mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock),
-        mock.patch("aios.api.routers.connectors.defer_wake", new_callable=mock.AsyncMock),
-        mock.patch("aios.services.inbound.defer_wake", new_callable=mock.AsyncMock),
-    ):
-        serve_task = asyncio.create_task(_serve())
-        try:
-            url = f"http://127.0.0.1:{port}"
-            await wait_for_health(url)
-            yield url
-        finally:
-            # See test_signal_registration.py for why ``should_exit`` alone
-            # loses the race against open SSE streams.
-            await server.shutdown()
-            serve_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await serve_task
-            await pool.close()
+    async with live_aios_server(pool_max_size=8) as url:
+        yield url
 
 
 async def _create_telegram_connection(


### PR DESCRIPTION
## Summary (big-win iteration 2 of 2)

6 e2e test files each had a ~50-line \`live_server\` pytest fixture spinning up uvicorn on a free port. Two of them had author-comments calling out the duplication: *"extracted-but-not-shared because per-file pytest fixtures keep the setup local..."*

- Extract \`live_aios_server(*, defer_wake_patches=..., pool_max_size=4)\` async context manager into \`tests/e2e/conftest.py\`.
- Each per-file fixture collapses from ~50 lines to ~3:
  \`\`\`python
  @pytest.fixture
  async def live_server(aios_env): 
      async with live_aios_server() as url:
          yield url
  \`\`\`
- Patch-set divergence handled via \`defer_wake_patches\` kwarg: default 3-patch (sessions+connectors+inbound) for connector-driven tests; 2-patch (sessions+inbound) override for SSE-only tests.
- \`pool_max_size=8\` for signal/telegram tests.

Net **+116 / -301 = -185 LOC** across 7 files.

## Why this matters

Followup to iter 13's \`seed_agent_env_session\` fixture (-243 LOC). Two consecutive thorough-search iterations have now cleared the biggest non-contested wins from the deferred queue (test fixture consolidation). Combined: **-428 LOC across 2 PRs**.

## Test plan

- [x] \`uv run mypy src\` — clean (155 files)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] \`uv run pytest tests/unit -q\` — 1405 passed
- [ ] CI: e2e suite (the real validator; the converted tests live here)

## Review notes

Code review returned **no findings ≥ 80** — \"Approve.\" Verified:
- **Patch-set preservation**: each call site passes the EXACT patches it used to inline.
- **Pool size preservation**: 4 (default) or 8 (passed explicitly) matches pre-refactor inline values.
- **Import cleanup**: removed \`socket\`, \`uvicorn\`, \`wait_for_health\` everywhere; retained \`mock\` / \`asyncio\` / \`contextlib\` where still used outside the removed fixture body.
- **Comment migration**: the load-bearing \"Uvicorn's \`should_exit\` is poll-based... \`server.shutdown()\` triggers the graceful drain\" rationale moved into the helper docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)