### PR TITLE
fix(db/queries): close archive TOCTOU in update_* family

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -177,8 +177,8 @@ async def update_environment(
     config: EnvironmentConfig | None = None,
 ) -> Environment:
     """Update an environment. Omitted fields are preserved."""
-    # Upfront read so "not found" vs "archived" produce distinct errors;
-    # folding archived into the UPDATE WHERE collapses them.
+    # Upfront read distinguishes 404 vs 409; the ``archived_at IS NULL``
+    # clause on the UPDATE closes the read->UPDATE race.
     current = await get_environment(conn, env_id, account_id=account_id)
     if current.archived_at is not None:
         raise ConflictError(f"environment {env_id} is archived", detail={"id": env_id})
@@ -198,7 +198,7 @@ async def update_environment(
     args.append(account_id)
     sql = (
         f"UPDATE environments SET {', '.join(sets)} "
-        f"WHERE id = $1 AND account_id = ${len(args)} RETURNING *"
+        f"WHERE id = $1 AND account_id = ${len(args)} AND archived_at IS NULL RETURNING *"
     )
     try:
         row = await conn.fetchrow(sql, *args)
@@ -207,7 +207,8 @@ async def update_environment(
             f"an environment named {name!r} already exists",
             detail={"name": name},
         ) from exc
-    assert row is not None
+    if row is None:
+        raise ConflictError(f"environment {env_id} is archived", detail={"id": env_id})
     return _row_to_environment(row)
 
 
@@ -538,6 +539,7 @@ async def update_agent(
                    window_min = $13, window_max = $14,
                    updated_at = now()
              WHERE id = $1 AND account_id = $15 AND version = $16
+               AND archived_at IS NULL
             RETURNING *
             """,
             agent_id,
@@ -558,13 +560,14 @@ async def update_agent(
             expected_version,
         )
         if row is None:
-            # Either the caller's ``expected_version`` was already stale
-            # when ``get_agent`` ran (sequential stale write) or a
-            # concurrent writer bumped the version between then and the
-            # UPDATE (race). Re-read for an accurate ``current`` —
-            # READ COMMITTED means this statement-level snapshot sees
-            # the concurrent writer's committed bump.
+            # No row matched the (id, account_id, version, NOT archived)
+            # tuple.  Re-read to distinguish the three possible causes:
+            # racing archive, stale ``expected_version``, or concurrent
+            # version bump.  READ COMMITTED means this statement-level
+            # snapshot sees the concurrent writer's committed state.
             fresh = await get_agent(conn, agent_id, account_id=account_id)
+            if fresh.archived_at is not None:
+                raise ConflictError(f"agent {agent_id} is archived", detail={"id": agent_id})
             raise ConflictError(
                 f"version mismatch: expected {expected_version}, current is {fresh.version}",
                 detail={
@@ -1106,11 +1109,13 @@ async def update_session(
     args.append(account_id)
     sql = (
         f"UPDATE sessions SET {', '.join(sets)} "
-        f"WHERE id = $1 AND account_id = ${len(args)} RETURNING *"
+        f"WHERE id = $1 AND account_id = ${len(args)} AND archived_at IS NULL RETURNING *"
     )
     row = await conn.fetchrow(sql, *args)
     if row is None:
-        raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
+        # The upfront read already raised on missing rows, so a no-row
+        # UPDATE here means an archive committed between read and UPDATE.
+        raise ConflictError(f"session {session_id} is archived", detail={"id": session_id})
     return _row_to_session(row)
 
 
@@ -1136,13 +1141,13 @@ async def update_session_stop_hook(
     serialised = json.dumps(stop_hook.model_dump(mode="json")) if stop_hook is not None else None
     row = await conn.fetchrow(
         "UPDATE sessions SET stop_hook = $1::jsonb, updated_at = now() "
-        "WHERE id = $2 AND account_id = $3 RETURNING *",
+        "WHERE id = $2 AND account_id = $3 AND archived_at IS NULL RETURNING *",
         serialised,
         session_id,
         account_id,
     )
     if row is None:
-        raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
+        raise ConflictError(f"session {session_id} is archived", detail={"id": session_id})
     return _row_to_session(row)
 
 
@@ -2486,11 +2491,11 @@ async def update_vault(
     args.append(account_id)
     sql = (
         f"UPDATE vaults SET {', '.join(sets)} "
-        f"WHERE id = $1 AND account_id = ${len(args)} RETURNING *"
+        f"WHERE id = $1 AND account_id = ${len(args)} AND archived_at IS NULL RETURNING *"
     )
     row = await conn.fetchrow(sql, *args)
     if row is None:
-        raise NotFoundError(f"vault {vault_id} not found", detail={"id": vault_id})
+        raise ConflictError(f"vault {vault_id} is archived", detail={"id": vault_id})
     return _row_to_vault(row)
 
 
@@ -4260,7 +4265,7 @@ async def update_session_template(
     args.append(account_id)
     sql = (
         f"UPDATE session_templates SET {', '.join(sets)} "
-        f"WHERE id = $1 AND account_id = ${len(args)} RETURNING *"
+        f"WHERE id = $1 AND account_id = ${len(args)} AND archived_at IS NULL RETURNING *"
     )
     try:
         row = await conn.fetchrow(sql, *args)
@@ -4275,8 +4280,8 @@ async def update_session_template(
             detail={"agent_id": agent_id, "environment_id": environment_id},
         ) from exc
     if row is None:
-        raise NotFoundError(
-            f"session template {template_id} not found",
+        raise ConflictError(
+            f"session template {template_id} is archived",
             detail={"id": template_id},
         )
     return _row_to_session_template(row)
@@ -4473,11 +4478,11 @@ async def update_memory_store(
     args.append(account_id)
     sql = (
         f"UPDATE memory_stores SET {', '.join(sets)} "
-        f"WHERE id = $1 AND account_id = ${len(args)} RETURNING *"
+        f"WHERE id = $1 AND account_id = ${len(args)} AND archived_at IS NULL RETURNING *"
     )
     row = await conn.fetchrow(sql, *args)
     if row is None:
-        raise NotFoundError(f"memory store {store_id} not found", detail={"id": store_id})
+        raise ConflictError(f"memory store {store_id} is archived", detail={"id": store_id})
     return _row_to_memory_store(row)
 
 

--- a/tests/integration/test_update_archive_toctou.py
+++ b/tests/integration/test_update_archive_toctou.py
@@ -1,0 +1,87 @@
+"""``update_*`` query functions must close the archive race: a
+concurrent ``archive_*`` committing between their upfront read and
+their UPDATE must not result in a rewrite of the archived row.
+
+This canary covers ``update_session``; the other update_* functions
+in the family share the same UPDATE-WHERE fix, verified by the
+sibling ``test_update_*_archived`` integration tests still passing.
+The race is simulated deterministically via ``monkey-patch`` on
+``get_session`` — feeding back the pre-archive snapshot while the
+DB row is already archived bypasses the upfront check, which is
+exactly the window the UPDATE WHERE clause has to close."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import ConflictError
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def archived_session_with_stale_snapshot(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, Any]]:
+    """Yield ``(pool, account_id, session_id, pre_archive_snapshot)``
+    for a session that has been archived AFTER a snapshot was captured.
+
+    The pre-archive snapshot is what ``get_session`` would return
+    immediately before the racing archive committed.  Re-using it via
+    monkey-patch lets the test deterministically reproduce the
+    archive-race window without timing-dependent task interleaving.
+    """
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_toctou', NULL, TRUE, 'toctou-test')
+                """
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_toctou", prefix="toctou"
+        )
+        async with pool.acquire() as conn:
+            snapshot = await queries.get_session(conn, session.id, account_id="acc_toctou")
+            await queries.archive_session(conn, session.id, account_id="acc_toctou")
+        assert snapshot.archived_at is None
+        yield pool, "acc_toctou", session.id, snapshot
+    finally:
+        await pool.close()
+
+
+async def test_update_session_closes_archive_toctou(
+    archived_session_with_stale_snapshot: tuple[asyncpg.Pool[Any], str, str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool, account_id, session_id, snapshot = archived_session_with_stale_snapshot
+
+    async def fake_get_session(*_: Any, **__: Any) -> Any:
+        return snapshot
+
+    monkeypatch.setattr(queries, "get_session", fake_get_session)
+
+    async with pool.acquire() as conn:
+        with pytest.raises(ConflictError):
+            await queries.update_session(
+                conn,
+                session_id,
+                title="post-archive",
+                account_id=account_id,
+            )
+
+    async with pool.acquire() as conn:
+        actual_title = await conn.fetchval("SELECT title FROM sessions WHERE id = $1", session_id)
+    assert actual_title == snapshot.title, (
+        f"archived session row was rewritten despite the race: "
+        f"title is {actual_title!r}, expected {snapshot.title!r}."
+    )


### PR DESCRIPTION
## Summary

- Seven `update_*` functions in `queries.py` (`update_environment`, `update_agent`, `update_session`, `update_session_stop_hook`, `update_vault`, `update_session_template`, `update_memory_store`) used the upfront-read-then-check pattern: read row, raise `ConflictError` if archived, then UPDATE with only `id` + `account_id` (and `version` for the agent) in the WHERE. An `archive_*` committing between the read and the UPDATE slipped through and rewrote the archived row's columns.
- Fix: each UPDATE now also filters `AND archived_at IS NULL`, and the post-UPDATE no-row branch raises `ConflictError` (not `NotFoundError`) — the upfront read already eliminated the missing-row case, so a no-row post-UPDATE is the TOCTOU losing the race.
- `update_agent`'s no-row re-read now distinguishes a racing archive from the version-mismatch cause it already handled.
- Closes the remaining TOCTOU window in the archive-rejection family (predecessors: #547, #554, #573, #587, #594, #605, #608, #611).

## Test plan

- [x] Type-checker — clean
- [x] Linter + format-check — clean
- [x] Unit suite — 1453 passed
- [x] New integration test (`test_update_session_closes_archive_toctou`) — canary for the family, monkey-patches `get_session` to simulate the race; pre-fix the bare UPDATE rewrites the archived row; post-fix the WHERE no-matches and `ConflictError` raises.
- [x] All existing `test_update_*_archived` sibling tests still pass (the upfront-check path is preserved).
- [ ] CI runs e2e + integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)