### PR TITLE
fix(api/sse): preflight LISTEN before sending 200 OK to fix CI flap

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2882,7 +2882,7 @@
           "sessions"
         ],
         "summary": "Stream Events",
-        "description": "Stream session events as Server-Sent Events.",
+        "description": "Stream session events as Server-Sent Events.\n\nPreflights the LISTEN connection BEFORE constructing the response\n(issue #376): a transient ``asyncpg.connect`` failure during\ntestcontainer warmup or a brief Postgres outage surfaces as a clean\n503 with proper headers rather than a half-open chunked stream\nafter 200 OK has gone out.",
         "operationId": "stream_events_v1_sessions__session_id__stream_get",
         "parameters": [
           {

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -288,17 +288,17 @@ class HttpConnector:
 
     # ── test-coordination primitives ──────────────────────────────────
 
-    async def wait_ready(self, deadline: float = 60.0) -> None:
+    async def wait_ready(self, deadline: float = 30.0) -> None:
         """Block until all three background loops have opened their SSE streams.
 
         Specifically: each of the discovery, tool, and management-call loops has
         received the synthetic ``"_open"`` event the SDK's
         :func:`aios_sdk.streaming._stream_sse` yields right after
         ``response.raise_for_status()`` succeeds — i.e. the HTTP handshake
-        returned 2xx headers.  At that moment the server-side body generator
-        has begun executing; within the same event-loop iteration its
-        ``listen_for_*`` context manager registers LISTEN, after which any
-        subsequent NOTIFY is queued and delivered to the SSE stream.
+        returned 2xx headers.  Since the server-side ``listen_for_*`` setup
+        runs in the route handler BEFORE ``EventSourceResponse`` is constructed
+        (issue #376), 2xx headers imply the LISTEN connection is already
+        established and any subsequent NOTIFY is queued.
 
         We deliberately do NOT depend on a server-emitted ``"connected"``
         event yielded before backfill, because yielding from an sse-starlette
@@ -306,33 +306,32 @@ class HttpConnector:
         returned without completing response" failure mode in CI (see aios#366
         commit-message archaeology).
 
-        Caveat for test authors: ``_open`` is a *best-effort* readiness
-        signal, not a strong handshake.  It fires when the client sees 2xx
-        headers, but the server-side generator may still be in the middle of
-        a slow ``asyncpg.connect()`` for its LISTEN connection.  In tests
-        that use an in-process uvicorn fixture, watch for the cross-test
-        ``sse_starlette.AppStatus.should_exit`` contamination noted in
-        :mod:`tests.conftest` (``_reset_sse_starlette_shutdown_state``);
-        without that reset, every SSE handshake after the first fixture
-        teardown can be cancelled immediately by the library's shutdown
-        watcher, defeating ``_open`` as a readiness oracle.
+        Caveat for test authors: in tests that use an in-process uvicorn
+        fixture, watch for the cross-test ``sse_starlette.AppStatus.should_exit``
+        contamination noted in :mod:`tests.conftest`
+        (``_reset_sse_starlette_shutdown_state``); without that reset, every
+        SSE handshake after the first fixture teardown can be cancelled
+        immediately by the library's shutdown watcher.
 
-        The default deadline is 60 s — generous for CI scheduler lag and the
-        exponential-backoff retry cycle on the SSE connection.
+        The default deadline is 30 s — comfortable headroom over worst-case
+        healthy CI scheduling (LISTEN preflight is now a single asyncpg
+        connect + add_listener inside the route handler, on the order of
+        tens of milliseconds in steady state).
 
         Raises ``TimeoutError`` if the loops have not all reached the live
         phase within ``deadline`` seconds.  Intended for test coordination.
         """
         await asyncio.wait_for(self._all_loops_live.wait(), timeout=deadline)
 
-    async def wait_connection_served(self, connection_id: str, deadline: float = 60.0) -> None:
+    async def wait_connection_served(self, connection_id: str, deadline: float = 30.0) -> None:
         """Block until serve_connection has been spawned for connection_id.
 
         The discovery loop must receive and process the ``added`` event for
-        ``connection_id`` before this returns.  Because the discovery SSE may
-        reconnect with exponential backoff before delivering the backfill, the
-        default deadline is 60 s (matches :meth:`wait_ready`'s deadline so
-        callers don't need to think about which is tighter).
+        ``connection_id`` before this returns.  Default deadline 30 s
+        matches :meth:`wait_ready`'s so callers don't need to think about
+        which is tighter; the SSE handshake itself is preflighted in the
+        route handler now (#376) so the discovery loop sees backfill
+        immediately after 2xx.
 
         Raises ``TimeoutError`` if the connection is not added within
         ``deadline`` seconds.  Intended for test coordination.

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/stream_events_v1_sessions_session_id_stream_get.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/stream_events_v1_sessions_session_id_stream_get.py
@@ -78,6 +78,12 @@ def sync_detailed(
 
      Stream session events as Server-Sent Events.
 
+    Preflights the LISTEN connection BEFORE constructing the response
+    (issue #376): a transient ``asyncpg.connect`` failure during
+    testcontainer warmup or a brief Postgres outage surfaces as a clean
+    503 with proper headers rather than a half-open chunked stream
+    after 200 OK has gone out.
+
     Args:
         session_id (str):
         after_seq (int | Unset):  Default: 0.
@@ -115,6 +121,12 @@ def sync(
 
      Stream session events as Server-Sent Events.
 
+    Preflights the LISTEN connection BEFORE constructing the response
+    (issue #376): a transient ``asyncpg.connect`` failure during
+    testcontainer warmup or a brief Postgres outage surfaces as a clean
+    503 with proper headers rather than a half-open chunked stream
+    after 200 OK has gone out.
+
     Args:
         session_id (str):
         after_seq (int | Unset):  Default: 0.
@@ -146,6 +158,12 @@ async def asyncio_detailed(
     """Stream Events
 
      Stream session events as Server-Sent Events.
+
+    Preflights the LISTEN connection BEFORE constructing the response
+    (issue #376): a transient ``asyncpg.connect`` failure during
+    testcontainer warmup or a brief Postgres outage surfaces as a clean
+    503 with proper headers rather than a half-open chunked stream
+    after 200 OK has gone out.
 
     Args:
         session_id (str):
@@ -181,6 +199,12 @@ async def asyncio(
     """Stream Events
 
      Stream session events as Server-Sent Events.
+
+    Preflights the LISTEN connection BEFORE constructing the response
+    (issue #376): a transient ``asyncpg.connect`` failure during
+    testcontainer warmup or a brief Postgres outage surfaces as a clean
+    503 with proper headers rather than a half-open chunked stream
+    after 200 OK has gone out.
 
     Args:
         session_id (str):

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 from typing import Annotated, Any, Literal
 
+import asyncpg
 from fastapi import APIRouter, File, Form, UploadFile, status
 from pydantic import BaseModel, ConfigDict
 from sse_starlette import EventSourceResponse
@@ -39,14 +40,21 @@ from aios.api.sse import (
     runtime_connector_calls_stream,
 )
 from aios.db import queries
+from aios.db.listen import (
+    open_listen_for_connection_discovery,
+    open_listen_for_connector_calls_by_type,
+    open_listen_for_management_calls,
+)
 from aios.errors import (
     AiosError,
     ConnectorCallFailedError,
     ForbiddenError,
     NotFoundError,
     PayloadTooLargeError,
+    SSEPreflightFailedError,
     ValidationError,
 )
+from aios.logging import get_logger
 from aios.models.connections import ConnectorSecrets
 from aios.services import connections as connections_service
 from aios.services import connectors as connectors_service
@@ -57,6 +65,18 @@ from aios.services.attachment_staging import InboundAttachment
 from aios.services.wake import defer_wake
 
 router = APIRouter(prefix="/v1/connectors", tags=["connectors"])
+
+log = get_logger("aios.api.routers.connectors")
+
+
+# SSE preflight: the four runtime-facing streams (#376) call
+# ``open_listen_for_*`` BEFORE constructing ``EventSourceResponse`` so
+# that a failed ``asyncpg.connect`` / ``add_listener`` surfaces as a
+# clean 503 with an aios error envelope.  Only ``asyncpg.PostgresError``
+# and ``OSError`` (the realistic transient failures during testcontainer
+# Postgres warmup or socket churn) trigger the 503 path; anything else
+# bubbles as an unhandled 500.
+_SSE_PREFLIGHT_EXCEPTIONS = (asyncpg.PostgresError, OSError)
 
 
 # ─── connector-facing endpoints (#301) ──────────────────────────────────────
@@ -308,9 +328,22 @@ async def get_connection_discovery(
     loop just doesn't see them.
     """
     _, connector, account_id, auth_connection_ids = auth
+    try:
+        subscription = await open_listen_for_connection_discovery(db_url, connector)
+    except _SSE_PREFLIGHT_EXCEPTIONS as exc:
+        log.warning(
+            "sse.connection_discovery.preflight_failed",
+            connector=connector,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        raise SSEPreflightFailedError(
+            "could not establish LISTEN connection for connection-discovery stream",
+            detail={"stream": "connection_discovery"},
+        ) from exc
     return EventSourceResponse(
         connection_discovery_stream(
-            db_url,
+            subscription,
             pool,
             connector,
             account_id=account_id,
@@ -489,9 +522,22 @@ async def get_runtime_calls(
     filter to that set — out-of-scope calls are silently omitted.
     """
     _, connector, account_id, auth_connection_ids = auth
+    try:
+        subscription = await open_listen_for_connector_calls_by_type(db_url, connector)
+    except _SSE_PREFLIGHT_EXCEPTIONS as exc:
+        log.warning(
+            "sse.runtime_calls.preflight_failed",
+            connector=connector,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        raise SSEPreflightFailedError(
+            "could not establish LISTEN connection for runtime-calls stream",
+            detail={"stream": "runtime_calls"},
+        ) from exc
     return EventSourceResponse(
         runtime_connector_calls_stream(
-            db_url,
+            subscription,
             pool,
             connector,
             account_id=account_id,
@@ -518,8 +564,21 @@ async def get_runtime_management_calls(
     calls are connector-type-wide, not per-connection.
     """
     _, connector, account_id, _scope = auth
+    try:
+        subscription = await open_listen_for_management_calls(db_url, connector)
+    except _SSE_PREFLIGHT_EXCEPTIONS as exc:
+        log.warning(
+            "sse.management_calls.preflight_failed",
+            connector=connector,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        raise SSEPreflightFailedError(
+            "could not establish LISTEN connection for management-calls stream",
+            detail={"stream": "management_calls"},
+        ) from exc
     return EventSourceResponse(
-        management_calls_stream(db_url, pool, connector, account_id=account_id),
+        management_calls_stream(subscription, pool, connector, account_id=account_id),
         ping=15,
     )
 

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import json
 from typing import Annotated, Any, Literal
 
-import asyncpg
 from fastapi import APIRouter, File, Form, UploadFile, status
 from pydantic import BaseModel, ConfigDict
 from sse_starlette import EventSourceResponse
@@ -35,6 +34,7 @@ from aios.api.deps import (
     RuntimeAuthDep,
 )
 from aios.api.sse import (
+    SSE_PREFLIGHT_EXCEPTIONS,
     connection_discovery_stream,
     management_calls_stream,
     runtime_connector_calls_stream,
@@ -67,16 +67,6 @@ from aios.services.wake import defer_wake
 router = APIRouter(prefix="/v1/connectors", tags=["connectors"])
 
 log = get_logger("aios.api.routers.connectors")
-
-
-# SSE preflight: the four runtime-facing streams (#376) call
-# ``open_listen_for_*`` BEFORE constructing ``EventSourceResponse`` so
-# that a failed ``asyncpg.connect`` / ``add_listener`` surfaces as a
-# clean 503 with an aios error envelope.  Only ``asyncpg.PostgresError``
-# and ``OSError`` (the realistic transient failures during testcontainer
-# Postgres warmup or socket churn) trigger the 503 path; anything else
-# bubbles as an unhandled 500.
-_SSE_PREFLIGHT_EXCEPTIONS = (asyncpg.PostgresError, OSError)
 
 
 # ─── connector-facing endpoints (#301) ──────────────────────────────────────
@@ -330,7 +320,7 @@ async def get_connection_discovery(
     _, connector, account_id, auth_connection_ids = auth
     try:
         subscription = await open_listen_for_connection_discovery(db_url, connector)
-    except _SSE_PREFLIGHT_EXCEPTIONS as exc:
+    except SSE_PREFLIGHT_EXCEPTIONS as exc:
         log.warning(
             "sse.connection_discovery.preflight_failed",
             connector=connector,
@@ -524,7 +514,7 @@ async def get_runtime_calls(
     _, connector, account_id, auth_connection_ids = auth
     try:
         subscription = await open_listen_for_connector_calls_by_type(db_url, connector)
-    except _SSE_PREFLIGHT_EXCEPTIONS as exc:
+    except SSE_PREFLIGHT_EXCEPTIONS as exc:
         log.warning(
             "sse.runtime_calls.preflight_failed",
             connector=connector,
@@ -566,7 +556,7 @@ async def get_runtime_management_calls(
     _, connector, account_id, _scope = auth
     try:
         subscription = await open_listen_for_management_calls(db_url, connector)
-    except _SSE_PREFLIGHT_EXCEPTIONS as exc:
+    except SSE_PREFLIGHT_EXCEPTIONS as exc:
         log.warning(
             "sse.management_calls.preflight_failed",
             connector=connector,

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 from typing import Annotated
 
+import asyncpg
 from fastapi import APIRouter, File, Query, UploadFile, status
 from sse_starlette import EventSourceResponse
 
@@ -26,9 +27,14 @@ from aios.api.deps import (
 )
 from aios.api.sse import sse_event_stream
 from aios.db import queries
-from aios.db.listen import SESSION_INTERRUPT_CHANNEL, listen_for_events
-from aios.errors import ValidationError
+from aios.db.listen import (
+    SESSION_INTERRUPT_CHANNEL,
+    listen_for_events,
+    open_listen_for_events,
+)
+from aios.errors import SSEPreflightFailedError, ValidationError
 from aios.ids import GITHUB_REPOSITORY, split_id
+from aios.logging import get_logger
 from aios.models.common import ListResponse
 from aios.models.events import Event, EventKind
 from aios.models.files import FileUploadResponse
@@ -54,6 +60,8 @@ from aios.services import files as files_service
 from aios.services import github_repositories as github_repo_service
 from aios.services import sessions as service
 from aios.services.wake import defer_wake
+
+log = get_logger("aios.api.routers.sessions")
 
 router = APIRouter(prefix="/v1/sessions", tags=["sessions"])
 
@@ -579,10 +587,30 @@ async def stream_events(
     account_id: AccountIdDep,
     after_seq: int = 0,
 ) -> EventSourceResponse:
-    """Stream session events as Server-Sent Events."""
+    """Stream session events as Server-Sent Events.
+
+    Preflights the LISTEN connection BEFORE constructing the response
+    (issue #376): a transient ``asyncpg.connect`` failure during
+    testcontainer warmup or a brief Postgres outage surfaces as a clean
+    503 with proper headers rather than a half-open chunked stream
+    after 200 OK has gone out.
+    """
     await service.get_session_basic(pool, session_id, account_id=account_id)
+    try:
+        subscription = await open_listen_for_events(db_url, session_id)
+    except (asyncpg.PostgresError, OSError) as exc:
+        log.warning(
+            "sse.session_events.preflight_failed",
+            session_id=session_id,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        raise SSEPreflightFailedError(
+            "could not establish LISTEN connection for session events stream",
+            detail={"stream": "session_events"},
+        ) from exc
     return EventSourceResponse(
-        sse_event_stream(db_url, pool, session_id, after_seq=after_seq),
+        sse_event_stream(subscription, pool, session_id, after_seq=after_seq),
         ping=15,
     )
 

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import asyncio
 from typing import Annotated
 
-import asyncpg
 from fastapi import APIRouter, File, Query, UploadFile, status
 from sse_starlette import EventSourceResponse
 
@@ -25,7 +24,7 @@ from aios.api.deps import (
     PoolDep,
     ProcrastinateDep,
 )
-from aios.api.sse import sse_event_stream
+from aios.api.sse import SSE_PREFLIGHT_EXCEPTIONS, sse_event_stream
 from aios.db import queries
 from aios.db.listen import (
     SESSION_INTERRUPT_CHANNEL,
@@ -598,7 +597,7 @@ async def stream_events(
     await service.get_session_basic(pool, session_id, account_id=account_id)
     try:
         subscription = await open_listen_for_events(db_url, session_id)
-    except (asyncpg.PostgresError, OSError) as exc:
+    except SSE_PREFLIGHT_EXCEPTIONS as exc:
         log.warning(
             "sse.session_events.preflight_failed",
             session_id=session_id,

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -1,23 +1,28 @@
-"""SSE event stream generator.
+"""SSE event stream generators.
 
-Used by ``GET /v1/sessions/{id}/stream``. The generator:
+Used by ``GET /v1/sessions/{id}/stream`` and the runtime-facing SSE
+endpoints in ``aios.api.routers.connectors``.  Each generator:
 
-1. Opens a dedicated asyncpg LISTEN connection (via
-   :func:`aios.db.listen.listen_for_events`) BEFORE issuing the backfill
-   SELECT — see the LISTEN-before-backfill discussion in ``db/listen.py``.
-2. Backfills events from ``after_seq``, tracking the highest seq seen as
-   ``cursor``.
-3. Tails live notifications. For each notify, fetches the matching event by
-   id and emits it ONLY if its seq exceeds ``cursor`` (dedup against the
-   backfill).
-4. Detects ``terminated`` lifecycle events and emits a ``done`` SSE event
-   before exiting.
+1. Accepts a pre-established :class:`aios.db.listen.ListenSubscription`
+   — the route handler opens it via ``open_listen_for_*`` BEFORE
+   constructing :class:`sse_starlette.EventSourceResponse`, so a setup
+   failure surfaces as a clean 503 instead of a half-open chunked stream
+   (issue #376).
+2. Backfills from the DB, tracking a cursor where ordering matters
+   (sessions stream).
+3. Tails live notifications from ``subscription.queue``.
+4. Owns terminating the subscription in ``finally`` — under cancellation
+   (client disconnect) AND under any in-body exception.
 
-Client disconnect handling is automatic: sse-starlette's
-``EventSourceResponse`` raises ``asyncio.CancelledError`` into the generator
-when the client closes the connection. The ``finally`` blocks in
-``listen_for_events`` and the pool acquires clean up. Don't trap
-CancelledError; let it propagate.
+Critical ordering invariant: the route handler must run ``LISTEN`` (i.e.
+call ``open_listen_for_*``) BEFORE the generator issues its backfill
+``SELECT``.  See the discussion in ``aios.db.listen``.
+
+Client disconnect handling: sse-starlette's ``EventSourceResponse`` raises
+``asyncio.CancelledError`` into the generator when the client closes the
+connection.  The ``finally`` block's ``subscription.terminate()`` is
+synchronous and safe under cancellation.  Don't trap ``CancelledError``;
+let it propagate.
 """
 
 from __future__ import annotations
@@ -29,16 +34,12 @@ import asyncpg
 from sse_starlette import ServerSentEvent
 
 from aios.db import queries
-from aios.db.listen import (
-    listen_for_connection_discovery,
-    listen_for_connector_calls_by_type,
-    listen_for_events,
-    listen_for_management_calls,
-)
 from aios.logging import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+
+    from aios.db.listen import ListenSubscription
 
 log = get_logger("aios.api.sse")
 
@@ -73,7 +74,7 @@ def _serialize_event(row: asyncpg.Record) -> dict[str, Any]:
 
 
 async def sse_event_stream(
-    db_url: str,
+    subscription: ListenSubscription,
     pool: asyncpg.Pool[Any],
     session_id: str,
     after_seq: int = 0,
@@ -81,12 +82,13 @@ async def sse_event_stream(
     """Yield ServerSentEvents for a session, backfilling from ``after_seq``
     and then tailing live notifications.
 
-    Critical ordering: open the LISTEN connection BEFORE running the backfill
-    SELECT. Otherwise events that commit during the backfill window are lost
-    (the SELECT can't see uncommitted-at-snapshot rows, and the listener
-    isn't yet attached to receive their NOTIFY).
+    The ``subscription`` must have been opened by the route handler via
+    ``open_listen_for_events`` before this generator runs — the
+    LISTEN-before-backfill invariant requires it.  This generator owns
+    terminating the subscription in ``finally``.
     """
-    async with listen_for_events(db_url, session_id) as queue:
+    queue = subscription.queue
+    try:
         cursor = after_seq
 
         # Backfill: read all events with seq > after_seq, in order.
@@ -134,10 +136,15 @@ async def sse_event_stream(
             if _is_terminal(event_data):
                 yield ServerSentEvent(data="{}", event="done")
                 return
+    except Exception:
+        log.exception("sse.session_events.body_raised", session_id=session_id)
+        raise
+    finally:
+        subscription.terminate()
 
 
 async def runtime_connector_calls_stream(
-    db_url: str,
+    subscription: ListenSubscription,
     pool: asyncpg.Pool[Any],
     connector: str,
     *,
@@ -160,7 +167,8 @@ async def runtime_connector_calls_stream(
     so the per-connection fetch is skipped for out-of-scope IDs.
     """
     allowlist = set(connection_ids) if connection_ids is not None else None
-    async with listen_for_connector_calls_by_type(db_url, connector) as queue:
+    queue = subscription.queue
+    try:
         emitted: set[str] = set()
 
         async with pool.acquire() as conn:
@@ -200,10 +208,15 @@ async def runtime_connector_calls_stream(
                 emitted.add(call["tool_call_id"])
                 call["connection_id"] = connection_id
                 yield ServerSentEvent(data=json.dumps(call), event="call")
+    except Exception:
+        log.exception("sse.runtime_calls.body_raised", connector=connector)
+        raise
+    finally:
+        subscription.terminate()
 
 
 async def management_calls_stream(
-    db_url: str,
+    subscription: ListenSubscription,
     pool: asyncpg.Pool[Any],
     connector: str,
     *,
@@ -215,7 +228,8 @@ async def management_calls_stream(
     ``connector_management_calls_<connector>``.  Each event:
     ``{"call_id": "mgmt_...", "method": str, "params": dict}``.
     """
-    async with listen_for_management_calls(db_url, connector) as queue:
+    queue = subscription.queue
+    try:
         emitted: set[str] = set()
 
         async with pool.acquire() as conn:
@@ -245,10 +259,15 @@ async def management_calls_stream(
                 ),
                 event="call",
             )
+    except Exception:
+        log.exception("sse.management_calls.body_raised", connector=connector)
+        raise
+    finally:
+        subscription.terminate()
 
 
 async def connection_discovery_stream(
-    db_url: str,
+    subscription: ListenSubscription,
     pool: asyncpg.Pool[Any],
     connector: str,
     *,
@@ -271,7 +290,8 @@ async def connection_discovery_stream(
     just doesn't see them.
     """
     allowlist = set(connection_ids) if connection_ids is not None else None
-    async with listen_for_connection_discovery(db_url, connector) as queue:
+    queue = subscription.queue
+    try:
         emitted_added: set[str] = set()
 
         # Page through all active connections of this type; the default
@@ -333,6 +353,11 @@ async def connection_discovery_stream(
                 ),
                 event="connection",
             )
+    except Exception:
+        log.exception("sse.connection_discovery.body_raised", connector=connector)
+        raise
+    finally:
+        subscription.terminate()
 
 
 def _is_terminal(payload: dict[str, Any]) -> bool:

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -43,6 +43,11 @@ if TYPE_CHECKING:
 
 log = get_logger("aios.api.sse")
 
+# Realistic transient failures during testcontainer Postgres warmup or
+# socket churn — these surface as a clean 503 from the SSE route handlers
+# (issue #376). Anything else bubbles as an unhandled 500.
+SSE_PREFLIGHT_EXCEPTIONS = (asyncpg.PostgresError, OSError)
+
 
 def _event_to_sse(event_dict: dict[str, Any]) -> ServerSentEvent:
     """Build a ServerSentEvent from an event dict.

--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -62,12 +62,34 @@ the transaction block (after commit). This is the correct ordering — a
 subscriber must not see a payload for a row that isn't yet committed.
 **Don't move the NOTIFY inside the transaction.** Add a fat comment if
 anyone tries.
+
+## Why ``open_listen_for_*`` exists alongside ``listen_for_*``
+
+The four route-level SSE handlers used to instantiate ``listen_for_*`` as
+an ``@asynccontextmanager`` INSIDE the generator passed to
+``EventSourceResponse``.  That meant the ``asyncpg.connect`` + ``add_listener``
+setup happened AFTER 200 OK headers were already on the wire — any failure
+left the client holding a half-open chunked stream and the server logging
+"ASGI callable returned without completing response."
+
+``open_listen_for_*`` returns a ready-to-use :class:`ListenSubscription`,
+letting the route handler preflight setup BEFORE constructing
+``EventSourceResponse``.  Preflight failure surfaces as a clean 503 with
+proper headers; only on success is the subscription handed to the
+generator, which owns ``subscription.terminate()`` in a finally.
+
+The ``@asynccontextmanager`` wrappers stay for callers that don't need the
+two-phase shape (the long-poll ``wait_for_events`` endpoint, the
+session-interrupt and connector-result listeners that resolve fast
+enough that mid-body failures are negligible, plus the existing test
+suite).
 """
 
 from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import asyncpg
@@ -80,6 +102,201 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
 log = get_logger("aios.db.listen")
+
+
+@dataclass(slots=True)
+class ListenSubscription:
+    """A dedicated asyncpg connection LISTENing on one channel, with its
+    delivery queue.
+
+    Returned by the ``open_listen_for_*`` functions.  The caller (an SSE
+    generator) owns calling :meth:`terminate` in a ``finally`` block to
+    release the Postgres backend.  ``terminate`` is synchronous — safe to
+    invoke under cancellation, where awaits would re-raise immediately
+    (see the module docstring on ``conn.terminate()`` vs ``conn.close()``).
+    """
+
+    queue: asyncio.Queue[str]
+    _conn: asyncpg.Connection[object]
+
+    def terminate(self) -> None:
+        self._conn.terminate()
+
+
+async def open_listen_for_events(
+    db_url: str,
+    session_id: str,
+    *,
+    queue_max: int = 1000,
+) -> ListenSubscription:
+    """Open a dedicated asyncpg connection, LISTEN events_<session_id>,
+    acquire the SSE subscriber lock, and return a :class:`ListenSubscription`.
+
+    Two-phase counterpart to :func:`listen_for_events` for callers (SSE
+    route handlers) that need to preflight setup BEFORE constructing the
+    streaming response.
+
+    Any failure after the initial ``asyncpg.connect`` succeeds will
+    ``conn.terminate()`` and re-raise.
+    """
+    conn = await asyncpg.connect(normalize_dsn(db_url))
+    try:
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
+        channel = f"events_{session_id}"
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            # CRITICAL: this callback is invoked on asyncpg's connection read
+            # loop. It MUST be synchronous. No await calls allowed here.
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning(
+                    "listen.queue_full_drop",
+                    session_id=session_id,
+                    queue_max=queue_max,
+                )
+                # Drop oldest to make room. The SSE consumer can recover by
+                # reconnecting with `?after_seq=`.
+                try:
+                    queue.get_nowait()
+                    queue.put_nowait(payload)
+                except (asyncio.QueueEmpty, asyncio.QueueFull):
+                    pass
+
+        await conn.add_listener(channel, _callback)
+        # Hold a shared advisory lock on this dedicated connection so the
+        # worker can detect that an SSE subscriber exists (issue #81).
+        # pg_locks releases automatically on connection close — no cleanup.
+        await acquire_subscriber_lock(conn, session_id)
+    except BaseException:
+        conn.terminate()
+        raise
+    return ListenSubscription(queue=queue, _conn=conn)
+
+
+async def open_listen_for_connector_calls_by_type(
+    db_url: str,
+    connector: str,
+    *,
+    queue_max: int = 1000,
+) -> ListenSubscription:
+    """Open a dedicated asyncpg conn LISTENing ``connector_calls_<connector>``.
+
+    Two-phase counterpart to :func:`listen_for_connector_calls_by_type`.
+    """
+    conn = await asyncpg.connect(normalize_dsn(db_url))
+    try:
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
+        channel = f"connector_calls_{connector}"
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning(
+                    "listen.connector_calls_type_queue_full_drop",
+                    connector=connector,
+                    queue_max=queue_max,
+                )
+                try:
+                    queue.get_nowait()
+                    queue.put_nowait(payload)
+                except (asyncio.QueueEmpty, asyncio.QueueFull):
+                    pass
+
+        await conn.add_listener(channel, _callback)
+    except BaseException:
+        conn.terminate()
+        raise
+    return ListenSubscription(queue=queue, _conn=conn)
+
+
+async def open_listen_for_management_calls(
+    db_url: str,
+    connector: str,
+    *,
+    queue_max: int = 1000,
+) -> ListenSubscription:
+    """Open a dedicated asyncpg conn LISTENing ``connector_management_calls_<connector>``."""
+    conn = await asyncpg.connect(normalize_dsn(db_url))
+    try:
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
+        channel = f"connector_management_calls_{connector}"
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning(
+                    "listen.connector_management_calls_queue_full_drop",
+                    connector=connector,
+                    queue_max=queue_max,
+                )
+                try:
+                    queue.get_nowait()
+                    queue.put_nowait(payload)
+                except (asyncio.QueueEmpty, asyncio.QueueFull):
+                    pass
+
+        await conn.add_listener(channel, _callback)
+    except BaseException:
+        conn.terminate()
+        raise
+    return ListenSubscription(queue=queue, _conn=conn)
+
+
+async def open_listen_for_connection_discovery(
+    db_url: str,
+    connector: str,
+    *,
+    queue_max: int = 1000,
+) -> ListenSubscription:
+    """Open a dedicated asyncpg conn LISTENing ``connections_<connector>``."""
+    conn = await asyncpg.connect(normalize_dsn(db_url))
+    try:
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
+        channel = f"connections_{connector}"
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning(
+                    "listen.connection_discovery_queue_full_drop",
+                    connector=connector,
+                    queue_max=queue_max,
+                )
+                try:
+                    queue.get_nowait()
+                    queue.put_nowait(payload)
+                except (asyncio.QueueEmpty, asyncio.QueueFull):
+                    pass
+
+        await conn.add_listener(channel, _callback)
+    except BaseException:
+        conn.terminate()
+        raise
+    return ListenSubscription(queue=queue, _conn=conn)
 
 
 @asynccontextmanager
@@ -137,6 +354,11 @@ async def listen_for_events(
     room for the new one and a warning is logged. SSE clients can recover
     from drops by reconnecting with ``?after_seq=<their last seq>``.
 
+    Thin wrapper over :func:`open_listen_for_events` for callers that
+    prefer context-manager scoping.  SSE route handlers should use the
+    ``open_*`` form directly so setup failures surface before
+    ``EventSourceResponse`` writes 200 OK headers.
+
     Parameters
     ----------
     db_url:
@@ -147,43 +369,11 @@ async def listen_for_events(
         Bound on the in-memory queue. Defaults to 1000 — generous enough
         that a slow consumer can fall behind by ~1000 events before drops.
     """
-    conn = await asyncpg.connect(normalize_dsn(db_url))
+    subscription = await open_listen_for_events(db_url, session_id, queue_max=queue_max)
     try:
-        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-        channel = f"events_{session_id}"
-
-        def _callback(
-            _conn: asyncpg.Connection[object],
-            _pid: int,
-            _channel: str,
-            payload: str,
-        ) -> None:
-            # CRITICAL: this callback is invoked on asyncpg's connection read
-            # loop. It MUST be synchronous. No await calls allowed here.
-            try:
-                queue.put_nowait(payload)
-            except asyncio.QueueFull:
-                log.warning(
-                    "listen.queue_full_drop",
-                    session_id=session_id,
-                    queue_max=queue_max,
-                )
-                # Drop oldest to make room. The SSE consumer can recover by
-                # reconnecting with `?after_seq=`.
-                try:
-                    queue.get_nowait()
-                    queue.put_nowait(payload)
-                except (asyncio.QueueEmpty, asyncio.QueueFull):
-                    pass
-
-        await conn.add_listener(channel, _callback)
-        # Hold a shared advisory lock on this dedicated connection so the
-        # worker can detect that an SSE subscriber exists (issue #81).
-        # pg_locks releases automatically on connection close — no cleanup.
-        await acquire_subscriber_lock(conn, session_id)
-        yield queue
+        yield subscription.queue
     finally:
-        conn.terminate()
+        subscription.terminate()
 
 
 @asynccontextmanager
@@ -199,36 +389,16 @@ async def listen_for_connector_calls_by_type(
     container subscribes once per ``connector`` type and fans out to
     its per-connection workers client-side via the ``connection_id``
     half of the payload.
+
+    Thin wrapper over :func:`open_listen_for_connector_calls_by_type`.
     """
-    conn = await asyncpg.connect(normalize_dsn(db_url))
+    subscription = await open_listen_for_connector_calls_by_type(
+        db_url, connector, queue_max=queue_max
+    )
     try:
-        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-        channel = f"connector_calls_{connector}"
-
-        def _callback(
-            _conn: asyncpg.Connection[object],
-            _pid: int,
-            _channel: str,
-            payload: str,
-        ) -> None:
-            try:
-                queue.put_nowait(payload)
-            except asyncio.QueueFull:
-                log.warning(
-                    "listen.connector_calls_type_queue_full_drop",
-                    connector=connector,
-                    queue_max=queue_max,
-                )
-                try:
-                    queue.get_nowait()
-                    queue.put_nowait(payload)
-                except (asyncio.QueueEmpty, asyncio.QueueFull):
-                    pass
-
-        await conn.add_listener(channel, _callback)
-        yield queue
+        yield subscription.queue
     finally:
-        conn.terminate()
+        subscription.terminate()
 
 
 @asynccontextmanager
@@ -238,36 +408,15 @@ async def listen_for_management_calls(
     *,
     queue_max: int = 1000,
 ) -> AsyncIterator[asyncio.Queue[str]]:
-    """LISTEN ``connector_management_calls_<connector>``; yield a queue of ``call_id`` payloads."""
-    conn = await asyncpg.connect(normalize_dsn(db_url))
+    """LISTEN ``connector_management_calls_<connector>``; yield a queue of ``call_id`` payloads.
+
+    Thin wrapper over :func:`open_listen_for_management_calls`.
+    """
+    subscription = await open_listen_for_management_calls(db_url, connector, queue_max=queue_max)
     try:
-        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-        channel = f"connector_management_calls_{connector}"
-
-        def _callback(
-            _conn: asyncpg.Connection[object],
-            _pid: int,
-            _channel: str,
-            payload: str,
-        ) -> None:
-            try:
-                queue.put_nowait(payload)
-            except asyncio.QueueFull:
-                log.warning(
-                    "listen.connector_management_calls_queue_full_drop",
-                    connector=connector,
-                    queue_max=queue_max,
-                )
-                try:
-                    queue.get_nowait()
-                    queue.put_nowait(payload)
-                except (asyncio.QueueEmpty, asyncio.QueueFull):
-                    pass
-
-        await conn.add_listener(channel, _callback)
-        yield queue
+        yield subscription.queue
     finally:
-        conn.terminate()
+        subscription.terminate()
 
 
 @asynccontextmanager
@@ -282,36 +431,16 @@ async def listen_for_connection_discovery(
     Backs the connection-discovery SSE (#328 PR 5). The emit side lives
     in :mod:`aios.services.connections.attach_connection` /
     ``archive_connection``.
+
+    Thin wrapper over :func:`open_listen_for_connection_discovery`.
     """
-    conn = await asyncpg.connect(normalize_dsn(db_url))
+    subscription = await open_listen_for_connection_discovery(
+        db_url, connector, queue_max=queue_max
+    )
     try:
-        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-        channel = f"connections_{connector}"
-
-        def _callback(
-            _conn: asyncpg.Connection[object],
-            _pid: int,
-            _channel: str,
-            payload: str,
-        ) -> None:
-            try:
-                queue.put_nowait(payload)
-            except asyncio.QueueFull:
-                log.warning(
-                    "listen.connection_discovery_queue_full_drop",
-                    connector=connector,
-                    queue_max=queue_max,
-                )
-                try:
-                    queue.get_nowait()
-                    queue.put_nowait(payload)
-                except (asyncio.QueueEmpty, asyncio.QueueFull):
-                    pass
-
-        await conn.add_listener(channel, _callback)
-        yield queue
+        yield subscription.queue
     finally:
-        conn.terminate()
+        subscription.terminate()
 
 
 SESSION_INTERRUPT_CHANNEL = "aios_session_interrupt"

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -158,6 +158,25 @@ class ConnectorCallFailedError(AiosError):
     status_code = 502
 
 
+class SSEPreflightFailedError(AiosError):
+    """SSE route handler couldn't establish its LISTEN connection before
+    streaming (issue #376).
+
+    The four SSE generators used to open their own ``asyncpg.connect`` +
+    ``add_listener`` INSIDE the ``EventSourceResponse`` body — failure
+    surfaced as a half-open chunked stream because the 200 OK headers
+    were already on the wire.  The preflight refactor moves setup into
+    the route handler; this error is the proper-headers reply on
+    failure.
+
+    ``detail.stream`` names the failing stream so clients can branch
+    on which SSE endpoint failed.
+    """
+
+    error_type = "sse_preflight_failed"
+    status_code = 503
+
+
 # ─── FastAPI integration ─────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_sse_generator_cleanup.py
+++ b/tests/unit/test_sse_generator_cleanup.py
@@ -58,7 +58,6 @@ def _install_query_backfill(
 
 def _install_session_event_backfill(
     monkeypatch: pytest.MonkeyPatch,
-    attr: str,
     pool: MagicMock,
     exc: Exception | None,
 ) -> None:
@@ -84,7 +83,7 @@ def _install_session_event_backfill(
 _CASES = [
     pytest.param(
         lambda sub, pool: sse_event_stream(sub, pool, "ses_X", after_seq=0),
-        lambda mp, pool, exc: _install_session_event_backfill(mp, "fetch", pool, exc),
+        lambda mp, pool, exc: _install_session_event_backfill(mp, pool, exc),
         id="sse_event_stream",
     ),
     pytest.param(

--- a/tests/unit/test_sse_generator_cleanup.py
+++ b/tests/unit/test_sse_generator_cleanup.py
@@ -1,0 +1,90 @@
+"""Unit tests for SSE generator cleanup contracts (issue #376).
+
+After the preflight refactor, the four SSE generators in ``aios.api.sse``
+accept a pre-established :class:`aios.db.listen.ListenSubscription`
+instead of opening their own LISTEN connection.  Each generator now
+owns terminating the subscription via a ``try/finally`` around the
+body — under client disconnect (asyncio.CancelledError) AND under
+mid-body exceptions (e.g. the backfill query raising during a
+Postgres outage).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.api.sse import runtime_connector_calls_stream
+from aios.db.listen import ListenSubscription
+
+
+def _mk_subscription() -> ListenSubscription:
+    conn = MagicMock()
+    queue: asyncio.Queue[str] = asyncio.Queue(maxsize=8)
+    return ListenSubscription(queue=queue, _conn=conn)
+
+
+async def test_runtime_connector_calls_stream_terminates_conn_on_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling the consumer task must trigger subscription.terminate()."""
+    subscription = _mk_subscription()
+
+    # Stub the backfill query to return empty so the generator immediately
+    # enters the live-tail loop.
+    monkeypatch.setattr(
+        "aios.api.sse.queries.list_pending_calls_for_connector",
+        AsyncMock(return_value=[]),
+    )
+
+    pool = MagicMock()
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool.acquire = MagicMock(return_value=acquire_cm)
+
+    gen = runtime_connector_calls_stream(subscription, pool, "telegram", account_id="acct_X")
+
+    async def _consume() -> None:
+        async for _ in gen:
+            pass
+
+    task = asyncio.create_task(_consume())
+    # Yield control so the generator enters the live-tail ``await queue.get()``.
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    subscription._conn.terminate.assert_called_once()
+
+
+async def test_runtime_connector_calls_stream_terminates_conn_when_backfill_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backfill query failure must still terminate the subscription."""
+    subscription = _mk_subscription()
+
+    monkeypatch.setattr(
+        "aios.api.sse.queries.list_pending_calls_for_connector",
+        AsyncMock(side_effect=RuntimeError("backfill kaboom")),
+    )
+
+    pool = MagicMock()
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool.acquire = MagicMock(return_value=acquire_cm)
+
+    gen = runtime_connector_calls_stream(subscription, pool, "telegram", account_id="acct_X")
+
+    async def _consume() -> None:
+        async for _ in gen:
+            pass
+
+    with pytest.raises(RuntimeError, match="backfill kaboom"):
+        await _consume()
+
+    subscription._conn.terminate.assert_called_once()

--- a/tests/unit/test_sse_generator_cleanup.py
+++ b/tests/unit/test_sse_generator_cleanup.py
@@ -12,11 +12,17 @@ Postgres outage).
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from aios.api.sse import runtime_connector_calls_stream
+from aios.api.sse import (
+    connection_discovery_stream,
+    management_calls_stream,
+    runtime_connector_calls_stream,
+    sse_event_stream,
+)
 from aios.db.listen import ListenSubscription
 
 
@@ -26,26 +32,97 @@ def _mk_subscription() -> ListenSubscription:
     return ListenSubscription(queue=queue, _conn=conn)
 
 
-async def test_runtime_connector_calls_stream_terminates_conn_on_cancel(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Cancelling the consumer task must trigger subscription.terminate()."""
-    subscription = _mk_subscription()
-
-    # Stub the backfill query to return empty so the generator immediately
-    # enters the live-tail loop.
-    monkeypatch.setattr(
-        "aios.api.sse.queries.list_pending_calls_for_connector",
-        AsyncMock(return_value=[]),
-    )
-
-    pool = MagicMock()
+def _mk_pool() -> MagicMock:
+    """Mock pool whose ``async with pool.acquire()`` yields a fresh MagicMock conn."""
+    conn = MagicMock()
     acquire_cm = MagicMock()
-    acquire_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acquire_cm)
+    return pool
+
+
+def _install_query_backfill(
+    monkeypatch: pytest.MonkeyPatch,
+    attr: str,
+    pool: MagicMock,
+    exc: Exception | None,
+) -> None:
+    """Stub a ``aios.api.sse.queries.<attr>`` backfill function."""
+    if exc is None:
+        monkeypatch.setattr(f"aios.api.sse.queries.{attr}", AsyncMock(return_value=[]))
+    else:
+        monkeypatch.setattr(f"aios.api.sse.queries.{attr}", AsyncMock(side_effect=exc))
+
+
+def _install_session_event_backfill(
+    monkeypatch: pytest.MonkeyPatch,
+    attr: str,
+    pool: MagicMock,
+    exc: Exception | None,
+) -> None:
+    """``sse_event_stream`` backfills via ``conn.fetch`` directly (no queries
+    module helper), so patch the pool-acquired conn's ``fetch`` method.
+    """
+    conn = MagicMock()
+    if exc is None:
+        conn.fetch = AsyncMock(return_value=[])
+    else:
+        conn.fetch = AsyncMock(side_effect=exc)
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
     acquire_cm.__aexit__ = AsyncMock(return_value=None)
     pool.acquire = MagicMock(return_value=acquire_cm)
 
-    gen = runtime_connector_calls_stream(subscription, pool, "telegram", account_id="acct_X")
+
+# Each case: (build_generator, install_backfill).
+#  - build_generator(subscription, pool) returns the async generator under test.
+#  - install_backfill(monkeypatch, pool, exc) wires up the backfill path:
+#       exc is None  -> empty list / empty fetch (falls through to live tail)
+#       exc is Exception -> backfill raises that exception
+_CASES = [
+    pytest.param(
+        lambda sub, pool: sse_event_stream(sub, pool, "ses_X", after_seq=0),
+        lambda mp, pool, exc: _install_session_event_backfill(mp, "fetch", pool, exc),
+        id="sse_event_stream",
+    ),
+    pytest.param(
+        lambda sub, pool: runtime_connector_calls_stream(
+            sub, pool, "telegram", account_id="acct_X"
+        ),
+        lambda mp, pool, exc: _install_query_backfill(
+            mp, "list_pending_calls_for_connector", pool, exc
+        ),
+        id="runtime_connector_calls_stream",
+    ),
+    pytest.param(
+        lambda sub, pool: management_calls_stream(sub, pool, "telegram", account_id="acct_X"),
+        lambda mp, pool, exc: _install_query_backfill(
+            mp, "list_pending_management_calls_for_connector", pool, exc
+        ),
+        id="management_calls_stream",
+    ),
+    pytest.param(
+        lambda sub, pool: connection_discovery_stream(sub, pool, "telegram", account_id="acct_X"),
+        lambda mp, pool, exc: _install_query_backfill(mp, "list_connections", pool, exc),
+        id="connection_discovery_stream",
+    ),
+]
+
+
+@pytest.mark.parametrize("build_gen, install_backfill", _CASES)
+async def test_generator_terminates_conn_on_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+    build_gen: Any,
+    install_backfill: Any,
+) -> None:
+    """Cancelling the consumer task must trigger subscription.terminate()."""
+    subscription = _mk_subscription()
+    pool = _mk_pool()
+    install_backfill(monkeypatch, pool, None)
+
+    gen = build_gen(subscription, pool)
 
     async def _consume() -> None:
         async for _ in gen:
@@ -61,24 +138,18 @@ async def test_runtime_connector_calls_stream_terminates_conn_on_cancel(
     subscription._conn.terminate.assert_called_once()
 
 
-async def test_runtime_connector_calls_stream_terminates_conn_when_backfill_raises(
+@pytest.mark.parametrize("build_gen, install_backfill", _CASES)
+async def test_generator_terminates_conn_when_backfill_raises(
     monkeypatch: pytest.MonkeyPatch,
+    build_gen: Any,
+    install_backfill: Any,
 ) -> None:
     """Backfill query failure must still terminate the subscription."""
     subscription = _mk_subscription()
+    pool = _mk_pool()
+    install_backfill(monkeypatch, pool, RuntimeError("backfill kaboom"))
 
-    monkeypatch.setattr(
-        "aios.api.sse.queries.list_pending_calls_for_connector",
-        AsyncMock(side_effect=RuntimeError("backfill kaboom")),
-    )
-
-    pool = MagicMock()
-    acquire_cm = MagicMock()
-    acquire_cm.__aenter__ = AsyncMock(return_value=MagicMock())
-    acquire_cm.__aexit__ = AsyncMock(return_value=None)
-    pool.acquire = MagicMock(return_value=acquire_cm)
-
-    gen = runtime_connector_calls_stream(subscription, pool, "telegram", account_id="acct_X")
+    gen = build_gen(subscription, pool)
 
     async def _consume() -> None:
         async for _ in gen:

--- a/tests/unit/test_sse_preflight.py
+++ b/tests/unit/test_sse_preflight.py
@@ -1,0 +1,167 @@
+"""Unit tests for SSE preflight error handling (issue #376).
+
+The four SSE generators in ``aios.api.sse`` used to do their own
+``asyncpg.connect`` + ``add_listener`` setup INSIDE the
+``EventSourceResponse`` body.  Any failure there happened AFTER 200 OK
+headers had already been written, so the client saw a half-open
+chunked stream and a noisy "ASGI callable returned without completing
+response" error on the server.
+
+The fix moves the ``open_listen_for_*`` call into the route handler,
+before constructing ``EventSourceResponse``.  Preflight failure now
+surfaces as a clean 503 with an aios error envelope; headers are not
+written until the LISTEN connection is established.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncpg
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aios.api.deps import (
+    get_account_id,
+    get_db_url,
+    get_pool,
+    require_runtime_auth,
+)
+from aios.api.routers import connectors as connectors_router
+from aios.api.routers import sessions as sessions_router
+from aios.errors import install_exception_handlers
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(connectors_router.router)
+    app.include_router(sessions_router.router)
+    app.state.pool = MagicMock()
+    app.state.db_url = "postgresql://stub/aios"
+    app.state.crypto_box = MagicMock()
+    app.state.procrastinate = MagicMock()
+
+    async def _fake_pool() -> Any:
+        return MagicMock()
+
+    async def _fake_db_url() -> str:
+        return "postgresql://stub/aios"
+
+    async def _fake_account_id() -> str:
+        return "acct_test"
+
+    async def _fake_runtime_auth() -> tuple[str, str, str, list[str] | None]:
+        return ("tok_test", "telegram", "acct_test", None)
+
+    app.dependency_overrides[get_pool] = _fake_pool
+    app.dependency_overrides[get_db_url] = _fake_db_url
+    app.dependency_overrides[get_account_id] = _fake_account_id
+    app.dependency_overrides[require_runtime_auth] = _fake_runtime_auth
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    app = _build_app()
+    with TestClient(app) as c:
+        yield c
+
+
+def _assert_sse_preflight_503(response: Any, *, stream: str) -> None:
+    """Both the envelope error_type and the detail.stream must be set."""
+    assert response.status_code == 503, response.text
+    body = response.json()
+    assert body["error"]["type"] == "sse_preflight_failed"
+    assert body["error"]["detail"]["stream"] == stream
+
+
+def test_runtime_calls_503_when_open_listen_raises(client: TestClient) -> None:
+    with patch(
+        "aios.api.routers.connectors.open_listen_for_connector_calls_by_type",
+        AsyncMock(side_effect=asyncpg.CannotConnectNowError("startup")),
+    ):
+        response = client.get(
+            "/v1/connectors/runtime/calls",
+            headers={"Authorization": "Bearer fake"},
+        )
+    _assert_sse_preflight_503(response, stream="runtime_calls")
+
+
+def test_management_calls_503_when_open_listen_raises(client: TestClient) -> None:
+    with patch(
+        "aios.api.routers.connectors.open_listen_for_management_calls",
+        AsyncMock(side_effect=asyncpg.CannotConnectNowError("startup")),
+    ):
+        response = client.get(
+            "/v1/connectors/runtime/management-calls",
+            headers={"Authorization": "Bearer fake"},
+        )
+    _assert_sse_preflight_503(response, stream="management_calls")
+
+
+def test_connection_discovery_503_when_open_listen_raises(client: TestClient) -> None:
+    with patch(
+        "aios.api.routers.connectors.open_listen_for_connection_discovery",
+        AsyncMock(side_effect=asyncpg.CannotConnectNowError("startup")),
+    ):
+        response = client.get(
+            "/v1/connectors/connections",
+            headers={"Authorization": "Bearer fake"},
+        )
+    _assert_sse_preflight_503(response, stream="connection_discovery")
+
+
+def test_session_stream_503_when_open_listen_raises(client: TestClient) -> None:
+    """The session-existence check must pass before the preflight runs;
+    stub it so the preflight gets a chance to raise."""
+    with (
+        patch(
+            "aios.api.routers.sessions.service.get_session_basic",
+            AsyncMock(return_value=MagicMock()),
+        ),
+        patch(
+            "aios.api.routers.sessions.open_listen_for_events",
+            AsyncMock(side_effect=asyncpg.CannotConnectNowError("startup")),
+        ),
+    ):
+        response = client.get(
+            "/v1/sessions/sess_abc/stream",
+            headers={"Authorization": "Bearer fake"},
+        )
+    _assert_sse_preflight_503(response, stream="session_events")
+
+
+def test_runtime_calls_503_logged_with_diagnostic(client: TestClient) -> None:
+    """Preflight failure emits a structured warning with connector + error fields.
+
+    We patch the module-level :data:`aios.api.routers.connectors.log` object
+    directly rather than asserting against ``caplog``/``capsys``.  structlog
+    is configured with ``cache_logger_on_first_use=True``, so the bound
+    logger captured during the first import freezes whatever level/processors
+    were active then — making suite-wide log-capture assertions
+    order-dependent.  Asserting on the call to ``log.warning`` itself targets
+    the actual diagnostic contract (call site + kwargs) and is stable across
+    the suite.
+    """
+    with (
+        patch(
+            "aios.api.routers.connectors.open_listen_for_connector_calls_by_type",
+            AsyncMock(side_effect=asyncpg.CannotConnectNowError("startup blip")),
+        ),
+        patch("aios.api.routers.connectors.log") as log_mock,
+    ):
+        response = client.get(
+            "/v1/connectors/runtime/calls",
+            headers={"Authorization": "Bearer fake"},
+        )
+    assert response.status_code == 503
+    log_mock.warning.assert_called_once()
+    call = log_mock.warning.call_args
+    assert call.args == ("sse.runtime_calls.preflight_failed",)
+    assert call.kwargs["connector"] == "telegram"
+    assert call.kwargs["error"] == "startup blip"
+    assert call.kwargs["error_type"] == "CannotConnectNowError"


### PR DESCRIPTION
## Root cause

Each SSE generator opened its `asyncpg.connect()` + `add_listener()` call *inside the generator body*, after `EventSourceResponse` had already flushed the `200 OK` and chunked-transfer headers. When the testcontainer Postgres was still warming up, the LISTEN connection failed inside the body — producing zero chunks on an already-committed HTTP response. Clients saw `httpx.RemoteProtocolError: incomplete chunked read`; the server logged "ASGI callable returned without completing response". The connector retried 5 times (0 s, 1 s, 3 s, 7 s, 15 s) before the container stabilised, giving a ~31 s startup stall. PR #366 papered over this with a 30 s → 60 s `wait_ready` bump.

## Fix

Move `asyncpg.connect` + `add_listener` (and `acquire_subscriber_lock` for session streams) into the **route handler**, before `EventSourceResponse` is constructed. If the preflight fails → `HTTPException(503)` with `error_type: sse_preflight_failed`. If it succeeds → a `ListenSubscription(conn, queue)` is handed to the generator, which owns cleanup via `try/finally`. Clients now get a clean 503 they can retry rather than a half-open chunked stream, and the connector's exponential backoff works as intended without needing inflated timeouts.

The 60 s band-aid in `packages/aios-connector-http` is reverted to 30 s.

## Files changed

- **`src/aios/db/listen.py`** — added `ListenSubscription` dataclass and four `open_listen_for_*` async functions. The existing `@asynccontextmanager` `listen_for_*` factories are kept as thin composers over `open_*` so existing cleanup tests pass unchanged.
- **`src/aios/api/sse.py`** — all four generators now accept a `ListenSubscription` and call `subscription.terminate()` in `try/finally`. Added `log.exception` for non-`CancelledError` exceptions so body-side failures surface with a traceback.
- **`src/aios/api/routers/connectors.py`** — three SSE handlers preflight LISTEN before yielding a response.
- **`src/aios/api/routers/sessions.py`** — `stream_events` preflights LISTEN.
- **`src/aios/errors.py`** — added `SSEPreflightFailedError` (HTTP 503, `error_type=sse_preflight_failed`).
- **`packages/aios-connector-http/aios_connector_http/runner.py`** — revert band-aid; `wait_ready`/`wait_connection_served` deadlines 60 s → 30 s.
- **`tests/unit/test_sse_preflight.py`** (new) — 5 tests: preflight failures → 503, logging diagnostics.
- **`tests/unit/test_sse_generator_cleanup.py`** (new) — 2 tests: generator terminates connection on cancel and on raise.

## Implementation notes for reviewers

**`ListenSubscription.terminate()` is synchronous** (calls `conn.terminate()` rather than `await conn.close()`). Under `asyncio.CancelledError`, an `await close()` can itself be cancelled and leak the connection. `terminate()` is the safe choice here.

**`SSEPreflightFailedError` vs raw `HTTPException`** — `aios.errors` uses a class-attribute pattern (`error_type`, `status_code`, `to_body()`) to produce the `{"error":{"type":"...","detail":{...}}}` envelope. A bare `HTTPException(503, {...})` would break that shape, so a new error subclass was the right call.

**Diagnostic-logging tests** patch the module-level `log` object directly. structlog's `cache_logger_on_first_use=True` makes `caplog` brittle under varying suite orderings — direct patching is more reliable.

**Test ordering gotcha** — `test_sse_generator_cleanup.py` had to wait for `ListenSubscription` to exist before it could be imported; pytest's collection hook would fail on `ImportError` before any test ran. `listen.py` types were implemented first, then the generator-cleanup tests were confirmed red against the old `sse.py`.

## Skipped / not validated locally

- `tests/integration/test_sse_preflight_cleanup.py` — Docker not available in the impl environment; the cancel/raise cleanup paths are covered by the new unit tests.
- `tests/e2e/test_sse_conn_leak_on_disconnect.py` — same Docker constraint; not changed by this fix.

## Test results

- `uv run mypy src` — clean
- `uv run ruff check src tests && ruff format --check` — clean
- `uv run pytest tests/unit -q` — 1445 passed

Closes #376