### PR TITLE
refactor(harness): extract join_blocks helper to consolidate 5 \n\n-joined-blocks sites

### DIFF
--- a/src/aios/harness/_text.py
+++ b/src/aios/harness/_text.py
@@ -1,0 +1,14 @@
+"""Plain-text composition helpers for the system-prompt builders."""
+
+from __future__ import annotations
+
+
+def join_blocks(*blocks: str) -> str:
+    """Join non-empty blocks with ``\\n\\n``; drop empty/falsy ones.
+
+    Used by the system-prompt augmenters (focal-paradigm, memory-stores,
+    skills, instructions) that compose multiple optional sections
+    without producing a leading or trailing ``\\n\\n`` when one half
+    is empty.
+    """
+    return "\n\n".join(block for block in blocks if block)

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
+from aios.harness._text import join_blocks
 from aios.models.events import Event
 
 MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: "
@@ -135,12 +136,7 @@ def build_focal_paradigm_block(channels: list[str]) -> str:
 
 
 def augment_with_focal_paradigm(base_system: str, channels: list[str]) -> str:
-    block = build_focal_paradigm_block(channels)
-    if not block:
-        return base_system
-    if base_system:
-        return base_system + "\n\n" + block
-    return block
+    return join_blocks(base_system, build_focal_paradigm_block(channels))
 
 
 def max_tail_block_local(channels: list[str]) -> int:

--- a/src/aios/harness/memory_stores.py
+++ b/src/aios/harness/memory_stores.py
@@ -10,6 +10,7 @@ instructions the caller attached.
 from __future__ import annotations
 
 from aios.errors import MemoryPreconditionFailedError
+from aios.harness._text import join_blocks
 from aios.models.memory_stores import MAX_CONTENT_BYTES, MemoryStoreResourceEcho
 
 # When #332 lands (bash writes durably persisted to the memory version log),
@@ -104,9 +105,4 @@ def build_memory_stores_block(echoes: list[MemoryStoreResourceEcho]) -> str:
 
 def augment_with_memory_stores(base_system: str, echoes: list[MemoryStoreResourceEcho]) -> str:
     """Append the memory-stores block to ``base_system`` if any are attached."""
-    block = build_memory_stores_block(echoes)
-    if not block:
-        return base_system
-    if base_system:
-        return base_system + "\n\n" + block
-    return block
+    return join_blocks(base_system, build_memory_stores_block(echoes))

--- a/src/aios/harness/skills.py
+++ b/src/aios/harness/skills.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from aios.db import queries
 from aios.harness import runtime
+from aios.harness._text import join_blocks
 from aios.logging import get_logger
 from aios.models.skills import SkillVersion
 from aios.sandbox.volumes import ensure_workspace_path
@@ -78,12 +79,7 @@ def augment_system_prompt(
     No-op if ``skill_versions`` is empty — returns ``base_system``
     unchanged.
     """
-    skills_block = build_skills_system_block(skill_versions)
-    if not skills_block:
-        return base_system
-    if base_system:
-        return base_system + "\n\n" + skills_block
-    return skills_block
+    return join_blocks(base_system, build_skills_system_block(skill_versions))
 
 
 # ── filesystem provisioning ────────────────────────────────────────────────

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from aios.harness._text import join_blocks
 from aios.harness.context import (
     build_messages,
     separate_adjacent_user_messages,
@@ -178,9 +179,7 @@ async def compute_step_prelude(
         mcp_servers_block = _build_instructions_block(agent.mcp_servers, mcp_instructions)
     http_servers_block = _build_http_servers_block(agent.http_servers)
     cli_hint = _MCP_CLI_HINT if _has_always_allow_mcp_tool(agent.tools) else ""
-    instructions_block = "\n\n".join(
-        s for s in (cli_hint, mcp_servers_block, http_servers_block) if s
-    )
+    instructions_block = join_blocks(cli_hint, mcp_servers_block, http_servers_block)
 
     # Custom tools declared on connections attached to this session
     # (single_session, per_chat origin, or operator-bound chat).  Each
@@ -205,11 +204,7 @@ async def compute_step_prelude(
     )
     system_prompt = augment_system_prompt(agent.system, skill_versions)
     system_prompt = augment_with_focal_paradigm(system_prompt, channels)
-    if instructions_block:
-        if system_prompt:
-            system_prompt = system_prompt + "\n\n" + instructions_block
-        else:
-            system_prompt = instructions_block
+    system_prompt = join_blocks(system_prompt, instructions_block)
     system_prompt = augment_with_memory_stores(system_prompt, memory_store_echoes)
 
     return StepPrelude(


### PR DESCRIPTION
## Summary

- Five sites in `harness/` implemented the same "join non-empty strings with `\n\n`" pattern via slightly-varied `if/else` ladders, each existing to avoid producing a leading/trailing `\n\n` when one side of the join was empty.
- Centralized as `join_blocks(*blocks: str) -> str` in new private module `aios/harness/_text.py`. Implementation is one line: `return "\n\n".join(block for block in blocks if block)`.
- Five sites collapsed: `augment_with_focal_paradigm`, `augment_with_memory_stores`, `augment_system_prompt`, `compute_step_prelude` instructions_block composition, and `compute_step_prelude` augmenter chain. Net `-3` LOC.

Semantics preserved at every site: `("", "") → ""`, `("a", "") → "a"`, `("", "b") → "b"`, `("a", "b") → "a\n\nb"`. Verified by reviewer at all 5 sites.

## Test plan

- [x] Type-checker (`mypy src`) — clean
- [x] Linter + format-check (`ruff check src tests`, `ruff format --check src tests`) — clean
- [x] Unit suite (`pytest tests/unit -q`) — 1406 passed
- [ ] CI runs e2e/integration suite

## Code review

`pr-review-toolkit:code-reviewer` reviewed: **no findings ≥ 80**. Sub-threshold notes (all informational, posted per project memory guidance):

1. **Justification (~30)** — 5 sites is well past the rule-of-3; call sites now visually identical.
2. **Semantics (~20)** — verified empty/empty, one-empty, both-non-empty at all 5 sites; behavior identical to pre-refactor.
3. **Module placement (~25)** — `_text.py` with leading underscore appropriately signals "internal to harness layer."
4. **Docstring (~15)** — adequate; names caller sites and the no-leading/trailing-`\n\n` invariant.
5. **Imports (~10)** — alphabetically positioned in third-party/local block at all 4 import sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)