### PR TITLE
refactor(tests): lift count_active_backends + drop dev-world refs (followups to #609)

### DIFF
--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -31,7 +31,7 @@ fires and the Postgres backend lingers until TCP keepalive reaps it
 (~2h). ``conn.terminate()`` is synchronous — it calls ``transport.abort()``
 directly, closing the socket without awaiting. Non-graceful but appropriate
 for SSE-style disconnects where the client is already gone, and equally
-correct on normal exit and exception unwinds (issue #606).
+correct on normal exit and exception unwinds.
 
 ## Why the callback must be synchronous
 
@@ -132,8 +132,6 @@ async def listen_for_events(
 ) -> AsyncIterator[asyncio.Queue[str]]:
     """Open a dedicated asyncpg connection, LISTEN events_<session_id>,
     yield an asyncio.Queue that receives event ids as they arrive.
-
-    On exit, the connection is closed (UNLISTEN is implicit at close).
 
     The queue is bounded. On overflow, the oldest payload is dropped to make
     room for the new one and a warning is logged. SSE clients can recover

--- a/tests/e2e/test_sse_conn_leak_on_disconnect.py
+++ b/tests/e2e/test_sse_conn_leak_on_disconnect.py
@@ -1,11 +1,11 @@
-"""High-fidelity repro for the conn-leak observed in production (#606).
+"""High-fidelity leak repro driving the full SSE stack to TCP disconnect.
 
 Spins up real uvicorn + real httpx; opens N SSE streams; abruptly drops
 each TCP connection (simulating client crash / network blip); polls
 ``pg_stat_activity`` to confirm the api-side Postgres backends are
 reaped.
 
-The production leak only manifests under the full SSE stack: sse-starlette
+The production leak only manifests under the full stack: sse-starlette
 runs the response generator inside an anyio task group, and on
 ``http.disconnect`` it cancels the group's scope.  Under anyio's
 scope-cancellation, every subsequent ``await`` in the cancelled scope
@@ -14,12 +14,10 @@ the listener's finally never completes, asyncpg never sends ``Terminate``
 or aborts the transport, and the Postgres backend lingers until TCP
 keepalive reaps it (~2h on most distros).
 
-Cleanup via synchronous ``conn.terminate()`` (transport.abort() directly,
-no await) closes the socket regardless of the cancellation state.  This
-test guards against any future regression that re-introduces an async
-cleanup step in the listener helpers' finally blocks.
-
-Issue #606.
+Cleanup via synchronous ``conn.terminate()`` (``transport.abort()``
+directly, no await) closes the socket regardless of cancellation state.
+This test guards against any future regression that re-introduces an
+async cleanup step in the listener helpers' finally blocks.
 """
 
 from __future__ import annotations
@@ -34,7 +32,8 @@ import httpx
 import pytest
 
 from tests.conftest import needs_docker
-from tests.e2e.conftest import live_aios_server
+from tests.e2e.conftest import live_aios_server, wait_for_predicate
+from tests.helpers.db import count_active_backends
 from tests.integration.conftest import seed_agent_env_session
 
 
@@ -53,20 +52,8 @@ async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:
         yield url
 
 
-async def _backend_count(db_url: str) -> int:
-    conn = await asyncpg.connect(db_url)
-    try:
-        result = await conn.fetchval(
-            "SELECT count(*) FROM pg_stat_activity "
-            "WHERE datname = current_database() AND pid <> pg_backend_pid()"
-        )
-        return int(result)
-    finally:
-        await conn.close()
-
-
 async def _backend_states(db_url: str) -> list[dict[str, Any]]:
-    """Snapshot all client backends with state + last query (debugging aid)."""
+    """Snapshot all client backends with state + last query (failure-only diagnostic)."""
     conn = await asyncpg.connect(db_url)
     try:
         rows = await conn.fetch(
@@ -83,26 +70,7 @@ async def _backend_states(db_url: str) -> list[dict[str, Any]]:
         await conn.close()
 
 
-async def _wait_for_backend_count(
-    db_url: str,
-    *,
-    le_to: int,
-    timeout_s: float = 8.0,
-) -> int:
-    """Poll until ``_backend_count() <= le_to`` or deadline; return last count."""
-    deadline = asyncio.get_running_loop().time() + timeout_s
-    cur = -1
-    while True:
-        cur = await _backend_count(db_url)
-        if cur <= le_to:
-            return cur
-        if asyncio.get_running_loop().time() > deadline:
-            return cur
-        await asyncio.sleep(0.1)
-
-
 async def _seed_session(db_url: str) -> str:
-    """Insert a session row directly via asyncpg pool; return its id."""
     pool = await asyncpg.create_pool(db_url, min_size=1, max_size=2)
     try:
         _agent, _env, session = await seed_agent_env_session(
@@ -128,7 +96,7 @@ class TestSseDisconnectLeak:
         # Baseline AFTER session is seeded so the seed-helper pool's
         # lifecycle is out of the way.
         await asyncio.sleep(0.2)
-        baseline = await _backend_count(migrated_db_url)
+        baseline = await count_active_backends(migrated_db_url)
 
         n_streams = 5
         clients: list[httpx.AsyncClient] = []
@@ -158,7 +126,7 @@ class TestSseDisconnectLeak:
             # backends.
             deadline = asyncio.get_running_loop().time() + 5.0
             while True:
-                peak = await _backend_count(migrated_db_url)
+                peak = await count_active_backends(migrated_db_url)
                 if peak >= baseline + n_streams:
                     break
                 if asyncio.get_running_loop().time() > deadline:
@@ -201,7 +169,13 @@ class TestSseDisconnectLeak:
         # the LISTENER reduction (peak - n_streams) rather than absolute
         # baseline so the test is robust to pool growth during peak.
         target = peak - n_streams
-        cur = await _wait_for_backend_count(migrated_db_url, le_to=target, timeout_s=8.0)
+
+        async def _reaped_to_target() -> bool:
+            return await count_active_backends(migrated_db_url) <= target
+
+        with contextlib.suppress(AssertionError):
+            await wait_for_predicate(_reaped_to_target, max_wait_s=8.0, interval_s=0.1)
+        cur = await count_active_backends(migrated_db_url)
         if cur > target:
             states = await _backend_states(migrated_db_url)
             print("\n=== LEAKED BACKENDS ===")

--- a/tests/helpers/db.py
+++ b/tests/helpers/db.py
@@ -1,0 +1,18 @@
+"""Postgres introspection helpers for tests."""
+
+from __future__ import annotations
+
+import asyncpg
+
+
+async def count_active_backends(db_url: str) -> int:
+    """Count this database's client backends, excluding the measurement conn itself."""
+    conn = await asyncpg.connect(db_url)
+    try:
+        result = await conn.fetchval(
+            "SELECT count(*) FROM pg_stat_activity "
+            "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+        )
+        return int(result)
+    finally:
+        await conn.close()

--- a/tests/integration/test_listen_conn_cleanup_on_cancel.py
+++ b/tests/integration/test_listen_conn_cleanup_on_cancel.py
@@ -1,19 +1,11 @@
-"""Sanity test that the listener helpers don't leak under raw task cancel.
+"""Sanity guard that the listener helpers don't leak Postgres backends
+under raw asyncio task cancellation.
 
-The 6 listener context managers in ``src/aios/db/listen.py`` cleanup via
-``conn.terminate()`` (synchronous transport-abort, never interrupted by
-cancellation).  Under raw ``asyncio.Task.cancel()`` the old
-``await conn.close()`` cleanup also worked — asyncpg's own ``close()``
-catches ``CancelledError`` and falls back to ``terminate()``.
-
-The production leak (#606) only manifests under sse-starlette's *anyio*
-task-group scope-cancellation, where every subsequent await raises
-``CancelledError`` immediately.  That stack is exercised by
-``tests/e2e/test_sse_conn_leak_on_disconnect.py``.  This integration
-test stays useful as a low-friction guard that the listener helpers
-themselves remain leak-free under plain task cancellation.
-
-Issue #606.
+The high-fidelity leak repro lives in ``tests/e2e/`` and exercises the
+sse-starlette anyio scope-cancellation path that motivated the
+``conn.terminate()`` cleanup.  This test covers the plain-asyncio path
+in isolation, so a regression that re-introduces an async cleanup step
+fails here before reaching e2e.
 """
 
 from __future__ import annotations
@@ -22,7 +14,6 @@ import asyncio
 import contextlib
 from collections.abc import Callable
 
-import asyncpg
 import pytest
 
 from aios.db.listen import (
@@ -34,14 +25,11 @@ from aios.db.listen import (
     listen_for_session_interrupts,
 )
 from tests.conftest import needs_docker
+from tests.helpers.db import count_active_backends
 
 pytestmark = [pytest.mark.integration, needs_docker]
 
 
-# One adapter per listener; each takes the db url and returns the
-# listener's async context manager.  The yield value (queue type) is
-# uniformly ``asyncio.Queue[str]`` so the consumer below can block on
-# ``queue.get()`` regardless of which listener is under test.
 ListenerFactory = Callable[[str], "contextlib.AbstractAsyncContextManager[asyncio.Queue[str]]"]
 
 LISTENERS: dict[str, ListenerFactory] = {
@@ -56,19 +44,6 @@ LISTENERS: dict[str, ListenerFactory] = {
 }
 
 
-async def _backend_count(db_url: str) -> int:
-    """Count this database's client backends, excluding our own measurement conn."""
-    conn = await asyncpg.connect(db_url)
-    try:
-        result = await conn.fetchval(
-            "SELECT count(*) FROM pg_stat_activity "
-            "WHERE datname = current_database() AND pid <> pg_backend_pid()"
-        )
-        return int(result)
-    finally:
-        await conn.close()
-
-
 @pytest.mark.parametrize("listener_name", list(LISTENERS.keys()))
 async def test_listener_cancellation_does_not_leak_pg_conn(
     migrated_db_url: str,
@@ -80,18 +55,17 @@ async def test_listener_cancellation_does_not_leak_pg_conn(
     async def _hold(ready: asyncio.Event) -> None:
         async with factory(migrated_db_url) as queue:
             ready.set()
-            await queue.get()  # blocks indefinitely until the task is cancelled
+            await queue.get()
 
-    baseline = await _backend_count(migrated_db_url)
+    baseline = await count_active_backends(migrated_db_url)
 
     n_streams = 5
     readies = [asyncio.Event() for _ in range(n_streams)]
     tasks = [asyncio.create_task(_hold(r)) for r in readies]
 
-    # Wait for every listener's LISTEN to be in place.
     await asyncio.wait_for(asyncio.gather(*(r.wait() for r in readies)), timeout=5.0)
 
-    peak = await _backend_count(migrated_db_url)
+    peak = await count_active_backends(migrated_db_url)
     assert peak >= baseline + n_streams, (
         f"only {peak - baseline}/{n_streams} backends observed during peak; "
         f"the LISTENs may not be using dedicated conns"
@@ -103,11 +77,9 @@ async def test_listener_cancellation_does_not_leak_pg_conn(
         with contextlib.suppress(asyncio.CancelledError):
             await t
 
-    # Give Postgres a small grace window for Terminate / TCP close to
-    # propagate.  pg_stat_activity is roughly real-time but can lag.
     deadline = asyncio.get_running_loop().time() + 5.0
     while True:
-        cur = await _backend_count(migrated_db_url)
+        cur = await count_active_backends(migrated_db_url)
         if cur <= baseline:
             return
         if asyncio.get_running_loop().time() > deadline:

--- a/tests/unit/test_listen.py
+++ b/tests/unit/test_listen.py
@@ -50,14 +50,7 @@ def _mk_listener(name: str) -> AbstractAsyncContextManager[Any]:
     ],
 )
 async def test_add_listener_failure_closes_conn(name: str) -> None:
-    """conn.terminate() must run if add_listener raises during setup.
-
-    Switched from ``conn.close()`` (async, graceful) to ``conn.terminate()``
-    (sync, non-graceful) in #606: under sse-starlette's anyio scope-cancellation,
-    every subsequent ``await`` re-raises ``CancelledError``, so an async close
-    never reaches Postgres and the backend lingers.  ``terminate()`` is
-    synchronous and always closes the socket.
-    """
+    """conn.terminate() must run if add_listener raises during setup."""
     conn = MagicMock()
     conn.add_listener = AsyncMock(side_effect=RuntimeError("simulated network blip"))
 
@@ -71,7 +64,7 @@ async def test_add_listener_failure_closes_conn(name: str) -> None:
     conn.terminate.assert_called_once()
 
 
-async def test_listen_for_events_acquire_subscriber_lock_failure_closes_conn() -> None:
+async def test_listen_for_events_acquire_subscriber_lock_failure_terminates_conn() -> None:
     """conn.terminate() must run if acquire_subscriber_lock raises after add_listener."""
     conn = MagicMock()
     conn.add_listener = AsyncMock()


### PR DESCRIPTION
## Summary

Post-/simplify cleanups on the merged #609 fix; landed separately because /simplify ran after the original PR landed.

- Extract ``count_active_backends`` from two test files into ``tests/helpers/db.py``; both new tests import the shared helper instead of copy-pasting the 8-line ``pg_stat_activity`` query.
- Drop the local ``_wait_for_backend_count`` poll loop in the e2e test; compose the existing ``wait_for_predicate`` from ``tests/e2e/conftest.py`` instead.
- Trim runtime docstring trailers (``(issue #606)``) and timeline-narrating docstrings in the test files. The WHY explanations stay; the dev-world references go.
- Drop the stale ``On exit, the connection is closed (UNLISTEN is implicit at close)`` line from ``listen_for_events`` — accurate before the ``terminate()`` switch, misleading after.

## Test plan

- [x] Type-checker (``mypy src``) — clean
- [x] Linter + format-check — clean
- [x] Unit suite — 1453 passed
- [x] Integration repro — still passing
- [x] E2E repro — still passing (~9s, baseline=2 peak=10 cur=5 → target satisfied)
- [ ] CI runs e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)