### PR TITLE
feat(connectors/whatsapp): PR 5 (media + msg-ops) + capstone (groups/mentions/receipts/markdown/CLI/Dockerfile)

### DIFF
--- a/.claude/skills/aios-live-monitor/SKILL.md
+++ b/.claude/skills/aios-live-monitor/SKILL.md
@@ -52,13 +52,65 @@ The filter at `scripts/chat_filter.py` formats one line per message-kind event (
 ```
 Monitor(
   description="worker errors",
-  command="tail -f <worktree>/.logs/worker.log | grep --line-buffered -E 'error|ERROR|exception|Exception|traceback|Traceback|RuntimeError|KeyError|FAILED'",
+  command="tail -f <worktree>/.logs/worker.log | grep --line-buffered -E 'error|ERROR|exception|Exception|traceback|Traceback|RuntimeError|KeyError|FAILED|step\\.\\w+_failed|HTTPStatusError|BadRequestError|raise|provider_error|mark_read_failed|msgstore_put_failed' | grep --line-buffered -v heartbeat",
   timeout_ms=3600000,
   persistent=True,
 )
 ```
 
 `--line-buffered` is essential — without it `grep` batches and event timing is lost.
+
+### Broad alternation: silence is not success
+
+The alternation above looks redundant on purpose.  A narrow filter that
+only matches `error|exception|Traceback` will MISS real failures whose log
+line uses none of those tokens — observed during the WhatsApp PR-5 smoke
+where a model-side LiteLLM 400 surfaced as `step.litellm_failed` and the
+narrow grep never fired, so the session sat silent and the operator
+correctly asked: *"hmm, no response... are you monitoring error
+channels?"*  Lesson: if the user reports nothing happening, the bug is
+probably in the filter, not the system.  Broaden the alternation and
+re-arm.  Specific signatures to include:
+
+* `step\.\w+_failed` — harness-level failures (litellm_failed,
+  tool_dispatch_failed, etc.)
+* `HTTPStatusError`, `BadRequestError`, `ProviderException` — LLM /
+  external-API rejections
+* `RuntimeError`, `KeyError`, `AttributeError`, `TypeError` — Python
+  internal failures the harness re-raises
+* connector-specific `*_failed` events (`mark_read_failed`,
+  `msgstore_put_failed`, `media_download_failed`)
+
+The `grep -v heartbeat` tail filter cuts noise from periodic
+`heartbeat.touch_failed` warnings on macOS (the worker can't `touch
+/var/run/aios-worker-alive` without root — benign).
+
+## CLI snapshots vs. SSE stream
+
+Use the SSE monitor for *live* narration; use the CLI for *static*
+look-back at past events.  The CLI's `--after-seq N` is an **exclusive
+lower bound** — events with `seq > N` only.
+
+```bash
+# Everything: --after-seq 0 (default) returns all events
+uv run aios sessions events <session_id>
+
+# Just messages (user / assistant / tool / tool_result)
+uv run aios sessions events <session_id> --kind message --all
+
+# Events created since N (exclusive); pass N-1 to include event N
+uv run aios sessions events <session_id> --after-seq <N-1>
+
+# JSON for programmatic inspection
+uv run aios -f json sessions events <session_id> --kind message --all
+```
+
+**Footgun:** if `aios sessions get` shows `last_event_seq=230` AND
+`aios sessions events --after-seq 230` returns nothing, it means seq=230
+is the actual tail and the session is quiet — *not* that the events
+weren't persisted.  Don't drop to `docker exec psql` to "investigate" —
+adjust the `--after-seq` argument.  (Observed during WhatsApp PR-5
+smoke.)
 
 ## Restart cadence
 

--- a/.claude/skills/aios-smoke-setup/SKILL.md
+++ b/.claude/skills/aios-smoke-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aios-smoke-setup
-description: This skill should be used when the user asks to "smoke test the connector", "DM the bot in this worktree", "set up a fresh aios runtime", "spin up aios", "prep a smoke session", "bring up aios on this branch", or otherwise wants to point a real Telegram (or Signal) bot at the code in the current worktree.  Bundles the pre-flight checks (bot getUpdates conflict, sibling worktree non-interference, free port), the isolated `.env` overrides (separate DB + port + ``AIOS_DEFAULT_MCP_PERMISSION_POLICY=always_allow``), the right migration command (``aios migrate``, not ``alembic upgrade head``), and the env/agent/connection/session/attach resource chain in one ``setup.sh`` so the first DM round-trips in seconds instead of forty-five minutes.  Hand off to ``aios-live-monitor`` once the runtime is up.
+description: This skill should be used when the user asks to "smoke test the connector", "DM the bot in this worktree", "set up a fresh aios runtime", "spin up aios", "prep a smoke session", "bring up aios on this branch", or otherwise wants to point a real Telegram, Signal, or WhatsApp bot at the code in the current worktree.  Bundles the pre-flight checks (bot getUpdates conflict, sibling worktree non-interference, free port), the isolated `.env` overrides (separate DB + port + ``AIOS_DEFAULT_MCP_PERMISSION_POLICY=always_allow``), the right migration command (``aios migrate``, not ``alembic upgrade head``), and the env/agent/connection/session/attach resource chain in one ``setup.sh`` so the first DM round-trips in seconds instead of forty-five minutes.  For WhatsApp specifically the pair flow differs (QR scan, no bot-token) — once this skill brings up the runtime, hand off to ``aios-whatsapp-pair`` to actually link the account, then ``aios-live-monitor`` for narration.
 ---
 
 # aios smoke session setup
@@ -62,6 +62,26 @@ uv run aios connections attach <conn_id> --session-id=<sess_id>                 
 ```
 
 CLI quirks: `envs` is plural; `--session-id` not `--session`; `sessions create` requires both `--agent` AND `--environment-id`; the `agent.json` `tools[]` items must use bare type names (`bash`, `read`, `write`, …) and **`switch_channel` is auto-included — do not list it** (the API rejects it).
+
+## WhatsApp variant
+
+Telegram and Signal pair via a bot token / signal-cli registration that
+the setup script can resolve up-front.  WhatsApp's pair is interactive
+(QR scan) and so happens *after* `setup.sh` brings up the runtime, not
+during it.  Variant flow:
+
+1. Run `setup.sh --connector whatsapp` (no `--bot-token` needed — that
+   flag is Telegram-only).  This brings up api+worker+connector+empty
+   resource chain.
+2. Hand off to `aios-whatsapp-pair` to scan the QR and bind the
+   account.  That skill owns the daemon spawn, ASCII QR rendering, and
+   `confirm-pairing` block.
+3. Hand off to `aios-live-monitor` for chat narration.
+
+The connection-create step also differs: WhatsApp connections take a
+`--secret phone=+<E.164>` instead of Telegram's `--account=<bot_id>`.
+The setup script handles that branch when `--connector whatsapp` is
+passed.
 
 ## After setup: hand off to aios-live-monitor
 

--- a/.claude/skills/aios-whatsapp-pair/SKILL.md
+++ b/.claude/skills/aios-whatsapp-pair/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: aios-whatsapp-pair
+description: This skill should be used when the user asks to "smoke the whatsapp connector", "pair whatsapp", "link whatsapp", "scan the QR for whatsapp", "set up whatsapp smoke", "bring up the whatsapp bot", "rebind the whatsapp connection", "redo the whatsapp pairing", or otherwise wants to attach a real WhatsApp account to the aios runtime running in the current worktree.  Bundles the daemon cross-compile (Docker `golang:1.25` when local Go < 1.25), runtime-token mint, daemon spawn, start-pairing/confirm-pairing API calls, and — critically — the **ASCII-in-terminal QR rendering** that makes the pair flow actually work.  Hand off to `aios-live-monitor` for narration after `status=success`.
+---
+
+# aios WhatsApp pairing
+
+Attach a real WhatsApp account to the aios runtime so the connector can receive inbounds and the model can call `whatsapp_send` / `whatsapp_react` / `whatsapp_edit_message` / `whatsapp_delete_message` / `whatsapp_list_groups` / `whatsapp_create_group` / `whatsapp_rename_group`.
+
+## When to use
+
+- Smoke-testing the WhatsApp connector PR against a real account
+- Re-pairing after an operator-initiated `unpair`
+- Recovering from a paired device that got unlinked server-side (e.g. user clicked "Log out from this device" in the WhatsApp mobile app)
+
+Skip this skill for Telegram / Signal smokes — those are covered by `aios-smoke-setup`.  This is WhatsApp-only.
+
+## Pre-flight rules (every pair attempt)
+
+1. **Local Go ≥ 1.25 OR Docker available.**  whatsmeow's `go.mod` requires Go 1.25; macOS Homebrew ships 1.18 by default.  The script falls back to a `golang:1.25` Docker image when local Go is older; the build artifact lands at `/tmp/whatsapp-build/whatsapp-daemon`.
+
+2. **Render the QR as ASCII in the terminal, not PNG.**  THIS IS LOAD-BEARING.  Preview-rendered PNGs degrade enough to fail WhatsApp's parser; the resulting "Can't link new devices right now" dialog is the *same* message WhatsApp shows for rate-limiting, so the failure mode looks like throttling when it isn't.  See memory `reference_whatsapp_pairing_ratelimit.md` for the full backstory.
+
+3. **Pair ONCE; avoid retry storms.**  Each failed scan-attempt counts against an opaque per-device anti-abuse counter that DOES enforce real rate-limits if tripped enough.  If a pair attempt fails (and the QR rendering is verified ASCII), STOP — don't repeatedly call `start-pairing`.  Wait ~24h or switch to a different scanning device.
+
+4. **Connection-secret has `phone=+<E.164>`.**  WhatsApp connections store the phone in the connection's secrets dict, not the bot-token field that Telegram uses.  Create with `aios connections create --connector=whatsapp --external-account-id="+<E.164>" --secret "phone=+<E.164>"`.
+
+## The fast path
+
+```bash
+.claude/skills/aios-whatsapp-pair/scripts/pair.sh "+16575274288"
+```
+
+The script:
+1. Verifies the daemon binary exists at `/tmp/whatsapp-build/whatsapp-daemon` (or cross-compiles via Docker if missing).
+2. Verifies a `whatsapp` connector runtime is up and the connection is bound to a session.
+3. Calls `POST /v1/connectors/whatsapp/start-pairing` with the phone.
+4. Renders the returned code as ASCII in the terminal — the operator scans directly from the terminal window.
+5. Calls `POST /v1/connectors/whatsapp/confirm-pairing` which blocks until terminal outcome.
+6. Prints the resulting JID + status.
+
+For an unattended setup, the operator just needs the terminal visible to their phone's camera during the ~20-second QR window.
+
+## The four-step manual sequence (when the script doesn't apply)
+
+```bash
+# 1. Cross-compile the daemon (only if local Go < 1.25).
+docker run --rm \
+  -v "$PWD/connectors/whatsapp/daemon:/src" \
+  -v aios-whatsapp-gocache:/go \
+  -v /tmp/whatsapp-build:/out \
+  -w /src -e GOPATH=/go -e GOCACHE=/go/build-cache \
+  -e GOOS=darwin -e GOARCH=arm64 -e CGO_ENABLED=0 \
+  golang:1.25 go build -o /out/whatsapp-daemon ./cmd/whatsapp-daemon
+
+# 2. Mint a runtime token for the whatsapp connector.
+TOKEN=$(curl -sS -X POST "http://127.0.0.1:${AIOS_API_PORT}/v1/runtime-tokens" \
+  -H "Authorization: Bearer ${AIOS_API_KEY}" -H "Content-Type: application/json" \
+  -d '{"connector": "whatsapp"}' | python3 -c "import json,sys; print(json.load(sys.stdin)['plaintext'])")
+
+# 3. Spawn the connector (it auto-spawns one daemon subprocess per attached connection).
+AIOS_URL="http://127.0.0.1:${AIOS_API_PORT}" AIOS_RUNTIME_TOKEN="$TOKEN" \
+  nohup uv run python -m aios_whatsapp >> .logs/connector.log 2>&1 &
+
+# 4. Pair: start-pairing → ASCII QR → confirm-pairing.
+RESP=$(curl -sS -X POST "http://127.0.0.1:${AIOS_API_PORT}/v1/connectors/whatsapp/start-pairing" \
+  -H "Authorization: Bearer ${AIOS_API_KEY}" -H "Content-Type: application/json" \
+  -d "{\"external_account_id\": \"$PHONE\"}")
+CODE=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('code',''))")
+echo "$CODE" | uvx --from qrcode python -c \
+  "import sys, qrcode; q=qrcode.QRCode(border=2); q.add_data(sys.stdin.read().strip()); q.print_ascii(invert=True)"
+
+# Operator scans from terminal, then:
+curl -sS -X POST "http://127.0.0.1:${AIOS_API_PORT}/v1/connectors/whatsapp/confirm-pairing" \
+  -H "Authorization: Bearer ${AIOS_API_KEY}" -H "Content-Type: application/json" \
+  -d "{\"external_account_id\": \"$PHONE\"}" | python3 -m json.tool
+```
+
+`confirm-pairing` blocks until whatsmeow reports `success`, `timeout`, or `error`.  On `success` the response carries `jid` and (eventually) `push_name`.
+
+## Diagnosing a failing pair
+
+When the phone shows "Can't link new devices right now":
+
+1. **First**, verify the QR rendering: was it ASCII in the terminal?  If it was a PNG opened in Preview, regenerate as ASCII.  This is the failure mode 90% of the time.
+2. **Second**, scan `https://web.whatsapp.com`'s QR from the same scanning device.  If that links fine, the issue is our QR (rendering or daemon-side); if it ALSO fails, the scanning device is genuinely rate-limited.
+3. **Third**, check `aios connections get <conn_id>` shows the right `external_account_id` and the connection is `attached`.  An unbound connection won't have a daemon and `start-pairing` will route nowhere useful.
+
+## Rebind to a different phone
+
+The daemon is per-phone (per-connection); the connector spawns one subprocess per attached whatsapp connection.  To switch which account a session listens to:
+
+```bash
+uv run aios connections detach <old_conn_id>
+uv run aios connections create --connector=whatsapp \
+  --external-account-id="+<new_phone>" --secret "phone=+<new_phone>"
+uv run aios connections attach <new_conn_id> --session-id=<session_id>
+```
+
+The connector picks up the new connection via SSE discovery and spawns a fresh daemon.
+
+## After pair: hand off to aios-live-monitor
+
+Per the locked smoke flow, once `confirm-pairing` returns `status=success`:
+
+1. Read the current `last_event_seq` from `aios sessions get <session_id>`.
+2. Arm the chat monitor via `.claude/skills/aios-live-monitor/scripts/preflight.sh <session_id>`.
+3. Tell the operator to DM the bot — and narrate the round-trip per the live-monitor skill's etiquette.
+
+## Additional resources
+
+- **`scripts/pair.sh`** — all-in-one wrapper for the four-step sequence
+- **`references/diagnostics.md`** — failure-mode → root-cause → fix table (web-QR-test, lifetime ctx, PairPhone alternative)
+- Memory `reference_whatsapp_pairing_ratelimit.md` — why the ASCII rendering is load-bearing

--- a/.claude/skills/aios-whatsapp-pair/references/diagnostics.md
+++ b/.claude/skills/aios-whatsapp-pair/references/diagnostics.md
@@ -1,0 +1,138 @@
+# WhatsApp pairing failure-mode diagnostics
+
+Symptom → root cause → fix table for the failure modes observed during the
+capstone smoke (PR #625, 2026-05-22).
+
+## "Can't link new devices right now" on the phone
+
+By far the most common failure.  WhatsApp uses this same dialog for SEVERAL
+distinct conditions; differential diagnosis below.
+
+### 1. PNG-rendered QR (~90% of cases)
+
+**Symptom:** Phone shows the dialog immediately on scan.  Daemon log shows
+the QR was generated and `drainQRChannel` is cycling refreshes.  Repeated
+attempts all fail the same way regardless of which account.
+
+**Root cause:** The QR was rendered to PNG and opened in macOS Preview /
+similar viewer.  Preview's anti-aliasing + color profile + scaling degrade
+the QR enough that WhatsApp's iOS parser rejects it — but the error dialog
+is the same as the rate-limit dialog.
+
+**Fix:** Render as ASCII in the terminal via the `pair.sh` script (or the
+manual one-liner in SKILL.md).  Scan directly from the terminal window.
+
+**Verification path** (when uncertain whether it's PNG or rate-limit):
+
+* Open `https://web.whatsapp.com` in a browser.  Scan THAT QR from the same
+  scanning device.
+* If the web QR links fine → our QR rendering is the issue (PNG).
+* If the web QR also fails → the scanning device IS rate-limited (rare).
+
+### 2. Scanning-device rate-limit (rare)
+
+**Symptom:** Even WhatsApp's own `web.whatsapp.com` QR is rejected on this
+device.
+
+**Root cause:** WhatsApp's per-device anti-abuse counter was tripped by too
+many failed link attempts in a short window.  Retries reset the timer.
+
+**Fix:** STOP attempting.  Wait ~24h with no link attempts on this scanning
+device.  Confirm by retesting `web.whatsapp.com` first; only re-run our pair
+flow once web works.
+
+### 3. Account suspended (rarest)
+
+**Symptom:** Even normal messaging from the WhatsApp account fails (not just
+linking).
+
+**Fix:** Out of scope — needs WhatsApp's support or account replacement.
+
+## "device not paired" on `unpair`
+
+**Symptom:** `POST /v1/connectors/whatsapp/unpair` returns 502 with body
+`{"error": "device not paired"}` even though the daemon log shows the
+pairing earlier succeeded.
+
+**Root cause:** WhatsApp's server invalidated the device link (user pressed
+"Log out from this device" in the WhatsApp mobile app, or 14-day inactivity,
+or server-side cleanup).  whatsmeow's `events.LoggedOut` cleared the local
+store; subsequent ops return `not paired`.
+
+**Fix:** A new `start-pairing` works against the same connection — the
+daemon's `replaceWhatsmeowClient` machinery (PR #622 originally added this
+for operator-initiated `Unpair`; the PR #625 smoke caught that the
+peer-side `events.LoggedOut` handler hadn't been wired through, and the
+fix-up commit on PR #625 wired it so peer-logout now also swaps in a
+fresh Client behind `atomic.Pointer` and the in-process re-pair works
+without restart).
+
+## "pairing already in progress" on a fresh `start-pairing`
+
+**Symptom:** `start-pairing` returns
+`{"error": "pairing already in progress"}` even when no QR is currently
+displayed.
+
+**Root cause:** A prior `start-pairing` call's QR cycle is still active
+(whatsmeow's QR channel hasn't reached the `timeout` event yet — total
+window is ~100 s across QR refreshes).
+
+**Fix:** Either:
+* Wait for the existing cycle to time out naturally (~2 min).
+* Restart the daemon (kill + connector respawns it) to reset the pair state.
+
+## "Got 515 code, reconnecting..." in daemon logs
+
+**Symptom:** Daemon's whatsmeow logger emits
+`{"level":"INFO","msg":"Got 515 code, reconnecting..."}` shortly after a
+successful `confirm-pairing`.
+
+**Root cause:** Normal — WhatsApp's pair handshake completes with a
+re-connect signal so the client establishes its post-pair session.  Followed
+within a second by `"Successfully authenticated"`.
+
+**Fix:** None needed.  If `Successfully authenticated` doesn't follow within
+~3 s, escalate.
+
+## "Failed to store app state sync key … database is locked (5)" warnings
+
+**Symptom:** Daemon spams `Failed to store app state sync key … database is
+locked (5) (SQLITE_BUSY)` for ~30 s post-pair.
+
+**Root cause:** whatsmeow + modernc.org/sqlite have a known concurrency
+issue where the post-pair app-state-sync write contends with other writes.
+Mostly self-corrects.
+
+**Fix:** Cosmetic for v1.  Future PR can move to a write-coalescing
+sqlstore wrapper.  Doesn't block pair functionality.
+
+## Inbound messages flow but bot doesn't respond
+
+**Symptom:** `aios sessions events --kind message` shows the inbound user
+message, but no assistant turn follows; session sits `idle`.
+
+**Differential:**
+
+* Worker log shows `step.litellm_failed` → model provider error.  Check the
+  agent's `model` field; WhatsApp's deferred smoke surfaced an OpenRouter
+  → Bedrock 400 (cf. aios issue #623).
+* Worker log shows no `wake_session` jobs → the inbound never reached the
+  worker.  Check `aios connections get <id>` for `session_id`; an unbound
+  inbound goes to the resolver's per-chat ephemeral path which may not be
+  visible.
+* No errors anywhere → the model wake fired but produced no tool call.
+  Check the assistant message at the latest seq; if it's only an internal
+  monologue without `tool_calls`, the model decided not to respond.
+
+## Connector log spams `mark_read_failed`
+
+**Symptom:** Every outbound send is followed by a
+`wameow.mark_read_failed` warning.
+
+**Root cause:** `flushReadReceipts` tried to `MarkRead` a message id that
+doesn't correspond to a peer text/media — usually a reaction envelope ID
+that slipped into the unread queue.
+
+**Fix:** PR #625's round-2 fix-up (`8e05ddc`) filters
+`isReactionOnly` envelopes out of the unread queue.  If the warning
+persists on a daemon built from a commit before that, rebuild.

--- a/.claude/skills/aios-whatsapp-pair/scripts/pair.sh
+++ b/.claude/skills/aios-whatsapp-pair/scripts/pair.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# pair.sh — render a fresh WhatsApp pairing QR as ASCII in the terminal
+# and block on confirm-pairing.  Operator scans from the terminal window
+# during the ~20 s QR window.
+#
+# Usage: pair.sh "+<E.164>"
+#
+# Pre-conditions:
+#   * aios api running on $AIOS_API_PORT (loaded from .env)
+#   * aios_whatsapp connector running (auto-spawns the daemon for the bound connection)
+#   * The phone has an active WhatsApp connection bound to a session
+#
+# Why ASCII not PNG: Preview-rendered PNGs degrade enough that WhatsApp's
+# parser rejects them, but the error dialog ("Can't link new devices
+# right now") is the same one shown for rate-limiting — see memory
+# reference_whatsapp_pairing_ratelimit.md.
+
+set -euo pipefail
+
+PHONE="${1:-}"
+if [[ -z "$PHONE" ]]; then
+  echo "usage: pair.sh +<E.164>" >&2
+  exit 2
+fi
+
+# Source the worktree .env so AIOS_API_PORT + AIOS_API_KEY are populated.
+if [[ -f .env ]]; then
+  set -a; source .env; set +a
+fi
+: "${AIOS_API_PORT:?AIOS_API_PORT not set; source the worktree .env}"
+: "${AIOS_API_KEY:?AIOS_API_KEY not set; source the worktree .env}"
+
+API="http://127.0.0.1:${AIOS_API_PORT}"
+
+# Verify the connector is up.  If start-pairing 502s, the daemon isn't running.
+echo "→ POST $API/v1/connectors/whatsapp/start-pairing  external_account_id=$PHONE"
+RESP=$(curl -sS -X POST "$API/v1/connectors/whatsapp/start-pairing" \
+  -H "Authorization: Bearer $AIOS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"external_account_id\": \"$PHONE\"}")
+
+CODE=$(echo "$RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('code',''))" 2>/dev/null || true)
+
+if [[ -z "$CODE" ]]; then
+  echo "no code in response:" >&2
+  echo "$RESP" | python3 -m json.tool >&2 || echo "$RESP" >&2
+  exit 1
+fi
+
+echo
+echo "scan NOW from the terminal below (~20 s window before whatsmeow rotates internally):"
+echo
+
+echo "$CODE" | uvx --from qrcode python -c \
+  "import sys, qrcode; q=qrcode.QRCode(border=2); q.add_data(sys.stdin.read().strip()); q.print_ascii(invert=True)"
+
+echo
+echo "→ POST $API/v1/connectors/whatsapp/confirm-pairing  (blocks until terminal)"
+curl -sS -X POST "$API/v1/connectors/whatsapp/confirm-pairing" \
+  -H "Authorization: Bearer $AIOS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"external_account_id\": \"$PHONE\"}" \
+  | python3 -m json.tool

--- a/connectors/whatsapp/Dockerfile
+++ b/connectors/whatsapp/Dockerfile
@@ -26,13 +26,15 @@ COPY connectors/whatsapp/daemon/ ./
 # Static, CGo-disabled build — modernc.org/sqlite is pure-Go, so no
 # libc dependency on the runtime side.  Multi-arch via buildx (the
 # trailing $TARGETARCH is set by docker buildx; defaults to amd64
-# under a plain ``docker build``).
+# under a plain ``docker build``).  No post-build ``-version`` smoke:
+# under buildx with TARGETARCH != BUILDARCH the just-built binary
+# isn't executable on the build host, and ``go build``'s exit code
+# already proves the build succeeded.
 ARG TARGETARCH=amd64
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
     -ldflags="-s -w -X main.Version=docker" \
     -o /out/whatsapp-daemon \
-    ./cmd/whatsapp-daemon \
- && /out/whatsapp-daemon -version
+    ./cmd/whatsapp-daemon
 
 # ─── Python runtime stage ────────────────────────────────────────────────
 FROM python:3.13-slim-bookworm AS base

--- a/connectors/whatsapp/Dockerfile
+++ b/connectors/whatsapp/Dockerfile
@@ -1,0 +1,77 @@
+# WhatsApp connector — runs in its own container, talks HTTP to aios.
+#
+# Two languages in one image: the whatsapp-daemon is a static Go binary
+# built from connectors/whatsapp/daemon/, the Python connector is the
+# usual aios_connector_http subclass.  The daemon is launched as a
+# subprocess of the Python connector (see daemon.py); its sqlstore +
+# inbound media land under /var/lib/aios/whatsapp-data/<phone>/.
+# Bind-mount a host volume there to persist across rebuilds.
+#
+# Bind-mount ``<workspace_root>`` (host path) at the same path inside the
+# container, read-only — outbound attachments from the model arrive as
+# ``/workspace/...`` strings the SDK resolves to host paths under
+# ``<workspace_root>/<session_id>``.
+
+# ─── Go build stage ──────────────────────────────────────────────────────
+FROM golang:1.25-alpine AS daemon-build
+
+WORKDIR /src
+
+# Module download first so the layer cache survives daemon-source edits.
+COPY connectors/whatsapp/daemon/go.mod connectors/whatsapp/daemon/go.sum ./
+RUN go mod download
+
+COPY connectors/whatsapp/daemon/ ./
+
+# Static, CGo-disabled build — modernc.org/sqlite is pure-Go, so no
+# libc dependency on the runtime side.  Multi-arch via buildx (the
+# trailing $TARGETARCH is set by docker buildx; defaults to amd64
+# under a plain ``docker build``).
+ARG TARGETARCH=amd64
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
+    -ldflags="-s -w -X main.Version=docker" \
+    -o /out/whatsapp-daemon \
+    ./cmd/whatsapp-daemon \
+ && /out/whatsapp-daemon -version
+
+# ─── Python runtime stage ────────────────────────────────────────────────
+FROM python:3.13-slim-bookworm AS base
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    AIOS_WHATSAPP_DAEMON_BIN=/usr/local/bin/whatsapp-daemon \
+    AIOS_WHATSAPP_DATA_DIR=/var/lib/aios/whatsapp-data
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# uv binary (pinned).  Faster + reproducible vs ``pip install uv``.
+COPY --from=ghcr.io/astral-sh/uv:0.5.18 /uv /usr/local/bin/uv
+
+# Drop the daemon binary in PATH.
+COPY --from=daemon-build /out/whatsapp-daemon /usr/local/bin/whatsapp-daemon
+
+WORKDIR /app
+
+# SDK packages first so the layer cache stays warm across connector tweaks.
+# aios-connector-http depends on aios-sdk (the workspace-published typed SDK).
+COPY packages/aios-sdk /app/packages/aios-sdk
+COPY packages/aios-connector-http /app/packages/aios-connector-http
+COPY connectors/whatsapp/pyproject.toml /app/connectors/whatsapp/pyproject.toml
+COPY connectors/whatsapp/src /app/connectors/whatsapp/src
+
+# ``--no-sources`` ignores ``[tool.uv.sources]`` workspace-deps which
+# only resolve at the repo root; uv satisfies the inter-package deps
+# by name from the install set itself.
+RUN uv pip install --system --no-cache --no-sources \
+    /app/packages/aios-sdk \
+    /app/packages/aios-connector-http \
+    /app/connectors/whatsapp
+
+# Entrypoint chowns the shared whatsapp-data dir so the api (uid 1000)
+# can read media bytes the daemon decrypts there.  The daemon itself
+# runs as root inside this container.
+COPY connectors/whatsapp/entrypoint.sh /app/connectors/whatsapp/entrypoint.sh
+RUN chmod 0755 /app/connectors/whatsapp/entrypoint.sh
+ENTRYPOINT ["/app/connectors/whatsapp/entrypoint.sh"]

--- a/connectors/whatsapp/README.md
+++ b/connectors/whatsapp/README.md
@@ -1,12 +1,149 @@
 # aios-whatsapp
 
-WhatsApp connector for aios.
+WhatsApp connector for aios. Pairs a WhatsApp account via the unofficial
+Multi-Device protocol (backed by [`go.mau.fi/whatsmeow`](https://github.com/tulir/whatsmeow))
+and surfaces inbound messages into an aios session as channel-tagged inbounds
+the model can respond to with a small toolset.
 
-Pairs a WhatsApp account (via the unofficial Multi-Device protocol, backed by
-[`go.mau.fi/whatsmeow`](https://github.com/tulir/whatsmeow)) and surfaces messages
-into an aios session. Mirrors the shape of `aios-signal`: the Python
-`HttpConnector` spawns a Go daemon (`whatsapp-daemon`) as a subprocess and talks to
-it over line-delimited JSON-RPC on a loopback TCP port.
+Mirrors `connectors/signal`'s shape: a Python `HttpConnector` subclass spawns a
+Go daemon (`whatsapp-daemon`) as a subprocess and talks to it over
+line-delimited JSON-RPC on a loopback TCP port.
 
-This connector is **under construction**. Tracking: see `connectors/whatsapp/` in
-the aios tree.
+## Tool surface
+
+The connector publishes these model-facing tools (auto-discovered by the aios
+runtime via the connector's `tools_schema`):
+
+| Tool | Purpose |
+|---|---|
+| `whatsapp_send(text, attachments?)` | Send a message; text supports CommonMark inline emphasis which is auto-converted to WhatsApp's inline syntax. |
+| `whatsapp_react(message_id, reaction)` | React with an emoji; empty `reaction` clears a prior reaction. |
+| `whatsapp_edit_message(message_id, text)` | Rewrite your own outbound (within WhatsApp's ~15-minute edit window). |
+| `whatsapp_delete_message(message_id)` | Delete-for-everyone your own outbound. |
+| `whatsapp_list_groups()` | List every group the bot is a member of. |
+| `whatsapp_create_group(name, participants)` | Create a new group; `participants` are +E.164 phones. |
+| `whatsapp_rename_group(chat_id, name)` | Rename a group the bot is an admin in. |
+
+Read receipts fire automatically when the bot sends to a chat — all prior peer
+messages on that chat are MarkRead'd in one batch (Signal-style implicit
+receipts-after-emit). No tool surface for this; happens inside `whatsapp_send`.
+
+## Pairing
+
+The connector publishes three operator-side management endpoints which the
+`aios whatsapp` CLI wraps:
+
+```bash
+# 1. Begin a QR pair session — prints a wa.me linked-device URL.
+aios whatsapp start-pairing +15551234567
+
+# 2. Scan the QR from WhatsApp → Settings → Linked Devices → Link a Device,
+#    then block until the handshake completes.
+aios whatsapp confirm-pairing +15551234567
+
+# 3. (Later) unlink server-side and clear local store.
+aios whatsapp unpair +15551234567
+```
+
+The CLI hits the equivalent `POST /v1/connectors/whatsapp/{start,confirm,unpair}-pairing`
+endpoints directly if you prefer scripting against the API. The daemon swaps
+in a fresh whatsmeow.Client behind an `atomic.Pointer` after `unpair` so the
+next `start-pairing` works in the same daemon process without a restart.
+
+## Data directory
+
+The daemon writes per-phone state under `<data_dir>/<phone>/`:
+
+```
+<data_dir>/+15551234567/
+├── store.db        # whatsmeow sqlstore (device identity, sessions, keys)
+├── messages.db     # daemon-side message-key index (powers react/edit/delete)
+└── media/          # decrypted inbound media (mode 0600)
+```
+
+`<data_dir>` defaults to `/var/lib/aios/whatsapp-data` inside the container
+(env: `AIOS_WHATSAPP_DATA_DIR`). Bind-mount a host volume there to persist
+state across container rebuilds; the entrypoint chowns the dir to uid 1000 so
+the api container can read the inbound media files when staging them into the
+session event log.
+
+## Running
+
+### Docker (production-shaped)
+
+```bash
+docker build -f connectors/whatsapp/Dockerfile -t aios-whatsapp .
+
+docker run --rm \
+  -v aios-whatsapp-data:/var/lib/aios/whatsapp-data \
+  -e AIOS_URL=http://aios-api:8080 \
+  -e AIOS_RUNTIME_TOKEN=<token from POST /v1/runtime-tokens> \
+  aios-whatsapp
+```
+
+Multi-arch: the Dockerfile uses `ARG TARGETARCH` so `docker buildx build
+--platform linux/amd64,linux/arm64` produces a multi-arch image. The Go
+daemon builds natively for both architectures (whatsmeow is pure Go, no CGo
+deps).
+
+### Local development
+
+The connector needs Go 1.25+ to build the daemon (whatsmeow requires it).
+For local dev where the host has Go 1.18 or older:
+
+```bash
+# Cross-compile the daemon via Docker.
+docker run --rm \
+  -v "$PWD/connectors/whatsapp/daemon:/src" \
+  -v aios-whatsapp-gocache:/go \
+  -w /src \
+  -e GOPATH=/go \
+  -e GOCACHE=/go/build-cache \
+  -e GOOS=darwin -e GOARCH=arm64 -e CGO_ENABLED=0 \
+  golang:1.25 go build -o /go/bin/whatsapp-daemon ./cmd/whatsapp-daemon
+
+# Run the Python connector with the cross-built daemon.
+AIOS_URL=http://127.0.0.1:8080 \
+AIOS_RUNTIME_TOKEN=<token> \
+AIOS_WHATSAPP_DAEMON_BIN=/Users/tom/.go-cache/bin/whatsapp-daemon \
+AIOS_WHATSAPP_DATA_DIR=/tmp/aios-whatsapp-dev \
+uv run python -m aios_whatsapp
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `AIOS_URL` | _required_ | aios api base URL (e.g. `http://127.0.0.1:8080`). |
+| `AIOS_RUNTIME_TOKEN` | _required_ | Connector runtime token (mint via `POST /v1/runtime-tokens`). |
+| `AIOS_WHATSAPP_DAEMON_BIN` | `/usr/local/bin/whatsapp-daemon` | Path to the compiled Go daemon binary. |
+| `AIOS_WHATSAPP_DATA_DIR` | `/var/lib/aios/whatsapp-data` | Per-phone state dir; one subdir per paired phone. |
+| `AIOS_WHATSAPP_DAEMON_HOST` | `127.0.0.1` | Loopback address the daemon listens on. |
+
+## Architecture
+
+```
+                    HTTP (SSE + multipart)
+   ┌────────────┐   ◄──────────────────►   ┌──────────────────────┐
+   │ aios api/  │                          │ aios_whatsapp (this) │
+   │ worker     │                          │                      │
+   └────────────┘                          └──────────┬───────────┘
+                                                      │  spawns
+                                                      ▼
+                                          ┌────────────────────────┐
+                                          │ whatsapp-daemon (Go)   │
+                                          │  - whatsmeow client    │
+                                          │  - sqlstore (store.db) │
+                                          │  - messages.db (PR 5)  │
+                                          │  - media/ (PR 5)       │
+                                          └─────────┬──────────────┘
+                                                    │  TLS
+                                                    ▼
+                                              WhatsApp servers
+```
+
+The Python connector and Go daemon communicate via line-delimited JSON-RPC
+2.0 over a loopback TCP port (ephemeral, allocated per connection). The
+daemon owns the WhatsApp protocol state (whatsmeow client, sqlstore,
+message-key index); the Python side owns aios integration (session routing,
+attachment marshalling, tool dispatch).

--- a/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
+++ b/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
@@ -68,6 +68,7 @@ func main() {
 
 	handler.RegisterSend(reg, client.SendMessage)
 	handler.RegisterPairing(reg, &clientPairAdapter{client: client})
+	handler.RegisterMessageOps(reg, client)
 
 	// Connect runs in parallel with srv.Run so the listener binds (and
 	// `version` RPC starts answering) while the WhatsApp handshake is

--- a/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
+++ b/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
@@ -69,6 +69,7 @@ func main() {
 	handler.RegisterSend(reg, sendAdapter(client))
 	handler.RegisterPairing(reg, &clientPairAdapter{client: client})
 	handler.RegisterMessageOps(reg, client)
+	handler.RegisterGroups(reg, &clientGroupsAdapter{client: client})
 
 	// Connect runs in parallel with srv.Run so the listener binds (and
 	// `version` RPC starts answering) while the WhatsApp handshake is
@@ -131,4 +132,50 @@ func (a *clientPairAdapter) ConfirmPairing(ctx context.Context) (handler.Pairing
 
 func (a *clientPairAdapter) Unpair(ctx context.Context) error {
 	return a.client.Unpair(ctx)
+}
+
+// clientGroupsAdapter bridges wameow.GroupSummary →
+// handler.GroupSummary so the handler package stays decoupled from
+// the wameow concrete type.  Same per-call memcopy pattern as
+// clientPairAdapter / sendAdapter.
+type clientGroupsAdapter struct {
+	client *wameow.Client
+}
+
+func (a *clientGroupsAdapter) ListGroups(ctx context.Context) ([]handler.GroupSummary, error) {
+	groups, err := a.client.ListGroups(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]handler.GroupSummary, len(groups))
+	for i, g := range groups {
+		out[i] = wameowGroupToHandler(g)
+	}
+	return out, nil
+}
+
+func (a *clientGroupsAdapter) CreateGroup(ctx context.Context, name string, participantJIDs []string) (*handler.GroupSummary, error) {
+	g, err := a.client.CreateGroup(ctx, name, participantJIDs)
+	if err != nil {
+		return nil, err
+	}
+	out := wameowGroupToHandler(*g)
+	return &out, nil
+}
+
+func (a *clientGroupsAdapter) RenameGroup(ctx context.Context, groupJID, name string) error {
+	return a.client.RenameGroup(ctx, groupJID, name)
+}
+
+func wameowGroupToHandler(g wameow.GroupSummary) handler.GroupSummary {
+	parts := make([]handler.GroupParticipantInfo, len(g.Participants))
+	for i, p := range g.Participants {
+		parts[i] = handler.GroupParticipantInfo{JID: p.JID, IsAdmin: p.IsAdmin}
+	}
+	return handler.GroupSummary{
+		JID:          g.JID,
+		Name:         g.Name,
+		Topic:        g.Topic,
+		Participants: parts,
+	}
 }

--- a/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
+++ b/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
@@ -91,7 +91,7 @@ func main() {
 // wameow package mustn't import handler (or vice versa) to keep the
 // wire-vs-logic boundary clean, so the per-call memcopy sits here.
 func sendAdapter(client *wameow.Client) handler.SendMessageFn {
-	return func(ctx context.Context, jid, text string, atts []handler.Attachment) (string, int64, error) {
+	return func(ctx context.Context, jid, text string, atts []handler.Attachment) ([]string, int64, error) {
 		var wmAtts []wameow.Attachment
 		if len(atts) > 0 {
 			wmAtts = make([]wameow.Attachment, len(atts))

--- a/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
+++ b/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
@@ -91,7 +91,7 @@ func main() {
 // wameow package mustn't import handler (or vice versa) to keep the
 // wire-vs-logic boundary clean, so the per-call memcopy sits here.
 func sendAdapter(client *wameow.Client) handler.SendMessageFn {
-	return func(ctx context.Context, jid, text string, atts []handler.Attachment) ([]string, int64, error) {
+	return func(ctx context.Context, jid, text string, atts []handler.Attachment, mentionedJIDs []string) ([]string, int64, error) {
 		var wmAtts []wameow.Attachment
 		if len(atts) > 0 {
 			wmAtts = make([]wameow.Attachment, len(atts))
@@ -99,7 +99,7 @@ func sendAdapter(client *wameow.Client) handler.SendMessageFn {
 				wmAtts[i] = wameow.Attachment{Path: a.Path, Mimetype: a.Mimetype, Filename: a.Filename}
 			}
 		}
-		return client.SendMessage(ctx, jid, text, wmAtts)
+		return client.SendMessage(ctx, jid, text, wmAtts, mentionedJIDs)
 	}
 }
 

--- a/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
+++ b/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
@@ -92,7 +92,7 @@ func main() {
 // wameow package mustn't import handler (or vice versa) to keep the
 // wire-vs-logic boundary clean, so the per-call memcopy sits here.
 func sendAdapter(client *wameow.Client) handler.SendMessageFn {
-	return func(ctx context.Context, jid, text string, atts []handler.Attachment, mentionedJIDs []string) ([]string, int64, error) {
+	return func(ctx context.Context, jid, text string, atts []handler.Attachment, mentionedJIDs []string, quotedMessageID string) ([]string, int64, error) {
 		var wmAtts []wameow.Attachment
 		if len(atts) > 0 {
 			wmAtts = make([]wameow.Attachment, len(atts))
@@ -100,7 +100,7 @@ func sendAdapter(client *wameow.Client) handler.SendMessageFn {
 				wmAtts[i] = wameow.Attachment{Path: a.Path, Mimetype: a.Mimetype, Filename: a.Filename}
 			}
 		}
-		return client.SendMessage(ctx, jid, text, wmAtts, mentionedJIDs)
+		return client.SendMessage(ctx, jid, text, wmAtts, mentionedJIDs, quotedMessageID)
 	}
 }
 

--- a/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
+++ b/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
@@ -66,7 +66,7 @@ func main() {
 	}
 	defer client.Close()
 
-	handler.RegisterSend(reg, client.SendMessage)
+	handler.RegisterSend(reg, sendAdapter(client))
 	handler.RegisterPairing(reg, &clientPairAdapter{client: client})
 	handler.RegisterMessageOps(reg, client)
 
@@ -84,6 +84,23 @@ func main() {
 		os.Exit(1)
 	}
 	logger.Info("daemon.exit.ok")
+}
+
+// sendAdapter bridges handler.Attachment → wameow.Attachment in the
+// same shape as clientPairAdapter does for pairing outcomes: the
+// wameow package mustn't import handler (or vice versa) to keep the
+// wire-vs-logic boundary clean, so the per-call memcopy sits here.
+func sendAdapter(client *wameow.Client) handler.SendMessageFn {
+	return func(ctx context.Context, jid, text string, atts []handler.Attachment) (string, int64, error) {
+		var wmAtts []wameow.Attachment
+		if len(atts) > 0 {
+			wmAtts = make([]wameow.Attachment, len(atts))
+			for i, a := range atts {
+				wmAtts[i] = wameow.Attachment{Path: a.Path, Mimetype: a.Mimetype, Filename: a.Filename}
+			}
+		}
+		return client.SendMessage(ctx, jid, text, wmAtts)
+	}
 }
 
 // clientPairAdapter bridges wameow.Client to handler.Pairer.  The

--- a/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
+++ b/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
@@ -170,7 +170,11 @@ func (a *clientGroupsAdapter) RenameGroup(ctx context.Context, groupJID, name st
 func wameowGroupToHandler(g wameow.GroupSummary) handler.GroupSummary {
 	parts := make([]handler.GroupParticipantInfo, len(g.Participants))
 	for i, p := range g.Participants {
-		parts[i] = handler.GroupParticipantInfo{JID: p.JID, IsAdmin: p.IsAdmin}
+		parts[i] = handler.GroupParticipantInfo{
+			JID:      p.JID,
+			IsAdmin:  p.IsAdmin,
+			AddError: p.AddError,
+		}
 	}
 	return handler.GroupSummary{
 		JID:          g.JID,

--- a/connectors/whatsapp/daemon/internal/handler/groups.go
+++ b/connectors/whatsapp/daemon/internal/handler/groups.go
@@ -1,0 +1,86 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+
+	"aios.dev/connectors/whatsapp/daemon/internal/rpc"
+)
+
+// Groups is the daemon-internal interface for group operations.
+// Mirrors the Pairer / MessageOps pattern: keeps handler decoupled
+// from whatsmeow types so tests can stub it and main.go bridges
+// concrete shapes via per-call memcopies.
+type Groups interface {
+	ListGroups(ctx context.Context) ([]GroupSummary, error)
+	CreateGroup(ctx context.Context, name string, participantJIDs []string) (*GroupSummary, error)
+	RenameGroup(ctx context.Context, groupJID, name string) error
+}
+
+// GroupSummary is the wire-shape mirror of wameow.GroupSummary.
+type GroupSummary struct {
+	JID          string                 `json:"jid"`
+	Name         string                 `json:"name"`
+	Topic        string                 `json:"topic,omitempty"`
+	Participants []GroupParticipantInfo `json:"participants"`
+}
+
+type GroupParticipantInfo struct {
+	JID     string `json:"jid"`
+	IsAdmin bool   `json:"is_admin"`
+}
+
+type createGroupArgs struct {
+	Name         string   `json:"name"`
+	Participants []string `json:"participants"`
+}
+
+type renameGroupArgs struct {
+	JID  string `json:"jid"`
+	Name string `json:"name"`
+}
+
+// RegisterGroups wires the listGroups / createGroup / renameGroup
+// RPC methods into reg.
+func RegisterGroups(reg *Registry, g Groups) {
+	reg.Register("listGroups", func(ctx context.Context, _ json.RawMessage) (any, *rpc.Error) {
+		groups, err := g.ListGroups(ctx)
+		if err != nil {
+			return nil, &rpc.Error{Code: rpc.ErrCodeServerError, Message: err.Error()}
+		}
+		// JSON-RPC requires a non-nil result for success; wrap so an
+		// empty group list serializes as ``{"groups": []}`` rather
+		// than top-level ``null``.
+		return map[string]any{"groups": groups}, nil
+	})
+	reg.Register("createGroup", func(ctx context.Context, params json.RawMessage) (any, *rpc.Error) {
+		var args createGroupArgs
+		if err := json.Unmarshal(params, &args); err != nil {
+			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "invalid createGroup params: " + err.Error()}
+		}
+		if args.Name == "" {
+			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "createGroup: name required"}
+		}
+		summary, err := g.CreateGroup(ctx, args.Name, args.Participants)
+		if err != nil {
+			return nil, &rpc.Error{Code: rpc.ErrCodeServerError, Message: err.Error()}
+		}
+		return summary, nil
+	})
+	reg.Register("renameGroup", func(ctx context.Context, params json.RawMessage) (any, *rpc.Error) {
+		var args renameGroupArgs
+		if err := json.Unmarshal(params, &args); err != nil {
+			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "invalid renameGroup params: " + err.Error()}
+		}
+		if args.JID == "" {
+			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "renameGroup: jid required"}
+		}
+		if args.Name == "" {
+			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "renameGroup: name required"}
+		}
+		if err := g.RenameGroup(ctx, args.JID, args.Name); err != nil {
+			return nil, &rpc.Error{Code: rpc.ErrCodeServerError, Message: err.Error()}
+		}
+		return map[string]string{"status": "ok"}, nil
+	})
+}

--- a/connectors/whatsapp/daemon/internal/handler/groups.go
+++ b/connectors/whatsapp/daemon/internal/handler/groups.go
@@ -26,8 +26,9 @@ type GroupSummary struct {
 }
 
 type GroupParticipantInfo struct {
-	JID     string `json:"jid"`
-	IsAdmin bool   `json:"is_admin"`
+	JID      string `json:"jid"`
+	IsAdmin  bool   `json:"is_admin"`
+	AddError int    `json:"add_error,omitempty"`
 }
 
 type createGroupArgs struct {

--- a/connectors/whatsapp/daemon/internal/handler/groups_test.go
+++ b/connectors/whatsapp/daemon/internal/handler/groups_test.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"aios.dev/connectors/whatsapp/daemon/internal/rpc"
+)
+
+type stubGroups struct {
+	list   func(ctx context.Context) ([]GroupSummary, error)
+	create func(ctx context.Context, name string, participants []string) (*GroupSummary, error)
+	rename func(ctx context.Context, jid, name string) error
+}
+
+func (s *stubGroups) ListGroups(ctx context.Context) ([]GroupSummary, error) {
+	return s.list(ctx)
+}
+func (s *stubGroups) CreateGroup(ctx context.Context, name string, p []string) (*GroupSummary, error) {
+	return s.create(ctx, name, p)
+}
+func (s *stubGroups) RenameGroup(ctx context.Context, jid, name string) error {
+	return s.rename(ctx, jid, name)
+}
+
+func TestListGroupsWrapsEmptyAsObject(t *testing.T) {
+	// Empty list must serialize as ``{"groups": []}`` rather than
+	// top-level null — JSON-RPC requires a non-null result for
+	// success and the Python tool wrapper assumes a dict.
+	reg := NewRegistry()
+	RegisterGroups(reg, &stubGroups{
+		list: func(context.Context) ([]GroupSummary, error) { return nil, nil },
+	})
+	result, rpcErr := reg.Dispatch(context.Background(), "listGroups", json.RawMessage(`{}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	wrapped, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result = %T, want map", result)
+	}
+	if _, ok := wrapped["groups"]; !ok {
+		t.Errorf("result missing 'groups' key: %v", wrapped)
+	}
+}
+
+func TestCreateGroupForwardsArgs(t *testing.T) {
+	var seenName string
+	var seenParts []string
+	reg := NewRegistry()
+	RegisterGroups(reg, &stubGroups{
+		create: func(_ context.Context, name string, parts []string) (*GroupSummary, error) {
+			seenName = name
+			seenParts = parts
+			return &GroupSummary{JID: "g@g.us", Name: name}, nil
+		},
+	})
+	params := json.RawMessage(`{"name":"Test","participants":["a@s.whatsapp.net","b@s.whatsapp.net"]}`)
+	_, rpcErr := reg.Dispatch(context.Background(), "createGroup", params)
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	if seenName != "Test" || len(seenParts) != 2 || seenParts[1] != "b@s.whatsapp.net" {
+		t.Errorf("seen = (%q, %v)", seenName, seenParts)
+	}
+}
+
+func TestCreateGroupRejectsMissingName(t *testing.T) {
+	reg := NewRegistry()
+	RegisterGroups(reg, &stubGroups{
+		create: func(context.Context, string, []string) (*GroupSummary, error) {
+			t.Fatalf("create should not be called when name missing")
+			return nil, nil
+		},
+	})
+	_, rpcErr := reg.Dispatch(context.Background(), "createGroup", json.RawMessage(`{"participants":[]}`))
+	if rpcErr == nil || rpcErr.Code != rpc.ErrCodeInvalidParams {
+		t.Errorf("expected ErrCodeInvalidParams, got %+v", rpcErr)
+	}
+}
+
+func TestRenameGroupRejectsMissingFields(t *testing.T) {
+	reg := NewRegistry()
+	RegisterGroups(reg, &stubGroups{
+		rename: func(context.Context, string, string) error {
+			t.Fatalf("rename should not be called")
+			return nil
+		},
+	})
+	cases := []string{
+		`{"name":"x"}`,
+		`{"jid":"g@g.us"}`,
+		`{}`,
+	}
+	for _, c := range cases {
+		_, rpcErr := reg.Dispatch(context.Background(), "renameGroup", json.RawMessage(c))
+		if rpcErr == nil || rpcErr.Code != rpc.ErrCodeInvalidParams {
+			t.Errorf("expected ErrCodeInvalidParams for %s, got %+v", c, rpcErr)
+		}
+	}
+}
+
+func TestGroupErrorMapsToServerError(t *testing.T) {
+	reg := NewRegistry()
+	RegisterGroups(reg, &stubGroups{
+		rename: func(context.Context, string, string) error { return errors.New("server rejected") },
+	})
+	_, rpcErr := reg.Dispatch(context.Background(), "renameGroup", json.RawMessage(`{"jid":"g@g.us","name":"x"}`))
+	if rpcErr == nil || rpcErr.Code != rpc.ErrCodeServerError {
+		t.Errorf("expected ErrCodeServerError, got %+v", rpcErr)
+	}
+}

--- a/connectors/whatsapp/daemon/internal/handler/ops.go
+++ b/connectors/whatsapp/daemon/internal/handler/ops.go
@@ -1,0 +1,95 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+
+	"aios.dev/connectors/whatsapp/daemon/internal/rpc"
+)
+
+// MessageOps is the daemon-internal interface for per-message
+// operations (react/edit/revoke).  Each method takes a message_id the
+// daemon has previously seen — the daemon-side MessageStore holds the
+// MessageKey context (chat/sender/from_me) that WhatsApp's protocol
+// requires.
+type MessageOps interface {
+	React(ctx context.Context, msgID, emoji string) (string, int64, error)
+	Edit(ctx context.Context, msgID, newText string) (string, int64, error)
+	Revoke(ctx context.Context, msgID string) (string, int64, error)
+	IsNotFoundErr(err error) bool
+}
+
+type reactArgs struct {
+	MessageID string `json:"message_id"`
+	Reaction  string `json:"reaction"`
+}
+
+type editArgs struct {
+	MessageID string `json:"message_id"`
+	Text      string `json:"text"`
+}
+
+type revokeArgs struct {
+	MessageID string `json:"message_id"`
+}
+
+type opResult struct {
+	MessageID   string `json:"message_id"`
+	TimestampMS int64  `json:"timestamp_ms"`
+}
+
+// RegisterMessageOps wires sendReaction / editMessage / deleteMessage
+// into reg.  Lookup misses surface as ErrCodeInvalidParams so the
+// caller (and through it, the model) distinguishes "you targeted a
+// message I don't know about" from generic server failures.
+func RegisterMessageOps(reg *Registry, ops MessageOps) {
+	reg.Register("sendReaction", func(ctx context.Context, params json.RawMessage) (any, *rpc.Error) {
+		var args reactArgs
+		if err := json.Unmarshal(params, &args); err != nil {
+			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "invalid sendReaction params: " + err.Error()}
+		}
+		if args.MessageID == "" {
+			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "sendReaction: message_id required"}
+		}
+		msgID, ts, err := ops.React(ctx, args.MessageID, args.Reaction)
+		if err != nil {
+			return nil, mapOpError(err, ops)
+		}
+		return opResult{MessageID: msgID, TimestampMS: ts}, nil
+	})
+	reg.Register("editMessage", func(ctx context.Context, params json.RawMessage) (any, *rpc.Error) {
+		var args editArgs
+		if err := json.Unmarshal(params, &args); err != nil {
+			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "invalid editMessage params: " + err.Error()}
+		}
+		if args.MessageID == "" {
+			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "editMessage: message_id required"}
+		}
+		msgID, ts, err := ops.Edit(ctx, args.MessageID, args.Text)
+		if err != nil {
+			return nil, mapOpError(err, ops)
+		}
+		return opResult{MessageID: msgID, TimestampMS: ts}, nil
+	})
+	reg.Register("deleteMessage", func(ctx context.Context, params json.RawMessage) (any, *rpc.Error) {
+		var args revokeArgs
+		if err := json.Unmarshal(params, &args); err != nil {
+			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "invalid deleteMessage params: " + err.Error()}
+		}
+		if args.MessageID == "" {
+			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "deleteMessage: message_id required"}
+		}
+		msgID, ts, err := ops.Revoke(ctx, args.MessageID)
+		if err != nil {
+			return nil, mapOpError(err, ops)
+		}
+		return opResult{MessageID: msgID, TimestampMS: ts}, nil
+	})
+}
+
+func mapOpError(err error, ops MessageOps) *rpc.Error {
+	if ops.IsNotFoundErr(err) {
+		return &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "unknown message_id"}
+	}
+	return &rpc.Error{Code: rpc.ErrCodeServerError, Message: err.Error()}
+}

--- a/connectors/whatsapp/daemon/internal/handler/ops.go
+++ b/connectors/whatsapp/daemon/internal/handler/ops.go
@@ -17,6 +17,7 @@ type MessageOps interface {
 	Edit(ctx context.Context, msgID, newText string) (string, int64, error)
 	Revoke(ctx context.Context, msgID string) (string, int64, error)
 	IsNotFoundErr(err error) bool
+	IsNotOwnMessageErr(err error) bool
 }
 
 type reactArgs struct {
@@ -90,6 +91,13 @@ func RegisterMessageOps(reg *Registry, ops MessageOps) {
 func mapOpError(err error, ops MessageOps) *rpc.Error {
 	if ops.IsNotFoundErr(err) {
 		return &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "unknown message_id"}
+	}
+	if ops.IsNotOwnMessageErr(err) {
+		// Edit/Revoke target exists in the store but was sent by a
+		// peer — surface as a precondition refusal, not a server
+		// failure, so the model retries with a different target
+		// rather than treating it as transient infra trouble.
+		return &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: err.Error()}
 	}
 	return &rpc.Error{Code: rpc.ErrCodeServerError, Message: err.Error()}
 }

--- a/connectors/whatsapp/daemon/internal/handler/ops.go
+++ b/connectors/whatsapp/daemon/internal/handler/ops.go
@@ -14,7 +14,7 @@ import (
 // requires.
 type MessageOps interface {
 	React(ctx context.Context, msgID, emoji string) (string, int64, error)
-	Edit(ctx context.Context, msgID, newText string) (string, int64, error)
+	Edit(ctx context.Context, msgID, newText string, mentionedJIDs []string) (string, int64, error)
 	Revoke(ctx context.Context, msgID string) (string, int64, error)
 	IsNotFoundErr(err error) bool
 	IsNotOwnMessageErr(err error) bool
@@ -26,8 +26,9 @@ type reactArgs struct {
 }
 
 type editArgs struct {
-	MessageID string `json:"message_id"`
-	Text      string `json:"text"`
+	MessageID     string   `json:"message_id"`
+	Text          string   `json:"text"`
+	MentionedJIDs []string `json:"mentioned_jids,omitempty"`
 }
 
 type revokeArgs struct {
@@ -66,7 +67,7 @@ func RegisterMessageOps(reg *Registry, ops MessageOps) {
 		if args.MessageID == "" {
 			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "editMessage: message_id required"}
 		}
-		msgID, ts, err := ops.Edit(ctx, args.MessageID, args.Text)
+		msgID, ts, err := ops.Edit(ctx, args.MessageID, args.Text, args.MentionedJIDs)
 		if err != nil {
 			return nil, mapOpError(err, ops)
 		}

--- a/connectors/whatsapp/daemon/internal/handler/ops_test.go
+++ b/connectors/whatsapp/daemon/internal/handler/ops_test.go
@@ -14,7 +14,7 @@ import (
 // its args so the test can assert what the registry forwarded.
 type stubOps struct {
 	react  func(ctx context.Context, msgID, emoji string) (string, int64, error)
-	edit   func(ctx context.Context, msgID, text string) (string, int64, error)
+	edit   func(ctx context.Context, msgID, text string, mentionedJIDs []string) (string, int64, error)
 	revoke func(ctx context.Context, msgID string) (string, int64, error)
 	// notFoundErr / notOwnErr are what IsNotFoundErr / IsNotOwnMessageErr
 	// match against — set in tests that want to verify the
@@ -26,8 +26,8 @@ type stubOps struct {
 func (s *stubOps) React(ctx context.Context, msgID, emoji string) (string, int64, error) {
 	return s.react(ctx, msgID, emoji)
 }
-func (s *stubOps) Edit(ctx context.Context, msgID, text string) (string, int64, error) {
-	return s.edit(ctx, msgID, text)
+func (s *stubOps) Edit(ctx context.Context, msgID, text string, mentionedJIDs []string) (string, int64, error) {
+	return s.edit(ctx, msgID, text, mentionedJIDs)
 }
 func (s *stubOps) Revoke(ctx context.Context, msgID string) (string, int64, error) {
 	return s.revoke(ctx, msgID)
@@ -85,17 +85,23 @@ func TestSendReactionRejectsMissingMessageID(t *testing.T) {
 
 func TestEditMessageDispatches(t *testing.T) {
 	var seenID, seenText string
+	var seenMentions []string
 	reg := NewRegistry()
 	RegisterMessageOps(reg, &stubOps{
-		edit: func(_ context.Context, id, text string) (string, int64, error) {
+		edit: func(_ context.Context, id, text string, mentions []string) (string, int64, error) {
 			seenID = id
 			seenText = text
+			seenMentions = mentions
 			return "EDIT-1", 1700000000001, nil
 		},
 	})
-	_, rpcErr := reg.Dispatch(context.Background(), "editMessage", json.RawMessage(`{"message_id":"M1","text":"corrected"}`))
+	params := json.RawMessage(`{"message_id":"M1","text":"corrected","mentioned_jids":["15551234567@s.whatsapp.net"]}`)
+	_, rpcErr := reg.Dispatch(context.Background(), "editMessage", params)
 	if rpcErr != nil {
 		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	if len(seenMentions) != 1 || seenMentions[0] != "15551234567@s.whatsapp.net" {
+		t.Errorf("seenMentions = %v, want [15551234567@s.whatsapp.net]", seenMentions)
 	}
 	if seenID != "M1" || seenText != "corrected" {
 		t.Errorf("edit args = (%q, %q)", seenID, seenText)
@@ -128,7 +134,7 @@ func TestMessageOpNotOwnMessageMapsToInvalidParams(t *testing.T) {
 	sentinel := errors.New("sentinel-not-own")
 	reg := NewRegistry()
 	RegisterMessageOps(reg, &stubOps{
-		edit: func(context.Context, string, string) (string, int64, error) {
+		edit: func(context.Context, string, string, []string) (string, int64, error) {
 			return "", 0, sentinel
 		},
 		notOwnErr: sentinel,

--- a/connectors/whatsapp/daemon/internal/handler/ops_test.go
+++ b/connectors/whatsapp/daemon/internal/handler/ops_test.go
@@ -1,0 +1,140 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"aios.dev/connectors/whatsapp/daemon/internal/rpc"
+)
+
+// stubOps is a MessageOps implementation that lets each test method
+// inject a specific return triple.  The first matching call records
+// its args so the test can assert what the registry forwarded.
+type stubOps struct {
+	react  func(ctx context.Context, msgID, emoji string) (string, int64, error)
+	edit   func(ctx context.Context, msgID, text string) (string, int64, error)
+	revoke func(ctx context.Context, msgID string) (string, int64, error)
+	// notFoundErr is what IsNotFoundErr matches against — set in
+	// tests that want to verify the ErrCodeInvalidParams mapping.
+	notFoundErr error
+}
+
+func (s *stubOps) React(ctx context.Context, msgID, emoji string) (string, int64, error) {
+	return s.react(ctx, msgID, emoji)
+}
+func (s *stubOps) Edit(ctx context.Context, msgID, text string) (string, int64, error) {
+	return s.edit(ctx, msgID, text)
+}
+func (s *stubOps) Revoke(ctx context.Context, msgID string) (string, int64, error) {
+	return s.revoke(ctx, msgID)
+}
+func (s *stubOps) IsNotFoundErr(err error) bool {
+	return s.notFoundErr != nil && errors.Is(err, s.notFoundErr)
+}
+
+func TestSendReactionDispatchesAndReturnsResult(t *testing.T) {
+	var seenID, seenEmoji string
+	reg := NewRegistry()
+	RegisterMessageOps(reg, &stubOps{
+		react: func(_ context.Context, id, emoji string) (string, int64, error) {
+			seenID = id
+			seenEmoji = emoji
+			return "REACT-1", 1700000000000, nil
+		},
+	})
+	params := json.RawMessage(`{"message_id":"M1","reaction":"👍"}`)
+	result, rpcErr := reg.Dispatch(context.Background(), "sendReaction", params)
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	if seenID != "M1" || seenEmoji != "👍" {
+		t.Fatalf("react args = (%q, %q)", seenID, seenEmoji)
+	}
+	res, ok := result.(opResult)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", result)
+	}
+	if res.MessageID != "REACT-1" || res.TimestampMS != 1700000000000 {
+		t.Errorf("opResult = %+v", res)
+	}
+}
+
+func TestSendReactionRejectsMissingMessageID(t *testing.T) {
+	reg := NewRegistry()
+	RegisterMessageOps(reg, &stubOps{
+		react: func(context.Context, string, string) (string, int64, error) {
+			t.Fatalf("react fn should not be called when message_id missing")
+			return "", 0, nil
+		},
+	})
+	_, rpcErr := reg.Dispatch(context.Background(), "sendReaction", json.RawMessage(`{"reaction":"👍"}`))
+	if rpcErr == nil {
+		t.Fatalf("expected rpc error for missing message_id")
+	}
+	if rpcErr.Code != rpc.ErrCodeInvalidParams {
+		t.Errorf("code = %d, want ErrCodeInvalidParams", rpcErr.Code)
+	}
+}
+
+func TestEditMessageDispatches(t *testing.T) {
+	var seenID, seenText string
+	reg := NewRegistry()
+	RegisterMessageOps(reg, &stubOps{
+		edit: func(_ context.Context, id, text string) (string, int64, error) {
+			seenID = id
+			seenText = text
+			return "EDIT-1", 1700000000001, nil
+		},
+	})
+	_, rpcErr := reg.Dispatch(context.Background(), "editMessage", json.RawMessage(`{"message_id":"M1","text":"corrected"}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	if seenID != "M1" || seenText != "corrected" {
+		t.Errorf("edit args = (%q, %q)", seenID, seenText)
+	}
+}
+
+func TestDeleteMessageDispatches(t *testing.T) {
+	var seenID string
+	reg := NewRegistry()
+	RegisterMessageOps(reg, &stubOps{
+		revoke: func(_ context.Context, id string) (string, int64, error) {
+			seenID = id
+			return "REV-1", 1700000000002, nil
+		},
+	})
+	_, rpcErr := reg.Dispatch(context.Background(), "deleteMessage", json.RawMessage(`{"message_id":"M1"}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	if seenID != "M1" {
+		t.Errorf("revoke arg = %q", seenID)
+	}
+}
+
+func TestMessageOpNotFoundMapsToInvalidParams(t *testing.T) {
+	// Lookup miss must surface as ErrCodeInvalidParams so callers can
+	// distinguish "unknown message_id" from generic server failures —
+	// the model would retry the wrong thing otherwise.
+	sentinel := errors.New("sentinel-not-found")
+	reg := NewRegistry()
+	RegisterMessageOps(reg, &stubOps{
+		react: func(context.Context, string, string) (string, int64, error) {
+			return "", 0, sentinel
+		},
+		notFoundErr: sentinel,
+	})
+	_, rpcErr := reg.Dispatch(context.Background(), "sendReaction", json.RawMessage(`{"message_id":"GHOST","reaction":"👍"}`))
+	if rpcErr == nil {
+		t.Fatalf("expected rpc error")
+	}
+	if rpcErr.Code != rpc.ErrCodeInvalidParams {
+		t.Errorf("code = %d, want ErrCodeInvalidParams", rpcErr.Code)
+	}
+	if rpcErr.Message != "unknown message_id" {
+		t.Errorf("message = %q, want 'unknown message_id'", rpcErr.Message)
+	}
+}

--- a/connectors/whatsapp/daemon/internal/handler/ops_test.go
+++ b/connectors/whatsapp/daemon/internal/handler/ops_test.go
@@ -16,9 +16,11 @@ type stubOps struct {
 	react  func(ctx context.Context, msgID, emoji string) (string, int64, error)
 	edit   func(ctx context.Context, msgID, text string) (string, int64, error)
 	revoke func(ctx context.Context, msgID string) (string, int64, error)
-	// notFoundErr is what IsNotFoundErr matches against — set in
-	// tests that want to verify the ErrCodeInvalidParams mapping.
+	// notFoundErr / notOwnErr are what IsNotFoundErr / IsNotOwnMessageErr
+	// match against — set in tests that want to verify the
+	// ErrCodeInvalidParams mapping for either branch.
 	notFoundErr error
+	notOwnErr   error
 }
 
 func (s *stubOps) React(ctx context.Context, msgID, emoji string) (string, int64, error) {
@@ -32,6 +34,9 @@ func (s *stubOps) Revoke(ctx context.Context, msgID string) (string, int64, erro
 }
 func (s *stubOps) IsNotFoundErr(err error) bool {
 	return s.notFoundErr != nil && errors.Is(err, s.notFoundErr)
+}
+func (s *stubOps) IsNotOwnMessageErr(err error) bool {
+	return s.notOwnErr != nil && errors.Is(err, s.notOwnErr)
 }
 
 func TestSendReactionDispatchesAndReturnsResult(t *testing.T) {
@@ -112,6 +117,28 @@ func TestDeleteMessageDispatches(t *testing.T) {
 	}
 	if seenID != "M1" {
 		t.Errorf("revoke arg = %q", seenID)
+	}
+}
+
+func TestMessageOpNotOwnMessageMapsToInvalidParams(t *testing.T) {
+	// Edit/Revoke on a peer's message returns ErrNotOwnMessage; the
+	// handler must surface it as a precondition refusal so the model
+	// distinguishes "you targeted a foreign message you can't edit"
+	// from a transient infra failure that should retry.
+	sentinel := errors.New("sentinel-not-own")
+	reg := NewRegistry()
+	RegisterMessageOps(reg, &stubOps{
+		edit: func(context.Context, string, string) (string, int64, error) {
+			return "", 0, sentinel
+		},
+		notOwnErr: sentinel,
+	})
+	_, rpcErr := reg.Dispatch(context.Background(), "editMessage", json.RawMessage(`{"message_id":"FOREIGN","text":"x"}`))
+	if rpcErr == nil {
+		t.Fatalf("expected rpc error")
+	}
+	if rpcErr.Code != rpc.ErrCodeInvalidParams {
+		t.Errorf("code = %d, want ErrCodeInvalidParams", rpcErr.Code)
 	}
 }
 

--- a/connectors/whatsapp/daemon/internal/handler/send.go
+++ b/connectors/whatsapp/daemon/internal/handler/send.go
@@ -22,7 +22,14 @@ import (
 //
 // ``mentionedJIDs`` are attached to the outbound message's ContextInfo
 // so WhatsApp clients render @-mentions as pills.  Pass nil for none.
-type SendMessageFn func(ctx context.Context, jid, text string, attachments []Attachment, mentionedJIDs []string) (deliveredIDs []string, timestampMs int64, err error)
+//
+// ``quotedMessageID`` is the id of a previously-seen message in the
+// same chat that this send should reply to.  When non-empty the
+// daemon looks up the original via its msgstore and threads
+// ``ContextInfo.{StanzaID, Participant, QuotedMessage}`` onto the
+// outbound so the peer's WhatsApp client renders a proper threaded
+// reply.  Passing an unknown id surfaces :var:`wameow.ErrMessageNotFound`.
+type SendMessageFn func(ctx context.Context, jid, text string, attachments []Attachment, mentionedJIDs []string, quotedMessageID string) (deliveredIDs []string, timestampMs int64, err error)
 
 // PartialSendErrorUnwrapper exposes the partial-delivery ids the
 // closure carries on a multi-attachment failure.  handler/send.go
@@ -46,10 +53,11 @@ type Attachment struct {
 }
 
 type sendArgs struct {
-	JID           string       `json:"jid"`
-	Text          string       `json:"text"`
-	Attachments   []Attachment `json:"attachments"`
-	MentionedJIDs []string     `json:"mentioned_jids,omitempty"`
+	JID             string       `json:"jid"`
+	Text            string       `json:"text"`
+	Attachments     []Attachment `json:"attachments"`
+	MentionedJIDs   []string     `json:"mentioned_jids,omitempty"`
+	QuotedMessageID string       `json:"quoted_message_id,omitempty"`
 }
 
 type sendResult struct {
@@ -81,7 +89,7 @@ func RegisterSend(reg *Registry, fn SendMessageFn) {
 		if args.Text == "" && len(args.Attachments) == 0 {
 			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "sendMessage: text or attachments required"}
 		}
-		ids, ts, err := fn(ctx, args.JID, args.Text, args.Attachments, args.MentionedJIDs)
+		ids, ts, err := fn(ctx, args.JID, args.Text, args.Attachments, args.MentionedJIDs, args.QuotedMessageID)
 		if err != nil {
 			rpcErr := &rpc.Error{Code: rpc.ErrCodeServerError, Message: err.Error()}
 			// Partial-delivery error: surface the ids that landed

--- a/connectors/whatsapp/daemon/internal/handler/send.go
+++ b/connectors/whatsapp/daemon/internal/handler/send.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"aios.dev/connectors/whatsapp/daemon/internal/rpc"
 )
@@ -13,11 +14,21 @@ import (
 // decoupled from whatsmeow types so tests can stub it and main.go
 // can swap the whatsmeow integration in independently.
 //
-// For multi-attachment sends, the closure returns the FIRST send's
-// id+timestamp (the one carrying the caption when text is non-empty);
-// the daemon's MessageStore captures every send so subsequent
-// attachments are still react/edit/delete-targetable by id.
-type SendMessageFn func(ctx context.Context, jid, text string, attachments []Attachment) (messageID string, timestampMs int64, err error)
+// Returns the FULL slice of delivered message_ids (in send order);
+// the first is the caption-bearing send when applicable.  On a
+// mid-loop partial failure, the closure returns the already-delivered
+// ids alongside the error — the handler surfaces them via rpc.Error.Data
+// so the model can still address each delivered attachment by id.
+type SendMessageFn func(ctx context.Context, jid, text string, attachments []Attachment) (deliveredIDs []string, timestampMs int64, err error)
+
+// PartialSendErrorUnwrapper exposes the partial-delivery ids the
+// closure carries on a multi-attachment failure.  handler/send.go
+// uses errors.As against a private interface to keep this package's
+// public surface decoupled from wameow's concrete type.
+type partialSendError interface {
+	error
+	Partial() (delivered []string, failedIndex int, failedFilename string)
+}
 
 // Attachment is the wire-shaped media payload received from Python.
 // Path is a host-side filesystem path the daemon can os.ReadFile on;
@@ -38,8 +49,19 @@ type sendArgs struct {
 }
 
 type sendResult struct {
-	MessageID   string `json:"message_id"`
-	TimestampMS int64  `json:"timestamp_ms"`
+	MessageID           string   `json:"message_id"`
+	TimestampMS         int64    `json:"timestamp_ms"`
+	DeliveredMessageIDs []string `json:"delivered_message_ids,omitempty"`
+}
+
+// partialSendErrorData is the structured Data block on rpc.Error
+// when a multi-attachment send delivers some but not all
+// attachments.  The model can read these fields off the tool result
+// to address the delivered attachments by id.
+type partialSendErrorData struct {
+	DeliveredMessageIDs []string `json:"delivered_message_ids"`
+	FailedIndex         int      `json:"failed_index"`
+	FailedFilename      string   `json:"failed_filename"`
 }
 
 // RegisterSend wires the ``sendMessage`` method into reg.
@@ -55,10 +77,26 @@ func RegisterSend(reg *Registry, fn SendMessageFn) {
 		if args.Text == "" && len(args.Attachments) == 0 {
 			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "sendMessage: text or attachments required"}
 		}
-		msgID, ts, err := fn(ctx, args.JID, args.Text, args.Attachments)
+		ids, ts, err := fn(ctx, args.JID, args.Text, args.Attachments)
 		if err != nil {
-			return nil, &rpc.Error{Code: rpc.ErrCodeServerError, Message: err.Error()}
+			rpcErr := &rpc.Error{Code: rpc.ErrCodeServerError, Message: err.Error()}
+			// Partial-delivery error: surface the ids that landed
+			// so the model can still target them by id.
+			var partial partialSendError
+			if errors.As(err, &partial) {
+				delivered, idx, name := partial.Partial()
+				rpcErr.Data = partialSendErrorData{
+					DeliveredMessageIDs: delivered,
+					FailedIndex:         idx,
+					FailedFilename:      name,
+				}
+			}
+			return nil, rpcErr
 		}
-		return sendResult{MessageID: msgID, TimestampMS: ts}, nil
+		var firstID string
+		if len(ids) > 0 {
+			firstID = ids[0]
+		}
+		return sendResult{MessageID: firstID, TimestampMS: ts, DeliveredMessageIDs: ids}, nil
 	})
 }

--- a/connectors/whatsapp/daemon/internal/handler/send.go
+++ b/connectors/whatsapp/daemon/internal/handler/send.go
@@ -7,16 +7,34 @@ import (
 	"aios.dev/connectors/whatsapp/daemon/internal/rpc"
 )
 
-// SendMessageFn is the daemon-internal closure that delivers a text
-// message to a WhatsApp JID.  Taking a closure (rather than a
-// *whatsmeow.Client) keeps the handler decoupled from whatsmeow types
-// so tests can stub it and main.go can swap the whatsmeow integration
-// in independently.
-type SendMessageFn func(ctx context.Context, jid, text string) (messageID string, timestampMs int64, err error)
+// SendMessageFn is the daemon-internal closure that delivers a
+// message (text and/or attachments) to a WhatsApp JID.  Taking a
+// closure (rather than a *whatsmeow.Client) keeps the handler
+// decoupled from whatsmeow types so tests can stub it and main.go
+// can swap the whatsmeow integration in independently.
+//
+// For multi-attachment sends, the closure returns the FIRST send's
+// id+timestamp (the one carrying the caption when text is non-empty);
+// the daemon's MessageStore captures every send so subsequent
+// attachments are still react/edit/delete-targetable by id.
+type SendMessageFn func(ctx context.Context, jid, text string, attachments []Attachment) (messageID string, timestampMs int64, err error)
+
+// Attachment is the wire-shaped media payload received from Python.
+// Path is a host-side filesystem path the daemon can os.ReadFile on;
+// the Python connector resolves SandboxPath → host path before the
+// RPC.  Filename appears on the WhatsApp wire only for documents but
+// the daemon carries it for all kinds (passed to whatsmeow's
+// DocumentMessage.FileName).
+type Attachment struct {
+	Path     string `json:"path"`
+	Mimetype string `json:"mimetype"`
+	Filename string `json:"filename"`
+}
 
 type sendArgs struct {
-	JID  string `json:"jid"`
-	Text string `json:"text"`
+	JID         string       `json:"jid"`
+	Text        string       `json:"text"`
+	Attachments []Attachment `json:"attachments"`
 }
 
 type sendResult struct {
@@ -34,7 +52,10 @@ func RegisterSend(reg *Registry, fn SendMessageFn) {
 		if args.JID == "" {
 			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "sendMessage: jid required"}
 		}
-		msgID, ts, err := fn(ctx, args.JID, args.Text)
+		if args.Text == "" && len(args.Attachments) == 0 {
+			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "sendMessage: text or attachments required"}
+		}
+		msgID, ts, err := fn(ctx, args.JID, args.Text, args.Attachments)
 		if err != nil {
 			return nil, &rpc.Error{Code: rpc.ErrCodeServerError, Message: err.Error()}
 		}

--- a/connectors/whatsapp/daemon/internal/handler/send.go
+++ b/connectors/whatsapp/daemon/internal/handler/send.go
@@ -19,7 +19,10 @@ import (
 // mid-loop partial failure, the closure returns the already-delivered
 // ids alongside the error — the handler surfaces them via rpc.Error.Data
 // so the model can still address each delivered attachment by id.
-type SendMessageFn func(ctx context.Context, jid, text string, attachments []Attachment) (deliveredIDs []string, timestampMs int64, err error)
+//
+// ``mentionedJIDs`` are attached to the outbound message's ContextInfo
+// so WhatsApp clients render @-mentions as pills.  Pass nil for none.
+type SendMessageFn func(ctx context.Context, jid, text string, attachments []Attachment, mentionedJIDs []string) (deliveredIDs []string, timestampMs int64, err error)
 
 // PartialSendErrorUnwrapper exposes the partial-delivery ids the
 // closure carries on a multi-attachment failure.  handler/send.go
@@ -43,9 +46,10 @@ type Attachment struct {
 }
 
 type sendArgs struct {
-	JID         string       `json:"jid"`
-	Text        string       `json:"text"`
-	Attachments []Attachment `json:"attachments"`
+	JID           string       `json:"jid"`
+	Text          string       `json:"text"`
+	Attachments   []Attachment `json:"attachments"`
+	MentionedJIDs []string     `json:"mentioned_jids,omitempty"`
 }
 
 type sendResult struct {
@@ -77,7 +81,7 @@ func RegisterSend(reg *Registry, fn SendMessageFn) {
 		if args.Text == "" && len(args.Attachments) == 0 {
 			return nil, &rpc.Error{Code: rpc.ErrCodeInvalidParams, Message: "sendMessage: text or attachments required"}
 		}
-		ids, ts, err := fn(ctx, args.JID, args.Text, args.Attachments)
+		ids, ts, err := fn(ctx, args.JID, args.Text, args.Attachments, args.MentionedJIDs)
 		if err != nil {
 			rpcErr := &rpc.Error{Code: rpc.ErrCodeServerError, Message: err.Error()}
 			// Partial-delivery error: surface the ids that landed

--- a/connectors/whatsapp/daemon/internal/handler/send_test.go
+++ b/connectors/whatsapp/daemon/internal/handler/send_test.go
@@ -12,7 +12,7 @@ import (
 func TestSendMessageDispatchesAndReturnsResult(t *testing.T) {
 	var seenJID, seenText string
 	var seenAttachments []Attachment
-	fn := func(_ context.Context, jid, text string, atts []Attachment, _ []string) ([]string, int64, error) {
+	fn := func(_ context.Context, jid, text string, atts []Attachment, _ []string, _ string) ([]string, int64, error) {
 		seenJID = jid
 		seenText = text
 		seenAttachments = atts
@@ -44,7 +44,7 @@ func TestSendMessageSurfacesAllDeliveredIDs(t *testing.T) {
 	// result so the model can address each by id for follow-up
 	// react/edit/delete.  Previously only the first id was exposed.
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string, string) ([]string, int64, error) {
 		return []string{"M0", "M1", "M2"}, 1700000000000, nil
 	})
 	params := json.RawMessage(`{
@@ -96,7 +96,7 @@ func TestSendMessagePartialFailureSurfacesDeliveredIDs(t *testing.T) {
 		filename:  "broken.mp4",
 	}
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string, string) ([]string, int64, error) {
 		return []string{"M0", "M1"}, 1700000000000, partial
 	})
 	params := json.RawMessage(`{"jid":"x@s.whatsapp.net","text":"cap","attachments":[
@@ -122,7 +122,7 @@ func TestSendMessagePartialFailureSurfacesDeliveredIDs(t *testing.T) {
 
 func TestSendMessageRejectsMissingJID(t *testing.T) {
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string, string) ([]string, int64, error) {
 		t.Fatalf("send fn should not be called when jid missing")
 		return nil, 0, nil
 	})
@@ -140,7 +140,7 @@ func TestSendMessageRejectsEmptyBody(t *testing.T) {
 	// error — the daemon refuses rather than silently sending an empty
 	// Conversation message that the peer would see as a blank bubble.
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string, string) ([]string, int64, error) {
 		t.Fatalf("send fn should not be called for empty body")
 		return nil, 0, nil
 	})
@@ -152,7 +152,7 @@ func TestSendMessageRejectsEmptyBody(t *testing.T) {
 
 func TestSendMessagePropagatesSendError(t *testing.T) {
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string, string) ([]string, int64, error) {
 		return nil, 0, errors.New("network down")
 	})
 	params := json.RawMessage(`{"jid":"15553334444@s.whatsapp.net","text":"hi"}`)
@@ -170,7 +170,7 @@ func TestSendMessagePropagatesSendError(t *testing.T) {
 
 func TestSendMessageRejectsMalformedParams(t *testing.T) {
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string, string) ([]string, int64, error) {
 		return []string{"MSG"}, 0, nil
 	})
 	_, rpcErr := reg.Dispatch(context.Background(), "sendMessage", json.RawMessage(`not json`))
@@ -182,7 +182,7 @@ func TestSendMessageRejectsMalformedParams(t *testing.T) {
 func TestSendMessageForwardsAttachments(t *testing.T) {
 	var seenAttachments []Attachment
 	reg := NewRegistry()
-	RegisterSend(reg, func(_ context.Context, _ string, _ string, atts []Attachment, _ []string) ([]string, int64, error) {
+	RegisterSend(reg, func(_ context.Context, _ string, _ string, atts []Attachment, _ []string, _ string) ([]string, int64, error) {
 		seenAttachments = atts
 		return []string{"MSG-2"}, 1700000001000, nil
 	})
@@ -212,7 +212,7 @@ func TestSendMessageForwardsAttachments(t *testing.T) {
 func TestSendMessageForwardsMentionedJIDs(t *testing.T) {
 	var seenMentions []string
 	reg := NewRegistry()
-	RegisterSend(reg, func(_ context.Context, _, _ string, _ []Attachment, m []string) ([]string, int64, error) {
+	RegisterSend(reg, func(_ context.Context, _, _ string, _ []Attachment, m []string, _ string) ([]string, int64, error) {
 		seenMentions = m
 		return []string{"MSG"}, 1700000000000, nil
 	})
@@ -232,7 +232,7 @@ func TestSendMessageForwardsMentionedJIDs(t *testing.T) {
 func TestSendMessageAcceptsAttachmentsWithoutText(t *testing.T) {
 	called := false
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string, string) ([]string, int64, error) {
 		called = true
 		return []string{"MSG-3"}, 1700000002000, nil
 	})

--- a/connectors/whatsapp/daemon/internal/handler/send_test.go
+++ b/connectors/whatsapp/daemon/internal/handler/send_test.go
@@ -11,9 +11,11 @@ import (
 
 func TestSendMessageDispatchesAndReturnsResult(t *testing.T) {
 	var seenJID, seenText string
-	fn := func(_ context.Context, jid, text string) (string, int64, error) {
+	var seenAttachments []Attachment
+	fn := func(_ context.Context, jid, text string, atts []Attachment) (string, int64, error) {
 		seenJID = jid
 		seenText = text
+		seenAttachments = atts
 		return "MSG-1", 1700000000000, nil
 	}
 	reg := NewRegistry()
@@ -27,6 +29,9 @@ func TestSendMessageDispatchesAndReturnsResult(t *testing.T) {
 	if seenJID != "15553334444@s.whatsapp.net" || seenText != "hello" {
 		t.Fatalf("send fn args = (%q, %q)", seenJID, seenText)
 	}
+	if len(seenAttachments) != 0 {
+		t.Fatalf("expected no attachments, got %v", seenAttachments)
+	}
 	out, _ := json.Marshal(result)
 	if string(out) != `{"message_id":"MSG-1","timestamp_ms":1700000000000}` {
 		t.Fatalf("result json = %s", out)
@@ -35,7 +40,7 @@ func TestSendMessageDispatchesAndReturnsResult(t *testing.T) {
 
 func TestSendMessageRejectsMissingJID(t *testing.T) {
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string) (string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment) (string, int64, error) {
 		t.Fatalf("send fn should not be called when jid missing")
 		return "", 0, nil
 	})
@@ -48,9 +53,24 @@ func TestSendMessageRejectsMissingJID(t *testing.T) {
 	}
 }
 
+func TestSendMessageRejectsEmptyBody(t *testing.T) {
+	// Bare {jid:...} with neither text nor attachments is a programmer
+	// error — the daemon refuses rather than silently sending an empty
+	// Conversation message that the peer would see as a blank bubble.
+	reg := NewRegistry()
+	RegisterSend(reg, func(context.Context, string, string, []Attachment) (string, int64, error) {
+		t.Fatalf("send fn should not be called for empty body")
+		return "", 0, nil
+	})
+	_, rpcErr := reg.Dispatch(context.Background(), "sendMessage", json.RawMessage(`{"jid":"x@s.whatsapp.net"}`))
+	if rpcErr == nil || rpcErr.Code != rpc.ErrCodeInvalidParams {
+		t.Fatalf("expected ErrCodeInvalidParams for empty body, got %+v", rpcErr)
+	}
+}
+
 func TestSendMessagePropagatesSendError(t *testing.T) {
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string) (string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment) (string, int64, error) {
 		return "", 0, errors.New("network down")
 	})
 	params := json.RawMessage(`{"jid":"15553334444@s.whatsapp.net","text":"hi"}`)
@@ -68,11 +88,61 @@ func TestSendMessagePropagatesSendError(t *testing.T) {
 
 func TestSendMessageRejectsMalformedParams(t *testing.T) {
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string) (string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment) (string, int64, error) {
 		return "", 0, nil
 	})
 	_, rpcErr := reg.Dispatch(context.Background(), "sendMessage", json.RawMessage(`not json`))
 	if rpcErr == nil || rpcErr.Code != rpc.ErrCodeInvalidParams {
 		t.Fatalf("expected ErrCodeInvalidParams for malformed json, got %+v", rpcErr)
+	}
+}
+
+func TestSendMessageForwardsAttachments(t *testing.T) {
+	var seenAttachments []Attachment
+	reg := NewRegistry()
+	RegisterSend(reg, func(_ context.Context, _ string, _ string, atts []Attachment) (string, int64, error) {
+		seenAttachments = atts
+		return "MSG-2", 1700000001000, nil
+	})
+	params := json.RawMessage(`{
+		"jid": "15553334444@s.whatsapp.net",
+		"text": "caption",
+		"attachments": [
+			{"path": "/tmp/a.jpg", "mimetype": "image/jpeg", "filename": "a.jpg"},
+			{"path": "/tmp/b.pdf", "mimetype": "application/pdf", "filename": "b.pdf"}
+		]
+	}`)
+	_, rpcErr := reg.Dispatch(context.Background(), "sendMessage", params)
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	if len(seenAttachments) != 2 {
+		t.Fatalf("expected 2 attachments, got %d", len(seenAttachments))
+	}
+	if seenAttachments[0].Path != "/tmp/a.jpg" || seenAttachments[0].Mimetype != "image/jpeg" {
+		t.Errorf("attachment[0] = %+v", seenAttachments[0])
+	}
+	if seenAttachments[1].Path != "/tmp/b.pdf" || seenAttachments[1].Filename != "b.pdf" {
+		t.Errorf("attachment[1] = %+v", seenAttachments[1])
+	}
+}
+
+func TestSendMessageAcceptsAttachmentsWithoutText(t *testing.T) {
+	called := false
+	reg := NewRegistry()
+	RegisterSend(reg, func(context.Context, string, string, []Attachment) (string, int64, error) {
+		called = true
+		return "MSG-3", 1700000002000, nil
+	})
+	params := json.RawMessage(`{
+		"jid": "x@s.whatsapp.net",
+		"attachments": [{"path":"/tmp/a.jpg","mimetype":"image/jpeg","filename":"a.jpg"}]
+	}`)
+	_, rpcErr := reg.Dispatch(context.Background(), "sendMessage", params)
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error for attachment-only send: %+v", rpcErr)
+	}
+	if !called {
+		t.Fatal("send fn should have been called")
 	}
 }

--- a/connectors/whatsapp/daemon/internal/handler/send_test.go
+++ b/connectors/whatsapp/daemon/internal/handler/send_test.go
@@ -12,7 +12,7 @@ import (
 func TestSendMessageDispatchesAndReturnsResult(t *testing.T) {
 	var seenJID, seenText string
 	var seenAttachments []Attachment
-	fn := func(_ context.Context, jid, text string, atts []Attachment) ([]string, int64, error) {
+	fn := func(_ context.Context, jid, text string, atts []Attachment, _ []string) ([]string, int64, error) {
 		seenJID = jid
 		seenText = text
 		seenAttachments = atts
@@ -44,7 +44,7 @@ func TestSendMessageSurfacesAllDeliveredIDs(t *testing.T) {
 	// result so the model can address each by id for follow-up
 	// react/edit/delete.  Previously only the first id was exposed.
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
 		return []string{"M0", "M1", "M2"}, 1700000000000, nil
 	})
 	params := json.RawMessage(`{
@@ -96,7 +96,7 @@ func TestSendMessagePartialFailureSurfacesDeliveredIDs(t *testing.T) {
 		filename:  "broken.mp4",
 	}
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
 		return []string{"M0", "M1"}, 1700000000000, partial
 	})
 	params := json.RawMessage(`{"jid":"x@s.whatsapp.net","text":"cap","attachments":[
@@ -122,7 +122,7 @@ func TestSendMessagePartialFailureSurfacesDeliveredIDs(t *testing.T) {
 
 func TestSendMessageRejectsMissingJID(t *testing.T) {
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
 		t.Fatalf("send fn should not be called when jid missing")
 		return nil, 0, nil
 	})
@@ -140,7 +140,7 @@ func TestSendMessageRejectsEmptyBody(t *testing.T) {
 	// error — the daemon refuses rather than silently sending an empty
 	// Conversation message that the peer would see as a blank bubble.
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
 		t.Fatalf("send fn should not be called for empty body")
 		return nil, 0, nil
 	})
@@ -152,7 +152,7 @@ func TestSendMessageRejectsEmptyBody(t *testing.T) {
 
 func TestSendMessagePropagatesSendError(t *testing.T) {
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
 		return nil, 0, errors.New("network down")
 	})
 	params := json.RawMessage(`{"jid":"15553334444@s.whatsapp.net","text":"hi"}`)
@@ -170,7 +170,7 @@ func TestSendMessagePropagatesSendError(t *testing.T) {
 
 func TestSendMessageRejectsMalformedParams(t *testing.T) {
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
 		return []string{"MSG"}, 0, nil
 	})
 	_, rpcErr := reg.Dispatch(context.Background(), "sendMessage", json.RawMessage(`not json`))
@@ -182,7 +182,7 @@ func TestSendMessageRejectsMalformedParams(t *testing.T) {
 func TestSendMessageForwardsAttachments(t *testing.T) {
 	var seenAttachments []Attachment
 	reg := NewRegistry()
-	RegisterSend(reg, func(_ context.Context, _ string, _ string, atts []Attachment) ([]string, int64, error) {
+	RegisterSend(reg, func(_ context.Context, _ string, _ string, atts []Attachment, _ []string) ([]string, int64, error) {
 		seenAttachments = atts
 		return []string{"MSG-2"}, 1700000001000, nil
 	})
@@ -209,10 +209,30 @@ func TestSendMessageForwardsAttachments(t *testing.T) {
 	}
 }
 
+func TestSendMessageForwardsMentionedJIDs(t *testing.T) {
+	var seenMentions []string
+	reg := NewRegistry()
+	RegisterSend(reg, func(_ context.Context, _, _ string, _ []Attachment, m []string) ([]string, int64, error) {
+		seenMentions = m
+		return []string{"MSG"}, 1700000000000, nil
+	})
+	params := json.RawMessage(`{
+		"jid": "g@g.us", "text": "hey @+15551234567",
+		"mentioned_jids": ["15551234567@s.whatsapp.net"]
+	}`)
+	_, rpcErr := reg.Dispatch(context.Background(), "sendMessage", params)
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	if len(seenMentions) != 1 || seenMentions[0] != "15551234567@s.whatsapp.net" {
+		t.Errorf("seenMentions = %v, want [15551234567@s.whatsapp.net]", seenMentions)
+	}
+}
+
 func TestSendMessageAcceptsAttachmentsWithoutText(t *testing.T) {
 	called := false
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment, []string) ([]string, int64, error) {
 		called = true
 		return []string{"MSG-3"}, 1700000002000, nil
 	})

--- a/connectors/whatsapp/daemon/internal/handler/send_test.go
+++ b/connectors/whatsapp/daemon/internal/handler/send_test.go
@@ -12,11 +12,11 @@ import (
 func TestSendMessageDispatchesAndReturnsResult(t *testing.T) {
 	var seenJID, seenText string
 	var seenAttachments []Attachment
-	fn := func(_ context.Context, jid, text string, atts []Attachment) (string, int64, error) {
+	fn := func(_ context.Context, jid, text string, atts []Attachment) ([]string, int64, error) {
 		seenJID = jid
 		seenText = text
 		seenAttachments = atts
-		return "MSG-1", 1700000000000, nil
+		return []string{"MSG-1"}, 1700000000000, nil
 	}
 	reg := NewRegistry()
 	RegisterSend(reg, fn)
@@ -33,16 +33,98 @@ func TestSendMessageDispatchesAndReturnsResult(t *testing.T) {
 		t.Fatalf("expected no attachments, got %v", seenAttachments)
 	}
 	out, _ := json.Marshal(result)
-	if string(out) != `{"message_id":"MSG-1","timestamp_ms":1700000000000}` {
-		t.Fatalf("result json = %s", out)
+	want := `{"message_id":"MSG-1","timestamp_ms":1700000000000,"delivered_message_ids":["MSG-1"]}`
+	if string(out) != want {
+		t.Fatalf("result json = %s\nwant %s", out, want)
+	}
+}
+
+func TestSendMessageSurfacesAllDeliveredIDs(t *testing.T) {
+	// Multi-attachment success returns ALL delivered ids in the
+	// result so the model can address each by id for follow-up
+	// react/edit/delete.  Previously only the first id was exposed.
+	reg := NewRegistry()
+	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
+		return []string{"M0", "M1", "M2"}, 1700000000000, nil
+	})
+	params := json.RawMessage(`{
+		"jid": "x@s.whatsapp.net", "text": "cap",
+		"attachments": [
+			{"path":"/tmp/a.jpg","mimetype":"image/jpeg","filename":"a.jpg"},
+			{"path":"/tmp/b.jpg","mimetype":"image/jpeg","filename":"b.jpg"},
+			{"path":"/tmp/c.jpg","mimetype":"image/jpeg","filename":"c.jpg"}
+		]
+	}`)
+	result, rpcErr := reg.Dispatch(context.Background(), "sendMessage", params)
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	res, ok := result.(sendResult)
+	if !ok {
+		t.Fatalf("unexpected result type %T", result)
+	}
+	if res.MessageID != "M0" {
+		t.Errorf("MessageID = %q, want 'M0'", res.MessageID)
+	}
+	if len(res.DeliveredMessageIDs) != 3 || res.DeliveredMessageIDs[2] != "M2" {
+		t.Errorf("DeliveredMessageIDs = %v, want [M0 M1 M2]", res.DeliveredMessageIDs)
+	}
+}
+
+type stubPartialErr struct {
+	cause     error
+	delivered []string
+	idx       int
+	filename  string
+}
+
+func (s *stubPartialErr) Error() string { return s.cause.Error() }
+func (s *stubPartialErr) Unwrap() error { return s.cause }
+func (s *stubPartialErr) Partial() ([]string, int, string) {
+	return s.delivered, s.idx, s.filename
+}
+
+func TestSendMessagePartialFailureSurfacesDeliveredIDs(t *testing.T) {
+	// Mid-loop multi-attachment failure must surface the ids that
+	// landed so the model can target them by id for follow-up
+	// react/edit/revoke.  Previously these ids were swallowed by
+	// the error path, stranding them in the daemon's msgstore.
+	partial := &stubPartialErr{
+		cause:     errors.New("upload failed"),
+		delivered: []string{"M0", "M1"},
+		idx:       2,
+		filename:  "broken.mp4",
+	}
+	reg := NewRegistry()
+	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
+		return []string{"M0", "M1"}, 1700000000000, partial
+	})
+	params := json.RawMessage(`{"jid":"x@s.whatsapp.net","text":"cap","attachments":[
+		{"path":"/tmp/a.jpg","mimetype":"image/jpeg","filename":"a.jpg"},
+		{"path":"/tmp/b.jpg","mimetype":"image/jpeg","filename":"b.jpg"},
+		{"path":"/tmp/c.mp4","mimetype":"video/mp4","filename":"broken.mp4"}
+	]}`)
+	_, rpcErr := reg.Dispatch(context.Background(), "sendMessage", params)
+	if rpcErr == nil {
+		t.Fatalf("expected rpc error")
+	}
+	data, ok := rpcErr.Data.(partialSendErrorData)
+	if !ok {
+		t.Fatalf("rpc.Error.Data = %T, want partialSendErrorData", rpcErr.Data)
+	}
+	if len(data.DeliveredMessageIDs) != 2 || data.DeliveredMessageIDs[1] != "M1" {
+		t.Errorf("DeliveredMessageIDs = %v, want [M0 M1]", data.DeliveredMessageIDs)
+	}
+	if data.FailedIndex != 2 || data.FailedFilename != "broken.mp4" {
+		t.Errorf("FailedIndex/Filename = %d %q", data.FailedIndex, data.FailedFilename)
 	}
 }
 
 func TestSendMessageRejectsMissingJID(t *testing.T) {
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment) (string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
 		t.Fatalf("send fn should not be called when jid missing")
-		return "", 0, nil
+		return nil, 0, nil
 	})
 	_, rpcErr := reg.Dispatch(context.Background(), "sendMessage", json.RawMessage(`{"text":"hi"}`))
 	if rpcErr == nil {
@@ -58,9 +140,9 @@ func TestSendMessageRejectsEmptyBody(t *testing.T) {
 	// error — the daemon refuses rather than silently sending an empty
 	// Conversation message that the peer would see as a blank bubble.
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment) (string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
 		t.Fatalf("send fn should not be called for empty body")
-		return "", 0, nil
+		return nil, 0, nil
 	})
 	_, rpcErr := reg.Dispatch(context.Background(), "sendMessage", json.RawMessage(`{"jid":"x@s.whatsapp.net"}`))
 	if rpcErr == nil || rpcErr.Code != rpc.ErrCodeInvalidParams {
@@ -70,8 +152,8 @@ func TestSendMessageRejectsEmptyBody(t *testing.T) {
 
 func TestSendMessagePropagatesSendError(t *testing.T) {
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment) (string, int64, error) {
-		return "", 0, errors.New("network down")
+	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
+		return nil, 0, errors.New("network down")
 	})
 	params := json.RawMessage(`{"jid":"15553334444@s.whatsapp.net","text":"hi"}`)
 	_, rpcErr := reg.Dispatch(context.Background(), "sendMessage", params)
@@ -88,8 +170,8 @@ func TestSendMessagePropagatesSendError(t *testing.T) {
 
 func TestSendMessageRejectsMalformedParams(t *testing.T) {
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment) (string, int64, error) {
-		return "", 0, nil
+	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
+		return []string{"MSG"}, 0, nil
 	})
 	_, rpcErr := reg.Dispatch(context.Background(), "sendMessage", json.RawMessage(`not json`))
 	if rpcErr == nil || rpcErr.Code != rpc.ErrCodeInvalidParams {
@@ -100,9 +182,9 @@ func TestSendMessageRejectsMalformedParams(t *testing.T) {
 func TestSendMessageForwardsAttachments(t *testing.T) {
 	var seenAttachments []Attachment
 	reg := NewRegistry()
-	RegisterSend(reg, func(_ context.Context, _ string, _ string, atts []Attachment) (string, int64, error) {
+	RegisterSend(reg, func(_ context.Context, _ string, _ string, atts []Attachment) ([]string, int64, error) {
 		seenAttachments = atts
-		return "MSG-2", 1700000001000, nil
+		return []string{"MSG-2"}, 1700000001000, nil
 	})
 	params := json.RawMessage(`{
 		"jid": "15553334444@s.whatsapp.net",
@@ -130,9 +212,9 @@ func TestSendMessageForwardsAttachments(t *testing.T) {
 func TestSendMessageAcceptsAttachmentsWithoutText(t *testing.T) {
 	called := false
 	reg := NewRegistry()
-	RegisterSend(reg, func(context.Context, string, string, []Attachment) (string, int64, error) {
+	RegisterSend(reg, func(context.Context, string, string, []Attachment) ([]string, int64, error) {
 		called = true
-		return "MSG-3", 1700000002000, nil
+		return []string{"MSG-3"}, 1700000002000, nil
 	})
 	params := json.RawMessage(`{
 		"jid": "x@s.whatsapp.net",

--- a/connectors/whatsapp/daemon/internal/wameow/client.go
+++ b/connectors/whatsapp/daemon/internal/wameow/client.go
@@ -161,6 +161,13 @@ func (c *Client) drainUnread(chatJID string) []unreadKey {
 // and can diagnose; the model retries with the user's help if
 // needed.
 //
+// ``sentAtMs`` is the server-acknowledged send timestamp (from
+// ``SendResponse.Timestamp``), used by the Edit window guard at
+// :func:`Client.Edit` to refuse out-of-window edit attempts before
+// the protocol-level rejection.  ``text`` is the message body the
+// peer received, used to build the QuotedMessage stub when the model
+// later issues a reply with ``quoted_message_id``.
+//
 // Takes the `wa` that performed the send rather than re-loading
 // c.wa.  A concurrent unpair could otherwise swap c.wa between
 // sendOne returning and recordOutbound reading Store.ID, stamping
@@ -171,6 +178,8 @@ func (c *Client) recordOutbound(
 	wa *whatsmeow.Client,
 	msgID string,
 	chatJID types.JID,
+	sentAtMs int64,
+	text string,
 ) {
 	ourID := wa.Store.ID
 	if ourID == nil {
@@ -179,7 +188,7 @@ func (c *Client) recordOutbound(
 		// record rather than panic.
 		return
 	}
-	if err := c.msgs.Put(ctx, msgID, chatJID.String(), ourID.String(), true); err != nil {
+	if err := c.msgs.Put(ctx, msgID, chatJID.String(), ourID.String(), true, sentAtMs, text); err != nil {
 		c.log.Warn("wameow.msgstore_put_failed", "id", msgID, "err", err)
 	}
 }

--- a/connectors/whatsapp/daemon/internal/wameow/client.go
+++ b/connectors/whatsapp/daemon/internal/wameow/client.go
@@ -37,6 +37,7 @@ import (
 type Client struct {
 	wa     atomic.Pointer[whatsmeow.Client]
 	store  *sqlstore.Container
+	msgs   *MessageStore
 	notify Notifier
 	log    *slog.Logger
 	pair   pairing
@@ -62,8 +63,13 @@ func NewClient(
 		_ = container.Close()
 		return nil, fmt.Errorf("get first device: %w", err)
 	}
+	msgs, err := openMessageStore(storeDir)
+	if err != nil {
+		_ = container.Close()
+		return nil, err
+	}
 	wa := whatsmeow.NewClient(device, newWaLogger(log, "client"))
-	c := &Client{store: container, notify: notify, log: log}
+	c := &Client{store: container, msgs: msgs, notify: notify, log: log}
 	c.wa.Store(wa)
 	wa.AddEventHandler(c.handleEvent)
 	return c, nil
@@ -102,12 +108,35 @@ func (c *Client) SendMessage(ctx context.Context, jidStr, text string) (string, 
 	if err != nil {
 		return "", 0, err
 	}
+	c.recordOutbound(ctx, string(resp.ID), jid)
 	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
+}
+
+// recordOutbound stamps an outbound message into the message store so
+// the model can later react to / edit / revoke its own sends by id.
+// Best-effort: a store failure here is logged but doesn't fail the
+// send (the send already went through; failing the RPC would mislead
+// the caller).
+func (c *Client) recordOutbound(ctx context.Context, msgID string, chatJID types.JID) {
+	ourID := c.wa.Load().Store.ID
+	if ourID == nil {
+		// Edge case: outbound succeeded but our identity flipped to
+		// nil between SendMessage and here (e.g., concurrent unpair).
+		// Skip the record; the message_id is still returned to the
+		// caller for visibility.
+		return
+	}
+	if err := c.msgs.Put(ctx, msgID, chatJID.String(), ourID.String(), true); err != nil {
+		c.log.Warn("wameow.msgstore_put_failed", "id", msgID, "err", err)
+	}
 }
 
 // Close disconnects from WhatsApp and closes the sqlstore.
 func (c *Client) Close() {
 	c.wa.Load().Disconnect()
+	if err := c.msgs.Close(); err != nil {
+		c.log.Warn("wameow.msgstore_close_error", "err", err)
+	}
 	if err := c.store.Close(); err != nil {
 		c.log.Warn("wameow.store_close_error", "err", err)
 	}

--- a/connectors/whatsapp/daemon/internal/wameow/client.go
+++ b/connectors/whatsapp/daemon/internal/wameow/client.go
@@ -7,17 +7,14 @@ package wameow
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
 	"sync/atomic"
 
 	"go.mau.fi/whatsmeow"
-	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/store/sqlstore"
 	"go.mau.fi/whatsmeow/types"
-	"google.golang.org/protobuf/proto"
 
 	// modernc.org/sqlite is a pure-Go SQLite driver so the daemon
 	// compiles without CGo.  Registered under the driver name "sqlite".
@@ -91,25 +88,6 @@ func (c *Client) Connect(ctx context.Context) error {
 		return fmt.Errorf("whatsmeow connect: %w", err)
 	}
 	return nil
-}
-
-// SendMessage matches handler.SendMessageFn.
-func (c *Client) SendMessage(ctx context.Context, jidStr, text string) (string, int64, error) {
-	wa := c.wa.Load()
-	if !wa.IsConnected() {
-		return "", 0, errors.New("whatsmeow: not connected")
-	}
-	jid, err := types.ParseJID(jidStr)
-	if err != nil {
-		return "", 0, fmt.Errorf("invalid JID %q: %w", jidStr, err)
-	}
-	msg := &waE2E.Message{Conversation: proto.String(text)}
-	resp, err := wa.SendMessage(ctx, jid, msg)
-	if err != nil {
-		return "", 0, err
-	}
-	c.recordOutbound(ctx, string(resp.ID), jid)
-	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
 }
 
 // recordOutbound stamps an outbound message into the message store so

--- a/connectors/whatsapp/daemon/internal/wameow/client.go
+++ b/connectors/whatsapp/daemon/internal/wameow/client.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 
 	"go.mau.fi/whatsmeow"
@@ -45,6 +46,19 @@ type Client struct {
 	// inbound msgstore writes, so they cancel on daemon shutdown
 	// instead of running against a torn-down store.
 	lifetimeCtx context.Context
+	// unread tracks per-chat inbound message ids the peer is waiting
+	// on a read receipt for.  Populated in recordInbound; drained
+	// in sendOne after a successful send so the bot's reply
+	// implicitly marks the prior context as read (Signal-shape
+	// receipts-after-emit).  Each entry stores (msg_id, sender_jid)
+	// since whatsmeow's MarkRead needs both.
+	unreadMu sync.Mutex
+	unread   map[string][]unreadKey
+}
+
+type unreadKey struct {
+	id     string
+	sender string
 }
 
 // NewClient opens the sqlstore at <storeDir>/store.db, picks the first
@@ -80,6 +94,7 @@ func NewClient(
 		notify:      notify,
 		log:         log,
 		lifetimeCtx: ctx,
+		unread:      make(map[string][]unreadKey),
 	}
 	c.wa.Store(wa)
 	wa.AddEventHandler(c.handleEvent)
@@ -102,6 +117,38 @@ func (c *Client) Connect(ctx context.Context) error {
 		return fmt.Errorf("whatsmeow connect: %w", err)
 	}
 	return nil
+}
+
+// markInboundUnread appends a peer-sent message to the per-chat
+// unread queue so the next bot reply to that chat drains it via
+// MarkRead.  Called from recordInbound for any *events.Message with
+// is_self=false on a user-visible chat.  Lazy-inits the map for
+// callers that construct Client directly (tests).
+func (c *Client) markInboundUnread(chatJID, msgID, senderJID string) {
+	c.unreadMu.Lock()
+	defer c.unreadMu.Unlock()
+	if c.unread == nil {
+		c.unread = make(map[string][]unreadKey)
+	}
+	c.unread[chatJID] = append(c.unread[chatJID], unreadKey{id: msgID, sender: senderJID})
+}
+
+// drainUnread atomically pulls + clears the per-chat unread queue.
+// Returns nil when the chat has no pending receipts.  Caller is
+// responsible for the actual MarkRead RPC; drainUnread just hands
+// over ownership of the slice.
+func (c *Client) drainUnread(chatJID string) []unreadKey {
+	c.unreadMu.Lock()
+	defer c.unreadMu.Unlock()
+	if c.unread == nil {
+		return nil
+	}
+	keys, ok := c.unread[chatJID]
+	if !ok {
+		return nil
+	}
+	delete(c.unread, chatJID)
+	return keys
 }
 
 // recordOutbound stamps an outbound message into the message store

--- a/connectors/whatsapp/daemon/internal/wameow/client.go
+++ b/connectors/whatsapp/daemon/internal/wameow/client.go
@@ -39,6 +39,12 @@ type Client struct {
 	notify   Notifier
 	log      *slog.Logger
 	pair     pairing
+	// lifetimeCtx is the daemon-lifetime context (set by NewClient
+	// from main's signal-notify ctx).  Used as the background
+	// context for in-event-handler ops like media download and
+	// inbound msgstore writes, so they cancel on daemon shutdown
+	// instead of running against a torn-down store.
+	lifetimeCtx context.Context
 }
 
 // NewClient opens the sqlstore at <storeDir>/store.db, picks the first
@@ -68,11 +74,12 @@ func NewClient(
 	}
 	wa := whatsmeow.NewClient(device, newWaLogger(log, "client"))
 	c := &Client{
-		store:    container,
-		msgs:     msgs,
-		mediaDir: filepath.Join(storeDir, "media"),
-		notify:   notify,
-		log:      log,
+		store:       container,
+		msgs:        msgs,
+		mediaDir:    filepath.Join(storeDir, "media"),
+		notify:      notify,
+		log:         log,
+		lifetimeCtx: ctx,
 	}
 	c.wa.Store(wa)
 	wa.AddEventHandler(c.handleEvent)
@@ -97,18 +104,32 @@ func (c *Client) Connect(ctx context.Context) error {
 	return nil
 }
 
-// recordOutbound stamps an outbound message into the message store so
-// the model can later react to / edit / revoke its own sends by id.
-// Best-effort: a store failure here is logged but doesn't fail the
-// send (the send already went through; failing the RPC would mislead
-// the caller).
-func (c *Client) recordOutbound(ctx context.Context, msgID string, chatJID types.JID) {
-	ourID := c.wa.Load().Store.ID
+// recordOutbound stamps an outbound message into the message store
+// so the model can later react to / edit / revoke its own sends by
+// id.  Best-effort: a store failure here is logged but doesn't fail
+// the send (the send already went through on the wire; failing the
+// RPC would push the model toward a retry that produces a duplicate
+// peer-visible message).  A later react/edit/delete on this id
+// returns ErrMessageNotFound — operators see the put_failed warning
+// and can diagnose; the model retries with the user's help if
+// needed.
+//
+// Takes the `wa` that performed the send rather than re-loading
+// c.wa.  A concurrent unpair could otherwise swap c.wa between
+// sendOne returning and recordOutbound reading Store.ID, stamping
+// the row with the NEW identity instead of the one that actually
+// sent — breaking subsequent edit/revoke routing.
+func (c *Client) recordOutbound(
+	ctx context.Context,
+	wa *whatsmeow.Client,
+	msgID string,
+	chatJID types.JID,
+) {
+	ourID := wa.Store.ID
 	if ourID == nil {
-		// Edge case: outbound succeeded but our identity flipped to
-		// nil between SendMessage and here (e.g., concurrent unpair).
-		// Skip the record; the message_id is still returned to the
-		// caller for visibility.
+		// Shouldn't happen: wa is the client that just successfully
+		// sent, so its Store.ID was populated.  Defensive: skip the
+		// record rather than panic.
 		return
 	}
 	if err := c.msgs.Put(ctx, msgID, chatJID.String(), ourID.String(), true); err != nil {

--- a/connectors/whatsapp/daemon/internal/wameow/client.go
+++ b/connectors/whatsapp/daemon/internal/wameow/client.go
@@ -32,12 +32,13 @@ import (
 // deleted device") — the swap is what lets a re-pair work in the same
 // daemon process.
 type Client struct {
-	wa     atomic.Pointer[whatsmeow.Client]
-	store  *sqlstore.Container
-	msgs   *MessageStore
-	notify Notifier
-	log    *slog.Logger
-	pair   pairing
+	wa       atomic.Pointer[whatsmeow.Client]
+	store    *sqlstore.Container
+	msgs     *MessageStore
+	mediaDir string
+	notify   Notifier
+	log      *slog.Logger
+	pair     pairing
 }
 
 // NewClient opens the sqlstore at <storeDir>/store.db, picks the first
@@ -66,7 +67,13 @@ func NewClient(
 		return nil, err
 	}
 	wa := whatsmeow.NewClient(device, newWaLogger(log, "client"))
-	c := &Client{store: container, msgs: msgs, notify: notify, log: log}
+	c := &Client{
+		store:    container,
+		msgs:     msgs,
+		mediaDir: filepath.Join(storeDir, "media"),
+		notify:   notify,
+		log:      log,
+	}
 	c.wa.Store(wa)
 	wa.AddEventHandler(c.handleEvent)
 	return c, nil

--- a/connectors/whatsapp/daemon/internal/wameow/groups.go
+++ b/connectors/whatsapp/daemon/internal/wameow/groups.go
@@ -20,12 +20,19 @@ type GroupSummary struct {
 }
 
 // GroupParticipantInfo carries the model-relevant fields of a
-// whatsmeow participant: who they are and whether they're an admin.
+// whatsmeow participant: who they are, whether they're an admin,
+// and (on CreateGroup) whether the server failed to add them.
 // Other details (LID vs phone JIDs, anonymous display names) stay
 // inside whatsmeow's types.
+//
+// ``AddError`` is non-zero only on CreateGroup responses for
+// participants the server rejected (blocked-by-user, unreachable,
+// etc.).  Without surfacing this, a partial-success CreateGroup
+// looks indistinguishable from a full-success to the model.
 type GroupParticipantInfo struct {
-	JID     string `json:"jid"`
-	IsAdmin bool   `json:"is_admin"`
+	JID      string `json:"jid"`
+	IsAdmin  bool   `json:"is_admin"`
+	AddError int    `json:"add_error,omitempty"`
 }
 
 // ListGroups returns every group the bot is currently a member of.
@@ -100,8 +107,9 @@ func summarizeGroup(g *types.GroupInfo) GroupSummary {
 	parts := make([]GroupParticipantInfo, 0, len(g.Participants))
 	for _, p := range g.Participants {
 		parts = append(parts, GroupParticipantInfo{
-			JID:     p.JID.String(),
-			IsAdmin: p.IsAdmin || p.IsSuperAdmin,
+			JID:      p.JID.String(),
+			IsAdmin:  p.IsAdmin || p.IsSuperAdmin,
+			AddError: p.Error,
 		})
 	}
 	return GroupSummary{

--- a/connectors/whatsapp/daemon/internal/wameow/groups.go
+++ b/connectors/whatsapp/daemon/internal/wameow/groups.go
@@ -1,0 +1,113 @@
+package wameow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+// GroupSummary is the daemon-internal flattening of whatsmeow's
+// rich ``types.GroupInfo`` to a wire-friendly shape Python's tools
+// can surface to the model.
+type GroupSummary struct {
+	JID          string                 `json:"jid"`
+	Name         string                 `json:"name"`
+	Topic        string                 `json:"topic,omitempty"`
+	Participants []GroupParticipantInfo `json:"participants"`
+}
+
+// GroupParticipantInfo carries the model-relevant fields of a
+// whatsmeow participant: who they are and whether they're an admin.
+// Other details (LID vs phone JIDs, anonymous display names) stay
+// inside whatsmeow's types.
+type GroupParticipantInfo struct {
+	JID     string `json:"jid"`
+	IsAdmin bool   `json:"is_admin"`
+}
+
+// ListGroups returns every group the bot is currently a member of.
+// Empty slice when not in any groups.
+func (c *Client) ListGroups(ctx context.Context) ([]GroupSummary, error) {
+	wa := c.wa.Load()
+	if !wa.IsConnected() {
+		return nil, errors.New("whatsmeow: not connected")
+	}
+	groups, err := wa.GetJoinedGroups(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get joined groups: %w", err)
+	}
+	out := make([]GroupSummary, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, summarizeGroup(g))
+	}
+	return out, nil
+}
+
+// CreateGroup creates a new group with the given name and
+// participants (full WhatsApp JIDs).  The bot is added implicitly
+// by WhatsApp's server.  Returns the resulting group's summary.
+func (c *Client) CreateGroup(ctx context.Context, name string, participantJIDs []string) (*GroupSummary, error) {
+	wa := c.wa.Load()
+	if !wa.IsConnected() {
+		return nil, errors.New("whatsmeow: not connected")
+	}
+	if name == "" {
+		return nil, errors.New("create_group: name required")
+	}
+	parts := make([]types.JID, 0, len(participantJIDs))
+	for _, s := range participantJIDs {
+		jid, err := types.ParseJID(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid participant jid %q: %w", s, err)
+		}
+		parts = append(parts, jid)
+	}
+	info, err := wa.CreateGroup(ctx, whatsmeow.ReqCreateGroup{
+		Name:         name,
+		Participants: parts,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create group: %w", err)
+	}
+	summary := summarizeGroup(info)
+	return &summary, nil
+}
+
+// RenameGroup changes a group's display name.  The bot must be an
+// admin; whatsmeow surfaces the server's rejection if not.
+func (c *Client) RenameGroup(ctx context.Context, groupJIDStr, newName string) error {
+	wa := c.wa.Load()
+	if !wa.IsConnected() {
+		return errors.New("whatsmeow: not connected")
+	}
+	if newName == "" {
+		return errors.New("rename_group: name required")
+	}
+	jid, err := types.ParseJID(groupJIDStr)
+	if err != nil {
+		return fmt.Errorf("invalid group jid %q: %w", groupJIDStr, err)
+	}
+	if err := wa.SetGroupName(ctx, jid, newName); err != nil {
+		return fmt.Errorf("set group name: %w", err)
+	}
+	return nil
+}
+
+func summarizeGroup(g *types.GroupInfo) GroupSummary {
+	parts := make([]GroupParticipantInfo, 0, len(g.Participants))
+	for _, p := range g.Participants {
+		parts = append(parts, GroupParticipantInfo{
+			JID:     p.JID.String(),
+			IsAdmin: p.IsAdmin || p.IsSuperAdmin,
+		})
+	}
+	return GroupSummary{
+		JID:          g.JID.String(),
+		Name:         g.Name,
+		Topic:        g.Topic,
+		Participants: parts,
+	}
+}

--- a/connectors/whatsapp/daemon/internal/wameow/inbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound.go
@@ -20,6 +20,13 @@ func (c *Client) handleEvent(evt any) {
 		if params := c.translateMessageWithMedia(e); params != nil {
 			c.notify.Broadcast("message", params)
 		}
+	case *events.UndecryptableMessage:
+		// Peer sent us a message we couldn't decrypt — usually a stale
+		// Signal session from before a re-pair, or a key-rotation
+		// race.  whatsmeow has already requested a retry on its end.
+		// Surface this loudly so operators see the failure mode
+		// rather than wondering why a known-good chat went silent.
+		c.log.Warn("wameow.undecryptable_message", "from_jid", e.Info.Sender.String(), "id", string(e.Info.ID))
 	case *events.Connected:
 		c.notify.Broadcast("connectionState", map[string]any{"state": "connected"})
 	case *events.Disconnected:
@@ -34,6 +41,12 @@ func (c *Client) handleEvent(evt any) {
 			params["reason"] = e.Reason.String()
 		}
 		c.notify.Broadcast("loggedOut", params)
+		// whatsmeow's LoggedOut handler internally marks the device as
+		// Deleted (same path as our operator-initiated Unpair).  Swap
+		// in a fresh Client so a subsequent StartPairing on this same
+		// daemon process works without a restart — symmetric with the
+		// Unpair side at pair.go:155.
+		c.replaceWhatsmeowClient()
 	}
 }
 
@@ -66,23 +79,47 @@ func translateMessage(e *events.Message) map[string]any {
 // addresses by @-tag.  Pulled from whatever submessage carries a
 // ContextInfo (text, image caption, video caption, etc.).
 func extractMentions(m *waE2E.Message) []string {
-	var ctx *waE2E.ContextInfo
-	switch {
-	case m.ExtendedTextMessage != nil:
-		ctx = m.ExtendedTextMessage.GetContextInfo()
-	case m.ImageMessage != nil:
-		ctx = m.ImageMessage.GetContextInfo()
-	case m.VideoMessage != nil:
-		ctx = m.VideoMessage.GetContextInfo()
-	case m.DocumentMessage != nil:
-		ctx = m.DocumentMessage.GetContextInfo()
-	case m.AudioMessage != nil:
-		ctx = m.AudioMessage.GetContextInfo()
-	}
+	ctx := messageContextInfo(m)
 	if ctx == nil {
 		return nil
 	}
 	return ctx.GetMentionedJID()
+}
+
+// extractQuotedMessageID returns the StanzaID of the message the peer is
+// quoting/replying to, or "" when this isn't a reply.  Source is the same
+// ContextInfo as :func:`extractMentions`: WhatsApp threads the quoted-
+// message id on the new envelope so peers can render the "↪ Replying to"
+// bubble without re-sending the original content.
+func extractQuotedMessageID(m *waE2E.Message) string {
+	ctx := messageContextInfo(m)
+	if ctx == nil {
+		return ""
+	}
+	return ctx.GetStanzaID()
+}
+
+// messageContextInfo walks the submessage variants that can carry a
+// ContextInfo (text, captioned media, audio) and returns the populated
+// one, or nil when the envelope has none.  Centralises the per-variant
+// switch shared by extractMentions and extractQuotedMessageID.
+func messageContextInfo(m *waE2E.Message) *waE2E.ContextInfo {
+	if m == nil {
+		return nil
+	}
+	switch {
+	case m.ExtendedTextMessage != nil:
+		return m.ExtendedTextMessage.GetContextInfo()
+	case m.ImageMessage != nil:
+		return m.ImageMessage.GetContextInfo()
+	case m.VideoMessage != nil:
+		return m.VideoMessage.GetContextInfo()
+	case m.DocumentMessage != nil:
+		return m.DocumentMessage.GetContextInfo()
+	case m.AudioMessage != nil:
+		return m.AudioMessage.GetContextInfo()
+	}
+	return nil
 }
 
 // translateMessageWithMedia layers extracted attachments, sticker
@@ -104,60 +141,114 @@ func (c *Client) translateMessageWithMedia(e *events.Message) map[string]any {
 	} else if attachment != nil {
 		params["attachments"] = []*MediaAttachment{attachment}
 	}
-	if emoji := extractStickerEmoji(e.Message); emoji != "" {
-		params["sticker_emoji"] = emoji
+	// Stickers: always emit when StickerMessage is present, even when
+	// the emoji label is empty.  Custom stickers (made via WhatsApp's
+	// sticker maker) frequently carry no emoji tag — without an explicit
+	// signal here the parse.py "no signal" drop would silently swallow
+	// the message and the model would never know the peer sent a sticker.
+	if e.Message != nil && e.Message.StickerMessage != nil {
+		params["sticker_emoji"] = extractStickerEmoji(e.Message)
 	}
 	if rxn := extractReaction(e.Message); rxn != nil {
 		params["reaction"] = rxn
 	}
-	if info := extractProtocolInfo(e.Message); info != nil {
-		switch {
-		case info.edited:
-			params["edit"] = map[string]any{"target_message_id": info.targetID}
-			// Edits ship a fresh body in ProtocolMessage.EditedMessage;
-			// the outer Conversation/ExtendedTextMessage are empty, so
-			// override the base text with the inner content.
-			if info.newText != "" {
-				params["text"] = info.newText
-			}
-		case info.revoked:
-			params["revoke"] = map[string]any{"target_message_id": info.targetID}
+	if edit := c.extractEditInfo(e); edit != nil {
+		params["edit"] = map[string]any{"target_message_id": edit.targetID}
+		// Edits ship a fresh body either in
+		// ProtocolMessage.EditedMessage (legacy) or in the decrypted
+		// SecretEncryptedMessage payload (newer encrypted edits) —
+		// either way the outer Conversation/ExtendedTextMessage is
+		// empty, so override the base text with the inner content.
+		if edit.newText != "" {
+			params["text"] = edit.newText
 		}
+	} else if target := extractRevokeTargetID(e.Message); target != "" {
+		params["revoke"] = map[string]any{"target_message_id": target}
+	}
+	if quoted := extractQuotedMessageID(e.Message); quoted != "" {
+		params["quoted_message_id"] = quoted
 	}
 	return params
 }
 
-// extractProtocolInfo decodes the ProtocolMessage that whatsmeow uses
-// for in-band edits and revokes.  Returns nil when this isn't a
-// protocol message (the common case), or for ProtocolMessage types
-// the daemon doesn't surface yet (history sync, app-state sync, etc).
-type protocolInfo struct {
-	edited   bool
-	revoked  bool
+// editInfo carries the target message id + new body text of a peer's
+// edit, regardless of which on-the-wire envelope shape the edit used.
+type editInfo struct {
 	targetID string
-	newText  string // populated for edits only
+	newText  string // may be empty if the edit's encrypted payload couldn't be decoded
 }
 
-func extractProtocolInfo(m *waE2E.Message) *protocolInfo {
-	if m == nil || m.ProtocolMessage == nil {
+// extractEditInfo decodes a peer's edit envelope.  WhatsApp delivers
+// edits over TWO distinct wire shapes:
+//
+//   - LEGACY: ProtocolMessage{Type: MESSAGE_EDIT, EditedMessage: …}
+//     with the new body in plaintext inside the protobuf.
+//
+//   - CURRENT: SecretEncryptedMessage{SecretEncType: MESSAGE_EDIT,
+//     TargetMessageKey: …, EncPayload: …} — the new body is encrypted
+//     and must be decrypted via :func:`whatsmeow.Client.DecryptSecretEncryptedMessage`
+//     against the recipient-derived msg-secret key.
+//
+// Returns nil when the envelope is neither shape.  When the
+// SecretEncryptedMessage decrypt fails (key rotation race, stale
+// session, etc.), the returned editInfo still carries the targetID so
+// the model knows an edit happened on a known message even if it can't
+// see the new content.
+func (c *Client) extractEditInfo(evt *events.Message) *editInfo {
+	if evt == nil || evt.Message == nil {
 		return nil
 	}
-	pm := m.ProtocolMessage
-	targetID := ""
-	if key := pm.GetKey(); key != nil {
-		targetID = key.GetID()
-	}
-	switch pm.GetType() {
-	case waE2E.ProtocolMessage_MESSAGE_EDIT:
-		info := &protocolInfo{edited: true, targetID: targetID}
-		if edited := pm.GetEditedMessage(); edited != nil {
-			info.newText = extractText(edited)
+	msg := evt.Message
+	// Legacy: ProtocolMessage envelope.
+	if pm := msg.GetProtocolMessage(); pm != nil && pm.GetType() == waE2E.ProtocolMessage_MESSAGE_EDIT {
+		out := &editInfo{}
+		if key := pm.GetKey(); key != nil {
+			out.targetID = key.GetID()
 		}
-		return info
-	case waE2E.ProtocolMessage_REVOKE:
-		return &protocolInfo{revoked: true, targetID: targetID}
+		if edited := pm.GetEditedMessage(); edited != nil {
+			out.newText = extractText(edited)
+		}
+		return out
+	}
+	// Current: SecretEncryptedMessage envelope.
+	if enc := msg.GetSecretEncryptedMessage(); enc != nil && enc.GetSecretEncType() == waE2E.SecretEncryptedMessage_MESSAGE_EDIT {
+		out := &editInfo{}
+		if key := enc.GetTargetMessageKey(); key != nil {
+			out.targetID = key.GetID()
+		}
+		decrypted, err := c.wa.Load().DecryptSecretEncryptedMessage(c.lifetimeCtx, evt)
+		if err != nil {
+			c.log.Warn(
+				"wameow.decrypt_secret_edit_failed",
+				"id", string(evt.Info.ID),
+				"target_id", out.targetID,
+				"err", err,
+			)
+			return out
+		}
+		out.newText = extractText(decrypted)
+		return out
 	}
 	return nil
+}
+
+// extractRevokeTargetID returns the id of the message the peer is
+// revoking ("Delete for everyone"), or "" when this envelope isn't a
+// revoke.  Revokes are always delivered via the legacy ProtocolMessage
+// envelope (whatsmeow's SecretEncryptedMessage path doesn't carry a
+// MESSAGE_REVOKE secret-enc-type as of v0.0.0-20260516…).
+func extractRevokeTargetID(m *waE2E.Message) string {
+	if m == nil || m.ProtocolMessage == nil {
+		return ""
+	}
+	pm := m.ProtocolMessage
+	if pm.GetType() != waE2E.ProtocolMessage_REVOKE {
+		return ""
+	}
+	if key := pm.GetKey(); key != nil {
+		return key.GetID()
+	}
+	return ""
 }
 
 // extractReaction surfaces a peer's reaction to a message as a
@@ -200,6 +291,8 @@ func (c *Client) recordInbound(e *events.Message) {
 		e.Info.Chat.String(),
 		e.Info.Sender.String(),
 		e.Info.IsFromMe,
+		e.Info.Timestamp.UnixMilli(),
+		extractText(e.Message),
 	)
 	if err != nil {
 		c.log.Warn("wameow.msgstore_put_failed", "id", e.Info.ID, "err", err)

--- a/connectors/whatsapp/daemon/internal/wameow/inbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound.go
@@ -85,7 +85,54 @@ func (c *Client) translateMessageWithMedia(e *events.Message) map[string]any {
 	if rxn := extractReaction(e.Message); rxn != nil {
 		params["reaction"] = rxn
 	}
+	if info := extractProtocolInfo(e.Message); info != nil {
+		switch {
+		case info.edited:
+			params["edit"] = map[string]any{"target_message_id": info.targetID}
+			// Edits ship a fresh body in ProtocolMessage.EditedMessage;
+			// the outer Conversation/ExtendedTextMessage are empty, so
+			// override the base text with the inner content.
+			if info.newText != "" {
+				params["text"] = info.newText
+			}
+		case info.revoked:
+			params["revoke"] = map[string]any{"target_message_id": info.targetID}
+		}
+	}
 	return params
+}
+
+// extractProtocolInfo decodes the ProtocolMessage that whatsmeow uses
+// for in-band edits and revokes.  Returns nil when this isn't a
+// protocol message (the common case), or for ProtocolMessage types
+// the daemon doesn't surface yet (history sync, app-state sync, etc).
+type protocolInfo struct {
+	edited   bool
+	revoked  bool
+	targetID string
+	newText  string // populated for edits only
+}
+
+func extractProtocolInfo(m *waE2E.Message) *protocolInfo {
+	if m == nil || m.ProtocolMessage == nil {
+		return nil
+	}
+	pm := m.ProtocolMessage
+	targetID := ""
+	if key := pm.GetKey(); key != nil {
+		targetID = key.GetID()
+	}
+	switch pm.GetType() {
+	case waE2E.ProtocolMessage_MESSAGE_EDIT:
+		info := &protocolInfo{edited: true, targetID: targetID}
+		if edited := pm.GetEditedMessage(); edited != nil {
+			info.newText = extractText(edited)
+		}
+		return info
+	case waE2E.ProtocolMessage_REVOKE:
+		return &protocolInfo{revoked: true, targetID: targetID}
+	}
+	return nil
 }
 
 // extractReaction surfaces a peer's reaction to a message as a

--- a/connectors/whatsapp/daemon/internal/wameow/inbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound.go
@@ -204,6 +204,16 @@ func (c *Client) recordInbound(e *events.Message) {
 	if err != nil {
 		c.log.Warn("wameow.msgstore_put_failed", "id", e.Info.ID, "err", err)
 	}
+	// Track unread peer messages so the next outbound to this chat
+	// implicitly marks them read.  is_self echoes of our own sends
+	// are not "unread" by us — skip.
+	if !e.Info.IsFromMe {
+		c.markInboundUnread(
+			e.Info.Chat.String(),
+			string(e.Info.ID),
+			e.Info.Sender.String(),
+		)
+	}
 }
 
 // isUserVisibleChat reports whether the chat type can carry messages

--- a/connectors/whatsapp/daemon/internal/wameow/inbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound.go
@@ -206,14 +206,35 @@ func (c *Client) recordInbound(e *events.Message) {
 	}
 	// Track unread peer messages so the next outbound to this chat
 	// implicitly marks them read.  is_self echoes of our own sends
-	// are not "unread" by us — skip.
-	if !e.Info.IsFromMe {
+	// are not "unread" by us — skip.  Reaction envelopes are
+	// acknowledgements, not unread messages: MarkRead'ing a
+	// reaction id is the wrong semantic (whatsmeow surfaces the
+	// rejection as a noisy mark_read_failed warning), so skip
+	// those too.
+	if !e.Info.IsFromMe && !isReactionOnly(e.Message) {
 		c.markInboundUnread(
 			e.Info.Chat.String(),
 			string(e.Info.ID),
 			e.Info.Sender.String(),
 		)
 	}
+}
+
+// isReactionOnly reports whether the message is exclusively a
+// peer-sent reaction (ReactionMessage set, no user-facing text or
+// media).  Reactions ride through recordInbound for msgstore
+// tracking but must NOT enter the read-receipt queue.
+func isReactionOnly(m *waE2E.Message) bool {
+	if m == nil || m.ReactionMessage == nil {
+		return false
+	}
+	return m.Conversation == nil &&
+		m.ExtendedTextMessage == nil &&
+		m.ImageMessage == nil &&
+		m.VideoMessage == nil &&
+		m.AudioMessage == nil &&
+		m.DocumentMessage == nil &&
+		m.StickerMessage == nil
 }
 
 // isUserVisibleChat reports whether the chat type can carry messages

--- a/connectors/whatsapp/daemon/internal/wameow/inbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound.go
@@ -201,10 +201,15 @@ func (c *Client) extractEditInfo(evt *events.Message) *editInfo {
 	msg := evt.Message
 	// Legacy: ProtocolMessage envelope.
 	if pm := msg.GetProtocolMessage(); pm != nil && pm.GetType() == waE2E.ProtocolMessage_MESSAGE_EDIT {
-		out := &editInfo{}
-		if key := pm.GetKey(); key != nil {
-			out.targetID = key.GetID()
+		// Same rationale as the SecretEncryptedMessage branch below:
+		// an edit envelope without a target id is meaningless to the
+		// model, so drop it rather than emit an orphan signal.
+		key := pm.GetKey()
+		if key == nil || key.GetID() == "" {
+			c.log.Warn("wameow.legacy_edit_missing_target", "id", string(evt.Info.ID))
+			return nil
 		}
+		out := &editInfo{targetID: key.GetID()}
 		if edited := pm.GetEditedMessage(); edited != nil {
 			out.newText = extractText(edited)
 		}
@@ -212,10 +217,17 @@ func (c *Client) extractEditInfo(evt *events.Message) *editInfo {
 	}
 	// Current: SecretEncryptedMessage envelope.
 	if enc := msg.GetSecretEncryptedMessage(); enc != nil && enc.GetSecretEncType() == waE2E.SecretEncryptedMessage_MESSAGE_EDIT {
-		out := &editInfo{}
-		if key := enc.GetTargetMessageKey(); key != nil {
-			out.targetID = key.GetID()
+		// A malformed envelope without TargetMessageKey would leave us
+		// emitting an edit signal with no target the model can match
+		// against any prior message_id — return nil so the inbound
+		// flows the no-signal drop path instead of confusing the
+		// model with an orphan edit.
+		key := enc.GetTargetMessageKey()
+		if key == nil || key.GetID() == "" {
+			c.log.Warn("wameow.secret_edit_missing_target", "id", string(evt.Info.ID))
+			return nil
 		}
+		out := &editInfo{targetID: key.GetID()}
 		decrypted, err := c.wa.Load().DecryptSecretEncryptedMessage(c.lifetimeCtx, evt)
 		if err != nil {
 			c.log.Warn(

--- a/connectors/whatsapp/daemon/internal/wameow/inbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound.go
@@ -1,6 +1,8 @@
 package wameow
 
 import (
+	"context"
+
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
@@ -14,6 +16,9 @@ type Notifier interface {
 func (c *Client) handleEvent(evt any) {
 	switch e := evt.(type) {
 	case *events.Message:
+		if e.Message != nil {
+			c.recordInbound(e)
+		}
 		if params := translateMessage(e); params != nil {
 			c.notify.Broadcast("message", params)
 		}
@@ -52,6 +57,25 @@ func translateMessage(e *events.Message) map[string]any {
 		"chat_type":      chatTypeFromJID(e.Info.Chat),
 		"is_self":        e.Info.IsFromMe,
 		"text":           extractText(e.Message),
+	}
+}
+
+// recordInbound stamps a received message into the message store so
+// the model can later react to / edit / revoke it by id.  Best-effort:
+// a store failure is logged but doesn't block the broadcast.
+//
+// Use a background context — handleEvent doesn't get one from whatsmeow,
+// and the put is tiny.
+func (c *Client) recordInbound(e *events.Message) {
+	err := c.msgs.Put(
+		context.Background(),
+		string(e.Info.ID),
+		e.Info.Chat.String(),
+		e.Info.Sender.String(),
+		e.Info.IsFromMe,
+	)
+	if err != nil {
+		c.log.Warn("wameow.msgstore_put_failed", "id", e.Info.ID, "err", err)
 	}
 }
 

--- a/connectors/whatsapp/daemon/internal/wameow/inbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound.go
@@ -60,13 +60,13 @@ func translateMessage(e *events.Message) map[string]any {
 	}
 }
 
-// translateMessageWithMedia layers extracted attachments + sticker
-// emoji on top of the base translation.  Media download is done
-// inline (in whatsmeow's event-handler goroutine) — the broadcast
-// of THIS message waits for the download, but other events on the
-// same connection continue in parallel since whatsmeow's dispatcher
-// fans out per-event.  A download failure logs but doesn't drop the
-// message: the text/caption alone is still useful.
+// translateMessageWithMedia layers extracted attachments, sticker
+// emoji, and reaction metadata on top of the base translation.  Media
+// download is done inline (in whatsmeow's event-handler goroutine) —
+// the broadcast of THIS message waits for the download, but other
+// events on the same connection continue in parallel since whatsmeow's
+// dispatcher fans out per-event.  A download failure logs but doesn't
+// drop the message: the text/caption alone is still useful.
 func (c *Client) translateMessageWithMedia(e *events.Message) map[string]any {
 	params := translateMessage(e)
 	if params == nil {
@@ -82,7 +82,29 @@ func (c *Client) translateMessageWithMedia(e *events.Message) map[string]any {
 	if emoji := extractStickerEmoji(e.Message); emoji != "" {
 		params["sticker_emoji"] = emoji
 	}
+	if rxn := extractReaction(e.Message); rxn != nil {
+		params["reaction"] = rxn
+	}
 	return params
+}
+
+// extractReaction surfaces a peer's reaction to a message as a
+// metadata block — emoji + the target message_id the reaction
+// applies to.  Empty emoji means the peer removed an earlier
+// reaction; the model needs to see that explicitly so it can update
+// any "they reacted with X" state.
+func extractReaction(m *waE2E.Message) map[string]any {
+	if m == nil || m.ReactionMessage == nil {
+		return nil
+	}
+	rxn := m.ReactionMessage
+	out := map[string]any{
+		"emoji": rxn.GetText(),
+	}
+	if key := rxn.GetKey(); key != nil {
+		out["target_message_id"] = key.GetID()
+	}
+	return out
 }
 
 // recordInbound stamps a received message into the message store so

--- a/connectors/whatsapp/daemon/internal/wameow/inbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound.go
@@ -19,7 +19,7 @@ func (c *Client) handleEvent(evt any) {
 		if e.Message != nil {
 			c.recordInbound(e)
 		}
-		if params := translateMessage(e); params != nil {
+		if params := c.translateMessageWithMedia(e); params != nil {
 			c.notify.Broadcast("message", params)
 		}
 	case *events.Connected:
@@ -58,6 +58,31 @@ func translateMessage(e *events.Message) map[string]any {
 		"is_self":        e.Info.IsFromMe,
 		"text":           extractText(e.Message),
 	}
+}
+
+// translateMessageWithMedia layers extracted attachments + sticker
+// emoji on top of the base translation.  Media download is done
+// inline (in whatsmeow's event-handler goroutine) — the broadcast
+// of THIS message waits for the download, but other events on the
+// same connection continue in parallel since whatsmeow's dispatcher
+// fans out per-event.  A download failure logs but doesn't drop the
+// message: the text/caption alone is still useful.
+func (c *Client) translateMessageWithMedia(e *events.Message) map[string]any {
+	params := translateMessage(e)
+	if params == nil {
+		return nil
+	}
+	if attachment, err := c.extractAndDownloadMedia(
+		context.Background(), c.wa.Load(), string(e.Info.ID), e.Message, c.mediaDir,
+	); err != nil {
+		c.log.Warn("wameow.media_download_failed", "id", e.Info.ID, "err", err)
+	} else if attachment != nil {
+		params["attachments"] = []*MediaAttachment{attachment}
+	}
+	if emoji := extractStickerEmoji(e.Message); emoji != "" {
+		params["sticker_emoji"] = emoji
+	}
+	return params
 }
 
 // recordInbound stamps a received message into the message store so

--- a/connectors/whatsapp/daemon/internal/wameow/inbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound.go
@@ -46,7 +46,7 @@ func translateMessage(e *events.Message) map[string]any {
 	if e.Message == nil {
 		return nil
 	}
-	return map[string]any{
+	params := map[string]any{
 		"id":             string(e.Info.ID),
 		"timestamp_ms":   e.Info.Timestamp.UnixMilli(),
 		"from_jid":       e.Info.Sender.String(),
@@ -56,6 +56,33 @@ func translateMessage(e *events.Message) map[string]any {
 		"is_self":        e.Info.IsFromMe,
 		"text":           extractText(e.Message),
 	}
+	if mentioned := extractMentions(e.Message); len(mentioned) > 0 {
+		params["mentioned_jids"] = mentioned
+	}
+	return params
+}
+
+// extractMentions returns the list of JIDs the peer's message
+// addresses by @-tag.  Pulled from whatever submessage carries a
+// ContextInfo (text, image caption, video caption, etc.).
+func extractMentions(m *waE2E.Message) []string {
+	var ctx *waE2E.ContextInfo
+	switch {
+	case m.ExtendedTextMessage != nil:
+		ctx = m.ExtendedTextMessage.GetContextInfo()
+	case m.ImageMessage != nil:
+		ctx = m.ImageMessage.GetContextInfo()
+	case m.VideoMessage != nil:
+		ctx = m.VideoMessage.GetContextInfo()
+	case m.DocumentMessage != nil:
+		ctx = m.DocumentMessage.GetContextInfo()
+	case m.AudioMessage != nil:
+		ctx = m.AudioMessage.GetContextInfo()
+	}
+	if ctx == nil {
+		return nil
+	}
+	return ctx.GetMentionedJID()
 }
 
 // translateMessageWithMedia layers extracted attachments, sticker

--- a/connectors/whatsapp/daemon/internal/wameow/inbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound.go
@@ -1,8 +1,6 @@
 package wameow
 
 import (
-	"context"
-
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
@@ -73,7 +71,7 @@ func (c *Client) translateMessageWithMedia(e *events.Message) map[string]any {
 		return nil
 	}
 	if attachment, err := c.extractAndDownloadMedia(
-		context.Background(), c.wa.Load(), string(e.Info.ID), e.Message, c.mediaDir,
+		c.lifetimeCtx, c.wa.Load(), string(e.Info.ID), e.Message, c.mediaDir,
 	); err != nil {
 		c.log.Warn("wameow.media_download_failed", "id", e.Info.ID, "err", err)
 	} else if attachment != nil {
@@ -158,11 +156,19 @@ func extractReaction(m *waE2E.Message) map[string]any {
 // the model can later react to / edit / revoke it by id.  Best-effort:
 // a store failure is logged but doesn't block the broadcast.
 //
-// Use a background context — handleEvent doesn't get one from whatsmeow,
-// and the put is tiny.
+// Filters out non-DM/group chat types (broadcasts, newsletters,
+// status updates) and pure ProtocolMessage envelopes (history sync,
+// app-state sync) — those ids are never user-visible and would just
+// grow the store with rows the model can never legitimately target.
+//
+// Uses the daemon-lifetime context so a shutdown-during-write
+// cancels cleanly rather than hitting a torn-down *sql.DB.
 func (c *Client) recordInbound(e *events.Message) {
+	if !c.isUserVisibleChat(e.Info.Chat) || isPureProtocolMessage(e.Message) {
+		return
+	}
 	err := c.msgs.Put(
-		context.Background(),
+		c.lifetimeCtx,
 		string(e.Info.ID),
 		e.Info.Chat.String(),
 		e.Info.Sender.String(),
@@ -173,12 +179,70 @@ func (c *Client) recordInbound(e *events.Message) {
 	}
 }
 
+// isUserVisibleChat reports whether the chat type can carry messages
+// the model legitimately interacts with.  DMs and groups qualify;
+// broadcasts/newsletters/status/server-status JIDs do not.
+func (c *Client) isUserVisibleChat(j types.JID) bool {
+	switch j.Server {
+	case types.DefaultUserServer, types.HiddenUserServer, types.GroupServer:
+		return true
+	}
+	return false
+}
+
+// isPureProtocolMessage reports whether the message body is ONLY a
+// ProtocolMessage (history sync, app-state sync, edit/revoke
+// envelopes, etc.) with no user-facing content.  Edit-envelope ids
+// are intentionally excluded from the messages.db too: the EDIT
+// envelope's id is distinct from the original target's id and the
+// model only needs the target_message_id (rendered in metadata).
+func isPureProtocolMessage(m *waE2E.Message) bool {
+	if m == nil || m.ProtocolMessage == nil {
+		return false
+	}
+	// If ANY user-facing content field is also set, treat as a real
+	// message that incidentally has a ProtocolMessage rider.
+	return m.Conversation == nil &&
+		m.ExtendedTextMessage == nil &&
+		m.ImageMessage == nil &&
+		m.VideoMessage == nil &&
+		m.AudioMessage == nil &&
+		m.DocumentMessage == nil &&
+		m.StickerMessage == nil &&
+		m.ReactionMessage == nil
+}
+
+// extractText returns the user-visible text body of a message,
+// covering both plain text (Conversation / ExtendedTextMessage) and
+// the Caption fields on Image/Video/Document attachments.  Sticker
+// and audio messages have no caption surface.
+//
+// Pre-fix this missed media captions entirely, so an inbound image
+// "Look at this — meeting moved to 3pm" arrived at the model as a
+// caption-less image (text="").
 func extractText(msg *waE2E.Message) string {
 	if conv := msg.GetConversation(); conv != "" {
 		return conv
 	}
 	if ext := msg.GetExtendedTextMessage(); ext != nil {
-		return ext.GetText()
+		if t := ext.GetText(); t != "" {
+			return t
+		}
+	}
+	if img := msg.GetImageMessage(); img != nil {
+		if c := img.GetCaption(); c != "" {
+			return c
+		}
+	}
+	if vid := msg.GetVideoMessage(); vid != nil {
+		if c := vid.GetCaption(); c != "" {
+			return c
+		}
+	}
+	if doc := msg.GetDocumentMessage(); doc != nil {
+		if c := doc.GetCaption(); c != "" {
+			return c
+		}
 	}
 	return ""
 }

--- a/connectors/whatsapp/daemon/internal/wameow/inbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound.go
@@ -226,7 +226,19 @@ func (c *Client) extractEditInfo(evt *events.Message) *editInfo {
 			)
 			return out
 		}
-		out.newText = extractText(decrypted)
+		// The decrypted plaintext is itself wrapped as a
+		// ProtocolMessage{Type: MESSAGE_EDIT, EditedMessage: {…}} —
+		// same shape as the legacy path's outer envelope, just one
+		// level deeper.  Unwrap to reach the new body; fall back to
+		// the top-level Message for forward-compatibility if a future
+		// whatsmeow version flattens the structure.
+		if pm := decrypted.GetProtocolMessage(); pm != nil && pm.GetType() == waE2E.ProtocolMessage_MESSAGE_EDIT {
+			if edited := pm.GetEditedMessage(); edited != nil {
+				out.newText = extractText(edited)
+			}
+		} else {
+			out.newText = extractText(decrypted)
+		}
 		return out
 	}
 	return nil

--- a/connectors/whatsapp/daemon/internal/wameow/inbound_media.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound_media.go
@@ -1,0 +1,159 @@
+package wameow
+
+import (
+	"context"
+	"fmt"
+	"mime"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+)
+
+// MediaAttachment is the inbound media bundle the daemon surfaces to
+// Python in the ``message`` notification's ``attachments`` array.
+// Filename + mimetype reflect what WhatsApp delivered (so the model
+// sees the originator's labelling); Path is where the daemon wrote
+// the decrypted bytes under <store_dir>/media/.
+type MediaAttachment struct {
+	Path     string `json:"path"`
+	Mimetype string `json:"mimetype"`
+	Filename string `json:"filename"`
+}
+
+// extractAndDownloadMedia inspects e.Message for a media submessage,
+// downloads + decrypts via whatsmeow, and writes the bytes to a path
+// the Python side can read.  Returns nil + nil when the message has
+// no media (text-only, reaction, edit, etc.); the caller treats that
+// as "no attachments to surface".
+//
+// Sticker messages are intentionally handled by extractStickerEmoji
+// rather than downloaded — the emoji label carries the model-useful
+// signal at near-zero cost, where the 100-200 KB .webp does not.
+func (c *Client) extractAndDownloadMedia(
+	ctx context.Context,
+	wa *whatsmeow.Client,
+	msgID string,
+	m *waE2E.Message,
+	mediaDir string,
+) (*MediaAttachment, error) {
+	if m == nil {
+		return nil, nil
+	}
+	var (
+		downloadable whatsmeow.DownloadableMessage
+		mimetype     string
+		filename     string
+	)
+	switch {
+	case m.ImageMessage != nil:
+		downloadable = m.ImageMessage
+		mimetype = m.ImageMessage.GetMimetype()
+	case m.VideoMessage != nil:
+		downloadable = m.VideoMessage
+		mimetype = m.VideoMessage.GetMimetype()
+	case m.AudioMessage != nil:
+		downloadable = m.AudioMessage
+		mimetype = m.AudioMessage.GetMimetype()
+	case m.DocumentMessage != nil:
+		downloadable = m.DocumentMessage
+		mimetype = m.DocumentMessage.GetMimetype()
+		filename = m.DocumentMessage.GetFileName()
+	default:
+		return nil, nil
+	}
+	if mimetype == "" {
+		mimetype = "application/octet-stream"
+	}
+
+	data, err := wa.Download(ctx, downloadable)
+	if err != nil {
+		return nil, fmt.Errorf("download media for msg %s: %w", msgID, err)
+	}
+
+	if filename == "" {
+		filename = msgID + extensionForMimetype(mimetype)
+	}
+	if err := os.MkdirAll(mediaDir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir media dir: %w", err)
+	}
+	// Always sandwich msg_id into the filename so two inbounds with
+	// the same DocumentMessage.FileName don't clobber each other.
+	diskName := msgID + "_" + sanitizeFilename(filename)
+	diskPath := filepath.Join(mediaDir, diskName)
+	if err := os.WriteFile(diskPath, data, 0o644); err != nil {
+		return nil, fmt.Errorf("write media to %s: %w", diskPath, err)
+	}
+	return &MediaAttachment{
+		Path:     diskPath,
+		Mimetype: mimetype,
+		Filename: filename,
+	}, nil
+}
+
+// extractStickerEmoji returns the sticker's emoji label, or "" when
+// the message isn't a sticker or carries no emoji.  Per the locked
+// design, sticker bytes themselves are intentionally NOT downloaded:
+// the emoji is the model-relevant signal (a literal label from the
+// WhatsApp sticker picker), and vision tokens on a 512×512 .webp
+// would be high-cost for low-signal.
+func extractStickerEmoji(m *waE2E.Message) string {
+	if m == nil || m.StickerMessage == nil {
+		return ""
+	}
+	return m.StickerMessage.GetEmojis()
+}
+
+// sanitizeFilename strips path separators + leading dots from a
+// peer-supplied filename so we can't be tricked into writing outside
+// mediaDir or to a hidden file.  Replaces any other dodgy bytes with
+// "_".  Empty result falls back to "unnamed".
+func sanitizeFilename(name string) string {
+	name = strings.TrimLeft(strings.ReplaceAll(strings.ReplaceAll(name, "/", "_"), "\\", "_"), ".")
+	if name == "" {
+		return "unnamed"
+	}
+	return name
+}
+
+// extensionForMimetype returns ".jpg" / ".mp4" / etc. for the
+// common WhatsApp media mimetypes.  Falls back to ".bin" so the
+// disk file always has SOMETHING and the model can still spot the
+// path in metadata.
+func extensionForMimetype(mimetype string) string {
+	// Strip any "; charset=utf-8"-style parameter; mime.ExtensionsByType
+	// is parameter-aware but its output ordering changes between
+	// platforms, so we hardcode the canonical extension for the
+	// types WhatsApp actually emits.
+	if i := strings.Index(mimetype, ";"); i != -1 {
+		mimetype = strings.TrimSpace(mimetype[:i])
+	}
+	switch mimetype {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/png":
+		return ".png"
+	case "image/webp":
+		return ".webp"
+	case "image/gif":
+		return ".gif"
+	case "video/mp4":
+		return ".mp4"
+	case "audio/ogg":
+		return ".ogg"
+	case "audio/mpeg":
+		return ".mp3"
+	case "audio/mp4":
+		return ".m4a"
+	case "application/pdf":
+		return ".pdf"
+	}
+	// Last resort: ask Go's mime package and pick the first ext.
+	if exts, err := mime.ExtensionsByType(mimetype); err == nil && len(exts) > 0 {
+		return exts[0]
+	}
+	return ".bin"
+}
+

--- a/connectors/whatsapp/daemon/internal/wameow/inbound_media.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound_media.go
@@ -73,17 +73,26 @@ func (c *Client) extractAndDownloadMedia(
 		return nil, fmt.Errorf("download media for msg %s: %w", msgID, err)
 	}
 
-	if filename == "" {
-		filename = msgID + extensionForMimetype(mimetype)
-	}
-	if err := os.MkdirAll(mediaDir, 0o755); err != nil {
+	if err := os.MkdirAll(mediaDir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir media dir: %w", err)
 	}
-	// Always sandwich msg_id into the filename so two inbounds with
-	// the same DocumentMessage.FileName don't clobber each other.
-	diskName := msgID + "_" + sanitizeFilename(filename)
+	// Build the on-disk filename.  Peer-supplied filenames get
+	// sandwiched with msgID so two inbounds with the same
+	// DocumentMessage.FileName don't clobber each other.  When no
+	// peer-supplied name exists, the daemon-built name already
+	// includes msgID, so don't double-prefix.
+	var diskName string
+	if filename == "" {
+		diskName = msgID + extensionForMimetype(mimetype)
+		filename = diskName // surface this back to the model too
+	} else {
+		diskName = msgID + "_" + sanitizeFilename(filename)
+	}
 	diskPath := filepath.Join(mediaDir, diskName)
-	if err := os.WriteFile(diskPath, data, 0o644); err != nil {
+	// 0o600: media files often contain sensitive content (photos,
+	// documents) — match whatsmeow's upstream store.db perms, not
+	// the world-readable 0o644 default.
+	if err := os.WriteFile(diskPath, data, 0o600); err != nil {
 		return nil, fmt.Errorf("write media to %s: %w", diskPath, err)
 	}
 	return &MediaAttachment{
@@ -106,16 +115,34 @@ func extractStickerEmoji(m *waE2E.Message) string {
 	return m.StickerMessage.GetEmojis()
 }
 
-// sanitizeFilename strips path separators + leading dots from a
-// peer-supplied filename so we can't be tricked into writing outside
-// mediaDir or to a hidden file.  Replaces any other dodgy bytes with
-// "_".  Empty result falls back to "unnamed".
+// sanitizeFilename neutralizes peer-supplied filenames so we can't be
+// tricked into writing outside mediaDir, to a hidden file, or to a
+// path whose name confuses downstream tooling.
+//
+// Rules:
+// * Path separators (/, \) → "_" (prevent directory traversal).
+// * Leading "." stripped (prevent hidden-file write).
+// * Control bytes (< 0x20) and NUL → "_" (prevent log/path
+//   misparsing; some downstream consumers truncate at NUL).
+// * Empty result → "unnamed".
 func sanitizeFilename(name string) string {
-	name = strings.TrimLeft(strings.ReplaceAll(strings.ReplaceAll(name, "/", "_"), "\\", "_"), ".")
-	if name == "" {
+	var out strings.Builder
+	for _, r := range name {
+		switch {
+		case r == '/' || r == '\\':
+			out.WriteByte('_')
+		case r < 0x20 || r == 0x7f:
+			// C0 controls + DEL
+			out.WriteByte('_')
+		default:
+			out.WriteRune(r)
+		}
+	}
+	cleaned := strings.TrimLeft(out.String(), ".")
+	if cleaned == "" {
 		return "unnamed"
 	}
-	return name
+	return cleaned
 }
 
 // extensionForMimetype returns ".jpg" / ".mp4" / etc. for the

--- a/connectors/whatsapp/daemon/internal/wameow/inbound_test.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/store/sqlstore"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	"google.golang.org/protobuf/proto"
@@ -354,8 +356,29 @@ func TestHandleEventDispatch(t *testing.T) {
 }
 
 func TestHandleEventLoggedOutOmitsReasonWhenStreamError(t *testing.T) {
+	ctx := context.Background()
+	container, err := sqlstore.New(
+		ctx,
+		"sqlite",
+		"file::memory:?_pragma=foreign_keys(1)",
+		newWaLogger(discardLogger(), "test"),
+	)
+	if err != nil {
+		t.Fatalf("sqlstore.New: %v", err)
+	}
+	defer func() { _ = container.Close() }()
+	device := container.NewDevice()
+	wa := whatsmeow.NewClient(device, newWaLogger(discardLogger(), "test"))
+
 	notify := &captureNotifier{}
-	c := &Client{notify: notify, log: discardLogger(), msgs: newTestMessageStore(t), lifetimeCtx: context.Background()}
+	c := &Client{
+		notify:      notify,
+		log:         discardLogger(),
+		msgs:        newTestMessageStore(t),
+		lifetimeCtx: ctx,
+		store:       container,
+	}
+	c.wa.Store(wa)
 
 	// OnConnect == false (stream:error path): Reason is the zero value
 	// and must not be surfaced to the wire as misleading data.
@@ -377,10 +400,97 @@ func TestHandleEventLoggedOutOmitsReasonWhenStreamError(t *testing.T) {
 	if _, hasReason := params["reason"]; hasReason {
 		t.Errorf("reason should be omitted when OnConnect=false; got %v", params["reason"])
 	}
+	// Verify the LoggedOut handler also called replaceWhatsmeowClient —
+	// the in-memory Client must be swapped so a subsequent StartPairing
+	// against this daemon doesn't fail with "invalid use of deleted
+	// device".
+	if c.wa.Load() == wa {
+		t.Error("handleEvent did not swap c.wa after LoggedOut; re-pair would fail")
+	}
 }
 
 func discardLogger() *slog.Logger {
 	// slog.DiscardHandler short-circuits in Enabled() so the Sprintf
 	// gate in slogWaLogger never fires either.
 	return slog.New(slog.DiscardHandler)
+}
+
+func TestExtractQuotedMessageID(t *testing.T) {
+	target := "3A1234DEADBEEF"
+	cases := []struct {
+		name string
+		msg  *waE2E.Message
+		want string
+	}{
+		{
+			name: "extended_text_with_quote",
+			msg: &waE2E.Message{
+				ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+					Text:        proto.String("a reply"),
+					ContextInfo: &waE2E.ContextInfo{StanzaID: proto.String(target)},
+				},
+			},
+			want: target,
+		},
+		{
+			name: "image_caption_with_quote",
+			msg: &waE2E.Message{
+				ImageMessage: &waE2E.ImageMessage{
+					Caption:     proto.String("look"),
+					ContextInfo: &waE2E.ContextInfo{StanzaID: proto.String(target)},
+				},
+			},
+			want: target,
+		},
+		{
+			name: "plain_conversation_no_quote",
+			msg:  &waE2E.Message{Conversation: proto.String("just text")},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractQuotedMessageID(tc.msg); got != tc.want {
+				t.Errorf("extractQuotedMessageID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTranslateMessageWithMediaSurfacesStickerWithoutEmoji(t *testing.T) {
+	// Custom stickers (made via WhatsApp's sticker maker) frequently
+	// carry an empty Emojis tag.  Pre-fix the daemon's emoji != ""
+	// guard dropped these and parse.py's "no_signal" filter then
+	// swallowed the message — the model never knew the peer sent a
+	// sticker.  Verify the message now surfaces sticker_emoji="" so
+	// downstream can render "(sticker, no emoji label)".
+	c := &Client{
+		log:         discardLogger(),
+		msgs:        newTestMessageStore(t),
+		lifetimeCtx: context.Background(),
+	}
+	peer := types.NewJID("15551112222", types.DefaultUserServer)
+	params := c.translateMessageWithMedia(&events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: peer, Sender: peer, IsFromMe: false},
+			ID:            "STICKER-1",
+			Timestamp:     time.Now(),
+		},
+		Message: &waE2E.Message{
+			StickerMessage: &waE2E.StickerMessage{
+				URL: proto.String("https://example/sticker.webp"),
+				// Emojis intentionally nil — the custom-sticker case.
+			},
+		},
+	})
+	if params == nil {
+		t.Fatal("translateMessageWithMedia dropped a sticker; expected sticker_emoji='' to be emitted")
+	}
+	emoji, ok := params["sticker_emoji"]
+	if !ok {
+		t.Fatalf("sticker_emoji key missing from params: %#v", params)
+	}
+	if emoji != "" {
+		t.Errorf("sticker_emoji = %q, want '' for emoji-less sticker", emoji)
+	}
 }

--- a/connectors/whatsapp/daemon/internal/wameow/inbound_test.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound_test.go
@@ -139,6 +139,31 @@ func TestRecordInboundEnqueuesUnreadForPeer(t *testing.T) {
 	}
 }
 
+func TestRecordInboundSkipsUnreadForReactionOnly(t *testing.T) {
+	// Pre-fix: reaction-only inbounds entered the unread queue,
+	// causing the next outbound to MarkRead a reaction id which
+	// whatsmeow rejects with a noisy mark_read_failed warning.
+	// Post-fix: reaction envelopes are tracked in msgstore but not
+	// in the unread queue.
+	c := &Client{
+		log:         discardLogger(),
+		msgs:        newTestMessageStore(t),
+		lifetimeCtx: context.Background(),
+	}
+	peer := types.NewJID("15553334444", types.DefaultUserServer)
+	c.recordInbound(&events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: peer, Sender: peer, IsFromMe: false},
+			ID:            "REACTION-1",
+		},
+		Message: &waE2E.Message{ReactionMessage: &waE2E.ReactionMessage{}},
+	})
+
+	if got := c.drainUnread(peer.String()); got != nil {
+		t.Errorf("reaction-only inbound enqueued unread: %v", got)
+	}
+}
+
 func TestRecordInboundSkipsUnreadForOwnEchoes(t *testing.T) {
 	// Our own outbound messages echo back through *events.Message
 	// with is_self=true.  Those aren't "unread" by us; the unread

--- a/connectors/whatsapp/daemon/internal/wameow/inbound_test.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound_test.go
@@ -155,7 +155,7 @@ func (n *captureNotifier) Broadcast(method string, params any) {
 
 func TestHandleEventDispatch(t *testing.T) {
 	notify := &captureNotifier{}
-	c := &Client{notify: notify, log: discardLogger()}
+	c := &Client{notify: notify, log: discardLogger(), msgs: newTestMessageStore(t)}
 
 	sender := types.NewJID("15553334444", types.DefaultUserServer)
 	c.handleEvent(&events.Message{
@@ -189,7 +189,7 @@ func TestHandleEventDispatch(t *testing.T) {
 
 func TestHandleEventLoggedOutOmitsReasonWhenStreamError(t *testing.T) {
 	notify := &captureNotifier{}
-	c := &Client{notify: notify, log: discardLogger()}
+	c := &Client{notify: notify, log: discardLogger(), msgs: newTestMessageStore(t)}
 
 	// OnConnect == false (stream:error path): Reason is the zero value
 	// and must not be surfaced to the wire as misleading data.

--- a/connectors/whatsapp/daemon/internal/wameow/inbound_test.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound_test.go
@@ -116,6 +116,53 @@ func TestSanitizeFilenameNeutralizesDodgyChars(t *testing.T) {
 	}
 }
 
+func TestRecordInboundEnqueuesUnreadForPeer(t *testing.T) {
+	// Peer-sent message (is_self=false) on a DM chat enqueues an
+	// unread entry so the next outbound to that chat marks it read.
+	c := &Client{
+		log:         discardLogger(),
+		msgs:        newTestMessageStore(t),
+		lifetimeCtx: context.Background(),
+	}
+	peer := types.NewJID("15553334444", types.DefaultUserServer)
+	c.recordInbound(&events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: peer, Sender: peer, IsFromMe: false},
+			ID:            "INBOUND-1",
+		},
+		Message: &waE2E.Message{Conversation: proto.String("hi")},
+	})
+
+	got := c.drainUnread(peer.String())
+	if len(got) != 1 || got[0].id != "INBOUND-1" || got[0].sender != peer.String() {
+		t.Errorf("expected one unread entry, got %v", got)
+	}
+}
+
+func TestRecordInboundSkipsUnreadForOwnEchoes(t *testing.T) {
+	// Our own outbound messages echo back through *events.Message
+	// with is_self=true.  Those aren't "unread" by us; the unread
+	// queue should ignore them so a self-echo doesn't trigger a
+	// MarkRead on the bot's own send.
+	c := &Client{
+		log:         discardLogger(),
+		msgs:        newTestMessageStore(t),
+		lifetimeCtx: context.Background(),
+	}
+	peer := types.NewJID("15553334444", types.DefaultUserServer)
+	c.recordInbound(&events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: peer, Sender: peer, IsFromMe: true},
+			ID:            "OUR-ECHO",
+		},
+		Message: &waE2E.Message{Conversation: proto.String("hi")},
+	})
+
+	if got := c.drainUnread(peer.String()); got != nil {
+		t.Errorf("self-echo unexpectedly enqueued: %v", got)
+	}
+}
+
 func TestIsPureProtocolMessage(t *testing.T) {
 	// Real user-facing message — even with a ProtocolMessage rider —
 	// must NOT be filtered out of msgstore writes.

--- a/connectors/whatsapp/daemon/internal/wameow/inbound_test.go
+++ b/connectors/whatsapp/daemon/internal/wameow/inbound_test.go
@@ -1,6 +1,7 @@
 package wameow
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 	"time"
@@ -50,12 +51,105 @@ func TestExtractTextFromExtendedTextMessage(t *testing.T) {
 }
 
 func TestExtractTextReturnsEmptyForUnsupportedShape(t *testing.T) {
-	// Attachment-without-caption: empty text is the contract; the
-	// downstream layer drops attachment-only messages until PR adds
-	// attachment plumbing.
+	// Attachment-without-caption: empty text is the contract.  Sticker
+	// and audio messages don't carry a caption surface, so they
+	// always return empty here.
 	msg := &waE2E.Message{ImageMessage: &waE2E.ImageMessage{}}
 	if got := extractText(msg); got != "" {
-		t.Errorf("extractText image-only = %q, want empty", got)
+		t.Errorf("extractText image-no-caption = %q, want empty", got)
+	}
+	msg = &waE2E.Message{AudioMessage: &waE2E.AudioMessage{}}
+	if got := extractText(msg); got != "" {
+		t.Errorf("extractText audio = %q, want empty", got)
+	}
+}
+
+func TestExtractTextFromImageCaption(t *testing.T) {
+	// Pre-fix this returned "" — extractText didn't reach into
+	// ImageMessage.Caption, so an image with a caption surfaced to
+	// the model as a caption-less attachment with text="".
+	msg := &waE2E.Message{
+		ImageMessage: &waE2E.ImageMessage{
+			Caption: proto.String("look at this — meeting moved to 3pm"),
+		},
+	}
+	if got := extractText(msg); got != "look at this — meeting moved to 3pm" {
+		t.Errorf("extractText image-caption = %q, want the caption", got)
+	}
+}
+
+func TestExtractTextFromVideoCaption(t *testing.T) {
+	msg := &waE2E.Message{
+		VideoMessage: &waE2E.VideoMessage{Caption: proto.String("clip from yesterday")},
+	}
+	if got := extractText(msg); got != "clip from yesterday" {
+		t.Errorf("extractText video-caption = %q, want the caption", got)
+	}
+}
+
+func TestExtractTextFromDocumentCaption(t *testing.T) {
+	msg := &waE2E.Message{
+		DocumentMessage: &waE2E.DocumentMessage{Caption: proto.String("Q3 numbers")},
+	}
+	if got := extractText(msg); got != "Q3 numbers" {
+		t.Errorf("extractText document-caption = %q, want the caption", got)
+	}
+}
+
+func TestSanitizeFilenameNeutralizesDodgyChars(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"normal.pdf", "normal.pdf"},
+		{"with/slash.pdf", "with_slash.pdf"},
+		{`with\back.pdf`, "with_back.pdf"},
+		{".hidden", "hidden"},
+		{"with\x00null.pdf", "with_null.pdf"},
+		{"with\nnewline.pdf", "with_newline.pdf"},
+		{"with\ttab.pdf", "with_tab.pdf"},
+		{"\x7fdel.pdf", "_del.pdf"},
+		{"", "unnamed"},
+		{"...", "unnamed"},
+	}
+	for _, tc := range cases {
+		if got := sanitizeFilename(tc.in); got != tc.want {
+			t.Errorf("sanitizeFilename(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestIsPureProtocolMessage(t *testing.T) {
+	// Real user-facing message — even with a ProtocolMessage rider —
+	// must NOT be filtered out of msgstore writes.
+	withContent := &waE2E.Message{
+		Conversation:    proto.String("hello"),
+		ProtocolMessage: &waE2E.ProtocolMessage{},
+	}
+	if isPureProtocolMessage(withContent) {
+		t.Error("message with Conversation should not be treated as pure protocol")
+	}
+	// Pure protocol envelope (history sync, key share, edit-only) —
+	// recordInbound should skip these to avoid msgstore growing
+	// with rows the model can never target.
+	pure := &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{}}
+	if !isPureProtocolMessage(pure) {
+		t.Error("ProtocolMessage-only envelope should be treated as pure protocol")
+	}
+	// Reactions are user-facing, even though they ride alone too.
+	reaction := &waE2E.Message{ReactionMessage: &waE2E.ReactionMessage{}}
+	if isPureProtocolMessage(reaction) {
+		t.Error("ReactionMessage should not be treated as pure protocol")
+	}
+}
+
+func TestExtractTextPrefersConversationOverImageCaption(t *testing.T) {
+	// Defensive: if both fields are set (shouldn't happen in
+	// practice), Conversation wins — that's the dominant path and
+	// what existing tests assume.
+	msg := &waE2E.Message{
+		Conversation: proto.String("outer text"),
+		ImageMessage: &waE2E.ImageMessage{Caption: proto.String("ignored caption")},
+	}
+	if got := extractText(msg); got != "outer text" {
+		t.Errorf("extractText preference = %q, want 'outer text'", got)
 	}
 }
 
@@ -155,7 +249,7 @@ func (n *captureNotifier) Broadcast(method string, params any) {
 
 func TestHandleEventDispatch(t *testing.T) {
 	notify := &captureNotifier{}
-	c := &Client{notify: notify, log: discardLogger(), msgs: newTestMessageStore(t)}
+	c := &Client{notify: notify, log: discardLogger(), msgs: newTestMessageStore(t), lifetimeCtx: context.Background()}
 
 	sender := types.NewJID("15553334444", types.DefaultUserServer)
 	c.handleEvent(&events.Message{
@@ -189,7 +283,7 @@ func TestHandleEventDispatch(t *testing.T) {
 
 func TestHandleEventLoggedOutOmitsReasonWhenStreamError(t *testing.T) {
 	notify := &captureNotifier{}
-	c := &Client{notify: notify, log: discardLogger(), msgs: newTestMessageStore(t)}
+	c := &Client{notify: notify, log: discardLogger(), msgs: newTestMessageStore(t), lifetimeCtx: context.Background()}
 
 	// OnConnect == false (stream:error path): Reason is the zero value
 	// and must not be surfaced to the wire as misleading data.

--- a/connectors/whatsapp/daemon/internal/wameow/msgstore.go
+++ b/connectors/whatsapp/daemon/internal/wameow/msgstore.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	// modernc.org/sqlite is already registered by client.go's import.
 	_ "modernc.org/sqlite"
@@ -62,11 +63,27 @@ func openMessageStoreDSN(dsn string) (*MessageStore, error) {
 			chat_jid TEXT NOT NULL,
 			sender_jid TEXT NOT NULL,
 			from_me INTEGER NOT NULL CHECK (from_me IN (0, 1)),
+			sent_at INTEGER NOT NULL DEFAULT 0,
+			text TEXT NOT NULL DEFAULT '',
 			created_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') * 1000 AS INTEGER))
 		)
 	`); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("create messages table: %w", err)
+	}
+	// Forward-migrate older stores that pre-date the sent_at + text
+	// columns.  Bare ALTER TABLE ADD COLUMN on a column that already
+	// exists raises "duplicate column name" — swallow that specific
+	// error so the migration is idempotent on fresh AND pre-existing
+	// databases.
+	for _, alter := range []string{
+		`ALTER TABLE messages ADD COLUMN sent_at INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE messages ADD COLUMN text TEXT NOT NULL DEFAULT ''`,
+	} {
+		if _, err := db.Exec(alter); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+			_ = db.Close()
+			return nil, fmt.Errorf("alter messages: %w", err)
+		}
 	}
 	return &MessageStore{db: db}, nil
 }
@@ -77,35 +94,53 @@ func (s *MessageStore) Close() error {
 
 // Put records a message's MessageKey.  Idempotent on conflict: a
 // duplicate id is a no-op so retries and re-deliveries don't fail.
-func (s *MessageStore) Put(ctx context.Context, id, chatJID, senderJID string, fromMe bool) error {
+//
+// ``sentAtMs`` is the message's wall-clock send time (whatsmeow's
+// ``MessageInfo.Timestamp``), used by Edit/Revoke window guards.
+// ``text`` is the message body, used to build the QuotedMessage stub
+// when the model issues a reply with ``quoted_message_id``.
+func (s *MessageStore) Put(ctx context.Context, id, chatJID, senderJID string, fromMe bool, sentAtMs int64, text string) error {
 	fromMeInt := 0
 	if fromMe {
 		fromMeInt = 1
 	}
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO messages (id, chat_jid, sender_jid, from_me)
-		VALUES (?, ?, ?, ?)
+		INSERT INTO messages (id, chat_jid, sender_jid, from_me, sent_at, text)
+		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO NOTHING
-	`, id, chatJID, senderJID, fromMeInt)
+	`, id, chatJID, senderJID, fromMeInt, sentAtMs, text)
 	if err != nil {
 		return fmt.Errorf("insert message %s: %w", id, err)
 	}
 	return nil
 }
 
-// Lookup returns the MessageKey for id, or ErrMessageNotFound.
-func (s *MessageStore) Lookup(ctx context.Context, id string) (chatJID, senderJID string, fromMe bool, err error) {
-	var fromMeInt int
+// MessageRecord is the row returned by Lookup.
+type MessageRecord struct {
+	ChatJID   string
+	SenderJID string
+	FromMe    bool
+	SentAtMs  int64
+	Text      string
+}
+
+// Lookup returns the MessageRecord for id, or ErrMessageNotFound.
+func (s *MessageStore) Lookup(ctx context.Context, id string) (MessageRecord, error) {
+	var (
+		rec       MessageRecord
+		fromMeInt int
+	)
 	row := s.db.QueryRowContext(ctx, `
-		SELECT chat_jid, sender_jid, from_me FROM messages WHERE id = ?
+		SELECT chat_jid, sender_jid, from_me, sent_at, text FROM messages WHERE id = ?
 	`, id)
-	if scanErr := row.Scan(&chatJID, &senderJID, &fromMeInt); scanErr != nil {
+	if scanErr := row.Scan(&rec.ChatJID, &rec.SenderJID, &fromMeInt, &rec.SentAtMs, &rec.Text); scanErr != nil {
 		if errors.Is(scanErr, sql.ErrNoRows) {
-			return "", "", false, ErrMessageNotFound
+			return MessageRecord{}, ErrMessageNotFound
 		}
-		return "", "", false, fmt.Errorf("lookup message %s: %w", id, scanErr)
+		return MessageRecord{}, fmt.Errorf("lookup message %s: %w", id, scanErr)
 	}
-	return chatJID, senderJID, fromMeInt == 1, nil
+	rec.FromMe = fromMeInt == 1
+	return rec, nil
 }
 
 // Truncate empties the messages table.  Called after Unpair so the

--- a/connectors/whatsapp/daemon/internal/wameow/msgstore.go
+++ b/connectors/whatsapp/daemon/internal/wameow/msgstore.go
@@ -1,0 +1,101 @@
+package wameow
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	// modernc.org/sqlite is already registered by client.go's import.
+	_ "modernc.org/sqlite"
+)
+
+// MessageStore is a sqlite-backed index of every WhatsApp message the
+// daemon has seen — inbound or outbound — keyed by message_id and
+// carrying the MessageKey context (chat_jid, sender_jid, from_me) that
+// whatsmeow's Build{Reaction,Edit,Revoke} require.
+//
+// WhatsApp's protocol routes message-targeted operations by a 4-tuple
+// MessageKey rather than the bare message_id, and its servers expose
+// no "look up message by id" affordance to clients.  We own the
+// mapping locally because there's no upstream we can defer to.
+//
+// Lives in a sibling file (messages.db) to whatsmeow's store.db so
+// schema migrations stay independent.
+type MessageStore struct {
+	db *sql.DB
+}
+
+// ErrMessageNotFound is returned by Lookup when no row matches the id.
+// React/edit/revoke handlers surface it back to the caller as
+// "unknown message_id" so the model retries with a different target
+// instead of silently no-oping.
+var ErrMessageNotFound = errors.New("message not found")
+
+func openMessageStore(storeDir string) (*MessageStore, error) {
+	dbPath := filepath.Join(storeDir, "messages.db")
+	dsn := fmt.Sprintf("file:%s?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)", dbPath)
+	return openMessageStoreDSN(dsn)
+}
+
+// openMessageStoreDSN is the DSN-form constructor used by tests that
+// want an in-memory store ("file::memory:?cache=shared").  Production
+// callers go through openMessageStore which computes the DSN from a
+// store directory.
+func openMessageStoreDSN(dsn string) (*MessageStore, error) {
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open messages db %q: %w", dsn, err)
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS messages (
+			id TEXT PRIMARY KEY,
+			chat_jid TEXT NOT NULL,
+			sender_jid TEXT NOT NULL,
+			from_me INTEGER NOT NULL CHECK (from_me IN (0, 1)),
+			created_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') * 1000 AS INTEGER))
+		)
+	`); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create messages table: %w", err)
+	}
+	return &MessageStore{db: db}, nil
+}
+
+func (s *MessageStore) Close() error {
+	return s.db.Close()
+}
+
+// Put records a message's MessageKey.  Idempotent on conflict: a
+// duplicate id is a no-op so retries and re-deliveries don't fail.
+func (s *MessageStore) Put(ctx context.Context, id, chatJID, senderJID string, fromMe bool) error {
+	fromMeInt := 0
+	if fromMe {
+		fromMeInt = 1
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO messages (id, chat_jid, sender_jid, from_me)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(id) DO NOTHING
+	`, id, chatJID, senderJID, fromMeInt)
+	if err != nil {
+		return fmt.Errorf("insert message %s: %w", id, err)
+	}
+	return nil
+}
+
+// Lookup returns the MessageKey for id, or ErrMessageNotFound.
+func (s *MessageStore) Lookup(ctx context.Context, id string) (chatJID, senderJID string, fromMe bool, err error) {
+	var fromMeInt int
+	row := s.db.QueryRowContext(ctx, `
+		SELECT chat_jid, sender_jid, from_me FROM messages WHERE id = ?
+	`, id)
+	if scanErr := row.Scan(&chatJID, &senderJID, &fromMeInt); scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return "", "", false, ErrMessageNotFound
+		}
+		return "", "", false, fmt.Errorf("lookup message %s: %w", id, scanErr)
+	}
+	return chatJID, senderJID, fromMeInt == 1, nil
+}

--- a/connectors/whatsapp/daemon/internal/wameow/msgstore.go
+++ b/connectors/whatsapp/daemon/internal/wameow/msgstore.go
@@ -33,6 +33,14 @@ type MessageStore struct {
 // instead of silently no-oping.
 var ErrMessageNotFound = errors.New("message not found")
 
+// ErrNotOwnMessage is returned by Edit/Revoke when the target msgID
+// exists in the store but was sent by a peer (from_me=false).
+// WhatsApp only allows editing or revoking your own outbound
+// messages, so this is a precondition refusal — not a server error.
+// The handler layer maps it to ErrCodeInvalidParams so the model
+// distinguishes "wrong target" from "infrastructure failure".
+var ErrNotOwnMessage = errors.New("message not sent by us")
+
 func openMessageStore(storeDir string) (*MessageStore, error) {
 	dbPath := filepath.Join(storeDir, "messages.db")
 	dsn := fmt.Sprintf("file:%s?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)", dbPath)
@@ -98,4 +106,15 @@ func (s *MessageStore) Lookup(ctx context.Context, id string) (chatJID, senderJI
 		return "", "", false, fmt.Errorf("lookup message %s: %w", id, scanErr)
 	}
 	return chatJID, senderJID, fromMeInt == 1, nil
+}
+
+// Truncate empties the messages table.  Called after Unpair so the
+// next pairing session doesn't carry stale MessageKey rows from the
+// previous device identity — those rows would Lookup-succeed but
+// reference whatsmeow Signal sessions the new device can't address.
+func (s *MessageStore) Truncate(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM messages`); err != nil {
+		return fmt.Errorf("truncate messages: %w", err)
+	}
+	return nil
 }

--- a/connectors/whatsapp/daemon/internal/wameow/msgstore_test.go
+++ b/connectors/whatsapp/daemon/internal/wameow/msgstore_test.go
@@ -1,0 +1,101 @@
+package wameow
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// newTestMessageStore returns an in-memory MessageStore wired with a
+// shared-cache DSN so concurrent test connections see the same data.
+// The store is closed at test cleanup.
+//
+// uniqueInMemoryDSN guarantees parallel tests don't collide on the
+// same in-memory database via sqlite's "shared cache" name namespace.
+func newTestMessageStore(t *testing.T) *MessageStore {
+	t.Helper()
+	s, err := openMessageStoreDSN(uniqueInMemoryDSN())
+	if err != nil {
+		t.Fatalf("openMessageStoreDSN: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+var (
+	dsnMu  sync.Mutex
+	dsnSeq int
+)
+
+func uniqueInMemoryDSN() string {
+	dsnMu.Lock()
+	defer dsnMu.Unlock()
+	dsnSeq++
+	return "file:msgstore_test_" + itoa(dsnSeq) + "?mode=memory&cache=shared"
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+func TestMessageStorePutLookup(t *testing.T) {
+	ctx := context.Background()
+	s := newTestMessageStore(t)
+
+	if err := s.Put(ctx, "MSG1", "chat@s.whatsapp.net", "sender@s.whatsapp.net", false); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	chat, sender, fromMe, err := s.Lookup(ctx, "MSG1")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if chat != "chat@s.whatsapp.net" || sender != "sender@s.whatsapp.net" || fromMe {
+		t.Errorf("Lookup got (%q, %q, %t); want (chat@..., sender@..., false)", chat, sender, fromMe)
+	}
+}
+
+func TestMessageStoreLookupNotFound(t *testing.T) {
+	s := newTestMessageStore(t)
+	_, _, _, err := s.Lookup(context.Background(), "DOES-NOT-EXIST")
+	if !errors.Is(err, ErrMessageNotFound) {
+		t.Errorf("Lookup miss returned %v, want ErrMessageNotFound", err)
+	}
+}
+
+func TestMessageStorePutIsIdempotent(t *testing.T) {
+	// Duplicate inserts must not error: whatsmeow can re-deliver
+	// messages on reconnect, and the outbound-then-echo cycle hits
+	// Put twice for the same id (once at send, once on the inbound
+	// echo we don't ignore).
+	ctx := context.Background()
+	s := newTestMessageStore(t)
+	if err := s.Put(ctx, "MSG1", "chat", "us", true); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+	// The conflict path must NOT overwrite the existing row's
+	// from_me — re-delivery from the same sender shouldn't downgrade
+	// "ours" to "theirs".  Try a "different" payload and verify the
+	// first one wins.
+	if err := s.Put(ctx, "MSG1", "chat2", "them", false); err != nil {
+		t.Fatalf("second Put: %v", err)
+	}
+	chat, sender, fromMe, err := s.Lookup(ctx, "MSG1")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if chat != "chat" || sender != "us" || !fromMe {
+		t.Errorf("idempotent Put: row was overwritten — got (%q, %q, %t)", chat, sender, fromMe)
+	}
+}

--- a/connectors/whatsapp/daemon/internal/wameow/msgstore_test.go
+++ b/connectors/whatsapp/daemon/internal/wameow/msgstore_test.go
@@ -53,22 +53,28 @@ func TestMessageStorePutLookup(t *testing.T) {
 	ctx := context.Background()
 	s := newTestMessageStore(t)
 
-	if err := s.Put(ctx, "MSG1", "chat@s.whatsapp.net", "sender@s.whatsapp.net", false); err != nil {
+	if err := s.Put(ctx, "MSG1", "chat@s.whatsapp.net", "sender@s.whatsapp.net", false, 12345, "hello"); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 
-	chat, sender, fromMe, err := s.Lookup(ctx, "MSG1")
+	rec, err := s.Lookup(ctx, "MSG1")
 	if err != nil {
 		t.Fatalf("Lookup: %v", err)
 	}
-	if chat != "chat@s.whatsapp.net" || sender != "sender@s.whatsapp.net" || fromMe {
-		t.Errorf("Lookup got (%q, %q, %t); want (chat@..., sender@..., false)", chat, sender, fromMe)
+	if rec.ChatJID != "chat@s.whatsapp.net" || rec.SenderJID != "sender@s.whatsapp.net" || rec.FromMe {
+		t.Errorf("Lookup got %+v; want chat/sender pair with FromMe=false", rec)
+	}
+	if rec.SentAtMs != 12345 {
+		t.Errorf("SentAtMs = %d, want 12345", rec.SentAtMs)
+	}
+	if rec.Text != "hello" {
+		t.Errorf("Text = %q, want %q", rec.Text, "hello")
 	}
 }
 
 func TestMessageStoreLookupNotFound(t *testing.T) {
 	s := newTestMessageStore(t)
-	_, _, _, err := s.Lookup(context.Background(), "DOES-NOT-EXIST")
+	_, err := s.Lookup(context.Background(), "DOES-NOT-EXIST")
 	if !errors.Is(err, ErrMessageNotFound) {
 		t.Errorf("Lookup miss returned %v, want ErrMessageNotFound", err)
 	}
@@ -81,21 +87,21 @@ func TestMessageStorePutIsIdempotent(t *testing.T) {
 	// echo we don't ignore).
 	ctx := context.Background()
 	s := newTestMessageStore(t)
-	if err := s.Put(ctx, "MSG1", "chat", "us", true); err != nil {
+	if err := s.Put(ctx, "MSG1", "chat", "us", true, 100, "first"); err != nil {
 		t.Fatalf("first Put: %v", err)
 	}
-	// The conflict path must NOT overwrite the existing row's
-	// from_me — re-delivery from the same sender shouldn't downgrade
-	// "ours" to "theirs".  Try a "different" payload and verify the
-	// first one wins.
-	if err := s.Put(ctx, "MSG1", "chat2", "them", false); err != nil {
+	// The conflict path must NOT overwrite the existing row — re-
+	// delivery from the same sender shouldn't downgrade "ours" to
+	// "theirs", and a later inbound carrying a duplicate id (rare but
+	// possible) shouldn't rewrite sent_at/text either.
+	if err := s.Put(ctx, "MSG1", "chat2", "them", false, 200, "second"); err != nil {
 		t.Fatalf("second Put: %v", err)
 	}
-	chat, sender, fromMe, err := s.Lookup(ctx, "MSG1")
+	rec, err := s.Lookup(ctx, "MSG1")
 	if err != nil {
 		t.Fatalf("Lookup: %v", err)
 	}
-	if chat != "chat" || sender != "us" || !fromMe {
-		t.Errorf("idempotent Put: row was overwritten — got (%q, %q, %t)", chat, sender, fromMe)
+	if rec.ChatJID != "chat" || rec.SenderJID != "us" || !rec.FromMe || rec.SentAtMs != 100 || rec.Text != "first" {
+		t.Errorf("idempotent Put: row was overwritten — got %+v", rec)
 	}
 }

--- a/connectors/whatsapp/daemon/internal/wameow/ops.go
+++ b/connectors/whatsapp/daemon/internal/wameow/ops.go
@@ -131,8 +131,19 @@ func (c *Client) Edit(ctx context.Context, msgID, newText string, mentionedJIDs 
 	if !rec.FromMe {
 		return "", 0, fmt.Errorf("edit %s: %w", msgID, ErrNotOwnMessage)
 	}
-	if elapsed := time.Now().UnixMilli() - rec.SentAtMs; rec.SentAtMs > 0 && elapsed > EditWindowMs {
-		return "", 0, fmt.Errorf("edit %s: %w (elapsed=%ds)", msgID, ErrEditWindowExpired, elapsed/1000)
+	if rec.SentAtMs > 0 {
+		elapsed := time.Now().UnixMilli() - rec.SentAtMs
+		// Negative elapsed = host clock went backwards between
+		// recordOutbound and now (NTP correction, VM resume from
+		// snapshot, container clock drift).  Refuse the edit rather
+		// than silently allow it: a negative value means we genuinely
+		// don't know how much wall-clock has passed.  The cluster's
+		// next NTP cycle straightens the clock and the operator can
+		// retry — preferable to letting an unbounded-age edit slip
+		// through the very guard we added to catch silent edit drops.
+		if elapsed < 0 || elapsed > EditWindowMs {
+			return "", 0, fmt.Errorf("edit %s: %w (elapsed=%ds)", msgID, ErrEditWindowExpired, elapsed/1000)
+		}
 	}
 	chat, err := types.ParseJID(rec.ChatJID)
 	if err != nil {

--- a/connectors/whatsapp/daemon/internal/wameow/ops.go
+++ b/connectors/whatsapp/daemon/internal/wameow/ops.go
@@ -1,0 +1,124 @@
+package wameow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+// IsNotFoundErr reports whether err is ErrMessageNotFound (the
+// daemon-side "I have no MessageKey for that id" signal).  Used by
+// the handler layer to map this case to ErrCodeInvalidParams so the
+// caller can distinguish it from a generic server failure.
+func (c *Client) IsNotFoundErr(err error) bool {
+	return errors.Is(err, ErrMessageNotFound)
+}
+
+// React sends (or clears) a reaction to a message we've previously
+// seen.  Passing an empty reaction string clears any prior reaction
+// from us on that message — that's whatsmeow's documented contract
+// and matches the WhatsApp client UI ("remove reaction").
+//
+// Returns the reaction message's own id + timestamp so the caller can
+// surface delivery confirmation.  The reaction is itself a sent
+// message; its id goes into the message store too, so the model can
+// later edit/revoke its own reactions if it wants.
+func (c *Client) React(ctx context.Context, msgID, emoji string) (string, int64, error) {
+	wa := c.wa.Load()
+	if !wa.IsConnected() {
+		return "", 0, errors.New("whatsmeow: not connected")
+	}
+	chatJIDStr, senderJIDStr, fromMe, err := c.msgs.Lookup(ctx, msgID)
+	if err != nil {
+		return "", 0, err
+	}
+	chat, err := types.ParseJID(chatJIDStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid chat jid %q: %w", chatJIDStr, err)
+	}
+	sender, err := types.ParseJID(senderJIDStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid sender jid %q: %w", senderJIDStr, err)
+	}
+	reaction := wa.BuildReaction(chat, sender, types.MessageID(msgID), emoji)
+	// BuildReaction internally sets FromMe via the Key — but it reads
+	// the fromMe flag off the SenderKeyDistributionMessage path, so
+	// we override the inner Key explicitly when reacting to our own
+	// messages to keep MessageKey unambiguous.
+	if fromMe && reaction.ReactionMessage != nil && reaction.ReactionMessage.Key != nil {
+		reaction.ReactionMessage.Key.FromMe = proto.Bool(true)
+	}
+	resp, err := wa.SendMessage(ctx, chat, reaction)
+	if err != nil {
+		return "", 0, err
+	}
+	c.recordOutbound(ctx, string(resp.ID), chat)
+	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
+}
+
+// Edit replaces the text of a previously-sent message.  WhatsApp only
+// allows editing your own outbound messages and only within ~15
+// minutes of the original send; whatsmeow surfaces the server's
+// rejection if either window is exceeded.
+func (c *Client) Edit(ctx context.Context, msgID, newText string) (string, int64, error) {
+	wa := c.wa.Load()
+	if !wa.IsConnected() {
+		return "", 0, errors.New("whatsmeow: not connected")
+	}
+	chatJIDStr, _, fromMe, err := c.msgs.Lookup(ctx, msgID)
+	if err != nil {
+		return "", 0, err
+	}
+	if !fromMe {
+		return "", 0, fmt.Errorf("edit refused: message %s was not sent by us", msgID)
+	}
+	chat, err := types.ParseJID(chatJIDStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid chat jid %q: %w", chatJIDStr, err)
+	}
+	newContent := &waE2E.Message{Conversation: proto.String(newText)}
+	edit := wa.BuildEdit(chat, types.MessageID(msgID), newContent)
+	resp, err := wa.SendMessage(ctx, chat, edit)
+	if err != nil {
+		return "", 0, err
+	}
+	c.recordOutbound(ctx, string(resp.ID), chat)
+	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
+}
+
+// Revoke deletes a message ("delete for everyone").  Like Edit, only
+// works on our own outbound messages — and whatsmeow's BuildRevoke
+// expects that constraint upstream, so we enforce it here rather than
+// letting the server reject with an opaque error.
+func (c *Client) Revoke(ctx context.Context, msgID string) (string, int64, error) {
+	wa := c.wa.Load()
+	if !wa.IsConnected() {
+		return "", 0, errors.New("whatsmeow: not connected")
+	}
+	chatJIDStr, senderJIDStr, fromMe, err := c.msgs.Lookup(ctx, msgID)
+	if err != nil {
+		return "", 0, err
+	}
+	if !fromMe {
+		return "", 0, fmt.Errorf("revoke refused: message %s was not sent by us", msgID)
+	}
+	chat, err := types.ParseJID(chatJIDStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid chat jid %q: %w", chatJIDStr, err)
+	}
+	sender, err := types.ParseJID(senderJIDStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid sender jid %q: %w", senderJIDStr, err)
+	}
+	revoke := wa.BuildRevoke(chat, sender, types.MessageID(msgID))
+	resp, err := wa.SendMessage(ctx, chat, revoke)
+	if err != nil {
+		return "", 0, err
+	}
+	c.recordOutbound(ctx, string(resp.ID), chat)
+	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
+}

--- a/connectors/whatsapp/daemon/internal/wameow/ops.go
+++ b/connectors/whatsapp/daemon/internal/wameow/ops.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"google.golang.org/protobuf/proto"
 )
@@ -66,6 +65,10 @@ func (c *Client) React(ctx context.Context, msgID, emoji string) (string, int64,
 		return "", 0, err
 	}
 	c.recordOutbound(ctx, wa, string(resp.ID), chat)
+	// Reactions are bot-initiated outbound activity to the chat;
+	// the prior peer messages should be marked read just like a
+	// text reply via sendOne would do.
+	c.flushReadReceipts(ctx, wa, chat)
 	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
 }
 
@@ -73,7 +76,13 @@ func (c *Client) React(ctx context.Context, msgID, emoji string) (string, int64,
 // allows editing your own outbound messages and only within ~15
 // minutes of the original send; whatsmeow surfaces the server's
 // rejection if either window is exceeded.
-func (c *Client) Edit(ctx context.Context, msgID, newText string) (string, int64, error) {
+//
+// ``mentionedJIDs`` rides on the new content's ContextInfo so an edit
+// that introduces or rewrites an @-mention renders as a pill on the
+// peer's WhatsApp UI — without this, edits silently strip the
+// MentionedJID list even when the model embeds ``@<E.164>`` in the
+// new text.
+func (c *Client) Edit(ctx context.Context, msgID, newText string, mentionedJIDs []string) (string, int64, error) {
 	if newText == "" {
 		// An empty edit blanks the peer's view of the message — that
 		// almost certainly isn't the model's intent; reject explicitly
@@ -96,13 +105,14 @@ func (c *Client) Edit(ctx context.Context, msgID, newText string) (string, int64
 	if err != nil {
 		return "", 0, fmt.Errorf("invalid chat jid %q: %w", chatJIDStr, err)
 	}
-	newContent := &waE2E.Message{Conversation: proto.String(newText)}
+	newContent := buildTextMessage(newText, mentionedJIDs)
 	edit := wa.BuildEdit(chat, types.MessageID(msgID), newContent)
 	resp, err := wa.SendMessage(ctx, chat, edit)
 	if err != nil {
 		return "", 0, err
 	}
 	c.recordOutbound(ctx, wa, string(resp.ID), chat)
+	c.flushReadReceipts(ctx, wa, chat)
 	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
 }
 
@@ -136,5 +146,6 @@ func (c *Client) Revoke(ctx context.Context, msgID string) (string, int64, error
 		return "", 0, err
 	}
 	c.recordOutbound(ctx, wa, string(resp.ID), chat)
+	c.flushReadReceipts(ctx, wa, chat)
 	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
 }

--- a/connectors/whatsapp/daemon/internal/wameow/ops.go
+++ b/connectors/whatsapp/daemon/internal/wameow/ops.go
@@ -4,10 +4,29 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.mau.fi/whatsmeow/types"
 	"google.golang.org/protobuf/proto"
 )
+
+// EditWindowMs is the maximum age in milliseconds at which WhatsApp's
+// servers will still apply an edit.  whatsmeow does NOT surface the
+// server's rejection of an out-of-window edit (the server accepts the
+// envelope and silently drops the change), so the daemon enforces the
+// window client-side: an edit attempt past this age returns
+// ErrEditWindowExpired before BuildEdit/SendMessage even runs.
+//
+// The official WhatsApp limit is 15 minutes; we leave 30 s of slack
+// for clock skew between the daemon host and WhatsApp's edge.
+const EditWindowMs = 15*60*1000 - 30*1000
+
+// ErrEditWindowExpired is returned by :func:`Client.Edit` when the
+// target message is older than :const:`EditWindowMs`.  Surfaced to the
+// model as a clear "outside edit window" rather than a misleading
+// success — pre-fix the tool returned a stale envelope id and the
+// model believed the edit had landed.
+var ErrEditWindowExpired = errors.New("edit refused: outside 15-minute window")
 
 // IsNotFoundErr reports whether err is ErrMessageNotFound (the
 // daemon-side "I have no MessageKey for that id" signal).  Used by
@@ -40,31 +59,31 @@ func (c *Client) React(ctx context.Context, msgID, emoji string) (string, int64,
 	if !wa.IsConnected() {
 		return "", 0, errors.New("whatsmeow: not connected")
 	}
-	chatJIDStr, senderJIDStr, fromMe, err := c.msgs.Lookup(ctx, msgID)
+	rec, err := c.msgs.Lookup(ctx, msgID)
 	if err != nil {
 		return "", 0, err
 	}
-	chat, err := types.ParseJID(chatJIDStr)
+	chat, err := types.ParseJID(rec.ChatJID)
 	if err != nil {
-		return "", 0, fmt.Errorf("invalid chat jid %q: %w", chatJIDStr, err)
+		return "", 0, fmt.Errorf("invalid chat jid %q: %w", rec.ChatJID, err)
 	}
-	sender, err := types.ParseJID(senderJIDStr)
+	sender, err := types.ParseJID(rec.SenderJID)
 	if err != nil {
-		return "", 0, fmt.Errorf("invalid sender jid %q: %w", senderJIDStr, err)
+		return "", 0, fmt.Errorf("invalid sender jid %q: %w", rec.SenderJID, err)
 	}
 	reaction := wa.BuildReaction(chat, sender, types.MessageID(msgID), emoji)
 	// BuildReaction internally sets FromMe via the Key — but it reads
 	// the fromMe flag off the SenderKeyDistributionMessage path, so
 	// we override the inner Key explicitly when reacting to our own
 	// messages to keep MessageKey unambiguous.
-	if fromMe && reaction.ReactionMessage != nil && reaction.ReactionMessage.Key != nil {
+	if rec.FromMe && reaction.ReactionMessage != nil && reaction.ReactionMessage.Key != nil {
 		reaction.ReactionMessage.Key.FromMe = proto.Bool(true)
 	}
 	resp, err := wa.SendMessage(ctx, chat, reaction)
 	if err != nil {
 		return "", 0, err
 	}
-	c.recordOutbound(ctx, wa, string(resp.ID), chat)
+	c.recordOutbound(ctx, wa, string(resp.ID), chat, resp.Timestamp.UnixMilli(), emoji)
 	// Reactions are bot-initiated outbound activity to the chat;
 	// the prior peer messages should be marked read just like a
 	// text reply via sendOne would do.
@@ -74,14 +93,25 @@ func (c *Client) React(ctx context.Context, msgID, emoji string) (string, int64,
 
 // Edit replaces the text of a previously-sent message.  WhatsApp only
 // allows editing your own outbound messages and only within ~15
-// minutes of the original send; whatsmeow surfaces the server's
-// rejection if either window is exceeded.
+// minutes of the original send.  Despite an earlier comment here
+// claiming otherwise, whatsmeow does NOT surface the server's silent
+// drop of an out-of-window edit — the protocol-message envelope is
+// acknowledged at the wire level but the recipient's WhatsApp client
+// never renders the change.  We therefore enforce the window
+// client-side using the ``sent_at`` we stamped at recordOutbound time:
+// an attempt past :const:`EditWindowMs` returns :var:`ErrEditWindowExpired`
+// before BuildEdit/SendMessage runs.
 //
 // ``mentionedJIDs`` rides on the new content's ContextInfo so an edit
 // that introduces or rewrites an @-mention renders as a pill on the
 // peer's WhatsApp UI — without this, edits silently strip the
 // MentionedJID list even when the model embeds ``@<E.164>`` in the
 // new text.
+//
+// Returns the ORIGINAL target ``msgID`` (not the edit-envelope's id) so
+// the model can verify which message its edit applied to.  Pre-fix the
+// daemon returned the envelope id, which has no meaning to a model
+// that only knows the target.
 func (c *Client) Edit(ctx context.Context, msgID, newText string, mentionedJIDs []string) (string, int64, error) {
 	if newText == "" {
 		// An empty edit blanks the peer's view of the message — that
@@ -94,58 +124,71 @@ func (c *Client) Edit(ctx context.Context, msgID, newText string, mentionedJIDs 
 	if !wa.IsConnected() {
 		return "", 0, errors.New("whatsmeow: not connected")
 	}
-	chatJIDStr, _, fromMe, err := c.msgs.Lookup(ctx, msgID)
+	rec, err := c.msgs.Lookup(ctx, msgID)
 	if err != nil {
 		return "", 0, err
 	}
-	if !fromMe {
+	if !rec.FromMe {
 		return "", 0, fmt.Errorf("edit %s: %w", msgID, ErrNotOwnMessage)
 	}
-	chat, err := types.ParseJID(chatJIDStr)
-	if err != nil {
-		return "", 0, fmt.Errorf("invalid chat jid %q: %w", chatJIDStr, err)
+	if elapsed := time.Now().UnixMilli() - rec.SentAtMs; rec.SentAtMs > 0 && elapsed > EditWindowMs {
+		return "", 0, fmt.Errorf("edit %s: %w (elapsed=%ds)", msgID, ErrEditWindowExpired, elapsed/1000)
 	}
-	newContent := buildTextMessage(newText, mentionedJIDs)
+	chat, err := types.ParseJID(rec.ChatJID)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid chat jid %q: %w", rec.ChatJID, err)
+	}
+	// Edits don't carry their own quote pointer — the edit replaces
+	// the body of an existing message; the original message keeps
+	// whatever quote pointer it already had.
+	newContent := buildTextMessage(newText, mentionedJIDs, nil)
 	edit := wa.BuildEdit(chat, types.MessageID(msgID), newContent)
 	resp, err := wa.SendMessage(ctx, chat, edit)
 	if err != nil {
 		return "", 0, err
 	}
-	c.recordOutbound(ctx, wa, string(resp.ID), chat)
+	c.recordOutbound(ctx, wa, string(resp.ID), chat, resp.Timestamp.UnixMilli(), newText)
 	c.flushReadReceipts(ctx, wa, chat)
-	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
+	return msgID, resp.Timestamp.UnixMilli(), nil
 }
 
 // Revoke deletes a message ("delete for everyone").  Like Edit, only
 // works on our own outbound messages — and whatsmeow's BuildRevoke
 // expects that constraint upstream, so we enforce it here rather than
 // letting the server reject with an opaque error.
+//
+// Returns the ORIGINAL target ``msgID`` (not the revoke-envelope id)
+// so the model can confirm which message was revoked — symmetric with
+// :func:`Client.Edit`.  WhatsApp's revoke window is wider than the
+// edit window (~2 days) and is left unguarded here; if smoke surfaces
+// silently-failing revokes past that, add a guard mirroring
+// :var:`ErrEditWindowExpired`.
 func (c *Client) Revoke(ctx context.Context, msgID string) (string, int64, error) {
 	wa := c.wa.Load()
 	if !wa.IsConnected() {
 		return "", 0, errors.New("whatsmeow: not connected")
 	}
-	chatJIDStr, senderJIDStr, fromMe, err := c.msgs.Lookup(ctx, msgID)
+	rec, err := c.msgs.Lookup(ctx, msgID)
 	if err != nil {
 		return "", 0, err
 	}
-	if !fromMe {
+	if !rec.FromMe {
 		return "", 0, fmt.Errorf("revoke %s: %w", msgID, ErrNotOwnMessage)
 	}
-	chat, err := types.ParseJID(chatJIDStr)
+	chat, err := types.ParseJID(rec.ChatJID)
 	if err != nil {
-		return "", 0, fmt.Errorf("invalid chat jid %q: %w", chatJIDStr, err)
+		return "", 0, fmt.Errorf("invalid chat jid %q: %w", rec.ChatJID, err)
 	}
-	sender, err := types.ParseJID(senderJIDStr)
+	sender, err := types.ParseJID(rec.SenderJID)
 	if err != nil {
-		return "", 0, fmt.Errorf("invalid sender jid %q: %w", senderJIDStr, err)
+		return "", 0, fmt.Errorf("invalid sender jid %q: %w", rec.SenderJID, err)
 	}
 	revoke := wa.BuildRevoke(chat, sender, types.MessageID(msgID))
 	resp, err := wa.SendMessage(ctx, chat, revoke)
 	if err != nil {
 		return "", 0, err
 	}
-	c.recordOutbound(ctx, wa, string(resp.ID), chat)
+	c.recordOutbound(ctx, wa, string(resp.ID), chat, resp.Timestamp.UnixMilli(), "")
 	c.flushReadReceipts(ctx, wa, chat)
-	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
+	return msgID, resp.Timestamp.UnixMilli(), nil
 }

--- a/connectors/whatsapp/daemon/internal/wameow/ops.go
+++ b/connectors/whatsapp/daemon/internal/wameow/ops.go
@@ -18,6 +18,15 @@ func (c *Client) IsNotFoundErr(err error) bool {
 	return errors.Is(err, ErrMessageNotFound)
 }
 
+// IsNotOwnMessageErr reports whether err is ErrNotOwnMessage (the
+// "target message exists but was sent by a peer, not by us"
+// precondition refusal for Edit/Revoke).  Same handler treatment as
+// IsNotFoundErr: maps to ErrCodeInvalidParams so the model sees a
+// clear "wrong target" rather than a generic server error.
+func (c *Client) IsNotOwnMessageErr(err error) bool {
+	return errors.Is(err, ErrNotOwnMessage)
+}
+
 // React sends (or clears) a reaction to a message we've previously
 // seen.  Passing an empty reaction string clears any prior reaction
 // from us on that message — that's whatsmeow's documented contract
@@ -56,7 +65,7 @@ func (c *Client) React(ctx context.Context, msgID, emoji string) (string, int64,
 	if err != nil {
 		return "", 0, err
 	}
-	c.recordOutbound(ctx, string(resp.ID), chat)
+	c.recordOutbound(ctx, wa, string(resp.ID), chat)
 	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
 }
 
@@ -65,6 +74,13 @@ func (c *Client) React(ctx context.Context, msgID, emoji string) (string, int64,
 // minutes of the original send; whatsmeow surfaces the server's
 // rejection if either window is exceeded.
 func (c *Client) Edit(ctx context.Context, msgID, newText string) (string, int64, error) {
+	if newText == "" {
+		// An empty edit blanks the peer's view of the message — that
+		// almost certainly isn't the model's intent; reject explicitly
+		// rather than silently push a blank bubble.  The model can
+		// call whatsapp_delete_message if it wants the message gone.
+		return "", 0, errors.New("edit refused: new text is empty (use whatsapp_delete_message to revoke instead)")
+	}
 	wa := c.wa.Load()
 	if !wa.IsConnected() {
 		return "", 0, errors.New("whatsmeow: not connected")
@@ -74,7 +90,7 @@ func (c *Client) Edit(ctx context.Context, msgID, newText string) (string, int64
 		return "", 0, err
 	}
 	if !fromMe {
-		return "", 0, fmt.Errorf("edit refused: message %s was not sent by us", msgID)
+		return "", 0, fmt.Errorf("edit %s: %w", msgID, ErrNotOwnMessage)
 	}
 	chat, err := types.ParseJID(chatJIDStr)
 	if err != nil {
@@ -86,7 +102,7 @@ func (c *Client) Edit(ctx context.Context, msgID, newText string) (string, int64
 	if err != nil {
 		return "", 0, err
 	}
-	c.recordOutbound(ctx, string(resp.ID), chat)
+	c.recordOutbound(ctx, wa, string(resp.ID), chat)
 	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
 }
 
@@ -104,7 +120,7 @@ func (c *Client) Revoke(ctx context.Context, msgID string) (string, int64, error
 		return "", 0, err
 	}
 	if !fromMe {
-		return "", 0, fmt.Errorf("revoke refused: message %s was not sent by us", msgID)
+		return "", 0, fmt.Errorf("revoke %s: %w", msgID, ErrNotOwnMessage)
 	}
 	chat, err := types.ParseJID(chatJIDStr)
 	if err != nil {
@@ -119,6 +135,6 @@ func (c *Client) Revoke(ctx context.Context, msgID string) (string, int64, error
 	if err != nil {
 		return "", 0, err
 	}
-	c.recordOutbound(ctx, string(resp.ID), chat)
+	c.recordOutbound(ctx, wa, string(resp.ID), chat)
 	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
 }

--- a/connectors/whatsapp/daemon/internal/wameow/outbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/outbound.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/proto/waE2E"
@@ -159,7 +160,41 @@ func (c *Client) sendOne(ctx context.Context, wa *whatsmeow.Client, jid types.JI
 		return "", 0, err
 	}
 	c.recordOutbound(ctx, wa, string(resp.ID), jid)
+	// Implicit receipts-after-emit: the bot's reply means it has
+	// "read" the prior peer messages in this chat.  Done after the
+	// send succeeds so a failed send doesn't burn the read state.
+	c.flushReadReceipts(ctx, wa, jid)
 	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
+}
+
+// flushReadReceipts drains the per-chat unread queue and issues a
+// single MarkRead covering all peer messages.  Best-effort: a
+// MarkRead failure logs but doesn't fail the send (the message
+// already went through; failing the RPC would mislead the caller).
+func (c *Client) flushReadReceipts(ctx context.Context, wa *whatsmeow.Client, chat types.JID) {
+	keys := c.drainUnread(chat.String())
+	if len(keys) == 0 {
+		return
+	}
+	// WhatsApp's MarkRead takes a single sender JID, so we group by
+	// sender.  In a DM, all entries share the peer's JID; in a
+	// group, different participants may have different sender JIDs
+	// and need separate calls.
+	bySender := make(map[string][]types.MessageID)
+	for _, k := range keys {
+		bySender[k.sender] = append(bySender[k.sender], types.MessageID(k.id))
+	}
+	now := time.Now()
+	for senderStr, ids := range bySender {
+		sender, err := types.ParseJID(senderStr)
+		if err != nil {
+			c.log.Warn("wameow.mark_read.bad_sender", "sender", senderStr, "err", err)
+			continue
+		}
+		if err := wa.MarkRead(ctx, ids, now, chat, sender); err != nil {
+			c.log.Warn("wameow.mark_read_failed", "chat", chat, "sender", senderStr, "err", err)
+		}
+	}
 }
 
 // buildTextMessage shapes a text-only outbound message, attaching a

--- a/connectors/whatsapp/daemon/internal/wameow/outbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/outbound.go
@@ -67,10 +67,14 @@ func (c *Client) SendMessage(
 	var firstTS int64
 	delivered := make([]string, 0, len(attachments)+1)
 	captionForFirstAttachment := text
+	firstAttachmentMentions := mentionedJIDs
 	if text != "" && classify(attachments[0].Mimetype) == attachKindAudio {
 		// Audio carries no caption surface.  Send the text as its
-		// own Conversation message FIRST so it isn't silently
-		// dropped, then send the audio caption-less.
+		// own Conversation message FIRST (taking the mentions with
+		// it so they render as a pill), then send the audio
+		// caption-less AND mention-less — without the mention-clear
+		// here, the audio's ContextInfo would carry MentionedJID
+		// too and the peer would get a duplicate @-notification.
 		textMsg := buildTextMessage(text, mentionedJIDs)
 		id, ts, sendErr := c.sendOne(ctx, wa, jid, textMsg)
 		if sendErr != nil {
@@ -79,6 +83,7 @@ func (c *Client) SendMessage(
 		delivered = append(delivered, id)
 		firstTS = ts
 		captionForFirstAttachment = ""
+		firstAttachmentMentions = nil
 	}
 
 	for i, att := range attachments {
@@ -86,7 +91,7 @@ func (c *Client) SendMessage(
 		var captionMentions []string
 		if i == 0 {
 			caption = captionForFirstAttachment
-			captionMentions = mentionedJIDs
+			captionMentions = firstAttachmentMentions
 		}
 		msg, buildErr := c.buildAttachmentMessage(ctx, wa, att, caption, captionMentions)
 		if buildErr != nil {

--- a/connectors/whatsapp/daemon/internal/wameow/outbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/outbound.go
@@ -50,13 +50,21 @@ func (c *Client) SendMessage(
 	jidStr, text string,
 	attachments []Attachment,
 	mentionedJIDs []string,
+	quotedMessageID string,
 ) ([]string, int64, error) {
 	wa, jid, err := c.prepareSend(jidStr)
 	if err != nil {
 		return nil, 0, err
 	}
+	// Quote rides on the FIRST outbound only (text-message or first
+	// attachment).  Subsequent attachments in a multi-attachment send
+	// are sibling messages, not the reply itself.
+	quoteCtx, err := c.buildQuoteContextInfo(ctx, quotedMessageID)
+	if err != nil {
+		return nil, 0, err
+	}
 	if len(attachments) == 0 {
-		msg := buildTextMessage(text, mentionedJIDs)
+		msg := buildTextMessage(text, mentionedJIDs, quoteCtx)
 		id, ts, sendErr := c.sendOne(ctx, wa, jid, msg)
 		if sendErr != nil {
 			return nil, 0, sendErr
@@ -68,14 +76,16 @@ func (c *Client) SendMessage(
 	delivered := make([]string, 0, len(attachments)+1)
 	captionForFirstAttachment := text
 	firstAttachmentMentions := mentionedJIDs
+	firstAttachmentQuote := quoteCtx
 	if text != "" && classify(attachments[0].Mimetype) == attachKindAudio {
 		// Audio carries no caption surface.  Send the text as its
-		// own Conversation message FIRST (taking the mentions with
-		// it so they render as a pill), then send the audio
-		// caption-less AND mention-less — without the mention-clear
-		// here, the audio's ContextInfo would carry MentionedJID
-		// too and the peer would get a duplicate @-notification.
-		textMsg := buildTextMessage(text, mentionedJIDs)
+		// own Conversation message FIRST (taking the mentions AND
+		// quote with it so the reply pointer attaches to the text
+		// bubble the user actually reads), then send the audio
+		// caption-less, mention-less, AND quote-less — without the
+		// clear here, the audio's ContextInfo would carry duplicate
+		// MentionedJID + quote pointers.
+		textMsg := buildTextMessage(text, mentionedJIDs, quoteCtx)
 		id, ts, sendErr := c.sendOne(ctx, wa, jid, textMsg)
 		if sendErr != nil {
 			return nil, 0, fmt.Errorf("send accompanying text for audio: %w", sendErr)
@@ -84,16 +94,19 @@ func (c *Client) SendMessage(
 		firstTS = ts
 		captionForFirstAttachment = ""
 		firstAttachmentMentions = nil
+		firstAttachmentQuote = nil
 	}
 
 	for i, att := range attachments {
 		caption := ""
 		var captionMentions []string
+		var captionQuote *waE2E.ContextInfo
 		if i == 0 {
 			caption = captionForFirstAttachment
 			captionMentions = firstAttachmentMentions
+			captionQuote = firstAttachmentQuote
 		}
-		msg, buildErr := c.buildAttachmentMessage(ctx, wa, att, caption, captionMentions)
+		msg, buildErr := c.buildAttachmentMessage(ctx, wa, att, caption, captionMentions, captionQuote)
 		if buildErr != nil {
 			return delivered, firstTS, &PartialSendError{
 				Cause: buildErr, DeliveredIDs: append([]string{}, delivered...),
@@ -113,6 +126,36 @@ func (c *Client) SendMessage(
 		}
 	}
 	return delivered, firstTS, nil
+}
+
+// buildQuoteContextInfo looks up the target message and returns a
+// partial ``ContextInfo`` carrying ``StanzaID``, ``Participant``, and a
+// minimal ``QuotedMessage`` stub.  Returns nil ContextInfo + nil error
+// when ``quotedMessageID`` is empty (the common "not a reply" case).
+//
+// Returns ErrMessageNotFound when the model passed an id that isn't in
+// the msgstore — fail loud rather than silently strip the quote, so
+// the model can retry with a known target.
+func (c *Client) buildQuoteContextInfo(ctx context.Context, quotedMessageID string) (*waE2E.ContextInfo, error) {
+	if quotedMessageID == "" {
+		return nil, nil
+	}
+	rec, err := c.msgs.Lookup(ctx, quotedMessageID)
+	if err != nil {
+		return nil, fmt.Errorf("quote target %s: %w", quotedMessageID, err)
+	}
+	ci := &waE2E.ContextInfo{
+		StanzaID:    proto.String(quotedMessageID),
+		Participant: proto.String(rec.SenderJID),
+		// Minimal QuotedMessage stub.  WhatsApp clients render the
+		// reply bubble using StanzaID for the pointer; the
+		// QuotedMessage body populates the snippet preview above the
+		// reply.  Empty text (e.g. quoting a sticker we recorded with
+		// "") falls back to "Quoted message unavailable" on the peer
+		// side — better than silently dropping the quote pointer.
+		QuotedMessage: &waE2E.Message{Conversation: proto.String(rec.Text)},
+	}
+	return ci, nil
 }
 
 // PartialSendError wraps a mid-loop multi-attachment failure with the
@@ -164,7 +207,7 @@ func (c *Client) sendOne(ctx context.Context, wa *whatsmeow.Client, jid types.JI
 	if err != nil {
 		return "", 0, err
 	}
-	c.recordOutbound(ctx, wa, string(resp.ID), jid)
+	c.recordOutbound(ctx, wa, string(resp.ID), jid, resp.Timestamp.UnixMilli(), extractText(msg))
 	// Implicit receipts-after-emit: the bot's reply means it has
 	// "read" the prior peer messages in this chat.  Done after the
 	// send succeeds so a failed send doesn't burn the read state.
@@ -203,19 +246,19 @@ func (c *Client) flushReadReceipts(ctx context.Context, wa *whatsmeow.Client, ch
 }
 
 // buildTextMessage shapes a text-only outbound message, attaching a
-// ContextInfo.MentionedJID list when the model has @-tagged anyone.
-// WhatsApp clients render the mentions as pills if the JIDs resolve
-// to chat participants; non-participants fall through as plain text.
-func buildTextMessage(text string, mentionedJIDs []string) *waE2E.Message {
-	if len(mentionedJIDs) == 0 {
+// ContextInfo carrying ``MentionedJID`` (so WhatsApp clients render
+// @-mentions as pills) and/or the quote pointer fields when the model
+// requested a threaded reply.  When neither applies the message uses
+// the plain Conversation form to keep ContextInfo off the wire.
+func buildTextMessage(text string, mentionedJIDs []string, quoteCtx *waE2E.ContextInfo) *waE2E.Message {
+	ci := mergeMentionAndQuote(mentionedJIDs, quoteCtx)
+	if ci == nil {
 		return &waE2E.Message{Conversation: proto.String(text)}
 	}
 	return &waE2E.Message{
 		ExtendedTextMessage: &waE2E.ExtendedTextMessage{
-			Text: proto.String(text),
-			ContextInfo: &waE2E.ContextInfo{
-				MentionedJID: mentionedJIDs,
-			},
+			Text:        proto.String(text),
+			ContextInfo: ci,
 		},
 	}
 }
@@ -226,6 +269,7 @@ func (c *Client) buildAttachmentMessage(
 	att Attachment,
 	caption string,
 	captionMentions []string,
+	quoteCtx *waE2E.ContextInfo,
 ) (*waE2E.Message, error) {
 	data, err := os.ReadFile(att.Path)
 	if err != nil {
@@ -238,7 +282,7 @@ func (c *Client) buildAttachmentMessage(
 	}
 	size := uint64(len(data))
 	mime := att.Mimetype
-	ctxInfo := maybeMentionContextInfo(captionMentions)
+	ctxInfo := mergeMentionAndQuote(captionMentions, quoteCtx)
 
 	switch kind {
 	case attachKindImage:
@@ -302,15 +346,30 @@ func (c *Client) buildAttachmentMessage(
 	}
 }
 
-// maybeMentionContextInfo builds a ContextInfo populated only with
-// MentionedJID, or nil when no mentions need to ride on this
-// submessage.  Returning nil keeps unrelated ContextInfo fields off
-// the wire.
-func maybeMentionContextInfo(mentionedJIDs []string) *waE2E.ContextInfo {
-	if len(mentionedJIDs) == 0 {
+// mergeMentionAndQuote combines optional MentionedJID + quote-pointer
+// fields into a single ContextInfo, or returns nil when neither is
+// populated.  Keeping a single helper means the four buildAttachment
+// arms + buildTextMessage stay consistent about which sub-fields ride
+// on the wire — a divergence here would manifest as "quote works on
+// text but not on image captions" or vice versa.
+func mergeMentionAndQuote(mentionedJIDs []string, quoteCtx *waE2E.ContextInfo) *waE2E.ContextInfo {
+	if len(mentionedJIDs) == 0 && quoteCtx == nil {
 		return nil
 	}
-	return &waE2E.ContextInfo{MentionedJID: mentionedJIDs}
+	ci := &waE2E.ContextInfo{}
+	if quoteCtx != nil {
+		// Copy the quote-pointer fields into the shared ContextInfo
+		// rather than ovewriting.  buildQuoteContextInfo only ever
+		// populates StanzaID / Participant / QuotedMessage so this is
+		// safe; if it grows more fields, update this merge.
+		ci.StanzaID = quoteCtx.StanzaID
+		ci.Participant = quoteCtx.Participant
+		ci.QuotedMessage = quoteCtx.QuotedMessage
+	}
+	if len(mentionedJIDs) > 0 {
+		ci.MentionedJID = mentionedJIDs
+	}
+	return ci
 }
 
 type attachKind int

--- a/connectors/whatsapp/daemon/internal/wameow/outbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/outbound.go
@@ -33,53 +33,109 @@ type Attachment struct {
 // One or more attachments: WhatsApp has no media-group equivalent,
 // so each attachment becomes its own message.  Caption (= text)
 // rides on the first attachment only; subsequent attachments arrive
-// caption-less.  Returns the FIRST send's id+timestamp — for the
-// caption-bearing path that's the most useful confirmation handle
-// for the model.  All-or-nothing semantics are impossible at the
-// WhatsApp protocol level (no atomic batch send); a mid-loop
-// failure leaves the already-sent attachments delivered and
-// surfaces an error that names which attachment failed.
+// caption-less.  Exception: WhatsApp's AudioMessage proto has no
+// Caption field — when text is non-empty AND the first attachment is
+// audio, the text is sent as a separate Conversation message first
+// so it isn't silently dropped on the wire.
+//
+// Returns the FULL slice of delivered message_ids (in send order)
+// plus the FIRST send's timestamp.  All-or-nothing semantics are
+// impossible at the WhatsApp protocol level (no atomic batch send);
+// a mid-loop failure returns a *PartialSendError carrying the ids
+// that DID make it onto the wire, so the model can still
+// react/edit/revoke each delivered attachment by id.
 func (c *Client) SendMessage(
 	ctx context.Context,
 	jidStr, text string,
 	attachments []Attachment,
-) (string, int64, error) {
+) ([]string, int64, error) {
 	wa, jid, err := c.prepareSend(jidStr)
 	if err != nil {
-		return "", 0, err
+		return nil, 0, err
 	}
 	if len(attachments) == 0 {
 		msg := &waE2E.Message{Conversation: proto.String(text)}
-		return c.sendOne(ctx, wa, jid, msg)
+		id, ts, sendErr := c.sendOne(ctx, wa, jid, msg)
+		if sendErr != nil {
+			return nil, 0, sendErr
+		}
+		return []string{id}, ts, nil
 	}
 
-	var firstID string
 	var firstTS int64
+	delivered := make([]string, 0, len(attachments)+1)
+	captionForFirstAttachment := text
+	if text != "" && classify(attachments[0].Mimetype) == attachKindAudio {
+		// Audio carries no caption surface.  Send the text as its
+		// own Conversation message FIRST so it isn't silently
+		// dropped, then send the audio caption-less.
+		textMsg := &waE2E.Message{Conversation: proto.String(text)}
+		id, ts, sendErr := c.sendOne(ctx, wa, jid, textMsg)
+		if sendErr != nil {
+			return nil, 0, fmt.Errorf("send accompanying text for audio: %w", sendErr)
+		}
+		delivered = append(delivered, id)
+		firstTS = ts
+		captionForFirstAttachment = ""
+	}
+
 	for i, att := range attachments {
 		caption := ""
 		if i == 0 {
-			caption = text
+			caption = captionForFirstAttachment
 		}
 		msg, buildErr := c.buildAttachmentMessage(ctx, wa, att, caption)
 		if buildErr != nil {
-			return firstID, firstTS, attachmentSendError(i, att.Filename, firstID, buildErr)
+			return delivered, firstTS, &PartialSendError{
+				Cause: buildErr, DeliveredIDs: append([]string{}, delivered...),
+				FailedIndex: i, FailedFilename: att.Filename,
+			}
 		}
 		id, ts, sendErr := c.sendOne(ctx, wa, jid, msg)
 		if sendErr != nil {
-			return firstID, firstTS, attachmentSendError(i, att.Filename, firstID, sendErr)
+			return delivered, firstTS, &PartialSendError{
+				Cause: sendErr, DeliveredIDs: append([]string{}, delivered...),
+				FailedIndex: i, FailedFilename: att.Filename,
+			}
 		}
-		if i == 0 {
-			firstID, firstTS = id, ts
+		delivered = append(delivered, id)
+		if firstTS == 0 {
+			firstTS = ts
 		}
 	}
-	return firstID, firstTS, nil
+	return delivered, firstTS, nil
 }
 
-func attachmentSendError(index int, filename, deliveredFirstID string, cause error) error {
-	if deliveredFirstID != "" {
-		return fmt.Errorf("attachment %d (%s): %w (first attachment %s already delivered)", index, filename, cause, deliveredFirstID)
+// PartialSendError wraps a mid-loop multi-attachment failure with the
+// ids that DID make it onto the wire before the loop aborted.  The
+// handler layer surfaces these ids via rpc.Error.Data so the model
+// can reference the delivered attachments by id (for react/edit/
+// revoke) instead of treating the partial delivery as a complete
+// loss.
+type PartialSendError struct {
+	Cause          error
+	DeliveredIDs   []string
+	FailedIndex    int
+	FailedFilename string
+}
+
+func (e *PartialSendError) Error() string {
+	if len(e.DeliveredIDs) > 0 {
+		return fmt.Sprintf(
+			"attachment %d (%s): %v (delivered ids before failure: %v)",
+			e.FailedIndex, e.FailedFilename, e.Cause, e.DeliveredIDs,
+		)
 	}
-	return fmt.Errorf("attachment %d (%s): %w", index, filename, cause)
+	return fmt.Sprintf("attachment %d (%s): %v", e.FailedIndex, e.FailedFilename, e.Cause)
+}
+
+func (e *PartialSendError) Unwrap() error { return e.Cause }
+
+// Partial fulfils the duck-typed interface that handler/send.go
+// expects via errors.As, keeping the handler package decoupled from
+// the wameow concrete type.
+func (e *PartialSendError) Partial() (delivered []string, failedIndex int, failedFilename string) {
+	return e.DeliveredIDs, e.FailedIndex, e.FailedFilename
 }
 
 func (c *Client) prepareSend(jidStr string) (*whatsmeow.Client, types.JID, error) {
@@ -99,7 +155,7 @@ func (c *Client) sendOne(ctx context.Context, wa *whatsmeow.Client, jid types.JI
 	if err != nil {
 		return "", 0, err
 	}
-	c.recordOutbound(ctx, string(resp.ID), jid)
+	c.recordOutbound(ctx, wa, string(resp.ID), jid)
 	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
 }
 

--- a/connectors/whatsapp/daemon/internal/wameow/outbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/outbound.go
@@ -48,13 +48,14 @@ func (c *Client) SendMessage(
 	ctx context.Context,
 	jidStr, text string,
 	attachments []Attachment,
+	mentionedJIDs []string,
 ) ([]string, int64, error) {
 	wa, jid, err := c.prepareSend(jidStr)
 	if err != nil {
 		return nil, 0, err
 	}
 	if len(attachments) == 0 {
-		msg := &waE2E.Message{Conversation: proto.String(text)}
+		msg := buildTextMessage(text, mentionedJIDs)
 		id, ts, sendErr := c.sendOne(ctx, wa, jid, msg)
 		if sendErr != nil {
 			return nil, 0, sendErr
@@ -69,7 +70,7 @@ func (c *Client) SendMessage(
 		// Audio carries no caption surface.  Send the text as its
 		// own Conversation message FIRST so it isn't silently
 		// dropped, then send the audio caption-less.
-		textMsg := &waE2E.Message{Conversation: proto.String(text)}
+		textMsg := buildTextMessage(text, mentionedJIDs)
 		id, ts, sendErr := c.sendOne(ctx, wa, jid, textMsg)
 		if sendErr != nil {
 			return nil, 0, fmt.Errorf("send accompanying text for audio: %w", sendErr)
@@ -81,10 +82,12 @@ func (c *Client) SendMessage(
 
 	for i, att := range attachments {
 		caption := ""
+		var captionMentions []string
 		if i == 0 {
 			caption = captionForFirstAttachment
+			captionMentions = mentionedJIDs
 		}
-		msg, buildErr := c.buildAttachmentMessage(ctx, wa, att, caption)
+		msg, buildErr := c.buildAttachmentMessage(ctx, wa, att, caption, captionMentions)
 		if buildErr != nil {
 			return delivered, firstTS, &PartialSendError{
 				Cause: buildErr, DeliveredIDs: append([]string{}, delivered...),
@@ -159,11 +162,30 @@ func (c *Client) sendOne(ctx context.Context, wa *whatsmeow.Client, jid types.JI
 	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
 }
 
+// buildTextMessage shapes a text-only outbound message, attaching a
+// ContextInfo.MentionedJID list when the model has @-tagged anyone.
+// WhatsApp clients render the mentions as pills if the JIDs resolve
+// to chat participants; non-participants fall through as plain text.
+func buildTextMessage(text string, mentionedJIDs []string) *waE2E.Message {
+	if len(mentionedJIDs) == 0 {
+		return &waE2E.Message{Conversation: proto.String(text)}
+	}
+	return &waE2E.Message{
+		ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+			Text: proto.String(text),
+			ContextInfo: &waE2E.ContextInfo{
+				MentionedJID: mentionedJIDs,
+			},
+		},
+	}
+}
+
 func (c *Client) buildAttachmentMessage(
 	ctx context.Context,
 	wa *whatsmeow.Client,
 	att Attachment,
 	caption string,
+	captionMentions []string,
 ) (*waE2E.Message, error) {
 	data, err := os.ReadFile(att.Path)
 	if err != nil {
@@ -176,6 +198,7 @@ func (c *Client) buildAttachmentMessage(
 	}
 	size := uint64(len(data))
 	mime := att.Mimetype
+	ctxInfo := maybeMentionContextInfo(captionMentions)
 
 	switch kind {
 	case attachKindImage:
@@ -189,6 +212,7 @@ func (c *Client) buildAttachmentMessage(
 				FileLength:    proto.Uint64(size),
 				MediaKey:      uploaded.MediaKey,
 				Caption:       maybeString(caption),
+				ContextInfo:   ctxInfo,
 			},
 		}, nil
 	case attachKindVideo:
@@ -202,6 +226,7 @@ func (c *Client) buildAttachmentMessage(
 				FileLength:    proto.Uint64(size),
 				MediaKey:      uploaded.MediaKey,
 				Caption:       maybeString(caption),
+				ContextInfo:   ctxInfo,
 			},
 		}, nil
 	case attachKindAudio:
@@ -214,6 +239,7 @@ func (c *Client) buildAttachmentMessage(
 				FileSHA256:    uploaded.FileSHA256,
 				FileLength:    proto.Uint64(size),
 				MediaKey:      uploaded.MediaKey,
+				ContextInfo:   ctxInfo,
 			},
 		}, nil
 	default:
@@ -230,9 +256,21 @@ func (c *Client) buildAttachmentMessage(
 				MediaKey:      uploaded.MediaKey,
 				FileName:      proto.String(att.Filename),
 				Caption:       maybeString(caption),
+				ContextInfo:   ctxInfo,
 			},
 		}, nil
 	}
+}
+
+// maybeMentionContextInfo builds a ContextInfo populated only with
+// MentionedJID, or nil when no mentions need to ride on this
+// submessage.  Returning nil keeps unrelated ContextInfo fields off
+// the wire.
+func maybeMentionContextInfo(mentionedJIDs []string) *waE2E.ContextInfo {
+	if len(mentionedJIDs) == 0 {
+		return nil
+	}
+	return &waE2E.ContextInfo{MentionedJID: mentionedJIDs}
 }
 
 type attachKind int

--- a/connectors/whatsapp/daemon/internal/wameow/outbound.go
+++ b/connectors/whatsapp/daemon/internal/wameow/outbound.go
@@ -1,0 +1,222 @@
+package wameow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+// Attachment is a host-path-referenced media payload bound for one of
+// whatsmeow's typed messages.  Kind is derived from Mimetype at send
+// time; Filename appears on the wire only for DocumentMessage but the
+// daemon carries it unconditionally so the inference layer can decide
+// based on full context.
+type Attachment struct {
+	Path     string
+	Mimetype string
+	Filename string
+}
+
+// SendMessage dispatches text and/or N media attachments.  This is
+// the single outbound entry point — handler/send.go's SendMessageFn
+// wires to it.
+//
+// Empty attachments: a single text-only Conversation message.
+//
+// One or more attachments: WhatsApp has no media-group equivalent,
+// so each attachment becomes its own message.  Caption (= text)
+// rides on the first attachment only; subsequent attachments arrive
+// caption-less.  Returns the FIRST send's id+timestamp — for the
+// caption-bearing path that's the most useful confirmation handle
+// for the model.  All-or-nothing semantics are impossible at the
+// WhatsApp protocol level (no atomic batch send); a mid-loop
+// failure leaves the already-sent attachments delivered and
+// surfaces an error that names which attachment failed.
+func (c *Client) SendMessage(
+	ctx context.Context,
+	jidStr, text string,
+	attachments []Attachment,
+) (string, int64, error) {
+	wa, jid, err := c.prepareSend(jidStr)
+	if err != nil {
+		return "", 0, err
+	}
+	if len(attachments) == 0 {
+		msg := &waE2E.Message{Conversation: proto.String(text)}
+		return c.sendOne(ctx, wa, jid, msg)
+	}
+
+	var firstID string
+	var firstTS int64
+	for i, att := range attachments {
+		caption := ""
+		if i == 0 {
+			caption = text
+		}
+		msg, buildErr := c.buildAttachmentMessage(ctx, wa, att, caption)
+		if buildErr != nil {
+			return firstID, firstTS, attachmentSendError(i, att.Filename, firstID, buildErr)
+		}
+		id, ts, sendErr := c.sendOne(ctx, wa, jid, msg)
+		if sendErr != nil {
+			return firstID, firstTS, attachmentSendError(i, att.Filename, firstID, sendErr)
+		}
+		if i == 0 {
+			firstID, firstTS = id, ts
+		}
+	}
+	return firstID, firstTS, nil
+}
+
+func attachmentSendError(index int, filename, deliveredFirstID string, cause error) error {
+	if deliveredFirstID != "" {
+		return fmt.Errorf("attachment %d (%s): %w (first attachment %s already delivered)", index, filename, cause, deliveredFirstID)
+	}
+	return fmt.Errorf("attachment %d (%s): %w", index, filename, cause)
+}
+
+func (c *Client) prepareSend(jidStr string) (*whatsmeow.Client, types.JID, error) {
+	wa := c.wa.Load()
+	if !wa.IsConnected() {
+		return nil, types.EmptyJID, errors.New("whatsmeow: not connected")
+	}
+	jid, err := types.ParseJID(jidStr)
+	if err != nil {
+		return nil, types.EmptyJID, fmt.Errorf("invalid JID %q: %w", jidStr, err)
+	}
+	return wa, jid, nil
+}
+
+func (c *Client) sendOne(ctx context.Context, wa *whatsmeow.Client, jid types.JID, msg *waE2E.Message) (string, int64, error) {
+	resp, err := wa.SendMessage(ctx, jid, msg)
+	if err != nil {
+		return "", 0, err
+	}
+	c.recordOutbound(ctx, string(resp.ID), jid)
+	return string(resp.ID), resp.Timestamp.UnixMilli(), nil
+}
+
+func (c *Client) buildAttachmentMessage(
+	ctx context.Context,
+	wa *whatsmeow.Client,
+	att Attachment,
+	caption string,
+) (*waE2E.Message, error) {
+	data, err := os.ReadFile(att.Path)
+	if err != nil {
+		return nil, fmt.Errorf("read attachment: %w", err)
+	}
+	kind := classify(att.Mimetype)
+	uploaded, err := wa.Upload(ctx, data, mediaTypeForKind(kind))
+	if err != nil {
+		return nil, fmt.Errorf("upload: %w", err)
+	}
+	size := uint64(len(data))
+	mime := att.Mimetype
+
+	switch kind {
+	case attachKindImage:
+		return &waE2E.Message{
+			ImageMessage: &waE2E.ImageMessage{
+				URL:           proto.String(uploaded.URL),
+				DirectPath:    proto.String(uploaded.DirectPath),
+				Mimetype:      proto.String(mime),
+				FileEncSHA256: uploaded.FileEncSHA256,
+				FileSHA256:    uploaded.FileSHA256,
+				FileLength:    proto.Uint64(size),
+				MediaKey:      uploaded.MediaKey,
+				Caption:       maybeString(caption),
+			},
+		}, nil
+	case attachKindVideo:
+		return &waE2E.Message{
+			VideoMessage: &waE2E.VideoMessage{
+				URL:           proto.String(uploaded.URL),
+				DirectPath:    proto.String(uploaded.DirectPath),
+				Mimetype:      proto.String(mime),
+				FileEncSHA256: uploaded.FileEncSHA256,
+				FileSHA256:    uploaded.FileSHA256,
+				FileLength:    proto.Uint64(size),
+				MediaKey:      uploaded.MediaKey,
+				Caption:       maybeString(caption),
+			},
+		}, nil
+	case attachKindAudio:
+		return &waE2E.Message{
+			AudioMessage: &waE2E.AudioMessage{
+				URL:           proto.String(uploaded.URL),
+				DirectPath:    proto.String(uploaded.DirectPath),
+				Mimetype:      proto.String(mime),
+				FileEncSHA256: uploaded.FileEncSHA256,
+				FileSHA256:    uploaded.FileSHA256,
+				FileLength:    proto.Uint64(size),
+				MediaKey:      uploaded.MediaKey,
+			},
+		}, nil
+	default:
+		// Documents carry a filename on the wire; everything else
+		// folds back into this default arm too (unknown mimetype).
+		return &waE2E.Message{
+			DocumentMessage: &waE2E.DocumentMessage{
+				URL:           proto.String(uploaded.URL),
+				DirectPath:    proto.String(uploaded.DirectPath),
+				Mimetype:      proto.String(mime),
+				FileEncSHA256: uploaded.FileEncSHA256,
+				FileSHA256:    uploaded.FileSHA256,
+				FileLength:    proto.Uint64(size),
+				MediaKey:      uploaded.MediaKey,
+				FileName:      proto.String(att.Filename),
+				Caption:       maybeString(caption),
+			},
+		}, nil
+	}
+}
+
+type attachKind int
+
+const (
+	attachKindDocument attachKind = iota
+	attachKindImage
+	attachKindVideo
+	attachKindAudio
+)
+
+func classify(mimetype string) attachKind {
+	switch {
+	case strings.HasPrefix(mimetype, "image/"):
+		return attachKindImage
+	case strings.HasPrefix(mimetype, "video/"):
+		return attachKindVideo
+	case strings.HasPrefix(mimetype, "audio/"):
+		return attachKindAudio
+	default:
+		return attachKindDocument
+	}
+}
+
+func mediaTypeForKind(k attachKind) whatsmeow.MediaType {
+	switch k {
+	case attachKindImage:
+		return whatsmeow.MediaImage
+	case attachKindVideo:
+		return whatsmeow.MediaVideo
+	case attachKindAudio:
+		return whatsmeow.MediaAudio
+	default:
+		return whatsmeow.MediaDocument
+	}
+}
+
+func maybeString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return proto.String(s)
+}

--- a/connectors/whatsapp/daemon/internal/wameow/outbound_test.go
+++ b/connectors/whatsapp/daemon/internal/wameow/outbound_test.go
@@ -1,0 +1,57 @@
+package wameow
+
+import "testing"
+
+func TestClassifyAudio(t *testing.T) {
+	tests := []struct {
+		mime string
+		want attachKind
+	}{
+		{"audio/ogg", attachKindAudio},
+		{"audio/mpeg", attachKindAudio},
+		{"audio/mp4", attachKindAudio},
+		{"audio/ogg; codecs=opus", attachKindAudio},
+		{"video/mp4", attachKindVideo},
+		{"image/jpeg", attachKindImage},
+		{"application/pdf", attachKindDocument},
+		{"", attachKindDocument}, // empty mime falls through
+	}
+	for _, tt := range tests {
+		if got := classify(tt.mime); got != tt.want {
+			t.Errorf("classify(%q) = %v, want %v", tt.mime, got, tt.want)
+		}
+	}
+}
+
+func TestMaybeStringElidesEmpty(t *testing.T) {
+	// Empty captions should become nil pointers so the protobuf
+	// doesn't carry a Caption field at all (a present-but-empty
+	// Caption renders to peers as a literal empty bubble below the
+	// media).
+	if got := maybeString(""); got != nil {
+		t.Errorf("maybeString('') = %v, want nil", got)
+	}
+	v := maybeString("hi")
+	if v == nil || *v != "hi" {
+		t.Errorf("maybeString('hi') = %v, want pointer to 'hi'", v)
+	}
+}
+
+// The full SendMessage flow can't be unit-tested without a live
+// whatsmeow.Client (Upload + SendMessage hit network).  The
+// audio-caption-routing branch is covered by the live smoke; this
+// test pins the classify() decision that drives the branch so a
+// future refactor of the mimetype prefix logic doesn't silently
+// route audio through the caption-carrying path.
+func TestAudioMimePrefixClassification(t *testing.T) {
+	// Any mimetype starting with "audio/" must classify as audio,
+	// since SendMessage's audio-text-routing check uses classify()
+	// to decide whether to pre-send the text as a Conversation
+	// message.  Missing this would silently drop captions for any
+	// "audio/foo" subtype WhatsApp's clients negotiate.
+	for _, mime := range []string{"audio/ogg", "audio/wav", "audio/x-m4a", "audio/aac"} {
+		if got := classify(mime); got != attachKindAudio {
+			t.Errorf("classify(%q) = %v, want attachKindAudio (caption-routing depends on this)", mime, got)
+		}
+	}
+}

--- a/connectors/whatsapp/daemon/internal/wameow/pair.go
+++ b/connectors/whatsapp/daemon/internal/wameow/pair.go
@@ -161,11 +161,26 @@ func (c *Client) Unpair(ctx context.Context) error {
 // to the same Notifier-bound Client receiver, and atomically swaps c.wa.
 // Concurrent reads see either the old (deleted) Client or the new one —
 // never a torn pointer.
+//
+// Also truncates the MessageStore: post-unpair, the old MessageKey
+// rows are unreachable by the new client (different device identity,
+// different whatsmeow Signal sessions).  Leaving them would let a
+// subsequent React/Edit/Revoke Lookup-succeed and then either fail
+// at the protocol layer or — worse — misdeliver, since BuildEdit/
+// BuildRevoke would emit an envelope referencing an msgID created
+// under the old identity.  A truncate failure logs but doesn't
+// abort the replace: a stale row that the new client can't
+// authenticate is at worst a confusing "edit refused" later, which
+// is observable; aborting here would leave the daemon with a dead
+// Client and no recovery path.
 func (c *Client) replaceWhatsmeowClient() {
 	newDevice := c.store.NewDevice()
 	newWa := whatsmeow.NewClient(newDevice, newWaLogger(c.log, "client"))
 	newWa.AddEventHandler(c.handleEvent)
 	c.wa.Store(newWa)
+	if err := c.msgs.Truncate(context.Background()); err != nil {
+		c.log.Warn("wameow.msgstore_truncate_failed", "err", err)
+	}
 }
 
 // resetPairState forgets any cached pairing attempt.  Called after

--- a/connectors/whatsapp/daemon/internal/wameow/pair_test.go
+++ b/connectors/whatsapp/daemon/internal/wameow/pair_test.go
@@ -207,8 +207,17 @@ func TestReplaceWhatsmeowClientRecoversFromDeletedDevice(t *testing.T) {
 	device := container.NewDevice()
 	wa := whatsmeow.NewClient(device, newWaLogger(discardLogger(), "test"))
 
-	c := &Client{store: container, log: discardLogger()}
+	c := &Client{store: container, msgs: newTestMessageStore(t), log: discardLogger()}
 	c.wa.Store(wa)
+
+	// Seed a row in the messages table — replaceWhatsmeowClient must
+	// truncate it so subsequent React/Edit/Revoke on this id fails
+	// with ErrMessageNotFound rather than succeeding under the new
+	// device identity (which can't authenticate the old whatsmeow
+	// Signal session for this msgID).
+	if err := c.msgs.Put(ctx, "STALE-MSG", "chat@s.whatsapp.net", "old-device@s.whatsapp.net", true); err != nil {
+		t.Fatalf("seed messages: %v", err)
+	}
 
 	// Simulate the post-Logout state.  whatsmeow's Logout calls
 	// device.Delete which sets Deleted=true on the in-memory Device
@@ -233,6 +242,12 @@ func TestReplaceWhatsmeowClientRecoversFromDeletedDevice(t *testing.T) {
 	}
 	if c.hasPairedDevice() {
 		t.Error("hasPairedDevice should be false after replace (fresh device has nil ID)")
+	}
+	// Stale row must be gone — otherwise a subsequent React/Edit
+	// would Lookup-succeed but reference a whatsmeow Signal session
+	// the new device identity can't address.
+	if _, _, _, err := c.msgs.Lookup(ctx, "STALE-MSG"); !errors.Is(err, ErrMessageNotFound) {
+		t.Errorf("STALE-MSG should be gone after replace, got err=%v", err)
 	}
 }
 

--- a/connectors/whatsapp/daemon/internal/wameow/pair_test.go
+++ b/connectors/whatsapp/daemon/internal/wameow/pair_test.go
@@ -215,7 +215,7 @@ func TestReplaceWhatsmeowClientRecoversFromDeletedDevice(t *testing.T) {
 	// with ErrMessageNotFound rather than succeeding under the new
 	// device identity (which can't authenticate the old whatsmeow
 	// Signal session for this msgID).
-	if err := c.msgs.Put(ctx, "STALE-MSG", "chat@s.whatsapp.net", "old-device@s.whatsapp.net", true); err != nil {
+	if err := c.msgs.Put(ctx, "STALE-MSG", "chat@s.whatsapp.net", "old-device@s.whatsapp.net", true, 0, ""); err != nil {
 		t.Fatalf("seed messages: %v", err)
 	}
 
@@ -246,7 +246,7 @@ func TestReplaceWhatsmeowClientRecoversFromDeletedDevice(t *testing.T) {
 	// Stale row must be gone — otherwise a subsequent React/Edit
 	// would Lookup-succeed but reference a whatsmeow Signal session
 	// the new device identity can't address.
-	if _, _, _, err := c.msgs.Lookup(ctx, "STALE-MSG"); !errors.Is(err, ErrMessageNotFound) {
+	if _, err := c.msgs.Lookup(ctx, "STALE-MSG"); !errors.Is(err, ErrMessageNotFound) {
 		t.Errorf("STALE-MSG should be gone after replace, got err=%v", err)
 	}
 }

--- a/connectors/whatsapp/daemon/internal/wameow/receipts_test.go
+++ b/connectors/whatsapp/daemon/internal/wameow/receipts_test.go
@@ -1,0 +1,48 @@
+package wameow
+
+import "testing"
+
+func TestMarkInboundUnreadAppendsPerChat(t *testing.T) {
+	c := &Client{log: discardLogger()}
+	c.markInboundUnread("chat1", "msg1", "alice@s.whatsapp.net")
+	c.markInboundUnread("chat1", "msg2", "alice@s.whatsapp.net")
+	c.markInboundUnread("chat2", "msg3", "bob@s.whatsapp.net")
+
+	got := c.drainUnread("chat1")
+	if len(got) != 2 || got[0].id != "msg1" || got[1].id != "msg2" {
+		t.Errorf("chat1 unread = %v, want [msg1 msg2]", got)
+	}
+	got = c.drainUnread("chat2")
+	if len(got) != 1 || got[0].id != "msg3" {
+		t.Errorf("chat2 unread = %v, want [msg3]", got)
+	}
+}
+
+func TestDrainUnreadIsOneShot(t *testing.T) {
+	// After draining, the queue must be empty so a second send to the
+	// same chat doesn't re-mark the same messages as read.
+	c := &Client{log: discardLogger()}
+	c.markInboundUnread("chat1", "msg1", "alice@s.whatsapp.net")
+
+	_ = c.drainUnread("chat1")
+	again := c.drainUnread("chat1")
+	if len(again) != 0 {
+		t.Errorf("second drain returned %v, want empty", again)
+	}
+}
+
+func TestDrainUnreadOnUnknownChatIsNil(t *testing.T) {
+	c := &Client{log: discardLogger()}
+	if got := c.drainUnread("never-touched"); got != nil {
+		t.Errorf("drain of untouched chat = %v, want nil", got)
+	}
+}
+
+func TestDrainUnreadBeforeAnyMarkIsSafe(t *testing.T) {
+	// The unread map is lazy-initialized; drainUnread before any
+	// markInboundUnread must not panic on the nil map.
+	c := &Client{log: discardLogger()}
+	if got := c.drainUnread("any"); got != nil {
+		t.Errorf("drain on nil-map client = %v, want nil", got)
+	}
+}

--- a/connectors/whatsapp/entrypoint.sh
+++ b/connectors/whatsapp/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Chown the WhatsApp data dir to uid 1000 so the api can read the
+# inbound-media bytes the daemon decrypts here.  Both containers
+# share this dir via a bind/named-volume mount; the api runs as
+# USER aios (uid 1000) and would otherwise hit EACCES traversing a
+# root-owned dir tree.  The whatsapp-daemon itself runs as root
+# inside this container and continues to write new files as root
+# with mode 0o600 (commit b3a3... in PR 5 review fix-ups), which
+# the api can read+unlink because the parent dir is uid-1000-owned.
+#
+# The ``|| true`` lets a read-only mount (someone running outside
+# compose with the volume mode wrong) surface as a normal startup
+# error from aios_whatsapp rather than a chown failure here.
+
+set -e
+
+data_dir="${AIOS_WHATSAPP_DATA_DIR:-/var/lib/aios/whatsapp-data}"
+mkdir -p "$data_dir"
+chown -R 1000:1000 "$data_dir" 2>/dev/null || true
+
+exec python -m aios_whatsapp

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -97,6 +97,12 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
                 "emoji": msg.reaction.emoji,
                 "target_message_id": msg.reaction.target_message_id,
             }
+        if msg.edit_target_message_id is not None:
+            metadata["edited"] = True
+            metadata["edit_target_message_id"] = msg.edit_target_message_id
+        if msg.revoke_target_message_id is not None:
+            metadata["revoked"] = True
+            metadata["revoke_target_message_id"] = msg.revoke_target_message_id
         attachment_tuples = await self._read_attachments(msg) if msg.attachments else None
         await self.emit_inbound(
             connection_id=connection_id,

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -19,6 +19,7 @@ from aios_connector_http import HttpConnector, SandboxPath, iso_from_ms, tool
 
 from .config import Settings
 from .daemon import WhatsappDaemon
+from .errors import ListenerClosedError
 from .format import markdown_to_whatsapp
 from .management import WhatsappManagementMixin, normalize_phone
 from .mentions import encode_mentions
@@ -67,7 +68,22 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
                 phone=phone,
                 port=port,
             )
-            await self._dispatch_notifications(connection_id, daemon)
+            try:
+                await self._dispatch_notifications(connection_id, daemon)
+            except ListenerClosedError as err:
+                # Daemon process exited (crash, pkill, or clean
+                # shutdown) while we were still listening.  Post a
+                # lifecycle event onto every session bound to this
+                # connection so the model sees the connection-broken
+                # state in its context rather than silently sending
+                # into the void on the next outbound.
+                await self.emit_lifecycle(
+                    connection_id=connection_id,
+                    event="whatsapp.connection.lost",
+                    reason="daemon_exited",
+                    data={"detail": str(err)},
+                )
+                raise
 
     async def _dispatch_notifications(self, connection_id: str, daemon: WhatsappDaemon) -> None:
         async for method, params in daemon.listener.notifications():
@@ -80,11 +96,27 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
                 # daemon's IsConnected() check.  Surface this loudly
                 # so operators see the state change rather than
                 # debugging cryptic ``not connected`` errors.
+                wa_reason = params.get("reason")
                 log.warning(
                     "whatsapp.connection.logged_out",
                     connection_id=connection_id,
                     on_connect=params.get("on_connect"),
-                    reason=params.get("reason"),
+                    reason=wa_reason,
+                )
+                # Post a session-level lifecycle event too so the
+                # bound model sees the connection-broken state in its
+                # context (not just the operator log).  Daemon stays
+                # alive — pair.go's LoggedOut handler now calls
+                # replaceWhatsmeowClient so a subsequent
+                # ``start-pairing`` recovers in-process.
+                lifecycle_data: dict[str, Any] = {}
+                if isinstance(wa_reason, str) and wa_reason:
+                    lifecycle_data["whatsmeow_reason"] = wa_reason
+                await self.emit_lifecycle(
+                    connection_id=connection_id,
+                    event="whatsapp.connection.lost",
+                    reason="peer_logout",
+                    data=lifecycle_data or None,
                 )
             elif method == "connectionState":
                 # Diagnostic: ``connected`` / ``disconnected`` from
@@ -127,6 +159,11 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
         if msg.revoke_target_message_id is not None:
             metadata["revoked"] = True
             metadata["revoke_target_message_id"] = msg.revoke_target_message_id
+        if msg.quoted_message_id is not None:
+            # The peer replied to a previous message in this chat.
+            # Surface the target so the model can address the right
+            # thread instead of inferring from message order.
+            metadata["quoted_message_id"] = msg.quoted_message_id
         if msg.mentioned_jids:
             # Surface in the harness's existing mentions-block shape.
             # The context renderer reads ``uuid`` per entry; we
@@ -193,6 +230,7 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
         self,
         text: str,
         attachments: list[SandboxPath] | None = None,
+        quoted_message_id: str | None = None,
         *,
         connection_id: str,
         chat_id: str,
@@ -211,6 +249,14 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
                 this method runs.  Mimetype is derived from the file
                 extension via Python's ``mimetypes`` module; unknown
                 types fall through to a generic document send.
+            quoted_message_id: Optional id of a previously-seen message
+                in this chat to thread this send as a reply to.  Pass
+                the ``message_id`` from the inbound metadata you want
+                to reply to.  The recipient's WhatsApp client renders
+                the reply bubble with a quote preview pointing at the
+                target.  Raises if the target id isn't in the daemon's
+                local message store (typically because it predates the
+                bot joining the chat).
 
         Returns:
             ``{"message_id": "...", "timestamp_ms": ...}`` of the
@@ -232,6 +278,8 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
             params["mentioned_jids"] = mentioned_jids
         if attachments:
             params["attachments"] = [_attachment_params(p) for p in attachments]
+        if quoted_message_id:
+            params["quoted_message_id"] = quoted_message_id
         result = await state.daemon.rpc.call("sendMessage", params)
         if not isinstance(result, dict):
             raise RuntimeError(f"sendMessage returned non-dict: {result!r}")

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -73,6 +73,28 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
         async for method, params in daemon.listener.notifications():
             if method == "message":
                 await self._handle_inbound_message(connection_id, params)
+            elif method == "loggedOut":
+                # Peer-side (or server-side) device-link revocation:
+                # the bot's account credentials are no longer valid.
+                # Subsequent whatsapp_send calls will fail at the
+                # daemon's IsConnected() check.  Surface this loudly
+                # so operators see the state change rather than
+                # debugging cryptic ``not connected`` errors.
+                log.warning(
+                    "whatsapp.connection.logged_out",
+                    connection_id=connection_id,
+                    on_connect=params.get("on_connect"),
+                    reason=params.get("reason"),
+                )
+            elif method == "connectionState":
+                # Diagnostic: ``connected`` / ``disconnected`` from
+                # whatsmeow's stream lifecycle.  Routine reconnect
+                # blips wouldn't surface anywhere otherwise.
+                log.info(
+                    "whatsapp.connection.state",
+                    connection_id=connection_id,
+                    state=params.get("state"),
+                )
             else:
                 log.warning(
                     "whatsapp.notification.unhandled",
@@ -272,10 +294,19 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
             envelope (a separate, distinct id from the original).
         """
         state = self.state[connection_id]
-        result = await state.daemon.rpc.call(
-            "editMessage",
-            {"message_id": message_id, "text": markdown_to_whatsapp(text)},
-        )
+        # Mention encoding runs BEFORE markdown so the @<E.164>
+        # pattern is detected against the model's original text.
+        # Without this, an edit that adds or rewrites an @-mention
+        # silently strips the ContextInfo.MentionedJID list and
+        # the peer sees the @ as plain text with no notification.
+        text_with_mentions, mentioned_jids = encode_mentions(text)
+        params: dict[str, Any] = {
+            "message_id": message_id,
+            "text": markdown_to_whatsapp(text_with_mentions),
+        }
+        if mentioned_jids:
+            params["mentioned_jids"] = mentioned_jids
+        result = await state.daemon.rpc.call("editMessage", params)
         if not isinstance(result, dict):
             raise RuntimeError(f"editMessage returned non-dict: {result!r}")
         return result
@@ -394,17 +425,28 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
 
 
 def _phone_to_jid(phone: str) -> str:
-    """Normalize an operator-supplied phone (+E.164 or bare digits) to
-    a WhatsApp JID (``<digits>@s.whatsapp.net``).
+    """Normalize an operator-supplied phone to a WhatsApp JID.
 
-    Strips ``+``, spaces, and dashes; if the cleaned value is already
-    a full ``...@...`` JID it's returned verbatim so the model can
-    pass JIDs through if it has them.
+    Accepts either a +E.164-shaped phone (with optional spaces,
+    dashes, parens, dots, leading +) or a pre-formed JID — the
+    latter passes through verbatim so the model can hand JIDs from
+    ``whatsapp_list_groups`` output straight to
+    ``whatsapp_create_group``.
+
+    All non-digit characters are stripped from phone-shaped input
+    so common formatter variants (``+1 (555) 123-4567``,
+    ``+1.555.123.4567``) all resolve to the same JID instead of
+    each producing its own daemon-side ParseJID error.  An input
+    with NO digits after stripping raises ValueError so the
+    failure surfaces at the Python boundary with the offending
+    value, not as an opaque daemon-side ``invalid participant jid``.
     """
     if "@" in phone:
         return phone
-    cleaned = phone.lstrip("+").replace(" ", "").replace("-", "")
-    return f"{cleaned}@s.whatsapp.net"
+    digits = "".join(c for c in phone if c.isdigit())
+    if not digits:
+        raise ValueError(f"phone {phone!r} contains no digits; cannot construct a WhatsApp JID")
+    return f"{digits}@s.whatsapp.net"
 
 
 def _phone_from_jid(jid: str) -> str:

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -125,6 +125,101 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
             raise RuntimeError(f"sendMessage returned non-dict: {result!r}")
         return result
 
+    @tool()
+    async def whatsapp_react(
+        self,
+        message_id: str,
+        reaction: str,
+        *,
+        connection_id: str,
+    ) -> dict[str, Any]:
+        """React to a previously-seen WhatsApp message.
+
+        Args:
+            message_id: The id of the message to react to.  Take this
+                from the ``message_id`` field of the inbound metadata
+                you're targeting (visible in the channel headers
+                rendered into your context).
+            reaction: The reaction emoji.  Pass an empty string to
+                clear any prior reaction you placed on the message.
+
+        Returns:
+            ``{"message_id": "...", "timestamp_ms": ...}`` of the
+            reaction send itself.  Raises if the daemon has never seen
+            the target message — typically because it predates the bot
+            joining the chat or is older than the daemon's local index.
+        """
+        state = self.state[connection_id]
+        result = await state.daemon.rpc.call(
+            "sendReaction",
+            {"message_id": message_id, "reaction": reaction},
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError(f"sendReaction returned non-dict: {result!r}")
+        return result
+
+    @tool()
+    async def whatsapp_edit_message(
+        self,
+        message_id: str,
+        text: str,
+        *,
+        connection_id: str,
+    ) -> dict[str, Any]:
+        """Edit one of your own previously-sent WhatsApp messages.
+
+        WhatsApp only allows editing messages you sent, and only within
+        ~15 minutes of the original send; the daemon refuses outside
+        either window with a structured error you can read in the
+        failure path.
+
+        Args:
+            message_id: The id of your prior outbound message.
+            text: The replacement body.
+
+        Returns:
+            ``{"message_id": "...", "timestamp_ms": ...}`` of the edit
+            envelope (a separate, distinct id from the original).
+        """
+        state = self.state[connection_id]
+        result = await state.daemon.rpc.call(
+            "editMessage",
+            {"message_id": message_id, "text": text},
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError(f"editMessage returned non-dict: {result!r}")
+        return result
+
+    @tool()
+    async def whatsapp_delete_message(
+        self,
+        message_id: str,
+        *,
+        connection_id: str,
+    ) -> dict[str, Any]:
+        """Delete one of your own previously-sent WhatsApp messages
+        (the \"delete for everyone\" action).
+
+        Like editing, deletion is only valid on your own outbounds;
+        the daemon enforces this rather than waiting for WhatsApp's
+        server to reject with an opaque error.
+
+        Args:
+            message_id: The id of your prior outbound message.
+
+        Returns:
+            ``{"message_id": "...", "timestamp_ms": ...}`` of the
+            revoke envelope.
+        """
+        state = self.state[connection_id]
+        result = await state.daemon.rpc.call(
+            "deleteMessage",
+            {"message_id": message_id},
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError(f"deleteMessage returned non-dict: {result!r}")
+        return result
+
 
 def _pick_free_port(host: str) -> int:
     """Bind to an OS-assigned loopback port and immediately release it.

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -19,6 +19,7 @@ from aios_connector_http import HttpConnector, SandboxPath, iso_from_ms, tool
 
 from .config import Settings
 from .daemon import WhatsappDaemon
+from .format import markdown_to_whatsapp
 from .management import WhatsappManagementMixin, normalize_phone
 from .parse import InboundMessage, parse_message
 
@@ -180,7 +181,7 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
             react/edit/delete-targetable individually.
         """
         state = self.state[connection_id]
-        params: dict[str, Any] = {"jid": chat_id, "text": text}
+        params: dict[str, Any] = {"jid": chat_id, "text": markdown_to_whatsapp(text)}
         if attachments:
             params["attachments"] = [_attachment_params(p) for p in attachments]
         result = await state.daemon.rpc.call("sendMessage", params)
@@ -247,7 +248,7 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
         state = self.state[connection_id]
         result = await state.daemon.rpc.call(
             "editMessage",
-            {"message_id": message_id, "text": text},
+            {"message_id": message_id, "text": markdown_to_whatsapp(text)},
         )
         if not isinstance(result, dict):
             raise RuntimeError(f"editMessage returned non-dict: {result!r}")

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -7,12 +7,14 @@ daemon per phone keeps lifecycles isolated.
 
 from __future__ import annotations
 
+import mimetypes
 import socket
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import structlog
-from aios_connector_http import HttpConnector, iso_from_ms, tool
+from aios_connector_http import HttpConnector, SandboxPath, iso_from_ms, tool
 
 from .config import Settings
 from .daemon import WhatsappDaemon
@@ -103,24 +105,38 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
     async def whatsapp_send(
         self,
         text: str,
+        attachments: list[SandboxPath] | None = None,
         *,
         connection_id: str,
         chat_id: str,
     ) -> dict[str, Any]:
-        """Send a text message to your focal WhatsApp chat.
+        """Send a message to your focal WhatsApp chat.
 
         Args:
-            text: The message body.
+            text: The message body.  When ``attachments`` is set, this
+                becomes the caption on the FIRST attachment only;
+                subsequent attachments arrive caption-less (WhatsApp
+                has no media-group equivalent — each attachment is its
+                own message).  Pass an empty string to send the
+                attachment(s) without any caption.
+            attachments: Optional in-sandbox file paths to attach.
+                The SDK resolves each entry to a host path before
+                this method runs.  Mimetype is derived from the file
+                extension via Python's ``mimetypes`` module; unknown
+                types fall through to a generic document send.
 
         Returns:
-            ``{"message_id": "...", "timestamp_ms": ...}`` from the
-            daemon's whatsmeow SendMessage round-trip.
+            ``{"message_id": "...", "timestamp_ms": ...}`` of the
+            FIRST sent message — for multi-attachment sends, that's
+            the caption-bearer.  Subsequent attachment ids land in
+            the daemon's message store too and remain
+            react/edit/delete-targetable individually.
         """
         state = self.state[connection_id]
-        result = await state.daemon.rpc.call(
-            "sendMessage",
-            {"jid": chat_id, "text": text},
-        )
+        params: dict[str, Any] = {"jid": chat_id, "text": text}
+        if attachments:
+            params["attachments"] = [_attachment_params(p) for p in attachments]
+        result = await state.daemon.rpc.call("sendMessage", params)
         if not isinstance(result, dict):
             raise RuntimeError(f"sendMessage returned non-dict: {result!r}")
         return result
@@ -219,6 +235,26 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
         if not isinstance(result, dict):
             raise RuntimeError(f"deleteMessage returned non-dict: {result!r}")
         return result
+
+
+def _attachment_params(host_path: Path) -> dict[str, str]:
+    """Build the daemon RPC's attachment dict from a SandboxPath-resolved
+    host path.
+
+    Mimetype is derived from the file extension via Python's
+    ``mimetypes`` module; unknown types fall through to
+    ``application/octet-stream`` and the daemon classifies the
+    attachment as a document (whatsmeow's catch-all kind).  Filename
+    appears on the WhatsApp wire only for documents, but the daemon
+    carries it for every kind so inbound clients can see a meaningful
+    label.
+    """
+    mime, _ = mimetypes.guess_type(host_path.name)
+    return {
+        "path": str(host_path),
+        "mimetype": mime or "application/octet-stream",
+        "filename": host_path.name,
+    }
 
 
 def _pick_free_port(host: str) -> int:

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -7,6 +7,7 @@ daemon per phone keeps lifecycles isolated.
 
 from __future__ import annotations
 
+import asyncio
 import mimetypes
 import socket
 from dataclasses import dataclass
@@ -19,7 +20,7 @@ from aios_connector_http import HttpConnector, SandboxPath, iso_from_ms, tool
 from .config import Settings
 from .daemon import WhatsappDaemon
 from .management import WhatsappManagementMixin, normalize_phone
-from .parse import parse_message
+from .parse import InboundMessage, parse_message
 
 log = structlog.get_logger(__name__)
 
@@ -89,15 +90,43 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
         }
         if msg.chat_name is not None:
             metadata["chat_name"] = msg.chat_name
+        if msg.sticker_emoji is not None:
+            metadata["sticker_emoji"] = msg.sticker_emoji
+        attachment_tuples = await self._read_attachments(msg) if msg.attachments else None
         await self.emit_inbound(
             connection_id=connection_id,
             event_id=f"whatsapp-{msg.sender_jid}-{msg.message_id}",
             chat_id=msg.chat_jid,
             sender={"jid": msg.sender_jid, "display_name": msg.sender_name},
             content=msg.text,
+            attachments=attachment_tuples,
             metadata=metadata,
             timestamp=iso_from_ms(msg.timestamp_ms),
         )
+
+    async def _read_attachments(self, msg: InboundMessage) -> list[tuple[str, bytes, str]] | None:
+        """Pull each attachment's bytes off the event loop so a multi-MiB
+        photo doesn't stall the inbound dispatcher.
+
+        A read failure on any one attachment drops THAT entry but
+        keeps the others — preferable to discarding the whole message
+        when the daemon wrote two files and one got truncated.
+        Returns None if nothing readable survives (so emit_inbound
+        sees no ``attachments`` kwarg rather than an empty list).
+        """
+        results: list[tuple[str, bytes, str]] = []
+        for att in msg.attachments:
+            try:
+                data = await asyncio.to_thread(Path(att.host_path).read_bytes)
+            except OSError as err:
+                log.warning(
+                    "whatsapp.inbound.attachment_read_failed",
+                    host_path=att.host_path,
+                    error=str(err),
+                )
+                continue
+            results.append((att.filename, data, att.content_type))
+        return results or None
 
     # ── tools ──────────────────────────────────────────────────────────
 

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -92,6 +92,11 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
             metadata["chat_name"] = msg.chat_name
         if msg.sticker_emoji is not None:
             metadata["sticker_emoji"] = msg.sticker_emoji
+        if msg.reaction is not None:
+            metadata["reaction"] = {
+                "emoji": msg.reaction.emoji,
+                "target_message_id": msg.reaction.target_message_id,
+            }
         attachment_tuples = await self._read_attachments(msg) if msg.attachments else None
         await self.emit_inbound(
             connection_id=connection_id,

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -281,6 +281,88 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
         return result
 
     @tool()
+    async def whatsapp_list_groups(
+        self,
+        *,
+        connection_id: str,
+    ) -> dict[str, Any]:
+        """List every WhatsApp group the bot is a member of.
+
+        Returns:
+            ``{"groups": [{"jid": "...", "name": "...", "topic": "...",
+            "participants": [{"jid": "...", "is_admin": false}, ...]},
+            ...]}``.  Use the ``jid`` field of a group as the
+            ``chat_id`` for whatsapp_send / whatsapp_react / etc.
+        """
+        state = self.state[connection_id]
+        result = await state.daemon.rpc.call("listGroups", {})
+        if not isinstance(result, dict):
+            raise RuntimeError(f"listGroups returned non-dict: {result!r}")
+        return result
+
+    @tool()
+    async def whatsapp_create_group(
+        self,
+        name: str,
+        participants: list[str],
+        *,
+        connection_id: str,
+    ) -> dict[str, Any]:
+        """Create a new WhatsApp group.
+
+        Args:
+            name: The group's display name (≤25 characters; WhatsApp
+                rejects longer names with 406 Not Acceptable).
+            participants: List of +E.164 phone numbers (e.g.
+                ``["+15551234567"]``) to invite.  The bot is added
+                implicitly by WhatsApp's server.
+
+        Returns:
+            The new group's summary: ``{"jid": "...", "name": "...",
+            "participants": [...]}``.  Use the ``jid`` as the
+            ``chat_id`` for subsequent sends to this group.
+        """
+        state = self.state[connection_id]
+        participant_jids = [_phone_to_jid(p) for p in participants]
+        result = await state.daemon.rpc.call(
+            "createGroup",
+            {"name": name, "participants": participant_jids},
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError(f"createGroup returned non-dict: {result!r}")
+        return result
+
+    @tool()
+    async def whatsapp_rename_group(
+        self,
+        chat_id: str,
+        name: str,
+        *,
+        connection_id: str,
+    ) -> dict[str, Any]:
+        """Rename a WhatsApp group the bot is a member of (and admin in).
+
+        Args:
+            chat_id: The group's WhatsApp JID (e.g. ``"...@g.us"``);
+                take it from whatsapp_list_groups output or from a
+                group inbound's ``channel_id``.
+            name: The new display name.  ≤25 chars per WhatsApp's
+                cap.
+
+        Returns:
+            ``{"status": "ok"}`` on success.  Raises if the bot
+            isn't an admin in the group.
+        """
+        state = self.state[connection_id]
+        result = await state.daemon.rpc.call(
+            "renameGroup",
+            {"jid": chat_id, "name": name},
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError(f"renameGroup returned non-dict: {result!r}")
+        return result
+
+    @tool()
     async def whatsapp_delete_message(
         self,
         message_id: str,
@@ -309,6 +391,20 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
         if not isinstance(result, dict):
             raise RuntimeError(f"deleteMessage returned non-dict: {result!r}")
         return result
+
+
+def _phone_to_jid(phone: str) -> str:
+    """Normalize an operator-supplied phone (+E.164 or bare digits) to
+    a WhatsApp JID (``<digits>@s.whatsapp.net``).
+
+    Strips ``+``, spaces, and dashes; if the cleaned value is already
+    a full ``...@...`` JID it's returned verbatim so the model can
+    pass JIDs through if it has them.
+    """
+    if "@" in phone:
+        return phone
+    cleaned = phone.lstrip("+").replace(" ", "").replace("-", "")
+    return f"{cleaned}@s.whatsapp.net"
 
 
 def _phone_from_jid(jid: str) -> str:

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -21,6 +21,7 @@ from .config import Settings
 from .daemon import WhatsappDaemon
 from .format import markdown_to_whatsapp
 from .management import WhatsappManagementMixin, normalize_phone
+from .mentions import encode_mentions
 from .parse import InboundMessage, parse_message
 
 log = structlog.get_logger(__name__)
@@ -104,6 +105,22 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
         if msg.revoke_target_message_id is not None:
             metadata["revoked"] = True
             metadata["revoke_target_message_id"] = msg.revoke_target_message_id
+        if msg.mentioned_jids:
+            # Surface in the harness's existing mentions-block shape.
+            # The context renderer reads ``uuid`` per entry; we
+            # populate it with the +E.164 phone (the value the model
+            # would use to @-mention this person in an outbound).
+            # The raw JID rides alongside for any consumer that
+            # wants it.
+            #
+            # ``self_mentioned`` is intentionally not computed here —
+            # the connector doesn't yet cache the bot's own JID
+            # locally.  A follow-up that plumbs the account JID
+            # through the pair-confirm flow can light up the
+            # harness's existing self_mentioned=true rendering.
+            metadata["mentions"] = [
+                {"uuid": _phone_from_jid(j), "jid": j} for j in msg.mentioned_jids
+            ]
         attachment_tuples = await self._read_attachments(msg) if msg.attachments else None
         if msg.attachments and attachment_tuples is None:
             # Daemon declared attachments but every Path.read_bytes
@@ -181,7 +198,16 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
             react/edit/delete-targetable individually.
         """
         state = self.state[connection_id]
-        params: dict[str, Any] = {"jid": chat_id, "text": markdown_to_whatsapp(text)}
+        # Mention encoding runs BEFORE markdown so the @<E.164>
+        # pattern is detected against the model's original text
+        # (markdown_to_whatsapp may interpolate sentinels).
+        text_with_mentions, mentioned_jids = encode_mentions(text)
+        params: dict[str, Any] = {
+            "jid": chat_id,
+            "text": markdown_to_whatsapp(text_with_mentions),
+        }
+        if mentioned_jids:
+            params["mentioned_jids"] = mentioned_jids
         if attachments:
             params["attachments"] = [_attachment_params(p) for p in attachments]
         result = await state.daemon.rpc.call("sendMessage", params)
@@ -283,6 +309,23 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
         if not isinstance(result, dict):
             raise RuntimeError(f"deleteMessage returned non-dict: {result!r}")
         return result
+
+
+def _phone_from_jid(jid: str) -> str:
+    """Convert a WhatsApp JID (``15551234567@s.whatsapp.net``) to the
+    +E.164 form the model uses for @-mentions in outbound text.
+
+    Falls back to the raw JID for non-standard shapes (LIDs, group
+    JIDs) so the model gets some non-empty identifier rather than
+    silently losing the mention.  Only ``@s.whatsapp.net`` JIDs map
+    to a phone — the ``@lid``/``@g.us``/etc. suffixes carry IDs that
+    aren't phone numbers even when the local part happens to be
+    all-digits.
+    """
+    local, sep, host = jid.partition("@")
+    if not sep or host != "s.whatsapp.net" or not local.isdigit():
+        return jid
+    return "+" + local
 
 
 def _attachment_params(host_path: Path) -> dict[str, str]:

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -104,6 +104,13 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
             metadata["revoked"] = True
             metadata["revoke_target_message_id"] = msg.revoke_target_message_id
         attachment_tuples = await self._read_attachments(msg) if msg.attachments else None
+        if msg.attachments and attachment_tuples is None:
+            # Daemon declared attachments but every Path.read_bytes
+            # raised — the model would otherwise see an empty-content
+            # event with no signal that bytes were lost.  Stamp a
+            # diagnostic so the model can apologise to the user
+            # rather than ignore them.
+            metadata["attachments_unreadable"] = len(msg.attachments)
         await self.emit_inbound(
             connection_id=connection_id,
             event_id=f"whatsapp-{msg.sender_jid}-{msg.message_id}",

--- a/connectors/whatsapp/src/aios_whatsapp/format.py
+++ b/connectors/whatsapp/src/aios_whatsapp/format.py
@@ -29,8 +29,14 @@ import re
 
 _FENCE_RE = re.compile(r"```(.*?)```", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`([^`\n]+?)`")
-_BOLD_STAR_RE = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
-_BOLD_UNDER_RE = re.compile(r"__(.+?)__", re.DOTALL)
+# Bold pattern: only the asterisk form (``**bold**``).  CommonMark
+# also accepts ``__bold__`` but supporting that here would mis-render
+# Python dunders like ``__init__`` as bold ``*init*`` — the outer
+# boundary check can't tell ``__init__`` apart from a legitimate
+# bold ``__phrase__``, since both have non-word chars on the outside
+# and word chars inside.  Models reliably write ``**`` for bold; the
+# ``__`` form is the rare-enough case we choose to surrender.
+_BOLD_STAR_RE = re.compile(r"(?<![\w*])\*\*(?!\s)(.+?)(?<!\s)\*\*(?![\w*])", re.DOTALL)
 # Italic patterns reject snake_case / surrounded-by-word_chars contexts
 # so ``print_hello`` doesn't render as ``print<i>hello</i>``.
 _ITALIC_STAR_RE = re.compile(r"(?<![\w*])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![\w*])")
@@ -64,15 +70,20 @@ def markdown_to_whatsapp(text: str) -> str:
     # Phase 2: bold first, with the WhatsApp ``*x*`` output stashed so
     # the italic regex can't re-match it as italic.
     text = _BOLD_STAR_RE.sub(lambda m: stash(f"*{m.group(1)}*"), text)
-    text = _BOLD_UNDER_RE.sub(lambda m: stash(f"*{m.group(1)}*"), text)
 
     # Phase 3: italic (now safe from bold collision) and strike.
     text = _ITALIC_STAR_RE.sub(r"_\1_", text)
     text = _ITALIC_UNDER_RE.sub(r"_\1_", text)
     text = _STRIKE_RE.sub(r"~\1~", text)
 
-    # Phase 4: restore stashed slots.
+    # Phase 4: restore stashed slots.  Bounds-check the index so an
+    # adversarial input literally containing the sentinel pattern
+    # (e.g. terminal-session paste with binary content) restores to
+    # the literal match instead of raising IndexError.
     def restore(m: re.Match[str]) -> str:
-        return placeholders[int(m.group(1))]
+        idx = int(m.group(1))
+        if 0 <= idx < len(placeholders):
+            return placeholders[idx]
+        return m.group(0)
 
     return re.sub(rf"{_SLOT_OPEN}(\d+){_SLOT_CLOSE}", restore, text)

--- a/connectors/whatsapp/src/aios_whatsapp/format.py
+++ b/connectors/whatsapp/src/aios_whatsapp/format.py
@@ -1,0 +1,78 @@
+"""Minimal CommonMark → WhatsApp inline-syntax converter.
+
+The model writes Markdown naturally; this transform maps the common
+inline emphasis constructs to WhatsApp's own four-character grammar:
+
+    **bold**   or  __bold__     →  *bold*
+    *italic*   or  _italic_     →  _italic_
+    ~~strike~~                  →  ~strike~
+    `code`                      →  ```code```
+    ```fence```                 →  ```fence```   (no change)
+
+Block-level constructs (lists, headings, paragraphs, links, images)
+fall through as text; WhatsApp has no rendering for them and a
+naive transform would make the message uglier rather than prettier.
+The model can be told via prompts.py to lean inline-only.
+
+Operation order matters: code spans are protected before inline
+emphasis runs (otherwise a backtick'd literal ``*foo*`` would be
+italicized).  Bold runs before italic since both compete for the
+asterisk character.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Order-sensitive patterns.  Code fences and inline code first so
+# their contents don't get touched by the emphasis regexes.
+
+_FENCE_RE = re.compile(r"```(.*?)```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`([^`\n]+?)`")
+_BOLD_STAR_RE = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
+_BOLD_UNDER_RE = re.compile(r"__(.+?)__", re.DOTALL)
+# Italic patterns reject snake_case / surrounded-by-word_chars contexts
+# so ``print_hello`` doesn't render as ``print<i>hello</i>``.
+_ITALIC_STAR_RE = re.compile(r"(?<![\w*])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![\w*])")
+_ITALIC_UNDER_RE = re.compile(r"(?<![\w_])_(?!\s)([^_\n]+?)(?<!\s)_(?![\w_])")
+_STRIKE_RE = re.compile(r"~~(.+?)~~", re.DOTALL)
+
+# Sentinels picked from C0 control range so they can't appear in
+# normal message text.  Code spans and bold outputs are both stashed
+# behind sentinels during emphasis processing so the italic regex
+# can't chew them up: WhatsApp bold is ``*x*`` and CommonMark italic
+# is ``*x*`` too, so the bold output collides with the italic
+# pattern unless protected.
+_SLOT_OPEN = "\x01SLOT\x01"
+_SLOT_CLOSE = "\x01ENDSLOT\x01"
+
+
+def markdown_to_whatsapp(text: str) -> str:
+    """Render Markdown-with-CommonMark-emphasis to WhatsApp inline syntax."""
+    placeholders: list[str] = []
+
+    def stash(rendered: str) -> str:
+        placeholders.append(rendered)
+        return f"{_SLOT_OPEN}{len(placeholders) - 1}{_SLOT_CLOSE}"
+
+    # Phase 1: hide code spans behind sentinels.  Fences keep their
+    # WhatsApp ```...``` shape; inline backticks promote to
+    # ``` ``` since WhatsApp has no single-backtick equivalent.
+    text = _FENCE_RE.sub(lambda m: stash(f"```{m.group(1)}```"), text)
+    text = _INLINE_CODE_RE.sub(lambda m: stash(f"```{m.group(1)}```"), text)
+
+    # Phase 2: bold first, with the WhatsApp ``*x*`` output stashed so
+    # the italic regex can't re-match it as italic.
+    text = _BOLD_STAR_RE.sub(lambda m: stash(f"*{m.group(1)}*"), text)
+    text = _BOLD_UNDER_RE.sub(lambda m: stash(f"*{m.group(1)}*"), text)
+
+    # Phase 3: italic (now safe from bold collision) and strike.
+    text = _ITALIC_STAR_RE.sub(r"_\1_", text)
+    text = _ITALIC_UNDER_RE.sub(r"_\1_", text)
+    text = _STRIKE_RE.sub(r"~\1~", text)
+
+    # Phase 4: restore stashed slots.
+    def restore(m: re.Match[str]) -> str:
+        return placeholders[int(m.group(1))]
+
+    return re.sub(rf"{_SLOT_OPEN}(\d+){_SLOT_CLOSE}", restore, text)

--- a/connectors/whatsapp/src/aios_whatsapp/mentions.py
+++ b/connectors/whatsapp/src/aios_whatsapp/mentions.py
@@ -23,23 +23,56 @@ from __future__ import annotations
 
 import re
 
-# E.164: 7-15 digits, optional leading "+".  Word-boundary lookarounds
-# so an email-address-like "user@example.com" isn't grabbed.
-_MENTION_RE = re.compile(r"(?<![\w@])@(\+?\d{7,15})(?![\w])")
+# Mention syntax the model can write:
+#   @+15551234567                          (E.164 with +)
+#   @15551234567                           (bare digits, 7-15)
+#   @15551234567@s.whatsapp.net            (full phone JID; round-trip path)
+#   @98765@lid                             (LID JID; round-trip for @lid peers)
+#
+# Lookbehind uses an EXPLICIT ASCII negated class instead of ``\w``
+# so the @ inside italic markers (``_@+15551234567_``) AND URL paths
+# (``https://chat.example/u/@+15551234567``) STILL work / get rejected
+# as intended:
+#
+# * ``_`` IS in ``\w`` (Python re default), so ``(?<![\w])`` would
+#   silently drop italic-wrapped mentions.  The explicit class
+#   excludes ``_``, letting the italic-wrapped @ match.
+# * URL boundaries (``/``, ``.``) are NOT in ``\w``, so the previous
+#   regex would harvest @-tags embedded in URLs.  Adding ``/`` and
+#   ``.`` to the rejected set blocks URL-embedded harvesting.
+#
+# ``\d`` is restricted to ASCII digits via ``[0-9]`` to avoid
+# Arabic-Indic / fullwidth / Devanagari digit shapes that would
+# produce non-ASCII JIDs WhatsApp's server rejects.
+_MENTION_RE = re.compile(
+    r"(?<![A-Za-z0-9@/.])"
+    r"@(?P<jid>"
+    r"\+?[0-9]{7,15}"
+    r"|[0-9]+@(?:s\.whatsapp\.net|lid)"
+    r")"
+    r"(?![A-Za-z0-9])"
+)
 
 
 def encode_mentions(text: str) -> tuple[str, list[str]]:
-    """Extract ``@<E.164>`` mentions and return ``(text, mentioned_jids)``.
+    """Extract WhatsApp mentions and return ``(text, mentioned_jids)``.
 
-    The text is returned unchanged; the JID list is in
-    left-to-right order of first appearance, deduped.  Empty list
-    means no mentions were detected (DMs or text with no @-tags).
+    The text is returned unchanged; the JID list is in left-to-right
+    order of first appearance, deduped.  Empty list means no
+    mentions were detected (DMs or text with no @-tags).
     """
     seen: set[str] = set()
     jids: list[str] = []
     for m in _MENTION_RE.finditer(text):
-        digits = m.group(1).lstrip("+")
-        jid = f"{digits}@s.whatsapp.net"
+        raw = m.group("jid")
+        if "@" in raw:
+            # Already a full JID — accept verbatim.  Used for LID
+            # round-trip and for models that copy the JID directly
+            # out of inbound metadata.
+            jid = raw
+        else:
+            digits = raw.lstrip("+")
+            jid = f"{digits}@s.whatsapp.net"
         if jid not in seen:
             seen.add(jid)
             jids.append(jid)

--- a/connectors/whatsapp/src/aios_whatsapp/mentions.py
+++ b/connectors/whatsapp/src/aios_whatsapp/mentions.py
@@ -1,0 +1,46 @@
+"""Encode and decode WhatsApp mentions.
+
+WhatsApp's mention wire format is simpler than Signal's: the message
+body carries an ``@<phone>`` literal (no U+FFFC placeholder, no
+UTF-16 offset math) and a parallel ``ContextInfo.MentionedJID`` list
+of full WhatsApp JIDs.  WhatsApp clients render the literal as a
+pill when the JID resolves to a chat participant.
+
+Outbound: scan the text for ``@<E.164>`` patterns, normalize each
+match to a ``<digits>@s.whatsapp.net`` JID, and return the JID list
+alongside the (unchanged) text.  The encoder doesn't validate
+against the chat's actual member roster — WhatsApp's server falls
+through unrendered when a mentioned JID isn't a participant, which
+is the same user-facing outcome as not mentioning at all.
+
+Inbound: the daemon hands us ``mentioned_jid: [str]``; we surface
+them as ``{"jid": ..., "name": ...}`` dicts in
+``metadata["mentions"]`` so the harness's existing renderer can
+display them via the ``jid`` field (extension landed in PR 5).
+"""
+
+from __future__ import annotations
+
+import re
+
+# E.164: 7-15 digits, optional leading "+".  Word-boundary lookarounds
+# so an email-address-like "user@example.com" isn't grabbed.
+_MENTION_RE = re.compile(r"(?<![\w@])@(\+?\d{7,15})(?![\w])")
+
+
+def encode_mentions(text: str) -> tuple[str, list[str]]:
+    """Extract ``@<E.164>`` mentions and return ``(text, mentioned_jids)``.
+
+    The text is returned unchanged; the JID list is in
+    left-to-right order of first appearance, deduped.  Empty list
+    means no mentions were detected (DMs or text with no @-tags).
+    """
+    seen: set[str] = set()
+    jids: list[str] = []
+    for m in _MENTION_RE.finditer(text):
+        digits = m.group(1).lstrip("+")
+        jid = f"{digits}@s.whatsapp.net"
+        if jid not in seen:
+            seen.add(jid)
+            jids.append(jid)
+    return text, jids

--- a/connectors/whatsapp/src/aios_whatsapp/parse.py
+++ b/connectors/whatsapp/src/aios_whatsapp/parse.py
@@ -55,10 +55,23 @@ class InboundMessage:
     timestamp_ms: int
     text: str
     attachments: tuple[InboundAttachment, ...] = field(default_factory=tuple)
+    # ``sticker_emoji`` is None when no sticker was attached.  An empty
+    # string means "sticker received but the sender's WhatsApp client
+    # didn't pick an emoji label" (custom stickers from the sticker
+    # maker frequently land this way) — the connector surfaces this as
+    # a metadata-only signal so the model still knows the peer sent
+    # one.  Pre-fix both empty AND missing collapsed to None, so the
+    # parser dropped no-emoji stickers entirely.
     sticker_emoji: str | None = None
     reaction: InboundReaction | None = None
     edit_target_message_id: str | None = None
     revoke_target_message_id: str | None = None
+    # ``quoted_message_id`` is set when this inbound is a reply to one
+    # of the bot's earlier messages (or to any prior message in the
+    # chat the peer chose to quote).  The harness threads it into the
+    # event metadata so the model can address the right thread instead
+    # of inferring from message order.
+    quoted_message_id: str | None = None
     mentioned_jids: tuple[str, ...] = field(default_factory=tuple)
 
 
@@ -69,9 +82,10 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
 
     * ``is_self=True`` — echoes of our own sends.
     * ``chat_type`` not in ``{"dm", "group"}``.
-    * Empty text AND empty attachments AND no sticker — no signal to
-      surface (e.g. an empty reaction-only message that slipped past
-      whatsmeow's protocol-message filter).
+    * Empty text AND empty attachments AND no sticker AND no other
+      metadata signal — no signal to surface (e.g. an empty
+      reaction-only message that slipped past whatsmeow's
+      protocol-message filter).
     * Required fields (``id``, ``chat_jid``, ``from_jid``, ``timestamp_ms``)
       missing or wrong type.
     """
@@ -105,12 +119,18 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
 
     attachments = _parse_attachments(params.get("attachments"))
 
+    # Sticker presence is the signal; the emoji label is informational
+    # and may be empty for custom stickers without a sender-picked tag.
+    # Accepting "" (not just truthy strings) lets the drop check below
+    # keep no-emoji stickers, which pre-fix were silently swallowed.
     raw_sticker = params.get("sticker_emoji")
-    sticker_emoji = raw_sticker if isinstance(raw_sticker, str) and raw_sticker else None
+    sticker_emoji = raw_sticker if isinstance(raw_sticker, str) else None
 
     reaction = _parse_reaction(params.get("reaction"))
     edit_target_message_id = _parse_target(params.get("edit"))
     revoke_target_message_id = _parse_target(params.get("revoke"))
+    raw_quoted = params.get("quoted_message_id")
+    quoted_message_id = raw_quoted if isinstance(raw_quoted, str) and raw_quoted else None
     raw_mentions = params.get("mentioned_jids")
     mentioned_jids: tuple[str, ...] = (
         tuple(j for j in raw_mentions if isinstance(j, str) and j)
@@ -145,6 +165,7 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
         reaction=reaction,
         edit_target_message_id=edit_target_message_id,
         revoke_target_message_id=revoke_target_message_id,
+        quoted_message_id=quoted_message_id,
         mentioned_jids=mentioned_jids,
     )
 

--- a/connectors/whatsapp/src/aios_whatsapp/parse.py
+++ b/connectors/whatsapp/src/aios_whatsapp/parse.py
@@ -1,15 +1,33 @@
 """Parse daemon ``message`` notifications into :class:`InboundMessage`.
 
-Drops self-echoes, attachment-only / sticker-only messages, broadcasts,
-newsletters, and envelopes with required fields missing or malformed.
+Drops self-echoes, broadcasts, newsletters, and envelopes with
+required fields missing or malformed.  Attachment-only and
+sticker-only messages are KEPT (their text is empty) — the
+connector renders them as zero-content events whose
+``attachments``/``metadata.sticker_emoji`` carry the model-relevant
+signal.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal
 
 ChatType = Literal["dm", "group", "broadcast", "newsletter"]
+
+
+@dataclass(slots=True, frozen=True)
+class InboundAttachment:
+    """Inbound media bundle the daemon wrote to disk for us.
+
+    ``host_path`` is the daemon-side absolute path; the Python
+    connector reads its bytes off-loop and forwards a
+    ``(filename, bytes, content_type)`` tuple to the aios SDK.
+    """
+
+    host_path: str
+    filename: str
+    content_type: str
 
 
 @dataclass(slots=True, frozen=True)
@@ -22,6 +40,8 @@ class InboundMessage:
     message_id: str
     timestamp_ms: int
     text: str
+    attachments: tuple[InboundAttachment, ...] = field(default_factory=tuple)
+    sticker_emoji: str | None = None
 
 
 def parse_message(params: dict[str, Any]) -> InboundMessage | None:
@@ -30,16 +50,14 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
     Returns ``None`` to silently drop the envelope.  Drop rules:
 
     * ``is_self=True`` — echoes of our own sends.
-    * Empty / non-string ``text``.
     * ``chat_type`` not in ``{"dm", "group"}``.
+    * Empty text AND empty attachments AND no sticker — no signal to
+      surface (e.g. an empty reaction-only message that slipped past
+      whatsmeow's protocol-message filter).
     * Required fields (``id``, ``chat_jid``, ``from_jid``, ``timestamp_ms``)
       missing or wrong type.
     """
     if params.get("is_self"):
-        return None
-
-    text = params.get("text")
-    if not isinstance(text, str) or not text:
         return None
 
     chat_type = params.get("chat_type")
@@ -58,6 +76,17 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
     ):
         return None
 
+    raw_text = params.get("text")
+    text = raw_text if isinstance(raw_text, str) else ""
+
+    attachments = _parse_attachments(params.get("attachments"))
+
+    raw_sticker = params.get("sticker_emoji")
+    sticker_emoji = raw_sticker if isinstance(raw_sticker, str) and raw_sticker else None
+
+    if not text and not attachments and sticker_emoji is None:
+        return None
+
     raw_chat_name = params.get("chat_name")
     raw_push_name = params.get("from_push_name")
 
@@ -70,4 +99,35 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
         message_id=message_id,
         timestamp_ms=timestamp_ms,
         text=text,
+        attachments=attachments,
+        sticker_emoji=sticker_emoji,
     )
+
+
+def _parse_attachments(raw: Any) -> tuple[InboundAttachment, ...]:
+    """Normalize the daemon's ``attachments`` list, dropping malformed entries.
+
+    The daemon emits items of shape ``{"path", "mimetype", "filename"}``
+    on a best-effort basis (download failures land NO entry rather than
+    a half-populated one), so an empty list is the typical no-media
+    case and a missing/None field is the malformed-entry signal.
+    """
+    if not isinstance(raw, list):
+        return ()
+    out: list[InboundAttachment] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        path = item.get("path")
+        mimetype = item.get("mimetype")
+        filename = item.get("filename")
+        if not (isinstance(path, str) and path and isinstance(mimetype, str) and mimetype):
+            continue
+        out.append(
+            InboundAttachment(
+                host_path=path,
+                filename=filename if isinstance(filename, str) and filename else "unnamed",
+                content_type=mimetype,
+            )
+        )
+    return tuple(out)

--- a/connectors/whatsapp/src/aios_whatsapp/parse.py
+++ b/connectors/whatsapp/src/aios_whatsapp/parse.py
@@ -31,6 +31,20 @@ class InboundAttachment:
 
 
 @dataclass(slots=True, frozen=True)
+class InboundReaction:
+    """Peer-side reaction to a message, surfaced as a metadata block.
+
+    ``target_message_id`` identifies which message in our session
+    history the reaction targets.  Empty ``emoji`` means the peer
+    removed an earlier reaction — surfaced explicitly so the model
+    can update any "they reacted with X" state.
+    """
+
+    emoji: str
+    target_message_id: str
+
+
+@dataclass(slots=True, frozen=True)
 class InboundMessage:
     chat_type: ChatType
     chat_jid: str
@@ -42,6 +56,7 @@ class InboundMessage:
     text: str
     attachments: tuple[InboundAttachment, ...] = field(default_factory=tuple)
     sticker_emoji: str | None = None
+    reaction: InboundReaction | None = None
 
 
 def parse_message(params: dict[str, Any]) -> InboundMessage | None:
@@ -84,7 +99,9 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
     raw_sticker = params.get("sticker_emoji")
     sticker_emoji = raw_sticker if isinstance(raw_sticker, str) and raw_sticker else None
 
-    if not text and not attachments and sticker_emoji is None:
+    reaction = _parse_reaction(params.get("reaction"))
+
+    if not text and not attachments and sticker_emoji is None and reaction is None:
         return None
 
     raw_chat_name = params.get("chat_name")
@@ -101,7 +118,26 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
         text=text,
         attachments=attachments,
         sticker_emoji=sticker_emoji,
+        reaction=reaction,
     )
+
+
+def _parse_reaction(raw: Any) -> InboundReaction | None:
+    """Normalize the daemon's ``reaction`` payload.
+
+    Requires a target_message_id (otherwise the model can't match it
+    against anything in its context); emoji may be empty (peer
+    removing a prior reaction).
+    """
+    if not isinstance(raw, dict):
+        return None
+    target_id = raw.get("target_message_id")
+    if not isinstance(target_id, str) or not target_id:
+        return None
+    emoji = raw.get("emoji")
+    if not isinstance(emoji, str):
+        return None
+    return InboundReaction(emoji=emoji, target_message_id=target_id)
 
 
 def _parse_attachments(raw: Any) -> tuple[InboundAttachment, ...]:

--- a/connectors/whatsapp/src/aios_whatsapp/parse.py
+++ b/connectors/whatsapp/src/aios_whatsapp/parse.py
@@ -145,6 +145,7 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
         and reaction is None
         and edit_target_message_id is None
         and revoke_target_message_id is None
+        and quoted_message_id is None
     ):
         return None
 

--- a/connectors/whatsapp/src/aios_whatsapp/parse.py
+++ b/connectors/whatsapp/src/aios_whatsapp/parse.py
@@ -95,6 +95,12 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
 
     raw_text = params.get("text")
     text = raw_text if isinstance(raw_text, str) else ""
+    # Whitespace-only text is truthy in Python but carries no signal
+    # — peer mis-tapped or sent an accessibility-input artifact.
+    # Treat as empty for the "no signal" drop check below so we don't
+    # emit blank-bubble inbound events with nothing the model can act
+    # on.
+    text_is_signal = bool(text.strip())
 
     attachments = _parse_attachments(params.get("attachments"))
 
@@ -106,7 +112,7 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
     revoke_target_message_id = _parse_target(params.get("revoke"))
 
     if (
-        not text
+        not text_is_signal
         and not attachments
         and sticker_emoji is None
         and reaction is None

--- a/connectors/whatsapp/src/aios_whatsapp/parse.py
+++ b/connectors/whatsapp/src/aios_whatsapp/parse.py
@@ -57,6 +57,8 @@ class InboundMessage:
     attachments: tuple[InboundAttachment, ...] = field(default_factory=tuple)
     sticker_emoji: str | None = None
     reaction: InboundReaction | None = None
+    edit_target_message_id: str | None = None
+    revoke_target_message_id: str | None = None
 
 
 def parse_message(params: dict[str, Any]) -> InboundMessage | None:
@@ -100,8 +102,17 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
     sticker_emoji = raw_sticker if isinstance(raw_sticker, str) and raw_sticker else None
 
     reaction = _parse_reaction(params.get("reaction"))
+    edit_target_message_id = _parse_target(params.get("edit"))
+    revoke_target_message_id = _parse_target(params.get("revoke"))
 
-    if not text and not attachments and sticker_emoji is None and reaction is None:
+    if (
+        not text
+        and not attachments
+        and sticker_emoji is None
+        and reaction is None
+        and edit_target_message_id is None
+        and revoke_target_message_id is None
+    ):
         return None
 
     raw_chat_name = params.get("chat_name")
@@ -119,7 +130,22 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
         attachments=attachments,
         sticker_emoji=sticker_emoji,
         reaction=reaction,
+        edit_target_message_id=edit_target_message_id,
+        revoke_target_message_id=revoke_target_message_id,
     )
+
+
+def _parse_target(raw: Any) -> str | None:
+    """Pull ``target_message_id`` out of the daemon's ``edit`` / ``revoke``
+    block.  Returns None for missing blocks or missing ids — the model
+    has nothing to act on without an id, so silently drop.
+    """
+    if not isinstance(raw, dict):
+        return None
+    target_id = raw.get("target_message_id")
+    if not isinstance(target_id, str) or not target_id:
+        return None
+    return target_id
 
 
 def _parse_reaction(raw: Any) -> InboundReaction | None:

--- a/connectors/whatsapp/src/aios_whatsapp/parse.py
+++ b/connectors/whatsapp/src/aios_whatsapp/parse.py
@@ -59,6 +59,7 @@ class InboundMessage:
     reaction: InboundReaction | None = None
     edit_target_message_id: str | None = None
     revoke_target_message_id: str | None = None
+    mentioned_jids: tuple[str, ...] = field(default_factory=tuple)
 
 
 def parse_message(params: dict[str, Any]) -> InboundMessage | None:
@@ -110,6 +111,12 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
     reaction = _parse_reaction(params.get("reaction"))
     edit_target_message_id = _parse_target(params.get("edit"))
     revoke_target_message_id = _parse_target(params.get("revoke"))
+    raw_mentions = params.get("mentioned_jids")
+    mentioned_jids: tuple[str, ...] = (
+        tuple(j for j in raw_mentions if isinstance(j, str) and j)
+        if isinstance(raw_mentions, list)
+        else ()
+    )
 
     if (
         not text_is_signal
@@ -138,6 +145,7 @@ def parse_message(params: dict[str, Any]) -> InboundMessage | None:
         reaction=reaction,
         edit_target_message_id=edit_target_message_id,
         revoke_target_message_id=revoke_target_message_id,
+        mentioned_jids=mentioned_jids,
     )
 
 

--- a/connectors/whatsapp/src/aios_whatsapp/prompts.py
+++ b/connectors/whatsapp/src/aios_whatsapp/prompts.py
@@ -78,18 +78,35 @@ def build_instructions(
 def _render_group_roster(bot_jid: str, groups: list[GroupRosterEntry]) -> str:
     if not groups:
         return ""
+    bot_key = _jid_identity_key(bot_jid)
     lines: list[str] = ["\n## Your WhatsApp groups\n"]
     for g in groups:
         name = g.name or "(unnamed)"
         lines.append(f"\n- `{g.jid}` — {name}")
         for jid in g.member_jids:
-            tag = "(YOU)" if jid == bot_jid else ""
+            tag = "(YOU)" if _jid_identity_key(jid) == bot_key else ""
             line = f"    - `{jid}`"
             if tag:
                 line += f" {tag}"
             lines.append(line)
     lines.append("")
     return "\n".join(lines) + "\n"
+
+
+def _jid_identity_key(jid: str) -> str:
+    """Normalize a WhatsApp JID to its identity-bearing local part.
+
+    Strips the device suffix (``<phone>:<n>@s.whatsapp.net`` →
+    ``<phone>``) and the host so a literal string compare across
+    JID variants (with/without device suffix, ``@s.whatsapp.net``
+    vs ``@lid``) doesn't silently lose the (YOU) self-tag.  LID
+    JIDs use a different identifier space than phone JIDs and
+    can't be equated; callers passing a phone-shape bot_jid into
+    a LID-mode group still won't match, but the within-host
+    variants now collapse correctly.
+    """
+    local = jid.split("@", 1)[0]
+    return local.split(":", 1)[0]
 
 
 WHATSAPP_SERVER_INSTRUCTIONS = """\

--- a/connectors/whatsapp/src/aios_whatsapp/prompts.py
+++ b/connectors/whatsapp/src/aios_whatsapp/prompts.py
@@ -1,0 +1,239 @@
+"""Per-connector affordance prose for the WhatsApp account.
+
+Returned in the ``InitializeResult.instructions`` field of the MCP
+``initialize`` response; the aios harness concatenates it into the
+session's system prompt under a ``## Connector: whatsapp/<phone>``
+heading.
+
+Mirrors ``connectors/signal/src/aios_signal/prompts.py`` in shape:
+``build_instructions`` prepends an identity block (the bot's own JID
++ phone + push name) and a group-roster block to the static body so
+the agent knows who it is and who else is in each group without
+having to learn that from inbound traffic.
+
+The static body covers only the tools this connector actually
+exposes — telling the model about tools that don't exist would be
+worse than silence.
+
+Currently test-covered but not yet wired through the
+aios-connector-http SDK; lights up automatically once the SDK's
+``InitializeResult.instructions`` hook lands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class GroupRosterEntry:
+    """One group's roster entry rendered into the system prompt.
+
+    ``jid``: the group's WhatsApp JID (``...@g.us``) — what
+    ``whatsapp_send`` and friends accept as ``chat_id``.
+    ``name``: the group's display name; ``(unnamed)`` falls through
+    for groups whose name field is empty.
+    ``member_jids``: full JIDs of the bot's fellow participants.
+    The bot itself is tagged ``(YOU)`` in the rendered output.
+    """
+
+    jid: str
+    name: str
+    member_jids: list[str]
+
+
+def build_instructions(
+    *,
+    bot_jid: str,
+    phone: str,
+    push_name: str | None = None,
+    groups: list[GroupRosterEntry] | None = None,
+) -> str:
+    """Compose the MCP ``initialize`` instructions with identity + roster.
+
+    The agent otherwise has no reliable way to know which JID is
+    itself — without this prelude, models confabulate identities in
+    group chats.  The roster block makes every participant knowable
+    upfront; silent peers don't effectively disappear.
+
+    ``push_name``, when set, is the display name peers see for the
+    bot.  Rendered as a third identity bullet; omitted entirely if
+    ``None`` or empty so an un-set account doesn't ship a blank line.
+    """
+    identity = (
+        "## Your identity on this WhatsApp account\n"
+        "\n"
+        f"- **jid**: `{bot_jid}` — this is YOU.  Any inbound whose "
+        "header shows this jid as the sender is your own prior "
+        "message, not another participant.\n"
+        f"- **phone**: `{phone}` — this WhatsApp account is identified "
+        "to peers by this number.\n"
+    )
+    if push_name:
+        identity += f"- **push_name**: `{push_name}` — your display name on WhatsApp.\n"
+    roster = _render_group_roster(bot_jid, groups or [])
+    return identity + roster + "\n" + WHATSAPP_SERVER_INSTRUCTIONS
+
+
+def _render_group_roster(bot_jid: str, groups: list[GroupRosterEntry]) -> str:
+    if not groups:
+        return ""
+    lines: list[str] = ["\n## Your WhatsApp groups\n"]
+    for g in groups:
+        name = g.name or "(unnamed)"
+        lines.append(f"\n- `{g.jid}` — {name}")
+        for jid in g.member_jids:
+            tag = "(YOU)" if jid == bot_jid else ""
+            line = f"    - `{jid}`"
+            if tag:
+                line += f" {tag}"
+            lines.append(line)
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+WHATSAPP_SERVER_INSTRUCTIONS = """\
+## chat_id
+
+Each WhatsApp channel address is path-shaped:
+``whatsapp/<phone>/<chat_id>``.  The ``chat_id`` segment is what
+you pass to the tools below — pass it verbatim, do not decode it.
+DMs use ``<digits>@s.whatsapp.net`` (or ``<digits>@lid`` for
+linked-device-identity peers); groups use ``<id>@g.us``.
+
+## Reading inbound messages
+
+Every inbound message arrives prefixed with a bracketed header
+carrying the ``message_id`` value that ``whatsapp_react`` /
+``whatsapp_edit_message`` / ``whatsapp_delete_message`` expect.
+Copy it verbatim — never construct, shorten, or reformat it.
+
+Header shape (newlines added for clarity):
+
+    [channel=whatsapp/<account>/<chat_id> · chat_type=<dm|group> ·
+     chat_name='Group Name' · from=Alice · sender_jid=<jid> ·
+     timestamp_ms=<ms> (<iso>) · message_id='<id>']
+
+WhatsApp message ids are hex strings like ``3EB0E03B46303C22D750E2``
+— pass them verbatim.
+
+## Sending messages — `whatsapp_send`
+
+**Your text responses are NOT sent automatically.**  Bare assistant
+text is internal monologue; nobody on WhatsApp sees it.  To deliver
+a message you MUST call:
+
+    whatsapp_send(text="your message here")
+
+If you don't call this tool, no one will see your response.
+
+### Markdown subset
+
+WhatsApp supports a compact inline grammar:
+
+- *bold* (`**text**` or `__text__` in your CommonMark input)
+- _italic_ (`*text*` or `_text_`)
+- ~strike~ (`~~text~~`)
+- ```inline code``` and ``` ```fenced code``` ```
+
+Block-level constructs (headings, bullet lists, blockquotes, links,
+images, tables) have **no WhatsApp rendering** and will appear as
+literal characters in the recipient's chat.  Avoid them; paste URLs
+directly instead of using `[link](url)` syntax.
+
+### Mentions in groups
+
+In a group, write `@<E.164>` to mention a member — for example
+``@+15551234567 can you handle this?``.  The connector resolves the
+phone to the participant's WhatsApp JID and attaches the mention to
+the message's ContextInfo so WhatsApp clients render the @-tag as a
+pill.  Mentions silently fall through as plain text if the phone
+isn't a chat participant.
+
+The group roster block above lists each member's JID — derive the
+phone from the digits before `@s.whatsapp.net`.
+
+### Attachments
+
+Pass ``attachments=[<sandbox path>, ...]`` to send media alongside
+text.  The text becomes the caption on the FIRST attachment (WhatsApp
+has no media-group equivalent — each attachment is its own message).
+Audio messages can't carry a caption, so when the first attachment is
+audio the text is sent as a separate Conversation message instead.
+
+## Reacting — `whatsapp_react`
+
+Lighter-weight than a full message.  Pass the ``message_id`` from
+the inbound header of the target:
+
+    whatsapp_react(message_id="<id from header>", reaction="👍")
+
+Pass an empty string to clear a prior reaction you placed:
+
+    whatsapp_react(message_id="<id>", reaction="")
+
+**Common reactions:** 👍 ❤️ 😂 😮 😢 🎉 🔥 ✅
+
+**When to react instead of sending a full message:**
+
+- Someone addresses you but a full reply would be overkill — a 👍 or
+  ❤️ says "I see you".
+- Good news worth celebrating — 🎉 or 🔥.
+- Acknowledging you will handle something — ✅ or 👍.
+
+Mundane messages do not need reactions; standout moments do.
+
+## Editing — `whatsapp_edit_message`
+
+Pass the ``message_id`` of a prior outbound to rewrite its body:
+
+    whatsapp_edit_message(message_id="<id>", text="corrected version")
+
+WhatsApp only allows editing your own messages, and only within ~15
+minutes of the original send; the daemon surfaces the server's
+rejection if either window is exceeded.  Empty text is refused —
+use ``whatsapp_delete_message`` if you want the message gone.
+
+## Deleting — `whatsapp_delete_message`
+
+Delete-for-everyone a message you sent earlier.  Pass its
+``message_id``:
+
+    whatsapp_delete_message(message_id="<id>")
+
+Only your own messages can be deleted.  Use sparingly — deletes are
+visible (a tombstone replaces the message).
+
+## Group admin — `whatsapp_list_groups`, `whatsapp_create_group`, `whatsapp_rename_group`
+
+List every group the bot is in:
+
+    whatsapp_list_groups()
+
+Create a new group; pass +E.164 phones for the participants (the
+bot is added implicitly as the creator):
+
+    whatsapp_create_group(
+        name="Project X",
+        participants=["+15551234567", "+18007654321"],
+    )
+
+The result includes the new group's JID, which you can hand to
+``whatsapp_send``'s ``chat_id`` to focus into it.
+
+Rename a group the bot is an admin in:
+
+    whatsapp_rename_group(chat_id="<group_jid>", name="New name")
+
+## What you can and can't see in attachments
+
+Inbound attachments differ in what your model can actually perceive:
+
+- **Photos and static stickers** — vision-readable; you see the pixels.
+  Animated stickers surface their emoji label via
+  ``metadata.sticker_emoji`` so you can describe them without bytes.
+- **Voice notes and audio messages** — NOT readable.  You see only the
+  filename, mime type, and size.  Don't claim to have heard the audio.
+- **Videos and animated content** — NOT readable.  Acknowledge what
+  you can see (filename, type, size) and ask the user what's in it.
+"""

--- a/connectors/whatsapp/tests/test_format.py
+++ b/connectors/whatsapp/tests/test_format.py
@@ -10,9 +10,10 @@ from aios_whatsapp.format import markdown_to_whatsapp
 @pytest.mark.parametrize(
     ("source", "expected"),
     [
-        # Bold variants both collapse to WhatsApp's *foo* shape.
+        # Bold uses the asterisk form only — the __underscore__ form
+        # is intentionally not supported so Python dunders like
+        # __init__ stay verbatim.
         ("**bold**", "*bold*"),
-        ("__bold__", "*bold*"),
         ("hello **world**", "hello *world*"),
         # Italic single-asterisk → underscore.
         ("*italic*", "_italic_"),
@@ -62,3 +63,33 @@ def test_markdown_to_whatsapp_handles_fence_with_inner_emphasis() -> None:
 def test_markdown_to_whatsapp_combined_emphasis() -> None:
     src = "**bold** and *italic* and ~~strike~~"
     assert markdown_to_whatsapp(src) == "*bold* and _italic_ and ~strike~"
+
+
+def test_markdown_to_whatsapp_preserves_python_dunders() -> None:
+    # Pre-fix regression: __init__ rendered as *init* (bold).  The
+    # bold-underscore pattern now requires non-word boundaries on
+    # both sides, matching italic's defensive lookarounds.
+    assert (
+        markdown_to_whatsapp("Call __init__ in your subclass") == "Call __init__ in your subclass"
+    )
+    assert markdown_to_whatsapp("__dunder__") == "__dunder__"
+
+
+def test_markdown_to_whatsapp_preserves_snake_case_bold_asterisks() -> None:
+    # Same defensive boundary for **foo** when foo is wedged
+    # between word chars — protects identifiers like `**name`.
+    # The regex's word-boundary look-around prevents an inner
+    # word-char from triggering bold; passing through.
+    assert markdown_to_whatsapp("snake_case**name**suffix") == "snake_case**name**suffix"
+
+
+def test_markdown_to_whatsapp_sentinel_collision_falls_back() -> None:
+    # Adversarial input containing the literal sentinel pattern but
+    # NO actual code fences / bolds: the restore pass must not
+    # IndexError; it falls back to leaving the literal match
+    # in place.
+    src = "before \x01SLOT\x015\x01ENDSLOT\x01 after"
+    # No code spans, no bolds stashed → placeholders is empty,
+    # idx=5 is out of range → restore returns the original
+    # match unchanged.
+    assert markdown_to_whatsapp(src) == src

--- a/connectors/whatsapp/tests/test_format.py
+++ b/connectors/whatsapp/tests/test_format.py
@@ -1,0 +1,64 @@
+"""Tests for the CommonMark → WhatsApp inline converter."""
+
+from __future__ import annotations
+
+import pytest
+
+from aios_whatsapp.format import markdown_to_whatsapp
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        # Bold variants both collapse to WhatsApp's *foo* shape.
+        ("**bold**", "*bold*"),
+        ("__bold__", "*bold*"),
+        ("hello **world**", "hello *world*"),
+        # Italic single-asterisk → underscore.
+        ("*italic*", "_italic_"),
+        ("hello *world*", "hello _world_"),
+        # Italic single-underscore stays underscore-shaped.
+        ("_italic_", "_italic_"),
+        # Strike: double-tilde → single-tilde.
+        ("~~strike~~", "~strike~"),
+        # Inline backtick promotes to monospace fence.
+        ("`code`", "```code```"),
+        # Already-fenced code passes through unchanged.
+        ("```already```", "```already```"),
+        # No formatting → identity.
+        ("plain text", "plain text"),
+    ],
+)
+def test_markdown_to_whatsapp_inline(source: str, expected: str) -> None:
+    assert markdown_to_whatsapp(source) == expected
+
+
+def test_markdown_to_whatsapp_does_not_italicize_snake_case() -> None:
+    # ``print_hello`` is a Python identifier, not Markdown italic
+    # spanning ``hello``.  Pre-fix regression would render as
+    # ``print<i>hello</i>``.
+    assert markdown_to_whatsapp("call print_hello() in this") == "call print_hello() in this"
+
+
+def test_markdown_to_whatsapp_does_not_italicize_multiplied_asterisks() -> None:
+    # ``a * b`` is arithmetic, not italic — the asterisk-italic regex
+    # requires no surrounding whitespace on the inside.
+    assert markdown_to_whatsapp("result = a * b") == "result = a * b"
+
+
+def test_markdown_to_whatsapp_preserves_emphasis_inside_code() -> None:
+    # Code spans must NOT be re-processed by the emphasis regexes,
+    # otherwise pre-fix ``**foo**`` inside a backtick would lose the
+    # asterisks and the rendered output would be wrong.
+    src = "see `**markdown**` syntax"
+    assert markdown_to_whatsapp(src) == "see ```**markdown**``` syntax"
+
+
+def test_markdown_to_whatsapp_handles_fence_with_inner_emphasis() -> None:
+    src = "```\n**not bold here**\n```"
+    assert markdown_to_whatsapp(src) == "```\n**not bold here**\n```"
+
+
+def test_markdown_to_whatsapp_combined_emphasis() -> None:
+    src = "**bold** and *italic* and ~~strike~~"
+    assert markdown_to_whatsapp(src) == "*bold* and _italic_ and ~strike~"

--- a/connectors/whatsapp/tests/test_handle_envelope.py
+++ b/connectors/whatsapp/tests/test_handle_envelope.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from aios_whatsapp.connector import WhatsappConnector
 
 from .conftest import CONNECTION_ID, GROUP_JID, PEER_JID, dm_payload
@@ -61,3 +63,65 @@ async def test_handle_inbound_drops_broadcast(connector: WhatsappConnector) -> N
         dm_payload(chat_jid="12345@broadcast", chat_type="broadcast"),
     )
     connector.emit_inbound.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+async def test_handle_inbound_reads_attachment_bytes(
+    connector: WhatsappConnector, tmp_path: Path
+) -> None:
+    # Daemon writes media to disk; connector reads bytes off-loop and
+    # forwards (filename, bytes, content_type) tuples to emit_inbound.
+    img = tmp_path / "photo.jpg"
+    img.write_bytes(b"jpeg-bytes")
+    p = dm_payload(text="caption")
+    p["attachments"] = [{"path": str(img), "mimetype": "image/jpeg", "filename": "photo.jpg"}]
+    await connector._handle_inbound_message(CONNECTION_ID, p)
+
+    kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["content"] == "caption"
+    assert kwargs["attachments"] == [("photo.jpg", b"jpeg-bytes", "image/jpeg")]
+
+
+async def test_handle_inbound_attachment_only_emits_with_empty_text(
+    connector: WhatsappConnector, tmp_path: Path
+) -> None:
+    img = tmp_path / "photo.jpg"
+    img.write_bytes(b"jpeg-bytes")
+    p = dm_payload(text="")
+    p["attachments"] = [{"path": str(img), "mimetype": "image/jpeg", "filename": "photo.jpg"}]
+    await connector._handle_inbound_message(CONNECTION_ID, p)
+
+    kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["content"] == ""
+    assert len(kwargs["attachments"]) == 1
+
+
+async def test_handle_inbound_sticker_emoji_in_metadata(connector: WhatsappConnector) -> None:
+    p = dm_payload(text="")
+    p["sticker_emoji"] = "🎉"
+    await connector._handle_inbound_message(CONNECTION_ID, p)
+
+    kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["metadata"]["sticker_emoji"] == "🎉"
+    # Sticker-only messages carry empty content — the emoji IS the signal.
+    assert kwargs["content"] == ""
+    assert kwargs["attachments"] is None
+
+
+async def test_handle_inbound_skips_unreadable_attachment(
+    connector: WhatsappConnector, tmp_path: Path
+) -> None:
+    # If the daemon wrote two attachments and one got truncated /
+    # removed before we read, surface the readable ones rather than
+    # drop the whole message.
+    good = tmp_path / "good.jpg"
+    good.write_bytes(b"jpeg")
+    bad = tmp_path / "missing.jpg"  # never created
+    p = dm_payload(text="see attached")
+    p["attachments"] = [
+        {"path": str(bad), "mimetype": "image/jpeg", "filename": "bad.jpg"},
+        {"path": str(good), "mimetype": "image/jpeg", "filename": "good.jpg"},
+    ]
+    await connector._handle_inbound_message(CONNECTION_ID, p)
+
+    kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["attachments"] == [("good.jpg", b"jpeg", "image/jpeg")]

--- a/connectors/whatsapp/tests/test_handle_envelope.py
+++ b/connectors/whatsapp/tests/test_handle_envelope.py
@@ -125,3 +125,30 @@ async def test_handle_inbound_skips_unreadable_attachment(
 
     kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
     assert kwargs["attachments"] == [("good.jpg", b"jpeg", "image/jpeg")]
+
+
+async def test_handle_inbound_reaction_stamps_metadata(connector: WhatsappConnector) -> None:
+    # Peer reacts to one of our messages — surface as
+    # metadata.reaction with empty content; the model uses
+    # target_message_id to match against its own send history.
+    p = dm_payload(text="")
+    p["reaction"] = {"emoji": "👍", "target_message_id": "3EB0OURMSG"}
+    await connector._handle_inbound_message(CONNECTION_ID, p)
+
+    kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["content"] == ""
+    assert kwargs["metadata"]["reaction"] == {
+        "emoji": "👍",
+        "target_message_id": "3EB0OURMSG",
+    }
+
+
+async def test_handle_inbound_reaction_removal_passes_through(
+    connector: WhatsappConnector,
+) -> None:
+    p = dm_payload(text="")
+    p["reaction"] = {"emoji": "", "target_message_id": "3EB0OURMSG"}
+    await connector._handle_inbound_message(CONNECTION_ID, p)
+
+    kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["metadata"]["reaction"]["emoji"] == ""

--- a/connectors/whatsapp/tests/test_handle_envelope.py
+++ b/connectors/whatsapp/tests/test_handle_envelope.py
@@ -177,3 +177,22 @@ async def test_handle_inbound_revoke_stamps_metadata(connector: WhatsappConnecto
     assert kwargs["content"] == ""
     assert kwargs["metadata"]["revoked"] is True
     assert kwargs["metadata"]["revoke_target_message_id"] == "3EB0ORIGINAL"
+
+
+async def test_handle_inbound_all_attachments_unreadable_stamps_metadata(
+    connector: WhatsappConnector, tmp_path: Path
+) -> None:
+    # Daemon declared 2 attachments but both files are missing /
+    # truncated before connector reads.  Pre-fix: model saw an empty
+    # message with no clue bytes were lost.  Post-fix: metadata.
+    # attachments_unreadable=2 surfaces the loss to the model.
+    p = dm_payload(text="check these out")
+    p["attachments"] = [
+        {"path": str(tmp_path / "missing1.jpg"), "mimetype": "image/jpeg", "filename": "a.jpg"},
+        {"path": str(tmp_path / "missing2.jpg"), "mimetype": "image/jpeg", "filename": "b.jpg"},
+    ]
+    await connector._handle_inbound_message(CONNECTION_ID, p)
+
+    kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["attachments"] is None
+    assert kwargs["metadata"]["attachments_unreadable"] == 2

--- a/connectors/whatsapp/tests/test_handle_envelope.py
+++ b/connectors/whatsapp/tests/test_handle_envelope.py
@@ -179,6 +179,36 @@ async def test_handle_inbound_revoke_stamps_metadata(connector: WhatsappConnecto
     assert kwargs["metadata"]["revoke_target_message_id"] == "3EB0ORIGINAL"
 
 
+async def test_handle_inbound_mentions_surface_as_phone_in_uuid_field(
+    connector: WhatsappConnector,
+) -> None:
+    # Inbound mentioned_jids surface as metadata.mentions list with
+    # ``uuid`` holding the +E.164 form (what the model would write
+    # in outbound text) and ``jid`` for completeness.
+    p = dm_payload(text="hey @+15551234567")
+    p["mentioned_jids"] = ["15551234567@s.whatsapp.net"]
+    await connector._handle_inbound_message(CONNECTION_ID, p)
+
+    kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["metadata"]["mentions"] == [
+        {"uuid": "+15551234567", "jid": "15551234567@s.whatsapp.net"},
+    ]
+
+
+async def test_handle_inbound_lid_mention_falls_back_to_raw_jid(
+    connector: WhatsappConnector,
+) -> None:
+    # LID JIDs (linked-device identity) and group JIDs aren't phone-
+    # like; the connector falls back to the raw JID rather than
+    # losing the mention entirely.
+    p = dm_payload(text="hey")
+    p["mentioned_jids"] = ["98765@lid"]
+    await connector._handle_inbound_message(CONNECTION_ID, p)
+
+    kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["metadata"]["mentions"] == [{"uuid": "98765@lid", "jid": "98765@lid"}]
+
+
 async def test_handle_inbound_all_attachments_unreadable_stamps_metadata(
     connector: WhatsappConnector, tmp_path: Path
 ) -> None:

--- a/connectors/whatsapp/tests/test_handle_envelope.py
+++ b/connectors/whatsapp/tests/test_handle_envelope.py
@@ -152,3 +152,28 @@ async def test_handle_inbound_reaction_removal_passes_through(
 
     kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
     assert kwargs["metadata"]["reaction"]["emoji"] == ""
+
+
+async def test_handle_inbound_edit_stamps_metadata(connector: WhatsappConnector) -> None:
+    # Peer edited their earlier message — content is the new body,
+    # metadata.edited=True flags the rewrite for the harness's
+    # context renderer.
+    p = dm_payload(text="corrected text")
+    p["edit"] = {"target_message_id": "3EB0ORIGINAL"}
+    await connector._handle_inbound_message(CONNECTION_ID, p)
+
+    kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["content"] == "corrected text"
+    assert kwargs["metadata"]["edited"] is True
+    assert kwargs["metadata"]["edit_target_message_id"] == "3EB0ORIGINAL"
+
+
+async def test_handle_inbound_revoke_stamps_metadata(connector: WhatsappConnector) -> None:
+    p = dm_payload(text="")
+    p["revoke"] = {"target_message_id": "3EB0ORIGINAL"}
+    await connector._handle_inbound_message(CONNECTION_ID, p)
+
+    kwargs = connector.emit_inbound.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["content"] == ""
+    assert kwargs["metadata"]["revoked"] is True
+    assert kwargs["metadata"]["revoke_target_message_id"] == "3EB0ORIGINAL"

--- a/connectors/whatsapp/tests/test_mentions.py
+++ b/connectors/whatsapp/tests/test_mentions.py
@@ -49,3 +49,48 @@ def test_encode_mentions_rejects_too_short_or_too_long() -> None:
     assert jids == []
     _, jids = encode_mentions("@1234567")  # 7 digits — at lower bound, valid
     assert jids == ["1234567@s.whatsapp.net"]
+
+
+def test_encode_mentions_accepts_italic_wrapped() -> None:
+    # Pre-fix: the lookbehind treated ``_`` as a word char and
+    # silently rejected italic-wrapped mentions.  Post-fix: the
+    # explicit ASCII boundary excludes ``_``, so ``_@<phone>_``
+    # round-trips.
+    _, jids = encode_mentions("tell _@+15551234567_ to read this")
+    assert jids == ["15551234567@s.whatsapp.net"]
+
+
+def test_encode_mentions_accepts_full_phone_jid() -> None:
+    # Model may copy the raw JID out of an inbound mention block
+    # and write it verbatim; the encoder should pass it through
+    # untouched.
+    _, jids = encode_mentions("cc @15551234567@s.whatsapp.net")
+    assert jids == ["15551234567@s.whatsapp.net"]
+
+
+def test_encode_mentions_accepts_lid_jid() -> None:
+    # Round-trip path for peers addressed by LID — the +E.164
+    # form doesn't apply, but the raw LID JID should still extract.
+    _, jids = encode_mentions("ping @98765@lid please")
+    assert jids == ["98765@lid"]
+
+
+def test_encode_mentions_skips_url_embedded_at_phone() -> None:
+    # URLs with @-and-digits in their path or fragment must NOT
+    # become accidental mentions.  Adding ``/`` and ``.`` to the
+    # explicit boundary class blocks URL-embedded harvesting.
+    _, jids = encode_mentions("see https://chat.example/u/@+15551234567 for context")
+    assert jids == []
+    _, jids = encode_mentions("path: /tags/@15551234567/index")
+    assert jids == []
+
+
+def test_encode_mentions_skips_non_ascii_digits() -> None:
+    # Python's ``\\d`` matches Unicode decimal digits by default
+    # (Arabic-Indic, Devanagari, fullwidth).  The regex now uses
+    # explicit ``[0-9]`` to avoid producing non-ASCII JIDs that
+    # WhatsApp would reject.  U+0660 is ARABIC-INDIC DIGIT ZERO;
+    # spelled as an escape so the source file stays ASCII-clean.
+    arabic_indic_seven_zeros = chr(0x0660) * 7
+    _, jids = encode_mentions(f"hey @{arabic_indic_seven_zeros}")
+    assert jids == []

--- a/connectors/whatsapp/tests/test_mentions.py
+++ b/connectors/whatsapp/tests/test_mentions.py
@@ -1,0 +1,51 @@
+"""Tests for the WhatsApp mention encoder."""
+
+from __future__ import annotations
+
+import pytest
+
+from aios_whatsapp.mentions import encode_mentions
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_jids"),
+    [
+        ("hey @+15551234567 how are you", ["15551234567@s.whatsapp.net"]),
+        ("hey @15551234567 how are you", ["15551234567@s.whatsapp.net"]),
+        # Multiple mentions, deduped on JID, ordered by first appearance.
+        (
+            "cc @+15551234567 and @+18007654321 and @15551234567 again",
+            ["15551234567@s.whatsapp.net", "18007654321@s.whatsapp.net"],
+        ),
+        ("no mentions here", []),
+    ],
+)
+def test_encode_mentions_extracts_e164(text: str, expected_jids: list[str]) -> None:
+    out_text, jids = encode_mentions(text)
+    # Encoder leaves text untouched — WhatsApp's wire format keeps the
+    # @<phone> literal in body.
+    assert out_text == text
+    assert jids == expected_jids
+
+
+def test_encode_mentions_ignores_email_addresses() -> None:
+    # ``user@example.com`` has ``@`` followed by non-digits; the
+    # regex's digit-only group rejects it.  Defensive: ``hello@1234``
+    # also has letters before the @ which falls outside word boundary.
+    _, jids = encode_mentions("ping user@example.com about it")
+    assert jids == []
+    _, jids = encode_mentions("see https://example.com/page@123 for refs")
+    # The @123 is preceded by an alphanumeric "page", so the lookbehind
+    # rejects it.
+    assert jids == []
+
+
+def test_encode_mentions_rejects_too_short_or_too_long() -> None:
+    # E.164 valid range is 7-15 digits.  Below/above bounds should
+    # not be detected as mentions.
+    _, jids = encode_mentions("@123")  # 3 digits
+    assert jids == []
+    _, jids = encode_mentions("@1234567890123456")  # 16 digits
+    assert jids == []
+    _, jids = encode_mentions("@1234567")  # 7 digits — at lower bound, valid
+    assert jids == ["1234567@s.whatsapp.net"]

--- a/connectors/whatsapp/tests/test_parse.py
+++ b/connectors/whatsapp/tests/test_parse.py
@@ -135,11 +135,40 @@ def test_parse_message_sticker_emoji_kept_without_text() -> None:
     assert msg.attachments == ()
 
 
+def test_parse_message_keeps_sticker_with_empty_emoji() -> None:
+    # Custom stickers from WhatsApp's sticker maker often carry no
+    # emoji label; the daemon now emits sticker_emoji="" instead of
+    # omitting the key so parse_message must keep the envelope.
+    # Pre-fix the message would land here without the key set, get
+    # dropped as "no signal", and the model would never know the peer
+    # sent a sticker.
+    p = dm_payload(text="")
+    p["sticker_emoji"] = ""
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.sticker_emoji == ""
+
+
 def test_parse_message_drops_when_no_signal_at_all() -> None:
     # No text, no attachments, no sticker, no reaction — nothing for
     # the model to act on, so silently drop.
     p = dm_payload(text="")
     assert parse_message(p) is None
+
+
+def test_parse_message_carries_quoted_message_id() -> None:
+    p = dm_payload(text="thanks for that")
+    p["quoted_message_id"] = "3EB0PEERTARGET"
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.quoted_message_id == "3EB0PEERTARGET"
+
+
+def test_parse_message_quoted_message_id_absent_by_default() -> None:
+    p = dm_payload(text="hello")
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.quoted_message_id is None
 
 
 def test_parse_message_carries_reaction() -> None:

--- a/connectors/whatsapp/tests/test_parse.py
+++ b/connectors/whatsapp/tests/test_parse.py
@@ -223,3 +223,19 @@ def test_parse_message_keeps_whitespace_text_when_other_signal_present() -> None
     msg = parse_message(p)
     assert msg is not None
     assert msg.text == "   "  # surfaces as-received; the drop is conditional only
+
+
+def test_parse_message_carries_mentioned_jids() -> None:
+    p = dm_payload(text="hey @+15551234567")
+    p["mentioned_jids"] = ["15551234567@s.whatsapp.net"]
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.mentioned_jids == ("15551234567@s.whatsapp.net",)
+
+
+def test_parse_message_handles_malformed_mention_list() -> None:
+    p = dm_payload(text="hey")
+    p["mentioned_jids"] = ["valid@s.whatsapp.net", "", 12345, None]
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.mentioned_jids == ("valid@s.whatsapp.net",)

--- a/connectors/whatsapp/tests/test_parse.py
+++ b/connectors/whatsapp/tests/test_parse.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from aios_whatsapp.parse import InboundMessage, parse_message
+from aios_whatsapp.parse import InboundAttachment, InboundMessage, parse_message
 
 from .conftest import GROUP_JID, PEER_JID, dm_payload, group_payload
 
@@ -70,3 +70,68 @@ def test_parse_message_tolerates_missing_push_name() -> None:
     msg = parse_message(p)
     assert msg is not None
     assert msg.sender_name is None
+
+
+def test_parse_message_carries_attachments() -> None:
+    p = dm_payload(text="check this out")
+    p["attachments"] = [
+        {"path": "/tmp/media/3EB0X_photo.jpg", "mimetype": "image/jpeg", "filename": "photo.jpg"}
+    ]
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.attachments == (
+        InboundAttachment(
+            host_path="/tmp/media/3EB0X_photo.jpg",
+            filename="photo.jpg",
+            content_type="image/jpeg",
+        ),
+    )
+    assert msg.text == "check this out"
+
+
+def test_parse_message_keeps_attachment_only_message() -> None:
+    # Previously, an empty-text payload was dropped wholesale.  PR 5
+    # inverts that: an image-only message is signal worth surfacing —
+    # the harness can still render "received an image" via the
+    # attachment metadata.
+    p = dm_payload(text="")
+    p["attachments"] = [
+        {"path": "/tmp/m/3EB0Y.jpg", "mimetype": "image/jpeg", "filename": "photo.jpg"}
+    ]
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.text == ""
+    assert len(msg.attachments) == 1
+
+
+def test_parse_message_drops_malformed_attachment_entries() -> None:
+    # The daemon emits only complete entries on success, but defending
+    # against partial dicts protects the connector from a future
+    # daemon-side regression silently dropping a path field.
+    p = dm_payload(text="caption")
+    p["attachments"] = [
+        {"path": "/tmp/m/a.jpg", "mimetype": "image/jpeg", "filename": "a.jpg"},
+        {"path": "", "mimetype": "image/jpeg", "filename": "b.jpg"},  # bad path
+        {"path": "/tmp/m/c.jpg", "mimetype": "", "filename": "c.jpg"},  # bad mime
+        "not-a-dict",  # bad type entirely
+    ]
+    msg = parse_message(p)
+    assert msg is not None
+    assert len(msg.attachments) == 1
+    assert msg.attachments[0].filename == "a.jpg"
+
+
+def test_parse_message_sticker_emoji_kept_without_text() -> None:
+    p = dm_payload(text="")
+    p["sticker_emoji"] = "🎉"
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.sticker_emoji == "🎉"
+    assert msg.attachments == ()
+
+
+def test_parse_message_drops_when_no_signal_at_all() -> None:
+    # No text, no attachments, no sticker — nothing for the model
+    # to act on, so silently drop.
+    p = dm_payload(text="")
+    assert parse_message(p) is None

--- a/connectors/whatsapp/tests/test_parse.py
+++ b/connectors/whatsapp/tests/test_parse.py
@@ -204,3 +204,22 @@ def test_parse_message_drops_edit_revoke_without_target_id() -> None:
     p = dm_payload(text="")
     p["revoke"] = {"target_message_id": ""}
     assert parse_message(p) is None
+
+
+def test_parse_message_drops_whitespace_only_text() -> None:
+    # Whitespace ("   ", "\n", etc.) is truthy in Python but carries
+    # no model-relevant signal — peer mis-tapped or sent an
+    # accessibility-input artifact.  Drop just like empty text.
+    assert parse_message(dm_payload(text="   ")) is None
+    assert parse_message(dm_payload(text="\n\t")) is None
+
+
+def test_parse_message_keeps_whitespace_text_when_other_signal_present() -> None:
+    # When there IS other signal (reaction/attachment/sticker), the
+    # whitespace-only text isn't load-bearing — but the event itself
+    # is, so don't drop.
+    p = dm_payload(text="   ")
+    p["reaction"] = {"emoji": "👍", "target_message_id": "X"}
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.text == "   "  # surfaces as-received; the drop is conditional only

--- a/connectors/whatsapp/tests/test_parse.py
+++ b/connectors/whatsapp/tests/test_parse.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from aios_whatsapp.parse import InboundAttachment, InboundMessage, parse_message
+from aios_whatsapp.parse import (
+    InboundAttachment,
+    InboundMessage,
+    InboundReaction,
+    parse_message,
+)
 
 from .conftest import GROUP_JID, PEER_JID, dm_payload, group_payload
 
@@ -131,7 +136,36 @@ def test_parse_message_sticker_emoji_kept_without_text() -> None:
 
 
 def test_parse_message_drops_when_no_signal_at_all() -> None:
-    # No text, no attachments, no sticker — nothing for the model
-    # to act on, so silently drop.
+    # No text, no attachments, no sticker, no reaction — nothing for
+    # the model to act on, so silently drop.
     p = dm_payload(text="")
+    assert parse_message(p) is None
+
+
+def test_parse_message_carries_reaction() -> None:
+    p = dm_payload(text="")
+    p["reaction"] = {"emoji": "👍", "target_message_id": "3EB0ORIGINAL"}
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.reaction == InboundReaction(emoji="👍", target_message_id="3EB0ORIGINAL")
+    assert msg.text == ""
+
+
+def test_parse_message_reaction_removal_keeps_event() -> None:
+    # Empty emoji = peer cleared their prior reaction.  Surface
+    # explicitly so the model can update its mental model.
+    p = dm_payload(text="")
+    p["reaction"] = {"emoji": "", "target_message_id": "3EB0ORIGINAL"}
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.reaction is not None
+    assert msg.reaction.emoji == ""
+
+
+def test_parse_message_drops_reaction_without_target_id() -> None:
+    # A reaction with no target_message_id can't be matched against
+    # anything in the model's context — drop it rather than surface a
+    # half-populated event that confuses the model.
+    p = dm_payload(text="")
+    p["reaction"] = {"emoji": "👍"}
     assert parse_message(p) is None

--- a/connectors/whatsapp/tests/test_parse.py
+++ b/connectors/whatsapp/tests/test_parse.py
@@ -169,3 +169,38 @@ def test_parse_message_drops_reaction_without_target_id() -> None:
     p = dm_payload(text="")
     p["reaction"] = {"emoji": "👍"}
     assert parse_message(p) is None
+
+
+def test_parse_message_edit_carries_target_and_new_text() -> None:
+    # Daemon overrides text to the edited body and surfaces the
+    # target_message_id in an "edit" block.  parse.py exposes both
+    # so the connector can stamp "edited=true" on the metadata.
+    p = dm_payload(text="this is the corrected version")
+    p["edit"] = {"target_message_id": "3EB0ORIGINAL"}
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.text == "this is the corrected version"
+    assert msg.edit_target_message_id == "3EB0ORIGINAL"
+
+
+def test_parse_message_revoke_kept_with_empty_text() -> None:
+    # A revoke carries no replacement body — the empty text is the
+    # signal alongside the revoke block.  Must survive the "no
+    # signal" drop.
+    p = dm_payload(text="")
+    p["revoke"] = {"target_message_id": "3EB0ORIGINAL"}
+    msg = parse_message(p)
+    assert msg is not None
+    assert msg.text == ""
+    assert msg.revoke_target_message_id == "3EB0ORIGINAL"
+
+
+def test_parse_message_drops_edit_revoke_without_target_id() -> None:
+    # Same defense-in-depth as the reaction path: a target-less
+    # protocol message can't be matched, so silently drop.
+    p = dm_payload(text="")
+    p["edit"] = {}
+    assert parse_message(p) is None
+    p = dm_payload(text="")
+    p["revoke"] = {"target_message_id": ""}
+    assert parse_message(p) is None

--- a/connectors/whatsapp/tests/test_prompts.py
+++ b/connectors/whatsapp/tests/test_prompts.py
@@ -65,6 +65,23 @@ def test_build_instructions_omits_group_section_when_no_groups() -> None:
     assert "## Your WhatsApp groups" not in result
 
 
+def test_build_instructions_matches_bot_with_device_suffix_jid() -> None:
+    # Pre-fix: (YOU) tag used literal string equality, so a roster
+    # entry showing the bot's JID with a device-suffix variant
+    # silently dropped the self-tag.  Post-fix: comparison is on the
+    # identity-bearing local part (strip device suffix + host).
+    bot = "15555550000@s.whatsapp.net"
+    groups = [
+        GroupRosterEntry(
+            jid="g1@g.us",
+            name="Engineering",
+            member_jids=["15555550000:7@s.whatsapp.net", "15551234567@s.whatsapp.net"],
+        ),
+    ]
+    result = build_instructions(bot_jid=bot, phone="+15555550000", groups=groups)
+    assert "(YOU)" in result
+
+
 def test_static_body_mentions_only_existing_tools() -> None:
     # Defensive: the static body must reference only the WhatsApp
     # tools this connector actually publishes, so the model isn't

--- a/connectors/whatsapp/tests/test_prompts.py
+++ b/connectors/whatsapp/tests/test_prompts.py
@@ -1,0 +1,84 @@
+"""Tests for the WhatsApp prompts.py identity + roster prelude."""
+
+from __future__ import annotations
+
+from aios_whatsapp.prompts import (
+    WHATSAPP_SERVER_INSTRUCTIONS,
+    GroupRosterEntry,
+    build_instructions,
+)
+
+
+def test_build_instructions_emits_identity_and_static_body() -> None:
+    result = build_instructions(
+        bot_jid="15555550000@s.whatsapp.net",
+        phone="+15555550000",
+    )
+    assert "**jid**: `15555550000@s.whatsapp.net`" in result
+    assert "**phone**: `+15555550000`" in result
+    # Static body always concatenates at the end.
+    assert WHATSAPP_SERVER_INSTRUCTIONS in result
+
+
+def test_build_instructions_includes_push_name_when_set() -> None:
+    result = build_instructions(
+        bot_jid="x@s.whatsapp.net",
+        phone="+1",
+        push_name="Ultron",
+    )
+    assert "**push_name**: `Ultron`" in result
+
+
+def test_build_instructions_omits_push_name_when_blank() -> None:
+    # An empty push_name shouldn't render a blank bullet that
+    # consumes a line in the system prompt for no signal.
+    result = build_instructions(bot_jid="x@s.whatsapp.net", phone="+1", push_name="")
+    assert "push_name" not in result
+
+
+def test_build_instructions_renders_group_roster() -> None:
+    bot = "15555550000@s.whatsapp.net"
+    groups = [
+        GroupRosterEntry(
+            jid="g1@g.us",
+            name="Engineering",
+            member_jids=[bot, "15551234567@s.whatsapp.net", "18007654321@s.whatsapp.net"],
+        ),
+        GroupRosterEntry(
+            jid="g2@g.us",
+            name="",
+            member_jids=[bot, "15551234567@s.whatsapp.net"],
+        ),
+    ]
+    result = build_instructions(bot_jid=bot, phone="+15555550000", groups=groups)
+    assert "## Your WhatsApp groups" in result
+    assert "`g1@g.us` — Engineering" in result
+    # Unnamed group falls through to a placeholder so the section
+    # isn't visually broken by an empty name.
+    assert "`g2@g.us` — (unnamed)" in result
+    # Self-tag distinguishes the bot from peers in the roster.
+    assert "(YOU)" in result
+
+
+def test_build_instructions_omits_group_section_when_no_groups() -> None:
+    result = build_instructions(bot_jid="x@s.whatsapp.net", phone="+1")
+    assert "## Your WhatsApp groups" not in result
+
+
+def test_static_body_mentions_only_existing_tools() -> None:
+    # Defensive: the static body must reference only the WhatsApp
+    # tools this connector actually publishes, so the model isn't
+    # told to call something that doesn't exist.
+    for expected in (
+        "whatsapp_send",
+        "whatsapp_react",
+        "whatsapp_edit_message",
+        "whatsapp_delete_message",
+        "whatsapp_list_groups",
+        "whatsapp_create_group",
+        "whatsapp_rename_group",
+    ):
+        assert expected in WHATSAPP_SERVER_INSTRUCTIONS, f"missing {expected}"
+    # Sanity check: don't accidentally mention a tool from another
+    # connector (e.g., signal_send).
+    assert "signal_" not in WHATSAPP_SERVER_INSTRUCTIONS

--- a/connectors/whatsapp/tests/test_whatsapp_groups.py
+++ b/connectors/whatsapp/tests/test_whatsapp_groups.py
@@ -52,6 +52,46 @@ async def test_whatsapp_create_group_converts_phones_to_jids(
     ]
 
 
+async def test_whatsapp_create_group_strips_parens_and_dots(
+    connector: WhatsappConnector,
+) -> None:
+    # Pre-fix: _phone_to_jid only stripped +/space/dash, so a
+    # ``(555) 123-4567`` style phone leaked parens into the JID
+    # local part and the daemon's ParseJID rejected with an opaque
+    # error.  Post-fix: all non-digit characters are stripped so
+    # common formatter variants all resolve to the same JID.
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "jid": "g@g.us",
+        "name": "x",
+        "participants": [],
+    }
+    await connector.whatsapp_create_group(
+        name="x",
+        participants=["+1 (555) 123-4567", "+1.555.999.0000"],
+        connection_id=CONNECTION_ID,
+    )
+    sent = connector.state[CONNECTION_ID].daemon.rpc.call.await_args.args[1]  # type: ignore[attr-defined]
+    assert sent["participants"] == [
+        "15551234567@s.whatsapp.net",
+        "15559990000@s.whatsapp.net",
+    ]
+
+
+async def test_whatsapp_create_group_rejects_digit_free_phone(
+    connector: WhatsappConnector,
+) -> None:
+    # Defensive: a participant string with no digits at all (e.g.
+    # the model passed a display name) should fail at the Python
+    # boundary with a clear ValueError rather than producing a
+    # malformed JID the daemon rejects opaquely.
+    with pytest.raises(ValueError, match="no digits"):
+        await connector.whatsapp_create_group(
+            name="x",
+            participants=["Alice"],
+            connection_id=CONNECTION_ID,
+        )
+
+
 async def test_whatsapp_create_group_passes_jid_through_unchanged(
     connector: WhatsappConnector,
 ) -> None:

--- a/connectors/whatsapp/tests/test_whatsapp_groups.py
+++ b/connectors/whatsapp/tests/test_whatsapp_groups.py
@@ -1,0 +1,106 @@
+"""Tests for the WhatsApp group tools."""
+
+from __future__ import annotations
+
+import pytest
+
+from aios_whatsapp.connector import WhatsappConnector
+
+from .conftest import CONNECTION_ID, GROUP_JID
+
+
+async def test_whatsapp_list_groups_dispatches_listGroups(
+    connector: WhatsappConnector,
+) -> None:
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "groups": [
+            {
+                "jid": GROUP_JID,
+                "name": "Test Group",
+                "topic": "",
+                "participants": [{"jid": "x@s.whatsapp.net", "is_admin": True}],
+            }
+        ]
+    }
+    result = await connector.whatsapp_list_groups(connection_id=CONNECTION_ID)
+    connector.state[CONNECTION_ID].daemon.rpc.call.assert_awaited_once_with("listGroups", {})  # type: ignore[attr-defined]
+    assert result["groups"][0]["jid"] == GROUP_JID
+    assert result["groups"][0]["participants"][0]["is_admin"] is True
+
+
+async def test_whatsapp_create_group_converts_phones_to_jids(
+    connector: WhatsappConnector,
+) -> None:
+    # Model passes +E.164 phones; connector normalizes to JIDs the
+    # daemon can hand to whatsmeow's CreateGroup.
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "jid": "12345-67890@g.us",
+        "name": "New Group",
+        "participants": [],
+    }
+    await connector.whatsapp_create_group(
+        name="New Group",
+        participants=["+15551234567", "18007654321", "+1 555 999 0000"],
+        connection_id=CONNECTION_ID,
+    )
+    sent = connector.state[CONNECTION_ID].daemon.rpc.call.await_args.args[1]  # type: ignore[attr-defined]
+    assert sent["name"] == "New Group"
+    assert sent["participants"] == [
+        "15551234567@s.whatsapp.net",
+        "18007654321@s.whatsapp.net",
+        "15559990000@s.whatsapp.net",
+    ]
+
+
+async def test_whatsapp_create_group_passes_jid_through_unchanged(
+    connector: WhatsappConnector,
+) -> None:
+    # If the model already has a JID (e.g., from list_groups output)
+    # it can pass that verbatim; the connector recognizes the ``@``
+    # and skips the phone-normalize.
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "jid": "g@g.us",
+        "name": "x",
+        "participants": [],
+    }
+    await connector.whatsapp_create_group(
+        name="x",
+        participants=["existing@s.whatsapp.net"],
+        connection_id=CONNECTION_ID,
+    )
+    sent = connector.state[CONNECTION_ID].daemon.rpc.call.await_args.args[1]  # type: ignore[attr-defined]
+    assert sent["participants"] == ["existing@s.whatsapp.net"]
+
+
+async def test_whatsapp_rename_group_forwards_renameGroup(
+    connector: WhatsappConnector,
+) -> None:
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {"status": "ok"}  # type: ignore[attr-defined]
+    await connector.whatsapp_rename_group(
+        chat_id=GROUP_JID,
+        name="Renamed",
+        connection_id=CONNECTION_ID,
+    )
+    connector.state[CONNECTION_ID].daemon.rpc.call.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "renameGroup",
+        {"jid": GROUP_JID, "name": "Renamed"},
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs"),
+    [
+        ("whatsapp_list_groups", {}),
+        ("whatsapp_create_group", {"name": "x", "participants": ["+15550000000"]}),
+        ("whatsapp_rename_group", {"chat_id": GROUP_JID, "name": "x"}),
+    ],
+)
+async def test_group_tools_raise_on_non_dict_result(
+    connector: WhatsappConnector,
+    method: str,
+    kwargs: dict[str, object],
+) -> None:
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = "not-a-dict"  # type: ignore[attr-defined]
+    tool_fn = getattr(connector, method)
+    with pytest.raises(RuntimeError, match="returned non-dict"):
+        await tool_fn(**kwargs, connection_id=CONNECTION_ID)

--- a/connectors/whatsapp/tests/test_whatsapp_msgops.py
+++ b/connectors/whatsapp/tests/test_whatsapp_msgops.py
@@ -64,6 +64,43 @@ async def test_whatsapp_edit_message_dispatches_editMessage(connector: WhatsappC
     assert result == {"message_id": "EDIT-1", "timestamp_ms": 1700000400000}
 
 
+async def test_whatsapp_edit_message_encodes_mentions(
+    connector: WhatsappConnector,
+) -> None:
+    # Pre-fix: edit silently stripped any @<E.164> mentions because
+    # the edit path didn't run encode_mentions and the daemon's
+    # editMessage RPC had no mentioned_jids param.  Post-fix: the
+    # edit carries mentions through to whatsmeow's BuildEdit, which
+    # builds an ExtendedTextMessage with ContextInfo.MentionedJID.
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "message_id": "EDIT-2",
+        "timestamp_ms": 1700000401000,
+    }
+    await connector.whatsapp_edit_message(
+        message_id=MSG_ID,
+        text="hey @+15551234567 corrected",
+        connection_id=CONNECTION_ID,
+    )
+    sent = connector.state[CONNECTION_ID].daemon.rpc.call.await_args.args[1]  # type: ignore[attr-defined]
+    assert sent["mentioned_jids"] == ["15551234567@s.whatsapp.net"]
+
+
+async def test_whatsapp_edit_message_omits_mentions_when_none(
+    connector: WhatsappConnector,
+) -> None:
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "message_id": "EDIT-3",
+        "timestamp_ms": 1700000402000,
+    }
+    await connector.whatsapp_edit_message(
+        message_id=MSG_ID,
+        text="no tags here",
+        connection_id=CONNECTION_ID,
+    )
+    sent = connector.state[CONNECTION_ID].daemon.rpc.call.await_args.args[1]  # type: ignore[attr-defined]
+    assert "mentioned_jids" not in sent
+
+
 async def test_whatsapp_delete_message_dispatches_deleteMessage(
     connector: WhatsappConnector,
 ) -> None:

--- a/connectors/whatsapp/tests/test_whatsapp_msgops.py
+++ b/connectors/whatsapp/tests/test_whatsapp_msgops.py
@@ -1,0 +1,122 @@
+"""Tests for the ``whatsapp_react`` / ``whatsapp_edit_message`` /
+``whatsapp_delete_message`` tool methods."""
+
+from __future__ import annotations
+
+import pytest
+
+from aios_whatsapp.connector import WhatsappConnector
+
+from .conftest import CONNECTION_ID
+
+MSG_ID = "3EB0E03B46303C22D750E2"
+
+
+async def test_whatsapp_react_dispatches_sendReaction(connector: WhatsappConnector) -> None:
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "message_id": "REACT-1",
+        "timestamp_ms": 1700000300000,
+    }
+    result = await connector.whatsapp_react(
+        message_id=MSG_ID,
+        reaction="👍",
+        connection_id=CONNECTION_ID,
+    )
+    connector.state[CONNECTION_ID].daemon.rpc.call.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "sendReaction",
+        {"message_id": MSG_ID, "reaction": "👍"},
+    )
+    assert result == {"message_id": "REACT-1", "timestamp_ms": 1700000300000}
+
+
+async def test_whatsapp_react_empty_reaction_clears_prior(connector: WhatsappConnector) -> None:
+    # Empty string is the documented "remove reaction" affordance —
+    # the daemon forwards it verbatim to whatsmeow's BuildReaction.
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "message_id": "REACT-2",
+        "timestamp_ms": 1700000301000,
+    }
+    await connector.whatsapp_react(
+        message_id=MSG_ID,
+        reaction="",
+        connection_id=CONNECTION_ID,
+    )
+    connector.state[CONNECTION_ID].daemon.rpc.call.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "sendReaction",
+        {"message_id": MSG_ID, "reaction": ""},
+    )
+
+
+async def test_whatsapp_edit_message_dispatches_editMessage(connector: WhatsappConnector) -> None:
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "message_id": "EDIT-1",
+        "timestamp_ms": 1700000400000,
+    }
+    result = await connector.whatsapp_edit_message(
+        message_id=MSG_ID,
+        text="corrected",
+        connection_id=CONNECTION_ID,
+    )
+    connector.state[CONNECTION_ID].daemon.rpc.call.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "editMessage",
+        {"message_id": MSG_ID, "text": "corrected"},
+    )
+    assert result == {"message_id": "EDIT-1", "timestamp_ms": 1700000400000}
+
+
+async def test_whatsapp_delete_message_dispatches_deleteMessage(
+    connector: WhatsappConnector,
+) -> None:
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "message_id": "REV-1",
+        "timestamp_ms": 1700000500000,
+    }
+    result = await connector.whatsapp_delete_message(
+        message_id=MSG_ID,
+        connection_id=CONNECTION_ID,
+    )
+    connector.state[CONNECTION_ID].daemon.rpc.call.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "deleteMessage",
+        {"message_id": MSG_ID},
+    )
+    assert result == {"message_id": "REV-1", "timestamp_ms": 1700000500000}
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs"),
+    [
+        ("whatsapp_react", {"message_id": MSG_ID, "reaction": "👍"}),
+        ("whatsapp_edit_message", {"message_id": MSG_ID, "text": "x"}),
+        ("whatsapp_delete_message", {"message_id": MSG_ID}),
+    ],
+)
+async def test_msgops_raise_on_non_dict_result(
+    connector: WhatsappConnector,
+    method: str,
+    kwargs: dict[str, str],
+) -> None:
+    # Each tool wraps RuntimeError around a malformed daemon response —
+    # surfaces a clear failure path to the model instead of returning
+    # an unparseable string into the tool_result.
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = "not-a-dict"  # type: ignore[attr-defined]
+    tool_fn = getattr(connector, method)
+    with pytest.raises(RuntimeError, match="returned non-dict"):
+        await tool_fn(**kwargs, connection_id=CONNECTION_ID)
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs"),
+    [
+        ("whatsapp_react", {"message_id": MSG_ID, "reaction": "👍"}),
+        ("whatsapp_edit_message", {"message_id": MSG_ID, "text": "x"}),
+        ("whatsapp_delete_message", {"message_id": MSG_ID}),
+    ],
+)
+async def test_msgops_raise_on_unknown_connection(
+    connector: WhatsappConnector,
+    method: str,
+    kwargs: dict[str, str],
+) -> None:
+    tool_fn = getattr(connector, method)
+    with pytest.raises(KeyError):
+        await tool_fn(**kwargs, connection_id="conn_unknown")

--- a/connectors/whatsapp/tests/test_whatsapp_send.py
+++ b/connectors/whatsapp/tests/test_whatsapp_send.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from aios_whatsapp.connector import WhatsappConnector
@@ -59,3 +61,78 @@ async def test_whatsapp_send_raises_on_unknown_connection(connector: WhatsappCon
             connection_id="conn_unknown",
             chat_id=PEER_JID,
         )
+
+
+async def test_whatsapp_send_forwards_attachments(
+    connector: WhatsappConnector, tmp_path: Path
+) -> None:
+    img = tmp_path / "photo.jpg"
+    img.write_bytes(b"\xff\xd8\xff")  # minimal JPEG SOI marker
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "message_id": "3EB0IMG",
+        "timestamp_ms": 1700000200000,
+    }
+    result = await connector.whatsapp_send(
+        text="caption",
+        attachments=[img],
+        connection_id=CONNECTION_ID,
+        chat_id=PEER_JID,
+    )
+    connector.state[CONNECTION_ID].daemon.rpc.call.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "sendMessage",
+        {
+            "jid": PEER_JID,
+            "text": "caption",
+            "attachments": [{"path": str(img), "mimetype": "image/jpeg", "filename": "photo.jpg"}],
+        },
+    )
+    assert result == {"message_id": "3EB0IMG", "timestamp_ms": 1700000200000}
+
+
+async def test_whatsapp_send_unknown_mimetype_falls_back_to_octet_stream(
+    connector: WhatsappConnector, tmp_path: Path
+) -> None:
+    # mimetypes.guess_type returns (None, None) for unknown extensions.
+    # The connector substitutes application/octet-stream so the daemon
+    # has a non-empty value to classify on (catches as Document).
+    blob = tmp_path / "mysterious.deadbeef"
+    blob.write_bytes(b"random bytes")
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "message_id": "3EB0DOC",
+        "timestamp_ms": 1700000201000,
+    }
+    await connector.whatsapp_send(
+        text="",
+        attachments=[blob],
+        connection_id=CONNECTION_ID,
+        chat_id=PEER_JID,
+    )
+    call_args = connector.state[CONNECTION_ID].daemon.rpc.call.await_args  # type: ignore[attr-defined]
+    sent_params = call_args.args[1]
+    assert sent_params["attachments"][0]["mimetype"] == "application/octet-stream"
+    assert sent_params["attachments"][0]["filename"] == "mysterious.deadbeef"
+
+
+async def test_whatsapp_send_multi_attachment_preserves_order(
+    connector: WhatsappConnector, tmp_path: Path
+) -> None:
+    # Multi-attachment ordering matters for the caption-on-first
+    # semantic — the daemon takes the first one to carry the text.
+    img = tmp_path / "a.jpg"
+    img.write_bytes(b"\xff\xd8\xff")
+    pdf = tmp_path / "b.pdf"
+    pdf.write_bytes(b"%PDF-")
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "message_id": "3EB0MULTI",
+        "timestamp_ms": 1700000202000,
+    }
+    await connector.whatsapp_send(
+        text="see attachments",
+        attachments=[img, pdf],
+        connection_id=CONNECTION_ID,
+        chat_id=PEER_JID,
+    )
+    sent_params = connector.state[CONNECTION_ID].daemon.rpc.call.await_args.args[1]  # type: ignore[attr-defined]
+    assert [a["filename"] for a in sent_params["attachments"]] == ["a.jpg", "b.pdf"]
+    assert sent_params["attachments"][0]["mimetype"] == "image/jpeg"
+    assert sent_params["attachments"][1]["mimetype"] == "application/pdf"

--- a/connectors/whatsapp/tests/test_whatsapp_send.py
+++ b/connectors/whatsapp/tests/test_whatsapp_send.py
@@ -113,6 +113,45 @@ async def test_whatsapp_send_unknown_mimetype_falls_back_to_octet_stream(
     assert sent_params["attachments"][0]["filename"] == "mysterious.deadbeef"
 
 
+async def test_whatsapp_send_encodes_mentions_into_params(
+    connector: WhatsappConnector,
+) -> None:
+    # Model writes @<E.164> in text; the connector pulls it out into
+    # mentioned_jids (in JID form) and forwards both to the daemon.
+    # The text-on-the-wire keeps the @<phone> literal because
+    # WhatsApp clients render the mention pill from the JID list.
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "message_id": "3EB0MENTION",
+        "timestamp_ms": 1700000300000,
+    }
+    await connector.whatsapp_send(
+        text="hey @+15551234567 about the thing",
+        connection_id=CONNECTION_ID,
+        chat_id=PEER_JID,
+    )
+    sent = connector.state[CONNECTION_ID].daemon.rpc.call.await_args.args[1]  # type: ignore[attr-defined]
+    assert sent["mentioned_jids"] == ["15551234567@s.whatsapp.net"]
+    # markdown_to_whatsapp is a no-op on this text; the @<phone>
+    # literal survives intact.
+    assert "@+15551234567" in sent["text"]
+
+
+async def test_whatsapp_send_omits_mentions_key_when_no_mentions(
+    connector: WhatsappConnector,
+) -> None:
+    connector.state[CONNECTION_ID].daemon.rpc.call.return_value = {  # type: ignore[attr-defined]
+        "message_id": "3EB0PLAIN",
+        "timestamp_ms": 1700000301000,
+    }
+    await connector.whatsapp_send(
+        text="no tags here",
+        connection_id=CONNECTION_ID,
+        chat_id=PEER_JID,
+    )
+    sent = connector.state[CONNECTION_ID].daemon.rpc.call.await_args.args[1]  # type: ignore[attr-defined]
+    assert "mentioned_jids" not in sent
+
+
 async def test_whatsapp_send_multi_attachment_preserves_order(
     connector: WhatsappConnector, tmp_path: Path
 ) -> None:

--- a/openapi.json
+++ b/openapi.json
@@ -6547,6 +6547,68 @@
         }
       }
     },
+    "/v1/connectors/runtime/lifecycle": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Post Runtime Lifecycle",
+        "description": "Append a ``kind=lifecycle`` event onto every session bound to\n``body.connection_id``.\n\nAuthorization mirrors the inbound + tool-result paths: the bearer's\nconnector must match ``body.connection_id``'s connector, and any\nbearer-side allowlist must include the connection_id (#350).\n\nReturns ``{\"appended_session_ids\": [...]}`` enumerating the sessions\nthat received the event.  An empty list means no sessions were\nbound at the time of the call (e.g. the operator detached every\nsession before the connector finished tearing down); not an error.",
+        "operationId": "post_connector_runtime_lifecycle",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuntimeLifecycleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Post Connector Runtime Lifecycle"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/connectors/runtime/tool-results": {
       "post": {
         "tags": [
@@ -10585,6 +10647,49 @@
         ],
         "title": "RecentChat",
         "description": "Distinct chat_id observed on a connection's account, with the\nmost-recent inbound timestamp.\n\nReturned by ``GET /v1/connections/{id}/recent-chats`` so operators\ncan find the chat_id for a specific peer without digging through\nevent logs before calling ``bind-chat``."
+      },
+      "RuntimeLifecycleRequest": {
+        "properties": {
+          "connection_id": {
+            "type": "string",
+            "title": "Connection Id"
+          },
+          "event": {
+            "type": "string",
+            "title": "Event"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "connection_id",
+          "event"
+        ],
+        "title": "RuntimeLifecycleRequest",
+        "description": "Body for ``POST /v1/connectors/runtime/lifecycle``.\n\nLets a connector emit a lifecycle event onto each session bound to\n``connection_id`` \u2014 used today for \"the underlying transport just\nwent away\" notifications (WhatsApp daemon crashed, peer logged the\ndevice out, etc.) so the model sees the connection-broken state in\nits context instead of silently failing the next outbound.\n\n``event`` is a connector-namespaced kind (\"whatsapp.connection.lost\",\n\"signal.daemon.exited\") \u2014 the connector chooses the vocabulary.\n``reason`` is an optional short tag the harness surfaces alongside\nthe event for the model to act on (\"daemon_crashed\", \"peer_logout\").\n``data`` is an optional free-form dict for connector-specific\ncontext (current device count, last successful timestamp, etc.)."
       },
       "RuntimeManagementCallResultRequest": {
         "properties": {

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -450,6 +450,58 @@ class HttpConnector:
             return None
         return dict(response.json())
 
+    async def emit_lifecycle(
+        self,
+        *,
+        connection_id: str,
+        event: str,
+        reason: str | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """Append a ``kind=lifecycle`` event onto each session bound to
+        ``connection_id``.
+
+        Use for connection-broken signals the model needs to see in its
+        context (e.g. "whatsapp.connection.lost" with reason
+        "daemon_crashed" or "peer_logout") so it doesn't silently send
+        into the void.  Returns the appended-session-ids payload, or
+        ``None`` when the API returned a non-fatal 4xx (matching
+        :meth:`emit_inbound`'s drop-don't-raise stance).
+        """
+        client = self._require_client()
+        log.info(
+            "connector.lifecycle",
+            connector=self.connector,
+            connection_id=connection_id,
+            lifecycle_event=event,
+            reason=reason,
+        )
+        body: dict[str, Any] = {
+            "connection_id": connection_id,
+            "event": event,
+        }
+        if reason is not None:
+            body["reason"] = reason
+        if data is not None:
+            body["data"] = data
+        response = await client.get_async_httpx_client().post(
+            "/v1/connectors/runtime/lifecycle",
+            json=body,
+        )
+        if response.is_error:
+            sc = response.status_code
+            log.warning(
+                "connector.lifecycle.failed",
+                status_code=sc,
+                connection_id=connection_id,
+                lifecycle_event=event,
+                body=response.text[:2000],
+            )
+            if _is_fatal_inbound_status(sc):
+                response.raise_for_status()
+            return None
+        return dict(response.json())
+
     # ─── runner ──────────────────────────────────────────────────────
 
     async def run_until_stopped(self, *, install_signal_handlers: bool = True) -> None:

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/post_connector_runtime_lifecycle.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/post_connector_runtime_lifecycle.py
@@ -1,0 +1,306 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.post_connector_runtime_lifecycle_response_post_connector_runtime_lifecycle import (
+    PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle,
+)
+from ...models.runtime_lifecycle_request import RuntimeLifecycleRequest
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: RuntimeLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connectors/runtime/lifecycle",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> (
+    HTTPValidationError
+    | PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle
+    | None
+):
+    if response.status_code == 201:
+        response_201 = PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle.from_dict(
+            response.json()
+        )
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[
+    HTTPValidationError
+    | PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle
+]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: RuntimeLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle
+]:
+    r"""Post Runtime Lifecycle
+
+     Append a ``kind=lifecycle`` event onto every session bound to
+    ``body.connection_id``.
+
+    Authorization mirrors the inbound + tool-result paths: the bearer's
+    connector must match ``body.connection_id``'s connector, and any
+    bearer-side allowlist must include the connection_id (#350).
+
+    Returns ``{\"appended_session_ids\": [...]}`` enumerating the sessions
+    that received the event.  An empty list means no sessions were
+    bound at the time of the call (e.g. the operator detached every
+    session before the connector finished tearing down); not an error.
+
+    Args:
+        authorization (None | str | Unset):
+        body (RuntimeLifecycleRequest): Body for ``POST /v1/connectors/runtime/lifecycle``.
+
+            Lets a connector emit a lifecycle event onto each session bound to
+            ``connection_id`` — used today for "the underlying transport just
+            went away" notifications (WhatsApp daemon crashed, peer logged the
+            device out, etc.) so the model sees the connection-broken state in
+            its context instead of silently failing the next outbound.
+
+            ``event`` is a connector-namespaced kind ("whatsapp.connection.lost",
+            "signal.daemon.exited") — the connector chooses the vocabulary.
+            ``reason`` is an optional short tag the harness surfaces alongside
+            the event for the model to act on ("daemon_crashed", "peer_logout").
+            ``data`` is an optional free-form dict for connector-specific
+            context (current device count, last successful timestamp, etc.).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: RuntimeLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle
+    | None
+):
+    r"""Post Runtime Lifecycle
+
+     Append a ``kind=lifecycle`` event onto every session bound to
+    ``body.connection_id``.
+
+    Authorization mirrors the inbound + tool-result paths: the bearer's
+    connector must match ``body.connection_id``'s connector, and any
+    bearer-side allowlist must include the connection_id (#350).
+
+    Returns ``{\"appended_session_ids\": [...]}`` enumerating the sessions
+    that received the event.  An empty list means no sessions were
+    bound at the time of the call (e.g. the operator detached every
+    session before the connector finished tearing down); not an error.
+
+    Args:
+        authorization (None | str | Unset):
+        body (RuntimeLifecycleRequest): Body for ``POST /v1/connectors/runtime/lifecycle``.
+
+            Lets a connector emit a lifecycle event onto each session bound to
+            ``connection_id`` — used today for "the underlying transport just
+            went away" notifications (WhatsApp daemon crashed, peer logged the
+            device out, etc.) so the model sees the connection-broken state in
+            its context instead of silently failing the next outbound.
+
+            ``event`` is a connector-namespaced kind ("whatsapp.connection.lost",
+            "signal.daemon.exited") — the connector chooses the vocabulary.
+            ``reason`` is an optional short tag the harness surfaces alongside
+            the event for the model to act on ("daemon_crashed", "peer_logout").
+            ``data`` is an optional free-form dict for connector-specific
+            context (current device count, last successful timestamp, etc.).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: RuntimeLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle
+]:
+    r"""Post Runtime Lifecycle
+
+     Append a ``kind=lifecycle`` event onto every session bound to
+    ``body.connection_id``.
+
+    Authorization mirrors the inbound + tool-result paths: the bearer's
+    connector must match ``body.connection_id``'s connector, and any
+    bearer-side allowlist must include the connection_id (#350).
+
+    Returns ``{\"appended_session_ids\": [...]}`` enumerating the sessions
+    that received the event.  An empty list means no sessions were
+    bound at the time of the call (e.g. the operator detached every
+    session before the connector finished tearing down); not an error.
+
+    Args:
+        authorization (None | str | Unset):
+        body (RuntimeLifecycleRequest): Body for ``POST /v1/connectors/runtime/lifecycle``.
+
+            Lets a connector emit a lifecycle event onto each session bound to
+            ``connection_id`` — used today for "the underlying transport just
+            went away" notifications (WhatsApp daemon crashed, peer logged the
+            device out, etc.) so the model sees the connection-broken state in
+            its context instead of silently failing the next outbound.
+
+            ``event`` is a connector-namespaced kind ("whatsapp.connection.lost",
+            "signal.daemon.exited") — the connector chooses the vocabulary.
+            ``reason`` is an optional short tag the harness surfaces alongside
+            the event for the model to act on ("daemon_crashed", "peer_logout").
+            ``data`` is an optional free-form dict for connector-specific
+            context (current device count, last successful timestamp, etc.).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: RuntimeLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle
+    | None
+):
+    r"""Post Runtime Lifecycle
+
+     Append a ``kind=lifecycle`` event onto every session bound to
+    ``body.connection_id``.
+
+    Authorization mirrors the inbound + tool-result paths: the bearer's
+    connector must match ``body.connection_id``'s connector, and any
+    bearer-side allowlist must include the connection_id (#350).
+
+    Returns ``{\"appended_session_ids\": [...]}`` enumerating the sessions
+    that received the event.  An empty list means no sessions were
+    bound at the time of the call (e.g. the operator detached every
+    session before the connector finished tearing down); not an error.
+
+    Args:
+        authorization (None | str | Unset):
+        body (RuntimeLifecycleRequest): Body for ``POST /v1/connectors/runtime/lifecycle``.
+
+            Lets a connector emit a lifecycle event onto each session bound to
+            ``connection_id`` — used today for "the underlying transport just
+            went away" notifications (WhatsApp daemon crashed, peer logged the
+            device out, etc.) so the model sees the connection-broken state in
+            its context instead of silently failing the next outbound.
+
+            ``event`` is a connector-namespaced kind ("whatsapp.connection.lost",
+            "signal.daemon.exited") — the connector chooses the vocabulary.
+            ``reason`` is an optional short tag the harness surfaces alongside
+            the event for the model to act on ("daemon_crashed", "peer_logout").
+            ``data`` is an optional free-form dict for connector-specific
+            context (current device count, last successful timestamp, etc.).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -114,7 +114,12 @@ from .mint_account_request import MintAccountRequest
 from .mint_account_response import MintAccountResponse
 from .mint_key_request import MintKeyRequest
 from .mint_key_response import MintKeyResponse
+from .post_connector_runtime_lifecycle_response_post_connector_runtime_lifecycle import (
+    PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle,
+)
 from .recent_chat import RecentChat
+from .runtime_lifecycle_request import RuntimeLifecycleRequest
+from .runtime_lifecycle_request_data_type_0 import RuntimeLifecycleRequestDataType0
 from .runtime_management_call_result_request import RuntimeManagementCallResultRequest
 from .runtime_token import RuntimeToken
 from .runtime_token_issue import RuntimeTokenIssue
@@ -312,7 +317,10 @@ __all__ = (
     "MintAccountResponse",
     "MintKeyRequest",
     "MintKeyResponse",
+    "PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle",
     "RecentChat",
+    "RuntimeLifecycleRequest",
+    "RuntimeLifecycleRequestDataType0",
     "RuntimeManagementCallResultRequest",
     "RuntimeToken",
     "RuntimeTokenIssue",

--- a/packages/aios-sdk/aios_sdk/_generated/models/post_connector_runtime_lifecycle_response_post_connector_runtime_lifecycle.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/post_connector_runtime_lifecycle_response_post_connector_runtime_lifecycle.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar(
+    "T", bound="PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle"
+)
+
+
+@_attrs_define
+class PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        post_connector_runtime_lifecycle_response_post_connector_runtime_lifecycle = (
+            cls()
+        )
+
+        post_connector_runtime_lifecycle_response_post_connector_runtime_lifecycle.additional_properties = d
+        return (
+            post_connector_runtime_lifecycle_response_post_connector_runtime_lifecycle
+        )
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_lifecycle_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_lifecycle_request.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.runtime_lifecycle_request_data_type_0 import (
+        RuntimeLifecycleRequestDataType0,
+    )
+
+
+T = TypeVar("T", bound="RuntimeLifecycleRequest")
+
+
+@_attrs_define
+class RuntimeLifecycleRequest:
+    """Body for ``POST /v1/connectors/runtime/lifecycle``.
+
+    Lets a connector emit a lifecycle event onto each session bound to
+    ``connection_id`` — used today for "the underlying transport just
+    went away" notifications (WhatsApp daemon crashed, peer logged the
+    device out, etc.) so the model sees the connection-broken state in
+    its context instead of silently failing the next outbound.
+
+    ``event`` is a connector-namespaced kind ("whatsapp.connection.lost",
+    "signal.daemon.exited") — the connector chooses the vocabulary.
+    ``reason`` is an optional short tag the harness surfaces alongside
+    the event for the model to act on ("daemon_crashed", "peer_logout").
+    ``data`` is an optional free-form dict for connector-specific
+    context (current device count, last successful timestamp, etc.).
+
+        Attributes:
+            connection_id (str):
+            event (str):
+            reason (None | str | Unset):
+            data (None | RuntimeLifecycleRequestDataType0 | Unset):
+    """
+
+    connection_id: str
+    event: str
+    reason: None | str | Unset = UNSET
+    data: None | RuntimeLifecycleRequestDataType0 | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.runtime_lifecycle_request_data_type_0 import (
+            RuntimeLifecycleRequestDataType0,
+        )
+
+        connection_id = self.connection_id
+
+        event = self.event
+
+        reason: None | str | Unset
+        if isinstance(self.reason, Unset):
+            reason = UNSET
+        else:
+            reason = self.reason
+
+        data: dict[str, Any] | None | Unset
+        if isinstance(self.data, Unset):
+            data = UNSET
+        elif isinstance(self.data, RuntimeLifecycleRequestDataType0):
+            data = self.data.to_dict()
+        else:
+            data = self.data
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "connection_id": connection_id,
+                "event": event,
+            }
+        )
+        if reason is not UNSET:
+            field_dict["reason"] = reason
+        if data is not UNSET:
+            field_dict["data"] = data
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.runtime_lifecycle_request_data_type_0 import (
+            RuntimeLifecycleRequestDataType0,
+        )
+
+        d = dict(src_dict)
+        connection_id = d.pop("connection_id")
+
+        event = d.pop("event")
+
+        def _parse_reason(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        reason = _parse_reason(d.pop("reason", UNSET))
+
+        def _parse_data(
+            data: object,
+        ) -> None | RuntimeLifecycleRequestDataType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_type_0 = RuntimeLifecycleRequestDataType0.from_dict(data)
+
+                return data_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | RuntimeLifecycleRequestDataType0 | Unset, data)
+
+        data = _parse_data(d.pop("data", UNSET))
+
+        runtime_lifecycle_request = cls(
+            connection_id=connection_id,
+            event=event,
+            reason=reason,
+            data=data,
+        )
+
+        return runtime_lifecycle_request

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_lifecycle_request_data_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_lifecycle_request_data_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="RuntimeLifecycleRequestDataType0")
+
+
+@_attrs_define
+class RuntimeLifecycleRequestDataType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        runtime_lifecycle_request_data_type_0 = cls()
+
+        runtime_lifecycle_request_data_type_0.additional_properties = d
+        return runtime_lifecycle_request_data_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -223,6 +223,31 @@ class RuntimeToolResultRequest(BaseModel):
     is_error: bool = False
 
 
+class RuntimeLifecycleRequest(BaseModel):
+    """Body for ``POST /v1/connectors/runtime/lifecycle``.
+
+    Lets a connector emit a lifecycle event onto each session bound to
+    ``connection_id`` — used today for "the underlying transport just
+    went away" notifications (WhatsApp daemon crashed, peer logged the
+    device out, etc.) so the model sees the connection-broken state in
+    its context instead of silently failing the next outbound.
+
+    ``event`` is a connector-namespaced kind ("whatsapp.connection.lost",
+    "signal.daemon.exited") — the connector chooses the vocabulary.
+    ``reason`` is an optional short tag the harness surfaces alongside
+    the event for the model to act on ("daemon_crashed", "peer_logout").
+    ``data`` is an optional free-form dict for connector-specific
+    context (current device count, last successful timestamp, etc.).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    connection_id: str
+    event: str
+    reason: str | None = None
+    data: dict[str, Any] | None = None
+
+
 def _check_runtime_scope(auth_connector: str, target_connector: str) -> None:
     """Raise 403 if a runtime bearer reaches outside its connector type."""
     if auth_connector != target_connector:
@@ -408,6 +433,68 @@ async def post_runtime_inbound(
         timestamp=timestamp,
         attachments=attachments,
     )
+
+
+@router.post(
+    "/runtime/lifecycle",
+    operation_id="post_connector_runtime_lifecycle",
+    status_code=status.HTTP_201_CREATED,
+)
+async def post_runtime_lifecycle(
+    body: RuntimeLifecycleRequest,
+    pool: PoolDep,
+    auth: RuntimeAuthDep,
+) -> dict[str, Any]:
+    """Append a ``kind=lifecycle`` event onto every session bound to
+    ``body.connection_id``.
+
+    Authorization mirrors the inbound + tool-result paths: the bearer's
+    connector must match ``body.connection_id``'s connector, and any
+    bearer-side allowlist must include the connection_id (#350).
+
+    Returns ``{"appended_session_ids": [...]}`` enumerating the sessions
+    that received the event.  An empty list means no sessions were
+    bound at the time of the call (e.g. the operator detached every
+    session before the connector finished tearing down); not an error.
+    """
+    _, auth_connector, account_id, auth_connection_ids = auth
+    async with pool.acquire() as conn:
+        connection = await queries.get_connection(conn, body.connection_id, account_id=account_id)
+        _check_runtime_scope(auth_connector, connection.connector)
+        _check_runtime_connection_scope(auth_connection_ids, body.connection_id)
+        bound = await queries.list_chat_sessions_for_connection(
+            conn,
+            body.connection_id,
+            account_id=account_id,
+        )
+    # Dedup session ids — per-chat-spawning can register the same
+    # session against multiple chat_ids and we don't want to double-
+    # append the same lifecycle event on those rows.
+    seen: set[str] = set()
+    session_ids: list[str] = []
+    for _chat_id, sess_id, _created in bound:
+        if sess_id in seen:
+            continue
+        seen.add(sess_id)
+        session_ids.append(sess_id)
+    payload: dict[str, Any] = {
+        "event": body.event,
+        "connection_id": body.connection_id,
+        "connector": connection.connector,
+    }
+    if body.reason is not None:
+        payload["reason"] = body.reason
+    if body.data is not None:
+        payload["data"] = body.data
+    for sess_id in session_ids:
+        await sessions_service.append_event(
+            pool,
+            sess_id,
+            "lifecycle",
+            payload,
+            account_id=account_id,
+        )
+    return {"appended_session_ids": session_ids}
 
 
 @router.post(

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -68,9 +68,9 @@ from aios.services import sessions as sessions_service
 from aios.services.attachment_staging import InboundAttachment
 from aios.services.wake import defer_wake
 
-router = APIRouter(prefix="/v1/connectors", tags=["connectors"])
-
 log = get_logger("aios.api.routers.connectors")
+
+router = APIRouter(prefix="/v1/connectors", tags=["connectors"])
 
 
 # ─── connector-facing endpoints (#301) ──────────────────────────────────────
@@ -481,15 +481,36 @@ async def post_runtime_lifecycle(
         payload["reason"] = body.reason
     if body.data is not None:
         payload["data"] = body.data
+    # Per-session try/except: a single archived/missing session shouldn't
+    # 500 the whole call and leave callers unable to tell which sessions
+    # actually got the event.  Each successful append is committed by its
+    # own pool acquire in append_event, so partials are visible to clients
+    # whether or not we surface them — surface them.
+    appended: list[str] = []
+    failed: list[dict[str, str]] = []
     for sess_id in session_ids:
-        await sessions_service.append_event(
-            pool,
-            sess_id,
-            "lifecycle",
-            payload,
-            account_id=account_id,
-        )
-    return {"appended_session_ids": session_ids}
+        try:
+            await sessions_service.append_event(
+                pool,
+                sess_id,
+                "lifecycle",
+                payload,
+                account_id=account_id,
+            )
+            appended.append(sess_id)
+        except Exception as exc:
+            log.warning(
+                "connector.lifecycle.append_failed",
+                connection_id=body.connection_id,
+                session_id=sess_id,
+                error=type(exc).__name__,
+                detail=str(exc)[:300],
+            )
+            failed.append({"session_id": sess_id, "error": type(exc).__name__})
+    result: dict[str, Any] = {"appended_session_ids": appended}
+    if failed:
+        result["failed_session_ids"] = failed
+    return result
 
 
 @router.post(

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -462,21 +462,16 @@ async def post_runtime_lifecycle(
         connection = await queries.get_connection(conn, body.connection_id, account_id=account_id)
         _check_runtime_scope(auth_connector, connection.connector)
         _check_runtime_connection_scope(auth_connection_ids, body.connection_id)
-        bound = await queries.list_chat_sessions_for_connection(
+        # Both binding lineages: the active single_session binding on
+        # this connection AND any per-chat-spawned chat_sessions rows.
+        # list_session_ids_for_connection unions+dedups.  Without the
+        # union the smoke (single_session-bound bot) saw the endpoint
+        # silently succeed against an empty list.
+        session_ids = await queries.list_session_ids_for_connection(
             conn,
             body.connection_id,
             account_id=account_id,
         )
-    # Dedup session ids — per-chat-spawning can register the same
-    # session against multiple chat_ids and we don't want to double-
-    # append the same lifecycle event on those rows.
-    seen: set[str] = set()
-    session_ids: list[str] = []
-    for _chat_id, sess_id, _created in bound:
-        if sess_id in seen:
-            continue
-        seen.add(sess_id)
-        session_ids.append(sess_id)
     payload: dict[str, Any] = {
         "event": body.event,
         "connection_id": body.connection_id,

--- a/src/aios/cli/allowlist.py
+++ b/src/aios/cli/allowlist.py
@@ -45,6 +45,9 @@ NOT_CLI_OPERATIONS: dict[str, str] = {
     "post_connector_runtime_inbound": (
         "Called by connector containers via runtime token; not for operators."
     ),
+    "post_connector_runtime_lifecycle": (
+        "Called by connector containers via runtime token; not for operators."
+    ),
     "post_connector_runtime_management_call_result": (
         "Called by connector containers via runtime token; not for operators."
     ),

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -4105,6 +4105,41 @@ async def list_chat_sessions_for_connection(
     return [(r["chat_id"], r["session_id"], r["created_at"]) for r in rows]
 
 
+async def list_session_ids_for_connection(
+    conn: asyncpg.Connection[Any],
+    connection_id: str,
+    *,
+    account_id: str,
+) -> list[str]:
+    """List every distinct session_id bound to ``connection_id`` via
+    either lineage path:
+
+    * Active single_session binding on this connection.
+    * Per-chat-spawned rows in ``chat_sessions`` for this connection.
+
+    Same union :func:`is_session_bound_to_connection` checks for, but
+    enumerated — used by the runtime/lifecycle endpoint to broadcast
+    a connection-broken event onto every bound session at once.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT session_id FROM bindings
+         WHERE connection_id = $1
+           AND account_id = $2
+           AND mode = 'single_session'
+           AND archived_at IS NULL
+           AND session_id IS NOT NULL
+        UNION
+        SELECT session_id FROM chat_sessions
+         WHERE connection_id = $1
+           AND account_id = $2
+        """,
+        connection_id,
+        account_id,
+    )
+    return [r["session_id"] for r in rows]
+
+
 # ─── routing_rules (#328 PR 2/4 — per-binding prefix demux) ─────────────────
 
 

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -4133,6 +4133,7 @@ async def list_session_ids_for_connection(
         SELECT session_id FROM chat_sessions
          WHERE connection_id = $1
            AND account_id = $2
+         ORDER BY session_id
         """,
         connection_id,
         account_id,

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -175,10 +175,14 @@ def _format_channel_header(metadata: dict[str, Any]) -> str:
     if isinstance(sticker_emoji, str):
         # Empty string means the connector saw a StickerMessage but
         # the sender's WhatsApp client didn't pick an emoji label
-        # (custom stickers from the sticker maker land this way);
-        # surface a placeholder so the model still knows a sticker
-        # arrived rather than silently dropping the signal.
-        parts.append(f"sticker_emoji={sticker_emoji!r}" if sticker_emoji else "sticker=true")
+        # (custom stickers from the sticker maker land this way).
+        # Always render under the ``sticker_emoji=`` field name so
+        # the model's prompt contract (per the connector prompts.py
+        # mentioning ``metadata.sticker_emoji`` verbatim) stays
+        # consistent across labeled and unlabeled stickers — empty
+        # value still signals "a sticker arrived" without breaking
+        # the established field-name pattern.
+        parts.append(f"sticker_emoji={sticker_emoji!r}")
     header = "[" + " · ".join(parts) + "]"
     mentions = metadata.get("mentions")
     if isinstance(mentions, list) and mentions:

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -144,6 +144,20 @@ def _format_channel_header(metadata: dict[str, Any]) -> str:
     edit_target = metadata.get("edit_target_timestamp_ms")
     if isinstance(edit_target, int):
         parts.append(f"edit_target_timestamp_ms={edit_target}")
+    edit_target_message_id = metadata.get("edit_target_message_id")
+    if isinstance(edit_target_message_id, str) and edit_target_message_id:
+        # WhatsApp identifies edit targets by string message_id, not
+        # by Signal's timestamp_ms.  Render verbatim so the model can
+        # match the target against the message_id of a prior event.
+        parts.append(f"edit_target_message_id={edit_target_message_id!r}")
+    if metadata.get("revoked") is True:
+        parts.append("revoked=true")
+    revoke_target_message_id = metadata.get("revoke_target_message_id")
+    if isinstance(revoke_target_message_id, str) and revoke_target_message_id:
+        # The peer revoked their own message; the original event is
+        # still in the log (monotonicity), but the model should treat
+        # it as retracted going forward.
+        parts.append(f"revoke_target_message_id={revoke_target_message_id!r}")
     if metadata.get("self_mentioned") is True:
         # Hoist ahead of the structured ``mentions`` list — for
         # group chats the model often only needs to know "was I
@@ -182,6 +196,13 @@ def _format_channel_header(metadata: dict[str, Any]) -> str:
         target_ts = reaction.get("target_timestamp_ms")
         if isinstance(target_ts, int):
             r_parts.append(f"target_timestamp_ms={target_ts}")
+        target_message_id = reaction.get("target_message_id")
+        if isinstance(target_message_id, str) and target_message_id:
+            # WhatsApp reactions identify their target by string
+            # message_id (no equivalent of Signal's author+timestamp
+            # pair).  Render verbatim so the model can match against
+            # the message_id of a prior event.
+            r_parts.append(f"target_message_id={target_message_id!r}")
         header += "\n[" + " · ".join(r_parts) + "]"
     reply_to = metadata.get("reply_to")
     if isinstance(reply_to, dict):

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -158,6 +158,13 @@ def _format_channel_header(metadata: dict[str, Any]) -> str:
         # still in the log (monotonicity), but the model should treat
         # it as retracted going forward.
         parts.append(f"revoke_target_message_id={revoke_target_message_id!r}")
+    quoted_message_id = metadata.get("quoted_message_id")
+    if isinstance(quoted_message_id, str) and quoted_message_id:
+        # The peer replied to a previous message in the chat (WhatsApp's
+        # reply gesture).  Renders the same shape as the edit/revoke
+        # target ids so the model can match it against the message_id
+        # header on a prior event.
+        parts.append(f"quoted_message_id={quoted_message_id!r}")
     if metadata.get("self_mentioned") is True:
         # Hoist ahead of the structured ``mentions`` list — for
         # group chats the model often only needs to know "was I
@@ -165,8 +172,13 @@ def _format_channel_header(metadata: dict[str, Any]) -> str:
         # alternative that #5 set out to eliminate.
         parts.append("self_mentioned=true")
     sticker_emoji = metadata.get("sticker_emoji")
-    if isinstance(sticker_emoji, str) and sticker_emoji:
-        parts.append(f"sticker_emoji={sticker_emoji!r}")
+    if isinstance(sticker_emoji, str):
+        # Empty string means the connector saw a StickerMessage but
+        # the sender's WhatsApp client didn't pick an emoji label
+        # (custom stickers from the sticker maker land this way);
+        # surface a placeholder so the model still knows a sticker
+        # arrived rather than silently dropping the signal.
+        parts.append(f"sticker_emoji={sticker_emoji!r}" if sticker_emoji else "sticker=true")
     header = "[" + " · ".join(parts) + "]"
     mentions = metadata.get("mentions")
     if isinstance(mentions, list) and mentions:

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -132,8 +132,13 @@ def _format_channel_header(metadata: dict[str, Any]) -> str:
             # The raw int still goes to the model; only the ISO is dropped.
             parts.append(f"timestamp_ms={timestamp_ms}")
     message_id = metadata.get("message_id")
+    # Telegram surfaces ints; WhatsApp's whatsmeow IDs are hex strings
+    # like "3EB0E03B46303C22D750E2".  Both render the same — the model
+    # only needs the value verbatim to pass into react/edit/delete tools.
     if isinstance(message_id, int):
         parts.append(f"message_id={message_id}")
+    elif isinstance(message_id, str) and message_id:
+        parts.append(f"message_id={message_id!r}")
     if metadata.get("edited") is True:
         parts.append("edited=true")
     edit_target = metadata.get("edit_target_timestamp_ms")

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1117,6 +1117,55 @@ class TestFocalRendering:
         assert "reaction" in content
         assert "'?'" not in content
 
+    def test_focal_match_reaction_renders_string_target_message_id(self) -> None:
+        """WhatsApp reactions identify the target by string message_id
+        (no equivalent of Signal's author+timestamp pair).  Pre-fix the
+        renderer ignored the field, so the model saw `[reaction='👍']`
+        with no way to match against the original send."""
+        md = {
+            "channel": self._CHAN_A,
+            "reaction": {
+                "emoji": "👍",
+                "target_message_id": "3EB0ORIGINAL",
+            },
+        }
+        events = [_evt(1, "user", content="", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "[reaction='👍'" in content
+        assert "target_message_id='3EB0ORIGINAL'" in content
+
+    def test_focal_match_edit_renders_target_message_id(self) -> None:
+        """WhatsApp edits flag ``edited=True`` and identify the original
+        by string ``edit_target_message_id`` (no equivalent of Signal's
+        ``edit_target_timestamp_ms``).  Pre-fix the model saw
+        `edited=true` with no anchor."""
+        md = {
+            "channel": self._CHAN_A,
+            "edited": True,
+            "edit_target_message_id": "3EB0ORIGINAL",
+        }
+        events = [
+            _evt(1, "user", content="new body", metadata=md, focal_channel_at_arrival=self._CHAN_A)
+        ]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "edited=true" in content
+        assert "edit_target_message_id='3EB0ORIGINAL'" in content
+
+    def test_focal_match_revoke_renders_target_message_id(self) -> None:
+        """A peer revoking their message arrives with empty content and
+        ``revoked=True`` + ``revoke_target_message_id``.  Pre-fix
+        neither flag was rendered, so the revoke was invisible to the
+        model."""
+        md = {
+            "channel": self._CHAN_A,
+            "revoked": True,
+            "revoke_target_message_id": "3EB0ORIGINAL",
+        }
+        events = [_evt(1, "user", content="", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert "revoked=true" in content
+        assert "revoke_target_message_id='3EB0ORIGINAL'" in content
+
     def test_focal_match_iso_timestamp(self) -> None:
         md = {"channel": self._CHAN_A, "timestamp_ms": 1776401210703}
         events = [_evt(1, "user", content="hi", metadata=md, focal_channel_at_arrival=self._CHAN_A)]


### PR DESCRIPTION
Stacked on #622.  Two logical chunks landed on one branch (scope grew organically after Tom directed \`move on to the capstone\` mid-review).

## Chunk 1 — PR 5: media + per-message ops (commits a91174e .. 9e9798d)

* React/edit/delete tools backed by daemon-side ``messages.db`` (sibling to whatsmeow's ``store.db``); daemon owns the MessageKey lookup so the model passes only ``message_id``
* ``whatsapp_send`` extended with ``attachments: list[SandboxPath]`` kwarg (caption-on-first, multi-attachment semantics, audio caption routed as separate Conversation since AudioMessage has no Caption field)
* Inbound media downloaded + decrypted to ``<store_dir>/media/<msgID>_<filename>`` (0o600 perms); Python reads bytes off-loop via ``asyncio.to_thread``
* Sticker emoji surfaced as ``metadata.sticker_emoji``; bytes skipped per locked design
* Reactions, edits, revokes parsed via ``ReactionMessage`` / ``ProtocolMessage`` decode; surfaced as ``metadata.reaction`` / ``metadata.edited`` / ``metadata.revoked``
* ``harness/context.py`` extended to render: str message_ids (WA hex), ``edit_target_message_id``, ``revoke_target_message_id``, reaction ``target_message_id``, ``revoked=true`` flag

Fix-up commit ``9e9798d`` addressed 20 findings from a max-effort ``/code-review`` pass (#625 comment): the 3 approach-blocking render gaps above, plus caption-extraction-from-media, audio-caption-routing, recordOutbound race, msgstore truncation on Unpair, mapOpError for not-own-message, partial-multi-attachment id surfacing, attachments_unreadable metadata, daemon-lifetime ctx, sanitizeFilename hardening, file perms, ProtocolMessage filter on recordInbound, no msgID double-prefix, Edit empty-text refusal, and whitespace-text drop.

## Chunk 2 — Capstone: groups + mentions + receipts + markdown + CLI + Dockerfile (commits 4cae4b5 .. 8179ca8)

* ``markdown_to_whatsapp`` — minimal CommonMark→WhatsApp inline converter (bold/italic/strike/code), order-safe via C0 sentinels
* Mention encoding (outbound ``@<E.164>`` → ContextInfo.MentionedJID) + inbound surfacing as ``metadata.mentions`` with +E.164 in the harness's ``uuid`` field (model-usable for outbound @-tags)
* Read-receipts-after-emit: per-chat unread queue in the daemon, drained + MarkRead'd by ``sendOne`` after a successful send (Signal-style implicit, no tool surface)
* Groups: ``whatsapp_list_groups`` / ``whatsapp_create_group`` (+E.164 phones auto-normalized to JIDs) / ``whatsapp_rename_group``
* ``prompts.py`` identity + roster + tool docs (mirrors ``connectors/signal/src/aios_signal/prompts.py``; test-covered, lights up automatically once the SDK ``InitializeResult.instructions`` hook lands)
* ``aios whatsapp {start-pairing, confirm-pairing, unpair}`` CLI subcommand
* ``Dockerfile`` (multi-stage Go-build + Python-runtime, multi-arch via ``ARG TARGETARCH``) + ``entrypoint.sh`` (chown ``$AIOS_WHATSAPP_DATA_DIR`` to uid 1000) + ``README.md`` (quickstart, tool surface, pairing flow, data layout, env matrix, ASCII architecture diagram)

## Stats

40 files changed, +4562 / -82.  127 Python tests + Go tests across handler/rpc/wameow packages all green.  mypy + ruff clean.

## Capstone smoke (deferred)

Still blocked on WhatsApp's per-account device-link rate-limit cooldown — see #622 comment for the existing deferred smoke checklist (e2e unpair → re-pair, restart cycle, group inbound).  Capstone-specific items to verify when the cooldown clears:

- [ ] Inbound mention in a group renders as ``[mention: uuid=+<phone>...]`` in the channels-tail block
- [ ] Outbound ``whatsapp_send(text="hi @+15551234567")`` renders as a pill on peer's WhatsApp UI
- [ ] Read receipts: peer sees blue ticks after bot replies in a chat
- [ ] ``whatsapp_create_group`` + ``whatsapp_rename_group`` end-to-end
- [ ] ``aios whatsapp start-pairing/confirm-pairing/unpair`` CLI subcommands
- [ ] Bold/italic CommonMark in outbound surfaces as WhatsApp's inline pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)