### PR TITLE
fix(harness): use "." instead of "" for adjacent-user separator placeholder (#623)

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING, Any
 
 import litellm
 
+from aios.harness.context import _USER_MESSAGE_SEPARATOR_CONTENT
+
 # Anthropic rejects empty text blocks that some OpenRouter models emit on
 # tool-call-only turns; modify_params tells LiteLLM to sanitize them.
 litellm.modify_params = True
@@ -259,17 +261,17 @@ def _last_stable_message_index(messages: list[dict[str, Any]]) -> int | None:
     * The channels tail block — identified by its content signature
       ``━━━ Channels ━━━`` (always the last user-role message when
       present).
-    * Any empty-assistant separator — inserted by
+    * Any role-transition separator — inserted by
       :func:`~aios.harness.context.separate_adjacent_user_messages` to
-      defeat Anthropic's adjacent-user-merge; carries no real content
-      and would be a wasted breakpoint.
+      defeat Anthropic's adjacent-user-merge; carries only a
+      single-byte placeholder and would be a wasted breakpoint.
 
     If nothing stable remains (messages list is just system + tail +
     separator), returns ``None``.
     """
     for i in range(len(messages) - 1, -1, -1):
         msg = messages[i]
-        if _is_tail_block(msg) or _is_empty_assistant(msg):
+        if _is_tail_block(msg) or _is_separator_placeholder(msg):
             continue
         return i
     return None
@@ -297,16 +299,23 @@ def _is_tail_block(msg: dict[str, Any]) -> bool:
     return False
 
 
-def _is_empty_assistant(msg: dict[str, Any]) -> bool:
-    """Detect the role-transition separator: ``assistant`` + empty content."""
+def _is_separator_placeholder(msg: dict[str, Any]) -> bool:
+    """Detect the role-transition separator placeholder.
+
+    Matches the exact shape produced by
+    :func:`~aios.harness.context.separate_adjacent_user_messages`:
+    ``assistant`` role, no tool calls, content equal to
+    :data:`~aios.harness.context._USER_MESSAGE_SEPARATOR_CONTENT`.
+
+    Strict matching (not a broader "empty-ish assistant" check) keeps
+    this recognizer aligned with the producer — if a genuine assistant
+    turn happens to be short, it still gets a cache breakpoint.
+    """
     if msg.get("role") != "assistant":
         return False
     if msg.get("tool_calls"):
         return False
-    content = msg.get("content")
-    if content == "" or content is None:
-        return True
-    return isinstance(content, list) and not content
+    return msg.get("content") == _USER_MESSAGE_SEPARATOR_CONTENT
 
 
 def _extract_cost(response: Any) -> float | None:

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -790,10 +790,29 @@ def stub_missing_reasoning_content(
     return messages
 
 
+_USER_MESSAGE_SEPARATOR_CONTENT = "."
+"""Single-byte placeholder for the role-transition separator.
+
+Must survive every validator the messages array can traverse on the way
+to a provider.  An earlier implementation used ``""`` and relied on
+LiteLLM's ``modify_params = True`` Anthropic sanitizer to strip the
+empty block — that only fires when LiteLLM is itself the Anthropic
+provider.  When the model routes through a relay (``openrouter/*``,
+``openai-compatible/*``), the placeholder reaches the upstream provider
+unchanged.  Strict providers (Bedrock confirmed; Vertex likely) reject
+non-final assistant messages with empty content, wedging the session.
+
+``"."`` is the minimal change with maximum portability: one printable
+byte that every text-content validator accepts.  Recognizer in
+``completion.py`` (cache-breakpoint placement skips the placeholder)
+imports this constant to stay in lock-step.
+"""
+
+
 def separate_adjacent_user_messages(
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Insert an empty assistant message between any two adjacent user messages.
+    """Insert a placeholder assistant message between any two adjacent user messages.
 
     LiteLLM's Anthropic translator enforces strict role alternation by
     merging adjacent same-role messages into a single multi-content-block
@@ -802,15 +821,15 @@ def separate_adjacent_user_messages(
     as one message with two text blocks — and models narrate "your
     message included the channel state" about their own scaffolding.
 
-    Inserting a no-content assistant turn between two consecutive user
-    messages blocks the merge.  LiteLLM's ``modify_params = True`` (set
-    in ``completion.py``) sanitizes the empty content block for
-    Anthropic at request time, so no visible turn is added to the
-    on-the-wire transcript — only the role transition remains.
+    Inserting an assistant turn between two consecutive user messages
+    blocks the merge.  The placeholder uses
+    :data:`_USER_MESSAGE_SEPARATOR_CONTENT` (a single printable byte) so
+    it survives validators on relay routes (OpenRouter → Bedrock, etc.)
+    that reject empty non-final assistant content.
     """
     result: list[dict[str, Any]] = []
     for msg in messages:
         if result and result[-1].get("role") == "user" and msg.get("role") == "user":
-            result.append({"role": "assistant", "content": ""})
+            result.append({"role": "assistant", "content": _USER_MESSAGE_SEPARATOR_CONTENT})
         result.append(msg)
     return result

--- a/tests/e2e/test_step_separator.py
+++ b/tests/e2e/test_step_separator.py
@@ -58,11 +58,14 @@ class TestSeparatorAtLiteLLMBoundary:
         assert tail_idx > 0, "tail block should not be first — there's an inbound before it"
 
         prev = msgs[tail_idx - 1]
-        # The separator is an empty-assistant message.  ``reasoning_content``
-        # is stubbed empty too so thinking-mode providers don't reject the
-        # transcript (see ``stub_missing_reasoning_content``).
-        assert prev.get("role") == "assistant" and prev.get("content") == "", (
-            f"expected empty-assistant separator before tail, got prev={prev!r}, tail={msgs[tail_idx]!r}"
+        # The separator is an assistant message carrying a single-byte
+        # placeholder ("."); an empty content block leaks through relay
+        # routes (OpenRouter → Bedrock) that don't sanitize it.
+        # ``reasoning_content`` is stubbed empty too so thinking-mode
+        # providers don't reject the transcript (see
+        # ``stub_missing_reasoning_content``).
+        assert prev.get("role") == "assistant" and prev.get("content") == ".", (
+            f"expected placeholder-assistant separator before tail, got prev={prev!r}, tail={msgs[tail_idx]!r}"
         )
         assert prev.get("reasoning_content") == "", (
             f"expected reasoning_content stub on separator, got prev={prev!r}"
@@ -80,6 +83,6 @@ class TestSeparatorAtLiteLLMBoundary:
 
         assert len(harness.model_calls) == 1
         msgs = harness.model_calls[0]["messages"]
-        assert not any(m == {"role": "assistant", "content": ""} for m in msgs), (
-            f"gratuitous empty-assistant separator in messages: {msgs!r}"
+        assert not any(m.get("role") == "assistant" and m.get("content") == "." for m in msgs), (
+            f"gratuitous placeholder-assistant separator in messages: {msgs!r}"
         )

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -566,7 +566,7 @@ class TestMonotonicity:
                     "━━━ Channels ━━━"
                 ):
                     stop = i
-                    if i > 0 and msgs[i - 1] == {"role": "assistant", "content": ""}:
+                    if i > 0 and msgs[i - 1] == {"role": "assistant", "content": "."}:
                         stop = i - 1
                     return msgs[:stop]
             return msgs
@@ -1383,7 +1383,7 @@ class TestSeparateAdjacentUserMessages:
         ]
         assert separate_adjacent_user_messages(msgs) == [
             {"role": "user", "content": "one"},
-            {"role": "assistant", "content": ""},
+            {"role": "assistant", "content": "."},
             {"role": "user", "content": "two"},
         ]
 
@@ -1413,9 +1413,9 @@ class TestSeparateAdjacentUserMessages:
         ]
         assert separate_adjacent_user_messages(msgs) == [
             {"role": "user", "content": "a"},
-            {"role": "assistant", "content": ""},
+            {"role": "assistant", "content": "."},
             {"role": "user", "content": "b"},
-            {"role": "assistant", "content": ""},
+            {"role": "assistant", "content": "."},
             {"role": "user", "content": "c"},
         ]
 
@@ -1431,7 +1431,7 @@ class TestSeparateAdjacentUserMessages:
         assert separate_adjacent_user_messages(msgs) == [
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "one"},
-            {"role": "assistant", "content": ""},
+            {"role": "assistant", "content": "."},
             {"role": "user", "content": "two"},
         ]
 
@@ -1462,17 +1462,17 @@ class TestStubMissingReasoningContent:
         stub_missing_reasoning_content(msgs)
         assert msgs[0] == {"role": "tool", "tool_call_id": "x", "content": "result"}
 
-    def test_stubs_empty_assistant_separator(self) -> None:
-        """The empty-assistant separator inserted by
+    def test_stubs_separator_placeholder(self) -> None:
+        """The placeholder assistant inserted by
         :func:`separate_adjacent_user_messages` is still an assistant
         message and must also carry the stub."""
         msgs = [
             {"role": "user", "content": "a"},
-            {"role": "assistant", "content": ""},
+            {"role": "assistant", "content": "."},
             {"role": "user", "content": "b"},
         ]
         stub_missing_reasoning_content(msgs)
-        assert msgs[1] == {"role": "assistant", "content": "", "reasoning_content": ""}
+        assert msgs[1] == {"role": "assistant", "content": ".", "reasoning_content": ""}
 
     def test_mutates_in_place_and_returns(self) -> None:
         msgs = [{"role": "assistant", "content": "x"}]
@@ -1498,7 +1498,7 @@ class TestSeparateAdjacentUserMessagesPipeline:
         msgs = _full_pipeline(events, ["signal/test/1"])
 
         assert [m["role"] for m in msgs] == ["user", "assistant", "user"]
-        assert msgs[1] == {"role": "assistant", "content": ""}
+        assert msgs[1] == {"role": "assistant", "content": "."}
         assert msgs[2]["content"].startswith("━━━ Channels ━━━")
 
     def test_blind_spot_injection_adjacent_user_gets_separator(self) -> None:
@@ -1525,7 +1525,7 @@ class TestSeparateAdjacentUserMessagesPipeline:
             for i, m in enumerate(msgs)
             if m["role"] == "user" and "RESULT" in str(m.get("content", ""))
         )
-        assert msgs[injection_idx + 1] == {"role": "assistant", "content": ""}
+        assert msgs[injection_idx + 1] == {"role": "assistant", "content": "."}
         assert msgs[injection_idx + 2]["role"] == "user"
         assert msgs[injection_idx + 2]["content"] == "anything else?"
 
@@ -1541,7 +1541,7 @@ class TestSeparateAdjacentUserMessagesPipeline:
         msgs = _full_pipeline(events, channels=[])
 
         assert [m["role"] for m in msgs] == ["user", "assistant", "user", "assistant"]
-        assert not any(m == {"role": "assistant", "content": ""} for m in msgs)
+        assert not any(m == {"role": "assistant", "content": "."} for m in msgs)
 
 
 class TestEventDataImmutability:

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -237,14 +237,15 @@ class TestInjectCacheBreakpoints:
 
     def test_skips_tail_and_adjacency_separator(self) -> None:
         """When the last stable event was user-role,
-        ``separate_adjacent_user_messages`` inserts an empty-assistant
-        separator before the tail.  The breakpoint must skip *both* —
-        annotating an empty content block would be a wasted breakpoint
-        (and may not survive Anthropic's empty-block sanitization).
+        ``separate_adjacent_user_messages`` inserts a placeholder
+        assistant before the tail.  The breakpoint must skip *both* —
+        annotating the single-byte placeholder would be a wasted
+        breakpoint that also wouldn't survive content normalization on
+        some routes.
         """
         tail = _msg("user", "━━━ Channels ━━━\n▸ channel_id=x (focal)")
         stable = _msg("user", "real peer message")
-        separator = {"role": "assistant", "content": ""}
+        separator = {"role": "assistant", "content": "."}
         msgs = [_msg("system", "sys"), stable, separator, tail]
         inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         # Breakpoint lands on the stable user message, not the separator.
@@ -252,7 +253,7 @@ class TestInjectCacheBreakpoints:
             {"type": "text", "text": "real peer message", "cache_control": _CACHE_CONTROL}
         ]
         # Separator stays bare; tail stays bare.
-        assert msgs[2] == {"role": "assistant", "content": ""}
+        assert msgs[2] == {"role": "assistant", "content": "."}
         assert msgs[3]["content"] == tail["content"]
 
     def test_tail_only_context_falls_back_to_system_and_tool(self) -> None:


### PR DESCRIPTION
## Summary

Closes #623.

When the harness inserts an empty assistant message between two adjacent user messages, it relies on LiteLLM's `modify_params=True` Anthropic sanitizer to strip the empty content. That sanitizer only fires when LiteLLM is itself the Anthropic provider. On relay routes (`openrouter/*` → Bedrock, `openai-compatible/*` → strict provider), the placeholder reaches the upstream provider unchanged and gets rejected with `messages.N: all messages must have non-empty content except for the optional final assistant message`. The harness then retry-loops and the session ends `errored`.

## Fix (Option 1 from the issue — single-byte placeholder)

- `src/aios/harness/context.py` — new module-level constant `_USER_MESSAGE_SEPARATOR_CONTENT = "."`; used in `separate_adjacent_user_messages`. Docstring updated to document the cross-provider portability invariant (replaces the obsolete `modify_params` claim).
- `src/aios/harness/completion.py` — imports the constant; renamed `_is_empty_assistant` → `_is_separator_placeholder`, matching by equality on the constant (not by emptiness). Keeps producer and consumer locked in step: a future change to either fails loudly, not silently.
- Tests: 8 assertions across `tests/unit/test_context.py`, `tests/unit/test_usage.py`, `tests/e2e/test_step_separator.py` now expect `content: "."`.

## Test plan

- [x] `uv run ruff check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1425 passed
- [ ] `tests/e2e/test_step_separator.py` — left to CI (Docker required locally)

## Why a single byte not a longer marker

The placeholder's only job is to force role transition for LiteLLM's Anthropic translator's merge-prevention. Once the merge is prevented, the byte is invisible from a model's POV — it's an assistant turn with no semantic content. A longer or more "scaffolding-looking" string would just take up more wire bytes for no benefit. The minimum that survives all validators is the right choice.

## Sealing note

This diff was produced by an `autodev eumemic/aios 623` dispatch but the orchestrator failed to seal it — tracked under [autodev#117](https://github.com/eumemic/autodev/issues/117) (the root-cause wiring bug) and [autodev#116](https://github.com/eumemic/autodev/issues/116) (defense-in-depth post-conditions). The diff itself is correct; sealed by hand the same way autodev#115 was.
