### PR TITLE
fix(db/listen): reap SSE listener PG backends on disconnect via conn.terminate()

### DIFF
--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -17,8 +17,21 @@ SSE responses can be very long-lived (hours). Borrowing from the pool would
 either starve other consumers or, worse, leak ``LISTEN`` state across pool
 borrowers. asyncpg's pool resets borrowed connections, but a still-LISTENing
 connection has subtle semantics that are easier to avoid by simply opening
-a fresh connection per SSE client. The connection is closed cleanly in the
-context manager's ``finally`` block, which implicitly issues ``UNLISTEN``.
+a fresh connection per SSE client.
+
+## Why ``terminate()`` instead of ``await conn.close()``
+
+The context manager's ``finally`` block must close the connection even when
+the caller is being cancelled — which is exactly what happens on SSE client
+disconnect, where sse-starlette cancels the response task group. Under
+anyio's scope-cancellation, every ``await`` inside the cancelled scope
+re-raises ``CancelledError`` immediately, so ``await conn.close()`` can't
+run to completion: asyncpg's close protocol stops before transport.abort()
+fires and the Postgres backend lingers until TCP keepalive reaps it
+(~2h). ``conn.terminate()`` is synchronous — it calls ``transport.abort()``
+directly, closing the socket without awaiting. Non-graceful but appropriate
+for SSE-style disconnects where the client is already gone, and equally
+correct on normal exit and exception unwinds (issue #606).
 
 ## Why the callback must be synchronous
 
@@ -54,7 +67,6 @@ anyone tries.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
@@ -106,14 +118,9 @@ async def listen_for_connector_result(
                 log.warning("listen.connector_result_queue_full", call_id=call_id)
 
         await conn.add_listener(channel, _callback)
-        try:
-            yield queue
-        finally:
-            with contextlib.suppress(Exception):
-                await conn.remove_listener(channel, _callback)
+        yield queue
     finally:
-        with contextlib.suppress(Exception):
-            await conn.close()
+        conn.terminate()
 
 
 @asynccontextmanager
@@ -176,14 +183,9 @@ async def listen_for_events(
         # worker can detect that an SSE subscriber exists (issue #81).
         # pg_locks releases automatically on connection close — no cleanup.
         await acquire_subscriber_lock(conn, session_id)
-        try:
-            yield queue
-        finally:
-            with contextlib.suppress(Exception):
-                await conn.remove_listener(channel, _callback)
+        yield queue
     finally:
-        with contextlib.suppress(Exception):
-            await conn.close()
+        conn.terminate()
 
 
 @asynccontextmanager
@@ -226,14 +228,9 @@ async def listen_for_connector_calls_by_type(
                     pass
 
         await conn.add_listener(channel, _callback)
-        try:
-            yield queue
-        finally:
-            with contextlib.suppress(Exception):
-                await conn.remove_listener(channel, _callback)
+        yield queue
     finally:
-        with contextlib.suppress(Exception):
-            await conn.close()
+        conn.terminate()
 
 
 @asynccontextmanager
@@ -270,14 +267,9 @@ async def listen_for_management_calls(
                     pass
 
         await conn.add_listener(channel, _callback)
-        try:
-            yield queue
-        finally:
-            with contextlib.suppress(Exception):
-                await conn.remove_listener(channel, _callback)
+        yield queue
     finally:
-        with contextlib.suppress(Exception):
-            await conn.close()
+        conn.terminate()
 
 
 @asynccontextmanager
@@ -319,14 +311,9 @@ async def listen_for_connection_discovery(
                     pass
 
         await conn.add_listener(channel, _callback)
-        try:
-            yield queue
-        finally:
-            with contextlib.suppress(Exception):
-                await conn.remove_listener(channel, _callback)
+        yield queue
     finally:
-        with contextlib.suppress(Exception):
-            await conn.close()
+        conn.terminate()
 
 
 SESSION_INTERRUPT_CHANNEL = "aios_session_interrupt"
@@ -353,11 +340,6 @@ async def listen_for_session_interrupts(
                 log.warning("listen.session_interrupt_queue_full")
 
         await conn.add_listener(SESSION_INTERRUPT_CHANNEL, _callback)
-        try:
-            yield queue
-        finally:
-            with contextlib.suppress(Exception):
-                await conn.remove_listener(SESSION_INTERRUPT_CHANNEL, _callback)
+        yield queue
     finally:
-        with contextlib.suppress(Exception):
-            await conn.close()
+        conn.terminate()

--- a/tests/e2e/test_sse_conn_leak_on_disconnect.py
+++ b/tests/e2e/test_sse_conn_leak_on_disconnect.py
@@ -1,0 +1,221 @@
+"""High-fidelity repro for the conn-leak observed in production (#606).
+
+Spins up real uvicorn + real httpx; opens N SSE streams; abruptly drops
+each TCP connection (simulating client crash / network blip); polls
+``pg_stat_activity`` to confirm the api-side Postgres backends are
+reaped.
+
+The production leak only manifests under the full SSE stack: sse-starlette
+runs the response generator inside an anyio task group, and on
+``http.disconnect`` it cancels the group's scope.  Under anyio's
+scope-cancellation, every subsequent ``await`` in the cancelled scope
+re-raises ``CancelledError`` immediately — so ``await conn.close()`` in
+the listener's finally never completes, asyncpg never sends ``Terminate``
+or aborts the transport, and the Postgres backend lingers until TCP
+keepalive reaps it (~2h on most distros).
+
+Cleanup via synchronous ``conn.terminate()`` (transport.abort() directly,
+no await) closes the socket regardless of the cancellation state.  This
+test guards against any future regression that re-introduces an async
+cleanup step in the listener helpers' finally blocks.
+
+Issue #606.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import httpx
+import pytest
+
+from tests.conftest import needs_docker
+from tests.e2e.conftest import live_aios_server
+from tests.integration.conftest import seed_agent_env_session
+
+
+@pytest.fixture
+async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
+    """Real-uvicorn aios server.  Sessions-router defer_wake is mocked so
+    the SSE backfill query and live tail behave identically to production
+    without dragging in a procrastinate worker.
+    """
+    async with live_aios_server(
+        defer_wake_patches=(
+            "aios.api.routers.sessions.defer_wake",
+            "aios.services.inbound.defer_wake",
+        ),
+    ) as url:
+        yield url
+
+
+async def _backend_count(db_url: str) -> int:
+    conn = await asyncpg.connect(db_url)
+    try:
+        result = await conn.fetchval(
+            "SELECT count(*) FROM pg_stat_activity "
+            "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+        )
+        return int(result)
+    finally:
+        await conn.close()
+
+
+async def _backend_states(db_url: str) -> list[dict[str, Any]]:
+    """Snapshot all client backends with state + last query (debugging aid)."""
+    conn = await asyncpg.connect(db_url)
+    try:
+        rows = await conn.fetch(
+            "SELECT pid, state, query, "
+            "  EXTRACT(EPOCH FROM (now() - backend_start)) AS age_s, "
+            "  EXTRACT(EPOCH FROM (now() - state_change)) AS state_age_s, "
+            "  wait_event_type, wait_event "
+            "FROM pg_stat_activity "
+            "WHERE datname = current_database() AND pid <> pg_backend_pid() "
+            "ORDER BY backend_start ASC"
+        )
+        return [dict(r) for r in rows]
+    finally:
+        await conn.close()
+
+
+async def _wait_for_backend_count(
+    db_url: str,
+    *,
+    le_to: int,
+    timeout_s: float = 8.0,
+) -> int:
+    """Poll until ``_backend_count() <= le_to`` or deadline; return last count."""
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    cur = -1
+    while True:
+        cur = await _backend_count(db_url)
+        if cur <= le_to:
+            return cur
+        if asyncio.get_running_loop().time() > deadline:
+            return cur
+        await asyncio.sleep(0.1)
+
+
+async def _seed_session(db_url: str) -> str:
+    """Insert a session row directly via asyncpg pool; return its id."""
+    pool = await asyncpg.create_pool(db_url, min_size=1, max_size=2)
+    try:
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_test_stub", prefix="sseleak"
+        )
+        return session.id
+    finally:
+        await pool.close()
+
+
+@needs_docker
+class TestSseDisconnectLeak:
+    async def test_tcp_close_mid_stream_does_not_leak_pg_conns(
+        self,
+        live_server: str,
+        aios_env: dict[str, str],
+        migrated_db_url: str,
+    ) -> None:
+        """Open N SSE streams, drop TCP abruptly, assert conns return to baseline."""
+        api_key = aios_env["AIOS_API_KEY"]
+        session_id = await _seed_session(migrated_db_url)
+
+        # Baseline AFTER session is seeded so the seed-helper pool's
+        # lifecycle is out of the way.
+        await asyncio.sleep(0.2)
+        baseline = await _backend_count(migrated_db_url)
+
+        n_streams = 5
+        clients: list[httpx.AsyncClient] = []
+        consumer_tasks: list[asyncio.Task[Any]] = []
+
+        async def _consume_one(client: httpx.AsyncClient) -> None:
+            """Open the SSE stream and sit on the response until cancelled."""
+            async with client.stream(
+                "GET",
+                f"/v1/sessions/{session_id}/stream",
+                headers={"Authorization": f"Bearer {api_key}"},
+            ) as resp:
+                resp.raise_for_status()
+                async for _line in resp.aiter_lines():
+                    pass
+
+        try:
+            for _ in range(n_streams):
+                c = httpx.AsyncClient(base_url=live_server, timeout=30.0)
+                clients.append(c)
+                consumer_tasks.append(asyncio.create_task(_consume_one(c)))
+
+            # Wait for the SSE backends to attach.  Each open stream
+            # adds one ``listen_for_events`` backend; the pool may add
+            # more on backfill ``pool.acquire()`` calls if it grew
+            # lazily.  Poll until we see at least n_streams new client
+            # backends.
+            deadline = asyncio.get_running_loop().time() + 5.0
+            while True:
+                peak = await _backend_count(migrated_db_url)
+                if peak >= baseline + n_streams:
+                    break
+                if asyncio.get_running_loop().time() > deadline:
+                    pytest.fail(
+                        f"only {peak - baseline}/{n_streams} backends observed "
+                        f"during peak (baseline={baseline}, peak={peak})"
+                    )
+                await asyncio.sleep(0.1)
+
+            # Hard TCP close: abruptly close each httpx client mid-stream.
+            # Closing the client tears down its transport, sending FIN
+            # to the server.  sse-starlette's ``_listen_for_disconnect``
+            # task should pick up the ``http.disconnect`` message and
+            # cancel the response task group.
+            for c in clients:
+                await c.aclose()
+
+            # Cancel any consumer tasks still hanging on aiter_lines.
+            for t in consumer_tasks:
+                t.cancel()
+            for t in consumer_tasks:
+                with contextlib.suppress(asyncio.CancelledError, httpx.HTTPError):
+                    await t
+
+        finally:
+            # Make sure clients/tasks are fully torn down for the final
+            # assertion to be meaningful.
+            for c in clients:
+                with contextlib.suppress(Exception):
+                    await c.aclose()
+            for t in consumer_tasks:
+                t.cancel()
+            for t in consumer_tasks:
+                with contextlib.suppress(BaseException):
+                    await t
+
+        # After cleanup, the N dedicated listener backends must be reaped.
+        # The api process's pool may keep up to pool_max_size pool conns
+        # idle for reuse — those aren't leaks, just capacity.  Assert on
+        # the LISTENER reduction (peak - n_streams) rather than absolute
+        # baseline so the test is robust to pool growth during peak.
+        target = peak - n_streams
+        cur = await _wait_for_backend_count(migrated_db_url, le_to=target, timeout_s=8.0)
+        if cur > target:
+            states = await _backend_states(migrated_db_url)
+            print("\n=== LEAKED BACKENDS ===")
+            for s in states:
+                age = s["age_s"]
+                state_age = s["state_age_s"]
+                print(
+                    f"pid={s['pid']} state={s['state']} "
+                    f"age={age:.1f}s state_age={state_age:.1f}s "
+                    f"wait={s['wait_event_type']}/{s['wait_event']} "
+                    f"query={(s['query'] or '')[:120]!r}"
+                )
+            print(f"=== baseline={baseline} peak={peak} current={cur} target={target} ===\n")
+        assert cur <= target, (
+            f"listener backends did not reap within 8s: peak={peak} "
+            f"current={cur} target={target} (expected drop of {n_streams})"
+        )

--- a/tests/integration/test_listen_conn_cleanup_on_cancel.py
+++ b/tests/integration/test_listen_conn_cleanup_on_cancel.py
@@ -1,0 +1,118 @@
+"""Sanity test that the listener helpers don't leak under raw task cancel.
+
+The 6 listener context managers in ``src/aios/db/listen.py`` cleanup via
+``conn.terminate()`` (synchronous transport-abort, never interrupted by
+cancellation).  Under raw ``asyncio.Task.cancel()`` the old
+``await conn.close()`` cleanup also worked — asyncpg's own ``close()``
+catches ``CancelledError`` and falls back to ``terminate()``.
+
+The production leak (#606) only manifests under sse-starlette's *anyio*
+task-group scope-cancellation, where every subsequent await raises
+``CancelledError`` immediately.  That stack is exercised by
+``tests/e2e/test_sse_conn_leak_on_disconnect.py``.  This integration
+test stays useful as a low-friction guard that the listener helpers
+themselves remain leak-free under plain task cancellation.
+
+Issue #606.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Callable
+
+import asyncpg
+import pytest
+
+from aios.db.listen import (
+    listen_for_connection_discovery,
+    listen_for_connector_calls_by_type,
+    listen_for_connector_result,
+    listen_for_events,
+    listen_for_management_calls,
+    listen_for_session_interrupts,
+)
+from tests.conftest import needs_docker
+
+pytestmark = [pytest.mark.integration, needs_docker]
+
+
+# One adapter per listener; each takes the db url and returns the
+# listener's async context manager.  The yield value (queue type) is
+# uniformly ``asyncio.Queue[str]`` so the consumer below can block on
+# ``queue.get()`` regardless of which listener is under test.
+ListenerFactory = Callable[[str], "contextlib.AbstractAsyncContextManager[asyncio.Queue[str]]"]
+
+LISTENERS: dict[str, ListenerFactory] = {
+    "events": lambda db_url: listen_for_events(db_url, "sess_test_leak"),
+    "connector_result": lambda db_url: listen_for_connector_result(db_url, "call_test_leak"),
+    "connector_calls_by_type": lambda db_url: listen_for_connector_calls_by_type(
+        db_url, "test_leak"
+    ),
+    "management_calls": lambda db_url: listen_for_management_calls(db_url, "test_leak"),
+    "connection_discovery": lambda db_url: listen_for_connection_discovery(db_url, "test_leak"),
+    "session_interrupts": lambda db_url: listen_for_session_interrupts(db_url),
+}
+
+
+async def _backend_count(db_url: str) -> int:
+    """Count this database's client backends, excluding our own measurement conn."""
+    conn = await asyncpg.connect(db_url)
+    try:
+        result = await conn.fetchval(
+            "SELECT count(*) FROM pg_stat_activity "
+            "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+        )
+        return int(result)
+    finally:
+        await conn.close()
+
+
+@pytest.mark.parametrize("listener_name", list(LISTENERS.keys()))
+async def test_listener_cancellation_does_not_leak_pg_conn(
+    migrated_db_url: str,
+    _reset_db_state: object,
+    listener_name: str,
+) -> None:
+    factory = LISTENERS[listener_name]
+
+    async def _hold(ready: asyncio.Event) -> None:
+        async with factory(migrated_db_url) as queue:
+            ready.set()
+            await queue.get()  # blocks indefinitely until the task is cancelled
+
+    baseline = await _backend_count(migrated_db_url)
+
+    n_streams = 5
+    readies = [asyncio.Event() for _ in range(n_streams)]
+    tasks = [asyncio.create_task(_hold(r)) for r in readies]
+
+    # Wait for every listener's LISTEN to be in place.
+    await asyncio.wait_for(asyncio.gather(*(r.wait() for r in readies)), timeout=5.0)
+
+    peak = await _backend_count(migrated_db_url)
+    assert peak >= baseline + n_streams, (
+        f"only {peak - baseline}/{n_streams} backends observed during peak; "
+        f"the LISTENs may not be using dedicated conns"
+    )
+
+    for t in tasks:
+        t.cancel()
+    for t in tasks:
+        with contextlib.suppress(asyncio.CancelledError):
+            await t
+
+    # Give Postgres a small grace window for Terminate / TCP close to
+    # propagate.  pg_stat_activity is roughly real-time but can lag.
+    deadline = asyncio.get_running_loop().time() + 5.0
+    while True:
+        cur = await _backend_count(migrated_db_url)
+        if cur <= baseline:
+            return
+        if asyncio.get_running_loop().time() > deadline:
+            pytest.fail(
+                f"backend count did not return to baseline within 5s: "
+                f"listener={listener_name} baseline={baseline} peak={peak} current={cur}"
+            )
+        await asyncio.sleep(0.1)

--- a/tests/unit/test_listen.py
+++ b/tests/unit/test_listen.py
@@ -50,10 +50,16 @@ def _mk_listener(name: str) -> AbstractAsyncContextManager[Any]:
     ],
 )
 async def test_add_listener_failure_closes_conn(name: str) -> None:
-    """conn.close() must run if add_listener raises during setup."""
+    """conn.terminate() must run if add_listener raises during setup.
+
+    Switched from ``conn.close()`` (async, graceful) to ``conn.terminate()``
+    (sync, non-graceful) in #606: under sse-starlette's anyio scope-cancellation,
+    every subsequent ``await`` re-raises ``CancelledError``, so an async close
+    never reaches Postgres and the backend lingers.  ``terminate()`` is
+    synchronous and always closes the socket.
+    """
     conn = MagicMock()
     conn.add_listener = AsyncMock(side_effect=RuntimeError("simulated network blip"))
-    conn.close = AsyncMock()
 
     with (
         patch("aios.db.listen.asyncpg.connect", AsyncMock(return_value=conn)),
@@ -62,15 +68,14 @@ async def test_add_listener_failure_closes_conn(name: str) -> None:
         async with _mk_listener(name):
             pytest.fail("context manager should not yield when setup raises")
 
-    conn.close.assert_awaited_once()
+    conn.terminate.assert_called_once()
 
 
 async def test_listen_for_events_acquire_subscriber_lock_failure_closes_conn() -> None:
-    """conn.close() must run if acquire_subscriber_lock raises after add_listener."""
+    """conn.terminate() must run if acquire_subscriber_lock raises after add_listener."""
     conn = MagicMock()
     conn.add_listener = AsyncMock()
     conn.remove_listener = AsyncMock()
-    conn.close = AsyncMock()
 
     with (
         patch("aios.db.listen.asyncpg.connect", AsyncMock(return_value=conn)),
@@ -83,4 +88,4 @@ async def test_listen_for_events_acquire_subscriber_lock_failure_closes_conn() -
         async with listen.listen_for_events("postgresql://stub/aios", "sess_X"):
             pytest.fail("context manager should not yield when setup raises")
 
-    conn.close.assert_awaited_once()
+    conn.terminate.assert_called_once()


### PR DESCRIPTION
## Summary

- The 6 listener context managers in `src/aios/db/listen.py` opened a dedicated asyncpg conn per stream and cleaned up via `with contextlib.suppress(Exception): await conn.close()`. Under sse-starlette's anyio task-group scope-cancellation (fired when `http.disconnect` arrives), every subsequent `await` in the cancelled scope re-raises `CancelledError` immediately — so `await conn.close()` is interrupted before transport.abort runs, and `suppress(Exception)` doesn't catch `CancelledError` (`BaseException` since Py 3.8). asyncpg's own internal `except CancelledError: terminate()` fallback in `Connection.close` relies on the close coroutine reaching its except handler, which under anyio scope cancellation it never does. Result: the PG backend lingers `idle/ClientRead` ~2h until TCP keepalive reaps it. Production saturated `max_connections` in 6h on a ~12 conns/hr leak rate.
- Fix: replace `await conn.close()` with synchronous `conn.terminate()` in all 6 listeners. `terminate()` is `transport.abort()` + `_cleanup_listeners()` — no await, can't be interrupted. The previously-explicit `await conn.remove_listener(...)` step becomes redundant (terminate clears the listener registry; PG drops LISTENs on socket close), collapsing the nested try/finally to a single outer `finally: conn.terminate()`.

## Diagnosis trail

The original hypothesis (``contextlib.suppress(Exception)`` vs ``CancelledError`` mismatch on raw asyncio cancellation) was **disproved** by `tests/integration/test_listen_conn_cleanup_on_cancel.py`, which passes unchanged: asyncpg handles raw `Task.cancel()` correctly via its own catch-and-terminate fallback. The leak only manifests under anyio's *scope-cancellation* where the close coroutine never reaches asyncpg's except handler. Validated via `tests/e2e/test_sse_conn_leak_on_disconnect.py` (real uvicorn + real httpx + real TCP disconnect): pre-fix, 5 backends linger with last-query ``UNLISTEN``; post-fix, returns to baseline.

## Test plan

- [x] Type-checker (`mypy src`) — clean
- [x] Linter + format-check (`ruff check src tests`, `ruff format --check src tests`) — clean
- [x] Unit suite (`pytest tests/unit -q`) — 1453 passed
- [x] Integration repro (raw task-cancel sanity guard) — 6/6 passed
- [x] E2E repro (full SSE stack TCP-disconnect leak detector) — passed
- [ ] CI runs e2e/integration suite

## Code review

`pr-review-toolkit:code-reviewer` reviewed: **no findings ≥ 80**. Sub-threshold notes (posted per project memory guidance to surface all findings):

- **N1 — wrong return annotation on `_hold` (~70)**: `tests/integration/.../_hold(...) -> AsyncIterator[None]` was a coroutine, not a generator. **Fixed**: changed to `-> None`, dropped the now-unneeded `# type: ignore[arg-type]`.
- **N2 — docstring drift on subscriber lock release (~55)**: `pg_locks releases automatically on connection close — no cleanup` is still true (PG drops session advisory locks on any backend exit, RST or graceful), so the comment stands. Skipped per brevity.
- **N3 — dead `_wait_for_backend_count(le_to=-1, ...)` call (~60)**: redundant first call before the while-loop that already did the same work. **Fixed**: dropped.
- **Audit broader codebase for the same pattern**: `pool.release` already terminates on cancel; remaining `await conn.close()` callers are in non-SSE paths (worker startup/shutdown, dev CLI, migrations). No further fixes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #606