### PR TITLE
feat(tools): wake_session built-in (one primitive subsuming supervisor-wake)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -11656,6 +11656,7 @@
                   "search_events",
                   "cancel",
                   "schedule_wake",
+                  "wake_session",
                   "http_request"
                 ]
               },

--- a/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
@@ -11,6 +11,7 @@ class ToolSpecTypeType0(str, Enum):
     READ = "read"
     SCHEDULE_WAKE = "schedule_wake"
     SEARCH_EVENTS = "search_events"
+    WAKE_SESSION = "wake_session"
     WEB_FETCH = "web_fetch"
     WEB_SEARCH = "web_search"
     WRITE = "write"

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -28,6 +28,7 @@ BuiltinToolType = Literal[
     "search_events",
     "cancel",
     "schedule_wake",
+    "wake_session",
     "http_request",
 ]
 

--- a/src/aios/tools/__init__.py
+++ b/src/aios/tools/__init__.py
@@ -29,6 +29,7 @@ from aios.tools import read as _read  # noqa: F401
 from aios.tools import schedule_wake as _schedule_wake  # noqa: F401
 from aios.tools import search_events as _search_events  # noqa: F401
 from aios.tools import switch_channel as _switch_channel  # noqa: F401
+from aios.tools import wake_session as _wake_session  # noqa: F401
 from aios.tools import web_fetch as _web_fetch  # noqa: F401
 from aios.tools import web_search as _web_search  # noqa: F401
 from aios.tools import write as _write  # noqa: F401

--- a/src/aios/tools/wake_session.py
+++ b/src/aios/tools/wake_session.py
@@ -1,0 +1,311 @@
+"""The wake_session tool — wake another session in the same account.
+
+The generalising primitive behind supervisor-wake, broadcast notification,
+inter-lieutenant coordination, and friends (see issue #373).  Calling this
+tool appends a user-role ``message`` event to the target session and
+defers a ``wake_session`` job for it, so the target's next step
+picks the new prompt up via the standard event-log mechanics.
+
+Same-account scoping: the caller's session loads its ``account_id``;
+the target session must have the SAME ``account_id``.  Cross-account
+wake is refused.  This collapses the earlier v1 (same-bearer) vs v2
+(account-scoped) framing — there's one model from day one.
+
+Wake-depth and rate-limit are enforced in this handler (not in
+``defer_wake``, which is a generic harness wake mechanism used for
+user messages, scheduled wakes, and tool completions; cross-session
+concerns don't belong there):
+
+* Wake-depth — the depth counter is stamped on the appended message's
+  ``data.metadata.wake_depth``.  The handler reads the source session's
+  most recent user-role message; if its metadata carries a ``wake_depth``,
+  the new message's depth is ``N + 1``.  Otherwise the new depth is 1.
+  Refuses at ``>= WAKE_SESSION_MAX_DEPTH`` so a wake loop
+  (A → B → A → ...) terminates in bounded steps.
+
+* Rate-limit — counts target-side user messages stamped with
+  ``data.metadata.wake_source_session_id == <this session>`` in the
+  last hour.  Refuses at ``>= WAKE_SESSION_MAX_PER_HOUR``.  This is
+  per (source, target) pair so an honest broadcast to many targets is
+  not throttled, but a single source can't DoS a single target.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.errors import AiosError
+from aios.harness import runtime
+from aios.services import sessions as sessions_service
+from aios.services.wake import defer_wake
+from aios.tools.registry import registry
+
+WAKE_SESSION_MAX_DEPTH = 10
+WAKE_SESSION_MAX_PER_HOUR = 10
+WAKE_SESSION_MAX_PROMPT_CHARS = 100_000
+
+
+class WakeSessionArgumentError(AiosError):
+    error_type = "wake_session_argument_error"
+    status_code = 400
+
+
+class WakeSessionPermissionError(AiosError):
+    error_type = "wake_session_permission_error"
+    status_code = 403
+
+
+class WakeSessionTargetUnavailableError(AiosError):
+    error_type = "wake_session_target_unavailable"
+    status_code = 409
+
+
+class WakeSessionDepthExceededError(AiosError):
+    error_type = "wake_session_depth_exceeded"
+    status_code = 429
+
+
+class WakeSessionRateLimitedError(AiosError):
+    error_type = "wake_session_rate_limited"
+    status_code = 429
+
+
+WAKE_SESSION_DESCRIPTION = (
+    "Wake another session by appending a user-role message to its log and "
+    "scheduling its next step. Use this for cross-session coordination — "
+    "escalate to a supervisor, hand work off to a peer, notify a watcher. "
+    "The target must be in the same account as you; archived or terminated "
+    "targets are refused. Wake-depth (chained wakes from one wake) is "
+    f"capped at {WAKE_SESSION_MAX_DEPTH}; per-pair rate is capped at "
+    f"{WAKE_SESSION_MAX_PER_HOUR} wakes/hour. You must already know the "
+    "target's session_id — there is no name lookup."
+)
+
+WAKE_SESSION_PARAMETERS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "target_session_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The session_id (e.g. 'sess_01...') of the session to wake.",
+        },
+        "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": WAKE_SESSION_MAX_PROMPT_CHARS,
+            "description": (
+                "The message to deliver to the target session. Appears in "
+                "the target's log as a user-role message — write it as if "
+                "speaking directly to the target agent. Include any urgency "
+                "or escalation framing in the prose; there is no separate "
+                "urgency parameter."
+            ),
+        },
+    },
+    "required": ["target_session_id", "prompt"],
+    "additionalProperties": False,
+}
+
+
+async def _read_source_wake_depth(pool: Any, session_id: str, *, account_id: str) -> int:
+    """Return the wake_depth stamped on the most recent user-role message.
+
+    Reads the source's own log to inherit the depth of the message that
+    triggered this step.  Returns 0 when no user message has ``wake_depth``
+    stamped (root call — a human-originated message or first wake of a
+    chain).
+    """
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT COALESCE(
+                (data->'metadata'->>'wake_depth')::int,
+                0
+            ) AS depth
+            FROM events
+            WHERE session_id = $1
+              AND account_id = $2
+              AND kind = 'message'
+              AND data->>'role' = 'user'
+            ORDER BY seq DESC
+            LIMIT 1
+            """,
+            session_id,
+            account_id,
+        )
+    if row is None:
+        return 0
+    return int(row["depth"])
+
+
+async def _count_recent_wakes_from(
+    pool: Any,
+    *,
+    source_session_id: str,
+    target_session_id: str,
+    account_id: str,
+) -> int:
+    """Count target-side user messages stamped with ``wake_source_session_id``
+    equal to ``source_session_id`` in the last hour.
+
+    The rate-limit window is per (source, target) pair so an honest
+    broadcast to many distinct targets isn't throttled; a single source
+    only gets ``WAKE_SESSION_MAX_PER_HOUR`` wakes/hour at any one target.
+    """
+    async with pool.acquire() as conn:
+        count = await conn.fetchval(
+            """
+            SELECT count(*)
+            FROM events
+            WHERE session_id = $1
+              AND account_id = $2
+              AND kind = 'message'
+              AND data->>'role' = 'user'
+              AND data->'metadata'->>'wake_source_session_id' = $3
+              AND created_at > now() - interval '1 hour'
+            """,
+            target_session_id,
+            account_id,
+            source_session_id,
+        )
+    return int(count or 0)
+
+
+async def wake_session_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    from aios.db import queries
+
+    target_session_id = arguments.get("target_session_id")
+    prompt = arguments.get("prompt")
+    if not isinstance(target_session_id, str) or not target_session_id:
+        raise WakeSessionArgumentError("target_session_id must be a non-empty string")
+    if not isinstance(prompt, str) or not prompt:
+        raise WakeSessionArgumentError("prompt must be a non-empty string")
+    if len(prompt) > WAKE_SESSION_MAX_PROMPT_CHARS:
+        raise WakeSessionArgumentError(
+            f"prompt exceeds {WAKE_SESSION_MAX_PROMPT_CHARS} characters (got {len(prompt)})"
+        )
+
+    if target_session_id == session_id:
+        # Self-wake has a dedicated tool (schedule_wake) — reject so an
+        # agent can't accidentally bypass that surface and the depth
+        # tracking doesn't conflate self-reentry with cross-session loops.
+        raise WakeSessionArgumentError(
+            "cannot wake your own session; use schedule_wake for self-reentry"
+        )
+
+    pool = runtime.require_pool()
+
+    # Caller's account_id: this is the authority the tool inherits.
+    source_account_id = await sessions_service.load_session_account_id(pool, session_id)
+
+    # Load the target row directly (unscoped) so we can produce a clear
+    # permission error when the target exists under a different account
+    # rather than a generic 404.  This is the only place in the codebase
+    # that needs an unscoped-by-id read for a cross-session check, so it
+    # justifies bypassing the usual ``account_id``-scoped helper.
+    async with pool.acquire() as conn:
+        target_row = await conn.fetchrow(
+            "SELECT account_id, status, archived_at FROM sessions WHERE id = $1",
+            target_session_id,
+        )
+    if target_row is None:
+        raise WakeSessionArgumentError(
+            f"target session {target_session_id} not found",
+            detail={"target_session_id": target_session_id},
+        )
+
+    target_account_id: str = target_row["account_id"]
+    if target_account_id != source_account_id:
+        # Don't leak the existence of cross-account sessions: present
+        # the same shape an attacker would see for an unknown id.
+        raise WakeSessionPermissionError(
+            f"target session {target_session_id} not found",
+            detail={"target_session_id": target_session_id},
+        )
+
+    if target_row["archived_at"] is not None:
+        raise WakeSessionTargetUnavailableError(
+            f"target session {target_session_id} is archived",
+            detail={"target_session_id": target_session_id, "reason": "archived"},
+        )
+    if target_row["status"] == "terminated":
+        raise WakeSessionTargetUnavailableError(
+            f"target session {target_session_id} is terminated",
+            detail={"target_session_id": target_session_id, "reason": "terminated"},
+        )
+
+    # Wake-depth: inherit from the source's most recent user message;
+    # bail before any side effect if the new depth would breach the cap.
+    source_depth = await _read_source_wake_depth(pool, session_id, account_id=source_account_id)
+    new_depth = source_depth + 1
+    if new_depth > WAKE_SESSION_MAX_DEPTH:
+        raise WakeSessionDepthExceededError(
+            f"wake-depth would exceed {WAKE_SESSION_MAX_DEPTH} "
+            f"(current={source_depth}); refusing to extend the chain",
+            detail={
+                "current_depth": source_depth,
+                "max_depth": WAKE_SESSION_MAX_DEPTH,
+            },
+        )
+
+    # Per (source, target) rate limit.  Counted BEFORE the append so the
+    # window starts fresh for the next hour — a burst at the cap doesn't
+    # rebuild forward on every retry.
+    recent_wakes = await _count_recent_wakes_from(
+        pool,
+        source_session_id=session_id,
+        target_session_id=target_session_id,
+        account_id=source_account_id,
+    )
+    if recent_wakes >= WAKE_SESSION_MAX_PER_HOUR:
+        raise WakeSessionRateLimitedError(
+            f"rate limit: {recent_wakes} wakes from {session_id} to "
+            f"{target_session_id} in the last hour (max "
+            f"{WAKE_SESSION_MAX_PER_HOUR})",
+            detail={
+                "recent_wakes": recent_wakes,
+                "max_per_hour": WAKE_SESSION_MAX_PER_HOUR,
+            },
+        )
+
+    # Append the user message to the TARGET, then defer a wake there.
+    # Using ``queries.append_event`` directly (rather than
+    # ``append_user_message``) so we can stamp wake-tracking metadata
+    # without involving the API-side size check / channel lift logic
+    # — those are not relevant for an in-process wake.
+    metadata: dict[str, Any] = {
+        "wake_source_session_id": session_id,
+        "wake_depth": new_depth,
+    }
+    async with pool.acquire() as conn:
+        await queries.append_event(
+            conn,
+            account_id=target_account_id,
+            session_id=target_session_id,
+            kind="message",
+            data={"role": "user", "content": prompt, "metadata": metadata},
+        )
+    await defer_wake(
+        pool,
+        target_session_id,
+        cause="agent_wake",
+        account_id=target_account_id,
+    )
+
+    return {
+        "woken": True,
+        "target_session_id": target_session_id,
+        "wake_depth": new_depth,
+    }
+
+
+def _register() -> None:
+    registry.register(
+        name="wake_session",
+        description=WAKE_SESSION_DESCRIPTION,
+        parameters_schema=WAKE_SESSION_PARAMETERS_SCHEMA,
+        handler=wake_session_handler,
+    )
+
+
+_register()

--- a/tests/integration/test_wake_session.py
+++ b/tests/integration/test_wake_session.py
@@ -1,0 +1,333 @@
+"""Integration tests for the ``wake_session`` tool handler against a real DB.
+
+These tests run the handler against a testcontainer-Postgres and
+inspect the resulting event-log rows. They cover the cross-session
+happy path, the same-account check (a session in account A can NOT
+wake a session in account B), the rate-limit cap counted from the
+target's event log, and the wake-depth cap counted from the source's
+event log.
+
+The procrastinate side of ``defer_wake`` is patched out per
+``tests/integration/test_worker_result_after_deny.py`` — the SQL
+surface under test is the event-log append + permission gates, not
+the job-queue enqueue.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.harness import runtime
+from aios.tools.wake_session import (
+    WAKE_SESSION_MAX_DEPTH,
+    WAKE_SESSION_MAX_PER_HOUR,
+    WakeSessionDepthExceededError,
+    WakeSessionPermissionError,
+    WakeSessionRateLimitedError,
+    WakeSessionTargetUnavailableError,
+    wake_session_handler,
+)
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def pool_with_runtime(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[asyncpg.Pool[Any]]:
+    """Yield a pool that's also been installed on ``runtime.pool`` so the
+    handler's ``runtime.require_pool()`` sees it."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    prev = runtime.pool
+    runtime.pool = pool
+    try:
+        yield pool
+    finally:
+        runtime.pool = prev
+        await pool.close()
+
+
+async def _seed_account(pool: asyncpg.Pool[Any], account_id: str, display: str) -> None:
+    """Idempotently seed a child tenant account under a shared root.
+
+    The ``accounts_one_active_root`` partial unique index only permits one
+    non-archived row with ``parent_account_id IS NULL``, so every test
+    account must descend from a single root.  We seed ``acc_wake_root``
+    on first call and parent each subsequent account under it.
+    """
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+            VALUES ('acc_wake_root', NULL, TRUE, 'wake-test-root')
+            ON CONFLICT (id) DO NOTHING
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+            VALUES ($1, 'acc_wake_root', FALSE, $2)
+            ON CONFLICT (id) DO NOTHING
+            """,
+            account_id,
+            display,
+        )
+
+
+async def _count_user_messages(pool: asyncpg.Pool[Any], session_id: str) -> int:
+    async with pool.acquire() as conn:
+        return int(
+            await conn.fetchval(
+                """
+                SELECT count(*) FROM events
+                WHERE session_id = $1
+                  AND kind = 'message'
+                  AND data->>'role' = 'user'
+                """,
+                session_id,
+            )
+            or 0
+        )
+
+
+@pytest.fixture
+def patched_defer_wake() -> Any:
+    """Patch out the procrastinate enqueue.  The handler's SQL surface
+    (event append, permission check, depth/rate-limit reads) is what's
+    under test; the job-queue enqueue is exercised by the existing
+    ``tests/unit/test_wake.py`` suite."""
+    with mock.patch("aios.tools.wake_session.defer_wake", new_callable=AsyncMock) as m:
+        yield m
+
+
+class TestWakeSessionIntegration:
+    async def test_happy_path_appends_user_message_to_target(
+        self,
+        pool_with_runtime: asyncpg.Pool[Any],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        pool = pool_with_runtime
+        await _seed_account(pool, "acc_wake_a", "wake-test-a")
+        _, _, source = await seed_agent_env_session(pool, account_id="acc_wake_a", prefix="src")
+        _, _, target = await seed_agent_env_session(pool, account_id="acc_wake_a", prefix="dst")
+
+        result = await wake_session_handler(
+            source.id,
+            {"target_session_id": target.id, "prompt": "please escalate"},
+        )
+
+        assert result == {
+            "woken": True,
+            "target_session_id": target.id,
+            "wake_depth": 1,
+        }
+
+        # One new user-message landed on the target.
+        assert await _count_user_messages(pool, target.id) == 1
+
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT data FROM events
+                WHERE session_id = $1
+                  AND kind = 'message'
+                  AND data->>'role' = 'user'
+                ORDER BY seq DESC LIMIT 1
+                """,
+                target.id,
+            )
+        assert row is not None
+        data = queries.parse_jsonb(row["data"])
+        assert data["content"] == "please escalate"
+        assert data["metadata"]["wake_source_session_id"] == source.id
+        assert data["metadata"]["wake_depth"] == 1
+
+        # defer_wake was called against the TARGET with the target's account.
+        patched_defer_wake.assert_awaited_once()
+        assert patched_defer_wake.await_args.args[1] == target.id
+        assert patched_defer_wake.await_args.kwargs["account_id"] == "acc_wake_a"
+        assert patched_defer_wake.await_args.kwargs["cause"] == "agent_wake"
+
+    async def test_cross_account_rejected(
+        self,
+        pool_with_runtime: asyncpg.Pool[Any],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        pool = pool_with_runtime
+        await _seed_account(pool, "acc_wake_x", "wake-test-x")
+        await _seed_account(pool, "acc_wake_y", "wake-test-y")
+        _, _, source = await seed_agent_env_session(pool, account_id="acc_wake_x", prefix="src-x")
+        _, _, target = await seed_agent_env_session(pool, account_id="acc_wake_y", prefix="dst-y")
+
+        with pytest.raises(WakeSessionPermissionError):
+            await wake_session_handler(
+                source.id,
+                {"target_session_id": target.id, "prompt": "cross-account"},
+            )
+
+        # No message landed on the target — refusal must be side-effect-free.
+        assert await _count_user_messages(pool, target.id) == 0
+        patched_defer_wake.assert_not_awaited()
+
+    async def test_archived_target_rejected(
+        self,
+        pool_with_runtime: asyncpg.Pool[Any],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        pool = pool_with_runtime
+        await _seed_account(pool, "acc_wake_arch", "wake-test-archived")
+        _, _, source = await seed_agent_env_session(pool, account_id="acc_wake_arch", prefix="src")
+        _, _, target = await seed_agent_env_session(pool, account_id="acc_wake_arch", prefix="dst")
+        async with pool.acquire() as conn:
+            await queries.archive_session(conn, target.id, account_id="acc_wake_arch")
+
+        with pytest.raises(WakeSessionTargetUnavailableError, match="archived"):
+            await wake_session_handler(
+                source.id,
+                {"target_session_id": target.id, "prompt": "into the void"},
+            )
+        patched_defer_wake.assert_not_awaited()
+
+    async def test_terminated_target_rejected(
+        self,
+        pool_with_runtime: asyncpg.Pool[Any],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        pool = pool_with_runtime
+        await _seed_account(pool, "acc_wake_term", "wake-test-terminated")
+        _, _, source = await seed_agent_env_session(pool, account_id="acc_wake_term", prefix="src")
+        _, _, target = await seed_agent_env_session(pool, account_id="acc_wake_term", prefix="dst")
+        async with pool.acquire() as conn:
+            await queries.set_session_status(
+                conn, target.id, "terminated", None, account_id="acc_wake_term"
+            )
+
+        with pytest.raises(WakeSessionTargetUnavailableError, match="terminated"):
+            await wake_session_handler(
+                source.id,
+                {"target_session_id": target.id, "prompt": "into the void"},
+            )
+        patched_defer_wake.assert_not_awaited()
+
+    async def test_wake_depth_inherits_then_caps(
+        self,
+        pool_with_runtime: asyncpg.Pool[Any],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        """Stamp a near-cap depth on the source's most recent user message;
+        a wake should bump to cap, the next attempt should refuse."""
+        pool = pool_with_runtime
+        await _seed_account(pool, "acc_wake_depth", "wake-test-depth")
+        _, _, source = await seed_agent_env_session(pool, account_id="acc_wake_depth", prefix="src")
+        _, _, target = await seed_agent_env_session(pool, account_id="acc_wake_depth", prefix="dst")
+
+        # Stamp depth = MAX_DEPTH - 1 on the source so the next wake lands
+        # exactly at the cap and the one after would breach it.
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id="acc_wake_depth",
+                session_id=source.id,
+                kind="message",
+                data={
+                    "role": "user",
+                    "content": "incoming-wake",
+                    "metadata": {"wake_depth": WAKE_SESSION_MAX_DEPTH - 1},
+                },
+            )
+
+        # First call: depth bumps from MAX-1 to MAX. Allowed.
+        result = await wake_session_handler(
+            source.id,
+            {"target_session_id": target.id, "prompt": "first"},
+        )
+        assert result["wake_depth"] == WAKE_SESSION_MAX_DEPTH
+
+        # Stamp depth = MAX on the source so the next wake would breach.
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id="acc_wake_depth",
+                session_id=source.id,
+                kind="message",
+                data={
+                    "role": "user",
+                    "content": "second-wake-incoming",
+                    "metadata": {"wake_depth": WAKE_SESSION_MAX_DEPTH},
+                },
+            )
+
+        with pytest.raises(WakeSessionDepthExceededError):
+            await wake_session_handler(
+                source.id,
+                {"target_session_id": target.id, "prompt": "should refuse"},
+            )
+
+    async def test_rate_limit_caps_per_pair(
+        self,
+        pool_with_runtime: asyncpg.Pool[Any],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        """Bursting wakes from one source to one target trips the hourly cap."""
+        pool = pool_with_runtime
+        await _seed_account(pool, "acc_wake_rate", "wake-test-rate")
+        _, _, source = await seed_agent_env_session(pool, account_id="acc_wake_rate", prefix="src")
+        _, _, target = await seed_agent_env_session(pool, account_id="acc_wake_rate", prefix="dst")
+
+        # Burst up to the cap.
+        for i in range(WAKE_SESSION_MAX_PER_HOUR):
+            await wake_session_handler(
+                source.id,
+                {"target_session_id": target.id, "prompt": f"wake-{i}"},
+            )
+
+        # One more breaches.
+        with pytest.raises(WakeSessionRateLimitedError):
+            await wake_session_handler(
+                source.id,
+                {"target_session_id": target.id, "prompt": "over-cap"},
+            )
+
+        # The cap counts CAP not CAP+1 messages on the target.
+        assert await _count_user_messages(pool, target.id) == WAKE_SESSION_MAX_PER_HOUR
+
+    async def test_rate_limit_is_per_pair_not_per_source(
+        self,
+        pool_with_runtime: asyncpg.Pool[Any],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        """Bursting from one source to TWO different targets must not
+        cross-count: each (source, target) pair has its own window."""
+        pool = pool_with_runtime
+        await _seed_account(pool, "acc_wake_fan", "wake-test-fanout")
+        _, _, source = await seed_agent_env_session(pool, account_id="acc_wake_fan", prefix="src")
+        _, _, t_a = await seed_agent_env_session(pool, account_id="acc_wake_fan", prefix="dst-a")
+        _, _, t_b = await seed_agent_env_session(pool, account_id="acc_wake_fan", prefix="dst-b")
+
+        # Cap-out target A.
+        for i in range(WAKE_SESSION_MAX_PER_HOUR):
+            await wake_session_handler(
+                source.id,
+                {"target_session_id": t_a.id, "prompt": f"a-{i}"},
+            )
+        with pytest.raises(WakeSessionRateLimitedError):
+            await wake_session_handler(
+                source.id,
+                {"target_session_id": t_a.id, "prompt": "a-over"},
+            )
+
+        # Target B should still accept the next wake — a different pair.
+        result = await wake_session_handler(
+            source.id,
+            {"target_session_id": t_b.id, "prompt": "b-first"},
+        )
+        assert result["woken"] is True

--- a/tests/unit/test_wake_session_handler.py
+++ b/tests/unit/test_wake_session_handler.py
@@ -1,0 +1,293 @@
+"""Unit tests for the ``wake_session`` tool handler.
+
+These tests stub the worker-process pool and DB so they don't need a
+live Postgres. They cover the argument-validation surface, the
+same-account permission check, the wake-depth cap, and the per-pair
+rate-limit cap. Full-stack DB behavior is covered separately by the
+integration tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import ANY, AsyncMock, MagicMock
+
+import pytest
+
+from aios.tools.wake_session import (
+    WAKE_SESSION_MAX_DEPTH,
+    WAKE_SESSION_MAX_PER_HOUR,
+    WakeSessionArgumentError,
+    WakeSessionDepthExceededError,
+    WakeSessionPermissionError,
+    WakeSessionRateLimitedError,
+    WakeSessionTargetUnavailableError,
+    wake_session_handler,
+)
+
+
+def _make_pool(*, target_row: dict[str, Any] | None, depth: int, recent_wakes: int) -> MagicMock:
+    """Build a mock pool whose ``pool.acquire()`` yields a single shared
+    conn whose ``fetchrow``/``fetchval`` walk through the handler's call
+    sequence in order:
+
+      1. fetchrow → target session row (SELECT account_id, status, archived_at)
+      2. fetchrow → wake_depth read on source (COALESCE … FROM events ...)
+      3. fetchval → recent-wake count (SELECT count(*) FROM events ...)
+      4. append_event is patched separately via ``queries.append_event``.
+
+    Each ``pool.acquire()`` invocation re-enters the same conn, so the
+    side_effect queue is shared across the three acquire blocks in the
+    handler.
+    """
+    pool = MagicMock()
+
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=[target_row, {"depth": depth}])
+    conn.fetchval = AsyncMock(side_effect=[recent_wakes])
+    conn.execute = AsyncMock()
+
+    class _PoolAcquireCM:
+        async def __aenter__(self) -> MagicMock:
+            return conn
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+    pool.acquire = lambda: _PoolAcquireCM()
+    return pool
+
+
+@pytest.fixture(autouse=True)
+def _mock_runtime_pool(monkeypatch: Any) -> None:
+    """Most tests construct their own pool — patch the runtime to use it."""
+
+    def _fake_require_pool() -> MagicMock:
+        return _DEFAULT_POOL_HOLDER["pool"]
+
+    monkeypatch.setattr("aios.tools.wake_session.runtime.require_pool", _fake_require_pool)
+
+
+_DEFAULT_POOL_HOLDER: dict[str, Any] = {"pool": None}
+
+
+@pytest.fixture
+def install_pool() -> Any:
+    """Install a pool that ``runtime.require_pool()`` will return."""
+
+    def _install(pool: MagicMock) -> None:
+        _DEFAULT_POOL_HOLDER["pool"] = pool
+
+    yield _install
+    _DEFAULT_POOL_HOLDER["pool"] = None
+
+
+class TestWakeSessionHandlerArguments:
+    async def test_missing_target_rejects(self) -> None:
+        with pytest.raises(WakeSessionArgumentError, match="target_session_id"):
+            await wake_session_handler("sess_01SOURCE", {"prompt": "hi"})
+
+    async def test_missing_prompt_rejects(self) -> None:
+        with pytest.raises(WakeSessionArgumentError, match="prompt"):
+            await wake_session_handler("sess_01SOURCE", {"target_session_id": "sess_01TARGET"})
+
+    async def test_empty_target_rejects(self) -> None:
+        with pytest.raises(WakeSessionArgumentError, match="target_session_id"):
+            await wake_session_handler("sess_01SOURCE", {"target_session_id": "", "prompt": "hi"})
+
+    async def test_self_wake_rejects(self) -> None:
+        with pytest.raises(WakeSessionArgumentError, match="schedule_wake"):
+            await wake_session_handler(
+                "sess_01SAME", {"target_session_id": "sess_01SAME", "prompt": "hi"}
+            )
+
+
+class TestWakeSessionHandlerPermission:
+    async def test_unknown_target_rejects(self, monkeypatch: Any, install_pool: Any) -> None:
+        install_pool(_make_pool(target_row=None, depth=0, recent_wakes=0))
+        monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
+        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        with pytest.raises(WakeSessionArgumentError, match="not found"):
+            await wake_session_handler(
+                "sess_01SOURCE",
+                {"target_session_id": "sess_01MISSING", "prompt": "hi"},
+            )
+
+    async def test_cross_account_rejects_without_disclosure(
+        self, monkeypatch: Any, install_pool: Any
+    ) -> None:
+        install_pool(
+            _make_pool(
+                target_row={
+                    "account_id": "acc_other",
+                    "status": "running",
+                    "archived_at": None,
+                },
+                depth=0,
+                recent_wakes=0,
+            )
+        )
+        monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
+        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        with pytest.raises(WakeSessionPermissionError, match="not found") as exc_info:
+            await wake_session_handler(
+                "sess_01SOURCE",
+                {"target_session_id": "sess_01TARGET", "prompt": "hi"},
+            )
+        # Don't leak account_id-presence: detail mirrors the unknown-target shape.
+        assert "account_id" not in (exc_info.value.detail or {})
+
+    async def test_archived_target_rejects(self, monkeypatch: Any, install_pool: Any) -> None:
+        install_pool(
+            _make_pool(
+                target_row={
+                    "account_id": "acc_test_stub",
+                    "status": "idle",
+                    "archived_at": "2026-01-01T00:00:00",
+                },
+                depth=0,
+                recent_wakes=0,
+            )
+        )
+        monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
+        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        with pytest.raises(WakeSessionTargetUnavailableError, match="archived"):
+            await wake_session_handler(
+                "sess_01SOURCE",
+                {"target_session_id": "sess_01TARGET", "prompt": "hi"},
+            )
+
+    async def test_terminated_target_rejects(self, monkeypatch: Any, install_pool: Any) -> None:
+        install_pool(
+            _make_pool(
+                target_row={
+                    "account_id": "acc_test_stub",
+                    "status": "terminated",
+                    "archived_at": None,
+                },
+                depth=0,
+                recent_wakes=0,
+            )
+        )
+        monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
+        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        with pytest.raises(WakeSessionTargetUnavailableError, match="terminated"):
+            await wake_session_handler(
+                "sess_01SOURCE",
+                {"target_session_id": "sess_01TARGET", "prompt": "hi"},
+            )
+
+    async def test_errored_target_allowed(self, monkeypatch: Any, install_pool: Any) -> None:
+        """Errored isn't a terminal state — a wake re-promotes it to pending."""
+        install_pool(
+            _make_pool(
+                target_row={
+                    "account_id": "acc_test_stub",
+                    "status": "errored",
+                    "archived_at": None,
+                },
+                depth=0,
+                recent_wakes=0,
+            )
+        )
+        mock_append = AsyncMock()
+        mock_defer = AsyncMock()
+        monkeypatch.setattr("aios.db.queries.append_event", mock_append)
+        monkeypatch.setattr("aios.tools.wake_session.defer_wake", mock_defer)
+
+        result = await wake_session_handler(
+            "sess_01SOURCE",
+            {"target_session_id": "sess_01TARGET", "prompt": "wake up"},
+        )
+        assert result["woken"] is True
+        mock_append.assert_awaited_once()
+        mock_defer.assert_awaited_once()
+
+
+class TestWakeSessionHandlerLimits:
+    async def test_depth_at_cap_rejects(self, monkeypatch: Any, install_pool: Any) -> None:
+        install_pool(
+            _make_pool(
+                target_row={
+                    "account_id": "acc_test_stub",
+                    "status": "idle",
+                    "archived_at": None,
+                },
+                depth=WAKE_SESSION_MAX_DEPTH,
+                recent_wakes=0,
+            )
+        )
+        monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
+        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        with pytest.raises(WakeSessionDepthExceededError, match="wake-depth"):
+            await wake_session_handler(
+                "sess_01SOURCE",
+                {"target_session_id": "sess_01TARGET", "prompt": "hi"},
+            )
+
+    async def test_rate_limit_at_cap_rejects(self, monkeypatch: Any, install_pool: Any) -> None:
+        install_pool(
+            _make_pool(
+                target_row={
+                    "account_id": "acc_test_stub",
+                    "status": "idle",
+                    "archived_at": None,
+                },
+                depth=0,
+                recent_wakes=WAKE_SESSION_MAX_PER_HOUR,
+            )
+        )
+        monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
+        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        with pytest.raises(WakeSessionRateLimitedError, match="rate limit"):
+            await wake_session_handler(
+                "sess_01SOURCE",
+                {"target_session_id": "sess_01TARGET", "prompt": "hi"},
+            )
+
+    async def test_happy_path_appends_and_defers(self, monkeypatch: Any, install_pool: Any) -> None:
+        install_pool(
+            _make_pool(
+                target_row={
+                    "account_id": "acc_test_stub",
+                    "status": "idle",
+                    "archived_at": None,
+                },
+                depth=2,
+                recent_wakes=0,
+            )
+        )
+        mock_append = AsyncMock()
+        mock_defer = AsyncMock()
+        monkeypatch.setattr("aios.db.queries.append_event", mock_append)
+        monkeypatch.setattr("aios.tools.wake_session.defer_wake", mock_defer)
+
+        result = await wake_session_handler(
+            "sess_01SOURCE",
+            {"target_session_id": "sess_01TARGET", "prompt": "escalation summary"},
+        )
+
+        # New depth carries over source +1.
+        assert result == {
+            "woken": True,
+            "target_session_id": "sess_01TARGET",
+            "wake_depth": 3,
+        }
+        # The append landed on the TARGET session under its account_id with
+        # wake_source_session_id + wake_depth metadata.
+        mock_append.assert_awaited_once()
+        kwargs = mock_append.call_args.kwargs
+        assert kwargs["session_id"] == "sess_01TARGET"
+        assert kwargs["account_id"] == "acc_test_stub"
+        assert kwargs["kind"] == "message"
+        assert kwargs["data"]["role"] == "user"
+        assert kwargs["data"]["content"] == "escalation summary"
+        assert kwargs["data"]["metadata"]["wake_source_session_id"] == "sess_01SOURCE"
+        assert kwargs["data"]["metadata"]["wake_depth"] == 3
+
+        mock_defer.assert_awaited_once_with(
+            ANY,
+            "sess_01TARGET",
+            cause="agent_wake",
+            account_id="acc_test_stub",
+        )


### PR DESCRIPTION
Closes #373.

Implements the `wake_session(target_session_id, prompt)` built-in tool per the v1 design decisions in the issue body. 941 lines: 311-line implementation + 333-line integration tests + 293-line unit tests + 4 small integrations (openapi snapshot, sdk snapshot, tool registry, model enum).

The pipeline finished implementation cleanly (12 unit tests + 7 integration tests passing, mypy clean across 156 files, ruff clean across 375 files) but paused before committing — same pattern as aios#370/PR#601 + autodev#93 (agent enters interactive pause after impl, dispatch ends without PR). Chief-of-staff committed + opened the PR manually from the worktree.

## Design

Single primitive subsuming supervisor-wake, broadcast notification, inter-lieutenant coordination, alarm clocks set by other agents. Calling the tool appends a user-role message event to the target session and defers a wake job; the target's next step picks the new prompt up via the standard event-log mechanics.

## v1 decisions (per issue body, supersede any earlier framing)

- **Auth**: same-account check. Caller's session loads its account_id; target must share it. Cross-account wake refused. (Collapses the earlier v1/v2 framing — one model from day one.)
- **`parent_session_id`**: NOT in this PR. Deferred to a follow-up issue.
- **Rate-limit + wake-depth**: enforced in this handler, NOT in defer_wake (which stays generic):
  - Wake-depth stamped on `data.metadata.wake_depth`; refused at `WAKE_SESSION_MAX_DEPTH` so wake loops terminate in bounded steps.
  - Rate-limit per (source, target) pair; counts target-side messages stamped with `wake_source_session_id == <this session>` in the last hour; refused at `WAKE_SESSION_MAX_PER_HOUR`.
- **`urgency` parameter**: dropped from v1 (agent writes urgency in prompt text).
- **Target session status**: refuses `archived_at IS NOT NULL` or `status='terminated'`; allows other statuses (harness wake mechanism handles them).

## Test plan
- `pytest tests/unit/test_wake_session_handler.py` — 12 passed (verified by agent)
- `pytest tests/integration/test_wake_session.py` — 7 passed against testcontainer-Postgres (verified by agent)
- `mypy src` (156 files), `ruff check`/`format --check` (375 files) — all clean

## Followups
- Closes the lieutenant-non-responsiveness gap I hit in this very session (chief-of-staff couldn't wake idle lieutenants). Once landed, the lieutenant charter pattern becomes viable end-to-end.
- `parent_session_id` field on Session model — separate issue.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>