### PR TITLE
fix(harness/sweep): isolate per-session failures in cross-session batches

### DIFF
--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -262,6 +262,9 @@ async def find_and_repair_ghosts(
         if _was_dispatched(name, tcid, confirmed, agent_tools):
             ghosts.append((sid, tcid, name))
 
+    # Per-ghost isolation; see ``wake_sessions_needing_inference`` below
+    # for the rationale.
+    repaired: list[tuple[str, str]] = []
     for sid, tcid, name in ghosts:
         content = json.dumps(
             {"error": "No result was received for this tool call."},
@@ -270,28 +273,37 @@ async def find_and_repair_ghosts(
         # Load each ghost's session account_id individually so the
         # cross-session sweeper (session_id=None) doesn't stamp empty
         # account_id onto repair events for real tenants.
-        sid_account_id = await sessions_service.load_session_account_id(pool, sid)
-        # Route through ``append_tool_result`` (services/sessions.py) rather
-        # than a bare ``append_event``: the FOR UPDATE session lock +
-        # ``find_tool_result_event`` check inside that function serialise
-        # concurrent repairs. The bare-append path had a TOCTOU window
-        # between the result-rows read above and the write here that
-        # admitted two duplicate synthetic results for the same
-        # ``tool_call_id`` under concurrent sweep invocation (periodic
-        # all-sessions sweep racing the per-tool tail sweep), violating
-        # invariant #4 (tool-always-appends-EXACTLY-one result).
-        async with pool.acquire() as conn:
-            await sessions_service.append_tool_result(
-                conn,
-                account_id=sid_account_id,
+        # Route through ``append_tool_result`` (services/sessions.py)
+        # rather than a bare ``append_event``: its session-row lock +
+        # ``find_tool_result_event`` dedup serialise concurrent
+        # repairs.  Bare-append had a TOCTOU window between the
+        # result-rows read above and the write here that admitted two
+        # duplicate synthetic results for the same ``tool_call_id``
+        # under concurrent sweep invocation, violating invariant #4
+        # (tool-always-appends-EXACTLY-one result).
+        try:
+            sid_account_id = await sessions_service.load_session_account_id(pool, sid)
+            async with pool.acquire() as conn:
+                await sessions_service.append_tool_result(
+                    conn,
+                    account_id=sid_account_id,
+                    session_id=sid,
+                    tool_call_id=tcid,
+                    content=content,
+                    is_error=True,
+                )
+        except Exception:
+            log.exception(
+                "sweep.ghost_repair_failed",
                 session_id=sid,
                 tool_call_id=tcid,
-                content=content,
-                is_error=True,
+                tool_name=name,
             )
+            continue
+        repaired.append((sid, tcid))
         log.info("sweep.ghost_repaired", session_id=sid, tool_call_id=tcid, tool_name=name)
 
-    return [(sid, tcid) for sid, tcid, _ in ghosts]
+    return repaired
 
 
 def _was_dispatched(
@@ -517,10 +529,18 @@ async def wake_sessions_needing_inference(
     """
     repaired = await find_and_repair_ghosts(pool, task_registry, session_id=session_id)
     woken = await find_sessions_needing_inference(pool, task_registry, session_id=session_id)
-    # Load each woken session's account_id individually: the cross-session
-    # sweeper (session_id=None) doesn't have one in scope, and using "" would
-    # leak an empty account onto the wake_deferred event for a real tenant.
+    # Per-session try/except: a transient failure on one session must
+    # not strand the rest of the cross-session batch.  account_id is
+    # loaded individually because the cross-session sweeper has none
+    # in scope, and "" would leak an empty account_id onto the
+    # ``wake_deferred`` event for a real tenant.
+    woken_count = 0
     for sid in woken:
-        sid_account_id = await sessions_service.load_session_account_id(pool, sid)
-        await defer_wake(pool, sid, cause="sweep", account_id=sid_account_id)
-    return SweepResult(repaired_ghosts=len(repaired), woken_sessions=len(woken))
+        try:
+            sid_account_id = await sessions_service.load_session_account_id(pool, sid)
+            await defer_wake(pool, sid, cause="sweep", account_id=sid_account_id)
+        except Exception:
+            log.exception("sweep.defer_wake_failed", session_id=sid)
+            continue
+        woken_count += 1
+    return SweepResult(repaired_ghosts=len(repaired), woken_sessions=woken_count)

--- a/tests/unit/test_sweep_isolation.py
+++ b/tests/unit/test_sweep_isolation.py
@@ -1,0 +1,90 @@
+"""The cross-session sweep loop in ``wake_sessions_needing_inference``
+and ``find_and_repair_ghosts`` must isolate per-session failures: a
+single bad row (DB transient, archived-mid-sweep, etc.) must not abort
+the whole batch — the remaining sessions in the same scan still need
+their wake deferred or their ghost repaired."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aios.harness.sweep import find_and_repair_ghosts, wake_sessions_needing_inference
+from aios.harness.task_registry import TaskRegistry
+from tests.unit.conftest import fake_pool_yielding_conn
+
+
+async def test_defer_wake_failure_does_not_abort_sweep_batch() -> None:
+    woken_sids = ["sess_a", "sess_b", "sess_c"]
+
+    defer_wake_mock = AsyncMock(side_effect=[None, RuntimeError("db blip"), None])
+    load_account_mock = AsyncMock(return_value="acc_test")
+    repair_mock = AsyncMock(return_value=[])
+    find_mock = AsyncMock(return_value=set(woken_sids))
+
+    with (
+        patch("aios.harness.sweep.find_and_repair_ghosts", repair_mock),
+        patch("aios.harness.sweep.find_sessions_needing_inference", find_mock),
+        patch("aios.harness.sweep.sessions_service.load_session_account_id", load_account_mock),
+        patch("aios.harness.sweep.defer_wake", defer_wake_mock),
+    ):
+        result = await wake_sessions_needing_inference(MagicMock(), TaskRegistry())
+
+    called_sids = {call.args[1] for call in defer_wake_mock.await_args_list}
+    assert called_sids == set(woken_sids), (
+        f"sweep aborted mid-batch: defer_wake was called for {called_sids}, "
+        f"expected {set(woken_sids)} — a per-session failure must not skip the rest"
+    )
+    assert result.woken_sessions == 2
+
+
+async def test_ghost_repair_failure_does_not_abort_batch(monkeypatch: Any) -> None:
+    ghost_rows = [
+        {
+            "session_id": "sess_a",
+            "data": {
+                "role": "assistant",
+                "tool_calls": [{"id": "tc_a", "type": "function", "function": {"name": "bash"}}],
+            },
+        },
+        {
+            "session_id": "sess_b",
+            "data": {
+                "role": "assistant",
+                "tool_calls": [{"id": "tc_b", "type": "function", "function": {"name": "bash"}}],
+            },
+        },
+    ]
+    # Mark both tool_calls as confirmed-via-lifecycle so ``_was_dispatched``
+    # returns True for the (default ``always_ask``) bash builtin — both
+    # candidates become ghosts.
+    lifecycle_rows = [
+        {"session_id": "sess_a", "tool_call_id": "tc_a"},
+        {"session_id": "sess_b", "tool_call_id": "tc_b"},
+    ]
+    agent_rows = [
+        {"session_id": "sess_a", "tools": "[]"},
+        {"session_id": "sess_b", "tools": "[]"},
+    ]
+    # find_and_repair_ghosts issues four ``conn.fetch`` calls in order:
+    # GHOST_ASST_SQL, ALL_RESULT_ROWS_SQL, GHOST_LIFECYCLE_SQL, agents.
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], lifecycle_rows, agent_rows])
+    pool = fake_pool_yielding_conn(conn)
+
+    append_mock = AsyncMock(side_effect=[RuntimeError("first ghost db blip"), None])
+    monkeypatch.setattr(
+        "aios.harness.sweep.sessions_service.load_session_account_id",
+        AsyncMock(return_value="acc_test"),
+    )
+    monkeypatch.setattr("aios.harness.sweep.sessions_service.append_tool_result", append_mock)
+
+    repaired = await find_and_repair_ghosts(pool, TaskRegistry())
+
+    assert append_mock.await_count == 2, (
+        f"sweep aborted mid-batch: append_tool_result was called {append_mock.await_count} "
+        f"times, expected 2 — a per-ghost failure must not skip the rest"
+    )
+    # The returned list reflects ghosts whose repair actually committed
+    # (the second one); the first is logged-and-skipped.
+    assert len(repaired) == 1


### PR DESCRIPTION
## Summary

- The for-loops in `find_and_repair_ghosts` and `wake_sessions_needing_inference` previously let a single raise abort the whole batch. Under the cross-session sweeper (`session_id=None`) — used by the periodic worker tick — that silently stranded every remaining session if any one tripped a transient failure (DB blip, archive racing the sweep, etc.).
- Per-iteration `try/except` + `log.exception` + `continue`. `SweepResult.woken_sessions` now counts actual successes rather than attempts, so a downstream "0 across a full sweep" alert can fire when every session in the batch fails.
- `Exception` (not `BaseException`) is the right catch: Python 3.13's `asyncio.CancelledError` is a `BaseException` and stays uncaught, so task cancellation still tears down the sweep cleanly.

## Test plan

- [x] Type-checker — clean
- [x] Linter + format-check — clean
- [x] Unit suite — 1455 passed
- [x] Two new unit tests (`tests/unit/test_sweep_isolation.py`): `defer_wake` raising on one of three sids — all three still attempted; ghost-repair `append_tool_result` raising on one of two ghosts — both still attempted, returned list reflects actual successes.
- [ ] CI runs e2e + integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)