### PR TITLE
fix(services/sessions): snapshot-isolate enrichment reads in list_/get_session

### DIFF
--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -244,7 +244,13 @@ async def compute_awaiting(
 
 
 async def get_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: str) -> Session:
-    async with pool.acquire() as conn:
+    # REPEATABLE READ snapshot pins all three enrichment reads to one
+    # moment in time so a concurrent ``update_session`` committing
+    # between reads can't return a torn ``Session`` (e.g. row columns
+    # from before the update with ``resources`` from after).
+    # ``compute_awaiting`` is event-derived and monotonic — running it on
+    # a separate connection sees ≥ the snapshot's events, not a tear.
+    async with pool.acquire() as conn, conn.transaction(isolation="repeatable_read", readonly=True):
         session = await queries.get_session(conn, session_id, account_id=account_id)
         vault_ids = await queries.get_session_vault_ids(conn, session_id, account_id=account_id)
         echoes = await _list_all_echoes(conn, session_id, account_id=account_id)
@@ -293,7 +299,8 @@ async def list_sessions(
     limit: int = 50,
     after: str | None = None,
 ) -> list[Session]:
-    async with pool.acquire() as conn:
+    # See ``get_session`` for the rationale on the snapshot wrap.
+    async with pool.acquire() as conn, conn.transaction(isolation="repeatable_read", readonly=True):
         sessions = await queries.list_sessions(
             conn, agent_id=agent_id, status=status, limit=limit, after=after, account_id=account_id
         )


### PR DESCRIPTION
## Summary

- `list_sessions` and `get_session` each issue 3 reads on one connection in autocommit mode (session row, vault-id batch, echo batch).  Under default READ COMMITTED, Postgres takes a fresh snapshot per statement, so a concurrent `update_session` committing between reads returns a torn `Session` — row columns from before the update with `resources` from after (or vice versa).
- Wrap both functions in `conn.transaction(isolation='repeatable_read', readonly=True)`.  REPEATABLE READ takes one snapshot at the first statement and freezes it; `readonly=True` rules out serialization failures (no writes → no 40001).  Cost at our scale is essentially zero — no extra round trips, no locks beyond the snapshot itself.

## Design notes (per #631)

- **`compute_awaiting` is intentionally NOT folded into the snapshot.**  It's event-derived (append-only, monotonic), so a freshness gap there is forward progress, not a tear.  Threading `conn` through `compute_awaiting` + `agents_service.load_for_session` would buy correctness for a property that wasn't violated.
- **`update_session` already wraps writes + post-mutation reads in one transaction**; reads see the writer's own snapshot, no change needed.
- **`clone_session` mints a fresh ID not yet observable to other writers** (it hasn't been returned), so the racy window is unreachable; left as-is.

## Failure mode being fixed

Stale-field-combination, not crash.  No bug report names it, but it's an unbounded source of "why does the dashboard look weird sometimes" — operator UI seeing `status="running"` + `updated_at=10:00:00` + `resources=[]` when really the session was just updated to idle with detached resources at 10:00:05.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1434 passed
- [ ] No new unit test: the race is hard to make deterministic without a concurrent-writer harness; the change rides on the underlying queries' existing coverage and the obvious correctness of the isolation kwarg.  Open to adding one if a reviewer wants it.

Fixes #631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)