### PR TITLE
fix(db/queries): refuse clone of parent parked in requires_action

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -1254,7 +1254,8 @@ async def clone_session(
 
     async with conn.transaction():
         row = await conn.fetchrow(
-            "SELECT status, archived_at FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
+            "SELECT status, stop_reason, archived_at FROM sessions "
+            "WHERE id = $1 AND account_id = $2 FOR UPDATE",
             parent_session_id,
             account_id,
         )
@@ -1265,8 +1266,7 @@ async def clone_session(
             )
         # Refuse archived parents: cloning would resurrect the parent's
         # event log into a live new session, defeating the archive
-        # intent.  Same family as PR #573 / #547 / #554 / #587 —
-        # archive must hold across every mutation/copy surface.
+        # intent.  Archive must hold across every mutation/copy surface.
         if row["archived_at"] is not None:
             raise ConflictError(
                 f"session {parent_session_id} is archived",
@@ -1278,6 +1278,16 @@ async def clone_session(
                 f"can only clone sessions in {_CLONEABLE_STATUSES} state; "
                 f"parent {parent_session_id} is in {status!r}",
                 detail={"id": parent_session_id, "status": status},
+            )
+        # Refuse parents parked in ``requires_action``: the clone
+        # inherits ``stop_reason`` verbatim, but the operator action
+        # (custom-tool result, always_ask confirmation) lands on the
+        # parent's URL only — the clone would sit idle forever.
+        stop_reason = parse_jsonb(row["stop_reason"])
+        if isinstance(stop_reason, dict) and stop_reason.get("type") == "requires_action":
+            raise ConflictError(
+                f"cannot clone session {parent_session_id}: parent is in requires_action",
+                detail={"id": parent_session_id, "stop_reason": stop_reason},
             )
 
         new_row = await conn.fetchrow(

--- a/tests/integration/test_clone_refuses_requires_action.py
+++ b/tests/integration/test_clone_refuses_requires_action.py
@@ -1,0 +1,88 @@
+"""``clone_session`` must refuse a parent parked in ``requires_action``:
+the clone inherits ``stop_reason`` verbatim, so the operator action the
+parent awaits would never reach the clone's URL."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import ConflictError
+from aios.services import sessions as sessions_service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def requires_action_parent(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, parent_id)`` for an idle session
+    parked in ``requires_action`` with a custom-tool pending."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_clone_ra', NULL, TRUE, 'clone-requires-action-test')
+                """
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_clone_ra", prefix="clone-ra"
+        )
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                session_id=session.id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "tc_custom",
+                            "type": "custom",
+                            "function": {"name": "ask_user", "arguments": "{}"},
+                        }
+                    ],
+                },
+                account_id="acc_clone_ra",
+            )
+            await queries.set_session_status(
+                conn,
+                session.id,
+                "idle",
+                {"type": "requires_action", "custom_tools": ["tc_custom"]},
+                account_id="acc_clone_ra",
+            )
+        yield pool, "acc_clone_ra", session.id
+    finally:
+        await pool.close()
+
+
+async def test_clone_refuses_requires_action_parent(
+    requires_action_parent: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    pool, account_id, parent_id = requires_action_parent
+
+    with pytest.raises(ConflictError) as excinfo:
+        await sessions_service.clone_session(pool, parent_id, account_id=account_id)
+
+    detail = excinfo.value.detail
+    assert detail is not None
+    assert detail.get("id") == parent_id
+
+    async with pool.acquire() as conn:
+        n = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE id <> $1 AND account_id = $2",
+            parent_id,
+            account_id,
+        )
+    assert n == 0, f"clone row leaked despite refusal: {n} extra sessions"


### PR DESCRIPTION
## Summary

- `clone_session` previously accepted any `idle`/`terminated` parent, including those parked in `requires_action`. The clone inherited `stop_reason` verbatim, so the operator action (custom-tool result or `always_ask` confirmation) the parent was waiting on landed on the parent's URL only — the clone sat idle forever with no surface to receive the action.
- Mirrors the existing `running`-parent refusal at `clone_session` (tool tasks in flight land only on the parent's session_id; the clone's expected event stream is undefined). Same defect class.
- Also strips a stale PR-number reference from the adjacent archived-parent refusal comment (broken-windows).

## Test plan

- [x] Type-checker — clean
- [x] Linter + format-check — clean
- [x] Unit suite — 1455 passed
- [x] New integration test (`test_clone_refuses_requires_action_parent`): parent in `idle + stop_reason={"type":"requires_action", "custom_tools":["tc_custom"]}` raises `ConflictError`, no clone row leaked.
- [x] Existing `test_clone_refuses_archived_parent` still passes.
- [ ] CI runs e2e + integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)