### PR TITLE
feat(connectors/whatsapp): scaffold connector + Go daemon skeleton (PR 1)

### DIFF
--- a/connectors/whatsapp/README.md
+++ b/connectors/whatsapp/README.md
@@ -1,0 +1,12 @@
+# aios-whatsapp
+
+WhatsApp connector for aios.
+
+Pairs a WhatsApp account (via the unofficial Multi-Device protocol, backed by
+[`go.mau.fi/whatsmeow`](https://github.com/tulir/whatsmeow)) and surfaces messages
+into an aios session. Mirrors the shape of `aios-signal`: the Python
+`HttpConnector` spawns a Go daemon (`whatsapp-daemon`) as a subprocess and talks to
+it over line-delimited JSON-RPC on a loopback TCP port.
+
+This connector is **under construction**. Tracking: see `connectors/whatsapp/` in
+the aios tree.

--- a/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
+++ b/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
@@ -1,0 +1,69 @@
+// Command whatsapp-daemon is the Go-side half of the aios WhatsApp
+// connector. It speaks line-delimited JSON-RPC 2.0 over a loopback TCP
+// port to the Python aios_whatsapp connector, which spawns it as a
+// subprocess and tears it down on shutdown.
+//
+// This binary is the long-running counterpart to signal-cli for the
+// Signal connector — same shape, different protocol. It owns the
+// whatsmeow WhatsApp client + sqlstore; the Python side owns aios
+// integration (session routing, attachment marshalling, tool dispatch).
+//
+// PR-1 scope: lifecycle + the `version` RPC only. Subsequent PRs add
+// pairing, send/receive, media, reactions, edits, groups.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"aios.dev/connectors/whatsapp/daemon/internal/handler"
+	"aios.dev/connectors/whatsapp/daemon/internal/rpc"
+)
+
+// Version is stamped at build time via -ldflags="-X main.Version=...".
+// Defaults to "dev" so a local `go run` round-trip surfaces an obvious
+// non-release tag in the `version` RPC response.
+var Version = "dev"
+
+const daemonName = "whatsapp-daemon"
+
+func main() {
+	listen := flag.String("listen", "127.0.0.1:7584", "TCP address to listen on (host:port)")
+	storeDir := flag.String("store-dir", "", "directory holding whatsmeow's sqlstore + media cache (required)")
+	logLevel := flag.String("log-level", "info", "log level: debug, info, warn, error (reserved; PR-1 logs everything)")
+	showVersion := flag.Bool("version", false, "print version and exit")
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("%s %s\n", daemonName, Version)
+		return
+	}
+
+	// -log-level is reserved for future per-level filtering once the
+	// daemon grows enough event types to warrant it. Accepted now so
+	// the Python side's spawn args are stable across PR boundaries.
+	_ = *logLevel
+
+	if *storeDir == "" {
+		log.Println("daemon.config.invalid reason=-store-dir is required")
+		os.Exit(2)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	reg := handler.NewRegistry()
+	handler.RegisterLifecycle(reg, daemonName, Version)
+
+	srv := rpc.NewServer(*listen, reg)
+	if err := srv.Run(ctx); err != nil {
+		log.Printf("daemon.exit.error err=%v", err)
+		os.Exit(1)
+	}
+	log.Println("daemon.exit.ok")
+}

--- a/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
+++ b/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
@@ -1,15 +1,8 @@
-// Command whatsapp-daemon is the Go-side half of the aios WhatsApp
-// connector. It speaks line-delimited JSON-RPC 2.0 over a loopback TCP
-// port to the Python aios_whatsapp connector, which spawns it as a
-// subprocess and tears it down on shutdown.
-//
-// This binary is the long-running counterpart to signal-cli for the
-// Signal connector — same shape, different protocol. It owns the
-// whatsmeow WhatsApp client + sqlstore; the Python side owns aios
+// Command whatsapp-daemon speaks line-delimited JSON-RPC 2.0 over a
+// loopback TCP port to the Python aios_whatsapp connector, which
+// spawns it as a subprocess and tears it down on shutdown.  It owns
+// the whatsmeow WhatsApp client + sqlstore; the Python side owns aios
 // integration (session routing, attachment marshalling, tool dispatch).
-//
-// PR-1 scope: lifecycle + the `version` RPC only. Subsequent PRs add
-// pairing, send/receive, media, reactions, edits, groups.
 package main
 
 import (
@@ -35,7 +28,6 @@ const daemonName = "whatsapp-daemon"
 func main() {
 	listen := flag.String("listen", "127.0.0.1:7584", "TCP address to listen on (host:port)")
 	storeDir := flag.String("store-dir", "", "directory holding whatsmeow's sqlstore + media cache (required)")
-	logLevel := flag.String("log-level", "info", "log level: debug, info, warn, error (reserved; PR-1 logs everything)")
 	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
 
@@ -43,11 +35,6 @@ func main() {
 		fmt.Printf("%s %s\n", daemonName, Version)
 		return
 	}
-
-	// -log-level is reserved for future per-level filtering once the
-	// daemon grows enough event types to warrant it. Accepted now so
-	// the Python side's spawn args are stable across PR boundaries.
-	_ = *logLevel
 
 	if *storeDir == "" {
 		log.Println("daemon.config.invalid reason=-store-dir is required")

--- a/connectors/whatsapp/daemon/go.mod
+++ b/connectors/whatsapp/daemon/go.mod
@@ -1,0 +1,3 @@
+module aios.dev/connectors/whatsapp/daemon
+
+go 1.21

--- a/connectors/whatsapp/daemon/internal/handler/handler.go
+++ b/connectors/whatsapp/daemon/internal/handler/handler.go
@@ -1,0 +1,50 @@
+// Package handler is the daemon's method registry. Each RPC method is
+// registered by name; Dispatch routes incoming requests to the
+// matching MethodFunc. Subsequent PRs add pairing, send, presence,
+// group, etc. files alongside lifecycle.go; each file calls
+// RegisterXxx(reg, deps...) from main.go to wire its methods in.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+
+	"aios.dev/connectors/whatsapp/daemon/internal/rpc"
+)
+
+// MethodFunc is the signature of an RPC method handler. Returning a
+// nil *rpc.Error means success; returning a non-nil Error means the
+// daemon rejected the call. params is the raw JSON; handlers
+// Unmarshal it into a method-specific struct.
+type MethodFunc func(ctx context.Context, params json.RawMessage) (any, *rpc.Error)
+
+// Registry maps method name → handler. Not goroutine-safe to register
+// into; Register is only called during process startup before
+// rpc.Server.Run accepts connections.
+type Registry struct {
+	methods map[string]MethodFunc
+}
+
+// NewRegistry returns an empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{methods: make(map[string]MethodFunc)}
+}
+
+// Register binds name to fn. Caller is responsible for not stepping
+// on an existing name — the only way a duplicate would happen is a
+// programmer error, so we panic to surface it during dev/CI.
+func (r *Registry) Register(name string, fn MethodFunc) {
+	if _, exists := r.methods[name]; exists {
+		panic("handler: duplicate registration for " + name)
+	}
+	r.methods[name] = fn
+}
+
+// Dispatch implements rpc.Handler.
+func (r *Registry) Dispatch(ctx context.Context, method string, params json.RawMessage) (any, *rpc.Error) {
+	fn, ok := r.methods[method]
+	if !ok {
+		return nil, &rpc.Error{Code: -32601, Message: "method not found: " + method}
+	}
+	return fn(ctx, params)
+}

--- a/connectors/whatsapp/daemon/internal/handler/handler.go
+++ b/connectors/whatsapp/daemon/internal/handler/handler.go
@@ -1,8 +1,6 @@
-// Package handler is the daemon's method registry. Each RPC method is
-// registered by name; Dispatch routes incoming requests to the
-// matching MethodFunc. Subsequent PRs add pairing, send, presence,
-// group, etc. files alongside lifecycle.go; each file calls
-// RegisterXxx(reg, deps...) from main.go to wire its methods in.
+// Package handler is the daemon's RPC method registry. Each method is
+// registered by name; Dispatch routes incoming requests to the matching
+// MethodFunc.
 package handler
 
 import (
@@ -30,9 +28,8 @@ func NewRegistry() *Registry {
 	return &Registry{methods: make(map[string]MethodFunc)}
 }
 
-// Register binds name to fn. Caller is responsible for not stepping
-// on an existing name — the only way a duplicate would happen is a
-// programmer error, so we panic to surface it during dev/CI.
+// Register binds name to fn. Panics on duplicate registration — that's
+// a programmer error caught at process startup before the listener binds.
 func (r *Registry) Register(name string, fn MethodFunc) {
 	if _, exists := r.methods[name]; exists {
 		panic("handler: duplicate registration for " + name)

--- a/connectors/whatsapp/daemon/internal/handler/lifecycle.go
+++ b/connectors/whatsapp/daemon/internal/handler/lifecycle.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+
+	"aios.dev/connectors/whatsapp/daemon/internal/rpc"
+)
+
+// VersionResult is the `version` method's response. Stable across
+// daemon versions so the Python side can probe readiness without
+// caring what version it's talking to.
+type VersionResult struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// RegisterLifecycle wires the `version` method into reg.
+//
+// `version` is the universal readiness probe — side-effect-free,
+// always answers immediately once the TCP listener is up. The Python
+// daemon-spawn helper polls it in a 200 ms loop until the daemon
+// answers (or 30 s elapses), so its existence is load-bearing for
+// startup correctness.
+func RegisterLifecycle(reg *Registry, name, version string) {
+	reg.Register("version", func(_ context.Context, _ json.RawMessage) (any, *rpc.Error) {
+		return VersionResult{Name: name, Version: version}, nil
+	})
+}

--- a/connectors/whatsapp/daemon/internal/handler/lifecycle.go
+++ b/connectors/whatsapp/daemon/internal/handler/lifecycle.go
@@ -7,9 +7,7 @@ import (
 	"aios.dev/connectors/whatsapp/daemon/internal/rpc"
 )
 
-// VersionResult is the `version` method's response. Stable across
-// daemon versions so the Python side can probe readiness without
-// caring what version it's talking to.
+// VersionResult is the `version` method's response.
 type VersionResult struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
@@ -17,11 +15,8 @@ type VersionResult struct {
 
 // RegisterLifecycle wires the `version` method into reg.
 //
-// `version` is the universal readiness probe — side-effect-free,
-// always answers immediately once the TCP listener is up. The Python
-// daemon-spawn helper polls it in a 200 ms loop until the daemon
-// answers (or 30 s elapses), so its existence is load-bearing for
-// startup correctness.
+// `version` returns the daemon name + build version.  Side-effect-free;
+// safe to call before any whatsmeow connection completes.
 func RegisterLifecycle(reg *Registry, name, version string) {
 	reg.Register("version", func(_ context.Context, _ json.RawMessage) (any, *rpc.Error) {
 		return VersionResult{Name: name, Version: version}, nil

--- a/connectors/whatsapp/daemon/internal/rpc/server.go
+++ b/connectors/whatsapp/daemon/internal/rpc/server.go
@@ -1,0 +1,181 @@
+// Package rpc implements a minimal JSON-RPC 2.0 server speaking
+// line-delimited JSON over TCP. One frame = one line. Requests carry
+// an "id"; notifications (server → client) omit it.
+//
+// Mirrors the wire shape Python's aios_whatsapp.rpc.RpcClient /
+// RpcListener expect, which in turn mirrors what signal-cli's daemon
+// produces. Keeping the wire shape identical to Signal means
+// aios_whatsapp.rpc is a near-verbatim copy of aios_signal.rpc and
+// the test patterns transfer.
+package rpc
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"sync"
+)
+
+// Handler dispatches a parsed JSON-RPC request to a registered method.
+// Implementors return either a result (which must be JSON-marshallable)
+// or an *Error; never both.
+type Handler interface {
+	Dispatch(ctx context.Context, method string, params json.RawMessage) (any, *Error)
+}
+
+// Error is the JSON-RPC 2.0 error object. Code follows the spec's
+// conventions where useful (e.g. -32601 = method not found) but the
+// daemon is free to use custom positive codes for application errors.
+type Error struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// Server accepts TCP connections, parses one JSON-RPC frame per line,
+// dispatches via the supplied Handler, and writes one response per
+// request. Notifications (frames without an "id") from the client are
+// ignored — the Python side does not send them.
+type Server struct {
+	addr    string
+	handler Handler
+
+	// Set by Run() once the listener binds, so callers can ask for the
+	// resolved address (useful for tests that pass :0 for an
+	// OS-assigned port).
+	mu      sync.Mutex
+	boundAt net.Addr
+}
+
+// NewServer builds an unstarted Server. Call Run() to bind + accept.
+func NewServer(addr string, h Handler) *Server {
+	return &Server{addr: addr, handler: h}
+}
+
+// Addr returns the resolved listen address once Run() has bound. Nil
+// before the bind completes.
+func (s *Server) Addr() net.Addr {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.boundAt
+}
+
+// Run binds the configured address and accepts connections until ctx
+// is cancelled. Cancellation triggers a graceful shutdown: the
+// listener closes, in-flight connections drain (their reads will
+// observe EOF on the next iteration), and Run returns nil.
+func (s *Server) Run(ctx context.Context) error {
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", s.addr)
+	if err != nil {
+		return fmt.Errorf("listen %q: %w", s.addr, err)
+	}
+	s.mu.Lock()
+	s.boundAt = ln.Addr()
+	s.mu.Unlock()
+	log.Printf("rpc.listening addr=%s", ln.Addr().String())
+
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	var wg sync.WaitGroup
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				wg.Wait()
+				return nil
+			}
+			return fmt.Errorf("accept: %w", err)
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.serve(ctx, conn)
+		}()
+	}
+}
+
+// request is the canonical JSON-RPC 2.0 request frame we accept.
+// Unknown fields are tolerated; missing "id" means notification (we
+// ignore client-initiated notifications).
+type request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// response mirrors the response shape. Exactly one of Result / Error
+// is populated; the other is omitted via omitempty.
+type response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *Error          `json:"error,omitempty"`
+}
+
+func (s *Server) serve(ctx context.Context, conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	remote := conn.RemoteAddr().String()
+
+	reader := bufio.NewReader(conn)
+	writer := bufio.NewWriter(conn)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				log.Printf("rpc.conn.read_error remote=%s err=%v", remote, err)
+			}
+			return
+		}
+
+		var req request
+		if err := json.Unmarshal(line, &req); err != nil {
+			// Malformed frame: close the connection. Don't try to
+			// recover — line framing is broken at this point.
+			log.Printf("rpc.frame.bad_json remote=%s err=%v", remote, err)
+			return
+		}
+
+		if len(req.ID) == 0 {
+			// Notification from the client side: ignore. The Python
+			// side talks request/response only; notifications flow
+			// the other direction.
+			continue
+		}
+
+		result, rpcErr := s.handler.Dispatch(ctx, req.Method, req.Params)
+		resp := response{JSONRPC: "2.0", ID: req.ID}
+		if rpcErr != nil {
+			resp.Error = rpcErr
+		} else {
+			resp.Result = result
+		}
+
+		out, err := json.Marshal(resp)
+		if err != nil {
+			log.Printf("rpc.response.marshal_failed method=%s err=%v", req.Method, err)
+			return
+		}
+		if _, err := writer.Write(out); err != nil {
+			return
+		}
+		if err := writer.WriteByte('\n'); err != nil {
+			return
+		}
+		if err := writer.Flush(); err != nil {
+			return
+		}
+	}
+}

--- a/connectors/whatsapp/daemon/internal/rpc/server.go
+++ b/connectors/whatsapp/daemon/internal/rpc/server.go
@@ -1,12 +1,6 @@
 // Package rpc implements a minimal JSON-RPC 2.0 server speaking
 // line-delimited JSON over TCP. One frame = one line. Requests carry
 // an "id"; notifications (server → client) omit it.
-//
-// Mirrors the wire shape Python's aios_whatsapp.rpc.RpcClient /
-// RpcListener expect, which in turn mirrors what signal-cli's daemon
-// produces. Keeping the wire shape identical to Signal means
-// aios_whatsapp.rpc is a near-verbatim copy of aios_signal.rpc and
-// the test patterns transfer.
 package rpc
 
 import (
@@ -19,6 +13,7 @@ import (
 	"log"
 	"net"
 	"sync"
+	"time"
 )
 
 // Handler dispatches a parsed JSON-RPC request to a registered method.
@@ -44,12 +39,6 @@ type Error struct {
 type Server struct {
 	addr    string
 	handler Handler
-
-	// Set by Run() once the listener binds, so callers can ask for the
-	// resolved address (useful for tests that pass :0 for an
-	// OS-assigned port).
-	mu      sync.Mutex
-	boundAt net.Addr
 }
 
 // NewServer builds an unstarted Server. Call Run() to bind + accept.
@@ -57,27 +46,21 @@ func NewServer(addr string, h Handler) *Server {
 	return &Server{addr: addr, handler: h}
 }
 
-// Addr returns the resolved listen address once Run() has bound. Nil
-// before the bind completes.
-func (s *Server) Addr() net.Addr {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.boundAt
-}
+// shutdownPollInterval is how often a serve loop checks ctx.Err() while
+// blocked on an idle read. Small enough that SIGTERM-to-Go-daemon (with
+// no traffic in flight) returns promptly; large enough not to burn CPU.
+const shutdownPollInterval = 500 * time.Millisecond
 
 // Run binds the configured address and accepts connections until ctx
 // is cancelled. Cancellation triggers a graceful shutdown: the
-// listener closes, in-flight connections drain (their reads will
-// observe EOF on the next iteration), and Run returns nil.
+// listener closes, in-flight serve loops observe ctx.Err() between
+// reads via a read deadline, and Run returns nil.
 func (s *Server) Run(ctx context.Context) error {
 	var lc net.ListenConfig
 	ln, err := lc.Listen(ctx, "tcp", s.addr)
 	if err != nil {
 		return fmt.Errorf("listen %q: %w", s.addr, err)
 	}
-	s.mu.Lock()
-	s.boundAt = ln.Addr()
-	s.mu.Unlock()
 	log.Printf("rpc.listening addr=%s", ln.Addr().String())
 
 	go func() {
@@ -113,13 +96,21 @@ type request struct {
 	Params  json.RawMessage `json:"params,omitempty"`
 }
 
-// response mirrors the response shape. Exactly one of Result / Error
-// is populated; the other is omitted via omitempty.
-type response struct {
+// successResponse and errorResponse are split structs so that a nil
+// result (e.g. an ack-only method that returns (nil, nil)) marshals to
+// the spec-compliant `"result": null` rather than being omitted via
+// omitempty — JSON-RPC 2.0 requires the result member to be present
+// on success.
+type successResponse struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      json.RawMessage `json:"id"`
-	Result  any             `json:"result,omitempty"`
-	Error   *Error          `json:"error,omitempty"`
+	Result  any             `json:"result"`
+}
+
+type errorResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Error   *Error          `json:"error"`
 }
 
 func (s *Server) serve(ctx context.Context, conn net.Conn) {
@@ -132,8 +123,18 @@ func (s *Server) serve(ctx context.Context, conn net.Conn) {
 		if ctx.Err() != nil {
 			return
 		}
+		// Reset the read deadline so an idle connection cannot pin the
+		// goroutine past ctx cancellation.  bufio.Reader returns from its
+		// buffer without hitting the syscall when data is queued, so an
+		// active client sees no behavior change.
+		_ = conn.SetReadDeadline(time.Now().Add(shutdownPollInterval))
 		line, err := reader.ReadBytes('\n')
 		if err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				// No data yet; loop to re-check ctx.Err().
+				continue
+			}
 			if !errors.Is(err, io.EOF) {
 				log.Printf("rpc.conn.read_error remote=%s err=%v", remote, err)
 			}
@@ -156,14 +157,12 @@ func (s *Server) serve(ctx context.Context, conn net.Conn) {
 		}
 
 		result, rpcErr := s.handler.Dispatch(ctx, req.Method, req.Params)
-		resp := response{JSONRPC: "2.0", ID: req.ID}
+		var out []byte
 		if rpcErr != nil {
-			resp.Error = rpcErr
+			out, err = json.Marshal(errorResponse{JSONRPC: "2.0", ID: req.ID, Error: rpcErr})
 		} else {
-			resp.Result = result
+			out, err = json.Marshal(successResponse{JSONRPC: "2.0", ID: req.ID, Result: result})
 		}
-
-		out, err := json.Marshal(resp)
 		if err != nil {
 			log.Printf("rpc.response.marshal_failed method=%s err=%v", req.Method, err)
 			return

--- a/connectors/whatsapp/pyproject.toml
+++ b/connectors/whatsapp/pyproject.toml
@@ -1,0 +1,88 @@
+[project]
+name = "aios-whatsapp"
+version = "0.1.0"
+description = "WhatsApp connector for aios"
+readme = "README.md"
+requires-python = ">=3.13"
+license = { text = "MIT" }
+authors = [{ name = "aios contributors" }]
+
+dependencies = [
+    "aios-connector-http",
+    "pydantic>=2.9",
+    "pydantic-settings>=2.6",
+    "structlog>=24.4",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3",
+    "pytest-asyncio>=0.24",
+    "pytest-mock>=3.14",
+    "ruff>=0.8",
+    "mypy>=1.13",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/aios_whatsapp"]
+
+# ─── ruff ────────────────────────────────────────────────────────────────────
+[tool.ruff]
+line-length = 100
+target-version = "py313"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "W",
+    "F",
+    "I",
+    "B",
+    "UP",
+    "SIM",
+    "RUF",
+    "TID",
+    "ASYNC",
+]
+ignore = [
+    "E501",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["B011"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+# ─── mypy ────────────────────────────────────────────────────────────────────
+[tool.mypy]
+python_version = "3.13"
+strict = true
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unreachable = true
+disallow_any_generics = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+plugins = ["pydantic.mypy"]
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+
+# ─── pytest ──────────────────────────────────────────────────────────────────
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = [
+    "-ra",
+    "--strict-markers",
+    "--strict-config",
+]

--- a/connectors/whatsapp/src/aios_whatsapp/__init__.py
+++ b/connectors/whatsapp/src/aios_whatsapp/__init__.py
@@ -1,0 +1,7 @@
+"""aios-whatsapp: WhatsApp connector for aios."""
+
+from __future__ import annotations
+
+from .connector import WhatsappConnector
+
+__all__ = ["WhatsappConnector"]

--- a/connectors/whatsapp/src/aios_whatsapp/__main__.py
+++ b/connectors/whatsapp/src/aios_whatsapp/__main__.py
@@ -1,0 +1,23 @@
+"""``python -m aios_whatsapp`` entry point.
+
+Reads ``AIOS_URL`` and ``AIOS_RUNTIME_TOKEN`` from env (the SDK does
+this automatically inside ``HttpConnector.__init__``).  Deployment-shape
+fields like ``AIOS_WHATSAPP_DATA_DIR`` feed pydantic-settings; the
+phone (the account identity) lives on each connection's encrypted
+secrets and is fetched per-connection in ``serve_connection``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from .config import Settings
+from .connector import WhatsappConnector
+
+
+def main() -> None:
+    asyncio.run(WhatsappConnector(Settings()).run_until_stopped())
+
+
+if __name__ == "__main__":
+    main()

--- a/connectors/whatsapp/src/aios_whatsapp/__main__.py
+++ b/connectors/whatsapp/src/aios_whatsapp/__main__.py
@@ -1,11 +1,4 @@
-"""``python -m aios_whatsapp`` entry point.
-
-Reads ``AIOS_URL`` and ``AIOS_RUNTIME_TOKEN`` from env (the SDK does
-this automatically inside ``HttpConnector.__init__``).  Deployment-shape
-fields like ``AIOS_WHATSAPP_DATA_DIR`` feed pydantic-settings; the
-phone (the account identity) lives on each connection's encrypted
-secrets and is fetched per-connection in ``serve_connection``.
-"""
+"""``python -m aios_whatsapp`` entry point."""
 
 from __future__ import annotations
 

--- a/connectors/whatsapp/src/aios_whatsapp/config.py
+++ b/connectors/whatsapp/src/aios_whatsapp/config.py
@@ -1,0 +1,41 @@
+"""Runtime configuration.
+
+``AIOS_WHATSAPP_*`` env vars feed pydantic-settings.  These are
+*deployment-shape* fields — host paths and binary names baked into how
+the container is wired — not credentials.  The phone (the account
+identity) lives on each connection record's encrypted secrets and is
+fetched per-connection via ``HttpConnector.secrets()``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="AIOS_WHATSAPP_",
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+    # Host directory bind-mounted into the container; per-phone
+    # subdirectories hold whatsmeow's sqlstore (``store.db``) plus the
+    # daemon's downloaded media cache (``media/``).  Required: without a
+    # persistent store, every container restart forces a fresh pairing.
+    data_dir: Path
+
+    # Daemon binary name/path.  Default assumes ``whatsapp-daemon`` is on
+    # ``$PATH`` (the Dockerfile installs it to ``/usr/local/bin/``).
+    daemon_bin: str = "whatsapp-daemon"
+
+    # Loopback host the daemon listens on; only ever 127.0.0.1 in production.
+    daemon_host: str = "127.0.0.1"
+
+    # Default port for single-daemon smoke testing.  The connector
+    # allocates ephemeral ports per-connection in production; this
+    # default exists so a single ``whatsapp-daemon`` can be run by hand
+    # and probed without a wrapping Python process.
+    daemon_port: int = 7584

--- a/connectors/whatsapp/src/aios_whatsapp/config.py
+++ b/connectors/whatsapp/src/aios_whatsapp/config.py
@@ -1,10 +1,8 @@
 """Runtime configuration.
 
-``AIOS_WHATSAPP_*`` env vars feed pydantic-settings.  These are
-*deployment-shape* fields — host paths and binary names baked into how
-the container is wired — not credentials.  The phone (the account
-identity) lives on each connection record's encrypted secrets and is
-fetched per-connection via ``HttpConnector.secrets()``.
+``AIOS_WHATSAPP_*`` env vars feed pydantic-settings.  Deployment-shape
+only — the phone (account identity) lives on each connection record's
+encrypted secrets and arrives per-connection via ``HttpConnector.secrets()``.
 """
 
 from __future__ import annotations
@@ -21,21 +19,6 @@ class Settings(BaseSettings):
         populate_by_name=True,
     )
 
-    # Host directory bind-mounted into the container; per-phone
-    # subdirectories hold whatsmeow's sqlstore (``store.db``) plus the
-    # daemon's downloaded media cache (``media/``).  Required: without a
-    # persistent store, every container restart forces a fresh pairing.
     data_dir: Path
-
-    # Daemon binary name/path.  Default assumes ``whatsapp-daemon`` is on
-    # ``$PATH`` (the Dockerfile installs it to ``/usr/local/bin/``).
     daemon_bin: str = "whatsapp-daemon"
-
-    # Loopback host the daemon listens on; only ever 127.0.0.1 in production.
     daemon_host: str = "127.0.0.1"
-
-    # Default port for single-daemon smoke testing.  The connector
-    # allocates ephemeral ports per-connection in production; this
-    # default exists so a single ``whatsapp-daemon`` can be run by hand
-    # and probed without a wrapping Python process.
-    daemon_port: int = 7584

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -1,34 +1,13 @@
 """WhatsApp connector built on the aios-connector-http SDK.
 
-One container, one connector type (``"whatsapp"``), N connections —
-each bound to one paired WhatsApp phone.  Unlike Signal's shared
-multi-account daemon, **each connection owns its own ``whatsapp-daemon``
-subprocess**: whatsmeow's ``Client`` is per-device, so a daemon per
-phone keeps lifecycles isolated (a crash of one phone's daemon doesn't
-take siblings down — :meth:`HttpConnector._isolated_serve_connection`
-contains the failure).
-
-Lifecycle:
-
-* :meth:`setup` is a no-op — no container-wide resource to bring up.
-* :meth:`serve_connection` per connection: read ``secrets["phone"]``,
-  spawn a :class:`WhatsappDaemon` for that phone, wait for readiness,
-  and drain the daemon's notification stream until the connection is
-  removed or the daemon crashes.
-* :meth:`teardown` is a no-op — each connection's daemon is cleaned up
-  inside its own ``serve_connection`` ``finally``.
-
-This module deliberately ships **no** ``@tool`` methods or platform
-event handling — that lands in subsequent PRs once the daemon
-integrates whatsmeow.  For now ``serve_connection`` just demonstrates
-that the daemon spawns, answers ``version``, and surfaces its
-notification stream so subsequent slices can plug parse/emit/dispatch
-logic into a stable boundary.
+Each connection owns its own ``whatsapp-daemon`` subprocess on an
+ephemeral loopback port — whatsmeow's ``Client`` is per-device, so a
+daemon per phone keeps lifecycles isolated.
 """
 
 from __future__ import annotations
 
-import asyncio
+import socket
 from dataclasses import dataclass
 
 import structlog
@@ -42,14 +21,6 @@ log = structlog.get_logger(__name__)
 
 @dataclass
 class _WhatsappConnectionState:
-    """Per-connection state: identity + handle to its daemon.
-
-    Subsequent PRs will extend this with the bot's own JID, push_name,
-    contact roster cache, and group roster cache — all populated at
-    ``serve_connection`` time after the daemon completes its WhatsApp
-    handshake.
-    """
-
     phone: str
     daemon: WhatsappDaemon
 
@@ -63,17 +34,6 @@ class WhatsappConnector(HttpConnector):
         self._cfg = cfg
 
     async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
-        """Bring up one phone's daemon and drain its notification stream.
-
-        ``secrets["phone"]`` identifies the phone this connection owns.
-        Missing → raise; the runner's
-        :meth:`HttpConnector._isolated_serve_connection` logs the
-        failure under ``connector.connection.serve_failed`` and keeps
-        the container serving its other connections.
-
-        The daemon's ``store_dir`` is ``<data_dir>/<phone>/`` — one
-        whatsmeow sqlstore per phone, naturally sharded by directory.
-        """
         phone = secrets.get("phone")
         if not phone:
             raise RuntimeError(
@@ -81,38 +41,25 @@ class WhatsappConnector(HttpConnector):
             )
 
         store_dir = self._cfg.data_dir / phone
+        port = _pick_free_port(self._cfg.daemon_host)
         async with WhatsappDaemon(
             daemon_bin=self._cfg.daemon_bin,
             host=self._cfg.daemon_host,
-            port=self._cfg.daemon_port,
+            port=port,
             store_dir=store_dir,
         ) as daemon:
-            state = _WhatsappConnectionState(phone=phone, daemon=daemon)
-            self.state[connection_id] = state
+            self.state[connection_id] = _WhatsappConnectionState(phone=phone, daemon=daemon)
             log.info(
                 "whatsapp.connection.ready",
                 connection_id=connection_id,
                 phone=phone,
-                port=self._cfg.daemon_port,
+                port=port,
             )
-            try:
-                await self._drain_notifications(connection_id, state)
-            finally:
-                self.state.pop(connection_id, None)
+            await self._drain_notifications(connection_id, daemon)
 
-    async def _drain_notifications(
-        self, connection_id: str, state: _WhatsappConnectionState
-    ) -> None:
-        """Consume the daemon's notification stream.
-
-        v0: log everything that arrives and discard.  Future PRs replace
-        this with method-dispatch (``message`` → parse → emit_inbound,
-        ``reaction`` → reaction-specific path, ``pairCode`` → pairing
-        management handler, etc.).  Notifications arriving at this stage
-        are unexpected (the daemon has no whatsmeow integration yet),
-        so logging them at WARNING surfaces wiring bugs early.
-        """
-        async for method, params in state.daemon.listener.notifications():
+    async def _drain_notifications(self, connection_id: str, daemon: WhatsappDaemon) -> None:
+        # No method dispatch yet — log unhandled to surface wiring bugs.
+        async for method, params in daemon.listener.notifications():
             log.warning(
                 "whatsapp.notification.unhandled",
                 connection_id=connection_id,
@@ -120,8 +67,15 @@ class WhatsappConnector(HttpConnector):
                 params=params,
             )
 
-    async def teardown(self) -> None:
-        # Each connection's daemon is owned by its own ``serve_connection``
-        # task and cleaned up via that task's ``async with`` exit.  Nothing
-        # for the connector itself to release.
-        await asyncio.sleep(0)
+
+def _pick_free_port(host: str) -> int:
+    """Bind to an OS-assigned loopback port and release it.
+
+    Small race window between release and the daemon's bind; the daemon
+    raises on EADDRINUSE so the operator gets a loud failure rather
+    than a silently-broken connection.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, 0))
+        port: int = s.getsockname()[1]
+    return port

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -1,0 +1,127 @@
+"""WhatsApp connector built on the aios-connector-http SDK.
+
+One container, one connector type (``"whatsapp"``), N connections —
+each bound to one paired WhatsApp phone.  Unlike Signal's shared
+multi-account daemon, **each connection owns its own ``whatsapp-daemon``
+subprocess**: whatsmeow's ``Client`` is per-device, so a daemon per
+phone keeps lifecycles isolated (a crash of one phone's daemon doesn't
+take siblings down — :meth:`HttpConnector._isolated_serve_connection`
+contains the failure).
+
+Lifecycle:
+
+* :meth:`setup` is a no-op — no container-wide resource to bring up.
+* :meth:`serve_connection` per connection: read ``secrets["phone"]``,
+  spawn a :class:`WhatsappDaemon` for that phone, wait for readiness,
+  and drain the daemon's notification stream until the connection is
+  removed or the daemon crashes.
+* :meth:`teardown` is a no-op — each connection's daemon is cleaned up
+  inside its own ``serve_connection`` ``finally``.
+
+This module deliberately ships **no** ``@tool`` methods or platform
+event handling — that lands in subsequent PRs once the daemon
+integrates whatsmeow.  For now ``serve_connection`` just demonstrates
+that the daemon spawns, answers ``version``, and surfaces its
+notification stream so subsequent slices can plug parse/emit/dispatch
+logic into a stable boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import structlog
+from aios_connector_http import HttpConnector
+
+from .config import Settings
+from .daemon import WhatsappDaemon
+
+log = structlog.get_logger(__name__)
+
+
+@dataclass
+class _WhatsappConnectionState:
+    """Per-connection state: identity + handle to its daemon.
+
+    Subsequent PRs will extend this with the bot's own JID, push_name,
+    contact roster cache, and group roster cache — all populated at
+    ``serve_connection`` time after the daemon completes its WhatsApp
+    handshake.
+    """
+
+    phone: str
+    daemon: WhatsappDaemon
+
+
+class WhatsappConnector(HttpConnector):
+    connector = "whatsapp"
+    state: dict[str, _WhatsappConnectionState]
+
+    def __init__(self, cfg: Settings) -> None:
+        super().__init__()
+        self._cfg = cfg
+
+    async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
+        """Bring up one phone's daemon and drain its notification stream.
+
+        ``secrets["phone"]`` identifies the phone this connection owns.
+        Missing → raise; the runner's
+        :meth:`HttpConnector._isolated_serve_connection` logs the
+        failure under ``connector.connection.serve_failed`` and keeps
+        the container serving its other connections.
+
+        The daemon's ``store_dir`` is ``<data_dir>/<phone>/`` — one
+        whatsmeow sqlstore per phone, naturally sharded by directory.
+        """
+        phone = secrets.get("phone")
+        if not phone:
+            raise RuntimeError(
+                f"whatsapp connection {connection_id!r} requires a 'phone' entry in its secrets"
+            )
+
+        store_dir = self._cfg.data_dir / phone
+        async with WhatsappDaemon(
+            daemon_bin=self._cfg.daemon_bin,
+            host=self._cfg.daemon_host,
+            port=self._cfg.daemon_port,
+            store_dir=store_dir,
+        ) as daemon:
+            state = _WhatsappConnectionState(phone=phone, daemon=daemon)
+            self.state[connection_id] = state
+            log.info(
+                "whatsapp.connection.ready",
+                connection_id=connection_id,
+                phone=phone,
+                port=self._cfg.daemon_port,
+            )
+            try:
+                await self._drain_notifications(connection_id, state)
+            finally:
+                self.state.pop(connection_id, None)
+
+    async def _drain_notifications(
+        self, connection_id: str, state: _WhatsappConnectionState
+    ) -> None:
+        """Consume the daemon's notification stream.
+
+        v0: log everything that arrives and discard.  Future PRs replace
+        this with method-dispatch (``message`` → parse → emit_inbound,
+        ``reaction`` → reaction-specific path, ``pairCode`` → pairing
+        management handler, etc.).  Notifications arriving at this stage
+        are unexpected (the daemon has no whatsmeow integration yet),
+        so logging them at WARNING surfaces wiring bugs early.
+        """
+        async for method, params in state.daemon.listener.notifications():
+            log.warning(
+                "whatsapp.notification.unhandled",
+                connection_id=connection_id,
+                method=method,
+                params=params,
+            )
+
+    async def teardown(self) -> None:
+        # Each connection's daemon is owned by its own ``serve_connection``
+        # task and cleaned up via that task's ``async with`` exit.  Nothing
+        # for the connector itself to release.
+        await asyncio.sleep(0)

--- a/connectors/whatsapp/src/aios_whatsapp/daemon.py
+++ b/connectors/whatsapp/src/aios_whatsapp/daemon.py
@@ -2,16 +2,9 @@
 
 Spawns the Go daemon, drains its stdio, waits for TCP readiness via
 ``version``, and exposes :class:`RpcClient` + :class:`RpcListener` for
-the per-connection :class:`aios_whatsapp.connector.WhatsappConnector`
-serve loop.
-
-Crash-is-fatal: an unexpected subprocess exit sets
-:class:`DaemonCrashError` on :meth:`crashed`.  The connector's listener
-drain (spawned under the runner's TaskGroup) observes this indirectly
-via :meth:`RpcListener.notifications` failing once the subprocess dies,
-and the resulting exception propagates through the TaskGroup — tearing
-the connection's ``serve_connection`` task down (but leaving sibling
-connections running, via :meth:`HttpConnector._isolated_serve_connection`).
+the connector's serve loop.  Crash mid-startup raises
+:class:`DaemonCrashError`; crash mid-session is observed via the
+listener stream raising :class:`ListenerClosedError`.
 """
 
 from __future__ import annotations
@@ -37,14 +30,7 @@ SHUTDOWN_GRACE_S = 5.0
 
 
 class WhatsappDaemon:
-    """Manages one whatsapp-daemon subprocess serving a single phone.
-
-    Per-connection scope (unlike Signal's shared multi-account daemon):
-    whatsmeow's ``Client`` is per-device, so we spawn one daemon per
-    phone and let crash isolation fall out from the runner's
-    :meth:`HttpConnector._isolated_serve_connection` per-connection
-    task scope.
-    """
+    """Manages one whatsapp-daemon subprocess serving one paired phone."""
 
     def __init__(
         self,
@@ -53,18 +39,14 @@ class WhatsappDaemon:
         host: str,
         port: int,
         store_dir: Path,
-        log_level: str = "info",
     ) -> None:
         self.daemon_bin = daemon_bin
         self.host = host
         self.port = port
         self.store_dir = store_dir
-        self.log_level = log_level
 
         self._proc: asyncio.subprocess.Process | None = None
         self._drain_tasks: list[asyncio.Task[None]] = []
-        self._watch_task: asyncio.Task[None] | None = None
-        self._crash_future: asyncio.Future[None] | None = None
 
         self.rpc = RpcClient(host, port)
         self.listener = RpcListener(host, port)
@@ -79,12 +61,6 @@ class WhatsappDaemon:
         return self
 
     async def __aexit__(self, *exc: object) -> None:
-        if self._watch_task is not None:
-            self._watch_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._watch_task
-            self._watch_task = None
-
         await self.listener.aclose()
 
         if self._proc is not None and self._proc.returncode is None:
@@ -112,8 +88,6 @@ class WhatsappDaemon:
             f"{self.host}:{self.port}",
             "-store-dir",
             str(self.store_dir),
-            "-log-level",
-            self.log_level,
         ]
         log.info(
             "whatsapp.daemon.spawn",
@@ -127,42 +101,25 @@ class WhatsappDaemon:
         assert self._proc.stderr is not None
         self._drain_tasks.append(
             asyncio.create_task(
-                _drain(self._proc.stdout, "whatsapp.daemon.stdout"),
+                _drain(self._proc.stdout, "stdout"),
                 name="whatsapp-daemon-stdout",
             )
         )
         self._drain_tasks.append(
             asyncio.create_task(
-                _drain(self._proc.stderr, "whatsapp.daemon.stderr"),
+                _drain(self._proc.stderr, "stderr"),
                 name="whatsapp-daemon-stderr",
             )
         )
-        self._crash_future = asyncio.get_running_loop().create_future()
-        self._watch_task = asyncio.create_task(self._watch_exit(), name="whatsapp-daemon-watch")
-
-    async def _watch_exit(self) -> None:
-        assert self._proc is not None
-        assert self._crash_future is not None
-        rc = await self._proc.wait()
-        if not self._crash_future.done():
-            self._crash_future.set_exception(
-                DaemonCrashError(f"whatsapp-daemon exited with code {rc}")
-            )
-
-    def crashed(self) -> asyncio.Future[None]:
-        assert self._crash_future is not None, "daemon not started"
-        return self._crash_future
 
     async def _wait_for_tcp(self) -> None:
-        """Poll ``version`` until the daemon answers or attempts exhaust.
-
-        Side-effect-free probe; works whether the daemon is mid-pairing
-        or fully connected to WhatsApp.  ``READY_POLL_ATTEMPTS *
-        READY_POLL_INTERVAL_S`` (30 s default) gives generous headroom
-        for Go's startup + sqlstore initialization.
-        """
+        """Poll ``version`` until the daemon answers, exits, or attempts exhaust."""
         last_error: Exception | None = None
         for _ in range(READY_POLL_ATTEMPTS):
+            if self._proc is not None and self._proc.returncode is not None:
+                raise DaemonCrashError(
+                    f"whatsapp-daemon exited with code {self._proc.returncode} during startup"
+                )
             try:
                 probe = RpcClient(self.host, self.port, timeout=READY_POLL_TIMEOUT_S)
                 await probe.call("version")
@@ -176,28 +133,12 @@ class WhatsappDaemon:
             f"whatsapp-daemon never became ready on {self.host}:{self.port}: {last_error!r}"
         )
 
-    async def version(self) -> dict[str, str]:
-        """Return ``{name, version}`` from the daemon.
-
-        Cheap, side-effect-free.  Used both at startup (via
-        :meth:`_wait_for_tcp`) and by tests that want to round-trip
-        the RPC layer without touching whatsmeow.
-        """
-        result = await self.rpc.call("version")
-        return result if isinstance(result, dict) else {}
-
 
 async def _spawn_subprocess(args: list[str]) -> asyncio.subprocess.Process:
-    """Spawn whatsapp-daemon detached into its own session + process group.
-
-    ``start_new_session=True`` (POSIX ``setsid()``) makes the child a
-    session and process group leader so foreground-terminal SIGINTs
-    don't reach the daemon — the connector's own SIGINT handler runs
-    ``__aexit__``, which sends a clean SIGTERM.  Same rationale as
-    :func:`aios_signal.daemon._spawn_subprocess`.
-    """
-    spawn = asyncio.create_subprocess_exec
-    return await spawn(
+    # Detach into own session so terminal SIGINT doesn't cascade — the
+    # connector's own SIGTERM handler runs __aexit__, which sends a
+    # clean SIGTERM here.
+    return await asyncio.create_subprocess_exec(
         *args,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -205,14 +146,21 @@ async def _spawn_subprocess(args: list[str]) -> asyncio.subprocess.Process:
     )
 
 
-async def _drain(reader: asyncio.StreamReader, log_event: str) -> None:
+async def _drain(reader: asyncio.StreamReader, stream_name: str) -> None:
+    # Background stdio forwarder.  Broad-except keeps a stream read
+    # failure (broken pipe after daemon dies) from silently dropping
+    # the task with an unobserved exception that asyncio would lose.
     try:
         while True:
             line = await reader.readline()
             if not line:
                 return
-            log.info(log_event, line=line.rstrip(b"\n").decode("utf-8", errors="replace"))
+            log.info(
+                "whatsapp.daemon.stream",
+                stream=stream_name,
+                line=line.rstrip(b"\n").decode("utf-8", errors="replace"),
+            )
     except asyncio.CancelledError:
         raise
     except Exception as e:
-        log.warning(f"{log_event}.read_error", error=str(e))
+        log.warning("whatsapp.daemon.stream.read_error", stream=stream_name, error=str(e))

--- a/connectors/whatsapp/src/aios_whatsapp/daemon.py
+++ b/connectors/whatsapp/src/aios_whatsapp/daemon.py
@@ -1,0 +1,218 @@
+"""whatsapp-daemon subprocess lifecycle.
+
+Spawns the Go daemon, drains its stdio, waits for TCP readiness via
+``version``, and exposes :class:`RpcClient` + :class:`RpcListener` for
+the per-connection :class:`aios_whatsapp.connector.WhatsappConnector`
+serve loop.
+
+Crash-is-fatal: an unexpected subprocess exit sets
+:class:`DaemonCrashError` on :meth:`crashed`.  The connector's listener
+drain (spawned under the runner's TaskGroup) observes this indirectly
+via :meth:`RpcListener.notifications` failing once the subprocess dies,
+and the resulting exception propagates through the TaskGroup — tearing
+the connection's ``serve_connection`` task down (but leaving sibling
+connections running, via :meth:`HttpConnector._isolated_serve_connection`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import signal
+from pathlib import Path
+from typing import Self
+
+import structlog
+
+from .errors import DaemonCrashError
+from .rpc import RpcClient, RpcListener
+
+log = structlog.get_logger(__name__)
+
+READY_POLL_ATTEMPTS = 150  # 150 attempts @ 200ms = 30s total
+READY_POLL_INTERVAL_S = 0.2
+READY_POLL_TIMEOUT_S = 2.0
+
+SHUTDOWN_GRACE_S = 5.0
+
+
+class WhatsappDaemon:
+    """Manages one whatsapp-daemon subprocess serving a single phone.
+
+    Per-connection scope (unlike Signal's shared multi-account daemon):
+    whatsmeow's ``Client`` is per-device, so we spawn one daemon per
+    phone and let crash isolation fall out from the runner's
+    :meth:`HttpConnector._isolated_serve_connection` per-connection
+    task scope.
+    """
+
+    def __init__(
+        self,
+        *,
+        daemon_bin: str,
+        host: str,
+        port: int,
+        store_dir: Path,
+        log_level: str = "info",
+    ) -> None:
+        self.daemon_bin = daemon_bin
+        self.host = host
+        self.port = port
+        self.store_dir = store_dir
+        self.log_level = log_level
+
+        self._proc: asyncio.subprocess.Process | None = None
+        self._drain_tasks: list[asyncio.Task[None]] = []
+        self._watch_task: asyncio.Task[None] | None = None
+        self._crash_future: asyncio.Future[None] | None = None
+
+        self.rpc = RpcClient(host, port)
+        self.listener = RpcListener(host, port)
+
+    async def __aenter__(self) -> Self:
+        await self._spawn()
+        try:
+            await self._wait_for_tcp()
+        except BaseException:
+            await self.__aexit__(None, None, None)
+            raise
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        if self._watch_task is not None:
+            self._watch_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._watch_task
+            self._watch_task = None
+
+        await self.listener.aclose()
+
+        if self._proc is not None and self._proc.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                self._proc.send_signal(signal.SIGTERM)
+            try:
+                await asyncio.wait_for(self._proc.wait(), timeout=SHUTDOWN_GRACE_S)
+            except TimeoutError:
+                log.warning("whatsapp.daemon.sigkill", port=self.port)
+                with contextlib.suppress(ProcessLookupError):
+                    self._proc.kill()
+                await self._proc.wait()
+
+        for t in self._drain_tasks:
+            t.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await t
+        self._drain_tasks.clear()
+
+    async def _spawn(self) -> None:
+        self.store_dir.mkdir(parents=True, exist_ok=True)
+        args = [
+            self.daemon_bin,
+            "-listen",
+            f"{self.host}:{self.port}",
+            "-store-dir",
+            str(self.store_dir),
+            "-log-level",
+            self.log_level,
+        ]
+        log.info(
+            "whatsapp.daemon.spawn",
+            daemon_bin=self.daemon_bin,
+            host=self.host,
+            port=self.port,
+            store_dir=str(self.store_dir),
+        )
+        self._proc = await _spawn_subprocess(args)
+        assert self._proc.stdout is not None
+        assert self._proc.stderr is not None
+        self._drain_tasks.append(
+            asyncio.create_task(
+                _drain(self._proc.stdout, "whatsapp.daemon.stdout"),
+                name="whatsapp-daemon-stdout",
+            )
+        )
+        self._drain_tasks.append(
+            asyncio.create_task(
+                _drain(self._proc.stderr, "whatsapp.daemon.stderr"),
+                name="whatsapp-daemon-stderr",
+            )
+        )
+        self._crash_future = asyncio.get_running_loop().create_future()
+        self._watch_task = asyncio.create_task(self._watch_exit(), name="whatsapp-daemon-watch")
+
+    async def _watch_exit(self) -> None:
+        assert self._proc is not None
+        assert self._crash_future is not None
+        rc = await self._proc.wait()
+        if not self._crash_future.done():
+            self._crash_future.set_exception(
+                DaemonCrashError(f"whatsapp-daemon exited with code {rc}")
+            )
+
+    def crashed(self) -> asyncio.Future[None]:
+        assert self._crash_future is not None, "daemon not started"
+        return self._crash_future
+
+    async def _wait_for_tcp(self) -> None:
+        """Poll ``version`` until the daemon answers or attempts exhaust.
+
+        Side-effect-free probe; works whether the daemon is mid-pairing
+        or fully connected to WhatsApp.  ``READY_POLL_ATTEMPTS *
+        READY_POLL_INTERVAL_S`` (30 s default) gives generous headroom
+        for Go's startup + sqlstore initialization.
+        """
+        last_error: Exception | None = None
+        for _ in range(READY_POLL_ATTEMPTS):
+            try:
+                probe = RpcClient(self.host, self.port, timeout=READY_POLL_TIMEOUT_S)
+                await probe.call("version")
+                await self.listener.connect()
+                log.info("whatsapp.daemon.ready", host=self.host, port=self.port)
+                return
+            except Exception as e:
+                last_error = e
+                await asyncio.sleep(READY_POLL_INTERVAL_S)
+        raise DaemonCrashError(
+            f"whatsapp-daemon never became ready on {self.host}:{self.port}: {last_error!r}"
+        )
+
+    async def version(self) -> dict[str, str]:
+        """Return ``{name, version}`` from the daemon.
+
+        Cheap, side-effect-free.  Used both at startup (via
+        :meth:`_wait_for_tcp`) and by tests that want to round-trip
+        the RPC layer without touching whatsmeow.
+        """
+        result = await self.rpc.call("version")
+        return result if isinstance(result, dict) else {}
+
+
+async def _spawn_subprocess(args: list[str]) -> asyncio.subprocess.Process:
+    """Spawn whatsapp-daemon detached into its own session + process group.
+
+    ``start_new_session=True`` (POSIX ``setsid()``) makes the child a
+    session and process group leader so foreground-terminal SIGINTs
+    don't reach the daemon — the connector's own SIGINT handler runs
+    ``__aexit__``, which sends a clean SIGTERM.  Same rationale as
+    :func:`aios_signal.daemon._spawn_subprocess`.
+    """
+    spawn = asyncio.create_subprocess_exec
+    return await spawn(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+
+
+async def _drain(reader: asyncio.StreamReader, log_event: str) -> None:
+    try:
+        while True:
+            line = await reader.readline()
+            if not line:
+                return
+            log.info(log_event, line=line.rstrip(b"\n").decode("utf-8", errors="replace"))
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        log.warning(f"{log_event}.read_error", error=str(e))

--- a/connectors/whatsapp/src/aios_whatsapp/errors.py
+++ b/connectors/whatsapp/src/aios_whatsapp/errors.py
@@ -12,9 +12,8 @@ class WhatsappConnectorError(Exception):
 class RpcError(WhatsappConnectorError):
     """JSON-RPC error from the WhatsApp daemon.
 
-    ``code`` / ``data`` carry the structured fields when present —
-    pairing-expired puts diagnostic data in ``data`` and would be lost
-    on a string flatten.
+    ``code`` / ``data`` preserve the JSON-RPC structured-error fields
+    so callers can discriminate on shape rather than string-flattening.
     """
 
     def __init__(self, message: str, *, code: int | None = None, data: Any = None) -> None:

--- a/connectors/whatsapp/src/aios_whatsapp/errors.py
+++ b/connectors/whatsapp/src/aios_whatsapp/errors.py
@@ -1,0 +1,35 @@
+"""Exception hierarchy for aios-whatsapp."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class WhatsappConnectorError(Exception):
+    """Base class for all aios-whatsapp errors."""
+
+
+class RpcError(WhatsappConnectorError):
+    """JSON-RPC error from the WhatsApp daemon.
+
+    ``code`` / ``data`` carry the structured fields when present —
+    pairing-expired puts diagnostic data in ``data`` and would be lost
+    on a string flatten.
+    """
+
+    def __init__(self, message: str, *, code: int | None = None, data: Any = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.data = data
+
+
+class RpcTimeoutError(RpcError):
+    pass
+
+
+class ListenerClosedError(RpcError):
+    pass
+
+
+class DaemonCrashError(WhatsappConnectorError):
+    pass

--- a/connectors/whatsapp/src/aios_whatsapp/rpc.py
+++ b/connectors/whatsapp/src/aios_whatsapp/rpc.py
@@ -1,21 +1,8 @@
-"""JSON-RPC transport for the WhatsApp daemon.
+"""JSON-RPC 2.0 over line-delimited TCP for the WhatsApp daemon.
 
-Two distinct transports share the same TCP endpoint:
-
-- :class:`RpcClient` — **fresh** TCP connection per request. Open, write a
-  single JSON-RPC line, read one response line, close. No pooling, no id
-  correlation dict — each call owns its socket.
-- :class:`RpcListener` — **persistent** TCP connection used exclusively for
-  the daemon's notification stream (``message``, ``reaction``, ``edit``,
-  ``receipt``, ``presence``, ``connectionState``, ``pairCode``,
-  ``loggedOut``).  Yields ``(method, params)`` tuples as ``AsyncIterator``;
-  disconnection is fatal and surfaces as :class:`ListenerClosedError`.
-
-Generalised from :mod:`aios_signal.rpc`: Signal's listener hard-codes
-``method == "receive"`` because signal-cli has exactly one notification
-shape.  The WhatsApp daemon multiplexes several methods on the same
-stream, so the listener yields the method name alongside the params and
-the connector dispatches on it.
+:class:`RpcClient` opens a fresh connection per call.
+:class:`RpcListener` holds one persistent connection for the daemon's
+notification stream and yields ``(method, params)`` tuples.
 """
 
 from __future__ import annotations
@@ -97,15 +84,12 @@ class RpcClient:
             return message.get("result")
         finally:
             writer.close()
-            try:
+            with contextlib.suppress(OSError):
                 await writer.wait_closed()
-            except OSError:
-                # Socket already torn down; not our problem.
-                log.debug("rpc.writer_close_error", host=self._host, port=self._port)
 
 
 class RpcListener:
-    """Persistent-connection listener for the WhatsApp daemon's notification stream."""
+    """Persistent-connection listener for the daemon's notification stream."""
 
     def __init__(self, host: str, port: int) -> None:
         self._host = host
@@ -125,13 +109,9 @@ class RpcListener:
     async def notifications(self) -> AsyncIterator[tuple[str, dict[str, Any]]]:
         """Yield ``(method, params)`` pairs for each notification frame.
 
-        Frames are JSON-RPC requests without an ``id`` (i.e. notifications,
-        per JSON-RPC 2.0).  RPC responses (frames with an ``id``) and
-        notifications with a non-dict ``params`` are silently dropped —
-        :class:`RpcClient` owns its own socket and never reuses the
-        listener's stream.
-
-        Raises :class:`ListenerClosedError` when the connection drops.
+        RPC responses (frames carrying ``id``) and frames with non-string
+        ``method`` / non-dict ``params`` are dropped.  Raises
+        :class:`ListenerClosedError` when the connection drops.
         """
         if self._reader is None:
             raise ListenerClosedError("listener not connected")
@@ -149,7 +129,6 @@ class RpcListener:
                 continue
             method = message.get("method")
             if not isinstance(method, str) or not method:
-                # RPC response or malformed frame — ignore.
                 continue
             params = message.get("params")
             if not isinstance(params, dict):

--- a/connectors/whatsapp/src/aios_whatsapp/rpc.py
+++ b/connectors/whatsapp/src/aios_whatsapp/rpc.py
@@ -1,0 +1,166 @@
+"""JSON-RPC transport for the WhatsApp daemon.
+
+Two distinct transports share the same TCP endpoint:
+
+- :class:`RpcClient` — **fresh** TCP connection per request. Open, write a
+  single JSON-RPC line, read one response line, close. No pooling, no id
+  correlation dict — each call owns its socket.
+- :class:`RpcListener` — **persistent** TCP connection used exclusively for
+  the daemon's notification stream (``message``, ``reaction``, ``edit``,
+  ``receipt``, ``presence``, ``connectionState``, ``pairCode``,
+  ``loggedOut``).  Yields ``(method, params)`` tuples as ``AsyncIterator``;
+  disconnection is fatal and surfaces as :class:`ListenerClosedError`.
+
+Generalised from :mod:`aios_signal.rpc`: Signal's listener hard-codes
+``method == "receive"`` because signal-cli has exactly one notification
+shape.  The WhatsApp daemon multiplexes several methods on the same
+stream, so the listener yields the method name alongside the params and
+the connector dispatches on it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import itertools
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import structlog
+
+from .errors import ListenerClosedError, RpcError, RpcTimeoutError
+
+log = structlog.get_logger(__name__)
+
+
+class RpcClient:
+    """Fresh-TCP-per-call JSON-RPC client for the WhatsApp daemon."""
+
+    def __init__(self, host: str, port: int, *, timeout: float = 30.0) -> None:
+        self._host = host
+        self._port = port
+        self._timeout = timeout
+        self._ids = itertools.count(1)
+
+    async def call(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        """Invoke ``method`` with ``params``. Returns the ``result`` field.
+
+        Raises :class:`RpcTimeoutError` if the call exceeds ``timeout``.
+        Raises :class:`RpcError` on transport failure or an RPC error response.
+        """
+        request: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "id": next(self._ids),
+        }
+        if params is not None:
+            request["params"] = params
+
+        try:
+            return await asyncio.wait_for(self._call(request), timeout=self._timeout)
+        except TimeoutError as e:
+            raise RpcTimeoutError(f"RPC {method!r} timed out after {self._timeout}s") from e
+
+    async def _call(self, request: dict[str, Any]) -> Any:
+        try:
+            reader, writer = await asyncio.open_connection(self._host, self._port)
+        except OSError as e:
+            raise RpcError(f"failed to connect to {self._host}:{self._port}: {e}") from e
+
+        try:
+            writer.write(json.dumps(request).encode("utf-8") + b"\n")
+            await writer.drain()
+            try:
+                line = await reader.readline()
+            except OSError as e:
+                raise RpcError(f"RPC read failed: {e}") from e
+            if not line:
+                raise RpcError("RPC connection closed before response")
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError as e:
+                raise RpcError(f"RPC returned non-JSON: {line!r}") from e
+            if "error" in message:
+                err = message["error"]
+                if isinstance(err, dict):
+                    raise RpcError(
+                        err.get("message", str(err)),
+                        code=err.get("code"),
+                        data=err.get("data"),
+                    )
+                raise RpcError(str(err))
+            return message.get("result")
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except OSError:
+                # Socket already torn down; not our problem.
+                log.debug("rpc.writer_close_error", host=self._host, port=self._port)
+
+
+class RpcListener:
+    """Persistent-connection listener for the WhatsApp daemon's notification stream."""
+
+    def __init__(self, host: str, port: int) -> None:
+        self._host = host
+        self._port = port
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+
+    async def connect(self) -> None:
+        """Open the persistent TCP connection. Call once before iterating."""
+        try:
+            self._reader, self._writer = await asyncio.open_connection(self._host, self._port)
+        except OSError as e:
+            raise ListenerClosedError(
+                f"failed to connect listener to {self._host}:{self._port}: {e}"
+            ) from e
+
+    async def notifications(self) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+        """Yield ``(method, params)`` pairs for each notification frame.
+
+        Frames are JSON-RPC requests without an ``id`` (i.e. notifications,
+        per JSON-RPC 2.0).  RPC responses (frames with an ``id``) and
+        notifications with a non-dict ``params`` are silently dropped —
+        :class:`RpcClient` owns its own socket and never reuses the
+        listener's stream.
+
+        Raises :class:`ListenerClosedError` when the connection drops.
+        """
+        if self._reader is None:
+            raise ListenerClosedError("listener not connected")
+        while True:
+            try:
+                line = await self._reader.readline()
+            except OSError as e:
+                raise ListenerClosedError(f"listener read failed: {e}") from e
+            if not line:
+                raise ListenerClosedError("listener connection closed")
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                log.warning("rpc.listener.bad_json", raw=line[:200].decode("latin-1"))
+                continue
+            method = message.get("method")
+            if not isinstance(method, str) or not method:
+                # RPC response or malformed frame — ignore.
+                continue
+            params = message.get("params")
+            if not isinstance(params, dict):
+                log.warning("rpc.listener.bad_params", method=method)
+                continue
+            yield method, params
+
+    async def aclose(self) -> None:
+        if self._writer is not None:
+            self._writer.close()
+            with contextlib.suppress(OSError):
+                await self._writer.wait_closed()
+            self._writer = None
+            self._reader = None

--- a/connectors/whatsapp/tests/conftest.py
+++ b/connectors/whatsapp/tests/conftest.py
@@ -1,0 +1,53 @@
+"""Shared test fixtures for aios-whatsapp."""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+# HttpConnector reads AIOS_URL / AIOS_RUNTIME_TOKEN at __init__ time.
+os.environ.setdefault("AIOS_URL", "http://test")
+os.environ.setdefault("AIOS_RUNTIME_TOKEN", "aios_runtime_test")
+
+
+def _unused_port() -> int:
+    """Bind to an OS-assigned port and immediately release it.
+
+    There's a (negligible) race window between us releasing the port and
+    the test using it — small enough to ignore for unit tests, and the
+    daemon spawn would fail loudly if another process grabbed it.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        port: int = s.getsockname()[1]
+    return port
+
+
+@pytest.fixture
+def unused_port() -> int:
+    return _unused_port()
+
+
+@pytest.fixture
+def fake_daemon_bin(tmp_path: Path) -> Iterator[Path]:
+    """A path that behaves like the real ``whatsapp-daemon`` for spawn tests.
+
+    The real daemon is a Go binary; for Python unit tests we wrap a
+    Python stand-in (``tests/fake_daemon.py``) in a tiny shell script
+    that invokes the current interpreter.  This avoids both a Go
+    toolchain dependency and any reliance on ``python3``-on-PATH being
+    the same interpreter the test suite is running under.
+    """
+    script = Path(__file__).parent / "fake_daemon.py"
+    wrapper = tmp_path / "whatsapp-daemon"
+    # ``exec`` so the wrapper doesn't sit between our subprocess and
+    # the Python interpreter when SIGTERM arrives — SIGTERM should hit
+    # python directly so its KeyboardInterrupt path runs.
+    wrapper.write_text(f'#!/bin/sh\nexec "{sys.executable}" "{script}" "$@"\n')
+    wrapper.chmod(0o755)
+    yield wrapper

--- a/connectors/whatsapp/tests/fake_daemon.py
+++ b/connectors/whatsapp/tests/fake_daemon.py
@@ -1,13 +1,7 @@
-"""A stand-in for the real Go ``whatsapp-daemon`` used in unit tests.
+"""Stand-in for ``whatsapp-daemon`` used in unit tests.
 
-Speaks the same wire protocol as the production daemon (line-delimited
-JSON-RPC 2.0 over TCP) so the Python side's spawn → readiness-probe →
-RPC-call → notification-stream code path can be exercised end-to-end
-without a Go toolchain in CI.
-
-Only implements the methods PR-1 tests need (``version``, ``echo``,
-``crash``).  Subsequent PRs may extend this — or replace it with a
-``go build`` fixture once the Go daemon grows whatsmeow integration.
+Speaks the same wire protocol (line-delimited JSON-RPC 2.0 over TCP) as
+the production Go daemon.  Implements: ``version``, ``crash``, ``notify``.
 """
 
 from __future__ import annotations
@@ -16,7 +10,6 @@ import argparse
 import asyncio
 import json
 import sys
-from typing import Any
 
 
 async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
@@ -34,23 +27,19 @@ async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) ->
             req_id = req.get("id")
 
             if method == "version":
-                resp: dict[str, Any] = {
+                resp: dict[str, object] = {
                     "jsonrpc": "2.0",
                     "id": req_id,
                     "result": {"name": "whatsapp-daemon-fake", "version": "test"},
                 }
-            elif method == "echo":
-                resp = {"jsonrpc": "2.0", "id": req_id, "result": params}
             elif method == "crash":
-                # Used by daemon-crash tests: terminate the process so the
-                # Python side's `crashed()` future fires.
                 writer.close()
-                # Defer the exit so the response (if any) flushes first.
+                # Defer the exit so any in-flight write flushes first.
                 asyncio.get_running_loop().call_later(0.05, sys.exit, 1)
                 return
             elif method == "notify":
-                # `notify` triggers a daemon-initiated notification on the
-                # SAME socket so the listener fixture can observe it.
+                # Emit a daemon-initiated notification on the same socket
+                # so listener fixtures can observe it.
                 notif = {
                     "jsonrpc": "2.0",
                     "method": params.get("method", "message"),
@@ -82,10 +71,6 @@ def main() -> None:
     p = argparse.ArgumentParser()
     p.add_argument("-listen", required=True)
     p.add_argument("-store-dir", required=True)
-    p.add_argument("-log-level", default="info")
-    # ``-version`` is the only flag mode the real daemon supports as an
-    # early exit; mirror it so fixtures that probe ``--version`` succeed
-    # without spinning up the server.
     p.add_argument("-version", action="store_true")
     args = p.parse_args()
 

--- a/connectors/whatsapp/tests/fake_daemon.py
+++ b/connectors/whatsapp/tests/fake_daemon.py
@@ -1,0 +1,101 @@
+"""A stand-in for the real Go ``whatsapp-daemon`` used in unit tests.
+
+Speaks the same wire protocol as the production daemon (line-delimited
+JSON-RPC 2.0 over TCP) so the Python side's spawn → readiness-probe →
+RPC-call → notification-stream code path can be exercised end-to-end
+without a Go toolchain in CI.
+
+Only implements the methods PR-1 tests need (``version``, ``echo``,
+``crash``).  Subsequent PRs may extend this — or replace it with a
+``go build`` fixture once the Go daemon grows whatsmeow integration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+
+async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    try:
+        while True:
+            line = await reader.readline()
+            if not line:
+                return
+            try:
+                req = json.loads(line)
+            except json.JSONDecodeError:
+                return
+            method = req.get("method")
+            params = req.get("params") or {}
+            req_id = req.get("id")
+
+            if method == "version":
+                resp: dict[str, Any] = {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {"name": "whatsapp-daemon-fake", "version": "test"},
+                }
+            elif method == "echo":
+                resp = {"jsonrpc": "2.0", "id": req_id, "result": params}
+            elif method == "crash":
+                # Used by daemon-crash tests: terminate the process so the
+                # Python side's `crashed()` future fires.
+                writer.close()
+                # Defer the exit so the response (if any) flushes first.
+                asyncio.get_running_loop().call_later(0.05, sys.exit, 1)
+                return
+            elif method == "notify":
+                # `notify` triggers a daemon-initiated notification on the
+                # SAME socket so the listener fixture can observe it.
+                notif = {
+                    "jsonrpc": "2.0",
+                    "method": params.get("method", "message"),
+                    "params": params.get("params") or {},
+                }
+                writer.write(json.dumps(notif).encode() + b"\n")
+                await writer.drain()
+                continue
+            else:
+                resp = {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32601, "message": f"method not found: {method}"},
+                }
+
+            writer.write(json.dumps(resp).encode() + b"\n")
+            await writer.drain()
+    finally:
+        writer.close()
+
+
+async def _serve(host: str, port: int) -> None:
+    server = await asyncio.start_server(_handle, host=host, port=port)
+    async with server:
+        await server.serve_forever()
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("-listen", required=True)
+    p.add_argument("-store-dir", required=True)
+    p.add_argument("-log-level", default="info")
+    # ``-version`` is the only flag mode the real daemon supports as an
+    # early exit; mirror it so fixtures that probe ``--version`` succeed
+    # without spinning up the server.
+    p.add_argument("-version", action="store_true")
+    args = p.parse_args()
+
+    if args.version:
+        print("whatsapp-daemon-fake test")
+        return
+
+    host_str, port_str = args.listen.rsplit(":", 1)
+    asyncio.run(_serve(host_str, int(port_str)))
+
+
+if __name__ == "__main__":
+    main()

--- a/connectors/whatsapp/tests/test_config.py
+++ b/connectors/whatsapp/tests/test_config.py
@@ -1,10 +1,4 @@
-"""Tests for the whatsapp connector's pydantic Settings.
-
-The phone (account identity) is not in env — it lives on the
-connection record's encrypted secrets blob and arrives per-connection
-in ``serve_connection``.  Settings carries only deployment-shape
-fields: the data dir, the daemon binary, and the loopback bind.
-"""
+"""Tests for the whatsapp connector's pydantic Settings."""
 
 from __future__ import annotations
 
@@ -30,7 +24,6 @@ def test_defaults_for_optional_fields(monkeypatch: pytest.MonkeyPatch) -> None:
     s = Settings()
     assert s.daemon_bin == "whatsapp-daemon"
     assert s.daemon_host == "127.0.0.1"
-    assert s.daemon_port == 7584
 
 
 def test_env_override_for_daemon_bin(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/connectors/whatsapp/tests/test_config.py
+++ b/connectors/whatsapp/tests/test_config.py
@@ -1,0 +1,40 @@
+"""Tests for the whatsapp connector's pydantic Settings.
+
+The phone (account identity) is not in env — it lives on the
+connection record's encrypted secrets blob and arrives per-connection
+in ``serve_connection``.  Settings carries only deployment-shape
+fields: the data dir, the daemon binary, and the loopback bind.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aios_whatsapp.config import Settings
+
+
+def test_data_dir_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AIOS_WHATSAPP_DATA_DIR", raising=False)
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_constructor_kwarg() -> None:
+    s = Settings(data_dir="/tmp/aios-whatsapp-test")
+    assert s.data_dir.as_posix() == "/tmp/aios-whatsapp-test"
+
+
+def test_defaults_for_optional_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIOS_WHATSAPP_DATA_DIR", "/tmp/aios-whatsapp-test")
+    s = Settings()
+    assert s.daemon_bin == "whatsapp-daemon"
+    assert s.daemon_host == "127.0.0.1"
+    assert s.daemon_port == 7584
+
+
+def test_env_override_for_daemon_bin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIOS_WHATSAPP_DATA_DIR", "/tmp/aios-whatsapp-test")
+    monkeypatch.setenv("AIOS_WHATSAPP_DAEMON_BIN", "/usr/local/bin/whatsapp-daemon-staging")
+    s = Settings()
+    assert s.daemon_bin == "/usr/local/bin/whatsapp-daemon-staging"

--- a/connectors/whatsapp/tests/test_daemon.py
+++ b/connectors/whatsapp/tests/test_daemon.py
@@ -1,0 +1,123 @@
+"""End-to-end tests for daemon.py against a Python stand-in binary.
+
+Unit tests for daemon.py have to exercise the actual subprocess spawn
+to be meaningful — port allocation, TCP readiness polling, stdio drain,
+and crash-fatal future propagation all depend on the OS-level process
+boundary.  Signal's test_daemon.py skips this because signal-cli would
+need a Java toolchain in CI; we mock signal-cli's place with a tiny
+Python script (``tests/fake_daemon.py``) wrapped by a shell wrapper
+fixture (``fake_daemon_bin``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from pathlib import Path
+
+import pytest
+
+from aios_whatsapp import daemon as daemon_mod
+from aios_whatsapp.daemon import WhatsappDaemon
+from aios_whatsapp.errors import DaemonCrashError
+
+
+async def test_daemon_spawn_and_version(
+    fake_daemon_bin: Path, unused_port: int, tmp_path: Path
+) -> None:
+    """Daemon spawns, becomes ready (TCP open + ``version`` answers), and
+    round-trips a follow-up ``version`` call.
+    """
+    daemon = WhatsappDaemon(
+        daemon_bin=str(fake_daemon_bin),
+        host="127.0.0.1",
+        port=unused_port,
+        store_dir=tmp_path / "store",
+    )
+    async with daemon:
+        result = await daemon.version()
+        assert result == {"name": "whatsapp-daemon-fake", "version": "test"}
+
+
+async def test_daemon_creates_store_dir(
+    fake_daemon_bin: Path, unused_port: int, tmp_path: Path
+) -> None:
+    """``serve_connection`` may be the first thing to ever touch the
+    per-phone dir; daemon spawn should create it rather than fail on a
+    missing parent.
+    """
+    store_dir = tmp_path / "nested" / "store"
+    assert not store_dir.exists()
+    daemon = WhatsappDaemon(
+        daemon_bin=str(fake_daemon_bin),
+        host="127.0.0.1",
+        port=unused_port,
+        store_dir=store_dir,
+    )
+    async with daemon:
+        pass
+    assert store_dir.is_dir()
+
+
+async def test_daemon_crash_sets_crashed_future(
+    fake_daemon_bin: Path, unused_port: int, tmp_path: Path
+) -> None:
+    """A subprocess exit while the daemon is running flips the
+    ``crashed()`` future to a :class:`DaemonCrashError`.  The connector
+    awaits this alongside the listener stream so a daemon death tears
+    the per-connection serve task down promptly.
+    """
+    daemon = WhatsappDaemon(
+        daemon_bin=str(fake_daemon_bin),
+        host="127.0.0.1",
+        port=unused_port,
+        store_dir=tmp_path / "store",
+    )
+    async with daemon:
+        # The fake daemon's ``crash`` method sys.exits with code 1 after
+        # a short delay.  Fire-and-forget the call: it closes the socket
+        # without responding, then exits; suppress the resulting RPC
+        # error so the exit-watcher gets a chance to fire.
+        with contextlib.suppress(Exception):
+            await daemon.rpc.call("crash")
+        with pytest.raises(DaemonCrashError):
+            await asyncio.wait_for(daemon.crashed(), timeout=5.0)
+
+
+async def test_daemon_readiness_times_out_when_no_listener(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the spawned process never opens a listener (wrong binary,
+    immediate-crash, etc.), ``__aenter__`` exhausts the readiness
+    attempts and raises :class:`DaemonCrashError`.
+    """
+    # A wrapper that just sleeps — accepts (and ignores) our argv but
+    # never binds the port.  Models the "binary spawned but never
+    # listened" failure mode without depending on the OS shell's flag
+    # handling.
+    sleeper = tmp_path / "sleeper"
+    sleeper.write_text("#!/bin/sh\nsleep 5\n")
+    sleeper.chmod(0o755)
+
+    # Shrink the readiness window so the test doesn't sit through the
+    # production default (~30 s).
+    monkeypatch.setattr(daemon_mod, "READY_POLL_ATTEMPTS", 3)
+    monkeypatch.setattr(daemon_mod, "READY_POLL_INTERVAL_S", 0.05)
+
+    daemon = WhatsappDaemon(
+        daemon_bin=str(sleeper),
+        host="127.0.0.1",
+        port=_unused_port_sync(),
+        store_dir=tmp_path / "store",
+    )
+    with pytest.raises(DaemonCrashError):
+        await daemon.__aenter__()
+
+
+def _unused_port_sync() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        port: int = s.getsockname()[1]
+    return port

--- a/connectors/whatsapp/tests/test_daemon.py
+++ b/connectors/whatsapp/tests/test_daemon.py
@@ -1,17 +1,13 @@
-"""End-to-end tests for daemon.py against a Python stand-in binary.
+"""Lifecycle tests for ``WhatsappDaemon`` against a Python stand-in.
 
-Unit tests for daemon.py have to exercise the actual subprocess spawn
-to be meaningful — port allocation, TCP readiness polling, stdio drain,
-and crash-fatal future propagation all depend on the OS-level process
-boundary.  Signal's test_daemon.py skips this because signal-cli would
-need a Java toolchain in CI; we mock signal-cli's place with a tiny
-Python script (``tests/fake_daemon.py``) wrapped by a shell wrapper
-fixture (``fake_daemon_bin``).
+The real daemon is a Go binary; tests use ``tests/fake_daemon.py``
+wrapped by the ``fake_daemon_bin`` conftest fixture so the subprocess
+spawn / readiness-probe / crash-detection paths exercise real OS-level
+process boundaries without a Go toolchain at test time.
 """
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 from pathlib import Path
 
@@ -19,15 +15,12 @@ import pytest
 
 from aios_whatsapp import daemon as daemon_mod
 from aios_whatsapp.daemon import WhatsappDaemon
-from aios_whatsapp.errors import DaemonCrashError
+from aios_whatsapp.errors import DaemonCrashError, ListenerClosedError
 
 
 async def test_daemon_spawn_and_version(
     fake_daemon_bin: Path, unused_port: int, tmp_path: Path
 ) -> None:
-    """Daemon spawns, becomes ready (TCP open + ``version`` answers), and
-    round-trips a follow-up ``version`` call.
-    """
     daemon = WhatsappDaemon(
         daemon_bin=str(fake_daemon_bin),
         host="127.0.0.1",
@@ -35,17 +28,13 @@ async def test_daemon_spawn_and_version(
         store_dir=tmp_path / "store",
     )
     async with daemon:
-        result = await daemon.version()
+        result = await daemon.rpc.call("version")
         assert result == {"name": "whatsapp-daemon-fake", "version": "test"}
 
 
 async def test_daemon_creates_store_dir(
     fake_daemon_bin: Path, unused_port: int, tmp_path: Path
 ) -> None:
-    """``serve_connection`` may be the first thing to ever touch the
-    per-phone dir; daemon spawn should create it rather than fail on a
-    missing parent.
-    """
     store_dir = tmp_path / "nested" / "store"
     assert not store_dir.exists()
     daemon = WhatsappDaemon(
@@ -59,13 +48,13 @@ async def test_daemon_creates_store_dir(
     assert store_dir.is_dir()
 
 
-async def test_daemon_crash_sets_crashed_future(
+async def test_daemon_crash_propagates_to_listener(
     fake_daemon_bin: Path, unused_port: int, tmp_path: Path
 ) -> None:
-    """A subprocess exit while the daemon is running flips the
-    ``crashed()`` future to a :class:`DaemonCrashError`.  The connector
-    awaits this alongside the listener stream so a daemon death tears
-    the per-connection serve task down promptly.
+    """A subprocess exit makes the listener stream raise ``ListenerClosedError``.
+
+    This is the path the connector's ``_drain_notifications`` observes
+    so the per-connection serve task tears down on daemon death.
     """
     daemon = WhatsappDaemon(
         daemon_bin=str(fake_daemon_bin),
@@ -74,50 +63,34 @@ async def test_daemon_crash_sets_crashed_future(
         store_dir=tmp_path / "store",
     )
     async with daemon:
-        # The fake daemon's ``crash`` method sys.exits with code 1 after
-        # a short delay.  Fire-and-forget the call: it closes the socket
-        # without responding, then exits; suppress the resulting RPC
-        # error so the exit-watcher gets a chance to fire.
+        # ``crash`` sys.exits the fake daemon shortly after closing the
+        # socket; fire-and-forget the call and suppress the resulting
+        # RPC error (the connection close races the exit).
         with contextlib.suppress(Exception):
             await daemon.rpc.call("crash")
-        with pytest.raises(DaemonCrashError):
-            await asyncio.wait_for(daemon.crashed(), timeout=5.0)
+        with pytest.raises(ListenerClosedError):
+            async for _ in daemon.listener.notifications():
+                pass
 
 
 async def test_daemon_readiness_times_out_when_no_listener(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, unused_port: int, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """If the spawned process never opens a listener (wrong binary,
-    immediate-crash, etc.), ``__aenter__`` exhausts the readiness
-    attempts and raises :class:`DaemonCrashError`.
-    """
-    # A wrapper that just sleeps — accepts (and ignores) our argv but
-    # never binds the port.  Models the "binary spawned but never
-    # listened" failure mode without depending on the OS shell's flag
-    # handling.
+    """A spawned process that never binds raises ``DaemonCrashError``."""
+    # Sleeper accepts our argv but never binds — models "binary spawned
+    # but never listened".
     sleeper = tmp_path / "sleeper"
     sleeper.write_text("#!/bin/sh\nsleep 5\n")
     sleeper.chmod(0o755)
 
-    # Shrink the readiness window so the test doesn't sit through the
-    # production default (~30 s).
     monkeypatch.setattr(daemon_mod, "READY_POLL_ATTEMPTS", 3)
     monkeypatch.setattr(daemon_mod, "READY_POLL_INTERVAL_S", 0.05)
 
     daemon = WhatsappDaemon(
         daemon_bin=str(sleeper),
         host="127.0.0.1",
-        port=_unused_port_sync(),
+        port=unused_port,
         store_dir=tmp_path / "store",
     )
     with pytest.raises(DaemonCrashError):
         await daemon.__aenter__()
-
-
-def _unused_port_sync() -> int:
-    import socket
-
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        port: int = s.getsockname()[1]
-    return port

--- a/connectors/whatsapp/tests/test_rpc.py
+++ b/connectors/whatsapp/tests/test_rpc.py
@@ -1,0 +1,165 @@
+"""Tests for rpc.py — RpcClient (fresh conn per call) + RpcListener (persistent)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+import pytest
+
+from aios_whatsapp.errors import ListenerClosedError, RpcError, RpcTimeoutError
+from aios_whatsapp.rpc import RpcClient, RpcListener
+
+Handler = Callable[[asyncio.StreamReader, asyncio.StreamWriter], Coroutine[Any, Any, None]]
+
+
+async def _start_server(handler: Handler) -> tuple[asyncio.Server, int]:
+    server = await asyncio.start_server(handler, host="127.0.0.1", port=0)
+    port = server.sockets[0].getsockname()[1]
+    return server, port
+
+
+async def test_rpc_client_opens_fresh_connection_per_call() -> None:
+    connection_count = 0
+
+    async def handler(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
+        nonlocal connection_count
+        connection_count += 1
+        line = await r.readline()
+        req = json.loads(line)
+        response = {"jsonrpc": "2.0", "id": req["id"], "result": {"ok": True}}
+        w.write(json.dumps(response).encode() + b"\n")
+        await w.drain()
+        w.close()
+
+    server, port = await _start_server(handler)
+    async with server:
+        client = RpcClient("127.0.0.1", port)
+        r1, r2, r3 = await asyncio.gather(
+            client.call("method_a"),
+            client.call("method_b"),
+            client.call("method_c"),
+        )
+    assert r1 == r2 == r3 == {"ok": True}
+    assert connection_count == 3  # fresh conn per call
+
+
+async def test_rpc_client_propagates_error_field() -> None:
+    async def handler(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
+        line = await r.readline()
+        req = json.loads(line)
+        response = {
+            "jsonrpc": "2.0",
+            "id": req["id"],
+            "error": {"code": -32601, "message": "method not found"},
+        }
+        w.write(json.dumps(response).encode() + b"\n")
+        await w.drain()
+        w.close()
+
+    server, port = await _start_server(handler)
+    async with server:
+        client = RpcClient("127.0.0.1", port)
+        with pytest.raises(RpcError, match="method not found") as ei:
+            await client.call("bogus")
+        assert ei.value.code == -32601
+
+
+async def test_rpc_client_timeout() -> None:
+    async def handler(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
+        await r.readline()
+        # Sleep longer than the client's timeout but short enough that
+        # `async with server` teardown doesn't stall the test.
+        await asyncio.sleep(1.0)
+
+    server, port = await _start_server(handler)
+    async with server:
+        client = RpcClient("127.0.0.1", port, timeout=0.1)
+        with pytest.raises(RpcTimeoutError):
+            await client.call("slow")
+
+
+async def test_rpc_listener_yields_method_and_params() -> None:
+    """The listener generalises Signal's hard-coded ``"receive"``: it
+    yields ``(method, params)`` for every JSON-RPC notification frame so
+    the connector can dispatch on method itself.
+    """
+
+    async def handler(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
+        for method, params in [
+            ("message", {"id": "m1", "text": "hello"}),
+            ("reaction", {"target_id": "m1", "emoji": "👍"}),
+            ("connectionState", {"state": "connected"}),
+        ]:
+            notification = {"jsonrpc": "2.0", "method": method, "params": params}
+            w.write(json.dumps(notification).encode() + b"\n")
+            await w.drain()
+        w.close()
+
+    server, port = await _start_server(handler)
+    async with server:
+        listener = RpcListener("127.0.0.1", port)
+        await listener.connect()
+        seen: list[tuple[str, dict[str, Any]]] = []
+        with pytest.raises(ListenerClosedError):
+            async for pair in listener.notifications():
+                seen.append(pair)
+        assert seen == [
+            ("message", {"id": "m1", "text": "hello"}),
+            ("reaction", {"target_id": "m1", "emoji": "👍"}),
+            ("connectionState", {"state": "connected"}),
+        ]
+        await listener.aclose()
+
+
+async def test_rpc_listener_ignores_responses_and_malformed_frames() -> None:
+    """Stray RPC responses (frames with ``id``), frames with missing /
+    non-string method, and frames with non-dict params are dropped; the
+    listener keeps reading.
+    """
+
+    async def handler(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
+        for msg in [
+            {"jsonrpc": "2.0", "id": 99, "result": {"ignored": True}},  # response
+            {"jsonrpc": "2.0", "method": 7, "params": {}},  # non-string method
+            {"jsonrpc": "2.0", "method": "bad", "params": "not-a-dict"},  # bad params
+            {"jsonrpc": "2.0", "method": "good", "params": {"k": "v"}},  # OK
+        ]:
+            w.write(json.dumps(msg).encode() + b"\n")
+            await w.drain()
+        w.close()
+
+    server, port = await _start_server(handler)
+    async with server:
+        listener = RpcListener("127.0.0.1", port)
+        await listener.connect()
+        seen: list[tuple[str, dict[str, Any]]] = []
+        with pytest.raises(ListenerClosedError):
+            async for pair in listener.notifications():
+                seen.append(pair)
+        assert seen == [("good", {"k": "v"})]
+        await listener.aclose()
+
+
+async def _unused_port() -> int:
+    server = await asyncio.start_server(lambda r, w: None, host="127.0.0.1", port=0)
+    port: int = server.sockets[0].getsockname()[1]
+    server.close()
+    await server.wait_closed()
+    return port
+
+
+async def test_rpc_client_fails_cleanly_when_server_closed() -> None:
+    port = await _unused_port()
+    client = RpcClient("127.0.0.1", port, timeout=2.0)
+    with pytest.raises(RpcError):
+        await client.call("ping")
+
+
+async def test_rpc_listener_connect_failure() -> None:
+    port = await _unused_port()
+    listener = RpcListener("127.0.0.1", port)
+    with pytest.raises(ListenerClosedError):
+        await listener.connect()

--- a/connectors/whatsapp/tests/test_rpc.py
+++ b/connectors/whatsapp/tests/test_rpc.py
@@ -143,23 +143,13 @@ async def test_rpc_listener_ignores_responses_and_malformed_frames() -> None:
         await listener.aclose()
 
 
-async def _unused_port() -> int:
-    server = await asyncio.start_server(lambda r, w: None, host="127.0.0.1", port=0)
-    port: int = server.sockets[0].getsockname()[1]
-    server.close()
-    await server.wait_closed()
-    return port
-
-
-async def test_rpc_client_fails_cleanly_when_server_closed() -> None:
-    port = await _unused_port()
-    client = RpcClient("127.0.0.1", port, timeout=2.0)
+async def test_rpc_client_fails_cleanly_when_server_closed(unused_port: int) -> None:
+    client = RpcClient("127.0.0.1", unused_port, timeout=2.0)
     with pytest.raises(RpcError):
         await client.call("ping")
 
 
-async def test_rpc_listener_connect_failure() -> None:
-    port = await _unused_port()
-    listener = RpcListener("127.0.0.1", port)
+async def test_rpc_listener_connect_failure(unused_port: int) -> None:
+    listener = RpcListener("127.0.0.1", unused_port)
     with pytest.raises(ListenerClosedError):
         await listener.connect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     "aios-echo-http",
     "aios-signal",
     "aios-telegram",
+    "aios-whatsapp",
 ]
 
 [project.scripts]
@@ -83,6 +84,7 @@ members = [
     "connectors/echo-http",
     "connectors/signal",
     "connectors/telegram",
+    "connectors/whatsapp",
     "packages/aios-connector-http",
     "packages/aios-sdk",
 ]
@@ -96,6 +98,7 @@ aios-echo-http = { workspace = true }
 aios-sdk = { workspace = true }
 aios-signal = { workspace = true }
 aios-telegram = { workspace = true }
+aios-whatsapp = { workspace = true }
 
 # ─── ruff ────────────────────────────────────────────────────────────────────
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ members = [
     "aios-sdk",
     "aios-signal",
     "aios-telegram",
+    "aios-whatsapp",
 ]
 
 [[package]]
@@ -139,6 +140,7 @@ dev = [
     { name = "aios-echo-http" },
     { name = "aios-signal" },
     { name = "aios-telegram" },
+    { name = "aios-whatsapp" },
     { name = "httpx" },
     { name = "mypy" },
     { name = "openapi-python-client" },
@@ -181,6 +183,7 @@ dev = [
     { name = "aios-echo-http", editable = "connectors/echo-http" },
     { name = "aios-signal", editable = "connectors/signal" },
     { name = "aios-telegram", editable = "connectors/telegram" },
+    { name = "aios-whatsapp", editable = "connectors/whatsapp" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", specifier = ">=1.13" },
     { name = "openapi-python-client", specifier = ">=0.21" },
@@ -351,6 +354,43 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.6" },
     { name = "python-telegram-bot", specifier = ">=22.6,<23" },
+    { name = "structlog", specifier = ">=24.4" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.13" },
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-mock", specifier = ">=3.14" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "aios-whatsapp"
+version = "0.1.0"
+source = { editable = "connectors/whatsapp" }
+dependencies = [
+    { name = "aios-connector-http" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "structlog" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aios-connector-http", editable = "packages/aios-connector-http" },
+    { name = "pydantic", specifier = ">=2.9" },
+    { name = "pydantic-settings", specifier = ">=2.6" },
     { name = "structlog", specifier = ">=24.4" },
 ]
 


### PR DESCRIPTION
## Summary

PR 1 of the WhatsApp connector epic — see [the plan](https://github.com/eumemic/aios/tree/wt/delegated-yawning-newell) for the broader stack. Lays the connector directory layout, the Python ↔ Go subprocess wiring, and a minimal Go daemon that answers a `version` RPC. No whatsmeow integration yet (lands in PR 2).

- **Python side** (mirrors `connectors/signal/src/aios_signal/`): `HttpConnector` subclass with `connector="whatsapp"`. `serve_connection` spawns one `WhatsappDaemon` per connection on an ephemeral loopback port (whatsmeow's `Client` is per-device, so per-connection daemon is the right scope). `RpcClient` (fresh-TCP-per-call) + `RpcListener` (persistent, yields `(method, params)` for any notification) over line-delimited JSON-RPC 2.0. Pydantic `Settings` carries deployment-shape fields only (`data_dir`, `daemon_bin`, `daemon_host`); the phone lives on `connection.secrets`.
- **Go side**: `whatsapp-daemon` at `connectors/whatsapp/daemon/`, module `aios.dev/connectors/whatsapp/daemon`. JSON-RPC 2.0 server with line-delimited framing, method registry, `version` method.
- **TODO (in commit body of b135002)**: upgrade Go to 1.21+ on dev/CI and restore `log/slog` for structured logging. Currently using stdlib `log` because Go 1.18 is installed locally.

This branch contains two commits:
- `b135002` — initial scaffold
- `730f5a5` — code-review fixes (port collision bug, Go JSON-RPC response bug, dead-code removal, comment cleanup; net -225 LOC)

## Test plan

- [x] `uv run ruff check + format --check` clean (whatsapp + repo)
- [x] `uv run mypy connectors/whatsapp/src` + `uv run mypy src` clean
- [x] `uv run pytest connectors/whatsapp/tests -q` → 15 passing
- [x] `uv run pytest tests/unit -q` → 1406 passing (no regressions)
- [x] `go build ./...` + `go vet ./...` in `connectors/whatsapp/daemon` clean
- [ ] Smoke test against real Go build + Python connector (PR 2 territory — daemon needs whatsmeow integration first to do anything meaningful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)