### PR TITLE
fix(config): reject relative AIOS_WORKSPACE_ROOT at Settings load

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field, SecretStr
+from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -79,8 +79,11 @@ class Settings(BaseSettings):
     workspace_root: Path = Field(
         default=Path("/var/lib/aios/workspaces"),
         description="Host directory containing per-session workspace subdirectories. "
-        "Each session gets <workspace_root>/<session_id> bind-mounted to /workspace "
-        "inside its sandbox container.",
+        "Each session gets <workspace_root>/<account_id>/<session_id> bind-mounted to /workspace "
+        "inside its sandbox container. Must be an absolute path — every consumer "
+        "calls ``.resolve()`` at use time, so a relative value silently produces "
+        "CWD-dependent paths and API/worker processes running from different "
+        "working directories would compute divergent results.",
     )
     sandbox_cpu_quota: float | None = Field(
         default=None,
@@ -200,6 +203,13 @@ class Settings(BaseSettings):
 
     # ── observability ──────────────────────────────────────────────────────
     log_level: str = Field(default="INFO")
+
+    @field_validator("workspace_root")
+    @classmethod
+    def _validate_workspace_root(cls, v: Path) -> Path:
+        if not v.is_absolute():
+            raise ValueError(f"workspace_root must be an absolute path; got {v!r}")
+        return v
 
 
 @lru_cache(maxsize=1)

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -52,10 +52,8 @@ def safe_filename(name: str | None) -> str:
 def workspace_dir_for(session_id: str) -> Path:
     """Return the absolute host directory for ``session_id``'s workspace.
 
-    The returned path is always absolute — Docker bind mounts reject
-    relative paths. If ``workspace_root`` was configured as a relative
-    path (e.g. ``./workspaces`` in a dev ``.env``), it is resolved
-    against the current working directory at call time.
+    ``Settings.workspace_root`` is enforced absolute at config load time,
+    so the joined path is always absolute — required by Docker bind mounts.
 
     Pure — does not touch the filesystem. Use :func:`ensure_workspace_dir`
     to both compute and create.

--- a/tests/unit/test_settings_workspace_root.py
+++ b/tests/unit/test_settings_workspace_root.py
@@ -1,0 +1,58 @@
+"""Unit coverage for the absolute-path invariant on ``Settings.workspace_root``.
+
+The rest of the codebase calls ``settings.workspace_root.resolve()`` at use
+time, which silently produces CWD-dependent paths if the configured value is
+relative. With API and worker processes running from different working
+directories (different systemd units, different ``uv run`` invocations), this
+can desynchronize the path each process computes — surfacing as a
+``ForbiddenError`` on the bind-mount boundary rather than a startup failure.
+
+These tests pin the validator that closes the gap at config load time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+
+def test_workspace_root_rejects_relative_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aios.config import Settings
+
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "./workspaces")
+    with pytest.raises(ValidationError, match=r"workspace_root must be an absolute path"):
+        Settings()
+
+
+def test_workspace_root_rejects_parent_relative_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aios.config import Settings
+
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "../workspaces")
+    with pytest.raises(ValidationError, match=r"workspace_root must be an absolute path"):
+        Settings()
+
+
+def test_workspace_root_rejects_bare_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aios.config import Settings
+
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "workspaces")
+    with pytest.raises(ValidationError, match=r"workspace_root must be an absolute path"):
+        Settings()
+
+
+def test_workspace_root_accepts_absolute_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aios.config import Settings
+
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "/var/lib/aios/workspaces")
+    s = Settings()
+    assert s.workspace_root == Path("/var/lib/aios/workspaces")
+
+
+def test_workspace_root_default_is_absolute() -> None:
+    """The hardcoded default must satisfy the new validator."""
+    from aios.config import Settings
+
+    s = Settings()
+    assert s.workspace_root.is_absolute()


### PR DESCRIPTION
## Summary

- Add a `@field_validator("workspace_root")` on `Settings` so a misconfigured relative `AIOS_WORKSPACE_ROOT` fails at config load rather than producing silent CWD-dependent paths at every consumer. Matches the existing project idiom from `models/sessions.py:160` (which validates `workspace_path` on `SessionCreate`).
- Drive-by: bring the field `description` into line with the post-#409 per-account layout (`<workspace_root>/<account_id>/<session_id>`), and drop the now-impossible relative-path caveat from `sandbox/volumes.py::workspace_dir_for`.

## Why this matters

Every consumer of `settings.workspace_root` calls `.resolve()` at use time. With a relative value configured, two processes running from different `WorkingDirectory` (e.g. two systemd units, two `uv run` invocations in different shells) compute divergent absolute paths for the same session — the API process inserts one path on the row, the worker validates against another, every tool call hits `ForbiddenError: workspace_path must resolve to within the account's workspace subdirectory`. The current deployment surface uses absolute roots everywhere (default, `.env.example`, `compose.yml`), so this is an operator footgun rather than an active production bug; closing it at config load matches the project's "fail hard, no fallbacks" stance.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1439 passed
- [x] Five new unit tests cover the validator: relative paths (`./workspaces`, `../workspaces`, `workspaces`), absolute path (accepted), default-is-absolute (regression guard on the hardcoded default).
- [ ] CI e2e suite

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)