### PR TITLE
fix(db/queries): set_session_status must not rewrite archived sessions

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -902,14 +902,19 @@ async def set_session_status(
     account_id: str,
 ) -> None:
     stop_json = json.dumps(stop_reason) if stop_reason is not None else None
-    await conn.execute(
+    # ``archived_at IS NULL`` guards the archive race: every caller is
+    # worker-internal and silent no-op is the right contract — surfacing
+    # would just cascade into an ``errored`` flip on the same archived row.
+    row = await conn.fetchrow(
         "UPDATE sessions SET status = $1, stop_reason = $2::jsonb, updated_at = now() "
-        "WHERE id = $3 AND account_id = $4",
+        "WHERE id = $3 AND account_id = $4 AND archived_at IS NULL RETURNING 1",
         status,
         stop_json,
         session_id,
         account_id,
     )
+    if row is None:
+        return
 
     # Connector-calls fan-out (#328 PR 5): when a session parks in
     # ``requires_action`` with pending custom_tools, NOTIFY the per-type

--- a/tests/integration/test_set_session_status_archived.py
+++ b/tests/integration/test_set_session_status_archived.py
@@ -1,0 +1,97 @@
+"""Integration test: ``set_session_status`` must not rewrite an
+archived session's row, and must skip the connector-calls fan-out
+when the row is gone."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def archived_running_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for a session pinned
+    to ``running`` then archived — gives the post-call read a
+    distinctive expected ``status`` value."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_sss_arch', NULL, TRUE, 'set-status-archived')
+                """
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_sss_arch", prefix="sss-arch"
+        )
+        async with pool.acquire() as conn:
+            await queries.set_session_status(
+                conn, session.id, "running", None, account_id="acc_sss_arch"
+            )
+            archived = await queries.archive_session(conn, session.id, account_id="acc_sss_arch")
+        assert archived.archived_at is not None
+        assert archived.status == "running"
+        yield pool, "acc_sss_arch", session.id
+    finally:
+        await pool.close()
+
+
+async def test_set_session_status_refuses_archived_silently(
+    archived_running_session: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    pool, account_id, session_id = archived_running_session
+
+    async with pool.acquire() as conn:
+        await queries.set_session_status(
+            conn, session_id, "idle", {"type": "interrupt"}, account_id=account_id
+        )
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT status, stop_reason, archived_at FROM sessions WHERE id = $1",
+            session_id,
+        )
+    assert row is not None
+    assert row["status"] == "running", (
+        f"archived row was rewritten: status is {row['status']!r}, expected 'running'."
+    )
+    assert row["stop_reason"] is None
+    assert row["archived_at"] is not None
+
+
+async def test_set_session_status_skips_notify_on_archived(
+    archived_running_session: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """The ``requires_action`` fan-out must short-circuit on the no-row
+    UPDATE — otherwise ``_list_bound_connection_ids`` runs and (with
+    bindings) emits ``pg_notify`` for an archived session."""
+    pool, account_id, session_id = archived_running_session
+
+    async with pool.acquire() as conn:
+        pre_updated_at = await conn.fetchval(
+            "SELECT updated_at FROM sessions WHERE id = $1", session_id
+        )
+        await queries.set_session_status(
+            conn,
+            session_id,
+            "idle",
+            {"type": "requires_action", "custom_tools": [{"name": "x"}]},
+            account_id=account_id,
+        )
+        post_updated_at = await conn.fetchval(
+            "SELECT updated_at FROM sessions WHERE id = $1", session_id
+        )
+
+    assert pre_updated_at == post_updated_at


### PR DESCRIPTION
## Summary

- `set_session_status`'s UPDATE filtered only `id` and `account_id` — a concurrent archive landing between a caller's archive-gate and this call would rewrite `status` and `stop_reason` on an already-archived row.
- Reachable via the interrupt route: `append_event` (which DOES gate on `archived_at IS NULL`) and `set_session_status` ran on separate `pool.acquire()` connections with no shared transaction; an archive committing between them slipped through.
- Fix: `AND archived_at IS NULL RETURNING 1` + early return on no-row, which also short-circuits the connector-calls `pg_notify` fan-out so archived sessions don't emit spurious notifications.
- Silent no-op rather than `ConflictError`: every caller of `set_session_status` is worker-internal, so surfacing would just cascade into an `errored` flip on the same archived row — ping-pong.

Closes the archive-rejection family for `set_session_status` (siblings already closed in #523 `append_event`, #547 `update_session_template`, #554 `update_vault`, #573 `update_session`, #587 `update_memory_store`, #594 `clone_session`).

## Test plan

- [x] Type-checker — clean
- [x] Linter + format-check — clean
- [x] Unit suite — 1453 passed
- [x] New integration tests (2) — both green pre-fix → red, post-fix → green
- [ ] CI runs e2e + integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)