### PR TITLE
fix(services/connectors): restrict tools_schema publication to root account [security]

### DIFF
--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -49,6 +49,7 @@ from aios.errors import (
 )
 from aios.models.connections import ConnectorSecrets
 from aios.services import connections as connections_service
+from aios.services import connectors as connectors_service
 from aios.services import inbound as inbound_service
 from aios.services import management_calls
 from aios.services import sessions as sessions_service
@@ -266,10 +267,14 @@ async def put_tools_schema(
     """
     _, auth_connector, account_id, _scope = auth
     _check_runtime_scope(auth_connector, connector)
-    async with pool.acquire() as conn:
-        await queries.update_connector_tools_schema(
-            conn, connector, tools_schema=body.tools, account_id=account_id
-        )
+    # Authorization: connectors are root-owned (the connector type IS
+    # the configuration).  Child tenants only add connections; they
+    # must not be able to publish a tools_schema that propagates into
+    # every other tenant's session prelude.  The check lives in the
+    # service layer so the route stays a thin shim.
+    await connectors_service.update_tools_schema(
+        pool, connector=connector, account_id=account_id, tools_schema=body.tools
+    )
 
 
 @router.get(

--- a/src/aios/services/connectors.py
+++ b/src/aios/services/connectors.py
@@ -1,0 +1,52 @@
+"""Business logic for connector-type configuration.
+
+Connectors are root-owned: the connector *type* (e.g. ``"telegram"``,
+``"signal"``, ``"echo-http"``) is configured once by the root account
+and shared across every tenant.  Tenants add their own *connections*
+(per-account instances of a connector), but they don't get to add
+their own connectors.  This module enforces that boundary on the
+publication surface — the route handler is a thin shim.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from aios.db import queries
+from aios.errors import ForbiddenError
+
+
+async def update_tools_schema(
+    pool: asyncpg.Pool[Any],
+    *,
+    connector: str,
+    account_id: str,
+    tools_schema: list[dict[str, Any]],
+) -> None:
+    """Publish ``connector``'s tool catalog.  Root-only.
+
+    The ``connectors`` table is keyed on connector type only — one
+    row per type, shared across every tenant — by design (migration
+    0033's "type IS the identity").  A child tenant publishing the
+    schema would overwrite the global row, and every other tenant
+    whose sessions are bound to a connection of that connector type
+    would see the new schema in its model's prelude.  A malicious
+    schema (tool names, descriptions, parameter docs) is a
+    cross-tenant prompt-injection vector.
+
+    Restricting publication to the root account preserves the
+    "connectors configured by root, connections added by tenants"
+    architectural invariant while closing the injection surface.
+    """
+    async with pool.acquire() as conn:
+        account = await queries.get_account(conn, account_id)
+        if account is None or account.parent_account_id is not None:
+            raise ForbiddenError(
+                "publishing a connector's tools_schema is reserved for the root account",
+                detail={"connector": connector},
+            )
+        await queries.update_connector_tools_schema(
+            conn, connector, account_id=account_id, tools_schema=tools_schema
+        )

--- a/tests/integration/test_connectors_tools_schema_root_only.py
+++ b/tests/integration/test_connectors_tools_schema_root_only.py
@@ -1,0 +1,134 @@
+"""Integration test: publishing a connector's ``tools_schema`` is
+root-only.
+
+Connectors are configured by the root account (the connector type IS
+the identity per migration 0033) — child tenants only add their own
+connections, never connectors.  The pre-fix
+``PUT /v1/connectors/{connector}/tools_schema`` route accepted a
+runtime token from any tenant; that runtime token is self-mintable
+by any child tenant via ``POST /v1/runtime-tokens``.  A child tenant
+could overwrite the global ``connectors.tools_schema`` row with
+malicious tool descriptions, and every other tenant's session bound
+to a connection of that connector type would see the poisoned tool
+list in its model's prelude — cross-tenant prompt-injection-as-a-
+service.
+
+The fix restricts the publication operation to the root account.
+``queries.update_connector_tools_schema`` itself remains global (one
+row per connector type) — the authorization decision lives at the
+service layer because "root vs child" is an account-policy concern,
+not a SQL one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import ForbiddenError
+from aios.services import connectors as connectors_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def root_and_child(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, root_account_id, child_account_id)`` with a
+    seeded ``echo`` connector row."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_root',  NULL,      TRUE,  'tenant-root'),
+                       ('acc_child', 'acc_root', FALSE, 'tenant-child')
+                """
+            )
+            await conn.execute(
+                "INSERT INTO connectors (connector) VALUES ('echo') ON CONFLICT DO NOTHING"
+            )
+        yield pool, "acc_root", "acc_child"
+    finally:
+        await pool.close()
+
+
+async def test_child_account_cannot_publish_tools_schema(
+    root_and_child: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """A child account's runtime token must not be able to publish
+    a connector's tools_schema.  Otherwise it could poison the global
+    row and inject prompts into every other tenant's session prelude."""
+    pool, _root_id, child_id = root_and_child
+
+    with pytest.raises(ForbiddenError) as excinfo:
+        await connectors_service.update_tools_schema(
+            pool,
+            connector="echo",
+            account_id=child_id,
+            tools_schema=[{"name": "malicious", "description": "injection", "parameters": {}}],
+        )
+
+    detail = excinfo.value.detail
+    assert detail is not None
+    assert detail.get("connector") == "echo"
+
+    # Defense-in-depth: the row must not have been written.
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT tools_schema FROM connectors WHERE connector = 'echo'")
+    assert row is not None
+    assert row["tools_schema"] in ("[]", b"[]")  # JSONB default
+
+
+async def test_root_account_can_publish_tools_schema(
+    root_and_child: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """The root account remains authorized — the connector type is a
+    root-owned configuration."""
+    pool, root_id, _child_id = root_and_child
+
+    await connectors_service.update_tools_schema(
+        pool,
+        connector="echo",
+        account_id=root_id,
+        tools_schema=[{"name": "send", "description": "send a message", "parameters": {}}],
+    )
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT tools_schema FROM connectors WHERE connector = 'echo'")
+    assert row is not None
+    # Round-trips through JSONB; just verify our tool name landed.
+    import json
+
+    raw = row["tools_schema"]
+    schema = json.loads(raw) if isinstance(raw, (str, bytes)) else raw
+    assert any(t.get("name") == "send" for t in schema)
+
+
+async def test_unknown_account_id_is_rejected(
+    root_and_child: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """A bogus account id (e.g., from a forged or stale token resolve)
+    must be rejected, not treated as root."""
+    pool, _root_id, _child_id = root_and_child
+
+    # Sanity check: the helper doesn't crash on missing accounts; it
+    # rejects them as non-root.
+    with pytest.raises(ForbiddenError):
+        await connectors_service.update_tools_schema(
+            pool,
+            connector="echo",
+            account_id="acc_does_not_exist",
+            tools_schema=[],
+        )
+    # Also verify the query layer's account-id retention; this exists
+    # to keep the audit pattern (kwarg → SQL) honest.
+    async with pool.acquire() as conn:
+        await queries.get_account(conn, "acc_root")


### PR DESCRIPTION
## Summary (cross-tenant prompt-injection surface)

- ``PUT /v1/connectors/{connector}/tools_schema`` accepted a runtime token from ANY tenant.  Runtime tokens are self-mintable by every account (``POST /v1/runtime-tokens``), so any child tenant could overwrite the GLOBAL ``connectors.tools_schema`` row for any connector type they hold a token for.  Every other tenant whose sessions are bound to a connection of that connector type then sees the new schema in its model's prelude — a malicious schema with crafted tool names / descriptions / parameter docs is a cross-tenant prompt-injection vector.
- The ``connectors`` table is keyed on connector type only (one row per type) by design — migration 0033's ``Natural-key PK: the connector type IS the identity``.  Architectural invariant: **connectors are root-configured (type-wide); tenants only add their own connections (per-account instances).**  The publication surface was the only place that invariant was unenforced.
- ``queries.update_connector_tools_schema`` had been accepting an ``account_id`` kwarg without referencing it in SQL — the canonical "audit pattern" shape from the project's ``feedback_account_id_kwarg_audit_pattern.md`` memory.  Signature lies; SQL is the truth.

## Fix

- New ``src/aios/services/connectors.py:update_tools_schema`` enforces that ``account_id`` resolves to the root account (``parent_account_id IS NULL``) before delegating to the query layer.
- Route handler ``put_tools_schema`` becomes a thin shim that calls the service.
- The ``connectors`` table remains type-keyed; the SQL stays global; the authorization decision lives at the service layer because "root vs child" is an account-policy concern, not a SQL one.

## Architecture decision (operator-confirmed)

> connectors are configured by root, tenants can add their own connections, i.e. telegram accounts, signal accounts, etc. tenants don't get to add their own connectors

This PR encodes that invariant on the only mutation surface that previously didn't enforce it.

## Test plan

- [x] ``tests/integration/test_connectors_tools_schema_root_only.py``:
  - child account → ``ForbiddenError``, row not written
  - root account → succeeds, row written
  - unknown account_id → ``ForbiddenError`` (no NoneType crash)
- [x] Type-checker — clean (156 source files)
- [x] Linter + format-check — clean
- [x] Unit suite — 1422 passed
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)