### PR TITLE
perf(services/sessions): batch resource-echo queries in list_sessions

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -5226,6 +5226,59 @@ async def list_session_github_repo_echoes(
     return [_row_to_github_repo_echo(r) for r in rows]
 
 
+async def batch_list_session_memory_store_echoes(
+    conn: asyncpg.Connection[Any],
+    session_ids: list[str],
+    *,
+    account_id: str,
+) -> dict[str, list[MemoryStoreResourceEcho]]:
+    """Batch-fetch memory-store echoes for multiple sessions, keyed by session_id."""
+    if not session_ids:
+        return {}
+    rows = await conn.fetch(
+        "SELECT * FROM session_memory_stores "
+        "WHERE session_id = ANY($1) AND account_id = $2 "
+        "ORDER BY session_id, rank",
+        session_ids,
+        account_id,
+    )
+    result: dict[str, list[MemoryStoreResourceEcho]] = {sid: [] for sid in session_ids}
+    for r in rows:
+        result[str(r["session_id"])].append(
+            MemoryStoreResourceEcho(
+                memory_store_id=r["memory_store_id"],
+                access=r["access"],
+                instructions=r["instructions"],
+                name=r["name_at_attach"],
+                description=r["description_at_attach"],
+                mount_path=f"/mnt/memory/{r['name_at_attach']}",
+            )
+        )
+    return result
+
+
+async def batch_list_session_github_repo_echoes(
+    conn: asyncpg.Connection[Any],
+    session_ids: list[str],
+    *,
+    account_id: str,
+) -> dict[str, list[GithubRepositoryResourceEcho]]:
+    """Batch-fetch github-repository echoes for multiple sessions, keyed by session_id."""
+    if not session_ids:
+        return {}
+    rows = await conn.fetch(
+        "SELECT * FROM session_github_repositories "
+        "WHERE session_id = ANY($1) AND account_id = $2 "
+        "ORDER BY session_id, rank",
+        session_ids,
+        account_id,
+    )
+    result: dict[str, list[GithubRepositoryResourceEcho]] = {sid: [] for sid in session_ids}
+    for r in rows:
+        result[str(r["session_id"])].append(_row_to_github_repo_echo(r))
+    return result
+
+
 async def get_session_github_repo(
     conn: asyncpg.Connection[Any],
     session_id: str,

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -5236,7 +5236,9 @@ async def batch_list_session_memory_store_echoes(
     if not session_ids:
         return {}
     rows = await conn.fetch(
-        "SELECT * FROM session_memory_stores "
+        "SELECT session_id, memory_store_id, access, instructions, "
+        "name_at_attach, description_at_attach "
+        "FROM session_memory_stores "
         "WHERE session_id = ANY($1) AND account_id = $2 "
         "ORDER BY session_id, rank",
         session_ids,
@@ -5244,7 +5246,7 @@ async def batch_list_session_memory_store_echoes(
     )
     result: dict[str, list[MemoryStoreResourceEcho]] = {sid: [] for sid in session_ids}
     for r in rows:
-        result[str(r["session_id"])].append(
+        result[r["session_id"]].append(
             MemoryStoreResourceEcho(
                 memory_store_id=r["memory_store_id"],
                 access=r["access"],
@@ -5267,7 +5269,9 @@ async def batch_list_session_github_repo_echoes(
     if not session_ids:
         return {}
     rows = await conn.fetch(
-        "SELECT * FROM session_github_repositories "
+        "SELECT session_id, id, repo_url, mount_path, created_at, updated_at, "
+        "git_user_name, git_user_email "
+        "FROM session_github_repositories "
         "WHERE session_id = ANY($1) AND account_id = $2 "
         "ORDER BY session_id, rank",
         session_ids,
@@ -5275,7 +5279,7 @@ async def batch_list_session_github_repo_echoes(
     )
     result: dict[str, list[GithubRepositoryResourceEcho]] = {sid: [] for sid in session_ids}
     for r in rows:
-        result[str(r["session_id"])].append(_row_to_github_repo_echo(r))
+        result[r["session_id"]].append(_row_to_github_repo_echo(r))
     return result
 
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -70,6 +70,31 @@ async def _list_all_echoes(
     return out
 
 
+async def _batch_list_all_echoes(
+    conn: asyncpg.Connection[Any],
+    session_ids: list[str],
+    *,
+    account_id: str,
+) -> dict[str, list[SessionResourceEcho]]:
+    """Batched form of :func:`_list_all_echoes` — one query per echo family
+    across all sessions instead of two per session."""
+    if not session_ids:
+        return {}
+    memory_map = await queries.batch_list_session_memory_store_echoes(
+        conn, session_ids, account_id=account_id
+    )
+    github_map = await queries.batch_list_session_github_repo_echoes(
+        conn, session_ids, account_id=account_id
+    )
+    result: dict[str, list[SessionResourceEcho]] = {}
+    for sid in session_ids:
+        merged: list[SessionResourceEcho] = []
+        merged.extend(memory_map.get(sid, []))
+        merged.extend(github_map.get(sid, []))
+        result[sid] = merged
+    return result
+
+
 async def create_session(
     pool: asyncpg.Pool[Any],
     *,
@@ -280,18 +305,15 @@ async def list_sessions(
         )
         if not sessions:
             return sessions
-        vault_map = await queries.batch_get_session_vault_ids(
-            conn, [s.id for s in sessions], account_id=account_id
-        )
-        echoes_by_sid: dict[str, list[SessionResourceEcho]] = {}
-        for s in sessions:
-            echoes_by_sid[s.id] = await _list_all_echoes(conn, s.id, account_id=account_id)
+        sid_list = [s.id for s in sessions]
+        vault_map = await queries.batch_get_session_vault_ids(conn, sid_list, account_id=account_id)
+        echoes_map = await _batch_list_all_echoes(conn, sid_list, account_id=account_id)
     awaiting_by_sid = await compute_awaiting(pool, sessions, account_id=account_id)
     return [
         s.model_copy(
             update={
                 "vault_ids": vault_map.get(s.id, []),
-                "resources": echoes_by_sid.get(s.id, []),
+                "resources": echoes_map.get(s.id, []),
                 "awaiting": awaiting_by_sid.get(s.id, []),
             }
         )

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -86,13 +86,7 @@ async def _batch_list_all_echoes(
     github_map = await queries.batch_list_session_github_repo_echoes(
         conn, session_ids, account_id=account_id
     )
-    result: dict[str, list[SessionResourceEcho]] = {}
-    for sid in session_ids:
-        merged: list[SessionResourceEcho] = []
-        merged.extend(memory_map.get(sid, []))
-        merged.extend(github_map.get(sid, []))
-        result[sid] = merged
-    return result
+    return {sid: [*memory_map[sid], *github_map[sid]] for sid in session_ids}
 
 
 async def create_session(
@@ -309,16 +303,17 @@ async def list_sessions(
         vault_map = await queries.batch_get_session_vault_ids(conn, sid_list, account_id=account_id)
         echoes_map = await _batch_list_all_echoes(conn, sid_list, account_id=account_id)
     awaiting_by_sid = await compute_awaiting(pool, sessions, account_id=account_id)
-    return [
+    enriched: list[Session] = [
         s.model_copy(
             update={
-                "vault_ids": vault_map.get(s.id, []),
-                "resources": echoes_map.get(s.id, []),
+                "vault_ids": vault_map[s.id],
+                "resources": echoes_map[s.id],
                 "awaiting": awaiting_by_sid.get(s.id, []),
             }
         )
         for s in sessions
     ]
+    return enriched
 
 
 async def append_user_message(

--- a/tests/e2e/test_memory_stores_api.py
+++ b/tests/e2e/test_memory_stores_api.py
@@ -568,3 +568,68 @@ class TestSessionResourcesUpdate:
         assert r.status_code == 200, r.text
         ids = [e["memory_store_id"] for e in r.json()["resources"]]
         assert ids == [prior["id"]]
+
+
+class TestSessionListResourcesBatched:
+    """``GET /v1/sessions`` enriches each row with its ``resources`` field via a
+    single batched query per echo family — regression guard for issue #617."""
+
+    async def test_list_returns_resources_for_each_session(
+        self, http_client: httpx.AsyncClient, pool: Any
+    ) -> None:
+        from aios.models.memory_stores import MemoryStoreResource
+        from aios.services import agents as agents_svc
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        account_id = "acc_test_stub"
+        store_a = await _create_store(http_client, name=f"list-a-{_uniq()}")
+        store_b = await _create_store(http_client, name=f"list-b-{_uniq()}")
+        store_c = await _create_store(http_client, name=f"list-c-{_uniq()}")
+
+        env = await env_svc.create_environment(
+            pool, name=f"list-resources-{_uniq()}", account_id=account_id
+        )
+        agent = await agents_svc.create_agent(
+            pool,
+            name=f"list-resources-agent-{_uniq()}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+            account_id=account_id,
+        )
+
+        async def _mk(initial: list[str]) -> str:
+            s = await sess_svc.create_session(
+                pool,
+                agent_id=agent.id,
+                environment_id=env.id,
+                title="list-resources",
+                metadata={},
+                resources=[
+                    MemoryStoreResource(type="memory_store", memory_store_id=sid) for sid in initial
+                ],
+                account_id=account_id,
+            )
+            return s.id
+
+        two_id = await _mk([store_a["id"], store_b["id"]])
+        zero_id = await _mk([])
+        one_id = await _mk([store_c["id"]])
+
+        r = await http_client.get(f"/v1/sessions?agent_id={agent.id}&limit=50")
+        assert r.status_code == 200, r.text
+        by_id = {s["id"]: s for s in r.json()["data"]}
+        assert {two_id, zero_id, one_id} <= by_id.keys()
+
+        ids_two = [e["memory_store_id"] for e in by_id[two_id]["resources"]]
+        assert ids_two == [store_a["id"], store_b["id"]]
+
+        assert by_id[zero_id]["resources"] == []
+
+        ids_one = [e["memory_store_id"] for e in by_id[one_id]["resources"]]
+        assert ids_one == [store_c["id"]]

--- a/tests/e2e/test_memory_stores_api.py
+++ b/tests/e2e/test_memory_stores_api.py
@@ -621,10 +621,10 @@ class TestSessionListResourcesBatched:
         zero_id = await _mk([])
         one_id = await _mk([store_c["id"]])
 
-        r = await http_client.get(f"/v1/sessions?agent_id={agent.id}&limit=50")
+        r = await http_client.get(f"/v1/sessions?agent_id={agent.id}")
         assert r.status_code == 200, r.text
         by_id = {s["id"]: s for s in r.json()["data"]}
-        assert {two_id, zero_id, one_id} <= by_id.keys()
+        assert by_id.keys() == {two_id, zero_id, one_id}
 
         ids_two = [e["memory_store_id"] for e in by_id[two_id]["resources"]]
         assert ids_two == [store_a["id"], store_b["id"]]


### PR DESCRIPTION
## Summary

- `GET /v1/sessions?limit=50` was issuing ~`2N+1` SQL round-trips — one for the page, one batched vault lookup, then a per-session loop calling `_list_all_echoes` (which itself runs two queries per session). On a 50-row page that's ~100 extra round trips just to populate `resources`.
- Add two batched query helpers in `db/queries.py` mirroring the existing `batch_get_session_vault_ids` pattern, plus a `_batch_list_all_echoes` composition helper in `services/sessions.py` that preserves the "memory first then github, each in rank order" invariant. A page now costs 4 round trips regardless of size.
- The four single-session callers of `_list_all_echoes` (`create_session`, `get_session`, `clone_session`, `update_session`) are unchanged — they correctly use the per-session helper.

Fixes #617.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1406 passed
- [x] New e2e regression test `TestSessionListResourcesBatched::test_list_returns_resources_for_each_session` — passes; creates three sessions with 2, 0, and 1 memory-store resources under one agent, lists via `GET /v1/sessions?agent_id=…`, and asserts each session's `resources` array. The zero-resource case exercises the dict pre-fill in the batched query.
- [x] Full `tests/e2e/test_memory_stores_api.py` — 23 passed, no sibling regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)