### PR TITLE
fix(config): fail-fast on relative AIOS_WORKSPACE_ROOT at Settings load

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -205,10 +205,10 @@ class Settings(BaseSettings):
     def _require_absolute_workspace_root(self) -> Settings:
         if not self.workspace_root.is_absolute():
             raise ValueError(
-                "AIOS_WORKSPACE_ROOT must be an absolute path; got "
-                f"{self.workspace_root!r}. API and worker processes "
-                "resolve relative paths against their own CWD, producing "
-                "diverging session workspace_path values and ForbiddenError "
+                f"AIOS_WORKSPACE_ROOT must be an absolute path; got '{self.workspace_root}'. "
+                "Note: pathlib does not expand '~'; write the full path. "
+                "API and worker processes resolve relative paths against their own CWD, "
+                "producing diverging session workspace_path values and ForbiddenError "
                 "on tool calls."
             )
         return self

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field, SecretStr
+from pydantic import Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -200,6 +200,18 @@ class Settings(BaseSettings):
 
     # ── observability ──────────────────────────────────────────────────────
     log_level: str = Field(default="INFO")
+
+    @model_validator(mode="after")
+    def _require_absolute_workspace_root(self) -> Settings:
+        if not self.workspace_root.is_absolute():
+            raise ValueError(
+                "AIOS_WORKSPACE_ROOT must be an absolute path; got "
+                f"{self.workspace_root!r}. API and worker processes "
+                "resolve relative paths against their own CWD, producing "
+                "diverging session workspace_path values and ForbiddenError "
+                "on tool calls."
+            )
+        return self
 
 
 @lru_cache(maxsize=1)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,58 @@
+"""Unit tests for ``aios.config.Settings`` validators.
+
+Tests live in their own file because ``test_cli_dev.py`` covers the dev
+bootstrap surface; this file covers process-load invariants enforced at
+``Settings()`` construction.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_workspace_root_must_be_absolute(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``AIOS_WORKSPACE_ROOT=./relative`` fails fast at process load.
+
+    Without enforcement, the API and worker processes can resolve the path
+    differently depending on each process's CWD, producing CWD-drift bugs
+    that surface much later as ``ForbiddenError`` on every tool call once a
+    sandbox recycles.
+    """
+    from pydantic import ValidationError
+
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_API_KEY=k\nAIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "./workspaces")
+
+    with pytest.raises(ValidationError, match="absolute"):
+        Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+
+
+def test_workspace_root_accepts_absolute(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Absolute paths pass through unchanged."""
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_API_KEY=k\nAIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "/var/lib/test")
+
+    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    assert s.workspace_root == Path("/var/lib/test")
+
+
+def test_workspace_root_default_is_absolute(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The hard-coded default in ``Settings`` must satisfy its own validator."""
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_API_KEY=k\nAIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.delenv("AIOS_WORKSPACE_ROOT", raising=False)
+
+    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    assert s.workspace_root.is_absolute()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,10 +25,32 @@ def test_workspace_root_must_be_absolute(tmp_path: Path, monkeypatch: pytest.Mon
     from aios.config import Settings
 
     secrets = tmp_path / "secrets.env"
-    secrets.write_text("AIOS_API_KEY=k\nAIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "./workspaces")
 
-    with pytest.raises(ValidationError, match="absolute"):
+    with pytest.raises(ValidationError, match="must be an absolute path"):
+        Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+
+
+def test_workspace_root_error_mentions_tilde(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The error message mentions that ``~`` is not expanded.
+
+    A common operator mistake is ``AIOS_WORKSPACE_ROOT=~/aios/workspaces``,
+    which pathlib stores verbatim — ``Path("~/aios/workspaces").is_absolute()``
+    is False. The message names this explicitly so the operator doesn't have
+    to relearn it.
+    """
+    from pydantic import ValidationError
+
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "~/aios/workspaces")
+
+    with pytest.raises(ValidationError, match=r"does not expand '~'"):
         Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
 
 
@@ -37,7 +59,7 @@ def test_workspace_root_accepts_absolute(tmp_path: Path, monkeypatch: pytest.Mon
     from aios.config import Settings
 
     secrets = tmp_path / "secrets.env"
-    secrets.write_text("AIOS_API_KEY=k\nAIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "/var/lib/test")
 
     s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
@@ -51,7 +73,7 @@ def test_workspace_root_default_is_absolute(
     from aios.config import Settings
 
     secrets = tmp_path / "secrets.env"
-    secrets.write_text("AIOS_API_KEY=k\nAIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.delenv("AIOS_WORKSPACE_ROOT", raising=False)
 
     s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

- Adds the minimal ``@model_validator(mode=\"after\")`` on ``Settings`` rejecting relative ``AIOS_WORKSPACE_ROOT`` at process load.
- Without enforcement, the API and worker processes silently resolve a relative path against their own CWD, producing diverging session ``workspace_path`` values that surface much later as ``ForbiddenError`` on every tool call — same operator-visible failure as #626 but a different root cause that survives the #628 fix.
- Deliberately does NOT bundle ``.resolve()``-at-load. Per the issue's framing, "the validator alone is the minimal correct-by-construction fix"; per project memory, no belt-and-suspenders without sign-off.

## Test plan

- [x] ``uv run mypy src`` — clean (160 source files)
- [x] ``uv run ruff check src tests && uv run ruff format --check src tests`` — clean
- [x] ``uv run pytest tests/unit -q`` — 1437 passed
- [x] New unit tests in ``tests/unit/test_config.py`` (3): relative path rejected (``ValidationError`` matching ``absolute``); absolute path accepted; hard-coded default is self-consistent.
- [ ] CI runs e2e + integration suites

## Code review findings

5-angle ``/code-review`` against the diff returned no findings ≥ 80. Posting all sub-threshold findings inline per the project's \"post all code review findings, don't filter by score\" policy:

**~40 — \`src/aios/harness/exit_diagnostics.py\` + \`procrastinate_app.py\` (pre-existing, surfaced by this PR)**
The new fail-fast happens at ``Settings()`` construction during module import. If an operator has ``AIOS_WORKSPACE_ROOT=./relative`` exported in a stale shell, ``aios worker`` now crashes at import time before ``exit_diagnostics``'s atexit hook is wired. Pydantic prints to stderr, but the structured ``worker.exit`` structlog trace never appears — the silent-exit failure mode exit_diagnostics exists to prevent. Not introduced by this PR (the import-time Settings load predates it); the new validator just makes the scenario more reachable. Worth a follow-up if it bites.

**~30 — \`src/aios/config.py:209\`**
Error message renders the path with ``!r``, producing ``PosixPath('.')`` for an empty-string env var. An operator setting ``AIOS_WORKSPACE_ROOT=\"\"`` sees a message that doesn't connect to their actual input. Cosmetic.

**~25 — \`src/aios/config.py:207-213\`**
Error message could note that ``~`` is not expanded. An operator setting ``AIOS_WORKSPACE_ROOT=~/foo`` triggers the validator (correctly, since pathlib doesn't expand ``~``), but may think ``~`` makes the path \"absolute.\" Adding a one-line hint would make the error clearer.

**~25 — \`tests/unit/test_config.py:33\`**
``pytest.raises(ValidationError, match=\"absolute\")`` matches the word anywhere in the error string. If a future refactor drops \"absolute\" from the primary message but keeps it in a tangential phrase, the test silently passes for the wrong reason. Low priority — the current message is sticky on \"must be an absolute path.\"

**~10 — \`tests/unit/test_config.py:30\`**
``secrets.env`` writes ``AIOS_API_KEY=k``, but ``api_key`` is not a field on the server-side ``Settings`` class (it lives in the CLI's settings). Harmless — pydantic-settings has ``extra=\"ignore\"`` configured — but the line is dead. Matches the existing pattern in ``test_cli_dev.py``; if cleaning here, should clean both.

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)