### PR TITLE
fix(harness/loop): dispatch confirmed tools from any assistant turn, not just latest

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -1062,14 +1062,22 @@ async def _dispatch_confirmed_tools(
     write a second ``tool_result`` event (violates CLAUDE.md
     invariant #4).
     """
-    # Find the latest assistant message with tool_calls.
+    # Collect tool_calls from EVERY assistant message, not just the
+    # latest.  An always_ask tool_call in turn A1 can outlive A1 if
+    # the model emits a later assistant A2 (e.g., reacting to an
+    # impatient user message that lifts the session out of
+    # ``requires_action``).  Stopping at A2 would silently drop A1's
+    # operator-confirmed dispatch — ghost-repair then papers over
+    # with the misleading ``"No result was received"`` synthetic
+    # error, even though the operator did allow the tool; the
+    # dispatch was lost.  Filtering by ``completed`` / ``in_flight``
+    # below correctly excludes anything already handled.
     asst_tool_calls: list[dict[str, Any]] = []
-    for e in reversed(message_events):
+    for e in message_events:
         if e.kind == "message" and e.data.get("role") == "assistant":
             tcs = e.data.get("tool_calls")
             if tcs:
-                asst_tool_calls = tcs
-                break
+                asst_tool_calls.extend(tcs)
 
     if not asst_tool_calls:
         return []

--- a/tests/unit/test_dispatch_confirmed_tools.py
+++ b/tests/unit/test_dispatch_confirmed_tools.py
@@ -81,6 +81,57 @@ class TestDispatchConfirmedTools:
         assert [tc["id"] for tc in pending] == ["tc1"]
         assert mock_read.call_args.kwargs["newest_first"] is True
 
+    async def test_dispatches_confirmed_from_older_assistant(self) -> None:
+        """Confirmed tool calls from older assistant turns must still be
+        dispatched, even when a later assistant turn carries different
+        tool_calls.
+
+        Reachable scenario: the model emits assistant message A1 with an
+        ``always_ask`` tool_call X.  Operator hasn't confirmed yet.  The
+        user — impatient — sends another message.  ``append_event`` lifts
+        idle to pending; the step fires; the model sees X as a synthetic
+        pending result and emits assistant message A2 with a NEW tool_call
+        Z (e.g., a search to gather context for the reply, or a new
+        ``always_allow`` action).  Z runs, lands its tool_result.  THEN
+        the operator finally confirms X.
+
+        Pre-fix ``_dispatch_confirmed_tools`` walked reversed events and
+        broke at the first assistant with non-empty tool_calls — A2's
+        ``[Z]``.  The dispatch filter checked ``confirmed={X}`` against
+        ``[Z]`` and returned ``[]``.  X is silently dropped; ghost-repair
+        eventually papers over with ``"No result was received"`` — a
+        misleading synthetic error, because the operator DID allow X;
+        only the dispatch was lost."""
+        msg_events = [
+            _assistant_with_tool_calls(["tc_X"]),  # older A1 with the confirmed tool
+            SimpleNamespace(
+                kind="message",
+                data={"role": "user", "content": "are you still there?"},
+            ),
+            _assistant_with_tool_calls(["tc_Z"]),  # newer A2 with a DIFFERENT tool_call
+            SimpleNamespace(
+                kind="message",
+                data={"role": "tool", "tool_call_id": "tc_Z", "content": "z done"},
+            ),
+        ]
+        pool = MagicMock()
+        with patch(
+            "aios.harness.loop.sessions_service.read_events",
+            AsyncMock(return_value=[_confirmed("tc_X")]),
+        ):
+            pending = await _dispatch_confirmed_tools(
+                pool,
+                "sess_x",
+                msg_events,
+                account_id="acc_test_stub",
+                task_registry=TaskRegistry(),
+            )
+        assert [tc["id"] for tc in pending] == ["tc_X"], (
+            "operator-confirmed tool_call from an older assistant turn was "
+            "dropped because _dispatch_confirmed_tools broke at the first "
+            "assistant-with-tool_calls it found, ignoring earlier turns"
+        )
+
     async def test_skips_tool_call_with_in_flight_task(self) -> None:
         """An in-flight task in ``task_registry`` blocks re-dispatch — without
         this guard, a wake firing step N+1 before the task appended its


### PR DESCRIPTION
## Summary

- ``_dispatch_confirmed_tools`` walked reversed events and broke at the first assistant message with non-empty ``tool_calls``.  When the model emitted a NEWER assistant turn between an always_ask's confirmation request and the operator's allow, every confirmed tool_call from an earlier assistant turn was silently dropped.
- Reachable sequence:
    1. Model emits assistant A1 with always_ask tool X.
    2. User impatiently sends another message; ``append_event`` lifts idle → pending; step fires.
    3. Model emits assistant A2 with a different tool_call Z (e.g., to research the user's follow-up).
    4. Z lands its tool_result.  Operator finally confirms X.
    5. Next step's ``_dispatch_confirmed_tools`` walks reversed, breaks at A2's ``[Z]``, filters against ``confirmed={X}`` → ``[]``.
    6. Step proceeds without dispatching X.  Ghost-repair eventually synthesizes ``is_error=True``, content ``"No result was received for this tool call."`` — a **misleading** semantic.  The operator DID allow X; only the dispatch was lost.
- Fix: collect tool_calls from EVERY assistant message in the events list (not just the latest).  The existing filter by ``completed`` / ``in_flight`` correctly excludes anything already handled, so collecting from older turns can't accidentally re-dispatch.

## Test plan

- [x] New ``test_dispatches_confirmed_from_older_assistant`` (unit) sets up A1 with ``[tc_X]``, a user message, A2 with ``[tc_Z]``, tc_Z's tool result, and a ``tool_confirmed allow`` for ``tc_X``.  Pre-fix the dispatch returns ``[]``; post-fix it returns ``[tc_X]``.
- [x] Type-checker — clean (162 source files)
- [x] Linter + format-check — clean
- [x] Unit suite — 1453 passed
- [x] Integration suite — 83 passed
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)