### PR TITLE
fix(services/sessions): reject tool-result/confirmation POSTs on errored sessions

### DIFF
--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -68,6 +68,7 @@ GHOST_ASST_SQL = """
       FROM events e
       JOIN sessions s ON s.id = e.session_id
      WHERE s.archived_at IS NULL
+       AND s.status <> 'errored'
        AND e.kind = 'message'
        AND e.role = 'assistant'
        AND jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls', 'null'::jsonb), '[]'::jsonb)) > 0

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -242,24 +242,31 @@ async def append_event(
         )
 
 
-async def _lock_session_or_raise(
+async def _lock_active_session_or_raise(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> None:
-    """``SELECT FOR UPDATE`` the session row; raise NotFoundError on miss.
+    """Enforce the active-session precondition: ``SELECT FOR UPDATE``
+    the session row, raise NotFoundError on miss / wrong account,
+    ConflictError when status is ``errored`` (a user message is
+    required to resume).
 
-    Called inside an outer ``async with conn.transaction()`` block to
-    serialize concurrent retries on the same session. The presence check
-    is a free side effect — the primary purpose is the row lock.
+    Must be called inside an outer ``conn.transaction()`` block — the
+    row lock is what serialises concurrent retries on the same session.
     """
-    locked = await conn.fetchval(
-        "SELECT id FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
+    row = await conn.fetchrow(
+        "SELECT status FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
         session_id,
         account_id,
     )
-    if locked is None:
+    if row is None:
         raise NotFoundError(
             f"session {session_id} not found",
             detail={"session_id": session_id},
+        )
+    if row["status"] == "errored":
+        raise ConflictError(
+            f"session {session_id} is errored; post a user message to resume",
+            detail={"session_id": session_id, "status": "errored"},
         )
 
 
@@ -292,7 +299,7 @@ async def append_tool_result(
     deferring the wake afterwards.
     """
     async with conn.transaction():
-        await _lock_session_or_raise(conn, session_id, account_id=account_id)
+        await _lock_active_session_or_raise(conn, session_id, account_id=account_id)
         existing = await queries.find_tool_result_event(
             conn, session_id, tool_call_id, account_id=account_id
         )
@@ -597,7 +604,7 @@ async def confirm_tool_allow(
     silently accept impossible inputs.
     """
     async with pool.acquire() as conn, conn.transaction():
-        await _lock_session_or_raise(conn, session_id, account_id=account_id)
+        await _lock_active_session_or_raise(conn, session_id, account_id=account_id)
         existing = await queries.find_tool_confirmed_event(
             conn, session_id, tool_call_id, account_id=account_id
         )

--- a/tests/integration/test_tool_actions_on_errored.py
+++ b/tests/integration/test_tool_actions_on_errored.py
@@ -1,0 +1,153 @@
+"""Tool-result and tool-confirmation POSTs on an ``errored`` session
+must raise ConflictError instead of silently appending events the
+sweep ignores.  Ghost-repair skips errored sessions for the same
+reason ``CANDIDATE_ROWS_SQL`` / ``CONFIRMED_ROWS_SQL`` already do."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import ConflictError
+from aios.harness.sweep import find_and_repair_ghosts
+from aios.harness.task_registry import TaskRegistry
+from aios.services import sessions as sessions_service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def errored_session_with_tool_call(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for an errored session
+    that has an assistant message carrying a tool_call ``tc_x``.  The
+    tool_call has no matching tool-role result, so it would be a
+    ghost candidate for the sweep."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_err_tool', NULL, TRUE, 'errored-tool-actions')
+                """
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_err_tool", prefix="err-tool"
+        )
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                session_id=session.id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "tc_x",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        }
+                    ],
+                },
+                account_id="acc_err_tool",
+            )
+            await queries.set_session_status(
+                conn, session.id, "errored", {"type": "error"}, account_id="acc_err_tool"
+            )
+        yield pool, "acc_err_tool", session.id
+    finally:
+        await pool.close()
+
+
+async def test_append_tool_result_rejects_errored_session(
+    errored_session_with_tool_call: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    pool, account_id, session_id = errored_session_with_tool_call
+
+    async with pool.acquire() as conn:
+        with pytest.raises(ConflictError) as excinfo:
+            await sessions_service.append_tool_result(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                tool_call_id="tc_x",
+                content="result",
+                is_error=False,
+            )
+    assert excinfo.value.detail is not None
+    assert excinfo.value.detail.get("session_id") == session_id
+
+    async with pool.acquire() as conn:
+        n = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE session_id = $1 AND role = 'tool'",
+            session_id,
+        )
+    assert n == 0, f"a tool-role event leaked onto the errored row (count={n})"
+
+
+async def test_confirm_tool_allow_rejects_errored_session(
+    errored_session_with_tool_call: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    pool, account_id, session_id = errored_session_with_tool_call
+
+    with pytest.raises(ConflictError) as excinfo:
+        await sessions_service.confirm_tool_allow(pool, session_id, "tc_x", account_id=account_id)
+    assert excinfo.value.detail is not None
+    assert excinfo.value.detail.get("session_id") == session_id
+
+    async with pool.acquire() as conn:
+        n = await conn.fetchval(
+            """
+            SELECT count(*) FROM events
+             WHERE session_id = $1
+               AND kind = 'lifecycle'
+               AND data->>'event' = 'tool_confirmed'
+            """,
+            session_id,
+        )
+    assert n == 0, f"a tool_confirmed lifecycle event leaked onto the errored row (count={n})"
+
+
+async def test_confirm_tool_deny_rejects_errored_session(
+    errored_session_with_tool_call: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """``confirm_tool_deny`` delegates to ``append_tool_result``; pin the
+    contract directly so a future refactor that bypasses the delegation
+    is caught here, not at runtime."""
+    pool, account_id, session_id = errored_session_with_tool_call
+
+    with pytest.raises(ConflictError):
+        await sessions_service.confirm_tool_deny(
+            pool, session_id, "tc_x", "user denied", account_id=account_id
+        )
+
+    async with pool.acquire() as conn:
+        n = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE session_id = $1 AND role = 'tool'",
+            session_id,
+        )
+    assert n == 0
+
+
+async def test_ghost_repair_skips_errored_session(
+    errored_session_with_tool_call: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """Without the ``GHOST_ASST_SQL`` filter, ghost-repair would trip
+    the new operator-facing ConflictError on every errored session and
+    abort the sweep loop."""
+    pool, _account_id, session_id = errored_session_with_tool_call
+
+    repaired = await find_and_repair_ghosts(pool, TaskRegistry(), session_id=session_id)
+    assert repaired == [], (
+        f"ghost-repair attempted on an errored session (got {repaired}); "
+        f"GHOST_ASST_SQL is missing the ``s.status <> 'errored'`` filter."
+    )


### PR DESCRIPTION
## Summary

- A session in `errored` status accepted tool-result and tool-confirmation POSTs that silently no-op'd: `queries.append_event` lifts `errored -> pending` ONLY for user messages, and the sweep filters out errored sessions. The event landed, `defer_wake` fired, the wake-step early-exited, and the operator saw 201 while the session stayed stuck — only a user message can resume (per `tests/e2e/test_errored_session_sweep.py:test_user_message_flips_errored_to_pending`).
- `_lock_session_or_raise` → `_lock_active_session_or_raise` in `services/sessions.py` now raises `ConflictError` when status is `errored`. Both callers — `append_tool_result` and `confirm_tool_allow` (and `confirm_tool_deny` via delegation) — inherit the gate.
- `GHOST_ASST_SQL` adopts the same `s.status <> 'errored'` filter its siblings `CANDIDATE_ROWS_SQL` and `CONFIRMED_ROWS_SQL` carry, so ghost repair doesn't trip the new ConflictError on every errored session and abort the sweep loop.

Defense-in-depth complement to the recently-merged archive-rejection family (#608 + earlier).

## Test plan

- [x] Type-checker — clean
- [x] Linter + format-check — clean
- [x] Unit suite — 1453 passed
- [x] New integration tests (4) — `append_tool_result`, `confirm_tool_allow`, `confirm_tool_deny`, `find_and_repair_ghosts` all reject / skip the errored row
- [ ] CI runs e2e + integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)