### PR TITLE
fix(sandbox/volumes): accept pre-#409 default workspace_path at bind-mount boundary

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -10814,7 +10814,7 @@
               }
             ],
             "title": "Workspace Path",
-            "description": "Override the clone's workspace volume path. Defaults to a fresh ``workspace_root/<new_session_id>`` so clones don't fight over files. The directory must exist; aios will not create it."
+            "description": "Override the clone's workspace volume path. Defaults to a fresh ``workspace_root/<account_id>/<new_session_id>`` so clones don't fight over files. Must resolve within the account's workspace subdirectory. The directory must exist; aios will not create it."
           }
         },
         "additionalProperties": false,
@@ -10878,7 +10878,7 @@
               }
             ],
             "title": "Workspace Path",
-            "description": "Absolute host path to use as the session workspace. If omitted, defaults to workspace_root/<session_id>. The directory must exist; aios will not create it."
+            "description": "Absolute host path to use as the session workspace. If omitted, defaults to workspace_root/<account_id>/<session_id>. Must resolve within the account's workspace subdirectory. The directory must exist; aios will not create it."
           },
           "env": {
             "additionalProperties": {

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_clone_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_clone_request.py
@@ -19,8 +19,8 @@ class SessionCloneRequest:
 
         Attributes:
             workspace_path (None | str | Unset): Override the clone's workspace volume path. Defaults to a fresh
-                ``workspace_root/<new_session_id>`` so clones don't fight over files. The directory must exist; aios will not
-                create it.
+                ``workspace_root/<account_id>/<new_session_id>`` so clones don't fight over files. Must resolve within the
+                account's workspace subdirectory. The directory must exist; aios will not create it.
     """
 
     workspace_path: None | str | Unset = UNSET

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_create.py
@@ -30,7 +30,8 @@ class SessionCreate:
         metadata (SessionCreateMetadata | Unset):
         vault_ids (list[str] | Unset): Vault ids to bind to this session for MCP credential resolution.
         workspace_path (None | str | Unset): Absolute host path to use as the session workspace. If omitted, defaults to
-            workspace_root/<session_id>. The directory must exist; aios will not create it.
+            workspace_root/<account_id>/<session_id>. Must resolve within the account's workspace subdirectory. The
+            directory must exist; aios will not create it.
         env (SessionCreateEnv | Unset): Environment variables injected into the sandbox container.
         initial_message (None | str | Unset): Convenience: when set, the server appends a user.message event with this
             content immediately after creating the session and enqueues a wake job. Equivalent to a follow-up POST

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -126,7 +126,8 @@ class SessionCreate(BaseModel):
         default=None,
         description=(
             "Absolute host path to use as the session workspace. "
-            "If omitted, defaults to workspace_root/<session_id>. "
+            "If omitted, defaults to workspace_root/<account_id>/<session_id>. "
+            "Must resolve within the account's workspace subdirectory. "
             "The directory must exist; aios will not create it."
         ),
     )
@@ -240,8 +241,9 @@ class SessionCloneRequest(BaseModel):
         default=None,
         description=(
             "Override the clone's workspace volume path. Defaults to a fresh "
-            "``workspace_root/<new_session_id>`` so clones don't fight over "
-            "files. The directory must exist; aios will not create it."
+            "``workspace_root/<account_id>/<new_session_id>`` so clones don't "
+            "fight over files. Must resolve within the account's workspace "
+            "subdirectory. The directory must exist; aios will not create it."
         ),
     )
 

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -280,7 +280,12 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     # let ``ensure_workspace_path``'s ``Path.resolve()`` dereference
     # to an out-of-jail target.  Re-running the check immediately
     # before the bind-mount closes that TOCTOU window.
-    validate_workspace_path(raw_path, account_id)
+    #
+    # Passing ``session_id`` enables the legacy carve-out for pre-#409
+    # sessions whose row still holds ``<workspace_root>/<session_id>``
+    # (no per-tenant subdir).  Without it those sessions cannot
+    # cold-start a sandbox post-#590 (issue #626).
+    validate_workspace_path(raw_path, account_id, session_id=session_id)
     workspace_path = ensure_workspace_path(raw_path)
     env_config = await _load_environment_config(session_id, account_id=account_id)
     memory_echoes = await _materialize_memory_mounts(session_id, account_id=account_id)

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -112,9 +112,13 @@ def validate_workspace_path(
     every tool call.  The carve-out is keyed on the session_id the
     caller is currently provisioning — a path matching the legacy shape
     but naming a *different* session_id is still rejected, so the
-    cross-tenant defense holds.  The create-time call sites leave
-    ``session_id`` unset so user-supplied paths remain strictly jailed
-    to the account subdir.
+    cross-tenant defense holds.  The carve-out also requires the
+    resolved path to remain under ``workspace_root``: a symlink at
+    ``<workspace_root>/<session_id>`` pointing at ``/etc`` (or any
+    other path outside the jail) is rejected, preserving the
+    host-FS-escape defense the strict branch provides.  The create-time
+    call sites leave ``session_id`` unset so user-supplied paths remain
+    strictly jailed to the account subdir.
 
     Limitations: this is the create-time + bind-mount-time check on
     the workspace_path argument.  Symlinks WRITTEN inside the
@@ -138,7 +142,7 @@ def validate_workspace_path(
         return
     if session_id is not None:
         legacy_path = (workspace_root / session_id).resolve()
-        if path == legacy_path:
+        if path == legacy_path and legacy_path.is_relative_to(workspace_root):
             return
     raise ForbiddenError(
         "workspace_path must resolve to within the account's workspace subdirectory",

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -81,7 +81,9 @@ def ensure_workspace_path(raw_path: str) -> Path:
     return path
 
 
-def validate_workspace_path(raw_path: str, account_id: str) -> None:
+def validate_workspace_path(
+    raw_path: str, account_id: str, *, session_id: str | None = None
+) -> None:
     """Refuse ``raw_path`` if it resolves outside the account's
     workspace subdirectory.
 
@@ -101,6 +103,19 @@ def validate_workspace_path(raw_path: str, account_id: str) -> None:
     ``workspace_root/{other_account_id}``, and symlinks under the
     account's subdir that point outward at validate time.
 
+    ``session_id`` opens a tiny backward-compat carve-out for the
+    pre-#409 default ``<workspace_root>/<session_id>`` (no per-tenant
+    subdir).  Sessions created before PR #409 have ``workspace_volume_path``
+    rows in exactly that shape; without the carve-out the bind-mount
+    boundary re-check (added by PR #590) rejects them on every
+    cold-start, leaving the model staring at a ``ForbiddenError`` on
+    every tool call.  The carve-out is keyed on the session_id the
+    caller is currently provisioning — a path matching the legacy shape
+    but naming a *different* session_id is still rejected, so the
+    cross-tenant defense holds.  The create-time call sites leave
+    ``session_id`` unset so user-supplied paths remain strictly jailed
+    to the account subdir.
+
     Limitations: this is the create-time + bind-mount-time check on
     the workspace_path argument.  Symlinks WRITTEN inside the
     mounted ``/workspace`` after the bind-mount is live still resolve
@@ -117,12 +132,18 @@ def validate_workspace_path(raw_path: str, account_id: str) -> None:
     in audit logs as such.
     """
     path = Path(raw_path).resolve()
-    account_root = (get_settings().workspace_root / account_id).resolve()
-    if not path.is_relative_to(account_root):
-        raise ForbiddenError(
-            "workspace_path must resolve to within the account's workspace subdirectory",
-            detail={"workspace_path": raw_path},
-        )
+    workspace_root = get_settings().workspace_root.resolve()
+    account_root = (workspace_root / account_id).resolve()
+    if path.is_relative_to(account_root):
+        return
+    if session_id is not None:
+        legacy_path = (workspace_root / session_id).resolve()
+        if path == legacy_path:
+            return
+    raise ForbiddenError(
+        "workspace_path must resolve to within the account's workspace subdirectory",
+        detail={"workspace_path": raw_path},
+    )
 
 
 _MEMORY_STORES_ROOT = "_memory_stores"

--- a/tests/unit/test_volumes_workspace_jail.py
+++ b/tests/unit/test_volumes_workspace_jail.py
@@ -104,3 +104,18 @@ class TestLegacyDefaultCompat:
         other_session_legacy = str(workspace_root / "sess_other")
         with pytest.raises(ForbiddenError):
             validate_workspace_path(other_session_legacy, "acc_a", session_id="sess_01abc")
+
+    def test_legacy_path_symlinked_outside_workspace_root_rejected(
+        self, workspace_root: Path, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        """If ``<workspace_root>/<session_id>`` is a symlink whose target
+        escapes ``workspace_root``, the carve-out must reject.  Without
+        this check ``Path.resolve()`` dereferences the symlink on both
+        sides of the equality comparison, the two resolved paths match,
+        and the bind-mount would target the symlink's destination —
+        re-opening the host-FS-escape vector that PR #590 closed."""
+        outside_target = tmp_path_factory.mktemp("outside")
+        symlink = workspace_root / "sess_01abc"
+        symlink.symlink_to(outside_target)
+        with pytest.raises(ForbiddenError):
+            validate_workspace_path(str(symlink), "acc_a", session_id="sess_01abc")

--- a/tests/unit/test_volumes_workspace_jail.py
+++ b/tests/unit/test_volumes_workspace_jail.py
@@ -1,0 +1,106 @@
+"""Unit coverage for ``validate_workspace_path``.
+
+The two-axis property the function guards:
+
+- **Host-FS escape rejection.** Paths that resolve outside
+  ``workspace_root`` (``/etc``, ``..``-traversal up and out) must be
+  rejected at every call site.
+- **Cross-tenant rejection.** Paths under
+  ``workspace_root/{other_account_id}/...`` must be rejected when the
+  caller is ``{account_id}``.
+
+Plus the backward-compat carve-out for the pre-#409 default
+(``<workspace_root>/<session_id>``): when callers at the bind-mount
+boundary supply the session_id, legacy session rows must still resolve
+so the worker can cold-start them after a restart. Callers at
+session-create time leave ``session_id`` unset and the strict
+account-jail check applies to user-supplied paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aios.config import get_settings
+from aios.errors import ForbiddenError
+from aios.sandbox.volumes import validate_workspace_path
+
+
+@pytest.fixture
+def workspace_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    return tmp_path
+
+
+class TestStrictJail:
+    """The create-time check (no session_id) must keep rejecting every
+    pre-#590 escape vector."""
+
+    def test_rejects_host_path(self, workspace_root: Path) -> None:
+        with pytest.raises(ForbiddenError):
+            validate_workspace_path("/etc", "acc_a")
+
+    def test_rejects_cross_tenant_path(self, workspace_root: Path) -> None:
+        cross = str(workspace_root / "acc_b" / "any_session")
+        with pytest.raises(ForbiddenError):
+            validate_workspace_path(cross, "acc_a")
+
+    def test_rejects_dotdot_traversal(self, workspace_root: Path) -> None:
+        traversed = str(workspace_root / "acc_a" / ".." / "acc_b" / "x")
+        with pytest.raises(ForbiddenError):
+            validate_workspace_path(traversed, "acc_a")
+
+    def test_accepts_within_account_subdir(self, workspace_root: Path) -> None:
+        own = str(workspace_root / "acc_a" / "shared")
+        validate_workspace_path(own, "acc_a")
+
+
+class TestLegacyDefaultCompat:
+    """Pre-#409 sessions have ``workspace_volume_path =
+    <workspace_root>/<session_id>`` — no per-tenant subdir. The
+    bind-mount-boundary re-check must let these existing rows through;
+    without that the worker can never cold-start any session that
+    pre-dates the per-tenant default.
+
+    See #626: the model surfaced a ``ForbiddenError`` on every tool
+    call after the worker recycled the legacy session's sandbox.
+    """
+
+    def test_legacy_default_with_session_id_accepted(self, workspace_root: Path) -> None:
+        """``<workspace_root>/<session_id>`` is the literal legacy
+        default. When the caller (sandbox provisioner) supplies
+        ``session_id``, this must resolve."""
+        legacy_path = str(workspace_root / "sess_01abc")
+        validate_workspace_path(legacy_path, "acc_a", session_id="sess_01abc")
+
+    def test_legacy_default_without_session_id_rejected(self, workspace_root: Path) -> None:
+        """At session-create time the caller doesn't know a
+        session_id yet. User-supplied legacy-shaped paths must still be
+        rejected so an attacker can't reach into ``<workspace_root>/
+        <victim_session_id>`` by inventing a ULID."""
+        legacy_path = str(workspace_root / "sess_01abc")
+        with pytest.raises(ForbiddenError):
+            validate_workspace_path(legacy_path, "acc_a")
+
+    def test_legacy_form_descendant_not_accepted_as_legacy(self, workspace_root: Path) -> None:
+        """Only the exact legacy path itself counts — descendants of
+        ``<workspace_root>/<session_id>`` never appeared in any default
+        and must not be treated as legacy. (The new-convention check
+        still accepts paths under ``<workspace_root>/<account_id>/``
+        unchanged.)"""
+        deeper = str(workspace_root / "sess_01abc" / "evil")
+        with pytest.raises(ForbiddenError):
+            validate_workspace_path(deeper, "acc_a", session_id="sess_01abc")
+
+    def test_legacy_form_for_a_different_session_rejected(self, workspace_root: Path) -> None:
+        """Cross-tenant defense: the legacy carve-out is keyed on the
+        session_id the provisioner is currently cold-starting. A path
+        that matches the legacy shape but names a DIFFERENT session_id
+        must be rejected — otherwise the carve-out would let any
+        session bind-mount any other session's legacy workspace."""
+        other_session_legacy = str(workspace_root / "sess_other")
+        with pytest.raises(ForbiddenError):
+            validate_workspace_path(other_session_legacy, "acc_a", session_id="sess_01abc")


### PR DESCRIPTION
## Summary

- Bind-mount-boundary re-validation (introduced by #590) rejects sessions whose row holds the pre-#409 default ``workspace_volume_path = <workspace_root>/<session_id>``. After any sandbox recycle the model sees ``ForbiddenError: workspace_path must resolve to within the account's workspace subdirectory`` on every tool call.
- ``validate_workspace_path`` learns an optional ``session_id`` kwarg. At the bind-mount boundary (``sandbox/spec.py``) the call passes it so legacy rows pass the check; create-time callers leave it unset so user-supplied paths remain strictly jailed to the account subdir.
- Closes #626.

## Root cause

#409 (per-tenant default paths, May 14 2026) explicitly promised backward-compat: *"Existing sessions' paths are already stored verbatim in `sessions.workspace_volume_path` and resolve through the unchanged `ensure_workspace_path` helper."* #590 (workspace_path jail, May 20 2026) then added an **unconditional** re-validation at the bind-mount boundary that requires every path to be under ``<workspace_root>/<account_id>/`` — quietly violating the #409 promise for any session whose row still holds the older shape.

When the model issues a tool call against a session that ran a step before the worker restart or sandbox recycle, ``build_spec_from_session`` re-runs ``validate_workspace_path`` and raises. The error percolates through ``tool_dispatch.py`` as ``ForbiddenError: workspace_path must resolve to within the account's workspace subdirectory``. The same error fires regardless of which path the model tries — #626 just happened to surface it via ``/mnt/memory/...`` because that's what the persona was working with.

## Fix shape

```python
def validate_workspace_path(
    raw_path: str, account_id: str, *, session_id: str | None = None
) -> None:
    path = Path(raw_path).resolve()
    workspace_root = get_settings().workspace_root.resolve()
    account_root = (workspace_root / account_id).resolve()
    if path.is_relative_to(account_root):
        return
    if session_id is not None:
        legacy_path = (workspace_root / session_id).resolve()
        if path == legacy_path:
            return
    raise ForbiddenError(...)
```

The carve-out is exact-match, keyed on the session currently being provisioned:

- A path matching the legacy shape but naming a *different* session_id still fails — cross-tenant defense intact.
- Descendants of ``<workspace_root>/<session_id>`` are not accepted via the carve-out; only the exact path is.
- Create-time callers (``services.create_session``, ``services.clone_session`` with explicit user path) leave ``session_id=None`` — user-supplied paths still strictly jailed.

## Test plan

- [x] New unit tests in ``tests/unit/test_volumes_workspace_jail.py`` covering:
  - Strict-jail tests (host path, cross-tenant, ``..``-traversal, legitimate within-account)
  - Legacy carve-out: accepted with matching session_id; rejected without session_id; descendant rejected; different session_id rejected
- [x] Existing ``tests/integration/test_workspace_path_jail.py`` still passes (the create-time call path leaves ``session_id`` unset → strict mode preserved)
- [x] ``uv run mypy src`` — clean
- [x] ``uv run ruff check src tests`` / ``ruff format --check`` — clean
- [x] ``uv run pytest tests/unit -q`` — 1433 passed
- [ ] CI runs full e2e + integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)