### PR TITLE
refactor(harness): remove session parking; unify custom + always_ask under async-tool responsiveness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,15 +86,18 @@ Both share Postgres: same database, same `LISTEN/NOTIFY`, same procrastinate job
 - **Blind-spot injection**: tool results that arrived during inference are injected as user messages at the tail.
 - **`reacting_to` watermark**: each assistant message records the max seq of events it saw, so `find_sessions_needing_inference` knows what's "new."
 
-### Custom tools (client-executed)
+### Externally-executed tools (custom + always_ask)
 
-When the model calls a custom tool (type="custom"), the harness does NOT execute it. Instead:
-1. Session idles with `stop_reason: {"type": "requires_action", "event_ids": [...]}`
-2. Client executes the tool externally
-3. Client POSTs result to `POST /sessions/:id/tool-results`
-4. Result appended → wake deferred → next step fires
+Tool calls the harness doesn't execute itself — `type="custom"` (client-executed) and `always_ask`-gated built-ins/MCP awaiting operator approval — sit unresolved in the event log alongside any async in-flight built-in. The session does NOT park. End of step flips `status="idle"` with `stop_reason={"type":"end_turn"}` regardless of what the model emitted; pending tool calls are observable via the derived `Session.awaiting` view.
 
-Built-in and custom tools can be called in the same response. The inference gate's batch logic waits for ALL tool_call_ids to have results.
+The same wake mechanism drives all three cases:
+- **In-flight async built-in**: task's `_tool_lifecycle.finally` appends the result and triggers a sweep.
+- **Custom tool**: client POSTs to `/sessions/:id/tool-results` (operator) or `/connectors/runtime/tool-results` (connector runtime) — both call `defer_wake` after appending.
+- **always_ask awaiting confirm**: operator POSTs to `/sessions/:id/tool-confirmations`; allow appends a lifecycle event that the next step's `_dispatch_confirmed_tools` consumes.
+
+A user message arriving during any of these wakes the session via the same `find_sessions_needing_inference` short-circuit (sweep.py — `if any(evt.role == "user")`). The model sees pending tool calls via the `_PENDING_BACKGROUND` / `_PENDING_EXTERNAL` synthesized placeholders in `build_messages` and can interleave responses freely.
+
+Built-in and externally-executed tools can be called in the same response. The inference gate waits for all tool_call_ids before re-firing under the no-user-stimulus path; a user message lifts that wait.
 
 ### Two pools in one process
 

--- a/openapi.json
+++ b/openapi.json
@@ -10805,7 +10805,7 @@
           "updated_at"
         ],
         "title": "Session",
-        "description": "Read view of a session. Internal-only columns are not exposed.\n\n``stop_reason`` records why the most recent step ended. Possible\n``type`` values: ``\"end_turn\"``, ``\"interrupt\"``, ``\"rescheduling\"``,\n``\"error\"``. To find tool calls the session is blocked on, read\n``awaiting`` (derived per read from the event log + task_registry)."
+        "description": "Read view of a session. Internal-only columns are not exposed.\n\n``stop_reason`` records why the most recent step ended. Possible\n``type`` values: ``\"end_turn\"``, ``\"interrupt\"``, ``\"rescheduling\"``,\n``\"error\"``. ``awaiting`` lists tool calls the session is blocked\non (derived per read from the event log + agent tool specs)."
       },
       "SessionCloneRequest": {
         "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -2823,7 +2823,7 @@
           "sessions"
         ],
         "summary": "Get Context",
-        "description": "Return the chat-completions payload the worker would send next.\n\nDry-run preview for debugging prompt construction.  Reuses the exact\ncomposer the worker's step function uses (:func:`compose_step_context`)\nso the endpoint's output is byte-identical to what the next model\ncall would see \u2014 no divergence.  Side effects (skill provisioning,\nsession-status bumps, event appends) are omitted; the endpoint is\nread-only.",
+        "description": "Return the chat-completions payload the worker would send next.\n\nDry-run preview for debugging prompt construction. Reuses the exact\ncomposer the worker's step function uses (:func:`compose_step_context`).\nSide effects (skill provisioning, session-status bumps, event\nappends) are omitted; the endpoint is read-only.\n\nOne known divergence from the worker's output: unresolved tool_calls\nthat the worker is currently executing render as ``_PENDING_EXTERNAL``\nhere (the API process has no view into the worker's task_registry).\nThe worker would render them as ``_PENDING_BACKGROUND``. Custom and\nawaiting-confirm calls render identically on both sides.",
         "operationId": "get_session_context",
         "parameters": [
           {
@@ -8003,21 +8003,16 @@
               "custom"
             ],
             "title": "Kind"
-          },
-          "needs_confirm": {
-            "type": "boolean",
-            "title": "Needs Confirm"
           }
         },
         "type": "object",
         "required": [
           "tool_call_id",
           "name",
-          "kind",
-          "needs_confirm"
+          "kind"
         ],
         "title": "AwaitingToolCall",
-        "description": "One pending tool call the harness will not dispatch itself.\n\nDerived view on session reads: each entry is a tool_call in the\nlatest assistant message that has no paired tool_result event and\nno in-process executor. Two flavors share this state:\n\n* ``kind == \"custom\"`` \u2014 client-executed; awaits a POST to\n  ``/sessions/:id/tool-results`` (operator-facing) or\n  ``/connectors/runtime/tool-results`` (runtime-container-facing).\n* ``kind == \"builtin\" | \"mcp\"`` with ``needs_confirm=True`` \u2014\n  ``always_ask``-gated; awaits a POST to ``/sessions/:id/tool-confirmations``."
+        "description": "One pending tool call the harness will not dispatch itself.\n\nDerived view on session reads. Each entry is a tool_call in the\nlatest assistant message with no paired tool_result and no\nin-process executor:\n\n* ``kind == \"custom\"`` \u2014 client-executed; awaits POST to\n  ``/sessions/:id/tool-results`` (operator-facing) or\n  ``/connectors/runtime/tool-results`` (runtime-container-facing).\n* ``kind == \"builtin\" | \"mcp\"`` \u2014 ``always_ask``-gated and not yet\n  confirmed; awaits POST to ``/sessions/:id/tool-confirmations``.\n  Confirmed-but-not-yet-dispatched and ``always_allow`` calls don't\n  appear here \u2014 they're harness-internal."
       },
       "BindChatRequest": {
         "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -1685,7 +1685,6 @@
                 {
                   "enum": [
                     "pending",
-                    "running",
                     "idle",
                     "rescheduling",
                     "errored",
@@ -7986,6 +7985,40 @@
         "title": "AgentVersion",
         "description": "Read view of a specific agent version from the version history."
       },
+      "AwaitingToolCall": {
+        "properties": {
+          "tool_call_id": {
+            "type": "string",
+            "title": "Tool Call Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "builtin",
+              "mcp",
+              "custom"
+            ],
+            "title": "Kind"
+          },
+          "needs_confirm": {
+            "type": "boolean",
+            "title": "Needs Confirm"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tool_call_id",
+          "name",
+          "kind",
+          "needs_confirm"
+        ],
+        "title": "AwaitingToolCall",
+        "description": "One pending tool call the harness will not dispatch itself.\n\nDerived view on session reads: each entry is a tool_call in the\nlatest assistant message that has no paired tool_result event and\nno in-process executor. Two flavors share this state:\n\n* ``kind == \"custom\"`` \u2014 client-executed; awaits a POST to\n  ``/sessions/:id/tool-results`` (operator-facing) or\n  ``/connectors/runtime/tool-results`` (runtime-container-facing).\n* ``kind == \"builtin\" | \"mcp\"`` with ``needs_confirm=True`` \u2014\n  ``always_ask``-gated; awaits a POST to ``/sessions/:id/tool-confirmations``."
+      },
       "BindChatRequest": {
         "properties": {
           "chat_id": {
@@ -8962,7 +8995,7 @@
           "path_pattern"
         ],
         "title": "HttpRouteSpec",
-        "description": "One entry in an ``HttpServerSpec.routes`` allowlist.\n\n``path_pattern`` is a glob against the request path (``*`` matches one\nsegment, ``**`` matches any number of segments).  ``description`` is\noperator-authored prose rendered into the system prompt so the agent\nknows what the route does and how to call it.  ``permission_policy``\ngates *invocation*: ``always_ask`` parks the call in\n``requires_action`` until the client confirms."
+        "description": "One entry in an ``HttpServerSpec.routes`` allowlist.\n\n``path_pattern`` is a glob against the request path (``*`` matches one\nsegment, ``**`` matches any number of segments).  ``description`` is\noperator-authored prose rendered into the system prompt so the agent\nknows what the route does and how to call it.  ``permission_policy``\ngates *invocation*: ``always_ask`` leaves the call unresolved in the\nevent log until the client confirms via\n``POST /sessions/:id/tool-confirmations``."
       },
       "HttpServerSpec": {
         "properties": {
@@ -10640,7 +10673,6 @@
             "type": "string",
             "enum": [
               "pending",
-              "running",
               "idle",
               "rescheduling",
               "errored",
@@ -10659,6 +10691,13 @@
               }
             ],
             "title": "Stop Reason"
+          },
+          "awaiting": {
+            "items": {
+              "$ref": "#/components/schemas/AwaitingToolCall"
+            },
+            "type": "array",
+            "title": "Awaiting"
           },
           "vault_ids": {
             "items": {
@@ -10766,7 +10805,7 @@
           "updated_at"
         ],
         "title": "Session",
-        "description": "Read view of a session. Internal-only columns are not exposed."
+        "description": "Read view of a session. Internal-only columns are not exposed.\n\n``stop_reason`` records why the most recent step ended. Possible\n``type`` values: ``\"end_turn\"``, ``\"interrupt\"``, ``\"rescheduling\"``,\n``\"error\"``. To find tool calls the session is blocked on, read\n``awaiting`` (derived per read from the event log + task_registry)."
       },
       "SessionCloneRequest": {
         "properties": {
@@ -11867,7 +11906,7 @@
           "type"
         ],
         "title": "ToolSpec",
-        "description": "One entry in an agent's ``tools`` list.\n\nFor built-in tools, ``type`` is the tool name (``\"bash\"``, ``\"read\"``,\netc.). For custom (client-executed) tools, ``type`` is ``\"custom\"`` and\n``name``, ``description``, and ``input_schema`` are required. For MCP\ntoolsets, ``type`` is ``\"mcp_toolset\"`` and ``mcp_server_name`` is\nrequired.\n\n``enabled`` controls whether the tool is included in the schema sent to\nthe model. Disabled tools are invisible to the model.\n\n``permission`` controls execution policy for built-in tools:\n``None`` or ``\"always_allow\"`` executes immediately (current default);\n``\"always_ask\"`` idles the session with ``requires_action`` until the\nclient confirms or denies."
+        "description": "One entry in an agent's ``tools`` list.\n\nFor built-in tools, ``type`` is the tool name (``\"bash\"``, ``\"read\"``,\netc.). For custom (client-executed) tools, ``type`` is ``\"custom\"`` and\n``name``, ``description``, and ``input_schema`` are required. For MCP\ntoolsets, ``type`` is ``\"mcp_toolset\"`` and ``mcp_server_name`` is\nrequired.\n\n``enabled`` controls whether the tool is included in the schema sent to\nthe model. Disabled tools are invisible to the model.\n\n``permission`` controls execution policy for built-in tools:\n``None`` or ``\"always_allow\"`` executes immediately (current default);\n``\"always_ask\"`` leaves the call unresolved in the event log until\nthe client confirms or denies via\n``POST /sessions/:id/tool-confirmations``. Pending calls surface on\n``Session.awaiting`` so clients can list what they need to act on."
       },
       "ToolsSchemaUpdate": {
         "properties": {
@@ -12592,7 +12631,6 @@
             "type": "string",
             "enum": [
               "pending",
-              "running",
               "idle",
               "rescheduling",
               "errored",
@@ -12611,6 +12649,13 @@
               }
             ],
             "title": "Session Stop Reason"
+          },
+          "session_awaiting": {
+            "items": {
+              "$ref": "#/components/schemas/AwaitingToolCall"
+            },
+            "type": "array",
+            "title": "Session Awaiting"
           },
           "next_after": {
             "type": "integer",

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/get_session_context.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/get_session_context.py
@@ -71,12 +71,16 @@ def sync_detailed(
 
      Return the chat-completions payload the worker would send next.
 
-    Dry-run preview for debugging prompt construction.  Reuses the exact
-    composer the worker's step function uses (:func:`compose_step_context`)
-    so the endpoint's output is byte-identical to what the next model
-    call would see — no divergence.  Side effects (skill provisioning,
-    session-status bumps, event appends) are omitted; the endpoint is
-    read-only.
+    Dry-run preview for debugging prompt construction. Reuses the exact
+    composer the worker's step function uses (:func:`compose_step_context`).
+    Side effects (skill provisioning, session-status bumps, event
+    appends) are omitted; the endpoint is read-only.
+
+    One known divergence from the worker's output: unresolved tool_calls
+    that the worker is currently executing render as ``_PENDING_EXTERNAL``
+    here (the API process has no view into the worker's task_registry).
+    The worker would render them as ``_PENDING_BACKGROUND``. Custom and
+    awaiting-confirm calls render identically on both sides.
 
     Args:
         session_id (str):
@@ -112,12 +116,16 @@ def sync(
 
      Return the chat-completions payload the worker would send next.
 
-    Dry-run preview for debugging prompt construction.  Reuses the exact
-    composer the worker's step function uses (:func:`compose_step_context`)
-    so the endpoint's output is byte-identical to what the next model
-    call would see — no divergence.  Side effects (skill provisioning,
-    session-status bumps, event appends) are omitted; the endpoint is
-    read-only.
+    Dry-run preview for debugging prompt construction. Reuses the exact
+    composer the worker's step function uses (:func:`compose_step_context`).
+    Side effects (skill provisioning, session-status bumps, event
+    appends) are omitted; the endpoint is read-only.
+
+    One known divergence from the worker's output: unresolved tool_calls
+    that the worker is currently executing render as ``_PENDING_EXTERNAL``
+    here (the API process has no view into the worker's task_registry).
+    The worker would render them as ``_PENDING_BACKGROUND``. Custom and
+    awaiting-confirm calls render identically on both sides.
 
     Args:
         session_id (str):
@@ -148,12 +156,16 @@ async def asyncio_detailed(
 
      Return the chat-completions payload the worker would send next.
 
-    Dry-run preview for debugging prompt construction.  Reuses the exact
-    composer the worker's step function uses (:func:`compose_step_context`)
-    so the endpoint's output is byte-identical to what the next model
-    call would see — no divergence.  Side effects (skill provisioning,
-    session-status bumps, event appends) are omitted; the endpoint is
-    read-only.
+    Dry-run preview for debugging prompt construction. Reuses the exact
+    composer the worker's step function uses (:func:`compose_step_context`).
+    Side effects (skill provisioning, session-status bumps, event
+    appends) are omitted; the endpoint is read-only.
+
+    One known divergence from the worker's output: unresolved tool_calls
+    that the worker is currently executing render as ``_PENDING_EXTERNAL``
+    here (the API process has no view into the worker's task_registry).
+    The worker would render them as ``_PENDING_BACKGROUND``. Custom and
+    awaiting-confirm calls render identically on both sides.
 
     Args:
         session_id (str):
@@ -187,12 +199,16 @@ async def asyncio(
 
      Return the chat-completions payload the worker would send next.
 
-    Dry-run preview for debugging prompt construction.  Reuses the exact
-    composer the worker's step function uses (:func:`compose_step_context`)
-    so the endpoint's output is byte-identical to what the next model
-    call would see — no divergence.  Side effects (skill provisioning,
-    session-status bumps, event appends) are omitted; the endpoint is
-    read-only.
+    Dry-run preview for debugging prompt construction. Reuses the exact
+    composer the worker's step function uses (:func:`compose_step_context`).
+    Side effects (skill provisioning, session-status bumps, event
+    appends) are omitted; the endpoint is read-only.
+
+    One known divergence from the worker's output: unresolved tool_calls
+    that the worker is currently executing render as ``_PENDING_EXTERNAL``
+    here (the API process has no view into the worker's task_registry).
+    The worker would render them as ``_PENDING_BACKGROUND``. Custom and
+    awaiting-confirm calls render identically on both sides.
 
     Args:
         session_id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -18,6 +18,8 @@ from .agent_update_litellm_extra_type_0 import AgentUpdateLitellmExtraType0
 from .agent_update_metadata_type_0 import AgentUpdateMetadataType0
 from .agent_version import AgentVersion
 from .agent_version_litellm_extra import AgentVersionLitellmExtra
+from .awaiting_tool_call import AwaitingToolCall
+from .awaiting_tool_call_kind import AwaitingToolCallKind
 from .bind_chat_request import BindChatRequest
 from .body_post_connector_runtime_inbound import BodyPostConnectorRuntimeInbound
 from .body_upload_session_file import BodyUploadSessionFile
@@ -207,6 +209,8 @@ __all__ = (
     "AgentUpdateMetadataType0",
     "AgentVersion",
     "AgentVersionLitellmExtra",
+    "AwaitingToolCall",
+    "AwaitingToolCallKind",
     "BindChatRequest",
     "BodyPostConnectorRuntimeInbound",
     "BodyUploadSessionFile",

--- a/packages/aios-sdk/aios_sdk/_generated/models/awaiting_tool_call.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/awaiting_tool_call.py
@@ -15,27 +15,27 @@ T = TypeVar("T", bound="AwaitingToolCall")
 class AwaitingToolCall:
     """One pending tool call the harness will not dispatch itself.
 
-    Derived view on session reads: each entry is a tool_call in the
-    latest assistant message that has no paired tool_result event and
-    no in-process executor. Two flavors share this state:
+    Derived view on session reads. Each entry is a tool_call in the
+    latest assistant message with no paired tool_result and no
+    in-process executor:
 
-    * ``kind == "custom"`` — client-executed; awaits a POST to
+    * ``kind == "custom"`` — client-executed; awaits POST to
       ``/sessions/:id/tool-results`` (operator-facing) or
       ``/connectors/runtime/tool-results`` (runtime-container-facing).
-    * ``kind == "builtin" | "mcp"`` with ``needs_confirm=True`` —
-      ``always_ask``-gated; awaits a POST to ``/sessions/:id/tool-confirmations``.
+    * ``kind == "builtin" | "mcp"`` — ``always_ask``-gated and not yet
+      confirmed; awaits POST to ``/sessions/:id/tool-confirmations``.
+      Confirmed-but-not-yet-dispatched and ``always_allow`` calls don't
+      appear here — they're harness-internal.
 
         Attributes:
             tool_call_id (str):
             name (str):
             kind (AwaitingToolCallKind):
-            needs_confirm (bool):
     """
 
     tool_call_id: str
     name: str
     kind: AwaitingToolCallKind
-    needs_confirm: bool
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -45,8 +45,6 @@ class AwaitingToolCall:
 
         kind = self.kind.value
 
-        needs_confirm = self.needs_confirm
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -54,7 +52,6 @@ class AwaitingToolCall:
                 "tool_call_id": tool_call_id,
                 "name": name,
                 "kind": kind,
-                "needs_confirm": needs_confirm,
             }
         )
 
@@ -69,13 +66,10 @@ class AwaitingToolCall:
 
         kind = AwaitingToolCallKind(d.pop("kind"))
 
-        needs_confirm = d.pop("needs_confirm")
-
         awaiting_tool_call = cls(
             tool_call_id=tool_call_id,
             name=name,
             kind=kind,
-            needs_confirm=needs_confirm,
         )
 
         awaiting_tool_call.additional_properties = d

--- a/packages/aios-sdk/aios_sdk/_generated/models/awaiting_tool_call.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/awaiting_tool_call.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.awaiting_tool_call_kind import AwaitingToolCallKind
+
+T = TypeVar("T", bound="AwaitingToolCall")
+
+
+@_attrs_define
+class AwaitingToolCall:
+    """One pending tool call the harness will not dispatch itself.
+
+    Derived view on session reads: each entry is a tool_call in the
+    latest assistant message that has no paired tool_result event and
+    no in-process executor. Two flavors share this state:
+
+    * ``kind == "custom"`` — client-executed; awaits a POST to
+      ``/sessions/:id/tool-results`` (operator-facing) or
+      ``/connectors/runtime/tool-results`` (runtime-container-facing).
+    * ``kind == "builtin" | "mcp"`` with ``needs_confirm=True`` —
+      ``always_ask``-gated; awaits a POST to ``/sessions/:id/tool-confirmations``.
+
+        Attributes:
+            tool_call_id (str):
+            name (str):
+            kind (AwaitingToolCallKind):
+            needs_confirm (bool):
+    """
+
+    tool_call_id: str
+    name: str
+    kind: AwaitingToolCallKind
+    needs_confirm: bool
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        tool_call_id = self.tool_call_id
+
+        name = self.name
+
+        kind = self.kind.value
+
+        needs_confirm = self.needs_confirm
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "tool_call_id": tool_call_id,
+                "name": name,
+                "kind": kind,
+                "needs_confirm": needs_confirm,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        tool_call_id = d.pop("tool_call_id")
+
+        name = d.pop("name")
+
+        kind = AwaitingToolCallKind(d.pop("kind"))
+
+        needs_confirm = d.pop("needs_confirm")
+
+        awaiting_tool_call = cls(
+            tool_call_id=tool_call_id,
+            name=name,
+            kind=kind,
+            needs_confirm=needs_confirm,
+        )
+
+        awaiting_tool_call.additional_properties = d
+        return awaiting_tool_call
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/awaiting_tool_call_kind.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/awaiting_tool_call_kind.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class AwaitingToolCallKind(str, Enum):
+    BUILTIN = "builtin"
+    CUSTOM = "custom"
+    MCP = "mcp"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/http_route_spec.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/http_route_spec.py
@@ -22,8 +22,9 @@ class HttpRouteSpec:
     segment, ``**`` matches any number of segments).  ``description`` is
     operator-authored prose rendered into the system prompt so the agent
     knows what the route does and how to call it.  ``permission_policy``
-    gates *invocation*: ``always_ask`` parks the call in
-    ``requires_action`` until the client confirms.
+    gates *invocation*: ``always_ask`` leaves the call unresolved in the
+    event log until the client confirms via
+    ``POST /sessions/:id/tool-confirmations``.
 
         Attributes:
             path_pattern (str):

--- a/packages/aios-sdk/aios_sdk/_generated/models/list_sessions_status_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/list_sessions_status_type_0.py
@@ -6,7 +6,6 @@ class ListSessionsStatusType0(str, Enum):
     IDLE = "idle"
     PENDING = "pending"
     RESCHEDULING = "rescheduling"
-    RUNNING = "running"
     TERMINATED = "terminated"
 
     def __str__(self) -> str:

--- a/packages/aios-sdk/aios_sdk/_generated/models/session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session.py
@@ -12,6 +12,7 @@ from ..models.session_status import SessionStatus
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
+    from ..models.awaiting_tool_call import AwaitingToolCall
     from ..models.github_repository_resource_echo import GithubRepositoryResourceEcho
     from ..models.memory_store_resource_echo import MemoryStoreResourceEcho
     from ..models.session_metadata import SessionMetadata
@@ -26,26 +27,32 @@ T = TypeVar("T", bound="Session")
 class Session:
     """Read view of a session. Internal-only columns are not exposed.
 
-    Attributes:
-        id (str):
-        agent_id (str):
-        environment_id (str):
-        agent_version (int | None):
-        title (None | str):
-        metadata (SessionMetadata):
-        status (SessionStatus):
-        stop_reason (None | SessionStopReasonType0):
-        last_event_seq (int):
-        created_at (datetime.datetime):
-        updated_at (datetime.datetime):
-        vault_ids (list[str] | Unset):
-        usage (SessionUsage | Unset): Cumulative token usage across all model calls in a session.
-        resources (list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho] | Unset):
-        archived_at (datetime.datetime | None | Unset):
-        focal_channel (None | str | Unset):
-        focal_locked (bool | Unset):  Default: False.
-        last_event_at (datetime.datetime | None | Unset):
-        total_events (int | Unset):  Default: 0.
+    ``stop_reason`` records why the most recent step ended. Possible
+    ``type`` values: ``"end_turn"``, ``"interrupt"``, ``"rescheduling"``,
+    ``"error"``. To find tool calls the session is blocked on, read
+    ``awaiting`` (derived per read from the event log + task_registry).
+
+        Attributes:
+            id (str):
+            agent_id (str):
+            environment_id (str):
+            agent_version (int | None):
+            title (None | str):
+            metadata (SessionMetadata):
+            status (SessionStatus):
+            stop_reason (None | SessionStopReasonType0):
+            last_event_seq (int):
+            created_at (datetime.datetime):
+            updated_at (datetime.datetime):
+            awaiting (list[AwaitingToolCall] | Unset):
+            vault_ids (list[str] | Unset):
+            usage (SessionUsage | Unset): Cumulative token usage across all model calls in a session.
+            resources (list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho] | Unset):
+            archived_at (datetime.datetime | None | Unset):
+            focal_channel (None | str | Unset):
+            focal_locked (bool | Unset):  Default: False.
+            last_event_at (datetime.datetime | None | Unset):
+            total_events (int | Unset):  Default: 0.
     """
 
     id: str
@@ -59,6 +66,7 @@ class Session:
     last_event_seq: int
     created_at: datetime.datetime
     updated_at: datetime.datetime
+    awaiting: list[AwaitingToolCall] | Unset = UNSET
     vault_ids: list[str] | Unset = UNSET
     usage: SessionUsage | Unset = UNSET
     resources: list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho] | Unset = (
@@ -102,6 +110,13 @@ class Session:
         created_at = self.created_at.isoformat()
 
         updated_at = self.updated_at.isoformat()
+
+        awaiting: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.awaiting, Unset):
+            awaiting = []
+            for awaiting_item_data in self.awaiting:
+                awaiting_item = awaiting_item_data.to_dict()
+                awaiting.append(awaiting_item)
 
         vault_ids: list[str] | Unset = UNSET
         if not isinstance(self.vault_ids, Unset):
@@ -166,6 +181,8 @@ class Session:
                 "updated_at": updated_at,
             }
         )
+        if awaiting is not UNSET:
+            field_dict["awaiting"] = awaiting
         if vault_ids is not UNSET:
             field_dict["vault_ids"] = vault_ids
         if usage is not UNSET:
@@ -187,6 +204,7 @@ class Session:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.awaiting_tool_call import AwaitingToolCall
         from ..models.github_repository_resource_echo import (
             GithubRepositoryResourceEcho,
         )
@@ -240,6 +258,15 @@ class Session:
         created_at = isoparse(d.pop("created_at"))
 
         updated_at = isoparse(d.pop("updated_at"))
+
+        _awaiting = d.pop("awaiting", UNSET)
+        awaiting: list[AwaitingToolCall] | Unset = UNSET
+        if _awaiting is not UNSET:
+            awaiting = []
+            for awaiting_item_data in _awaiting:
+                awaiting_item = AwaitingToolCall.from_dict(awaiting_item_data)
+
+                awaiting.append(awaiting_item)
 
         vault_ids = cast(list[str], d.pop("vault_ids", UNSET))
 
@@ -338,6 +365,7 @@ class Session:
             last_event_seq=last_event_seq,
             created_at=created_at,
             updated_at=updated_at,
+            awaiting=awaiting,
             vault_ids=vault_ids,
             usage=usage,
             resources=resources,

--- a/packages/aios-sdk/aios_sdk/_generated/models/session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session.py
@@ -29,8 +29,8 @@ class Session:
 
     ``stop_reason`` records why the most recent step ended. Possible
     ``type`` values: ``"end_turn"``, ``"interrupt"``, ``"rescheduling"``,
-    ``"error"``. To find tool calls the session is blocked on, read
-    ``awaiting`` (derived per read from the event log + task_registry).
+    ``"error"``. ``awaiting`` lists tool calls the session is blocked
+    on (derived per read from the event log + agent tool specs).
 
         Attributes:
             id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_status.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_status.py
@@ -6,7 +6,6 @@ class SessionStatus(str, Enum):
     IDLE = "idle"
     PENDING = "pending"
     RESCHEDULING = "rescheduling"
-    RUNNING = "running"
     TERMINATED = "terminated"
 
     def __str__(self) -> str:

--- a/packages/aios-sdk/aios_sdk/_generated/models/tool_spec.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/tool_spec.py
@@ -34,8 +34,10 @@ class ToolSpec:
 
     ``permission`` controls execution policy for built-in tools:
     ``None`` or ``"always_allow"`` executes immediately (current default);
-    ``"always_ask"`` idles the session with ``requires_action`` until the
-    client confirms or denies.
+    ``"always_ask"`` leaves the call unresolved in the event log until
+    the client confirms or denies via
+    ``POST /sessions/:id/tool-confirmations``. Pending calls surface on
+    ``Session.awaiting`` so clients can list what they need to act on.
 
         Attributes:
             type_ (ToolSpecTypeType0 | ToolSpecTypeType1):

--- a/packages/aios-sdk/aios_sdk/_generated/models/wait_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wait_response.py
@@ -7,8 +7,10 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..models.wait_response_session_status import WaitResponseSessionStatus
+from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
+    from ..models.awaiting_tool_call import AwaitingToolCall
     from ..models.event import Event
     from ..models.wait_response_session_stop_reason_type_0 import (
         WaitResponseSessionStopReasonType0,
@@ -27,12 +29,14 @@ class WaitResponse:
         session_status (WaitResponseSessionStatus):
         session_stop_reason (None | WaitResponseSessionStopReasonType0):
         next_after (int):
+        session_awaiting (list[AwaitingToolCall] | Unset):
     """
 
     events: list[Event]
     session_status: WaitResponseSessionStatus
     session_stop_reason: None | WaitResponseSessionStopReasonType0
     next_after: int
+    session_awaiting: list[AwaitingToolCall] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -55,6 +59,13 @@ class WaitResponse:
 
         next_after = self.next_after
 
+        session_awaiting: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.session_awaiting, Unset):
+            session_awaiting = []
+            for session_awaiting_item_data in self.session_awaiting:
+                session_awaiting_item = session_awaiting_item_data.to_dict()
+                session_awaiting.append(session_awaiting_item)
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -65,11 +76,14 @@ class WaitResponse:
                 "next_after": next_after,
             }
         )
+        if session_awaiting is not UNSET:
+            field_dict["session_awaiting"] = session_awaiting
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.awaiting_tool_call import AwaitingToolCall
         from ..models.event import Event
         from ..models.wait_response_session_stop_reason_type_0 import (
             WaitResponseSessionStopReasonType0,
@@ -106,11 +120,23 @@ class WaitResponse:
 
         next_after = d.pop("next_after")
 
+        _session_awaiting = d.pop("session_awaiting", UNSET)
+        session_awaiting: list[AwaitingToolCall] | Unset = UNSET
+        if _session_awaiting is not UNSET:
+            session_awaiting = []
+            for session_awaiting_item_data in _session_awaiting:
+                session_awaiting_item = AwaitingToolCall.from_dict(
+                    session_awaiting_item_data
+                )
+
+                session_awaiting.append(session_awaiting_item)
+
         wait_response = cls(
             events=events,
             session_status=session_status,
             session_stop_reason=session_stop_reason,
             next_after=next_after,
+            session_awaiting=session_awaiting,
         )
 
         wait_response.additional_properties = d

--- a/packages/aios-sdk/aios_sdk/_generated/models/wait_response_session_status.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wait_response_session_status.py
@@ -6,7 +6,6 @@ class WaitResponseSessionStatus(str, Enum):
     IDLE = "idle"
     PENDING = "pending"
     RESCHEDULING = "rescheduling"
-    RUNNING = "running"
     TERMINATED = "terminated"
 
     def __str__(self) -> str:

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -639,5 +639,6 @@ async def wait_for_events(
         events=events,
         session_status=session.status,
         session_stop_reason=session.stop_reason,
+        session_awaiting=session.awaiting,
         next_after=events[-1].seq if events else after,
     )

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -498,29 +498,24 @@ async def get_context(
 ) -> ContextResponse:
     """Return the chat-completions payload the worker would send next.
 
-    Dry-run preview for debugging prompt construction.  Reuses the exact
-    composer the worker's step function uses (:func:`compose_step_context`)
-    so the endpoint's output is byte-identical to what the next model
-    call would see — no divergence.  Side effects (skill provisioning,
-    session-status bumps, event appends) are omitted; the endpoint is
-    read-only.
+    Dry-run preview for debugging prompt construction. Reuses the exact
+    composer the worker's step function uses (:func:`compose_step_context`).
+    Side effects (skill provisioning, session-status bumps, event
+    appends) are omitted; the endpoint is read-only.
+
+    One known divergence from the worker's output: unresolved tool_calls
+    that the worker is currently executing render as ``_PENDING_EXTERNAL``
+    here (the API process has no view into the worker's task_registry).
+    The worker would render them as ``_PENDING_BACKGROUND``. Custom and
+    awaiting-confirm calls render identically on both sides.
     """
     from aios.harness.step_context import compose_step_context, compute_step_prelude
     from aios.harness.tokens import approx_tokens
-    from aios.models.agents import Agent, AgentVersion
     from aios.services import agents as agents_service
     from aios.services.channels import list_session_channels
 
-    session = await service.get_session(pool, session_id, account_id=account_id)
-
-    agent: Agent | AgentVersion
-    if session.agent_version is not None:
-        agent = await agents_service.get_agent_version(
-            pool, session.agent_id, session.agent_version, account_id=account_id
-        )
-    else:
-        agent = await agents_service.get_agent(pool, session.agent_id, account_id=account_id)
-
+    session = await service.get_session_basic(pool, session_id, account_id=account_id)
+    agent = await agents_service.load_for_session(pool, session, account_id=account_id)
     channels = await list_session_channels(pool, session_id, account_id=account_id)
 
     from aios.db import queries as _queries
@@ -557,6 +552,10 @@ async def get_context(
         account_id=account_id,
     )
 
+    # The API process has no task_registry — it lives only in the worker
+    # — so we can't tell which unresolved tool_calls are mid-execution
+    # versus awaiting external action. All unresolved calls render as
+    # ``_PENDING_EXTERNAL`` for this preview; see docstring.
     step_ctx = await compose_step_context(
         session=session,
         agent=agent,
@@ -608,7 +607,7 @@ async def wait_for_events(
     resume from where you left off. (The query param was previously named
     ``after_seq``; see issue #389.)
     """
-    await service.get_session(pool, session_id, account_id=account_id)
+    await service.get_session_basic(pool, session_id, account_id=account_id)
 
     async with listen_for_events(db_url, session_id) as queue:
         events = await service.read_events(pool, session_id, after_seq=after, account_id=account_id)

--- a/src/aios/cli/commands/chat.py
+++ b/src/aios/cli/commands/chat.py
@@ -324,7 +324,9 @@ def _is_turn_end(obj: dict[str, Any]) -> bool:
     data = obj.get("data") or {}
     event_name = data.get("event")
     status = data.get("status")
-    # turn_ended fires for both "end_turn" and "requires_action" cases.
+    # turn_ended fires after every step body, regardless of whether
+    # the model emitted custom/always_ask tool calls that the harness
+    # left for external execution.
     if event_name == "turn_ended":
         return True
     # Interrupt also returns us to the prompt.

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1088,12 +1088,10 @@ async def delete_session(
 ) -> None:
     """Delete a session and its events.
 
-    Operator-initiated. No safety check on in-flight work: with parking
-    removed there's no longer a session-row signal for "tools running"
-    (the task_registry is the live source of truth, but it only sees
-    one worker process). If a delete races a tool task, the task's
-    ``_tool_lifecycle.finally`` will fail loudly on the missing session
-    — that's an acceptable signal per fail-hard.
+    Operator-initiated, no in-flight-work check: the task_registry is the
+    only live source of truth and only sees one worker. If a delete races
+    a tool task, ``_tool_lifecycle.finally`` fails loudly on the missing
+    session — acceptable per fail-hard.
     """
     async with conn.transaction():
         row = await conn.fetchrow(
@@ -1848,15 +1846,11 @@ async def append_event(
     # treats the channel as a string literal and preserves it byte-for-byte.
     await conn.execute("SELECT pg_notify($1, $2)", f"events_{session_id}", new_id)
 
-    # Connector fan-out: an assistant message with tool_calls is the
-    # event that may produce work for connector runtimes (custom-tool
-    # calls). Fire ``connector_calls_<type>`` per bound connection so
-    # the runtime SSE can pull the call's args via the backfill query.
-    # NOTIFY fires whether or not the tool_calls include a custom name
-    # — the consumer's backfill filters by ``connector.tools_schema``,
-    # so over-fanout is harmless. Keeping the trigger here (instead of
-    # inside a custom-detector branch) avoids loading agent.tools on
-    # the append hot path.
+    # Connector fan-out: every assistant-with-tool_calls fires
+    # ``connector_calls_<type>`` per bound connection. The consumer's
+    # backfill filters by ``connector.tools_schema``, so over-fanout
+    # (when none of the tool_calls are custom) is harmless and avoids
+    # loading agent.tools on the append hot path.
     if (
         kind == "message"
         and role == "assistant"
@@ -1950,18 +1944,28 @@ async def list_pending_calls_for_connector(
             (row["connection_id"], row["focal_channel"])
         )
 
-    calls_by_session = await _unresolved_connector_calls_for_sessions(
-        conn,
-        session_ids=list(by_session.keys()),
-        account_id=account_id,
-        tool_names=tool_names,
+    raw_by_sid = await _latest_unresolved_tool_calls(
+        conn, list(by_session.keys()), account_id=account_id
     )
-
+    name_set = set(tool_names)
     out: list[dict[str, Any]] = []
-    for sid, calls in calls_by_session.items():
+    for sid, calls in raw_by_sid.items():
         for conn_id, focal in by_session[sid]:
-            for call in calls:
-                out.append({**call, "connection_id": conn_id, "focal_channel": focal})
+            for tc in calls:
+                fn = tc.get("function") or {}
+                name = fn.get("name")
+                if name not in name_set:
+                    continue
+                out.append(
+                    {
+                        "session_id": sid,
+                        "tool_call_id": tc["id"],
+                        "name": name,
+                        "arguments": fn.get("arguments", "{}"),
+                        "connection_id": conn_id,
+                        "focal_channel": focal,
+                    }
+                )
     return out
 
 
@@ -1997,35 +2001,43 @@ async def list_pending_calls_for_session_and_connection(
     if not tool_names:
         return []
 
-    calls_by_session = await _unresolved_connector_calls_for_sessions(
-        conn,
-        session_ids=[session_id],
-        account_id=account_id,
-        tool_names=tool_names,
-    )
+    raw_by_sid = await _latest_unresolved_tool_calls(conn, [session_id], account_id=account_id)
+    name_set = set(tool_names)
     focal = conn_row["focal_channel"]
-    return [
-        {**call, "connection_id": connection_id, "focal_channel": focal}
-        for call in calls_by_session.get(session_id, [])
-    ]
+    out: list[dict[str, Any]] = []
+    for tc in raw_by_sid.get(session_id, []):
+        fn = tc.get("function") or {}
+        name = fn.get("name")
+        if name not in name_set:
+            continue
+        out.append(
+            {
+                "session_id": session_id,
+                "tool_call_id": tc["id"],
+                "name": name,
+                "arguments": fn.get("arguments", "{}"),
+                "connection_id": connection_id,
+                "focal_channel": focal,
+            }
+        )
+    return out
 
 
-async def _unresolved_connector_calls_for_sessions(
+async def _latest_unresolved_tool_calls(
     conn: asyncpg.Connection[Any],
-    *,
     session_ids: list[str],
+    *,
     account_id: str,
-    tool_names: list[str],
 ) -> dict[str, list[dict[str, Any]]]:
-    """Return ``{session_id: [{tool_call_id, name, arguments}]}`` for the
-    latest assistant's unresolved tool_calls whose ``function.name`` is in
-    ``tool_names``.
+    """Return ``{session_id: [tool_call_dict]}`` for the latest assistant's
+    tool_calls (per session) that have no paired tool_result event.
 
-    Pending-ness is purely an event-log property: an assistant tool_call
-    with no paired tool-role event. The session row's ``status`` and
-    ``stop_reason`` are irrelevant — the harness no longer parks sessions
-    for custom tools (#TBD).
+    Pending-ness is purely an event-log property — the session row's
+    ``status`` and ``stop_reason`` are irrelevant. Tool_call dicts are
+    returned as-is from the assistant's ``data->'tool_calls'`` array.
     """
+    if not session_ids:
+        return {}
     asst_rows = await conn.fetch(
         """
         SELECT DISTINCT ON (session_id) session_id, data
@@ -2044,29 +2056,19 @@ async def _unresolved_connector_calls_for_sessions(
     )
     if not asst_rows:
         return {}
-    completed = await _tool_result_ids_by_session(conn, session_ids, account_id=account_id)
-    name_set = set(tool_names)
+    results_by_sid = await _tool_result_ids_by_session(conn, session_ids, account_id=account_id)
     out: dict[str, list[dict[str, Any]]] = {}
     for row in asst_rows:
-        sid = row["session_id"]
+        sid: str = row["session_id"]
         data = parse_jsonb(row["data"])
-        results = completed.get(sid, set())
-        for tc in data.get("tool_calls") or []:
-            tc_id = tc.get("id")
-            if not tc_id or tc_id in results:
-                continue
-            fn = tc.get("function") or {}
-            name = fn.get("name")
-            if name not in name_set:
-                continue
-            out.setdefault(sid, []).append(
-                {
-                    "session_id": sid,
-                    "tool_call_id": tc_id,
-                    "name": name,
-                    "arguments": fn.get("arguments", "{}"),
-                }
-            )
+        completed: set[str] = results_by_sid.get(sid, set())
+        unresolved = [
+            tc
+            for tc in (data.get("tool_calls") or [])
+            if tc.get("id") and tc["id"] not in completed
+        ]
+        if unresolved:
+            out[sid] = unresolved
     return out
 
 
@@ -2106,32 +2108,14 @@ async def list_unresolved_tool_calls_batch(
     """For each session, return the latest assistant's tool_calls that
     have no paired tool_result, annotated with allow-lifecycle presence.
 
-    Used by :func:`services.sessions._enrich_awaiting` to build the
+    Used by :func:`services.sessions.compute_awaiting` to build the
     ``Session.awaiting`` derived view. Returned dicts have keys
     ``tool_call_id``, ``name``, ``has_allow_lifecycle`` — the caller
     classifies kind/needs_confirm using ``agent.tools``.
     """
-    if not session_ids:
+    raw = await _latest_unresolved_tool_calls(conn, session_ids, account_id=account_id)
+    if not raw:
         return {}
-    asst_rows = await conn.fetch(
-        """
-        SELECT DISTINCT ON (session_id) session_id, data
-          FROM events
-         WHERE session_id = ANY($1::text[])
-           AND account_id = $2
-           AND kind = 'message'
-           AND role = 'assistant'
-           AND jsonb_array_length(
-                 COALESCE(NULLIF(data->'tool_calls','null'::jsonb), '[]'::jsonb)
-               ) > 0
-         ORDER BY session_id, seq DESC
-        """,
-        session_ids,
-        account_id,
-    )
-    if not asst_rows:
-        return {}
-    results_by_sid = await _tool_result_ids_by_session(conn, session_ids, account_id=account_id)
     allow_rows = await conn.fetch(
         """
         SELECT session_id, data->>'tool_call_id' AS tool_call_id
@@ -2152,29 +2136,19 @@ async def list_unresolved_tool_calls_batch(
             allows_by_sid.setdefault(r["session_id"], set()).add(tcid)
 
     out: dict[str, list[dict[str, Any]]] = {}
-    for row in asst_rows:
-        sid = row["session_id"]
-        data = parse_jsonb(row["data"])
-        completed = results_by_sid.get(sid, set())
+    for sid, calls in raw.items():
         allows = allows_by_sid.get(sid, set())
-        unresolved: list[dict[str, Any]] = []
-        for tc in data.get("tool_calls") or []:
-            tc_id = tc.get("id")
-            if not tc_id or tc_id in completed:
-                continue
-            fn = tc.get("function") or {}
-            name = fn.get("name")
-            if not name:
-                continue
-            unresolved.append(
-                {
-                    "tool_call_id": tc_id,
-                    "name": name,
-                    "has_allow_lifecycle": tc_id in allows,
-                }
-            )
-        if unresolved:
-            out[sid] = unresolved
+        entries = [
+            {
+                "tool_call_id": tc["id"],
+                "name": name,
+                "has_allow_lifecycle": tc["id"] in allows,
+            }
+            for tc in calls
+            if (name := (tc.get("function") or {}).get("name"))
+        ]
+        if entries:
+            out[sid] = entries
     return out
 
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -906,27 +906,6 @@ async def set_session_status(
     if row is None:
         return
 
-    # Connector-calls fan-out (#328 PR 5): when a session parks in
-    # ``requires_action`` with pending custom_tools, NOTIFY the per-type
-    # channel for each bound connection's connector type — the runtime
-    # SSE subscribes once per connector type and fans out to its N
-    # connections client-side.  Firing here (after stop_reason is
-    # committed) avoids the race where the SSE consumer's query checks
-    # for ``requires_action`` but stop_reason hasn't been written yet.
-    if (
-        isinstance(stop_reason, dict)
-        and stop_reason.get("type") == "requires_action"
-        and stop_reason.get("custom_tools")
-    ):
-        for cid, connector in await _list_bound_connection_ids(
-            conn, session_id, account_id=account_id
-        ):
-            await conn.execute(
-                "SELECT pg_notify($1, $2)",
-                f"connector_calls_{connector}",
-                f"{session_id}|{cid}",
-            )
-
 
 async def increment_session_usage(
     conn: asyncpg.Connection[Any],
@@ -953,25 +932,6 @@ async def increment_session_usage(
         cache_creation_input_tokens,
         account_id,
     )
-
-
-async def list_running_session_ids(conn: asyncpg.Connection[Any]) -> list[str]:
-    """Return ids of sessions with ``status = 'running'``.
-
-    Used by the sandbox orphan reaper at worker startup: any Docker
-    container labelled ``aios.managed=true`` whose ``aios.session_id``
-    is NOT in this list is a corpse from a dead worker and gets
-    force-removed.
-    """
-    rows = await conn.fetch(
-        """
-        SELECT id
-          FROM sessions
-         WHERE status = 'running'
-           AND archived_at IS NULL
-        """
-    )
-    return [str(r["id"]) for r in rows]
 
 
 async def get_session_model(
@@ -1126,20 +1086,24 @@ async def archive_session(
 async def delete_session(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> None:
+    """Delete a session and its events.
+
+    Operator-initiated. No safety check on in-flight work: with parking
+    removed there's no longer a session-row signal for "tools running"
+    (the task_registry is the live source of truth, but it only sees
+    one worker process). If a delete races a tool task, the task's
+    ``_tool_lifecycle.finally`` will fail loudly on the missing session
+    — that's an acceptable signal per fail-hard.
+    """
     async with conn.transaction():
         row = await conn.fetchrow(
-            "SELECT status FROM sessions WHERE id = $1 AND account_id = $2",
+            "SELECT 1 FROM sessions WHERE id = $1 AND account_id = $2",
             session_id,
             account_id,
         )
         if row is None:
             raise NotFoundError(
                 f"session {session_id} not found",
-                detail={"id": session_id},
-            )
-        if row["status"] == "running":
-            raise ConflictError(
-                f"session {session_id} is running and cannot be deleted",
                 detail={"id": session_id},
             )
         await conn.execute(
@@ -1883,6 +1847,30 @@ async def append_event(
     # preserving case, so the two would never match. pg_notify(text, text)
     # treats the channel as a string literal and preserves it byte-for-byte.
     await conn.execute("SELECT pg_notify($1, $2)", f"events_{session_id}", new_id)
+
+    # Connector fan-out: an assistant message with tool_calls is the
+    # event that may produce work for connector runtimes (custom-tool
+    # calls). Fire ``connector_calls_<type>`` per bound connection so
+    # the runtime SSE can pull the call's args via the backfill query.
+    # NOTIFY fires whether or not the tool_calls include a custom name
+    # — the consumer's backfill filters by ``connector.tools_schema``,
+    # so over-fanout is harmless. Keeping the trigger here (instead of
+    # inside a custom-detector branch) avoids loading agent.tools on
+    # the append hot path.
+    if (
+        kind == "message"
+        and role == "assistant"
+        and isinstance(data, dict)
+        and data.get("tool_calls")
+    ):
+        for cid, connector in await _list_bound_connection_ids(
+            conn, session_id, account_id=account_id
+        ):
+            await conn.execute(
+                "SELECT pg_notify($1, $2)",
+                f"connector_calls_{connector}",
+                f"{session_id}|{cid}",
+            )
     return _row_to_event(row)
 
 
@@ -1894,10 +1882,12 @@ async def list_pending_calls_for_connector(
 ) -> list[dict[str, Any]]:
     """Pending custom tool calls across every active connection of ``connector`` type.
 
-    Used by the runtime SSE (#328 PR 5) at subscribe-time backfill.
-    A "pending" call is one referenced in some session's
-    ``stop_reason.custom_tools`` array — i.e. the model called a
-    custom tool and the session is parked in ``requires_action``.
+    Used by the runtime SSE at subscribe-time backfill.  A "pending"
+    call is a tool_call on the latest assistant message of a bound
+    session whose ``function.name`` is in ``connector.tools_schema``
+    and has no paired tool_result event yet.  No dependency on
+    ``stop_reason`` — the source of truth is the event log.
+
     Each emitted record carries ``connection_id`` so the runtime can
     fan out to the right per-connection worker.
 
@@ -1921,26 +1911,21 @@ async def list_pending_calls_for_connector(
     if cat_row is None:
         return []
     tools_data = parse_jsonb(cat_row["tools"])
-    tool_names = {t["name"] for t in tools_data if isinstance(t, dict) and "name" in t}
+    tool_names = [t["name"] for t in tools_data if isinstance(t, dict) and "name" in t]
     if not tool_names:
         return []
 
-    # The lineage predicate joins ``s.id`` not a parameter, so we inline
-    # rather than calling ``_session_bound_to_connection_predicate``
-    # (which expects a $N param index for the session).
-    # Tenant isolation: both ``connections.account_id`` and
-    # ``sessions.account_id`` must match the bearer's account, otherwise
-    # a runtime token for tenant A could see pending tool calls (with
-    # arguments) from tenants B, C, D under the same connector type.
-    rows = await conn.fetch(
+    # Find bound sessions of this connector type. Tenant isolation: both
+    # ``connections.account_id`` and ``sessions.account_id`` must match the
+    # bearer's account, otherwise a runtime token for tenant A could see
+    # tool-call arguments from tenants B, C, D under the same connector type.
+    bound_rows = await conn.fetch(
         """
-        SELECT c.id AS connection_id,
-               s.id AS session_id, s.stop_reason, s.focal_channel
+        SELECT DISTINCT c.id AS connection_id,
+               s.id AS session_id, s.focal_channel
           FROM connections c
           JOIN sessions s
             ON s.archived_at IS NULL
-           AND s.status = 'idle'
-           AND s.stop_reason->>'type' = 'requires_action'
            AND s.account_id = $2
            AND (EXISTS (SELECT 1 FROM bindings b
                          WHERE b.connection_id = c.id
@@ -1956,19 +1941,27 @@ async def list_pending_calls_for_connector(
         connector,
         account_id,
     )
+    if not bound_rows:
+        return []
+
+    by_session: dict[str, list[tuple[str, str | None]]] = {}
+    for row in bound_rows:
+        by_session.setdefault(row["session_id"], []).append(
+            (row["connection_id"], row["focal_channel"])
+        )
+
+    calls_by_session = await _unresolved_connector_calls_for_sessions(
+        conn,
+        session_ids=list(by_session.keys()),
+        account_id=account_id,
+        tool_names=tool_names,
+    )
 
     out: list[dict[str, Any]] = []
-    for row in rows:
-        calls = await _pending_calls_for_session(
-            conn,
-            session_id=row["session_id"],
-            stop_reason=parse_jsonb(row["stop_reason"]),
-            focal_channel=row["focal_channel"],
-            tool_names=tool_names,
-        )
-        for call in calls:
-            call["connection_id"] = row["connection_id"]
-            out.append(call)
+    for sid, calls in calls_by_session.items():
+        for conn_id, focal in by_session[sid]:
+            for call in calls:
+                out.append({**call, "connection_id": conn_id, "focal_channel": focal})
     return out
 
 
@@ -1979,104 +1972,209 @@ async def list_pending_calls_for_session_and_connection(
     session_id: str,
     connection_id: str,
 ) -> list[dict[str, Any]]:
-    """Same shape as :func:`list_pending_calls_for_connection` but scoped
+    """Same shape as :func:`list_pending_calls_for_connector` but scoped
     to one session.  Used by the SSE NOTIFY tail to fetch calls only for
     the session that just emitted, instead of re-scanning all bound
     sessions.
     """
     conn_row = await conn.fetchrow(
         """
-        SELECT cat.tools_schema AS tools
+        SELECT cat.tools_schema AS tools, s.focal_channel
           FROM connections c
           JOIN connectors cat ON cat.connector = c.connector
+          JOIN sessions s
+            ON s.id = $3 AND s.archived_at IS NULL AND s.account_id = $2
          WHERE c.id = $1 AND c.archived_at IS NULL AND c.account_id = $2
         """,
         connection_id,
         account_id,
+        session_id,
     )
     if conn_row is None:
         return []
     tools_data = parse_jsonb(conn_row["tools"])
-    tool_names = {t["name"] for t in tools_data if isinstance(t, dict) and "name" in t}
+    tool_names = [t["name"] for t in tools_data if isinstance(t, dict) and "name" in t]
     if not tool_names:
         return []
 
-    sess_row = await conn.fetchrow(
-        "SELECT stop_reason, status, focal_channel FROM sessions "
-        "WHERE id = $1 AND archived_at IS NULL AND account_id = $2",
-        session_id,
-        account_id,
-    )
-    if sess_row is None:
-        return []
-    if sess_row["status"] != "idle":
-        return []
-    stop_reason = parse_jsonb(sess_row["stop_reason"])
-    if not isinstance(stop_reason, dict) or stop_reason.get("type") != "requires_action":
-        return []
-
-    return await _pending_calls_for_session(
+    calls_by_session = await _unresolved_connector_calls_for_sessions(
         conn,
-        session_id=session_id,
-        stop_reason=stop_reason,
-        focal_channel=sess_row["focal_channel"],
+        session_ids=[session_id],
+        account_id=account_id,
         tool_names=tool_names,
     )
+    focal = conn_row["focal_channel"]
+    return [
+        {**call, "connection_id": connection_id, "focal_channel": focal}
+        for call in calls_by_session.get(session_id, [])
+    ]
 
 
-async def _pending_calls_for_session(
+async def _unresolved_connector_calls_for_sessions(
     conn: asyncpg.Connection[Any],
     *,
-    session_id: str,
-    stop_reason: Any,
-    focal_channel: str | None,
-    tool_names: set[str],
-) -> list[dict[str, Any]]:
-    """Fetch the pending tool_call rows for one ``requires_action`` session."""
-    if not isinstance(stop_reason, dict):
-        return []
-    pending_ids = stop_reason.get("custom_tools") or []
-    if not pending_ids:
-        return []
+    session_ids: list[str],
+    account_id: str,
+    tool_names: list[str],
+) -> dict[str, list[dict[str, Any]]]:
+    """Return ``{session_id: [{tool_call_id, name, arguments}]}`` for the
+    latest assistant's unresolved tool_calls whose ``function.name`` is in
+    ``tool_names``.
 
-    # The pending call_ids are referenced in the most recent assistant
-    # event; walk that event's data->'tool_calls' array.  We could scan
-    # all assistant events but the loop only parks on the latest, so the
-    # latest assistant message owns every id in stop_reason.
-    rows = await conn.fetch(
+    Pending-ness is purely an event-log property: an assistant tool_call
+    with no paired tool-role event. The session row's ``status`` and
+    ``stop_reason`` are irrelevant — the harness no longer parks sessions
+    for custom tools (#TBD).
+    """
+    asst_rows = await conn.fetch(
         """
-        SELECT data
+        SELECT DISTINCT ON (session_id) session_id, data
           FROM events
-         WHERE session_id = $1
+         WHERE session_id = ANY($1::text[])
+           AND account_id = $2
            AND kind = 'message'
-           AND data->>'role' = 'assistant'
-         ORDER BY seq DESC
-         LIMIT 5
+           AND role = 'assistant'
+           AND jsonb_array_length(
+                 COALESCE(NULLIF(data->'tool_calls','null'::jsonb), '[]'::jsonb)
+               ) > 0
+         ORDER BY session_id, seq DESC
         """,
-        session_id,
+        session_ids,
+        account_id,
     )
-
-    pending_set = set(pending_ids)
-    out: list[dict[str, Any]] = []
-    for row in rows:
+    if not asst_rows:
+        return {}
+    completed = await _tool_result_ids_by_session(conn, session_ids, account_id=account_id)
+    name_set = set(tool_names)
+    out: dict[str, list[dict[str, Any]]] = {}
+    for row in asst_rows:
+        sid = row["session_id"]
         data = parse_jsonb(row["data"])
+        results = completed.get(sid, set())
         for tc in data.get("tool_calls") or []:
             tc_id = tc.get("id")
-            if tc_id not in pending_set:
+            if not tc_id or tc_id in results:
                 continue
             fn = tc.get("function") or {}
             name = fn.get("name")
-            if name not in tool_names:
+            if name not in name_set:
                 continue
-            out.append(
+            out.setdefault(sid, []).append(
                 {
-                    "session_id": session_id,
+                    "session_id": sid,
                     "tool_call_id": tc_id,
                     "name": name,
                     "arguments": fn.get("arguments", "{}"),
-                    "focal_channel": focal_channel,
                 }
             )
+    return out
+
+
+async def _tool_result_ids_by_session(
+    conn: asyncpg.Connection[Any],
+    session_ids: list[str],
+    *,
+    account_id: str,
+) -> dict[str, set[str]]:
+    """Map ``session_id → {tool_call_id}`` for every tool-role event."""
+    rows = await conn.fetch(
+        """
+        SELECT session_id, data->>'tool_call_id' AS tool_call_id
+          FROM events
+         WHERE session_id = ANY($1::text[])
+           AND account_id = $2
+           AND kind = 'message'
+           AND role = 'tool'
+        """,
+        session_ids,
+        account_id,
+    )
+    out: dict[str, set[str]] = {}
+    for r in rows:
+        tcid = r["tool_call_id"]
+        if tcid:
+            out.setdefault(r["session_id"], set()).add(tcid)
+    return out
+
+
+async def list_unresolved_tool_calls_batch(
+    conn: asyncpg.Connection[Any],
+    session_ids: list[str],
+    *,
+    account_id: str,
+) -> dict[str, list[dict[str, Any]]]:
+    """For each session, return the latest assistant's tool_calls that
+    have no paired tool_result, annotated with allow-lifecycle presence.
+
+    Used by :func:`services.sessions._enrich_awaiting` to build the
+    ``Session.awaiting`` derived view. Returned dicts have keys
+    ``tool_call_id``, ``name``, ``has_allow_lifecycle`` — the caller
+    classifies kind/needs_confirm using ``agent.tools``.
+    """
+    if not session_ids:
+        return {}
+    asst_rows = await conn.fetch(
+        """
+        SELECT DISTINCT ON (session_id) session_id, data
+          FROM events
+         WHERE session_id = ANY($1::text[])
+           AND account_id = $2
+           AND kind = 'message'
+           AND role = 'assistant'
+           AND jsonb_array_length(
+                 COALESCE(NULLIF(data->'tool_calls','null'::jsonb), '[]'::jsonb)
+               ) > 0
+         ORDER BY session_id, seq DESC
+        """,
+        session_ids,
+        account_id,
+    )
+    if not asst_rows:
+        return {}
+    results_by_sid = await _tool_result_ids_by_session(conn, session_ids, account_id=account_id)
+    allow_rows = await conn.fetch(
+        """
+        SELECT session_id, data->>'tool_call_id' AS tool_call_id
+          FROM events
+         WHERE session_id = ANY($1::text[])
+           AND account_id = $2
+           AND kind = 'lifecycle'
+           AND data->>'event' = 'tool_confirmed'
+           AND data->>'result' = 'allow'
+        """,
+        session_ids,
+        account_id,
+    )
+    allows_by_sid: dict[str, set[str]] = {}
+    for r in allow_rows:
+        tcid = r["tool_call_id"]
+        if tcid:
+            allows_by_sid.setdefault(r["session_id"], set()).add(tcid)
+
+    out: dict[str, list[dict[str, Any]]] = {}
+    for row in asst_rows:
+        sid = row["session_id"]
+        data = parse_jsonb(row["data"])
+        completed = results_by_sid.get(sid, set())
+        allows = allows_by_sid.get(sid, set())
+        unresolved: list[dict[str, Any]] = []
+        for tc in data.get("tool_calls") or []:
+            tc_id = tc.get("id")
+            if not tc_id or tc_id in completed:
+                continue
+            fn = tc.get("function") or {}
+            name = fn.get("name")
+            if not name:
+                continue
+            unresolved.append(
+                {
+                    "tool_call_id": tc_id,
+                    "name": name,
+                    "has_allow_lifecycle": tc_id in allows,
+                }
+            )
+        if unresolved:
+            out[sid] = unresolved
     return out
 
 
@@ -2085,10 +2183,10 @@ async def _list_bound_connection_ids(
 ) -> list[tuple[str, str]]:
     """``(connection_id, connector)`` pairs for active connections bound to ``session_id``.
 
-    Used by :func:`set_session_status` to fan an assistant-tool-calls
-    event out on the per-type ``connector_calls_<connector>`` NOTIFY
-    channel (#328 PR 5).  Tools-less connections receive notifications
-    and harmlessly no-op them on the consumer side.
+    Called from :func:`append_event` when an assistant message with
+    tool_calls lands, to fan a per-connection notification on the
+    ``connector_calls_<connector>`` channel.  Tools-less connections
+    receive notifications and harmlessly no-op them on the consumer side.
     """
     rows = await conn.fetch(
         f"""

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1086,13 +1086,6 @@ async def archive_session(
 async def delete_session(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> None:
-    """Delete a session and its events.
-
-    Operator-initiated, no in-flight-work check: the task_registry is the
-    only live source of truth and only sees one worker. If a delete races
-    a tool task, ``_tool_lifecycle.finally`` fails loudly on the missing
-    session — acceptable per fail-hard.
-    """
     async with conn.transaction():
         row = await conn.fetchrow(
             "SELECT 1 FROM sessions WHERE id = $1 AND account_id = $2",
@@ -1905,8 +1898,8 @@ async def list_pending_calls_for_connector(
     if cat_row is None:
         return []
     tools_data = parse_jsonb(cat_row["tools"])
-    tool_names = [t["name"] for t in tools_data if isinstance(t, dict) and "name" in t]
-    if not tool_names:
+    name_set = {t["name"] for t in tools_data if isinstance(t, dict) and "name" in t}
+    if not name_set:
         return []
 
     # Find bound sessions of this connector type. Tenant isolation: both
@@ -1947,7 +1940,6 @@ async def list_pending_calls_for_connector(
     raw_by_sid = await _latest_unresolved_tool_calls(
         conn, list(by_session.keys()), account_id=account_id
     )
-    name_set = set(tool_names)
     out: list[dict[str, Any]] = []
     for sid, calls in raw_by_sid.items():
         for conn_id, focal in by_session[sid]:
@@ -1982,13 +1974,18 @@ async def list_pending_calls_for_session_and_connection(
     sessions.
     """
     conn_row = await conn.fetchrow(
-        """
+        f"""
         SELECT cat.tools_schema AS tools, s.focal_channel
           FROM connections c
           JOIN connectors cat ON cat.connector = c.connector
           JOIN sessions s
             ON s.id = $3 AND s.archived_at IS NULL AND s.account_id = $2
          WHERE c.id = $1 AND c.archived_at IS NULL AND c.account_id = $2
+           AND {
+            _session_bound_to_connection_predicate(
+                connection_alias="c", session_param_index=3, account_id_param_index=2
+            )
+        }
         """,
         connection_id,
         account_id,
@@ -1997,12 +1994,11 @@ async def list_pending_calls_for_session_and_connection(
     if conn_row is None:
         return []
     tools_data = parse_jsonb(conn_row["tools"])
-    tool_names = [t["name"] for t in tools_data if isinstance(t, dict) and "name" in t]
-    if not tool_names:
+    name_set = {t["name"] for t in tools_data if isinstance(t, dict) and "name" in t}
+    if not name_set:
         return []
 
     raw_by_sid = await _latest_unresolved_tool_calls(conn, [session_id], account_id=account_id)
-    name_set = set(tool_names)
     focal = conn_row["focal_channel"]
     out: list[dict[str, Any]] = []
     for tc in raw_by_sid.get(session_id, []):

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -507,13 +507,24 @@ def _strip_to_spec(
 # ─── build_messages ──────────────────────────────────────────────────────────
 
 
-_PENDING_CONTENT = json.dumps(
+_PENDING_BACKGROUND = json.dumps(
     {
         "status": "pending",
         "message": (
             "This tool is still executing in the background. "
             "Its result will arrive when ready. "
             "Do not re-request this tool."
+        ),
+    }
+)
+_PENDING_EXTERNAL = json.dumps(
+    {
+        "status": "pending",
+        "message": (
+            "This tool is awaiting external action (client execution or "
+            "operator approval). Its result will arrive when that action "
+            "completes. Continue handling other work; do not re-request "
+            "this tool."
         ),
     }
 )
@@ -533,6 +544,7 @@ def build_messages(
     system_prompt: str | None,
     model: str | None = None,
     session_id: str | None = None,
+    in_flight_tool_call_ids: frozenset[str] = frozenset(),
 ) -> ContextResult:
     """Assemble a chat-completions message list from pre-windowed events.
 
@@ -614,9 +626,12 @@ def build_messages(
                     messages.append(real_results[tcid])
                     max_stimulus_seq = max(max_stimulus_seq, rseq)
                 else:
-                    messages.append(
-                        {"role": "tool", "tool_call_id": tcid, "content": _PENDING_CONTENT}
+                    placeholder = (
+                        _PENDING_BACKGROUND
+                        if tcid in in_flight_tool_call_ids
+                        else _PENDING_EXTERNAL
                     )
+                    messages.append({"role": "tool", "tool_call_id": tcid, "content": placeholder})
                     if tcid in real_results:
                         # Safe: last assistant has horizon=INF so rseq<=INF
                         # always takes the REAL branch above; only non-last

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -354,6 +354,7 @@ async def _run_session_step_body(
             channels=channels,
             prelude=prelude,
             events=events,
+            in_flight_tool_call_ids=frozenset(task_registry.in_flight_tool_call_ids(session_id)),
         )
     except Exception:
         await sessions_service.append_event(
@@ -397,9 +398,6 @@ async def _run_session_step_body(
     # when AIOS_DUMP_CONTEXT is set — useful for debugging prompt construction
     # (header inlining, system-prompt augmentation, tool list shape).
     await _dump_context_if_enabled(session_id, agent.model, messages, tools)
-
-    # Mark session as running.
-    await sessions_service.set_session_status(pool, session_id, "running", account_id=account_id)
 
     # Emit span start so consumers can measure inference latency.
     start_event = await sessions_service.append_event(
@@ -499,11 +497,13 @@ async def _run_session_step_body(
         pool, session_id, "message", assistant_msg, account_id=account_id
     )
 
-    # Check for tool calls — partition into four buckets:
-    #   immediate       — built-in with always_allow (execute now)
-    #   mcp_immediate   — MCP with always_allow (execute now via MCP client)
-    #   needs_confirm   — built-in or MCP with always_ask (hold for confirmation)
-    #   custom          — not in registry and not MCP (hold for client execution)
+    # Partition the model's tool calls into dispatch buckets. Immediate
+    # builtin/MCP tools launch as asyncio tasks now; ``needs_confirm``
+    # (always_ask awaiting allow) and ``custom`` (client-executed) tool
+    # calls sit unresolved in the log until an external POST lands their
+    # result. The session is NOT parked: a new user message or any other
+    # stimulus can wake the session and the model sees pending tool calls
+    # via the synthesized placeholder in ``build_messages``.
     tool_calls: list[dict[str, Any]] = assistant_msg.get("tool_calls") or []
 
     if tool_calls:
@@ -538,10 +538,8 @@ async def _run_session_step_body(
         # Unknown-MCP tools route through the regular MCP dispatcher,
         # bypassing the permission gate.  ``_execute_mcp_tool_async``
         # already detects unknown servers and appends a tool_error
-        # event for them; the prior code path parked the session in
-        # ``requires_action`` and dispatched only after a confirmation,
-        # which never came.  Routing them to immediate dispatch lets
-        # the model see the error in the next step and self-correct.
+        # event for them.  Routing them to immediate dispatch lets the
+        # model see the error in the next step and self-correct.
         immediate_mcp = mcp_immediate + unknown_mcp
         if immediate_mcp:
             launch_mcp_tool_calls(
@@ -561,49 +559,24 @@ async def _run_session_step_body(
             )
 
         if needs_confirm or custom:
-            confirm_ids = [tc.get("id") for tc in needs_confirm if tc.get("id")]
-            custom_ids = [tc.get("id") for tc in custom if tc.get("id")]
-            all_pending_ids = confirm_ids + custom_ids
-
-            stop_reason: dict[str, Any] = {
-                "type": "requires_action",
-                "event_ids": all_pending_ids,
-            }
-            if confirm_ids:
-                stop_reason["confirmations"] = confirm_ids
-            if custom_ids:
-                stop_reason["custom_tools"] = custom_ids
-
-            await sessions_service.set_session_status(
-                pool,
-                session_id,
-                "idle",
-                stop_reason=stop_reason,
-                account_id=account_id,
-            )
-            await _append_lifecycle(
-                pool,
-                session_id,
-                "turn_ended",
-                "idle",
-                "requires_action",
-                account_id=account_id,
-            )
             log.info(
-                "step.tools_pending",
+                "step.external_tools_pending",
                 session_id=session_id,
-                confirmations=confirm_ids,
-                custom_tools=custom_ids,
+                confirmations=[tc.get("id") for tc in needs_confirm if tc.get("id")],
+                custom_tools=[tc.get("id") for tc in custom if tc.get("id")],
             )
-    else:
-        # No tool calls — the model's turn is done.
-        await sessions_service.set_session_status(
-            pool, session_id, "idle", stop_reason={"type": "end_turn"}, account_id=account_id
-        )
-        await _append_lifecycle(
-            pool, session_id, "turn_ended", "idle", "end_turn", account_id=account_id
-        )
-        log.info("step.turn_ended", session_id=session_id, cause=cause)
+
+    # Always flip to idle with ``end_turn`` at the end of a step body.
+    # "End of turn" here means the model's step concluded; pending tool
+    # calls (custom or unconfirmed always_ask) are observable via
+    # ``Session.awaiting``, derived from the event log on each read.
+    await sessions_service.set_session_status(
+        pool, session_id, "idle", stop_reason={"type": "end_turn"}, account_id=account_id
+    )
+    await _append_lifecycle(
+        pool, session_id, "turn_ended", "idle", "end_turn", account_id=account_id
+    )
+    log.info("step.turn_ended", session_id=session_id, cause=cause)
     return None
 
 
@@ -687,9 +660,9 @@ def _is_known_mcp_server(server_name: str, mcp_server_map: dict[str, str]) -> bo
 
     Used by :func:`_classify_tool_call` to short-circuit hallucinated
     tool names before the permission gate, so the model gets a tool
-    error in one turn instead of parking in ``requires_action`` forever
-    waiting on a confirmation that would surface as an unknown-server
-    tool error anyway.
+    error in one turn instead of leaving the call sitting unresolved
+    forever waiting on a confirmation that would surface as an
+    unknown-server tool error anyway.
     """
     return server_name in mcp_server_map
 
@@ -716,7 +689,7 @@ def _classify_tool_call(
       the call until the client posts a tool-result).
     * ``"unknown_mcp"`` — MCP-namespaced tool whose server is not
       registered.  Routed to immediate tool-error so the model can
-      self-correct rather than parking in ``requires_action``.
+      self-correct rather than leaving the call unresolved.
     """
     from aios.harness.tool_dispatch import _parse_arguments, _parse_mcp_tool_name
     from aios.tools.registry import registry as tool_registry

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -33,7 +33,12 @@ from aios.harness.sweep import find_sessions_needing_inference
 from aios.harness.tokens import approx_tokens
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
 from aios.logging import get_logger
-from aios.models.agents import PermissionPolicy, ToolSpec
+from aios.models.agents import (
+    PermissionPolicy,
+    is_mcp_tool_name,
+    resolve_mcp_permission,
+    resolve_permission,
+)
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
 from aios.services.wake import defer_wake
@@ -247,24 +252,12 @@ async def _run_session_step_body(
         log.debug("step.early_out", session_id=session_id, cause=cause)
         return None
 
-    session = await sessions_service.get_session(pool, session_id, account_id=account_id)
+    session = await sessions_service.get_session_basic(pool, session_id, account_id=account_id)
 
-    from aios.models.agents import Agent, AgentVersion
     from aios.services.channels import list_session_channels
 
-    agent_task: asyncio.Task[Agent | AgentVersion]
-    if session.agent_version is not None:
-        agent_task = asyncio.create_task(
-            agents_service.get_agent_version(
-                pool, session.agent_id, session.agent_version, account_id=account_id
-            )
-        )
-    else:
-        agent_task = asyncio.create_task(
-            agents_service.get_agent(pool, session.agent_id, account_id=account_id)
-        )
     agent, channels, memory_echoes = await asyncio.gather(
-        agent_task,
+        agents_service.load_for_session(pool, session, account_id=account_id),
         list_session_channels(pool, session_id, account_id=account_id),
         refresh_session_mount_state(pool, session_id, account_id=account_id),
     )
@@ -313,8 +306,8 @@ async def _run_session_step_body(
         task_registry=task_registry,
     )
     if pending:
-        pending_builtin = [tc for tc in pending if not _is_mcp_tool(_tc_name(tc))]
-        pending_mcp = [tc for tc in pending if _is_mcp_tool(_tc_name(tc))]
+        pending_builtin = [tc for tc in pending if not is_mcp_tool_name(_tc_name(tc))]
+        pending_mcp = [tc for tc in pending if is_mcp_tool_name(_tc_name(tc))]
         if pending_builtin:
             launch_tool_calls(pool, session_id, pending_builtin, account_id=account_id)
         if pending_mcp:
@@ -642,11 +635,6 @@ def _tc_name(tc: dict[str, Any]) -> str:
     return name
 
 
-def _is_mcp_tool(name: str) -> bool:
-    """Return True if the tool name is an MCP-namespaced tool."""
-    return name.startswith("mcp__")
-
-
 def _is_known_mcp_server(server_name: str, mcp_server_map: dict[str, str]) -> bool:
     """Return True if ``server_name`` resolves to a registered MCP server.
 
@@ -693,7 +681,7 @@ def _classify_tool_call(
     function = tool_call.get("function") or {}
     name: str = function.get("name") or ""
 
-    if _is_mcp_tool(name):
+    if is_mcp_tool_name(name):
         try:
             server_name, _ = _parse_mcp_tool_name(name)
         except ValueError:
@@ -735,33 +723,6 @@ def _classify_tool_call(
         return "needs_confirm"
 
     return "immediate"
-
-
-def resolve_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
-    """Look up the permission policy for a built-in or custom tool by name."""
-    for spec in agent_tools:
-        tool_name = spec.name if spec.type == "custom" else spec.type
-        if tool_name == name:
-            return spec.permission
-    return None
-
-
-def resolve_mcp_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
-    """Look up the permission policy for an MCP tool.
-
-    Finds the ``mcp_toolset`` entry whose ``mcp_server_name`` matches
-    the server portion of the namespaced tool name, then returns the
-    ``default_config.permission_policy.type`` or ``None`` (which callers
-    treat as ``always_ask``).
-    """
-    server_name = name.split("__", 2)[1]
-    for spec in agent_tools:
-        if spec.type == "mcp_toolset" and spec.mcp_server_name == server_name:
-            cfg = spec.default_config
-            if cfg and cfg.permission_policy:
-                return cfg.permission_policy.type
-            return spec.permission
-    return None
 
 
 async def discover_session_mcp_tools(

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -497,13 +497,11 @@ async def _run_session_step_body(
         pool, session_id, "message", assistant_msg, account_id=account_id
     )
 
-    # Partition the model's tool calls into dispatch buckets. Immediate
-    # builtin/MCP tools launch as asyncio tasks now; ``needs_confirm``
-    # (always_ask awaiting allow) and ``custom`` (client-executed) tool
-    # calls sit unresolved in the log until an external POST lands their
-    # result. The session is NOT parked: a new user message or any other
-    # stimulus can wake the session and the model sees pending tool calls
-    # via the synthesized placeholder in ``build_messages``.
+    # Partition tool calls into dispatch buckets. Immediate builtin/MCP
+    # launch now; ``needs_confirm`` and ``custom`` sit unresolved in the
+    # log until an external POST lands the result — the session ends its
+    # turn anyway and any stimulus can wake it (``Session.awaiting``
+    # surfaces what's still pending).
     tool_calls: list[dict[str, Any]] = assistant_msg.get("tool_calls") or []
 
     if tool_calls:
@@ -566,10 +564,8 @@ async def _run_session_step_body(
                 custom_tools=[tc.get("id") for tc in custom if tc.get("id")],
             )
 
-    # Always flip to idle with ``end_turn`` at the end of a step body.
-    # "End of turn" here means the model's step concluded; pending tool
-    # calls (custom or unconfirmed always_ask) are observable via
-    # ``Session.awaiting``, derived from the event log on each read.
+    # End-of-turn is unconditional; pending tool calls live on
+    # ``Session.awaiting`` (derived from the event log per read).
     await sessions_service.set_session_status(
         pool, session_id, "idle", stop_reason={"type": "end_turn"}, account_id=account_id
     )

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -183,10 +183,11 @@ async def compute_step_prelude(
 
     # Custom tools declared on connections attached to this session
     # (single_session, per_chat origin, or operator-bound chat).  Each
-    # entry is dispatched via the requires_action / tool-results flow —
-    # the connector executes externally and POSTs the result back (#301).
-    # Resolved via the ``ToolProvider`` Protocol (#328) so the harness
-    # doesn't import connector-subsystem code directly.
+    # entry sits unresolved in the event log until the connector
+    # executes it externally and POSTs the result back via
+    # ``/tool-results`` (#301).  Resolved via the ``ToolProvider``
+    # Protocol (#328) so the harness doesn't import connector-subsystem
+    # code directly.
     from aios.harness import runtime as harness_runtime
     from aios.models.agents import ToolSpec
 
@@ -268,11 +269,17 @@ async def compose_step_context(
     channels: list[str],
     prelude: StepPrelude,
     events: list[Event],
+    in_flight_tool_call_ids: frozenset[str] = frozenset(),
 ) -> StepContext:
     """Compose the chat-completions payload for a step.
 
     Takes a prelude built by :func:`compute_step_prelude` and the
     windowed events slate; glues them into the final message list.
+
+    ``in_flight_tool_call_ids`` selects the pending placeholder variant
+    for each unresolved tool_call. Background-executing tasks get the
+    "still executing in the background" wording; everything else
+    (custom, awaiting-confirm) gets the "external action" wording.
     """
     from aios.harness.channels import build_channels_tail_block
 
@@ -281,6 +288,7 @@ async def compose_step_context(
         system_prompt=prelude.system_prompt,
         model=agent.model,
         session_id=session.id,
+        in_flight_tool_call_ids=in_flight_tool_call_ids,
     )
 
     # Tail block lives *after* build_messages so its per-step mutations

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -318,13 +318,16 @@ def _was_dispatched(
     ghost. A tool that was never dispatched (custom, or unconfirmed
     ``always_ask``) is legitimately waiting for the client.
 
-    Uses the same permission resolution as the step function
-    (``resolve_permission`` / ``resolve_mcp_permission`` from loop.py).
+    Uses the same permission resolution as the step function.
     """
-    from aios.harness.loop import resolve_mcp_permission, resolve_permission
+    from aios.models.agents import (
+        is_mcp_tool_name,
+        resolve_mcp_permission,
+        resolve_permission,
+    )
     from aios.tools.registry import registry
 
-    if name.startswith("mcp__"):
+    if is_mcp_tool_name(name):
         perm = resolve_mcp_permission(name, agent_tools)
         if perm == "always_allow":
             return True

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -164,11 +164,8 @@ async def worker_main() -> None:
                 repaired_ghosts=sweep.repaired_ghosts,
             )
 
-        # Reap every managed container from a prior worker run — at
-        # startup the task_registry is empty, so all surviving containers
-        # are corpses. Resuming sessions spawn fresh containers on their
-        # next step.
-        reaped = await sandbox_registry.reap_orphans([])
+        # Reap orphaned sandbox containers from prior worker runs.
+        reaped = await sandbox_registry.reap_orphans()
         if reaped:
             log.info("worker.reaped_orphan_containers", count=reaped)
 

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -164,11 +164,10 @@ async def worker_main() -> None:
                 repaired_ghosts=sweep.repaired_ghosts,
             )
 
-        # Reap orphaned sandbox containers. At startup the task_registry
-        # is empty by construction — no step or tool task has run yet —
-        # so every managed container surviving from a prior worker run is
-        # a corpse. Sessions that will resume on this worker spawn fresh
-        # containers on their first step.
+        # Reap every managed container from a prior worker run — at
+        # startup the task_registry is empty, so all surviving containers
+        # are corpses. Resuming sessions spawn fresh containers on their
+        # next step.
         reaped = await sandbox_registry.reap_orphans([])
         if reaped:
             log.info("worker.reaped_orphan_containers", count=reaped)

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -33,7 +33,6 @@ import asyncpg
 import aios.tools  # noqa: F401  — side-effect: register built-in tools
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
-from aios.db import queries
 from aios.db.listen import listen_for_session_interrupts
 from aios.db.pool import create_pool, normalize_dsn
 from aios.harness import runtime
@@ -165,10 +164,12 @@ async def worker_main() -> None:
                 repaired_ghosts=sweep.repaired_ghosts,
             )
 
-        # Reap orphaned sandbox containers.
-        async with pool.acquire() as conn:
-            active_session_ids = await queries.list_running_session_ids(conn)
-        reaped = await sandbox_registry.reap_orphans(active_session_ids)
+        # Reap orphaned sandbox containers. At startup the task_registry
+        # is empty by construction — no step or tool task has run yet —
+        # so every managed container surviving from a prior worker run is
+        # a corpse. Sessions that will resume on this worker spawn fresh
+        # containers on their first step.
+        reaped = await sandbox_registry.reap_orphans([])
         if reaped:
             log.info("worker.reaped_orphan_containers", count=reaped)
 

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -111,8 +111,9 @@ class HttpRouteSpec(BaseModel):
     segment, ``**`` matches any number of segments).  ``description`` is
     operator-authored prose rendered into the system prompt so the agent
     knows what the route does and how to call it.  ``permission_policy``
-    gates *invocation*: ``always_ask`` parks the call in
-    ``requires_action`` until the client confirms.
+    gates *invocation*: ``always_ask`` leaves the call unresolved in the
+    event log until the client confirms via
+    ``POST /sessions/:id/tool-confirmations``.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -160,8 +161,10 @@ class ToolSpec(BaseModel):
 
     ``permission`` controls execution policy for built-in tools:
     ``None`` or ``"always_allow"`` executes immediately (current default);
-    ``"always_ask"`` idles the session with ``requires_action`` until the
-    client confirms or denies.
+    ``"always_ask"`` leaves the call unresolved in the event log until
+    the client confirms or denies via
+    ``POST /sessions/:id/tool-confirmations``. Pending calls surface on
+    ``Session.awaiting`` so clients can list what they need to act on.
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -294,3 +294,38 @@ class AgentVersion(BaseModel):
     window_min: int
     window_max: int
     created_at: datetime
+
+
+# ── Tool-name + permission helpers ───────────────────────────────────────────
+
+
+def is_mcp_tool_name(name: str) -> bool:
+    """True if ``name`` is the namespaced form ``mcp__<server>__<tool>``."""
+    return name.startswith("mcp__")
+
+
+def resolve_permission(name: str, agent_tools: list[ToolSpec]) -> PermissionPolicy | None:
+    """Look up the permission policy for a built-in or custom tool by name."""
+    for spec in agent_tools:
+        tool_name = spec.name if spec.type == "custom" else spec.type
+        if tool_name == name:
+            return spec.permission
+    return None
+
+
+def resolve_mcp_permission(name: str, agent_tools: list[ToolSpec]) -> PermissionPolicy | None:
+    """Look up the permission policy for an MCP tool by namespaced name.
+
+    Returns the matched ``mcp_toolset`` entry's
+    ``default_config.permission_policy.type`` (or its bare ``permission``
+    if no policy is set), or ``None`` if no entry matches. ``None``
+    callers fall back to ``AIOS_DEFAULT_MCP_PERMISSION_POLICY``.
+    """
+    server_name = name.split("__", 2)[1]
+    for spec in agent_tools:
+        if spec.type == "mcp_toolset" and spec.mcp_server_name == server_name:
+            cfg = spec.default_config
+            if cfg and cfg.permission_policy:
+                return cfg.permission_policy.type
+            return spec.permission
+    return None

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -200,8 +200,8 @@ class Session(BaseModel):
 
     ``stop_reason`` records why the most recent step ended. Possible
     ``type`` values: ``"end_turn"``, ``"interrupt"``, ``"rescheduling"``,
-    ``"error"``. To find tool calls the session is blocked on, read
-    ``awaiting`` (derived per read from the event log + task_registry).
+    ``"error"``. ``awaiting`` lists tool calls the session is blocked
+    on (derived per read from the event log + agent tool specs).
     """
 
     id: str

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -83,21 +83,22 @@ class SessionUsage(BaseModel):
 class AwaitingToolCall(BaseModel):
     """One pending tool call the harness will not dispatch itself.
 
-    Derived view on session reads: each entry is a tool_call in the
-    latest assistant message that has no paired tool_result event and
-    no in-process executor. Two flavors share this state:
+    Derived view on session reads. Each entry is a tool_call in the
+    latest assistant message with no paired tool_result and no
+    in-process executor:
 
-    * ``kind == "custom"`` — client-executed; awaits a POST to
+    * ``kind == "custom"`` — client-executed; awaits POST to
       ``/sessions/:id/tool-results`` (operator-facing) or
       ``/connectors/runtime/tool-results`` (runtime-container-facing).
-    * ``kind == "builtin" | "mcp"`` with ``needs_confirm=True`` —
-      ``always_ask``-gated; awaits a POST to ``/sessions/:id/tool-confirmations``.
+    * ``kind == "builtin" | "mcp"`` — ``always_ask``-gated and not yet
+      confirmed; awaits POST to ``/sessions/:id/tool-confirmations``.
+      Confirmed-but-not-yet-dispatched and ``always_allow`` calls don't
+      appear here — they're harness-internal.
     """
 
     tool_call_id: str
     name: str
     kind: Literal["builtin", "mcp", "custom"]
-    needs_confirm: bool
 
 
 class SessionCreate(BaseModel):

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -66,7 +66,7 @@ def _validate_session_resources(resources: list[SessionResource]) -> None:
     _validate_github_resources(github)
 
 
-SessionStatus = Literal["pending", "running", "idle", "rescheduling", "errored", "terminated"]
+SessionStatus = Literal["pending", "idle", "rescheduling", "errored", "terminated"]
 
 MAX_USER_MESSAGE_CHARS = 1_000_000
 
@@ -78,6 +78,26 @@ class SessionUsage(BaseModel):
     output_tokens: int = 0
     cache_read_input_tokens: int = 0
     cache_creation_input_tokens: int = 0
+
+
+class AwaitingToolCall(BaseModel):
+    """One pending tool call the harness will not dispatch itself.
+
+    Derived view on session reads: each entry is a tool_call in the
+    latest assistant message that has no paired tool_result event and
+    no in-process executor. Two flavors share this state:
+
+    * ``kind == "custom"`` — client-executed; awaits a POST to
+      ``/sessions/:id/tool-results`` (operator-facing) or
+      ``/connectors/runtime/tool-results`` (runtime-container-facing).
+    * ``kind == "builtin" | "mcp"`` with ``needs_confirm=True`` —
+      ``always_ask``-gated; awaits a POST to ``/sessions/:id/tool-confirmations``.
+    """
+
+    tool_call_id: str
+    name: str
+    kind: Literal["builtin", "mcp", "custom"]
+    needs_confirm: bool
 
 
 class SessionCreate(BaseModel):
@@ -176,7 +196,13 @@ class SessionUpdate(BaseModel):
 
 
 class Session(BaseModel):
-    """Read view of a session. Internal-only columns are not exposed."""
+    """Read view of a session. Internal-only columns are not exposed.
+
+    ``stop_reason`` records why the most recent step ended. Possible
+    ``type`` values: ``"end_turn"``, ``"interrupt"``, ``"rescheduling"``,
+    ``"error"``. To find tool calls the session is blocked on, read
+    ``awaiting`` (derived per read from the event log + task_registry).
+    """
 
     id: str
     agent_id: str
@@ -186,6 +212,7 @@ class Session(BaseModel):
     metadata: dict[str, Any]
     status: SessionStatus
     stop_reason: dict[str, Any] | None
+    awaiting: list[AwaitingToolCall] = Field(default_factory=list)
     vault_ids: list[str] = Field(default_factory=list)
     last_event_seq: int
     usage: SessionUsage = Field(default_factory=SessionUsage)
@@ -269,6 +296,7 @@ class WaitResponse(BaseModel):
     events: list[Event]
     session_status: SessionStatus
     session_stop_reason: dict[str, Any] | None
+    session_awaiting: list[AwaitingToolCall] = Field(default_factory=list)
     next_after: int
 
 

--- a/src/aios/sandbox/mcp_proxy.py
+++ b/src/aios/sandbox/mcp_proxy.py
@@ -302,12 +302,8 @@ class McpBroker:
 
         pool = runtime.require_pool()
         account_id = await sessions_service.load_session_account_id(pool, session_id)
-        session = await sessions_service.get_session(pool, session_id, account_id=account_id)
-        if session.agent_version is not None:
-            return await agents_service.get_agent_version(
-                pool, session.agent_id, session.agent_version, account_id=account_id
-            )
-        return await agents_service.get_agent(pool, session.agent_id, account_id=account_id)
+        session = await sessions_service.get_session_basic(pool, session_id, account_id=account_id)
+        return await agents_service.load_for_session(pool, session, account_id=account_id)
 
     async def _load_auth_for(
         self, session_id: str, server_url: str

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 from aios.logging import get_logger
@@ -449,8 +448,15 @@ class SandboxRegistry:
                     error=str(result),
                 )
 
-    async def reap_orphans(self, active_session_ids: Iterable[str]) -> int:
-        """At startup, remove sandboxes not matching an active session."""
+    async def reap_orphans(self) -> int:
+        """At startup, remove every sandbox we manage.
+
+        Called once per worker boot, before any step or tool task runs;
+        the worker's ``task_registry`` is empty by construction, so every
+        managed container is a corpse from a prior run. Sessions that
+        resume on this worker will spawn fresh containers on their next
+        step.
+        """
         from aios.config import get_settings
 
         instance_id = get_settings().instance_id
@@ -462,11 +468,8 @@ class SandboxRegistry:
         if not managed:
             return 0
 
-        active = set(active_session_ids)
         removed = 0
         for ref in managed:
-            if ref.session_id and ref.session_id in active:
-                continue
             log.info(
                 "sandbox.reap_orphan",
                 container_id=ref.sandbox_id[:12],

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -131,6 +131,21 @@ async def get_agent_version(
         return await queries.get_agent_version(conn, agent_id, version, account_id=account_id)
 
 
+async def load_for_session(
+    pool: asyncpg.Pool[Any], session: Any, *, account_id: str
+) -> Agent | AgentVersion:
+    """Load the Agent / AgentVersion the harness sees for ``session`` at step time.
+
+    ``session.agent_version is None`` means "latest" — fetches the
+    current ``Agent``; an integer pins to a specific ``AgentVersion``.
+    """
+    if session.agent_version is not None:
+        return await get_agent_version(
+            pool, session.agent_id, session.agent_version, account_id=account_id
+        )
+    return await get_agent(pool, session.agent_id, account_id=account_id)
+
+
 async def list_agent_versions(
     pool: asyncpg.Pool[Any],
     agent_id: str,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -18,9 +18,11 @@ import asyncpg
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.errors import ConflictError, NotFoundError, PayloadTooLargeError
+from aios.models.agents import ToolSpec
 from aios.models.events import Event, EventKind
 from aios.models.sessions import (
     MAX_USER_MESSAGE_CHARS,
+    AwaitingToolCall,
     Session,
     SessionResource,
     SessionResourceEcho,
@@ -28,6 +30,7 @@ from aios.models.sessions import (
     split_resources_by_type,
 )
 from aios.sandbox.volumes import validate_workspace_path
+from aios.services import agents as agents_service
 from aios.services import github_repositories as github_repo_service
 from aios.services import memory_stores as memory_service
 
@@ -133,12 +136,138 @@ async def create_session(
         return session
 
 
+def _classify_awaiting(
+    name: str,
+    tool_call_id: str,
+    has_allow_lifecycle: bool,
+    agent_tools: list[ToolSpec],
+) -> AwaitingToolCall | None:
+    """Classify an unresolved tool_call into an ``AwaitingToolCall``, or
+    ``None`` if it does not represent a session blocked on external action.
+
+    Returns ``None`` for:
+    * builtin/mcp tools with ``always_allow`` permission — these are
+      executed by the worker; an unresolved one is either in-flight or
+      a ghost the sweep will repair.
+    * builtin/mcp tools with ``always_ask`` permission that already
+      have a ``tool_confirmed allow`` lifecycle event — these are just
+      awaiting the next step's dispatch, not external action.
+    """
+    # Late import to avoid a registration-time cycle: aios.tools.__init__
+    # imports schedule_wake, which imports services.wake, which imports
+    # services.sessions.  A top-level import here would close the loop.
+    from aios.tools.registry import registry as tool_registry
+
+    if name.startswith("mcp__"):
+        perm = _resolve_mcp_permission(name, agent_tools)
+        if perm == "always_ask" and not has_allow_lifecycle:
+            return AwaitingToolCall(
+                tool_call_id=tool_call_id, name=name, kind="mcp", needs_confirm=True
+            )
+        return None
+    if tool_registry.has(name):
+        perm = _resolve_builtin_permission(name, agent_tools)
+        if perm == "always_ask" and not has_allow_lifecycle:
+            return AwaitingToolCall(
+                tool_call_id=tool_call_id, name=name, kind="builtin", needs_confirm=True
+            )
+        return None
+    # Unknown name: classified as custom by the harness too. Always
+    # awaiting client execution; ``needs_confirm`` is meaningless for
+    # custom tools (they don't go through the confirmation gate).
+    return AwaitingToolCall(
+        tool_call_id=tool_call_id, name=name, kind="custom", needs_confirm=False
+    )
+
+
+def _resolve_builtin_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
+    for spec in agent_tools:
+        if spec.type == name:
+            return spec.permission
+    return None
+
+
+def _resolve_mcp_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
+    """Look up the permission policy for an MCP tool name.
+
+    Mirrors :func:`aios.harness.loop.resolve_mcp_permission` so the
+    awaiting view classifies tools the same way the dispatcher does.
+    """
+    server_name = name.split("__", 2)[1] if "__" in name else ""
+    for spec in agent_tools:
+        if spec.type == "mcp_toolset" and spec.mcp_server_name == server_name:
+            cfg = spec.default_config
+            if cfg and cfg.permission_policy:
+                return cfg.permission_policy.type
+            return spec.permission
+    return None
+
+
+async def _agent_tools_for_session(
+    pool: asyncpg.Pool[Any], session: Session, *, account_id: str
+) -> list[ToolSpec]:
+    """Load the ToolSpec list the harness sees for ``session`` at step time."""
+    if session.agent_version is not None:
+        version = await agents_service.get_agent_version(
+            pool, session.agent_id, session.agent_version, account_id=account_id
+        )
+        return version.tools
+    agent = await agents_service.get_agent(pool, session.agent_id, account_id=account_id)
+    return agent.tools
+
+
+async def compute_awaiting(
+    pool: asyncpg.Pool[Any], sessions: list[Session], *, account_id: str
+) -> dict[str, list[AwaitingToolCall]]:
+    """Compute the ``awaiting`` view for a batch of sessions.
+
+    One SQL round-trip for unresolved tool_calls across the batch, then
+    one agent load per distinct (agent_id, agent_version) pair, then
+    in-memory classification.
+    """
+    if not sessions:
+        return {}
+    async with pool.acquire() as conn:
+        unresolved_by_sid = await queries.list_unresolved_tool_calls_batch(
+            conn, [s.id for s in sessions], account_id=account_id
+        )
+    if not unresolved_by_sid:
+        return {}
+    sessions_with_pending = [s for s in sessions if s.id in unresolved_by_sid]
+    agent_tools_cache: dict[tuple[str, int | None], list[ToolSpec]] = {}
+    out: dict[str, list[AwaitingToolCall]] = {}
+    for session in sessions_with_pending:
+        key = (session.agent_id, session.agent_version)
+        if key not in agent_tools_cache:
+            agent_tools_cache[key] = await _agent_tools_for_session(
+                pool, session, account_id=account_id
+            )
+        tools = agent_tools_cache[key]
+        entries: list[AwaitingToolCall] = []
+        for tc in unresolved_by_sid[session.id]:
+            classified = _classify_awaiting(
+                tc["name"], tc["tool_call_id"], tc["has_allow_lifecycle"], tools
+            )
+            if classified is not None:
+                entries.append(classified)
+        if entries:
+            out[session.id] = entries
+    return out
+
+
 async def get_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: str) -> Session:
     async with pool.acquire() as conn:
         session = await queries.get_session(conn, session_id, account_id=account_id)
         vault_ids = await queries.get_session_vault_ids(conn, session_id, account_id=account_id)
         echoes = await _list_all_echoes(conn, session_id, account_id=account_id)
-        return session.model_copy(update={"vault_ids": vault_ids, "resources": echoes})
+    awaiting_by_sid = await compute_awaiting(pool, [session], account_id=account_id)
+    return session.model_copy(
+        update={
+            "vault_ids": vault_ids,
+            "resources": echoes,
+            "awaiting": awaiting_by_sid.get(session_id, []),
+        }
+    )
 
 
 async def get_session_event_stats(
@@ -167,23 +296,25 @@ async def list_sessions(
         sessions = await queries.list_sessions(
             conn, agent_id=agent_id, status=status, limit=limit, after=after, account_id=account_id
         )
-        if sessions:
-            vault_map = await queries.batch_get_session_vault_ids(
-                conn, [s.id for s in sessions], account_id=account_id
-            )
-            enriched: list[Session] = []
-            for s in sessions:
-                echoes = await _list_all_echoes(conn, s.id, account_id=account_id)
-                enriched.append(
-                    s.model_copy(
-                        update={
-                            "vault_ids": vault_map.get(s.id, []),
-                            "resources": echoes,
-                        }
-                    )
-                )
-            sessions = enriched
-        return sessions
+        if not sessions:
+            return sessions
+        vault_map = await queries.batch_get_session_vault_ids(
+            conn, [s.id for s in sessions], account_id=account_id
+        )
+        echoes_by_sid: dict[str, list[SessionResourceEcho]] = {}
+        for s in sessions:
+            echoes_by_sid[s.id] = await _list_all_echoes(conn, s.id, account_id=account_id)
+    awaiting_by_sid = await compute_awaiting(pool, sessions, account_id=account_id)
+    return [
+        s.model_copy(
+            update={
+                "vault_ids": vault_map.get(s.id, []),
+                "resources": echoes_by_sid.get(s.id, []),
+                "awaiting": awaiting_by_sid.get(s.id, []),
+            }
+        )
+        for s in sessions
+    ]
 
 
 async def append_user_message(

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -143,57 +143,36 @@ def _classify_awaiting(
     agent_tools: list[ToolSpec],
 ) -> AwaitingToolCall | None:
     """Classify an unresolved tool_call into an ``AwaitingToolCall``, or
-    ``None`` if it does not represent a session blocked on external action.
-
-    Returns ``None`` for:
-    * builtin/mcp tools with ``always_allow`` permission — these are
-      executed by the worker; an unresolved one is either in-flight or
-      a ghost the sweep will repair.
-    * builtin/mcp tools with ``always_ask`` permission that already
-      have a ``tool_confirmed allow`` lifecycle event — these are just
-      awaiting the next step's dispatch, not external action.
+    ``None`` if the session is not blocked on external action for it
+    (``always_allow`` builtin/mcp, or ``always_ask`` already confirmed).
     """
-    # Late import to avoid a registration-time cycle: aios.tools.__init__
-    # imports schedule_wake, which imports services.wake, which imports
-    # services.sessions.  A top-level import here would close the loop.
+    # Late import: aios.tools → services.wake → services.sessions cycle.
     from aios.tools.registry import registry as tool_registry
 
     if name.startswith("mcp__"):
-        perm = _resolve_mcp_permission(name, agent_tools)
-        if perm == "always_ask" and not has_allow_lifecycle:
+        if _mcp_permission(name, agent_tools) == "always_ask" and not has_allow_lifecycle:
             return AwaitingToolCall(
                 tool_call_id=tool_call_id, name=name, kind="mcp", needs_confirm=True
             )
         return None
     if tool_registry.has(name):
-        perm = _resolve_builtin_permission(name, agent_tools)
-        if perm == "always_ask" and not has_allow_lifecycle:
+        builtin_perm = next((s.permission for s in agent_tools if s.type == name), None)
+        if builtin_perm == "always_ask" and not has_allow_lifecycle:
             return AwaitingToolCall(
                 tool_call_id=tool_call_id, name=name, kind="builtin", needs_confirm=True
             )
         return None
-    # Unknown name: classified as custom by the harness too. Always
-    # awaiting client execution; ``needs_confirm`` is meaningless for
-    # custom tools (they don't go through the confirmation gate).
+    # Unknown name: client-executed custom tool. ``needs_confirm`` is
+    # meaningless for custom tools — they don't go through the gate.
     return AwaitingToolCall(
         tool_call_id=tool_call_id, name=name, kind="custom", needs_confirm=False
     )
 
 
-def _resolve_builtin_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
-    for spec in agent_tools:
-        if spec.type == name:
-            return spec.permission
-    return None
-
-
-def _resolve_mcp_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
-    """Look up the permission policy for an MCP tool name.
-
-    Mirrors :func:`aios.harness.loop.resolve_mcp_permission` so the
-    awaiting view classifies tools the same way the dispatcher does.
-    """
-    server_name = name.split("__", 2)[1] if "__" in name else ""
+def _mcp_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
+    """Look up the permission policy for an ``mcp__`` tool name. Mirrors
+    :func:`aios.harness.loop.resolve_mcp_permission`."""
+    server_name = name.split("__", 2)[1]
     for spec in agent_tools:
         if spec.type == "mcp_toolset" and spec.mcp_server_name == server_name:
             cfg = spec.default_config
@@ -233,20 +212,19 @@ async def compute_awaiting(
         )
     if not unresolved_by_sid:
         return {}
-    sessions_with_pending = [s for s in sessions if s.id in unresolved_by_sid]
-    agent_tools_cache: dict[tuple[str, int | None], list[ToolSpec]] = {}
+    tools_cache: dict[tuple[str, int | None], list[ToolSpec]] = {}
     out: dict[str, list[AwaitingToolCall]] = {}
-    for session in sessions_with_pending:
+    for session in sessions:
+        unresolved = unresolved_by_sid.get(session.id)
+        if not unresolved:
+            continue
         key = (session.agent_id, session.agent_version)
-        if key not in agent_tools_cache:
-            agent_tools_cache[key] = await _agent_tools_for_session(
-                pool, session, account_id=account_id
-            )
-        tools = agent_tools_cache[key]
+        if key not in tools_cache:
+            tools_cache[key] = await _agent_tools_for_session(pool, session, account_id=account_id)
         entries: list[AwaitingToolCall] = []
-        for tc in unresolved_by_sid[session.id]:
+        for tc in unresolved:
             classified = _classify_awaiting(
-                tc["name"], tc["tool_call_id"], tc["has_allow_lifecycle"], tools
+                tc["name"], tc["tool_call_id"], tc["has_allow_lifecycle"], tools_cache[key]
             )
             if classified is not None:
                 entries.append(classified)

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -18,7 +18,12 @@ import asyncpg
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.errors import ConflictError, NotFoundError, PayloadTooLargeError
-from aios.models.agents import ToolSpec
+from aios.models.agents import (
+    ToolSpec,
+    is_mcp_tool_name,
+    resolve_mcp_permission,
+    resolve_permission,
+)
 from aios.models.events import Event, EventKind
 from aios.models.sessions import (
     MAX_USER_MESSAGE_CHARS,
@@ -145,54 +150,27 @@ def _classify_awaiting(
     """Classify an unresolved tool_call into an ``AwaitingToolCall``, or
     ``None`` if the session is not blocked on external action for it
     (``always_allow`` builtin/mcp, or ``always_ask`` already confirmed).
+
+    Mirrors :func:`aios.harness.loop._classify_tool_call`'s dispatch
+    rules so the view stays consistent with what the harness will do.
     """
     # Late import: aios.tools → services.wake → services.sessions cycle.
+    from aios.config import get_settings
     from aios.tools.registry import registry as tool_registry
 
-    if name.startswith("mcp__"):
-        if _mcp_permission(name, agent_tools) == "always_ask" and not has_allow_lifecycle:
-            return AwaitingToolCall(
-                tool_call_id=tool_call_id, name=name, kind="mcp", needs_confirm=True
-            )
+    if is_mcp_tool_name(name):
+        perm = resolve_mcp_permission(name, agent_tools)
+        if perm is None:
+            perm = get_settings().default_mcp_permission_policy
+        if perm == "always_ask" and not has_allow_lifecycle:
+            return AwaitingToolCall(tool_call_id=tool_call_id, name=name, kind="mcp")
         return None
     if tool_registry.has(name):
-        builtin_perm = next((s.permission for s in agent_tools if s.type == name), None)
-        if builtin_perm == "always_ask" and not has_allow_lifecycle:
-            return AwaitingToolCall(
-                tool_call_id=tool_call_id, name=name, kind="builtin", needs_confirm=True
-            )
+        if resolve_permission(name, agent_tools) == "always_ask" and not has_allow_lifecycle:
+            return AwaitingToolCall(tool_call_id=tool_call_id, name=name, kind="builtin")
         return None
-    # Unknown name: client-executed custom tool. ``needs_confirm`` is
-    # meaningless for custom tools — they don't go through the gate.
-    return AwaitingToolCall(
-        tool_call_id=tool_call_id, name=name, kind="custom", needs_confirm=False
-    )
-
-
-def _mcp_permission(name: str, agent_tools: list[ToolSpec]) -> str | None:
-    """Look up the permission policy for an ``mcp__`` tool name. Mirrors
-    :func:`aios.harness.loop.resolve_mcp_permission`."""
-    server_name = name.split("__", 2)[1]
-    for spec in agent_tools:
-        if spec.type == "mcp_toolset" and spec.mcp_server_name == server_name:
-            cfg = spec.default_config
-            if cfg and cfg.permission_policy:
-                return cfg.permission_policy.type
-            return spec.permission
-    return None
-
-
-async def _agent_tools_for_session(
-    pool: asyncpg.Pool[Any], session: Session, *, account_id: str
-) -> list[ToolSpec]:
-    """Load the ToolSpec list the harness sees for ``session`` at step time."""
-    if session.agent_version is not None:
-        version = await agents_service.get_agent_version(
-            pool, session.agent_id, session.agent_version, account_id=account_id
-        )
-        return version.tools
-    agent = await agents_service.get_agent(pool, session.agent_id, account_id=account_id)
-    return agent.tools
+    # Unknown name: client-executed custom tool.
+    return AwaitingToolCall(tool_call_id=tool_call_id, name=name, kind="custom")
 
 
 async def compute_awaiting(
@@ -220,7 +198,8 @@ async def compute_awaiting(
             continue
         key = (session.agent_id, session.agent_version)
         if key not in tools_cache:
-            tools_cache[key] = await _agent_tools_for_session(pool, session, account_id=account_id)
+            loaded = await agents_service.load_for_session(pool, session, account_id=account_id)
+            tools_cache[key] = loaded.tools
         entries: list[AwaitingToolCall] = []
         for tc in unresolved:
             classified = _classify_awaiting(
@@ -246,6 +225,19 @@ async def get_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: s
             "awaiting": awaiting_by_sid.get(session_id, []),
         }
     )
+
+
+async def get_session_basic(
+    pool: asyncpg.Pool[Any], session_id: str, *, account_id: str
+) -> Session:
+    """Bare session read with no enrichment (no vaults / resources / awaiting).
+
+    Use this when the caller reads only core columns — the worker step
+    path (``agent_id``, ``agent_version``, ``focal_channel``) and the
+    long-poll wait endpoint's existence check.
+    """
+    async with pool.acquire() as conn:
+        return await queries.get_session(conn, session_id, account_id=account_id)
 
 
 async def get_session_event_stats(

--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -176,13 +176,8 @@ def _classify_permission(
 async def _load_session_agent(session_id: str) -> tuple[Agent | AgentVersion, str]:
     pool = runtime.require_pool()
     account_id = await sessions_service.load_session_account_id(pool, session_id)
-    session = await sessions_service.get_session(pool, session_id, account_id=account_id)
-    if session.agent_version is not None:
-        agent: Agent | AgentVersion = await agents_service.get_agent_version(
-            pool, session.agent_id, session.agent_version, account_id=account_id
-        )
-    else:
-        agent = await agents_service.get_agent(pool, session.agent_id, account_id=account_id)
+    session = await sessions_service.get_session_basic(pool, session_id, account_id=account_id)
+    agent = await agents_service.load_for_session(pool, session, account_id=account_id)
     return agent, account_id
 
 

--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -151,7 +151,8 @@ def _classify_permission(
     """Per-route permission lookup for the dispatch gate.
 
     Returns the matched route's ``permission_policy`` so the harness can
-    park the call in ``requires_action`` if the operator marked it
+    leave the call unresolved (pending confirmation via
+    ``POST /sessions/:id/tool-confirmations``) if the operator marked it
     ``always_ask``. Returns ``None`` for missing server / no route match
     / bad args / query-or-fragment-bearing / dot-segment-bearing path —
     the handler then runs and emits a typed error the model can

--- a/tests/e2e/test_connection_tools.py
+++ b/tests/e2e/test_connection_tools.py
@@ -4,14 +4,15 @@ Connections can carry a ``tools`` jsonb column (migration 0029).  When a
 session has connections attached — single_session, per_chat origin, or
 operator-bound chat — the connection's ``type="custom"`` tools are
 merged into the model's tool list at step time.  The model calls them,
-the session parks in ``requires_action``, an external client (a
-connector container) executes the tool and POSTs the result back.
+the tool_call sits unresolved in the event log (visible on
+``Session.awaiting``), an external client (a connector container)
+executes the tool and POSTs the result back.
 
 This file pins the contract end-to-end with the real harness:
 
 * Tools are sourced via ``services.connections.list_tools_for_session``.
 * Step prelude includes them alongside agent + MCP + connector-subprocess tools.
-* The standard custom-tool flow (requires_action → tool-results → resume)
+* The custom-tool flow (model calls → awaiting → tool-results → resume)
   works regardless of whether the tool came from an agent or a connection.
 * Multimodal tool-result content (``list[dict]``) flows through ``POST
   /v1/sessions/:id/tool-results`` intact.
@@ -227,7 +228,7 @@ class TestConnectionToolsInPrelude:
 
 @needs_docker
 class TestConnectionToolDispatch:
-    """Full requires_action round-trip with a connection-sourced tool."""
+    """Full ``awaiting``→ tool-result → resume round-trip with a connection-sourced tool."""
 
     async def test_model_calls_connection_tool_then_resumes_after_result(
         self, harness: Harness, crypto_box: CryptoBox
@@ -303,13 +304,13 @@ class TestConnectionToolDispatch:
             harness._pool, session.id, "say hi", account_id=account_id
         )
 
-        # Step 1: model calls chat_send → session parks in requires_action.
+        # Step 1: model calls chat_send → call appears in session.awaiting.
         await harness.run_step(session.id)
         s = await harness.session(session.id)
         assert s.status == "idle"
-        assert s.stop_reason is not None
-        assert s.stop_reason["type"] == "requires_action"
-        assert "cs_1" in (s.stop_reason.get("custom_tools") or [])
+        assert s.stop_reason == {"type": "end_turn"}
+        assert {a.tool_call_id for a in s.awaiting} == {"cs_1"}
+        assert s.awaiting[0].kind == "custom"
 
         # External client (the connector container, in production) POSTs the result.
         await sess_svc.append_event(

--- a/tests/e2e/test_echo_http_connector.py
+++ b/tests/e2e/test_echo_http_connector.py
@@ -138,6 +138,9 @@ class TestSdkAgainstLiveServer:
         token = await issue_runtime_token(api_key, live_server, "echo")
 
         # Pre-seed a pending call so backfill has something to deliver.
+        # The connector backfill scans the event log directly: an assistant
+        # event with a tool_call that has no paired tool_result and whose
+        # name is in connector.tools_schema is sufficient.
         await sess_svc.append_event(
             harness._pool,
             session.id,
@@ -152,17 +155,6 @@ class TestSdkAgainstLiveServer:
                         "function": {"name": "ping", "arguments": "{}"},
                     }
                 ],
-            },
-            account_id=account_id,
-        )
-        await sess_svc.set_session_status(
-            harness._pool,
-            session.id,
-            "idle",
-            stop_reason={
-                "type": "requires_action",
-                "event_ids": ["call_sse_bf"],
-                "custom_tools": ["call_sse_bf"],
             },
             account_id=account_id,
         )
@@ -248,8 +240,8 @@ class TestEchoHttpConnectorEndToEnd:
 
         connector_task = asyncio.create_task(connector.run())
         try:
-            # Step 1: model calls echo → session parks in requires_action,
-            # which fires connector_calls NOTIFY → connector receives via SSE
+            # Step 1: model calls echo → assistant message lands → append_event
+            # fires connector_calls NOTIFY → connector receives via SSE
             # → connector posts tool_result.
             await harness.run_step(session.id)
 

--- a/tests/e2e/test_session_clone.py
+++ b/tests/e2e/test_session_clone.py
@@ -166,18 +166,6 @@ class TestCloneBasic:
 
 
 class TestCloneRefusal:
-    async def test_refuses_running_parent(
-        self, http_client: httpx.AsyncClient, pool: Any, parent_session_id: str
-    ) -> None:
-        account_id = "acc_test_stub"  # PR 3 scaffolding
-        from aios.services import sessions as sessions_svc
-
-        await sessions_svc.set_session_status(
-            pool, parent_session_id, "running", account_id=account_id
-        )
-        r = await http_client.post(f"/v1/sessions/{parent_session_id}/clone", json={})
-        assert r.status_code == 409, r.text
-
     async def test_refuses_pending_parent(
         self, http_client: httpx.AsyncClient, pool: Any, parent_session_id: str
     ) -> None:

--- a/tests/e2e/test_session_status_pending.py
+++ b/tests/e2e/test_session_status_pending.py
@@ -101,27 +101,6 @@ class TestPendingStatus:
         r = await http_client.get(f"/v1/sessions/{idle_session_id}")
         assert r.json()["status"] == "pending"
 
-    async def test_running_status_not_clobbered_by_concurrent_message(
-        self, http_client: httpx.AsyncClient, pool: Any, idle_session_id: str
-    ) -> None:
-        """If the session is already ``running``, a new user message must not
-        rewrite the status — the in-flight worker owns it."""
-        account_id = "acc_test_stub"  # PR 3 scaffolding
-        from aios.services import sessions as sessions_svc
-
-        await sessions_svc.set_session_status(
-            pool, idle_session_id, "running", account_id=account_id
-        )
-
-        r = await http_client.post(
-            f"/v1/sessions/{idle_session_id}/messages",
-            json={"content": "arrived mid-turn"},
-        )
-        assert r.status_code == 201, r.text
-
-        r = await http_client.get(f"/v1/sessions/{idle_session_id}")
-        assert r.json()["status"] == "running"
-
     async def test_rescheduling_status_not_clobbered(
         self, http_client: httpx.AsyncClient, pool: Any, idle_session_id: str
     ) -> None:

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -1064,8 +1064,8 @@ class TestSessionVersionBinding:
 
 @needs_docker
 class TestCustomTools:
-    async def test_custom_tool_idles_with_requires_action(self, harness: Harness) -> None:
-        """When the model calls a custom tool, the session idles with requires_action."""
+    async def test_custom_tool_idles_with_awaiting(self, harness: Harness) -> None:
+        """When the model calls a custom tool, the call appears in ``session.awaiting``."""
         account_id = "acc_test_stub"  # PR 3 scaffolding
         from aios.models.agents import ToolSpec
         from aios.services import agents as agents_service
@@ -1126,12 +1126,13 @@ class TestCustomTools:
         # Run one step — model calls custom tool
         await harness.run_step(session.id)
 
-        # Session should be idle with requires_action
+        # Session ends turn cleanly; custom tool is observable via awaiting
         s = await harness.session(session.id)
         assert s.status == "idle"
-        assert s.stop_reason is not None
-        assert s.stop_reason["type"] == "requires_action"
-        assert "call_w1" in s.stop_reason["event_ids"]
+        assert s.stop_reason == {"type": "end_turn"}
+        assert {a.tool_call_id for a in s.awaiting} == {"call_w1"}
+        assert s.awaiting[0].kind == "custom"
+        assert s.awaiting[0].needs_confirm is False
 
     async def test_custom_tool_result_resumes_session(self, harness: Harness) -> None:
         """Submitting a custom tool result via the API resumes the session."""
@@ -1286,11 +1287,11 @@ class TestCustomTools:
         await harness.run_step(session.id)
         await harness.wait_for_tools(session.id)
 
-        # Session should be idle with requires_action for the custom tool
+        # Custom tool is awaiting external execution; built-in already completed
         s = await harness.session(session.id)
         assert s.status == "idle"
-        assert s.stop_reason is not None
-        assert s.stop_reason["type"] == "requires_action"
+        assert s.stop_reason == {"type": "end_turn"}
+        assert {a.tool_call_id for a in s.awaiting} == {"call_lookup"}
 
         # The built-in tool (echo) should have already completed
         events = await harness.events(session.id)
@@ -1340,8 +1341,8 @@ class TestPermissionPolicies:
         old = registry.get(name)
         registry._tools[name] = replace(old, handler=handler)
 
-    async def test_always_ask_idles_with_requires_action(self, harness: Harness) -> None:
-        """Model calls an always_ask tool → session idles with requires_action."""
+    async def test_always_ask_idles_with_awaiting_confirm(self, harness: Harness) -> None:
+        """Model calls an always_ask tool → call appears in ``session.awaiting`` with ``needs_confirm``."""
         from aios.models.agents import ToolSpec
 
         async def fake_glob(
@@ -1366,10 +1367,10 @@ class TestPermissionPolicies:
 
         s = await harness.session(session.id)
         assert s.status == "idle"
-        assert s.stop_reason is not None
-        assert s.stop_reason["type"] == "requires_action"
-        assert "call_ask1" in s.stop_reason["event_ids"]
-        assert "call_ask1" in s.stop_reason.get("confirmations", [])
+        assert s.stop_reason == {"type": "end_turn"}
+        assert {a.tool_call_id for a in s.awaiting} == {"call_ask1"}
+        assert s.awaiting[0].kind == "builtin"
+        assert s.awaiting[0].needs_confirm is True
 
     async def test_always_ask_allow_executes_tool(self, harness: Harness) -> None:
         """Confirm allow → tool executes → model sees result → responds."""
@@ -1395,11 +1396,11 @@ class TestPermissionPolicies:
             tool_specs=[ToolSpec(type="glob", permission="always_ask")],
         )
 
-        # Step 1: model calls always_ask tool → session idles
+        # Step 1: model calls always_ask tool → call appears in awaiting
         await harness.run_step(session.id)
         s = await harness.session(session.id)
-        assert s.stop_reason is not None
-        assert s.stop_reason["type"] == "requires_action"
+        assert s.stop_reason == {"type": "end_turn"}
+        assert {a.tool_call_id for a in s.awaiting} == {"call_allow1"}
 
         # Confirm allow
         await harness.confirm_tool(session.id, "call_allow1", "allow")
@@ -1507,13 +1508,12 @@ class TestPermissionPolicies:
         await harness.run_step(session.id)
         await harness.wait_for_tools(session.id)
 
-        # glob should have executed; session idles for grep
+        # glob should have executed; grep is awaiting confirmation
         s = await harness.session(session.id)
         assert s.status == "idle"
-        assert s.stop_reason is not None
-        assert s.stop_reason["type"] == "requires_action"
-        assert "call_slow" in s.stop_reason["event_ids"]
-        assert "call_slow" in s.stop_reason.get("confirmations", [])
+        assert s.stop_reason == {"type": "end_turn"}
+        assert {a.tool_call_id for a in s.awaiting} == {"call_slow"}
+        assert s.awaiting[0].needs_confirm is True
 
         # glob result should already be in the log
         events = await harness.events(session.id)

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -1132,7 +1132,6 @@ class TestCustomTools:
         assert s.stop_reason == {"type": "end_turn"}
         assert {a.tool_call_id for a in s.awaiting} == {"call_w1"}
         assert s.awaiting[0].kind == "custom"
-        assert s.awaiting[0].needs_confirm is False
 
     async def test_custom_tool_result_resumes_session(self, harness: Harness) -> None:
         """Submitting a custom tool result via the API resumes the session."""
@@ -1342,7 +1341,7 @@ class TestPermissionPolicies:
         registry._tools[name] = replace(old, handler=handler)
 
     async def test_always_ask_idles_with_awaiting_confirm(self, harness: Harness) -> None:
-        """Model calls an always_ask tool → call appears in ``session.awaiting`` with ``needs_confirm``."""
+        """Model calls an always_ask tool → call appears in ``session.awaiting`` with builtin kind."""
         from aios.models.agents import ToolSpec
 
         async def fake_glob(
@@ -1370,7 +1369,6 @@ class TestPermissionPolicies:
         assert s.stop_reason == {"type": "end_turn"}
         assert {a.tool_call_id for a in s.awaiting} == {"call_ask1"}
         assert s.awaiting[0].kind == "builtin"
-        assert s.awaiting[0].needs_confirm is True
 
     async def test_always_ask_allow_executes_tool(self, harness: Harness) -> None:
         """Confirm allow → tool executes → model sees result → responds."""
@@ -1513,7 +1511,7 @@ class TestPermissionPolicies:
         assert s.status == "idle"
         assert s.stop_reason == {"type": "end_turn"}
         assert {a.tool_call_id for a in s.awaiting} == {"call_slow"}
-        assert s.awaiting[0].needs_confirm is True
+        assert s.awaiting[0].kind == "builtin"
 
         # glob result should already be in the log
         events = await harness.events(session.id)

--- a/tests/e2e/test_wait_endpoint.py
+++ b/tests/e2e/test_wait_endpoint.py
@@ -106,7 +106,7 @@ class TestWaitEndpoint:
             e["kind"] == "message" and e["data"].get("content") == "hello" for e in body["events"]
         )
         assert body["next_after"] == body["events"][-1]["seq"]
-        assert body["session_status"] in {"pending", "running", "idle"}
+        assert body["session_status"] in {"pending", "idle"}
 
     async def test_empty_after_timeout(
         self, http_client: httpx.AsyncClient, session_id: str

--- a/tests/integration/test_confirm_tool_allow_after_resolved.py
+++ b/tests/integration/test_confirm_tool_allow_after_resolved.py
@@ -7,7 +7,8 @@ Pre-fix the allow path checks only for an existing
 NOT check whether a tool-role result already exists for the same
 ``tool_call_id``.  So:
 
-  1. Tool fires (always_ask).  Session parks in ``requires_action``.
+  1. Tool fires (always_ask).  Call sits unresolved on
+     ``Session.awaiting``.
   2. Operator denies in tab A → ``confirm_tool_deny`` →
      ``append_tool_result(is_error=True)``.  A tool-role error event
      lands on the log; no ``lifecycle/tool_confirmed`` event exists.

--- a/tests/integration/test_set_session_status_archived.py
+++ b/tests/integration/test_set_session_status_archived.py
@@ -1,6 +1,5 @@
 """Integration test: ``set_session_status`` must not rewrite an
-archived session's row, and must skip the connector-calls fan-out
-when the row is gone."""
+archived session's row."""
 
 from __future__ import annotations
 
@@ -18,11 +17,11 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.fixture
-async def archived_running_session(
+async def archived_marked_session(
     migrated_db_url: str, _reset_db_state: None
 ) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
     """Yield ``(pool, account_id, session_id)`` for a session pinned
-    to ``running`` then archived — gives the post-call read a
+    to ``rescheduling`` then archived — gives the post-call read a
     distinctive expected ``status`` value."""
     pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
     try:
@@ -38,20 +37,20 @@ async def archived_running_session(
         )
         async with pool.acquire() as conn:
             await queries.set_session_status(
-                conn, session.id, "running", None, account_id="acc_sss_arch"
+                conn, session.id, "rescheduling", None, account_id="acc_sss_arch"
             )
             archived = await queries.archive_session(conn, session.id, account_id="acc_sss_arch")
         assert archived.archived_at is not None
-        assert archived.status == "running"
+        assert archived.status == "rescheduling"
         yield pool, "acc_sss_arch", session.id
     finally:
         await pool.close()
 
 
 async def test_set_session_status_refuses_archived_silently(
-    archived_running_session: tuple[asyncpg.Pool[Any], str, str],
+    archived_marked_session: tuple[asyncpg.Pool[Any], str, str],
 ) -> None:
-    pool, account_id, session_id = archived_running_session
+    pool, account_id, session_id = archived_marked_session
 
     async with pool.acquire() as conn:
         await queries.set_session_status(
@@ -64,20 +63,19 @@ async def test_set_session_status_refuses_archived_silently(
             session_id,
         )
     assert row is not None
-    assert row["status"] == "running", (
-        f"archived row was rewritten: status is {row['status']!r}, expected 'running'."
+    assert row["status"] == "rescheduling", (
+        f"archived row was rewritten: status is {row['status']!r}, expected 'rescheduling'."
     )
     assert row["stop_reason"] is None
     assert row["archived_at"] is not None
 
 
-async def test_set_session_status_skips_notify_on_archived(
-    archived_running_session: tuple[asyncpg.Pool[Any], str, str],
+async def test_set_session_status_no_rewrite_on_archived(
+    archived_marked_session: tuple[asyncpg.Pool[Any], str, str],
 ) -> None:
-    """The ``requires_action`` fan-out must short-circuit on the no-row
-    UPDATE — otherwise ``_list_bound_connection_ids`` runs and (with
-    bindings) emits ``pg_notify`` for an archived session."""
-    pool, account_id, session_id = archived_running_session
+    """The no-row UPDATE on an archived session must not bump
+    ``updated_at`` (and therefore must not have written anything)."""
+    pool, account_id, session_id = archived_marked_session
 
     async with pool.acquire() as conn:
         pre_updated_at = await conn.fetchval(
@@ -87,7 +85,7 @@ async def test_set_session_status_skips_notify_on_archived(
             conn,
             session_id,
             "idle",
-            {"type": "requires_action", "custom_tools": [{"name": "x"}]},
+            {"type": "end_turn"},
             account_id=account_id,
         )
         post_updated_at = await conn.fetchval(

--- a/tests/unit/cli/test_cli_chat.py
+++ b/tests/unit/cli/test_cli_chat.py
@@ -85,7 +85,7 @@ def test_resolve_session_join_returns_last_event_seq(
     client.request.return_value = {
         "id": "sess_X",
         "agent_id": "agt_A",
-        "status": "running",
+        "status": "idle",
         "last_event_seq": 1234,
     }
 

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -147,7 +147,7 @@ def mock_step_dependencies() -> Any:
             AsyncMock(return_value={"sess_x"}),
         ),
         patch(
-            "aios.harness.loop.sessions_service.get_session",
+            "aios.harness.loop.sessions_service.get_session_basic",
             AsyncMock(return_value=session),
         ),
         patch(

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -167,7 +167,7 @@ class TestEntrySweepSpan:
                 AsyncMock(return_value={"sess_x"}),
             ),
             patch(
-                "aios.harness.loop.sessions_service.get_session",
+                "aios.harness.loop.sessions_service.get_session_basic",
                 AsyncMock(return_value=session),
             ),
             patch(

--- a/tests/unit/test_tool_confirmation.py
+++ b/tests/unit/test_tool_confirmation.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-from aios.harness.loop import resolve_permission
-from aios.models.agents import ToolSpec
+from aios.models.agents import ToolSpec, resolve_permission
 from aios.models.events import Event
 from aios.services.sessions import _find_tool_call
 

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -215,7 +215,7 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value={"sess_x"}),
             ),
             patch(
-                "aios.harness.loop.sessions_service.get_session",
+                "aios.harness.loop.sessions_service.get_session_basic",
                 AsyncMock(return_value=session),
             ),
             patch(
@@ -312,7 +312,7 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value={"sess_x"}),
             ),
             patch(
-                "aios.harness.loop.sessions_service.get_session",
+                "aios.harness.loop.sessions_service.get_session_basic",
                 AsyncMock(return_value=session),
             ),
             patch(
@@ -409,7 +409,7 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value={"sess_x"}),
             ),
             patch(
-                "aios.harness.loop.sessions_service.get_session",
+                "aios.harness.loop.sessions_service.get_session_basic",
                 AsyncMock(return_value=session),
             ),
             patch(


### PR DESCRIPTION
## Summary

- **Remove the session "parking" concept.** When the model emits a `type:"custom"` tool call or an `always_ask`-gated tool, the harness no longer sets `session.status="idle"` with `stop_reason={"type":"requires_action", ...}`. The tool_call sits unresolved in the event log alongside any async in-flight built-in; the step body unconditionally ends the turn with `end_turn`. The same wake mechanism (user message lift, tool-result POST, or tool-confirmations POST) wakes the session via the existing inference gate.
- **Add `Session.awaiting: list[AwaitingToolCall]`** as a derived view computed per read. Replaces the denormalised `stop_reason.requires_action` + `event_ids`/`confirmations`/`custom_tools` payload — and eliminates a real staleness bug where a user-message-then-text-response sequence used to overwrite `requires_action` to `end_turn` while a custom tool was still pending.
- **Relocate the connector NOTIFY trigger** from `set_session_status` to `append_event`, gated on `kind==message AND role==assistant AND data.tool_calls`. Same per-step frequency.
- **Rewrite the connector pending-calls SQL** to read directly from the event log (latest assistant's tool_calls minus paired tool_results, filtered by `connector.tools_schema`) — no `stop_reason` predicate.
- **Split `_PENDING_CONTENT`** into `_PENDING_BACKGROUND` (asyncio task running) and `_PENDING_EXTERNAL` (custom or awaiting-confirm). `build_messages` takes a new `in_flight_tool_call_ids` param.
- **Delete `"running"` from `SessionStatus`**. The `list_running_session_ids` query, the worker orphan reaper's "running session ids" lookup, and `delete_session`'s "is it running" safety check are all removed — `task_registry` is the live source of truth for in-process work and a fail-hard delete is consistent with the project's no-fallbacks stance.

Net code delta on the refactor commit: roughly **+50 LOC production** after the simplify pass (the new derived view + helpers offset the removed parking branch).

This PR also picks up two pre-existing fixes that have been sitting on this branch (`fix(api/sessions): repair events pagination, session stats, and single-event lookup` and its follow-up review-feedback commit).

## Background

See conversation context for the design discussion. Short version: the harness's async-tool responsiveness mechanism (pending-placeholder synthesis + horizon-aware blind-spot injection + the inference gate's user-message override) already handles "this tool result will arrive later" generically. Custom and `always_ask` tools were the same shape, distinguished only by an observability-layer convention that had three coupling points (NOTIFY trigger, backfill SQL filter, status flip). All three move; the harness state machine simplifies.

CLAUDE.md "Custom tools (client-executed)" section is rewritten with the new model.

## Test plan

- [x] `uv run mypy src` clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` clean
- [x] `uv run pytest tests/unit -q` — 1406 passed
- [x] `uv run pytest tests/e2e -q` — 421/423 passed (2 unrelated pre-existing failures: a sandbox-image arm64 vs x86_64 architecture mismatch on this dev box that also fails on master, and one flake in `test_memory_cross_session_sync` that passes in isolation)
- [x] OpenAPI snapshot + generated SDK regenerated via `scripts/regen-client.sh`
- [ ] Smoke test via `aios-smoke-setup` once the PR is on a branch you want to bot from:
  - [ ] Custom tool: model emits → session.awaiting populated → connector runtime dispatches → result arrives → model continues
  - [ ] Always_ask built-in: model emits → session.awaiting populated with `needs_confirm=True` → operator confirms via `/tool-confirmations allow` → tool dispatches → result arrives → model continues
  - [ ] User message during in-flight async tool: interleaves correctly (no regression)
  - [ ] User message during pending custom tool: wakes session, model responds with pending placeholder visible in its context (new behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)