### PR TITLE
refactor: fix awaiting-view permission gaps + restore partial index (#613 followup)

### DIFF
--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -459,9 +459,9 @@ async def list_events(
     # Scope check: 404 cross-tenant probes before reading events. The
     # ``read_events`` query also filters by account_id, so this is
     # belt-and-suspenders against a future query that forgets the
-    # filter — but ``get_session`` is what gives the caller a clean
-    # 404 rather than an empty list for a cross-tenant session id.
-    await service.get_session(pool, session_id, account_id=account_id)
+    # filter — but the lookup is what gives the caller a clean 404
+    # rather than an empty list for a cross-tenant session id.
+    await service.get_session_basic(pool, session_id, account_id=account_id)
     # Fetch one extra row so we can tell whether more exist without a
     # separate COUNT query — accurate has_more with no off-by-one.
     rows = await service.read_events(
@@ -580,7 +580,7 @@ async def stream_events(
     after_seq: int = 0,
 ) -> EventSourceResponse:
     """Stream session events as Server-Sent Events."""
-    await service.get_session(pool, session_id, account_id=account_id)
+    await service.get_session_basic(pool, session_id, account_id=account_id)
     return EventSourceResponse(
         sse_event_stream(db_url, pool, session_id, after_seq=after_seq),
         ping=15,

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2034,6 +2034,11 @@ async def _latest_unresolved_tool_calls(
     """
     if not session_ids:
         return {}
+    # ``data ? 'tool_calls'`` is the partial-index predicate on
+    # ``events_assistant_tool_calls_idx``; the ``jsonb_array_length > 0``
+    # post-filter narrows to non-empty arrays (the index admits
+    # ``null`` / ``[]`` too).  Without the ``?`` conjunct the planner
+    # falls back to the wider ``events_session_seq_idx``.
     asst_rows = await conn.fetch(
         """
         SELECT DISTINCT ON (session_id) session_id, data
@@ -2042,6 +2047,7 @@ async def _latest_unresolved_tool_calls(
            AND account_id = $2
            AND kind = 'message'
            AND role = 'assistant'
+           AND data ? 'tool_calls'
            AND jsonb_array_length(
                  COALESCE(NULLIF(data->'tool_calls','null'::jsonb), '[]'::jsonb)
                ) > 0
@@ -2106,8 +2112,10 @@ async def list_unresolved_tool_calls_batch(
 
     Used by :func:`services.sessions.compute_awaiting` to build the
     ``Session.awaiting`` derived view. Returned dicts have keys
-    ``tool_call_id``, ``name``, ``has_allow_lifecycle`` — the caller
-    classifies kind/needs_confirm using ``agent.tools``.
+    ``tool_call_id``, ``name``, ``arguments``, ``has_allow_lifecycle``
+    — the caller classifies kind / needs_confirm using ``agent`` (and
+    the tool's ``classify_permission`` for arg-aware routes like
+    ``http_request``).
     """
     raw = await _latest_unresolved_tool_calls(conn, session_ids, account_id=account_id)
     if not raw:
@@ -2134,15 +2142,20 @@ async def list_unresolved_tool_calls_batch(
     out: dict[str, list[dict[str, Any]]] = {}
     for sid, calls in raw.items():
         allows = allows_by_sid.get(sid, set())
-        entries = [
-            {
-                "tool_call_id": tc["id"],
-                "name": name,
-                "has_allow_lifecycle": tc["id"] in allows,
-            }
-            for tc in calls
-            if (name := (tc.get("function") or {}).get("name"))
-        ]
+        entries: list[dict[str, Any]] = []
+        for tc in calls:
+            fn = tc.get("function") or {}
+            name = fn.get("name")
+            if not name:
+                continue
+            entries.append(
+                {
+                    "tool_call_id": tc["id"],
+                    "name": name,
+                    "arguments": fn.get("arguments", "{}"),
+                    "has_allow_lifecycle": tc["id"] in allows,
+                }
+            )
         if entries:
             out[sid] = entries
     return out

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -36,7 +36,6 @@ from aios.logging import get_logger
 from aios.models.agents import (
     PermissionPolicy,
     is_mcp_tool_name,
-    resolve_mcp_permission,
     resolve_permission,
 )
 from aios.services import agents as agents_service
@@ -688,16 +687,7 @@ def _classify_tool_call(
             return "unknown_mcp"
         if not _is_known_mcp_server(server_name, mcp_server_map):
             return "unknown_mcp"
-        perm = resolve_mcp_permission(name, agent.tools)
-        if perm is None:
-            # Fallback to the operator-configured default for unmounted
-            # toolsets (``AIOS_DEFAULT_MCP_PERMISSION_POLICY``).  Unset
-            # → ``always_ask`` (safe default); explicit per-toolset
-            # policies on ``agent.tools`` always win and are returned
-            # above without reaching this branch.
-            from aios.config import get_settings
-
-            perm = get_settings().default_mcp_permission_policy
+        perm = agents_service.effective_mcp_permission(name, agent.tools)
         if perm == "always_allow":
             return "mcp_immediate"
         return "needs_confirm"

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -320,16 +320,12 @@ def _was_dispatched(
 
     Uses the same permission resolution as the step function.
     """
-    from aios.models.agents import (
-        is_mcp_tool_name,
-        resolve_mcp_permission,
-        resolve_permission,
-    )
+    from aios.models.agents import is_mcp_tool_name, resolve_permission
+    from aios.services.agents import effective_mcp_permission
     from aios.tools.registry import registry
 
     if is_mcp_tool_name(name):
-        perm = resolve_mcp_permission(name, agent_tools)
-        if perm == "always_allow":
+        if effective_mcp_permission(name, agent_tools) == "always_allow":
             return True
         return tool_call_id in confirmed_ids
 

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -12,7 +12,15 @@ from typing import Any
 import asyncpg
 
 from aios.db import queries
-from aios.models.agents import Agent, AgentVersion, HttpServerSpec, McpServerSpec, ToolSpec
+from aios.models.agents import (
+    Agent,
+    AgentVersion,
+    HttpServerSpec,
+    McpServerSpec,
+    PermissionPolicy,
+    ToolSpec,
+    resolve_mcp_permission,
+)
 from aios.models.skills import AgentSkillRef
 from aios.services import skills as skills_service
 
@@ -144,6 +152,23 @@ async def load_for_session(
             pool, session.agent_id, session.agent_version, account_id=account_id
         )
     return await get_agent(pool, session.agent_id, account_id=account_id)
+
+
+def effective_mcp_permission(name: str, agent_tools: list[ToolSpec]) -> PermissionPolicy:
+    """Resolved MCP permission with operator-default fallback applied.
+
+    Wraps :func:`aios.models.agents.resolve_mcp_permission` (which
+    returns ``None`` when no ``mcp_toolset`` entry matches the server)
+    and substitutes ``AIOS_DEFAULT_MCP_PERMISSION_POLICY`` (or
+    ``always_ask`` if no operator default is set) so callers see the
+    effective policy the dispatcher actually applies — never ``None``.
+    """
+    perm = resolve_mcp_permission(name, agent_tools)
+    if perm is not None:
+        return perm
+    from aios.config import get_settings
+
+    return get_settings().default_mcp_permission_policy or "always_ask"
 
 
 async def list_agent_versions(

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -19,9 +19,9 @@ from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.errors import ConflictError, NotFoundError, PayloadTooLargeError
 from aios.models.agents import (
-    ToolSpec,
+    Agent,
+    AgentVersion,
     is_mcp_tool_name,
-    resolve_mcp_permission,
     resolve_permission,
 )
 from aios.models.events import Event, EventKind
@@ -142,31 +142,43 @@ async def create_session(
 
 
 def _classify_awaiting(
-    name: str,
-    tool_call_id: str,
-    has_allow_lifecycle: bool,
-    agent_tools: list[ToolSpec],
+    tc: dict[str, Any],
+    agent: Agent | AgentVersion,
 ) -> AwaitingToolCall | None:
     """Classify an unresolved tool_call into an ``AwaitingToolCall``, or
     ``None`` if the session is not blocked on external action for it
     (``always_allow`` builtin/mcp, or ``always_ask`` already confirmed).
 
     Mirrors :func:`aios.harness.loop._classify_tool_call`'s dispatch
-    rules so the view stays consistent with what the harness will do.
+    rules — including arg-aware refinement via
+    ``ToolDefinition.classify_permission`` — so the view stays
+    consistent with what the harness will do.
     """
-    # Late import: aios.tools → services.wake → services.sessions cycle.
-    from aios.config import get_settings
+    # Late import: aios.tools package init pulls in services.wake which
+    # imports this module.
+    from aios.harness.tool_dispatch import _parse_arguments
     from aios.tools.registry import registry as tool_registry
 
+    name = tc["name"]
+    tool_call_id = tc["tool_call_id"]
+    has_allow_lifecycle = tc["has_allow_lifecycle"]
+
     if is_mcp_tool_name(name):
-        perm = resolve_mcp_permission(name, agent_tools)
-        if perm is None:
-            perm = get_settings().default_mcp_permission_policy
-        if perm == "always_ask" and not has_allow_lifecycle:
+        if (
+            agents_service.effective_mcp_permission(name, agent.tools) == "always_ask"
+            and not has_allow_lifecycle
+        ):
             return AwaitingToolCall(tool_call_id=tool_call_id, name=name, kind="mcp")
         return None
     if tool_registry.has(name):
-        if resolve_permission(name, agent_tools) == "always_ask" and not has_allow_lifecycle:
+        perm_tool = resolve_permission(name, agent.tools)
+        perm_route: str | None = None
+        tool_def = tool_registry.get(name)
+        if tool_def.classify_permission is not None:
+            args = _parse_arguments(tc.get("arguments"))
+            if args is not None:
+                perm_route = tool_def.classify_permission(args, agent)
+        if (perm_tool == "always_ask" or perm_route == "always_ask") and not has_allow_lifecycle:
             return AwaitingToolCall(tool_call_id=tool_call_id, name=name, kind="builtin")
         return None
     # Unknown name: client-executed custom tool.
@@ -190,21 +202,21 @@ async def compute_awaiting(
         )
     if not unresolved_by_sid:
         return {}
-    tools_cache: dict[tuple[str, int | None], list[ToolSpec]] = {}
+    agent_cache: dict[tuple[str, int | None], Agent | AgentVersion] = {}
     out: dict[str, list[AwaitingToolCall]] = {}
     for session in sessions:
         unresolved = unresolved_by_sid.get(session.id)
         if not unresolved:
             continue
         key = (session.agent_id, session.agent_version)
-        if key not in tools_cache:
-            loaded = await agents_service.load_for_session(pool, session, account_id=account_id)
-            tools_cache[key] = loaded.tools
+        if key not in agent_cache:
+            agent_cache[key] = await agents_service.load_for_session(
+                pool, session, account_id=account_id
+            )
+        agent = agent_cache[key]
         entries: list[AwaitingToolCall] = []
         for tc in unresolved:
-            classified = _classify_awaiting(
-                tc["name"], tc["tool_call_id"], tc["has_allow_lifecycle"], tools_cache[key]
-            )
+            classified = _classify_awaiting(tc, agent)
             if classified is not None:
                 entries.append(classified)
         if entries:


### PR DESCRIPTION
Follow-up to #613 addressing the second-pass code-review findings that landed after the merge.

## Substantive bugs

- **`http_request` route-level `always_ask` was invisible in `Session.awaiting`.** `_classify_awaiting` only consulted the spec-level `permission` field; the harness's dispatch consults `tool_def.classify_permission(args, agent)` too, which is what promotes a particular path under `http_request` to `always_ask` based on the matched `agent.http_servers` route. Without this fix a client receives an empty `awaiting` list while the harness is parked on a route-level confirmation it never told the client about. Fixed by threading `arguments` through `list_unresolved_tool_calls_batch` and passing the full `Agent`/`AgentVersion` to `_classify_awaiting`, which now mirrors `_classify_tool_call`'s logic.

- **MCP default-permission fallback was missing from `sweep._was_dispatched`.** `_classify_tool_call` and `_classify_awaiting` both fell back to `AIOS_DEFAULT_MCP_PERMISSION_POLICY` when no `mcp_toolset` entry matches; `_was_dispatched` didn't, so an unmounted-but-always-allow MCP tool would be flagged as a ghost on the next sweep. Consolidated all three callers behind a single `agents_service.effective_mcp_permission(name, agent_tools) -> PermissionPolicy` helper (never returns `None`).

## Performance

- **Restore partial-index usage in `_latest_unresolved_tool_calls`.** The query filtered on `jsonb_array_length(... data->'tool_calls' ...) > 0`, which Postgres can't prove implies `data ? 'tool_calls'` — so the planner skipped `events_assistant_tool_calls_idx` (migration 0023) and fell back to the wider `events_session_seq_idx`, re-scanning every assistant message. Adding `data ? 'tool_calls'` as an explicit AND-conjunct restores the partial index.

- **`list_events` and `stream_events` 404-existence checks** switched from `service.get_session` to `service.get_session_basic`, avoiding `compute_awaiting` + echoes + vault enrichment SQL on every `list_events` call and every SSE attach.

## Not addressed in this PR

The N+1 resource-echoes pattern in `list_sessions` (also flagged by the efficiency review) is filed as #617 — pre-existing, separate concern.

## Test plan

- [x] `uv run mypy src` clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` clean
- [x] `uv run pytest tests/unit -q` — 1425 passed
- [ ] `DOCKER_HOST=... uv run pytest tests/e2e -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)