### PR TITLE
test(e2e): regression test for SSE first-open flap (closes #377)

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -36,27 +36,19 @@ _DEFAULT_DEFER_WAKE_PATCHES: tuple[str, ...] = (
 
 
 @contextlib.asynccontextmanager
-async def live_aios_server(
+async def _live_aios_server_impl(
     *,
-    defer_wake_patches: tuple[str, ...] = _DEFAULT_DEFER_WAKE_PATCHES,
-    pool_max_size: int = 4,
+    defer_wake_patches: tuple[str, ...],
+    pool_max_size: int,
+    readiness: Callable[[str, uvicorn.Server], Awaitable[None]],
 ) -> AsyncIterator[str]:
-    """Run uvicorn on a free port serving the aios app; yield base URL.
+    """Shared body for :func:`live_aios_server` and :func:`live_aios_server_cold`.
 
-    Used by e2e tests that need a real HTTP socket (SSE streaming,
-    chunked transfer, real-uvicorn behaviour) rather than the
-    ``ASGITransport`` shortcut. ``defer_wake_patches`` is mocked for
-    the context's lifetime — the tests drive session advancement
-    directly via the harness, so the production ``defer_wake`` would
-    queue jobs the test never executes. The default covers the three
-    production sites; SSE-only tests that never hit the connectors
-    router can pass a narrower tuple to keep the mock surface tight.
-
-    Uvicorn's ``should_exit`` is poll-based (500 ms tick); with an
-    open SSE stream the poll routinely loses the race and the test
-    eats the full ``wait_for`` timeout. ``server.shutdown()`` triggers
-    the graceful drain synchronously instead, then cancelling the
-    serve task frees the asyncio bookkeeping.
+    The two variants differ only in their readiness probe — health-GET
+    vs. polling ``server.started`` without sending any HTTP request.
+    Everything else (pool, app state, uvicorn config, defer_wake mocks,
+    graceful shutdown) is identical, so factoring it out keeps the two
+    public entry points to a thin wrapper each.
     """
     from aios.api.app import create_app
     from aios.config import get_settings
@@ -90,7 +82,7 @@ async def live_aios_server(
         serve_task = asyncio.create_task(_serve())
         try:
             url = f"http://127.0.0.1:{port}"
-            await wait_for_health(url)
+            await readiness(url, server)
             yield url
         finally:
             await server.shutdown()
@@ -98,6 +90,90 @@ async def live_aios_server(
             with contextlib.suppress(asyncio.CancelledError):
                 await serve_task
             await pool.close()
+
+
+async def _readiness_via_health(url: str, _server: uvicorn.Server) -> None:
+    await wait_for_health(url)
+
+
+async def _readiness_via_started_flag(
+    _url: str, server: uvicorn.Server, *, deadline_s: float = 5.0
+) -> None:
+    """Wait until uvicorn finishes ``startup()`` without issuing any HTTP request.
+
+    Polling ``server.started`` — set to ``True`` at the end of
+    :meth:`uvicorn.Server.startup` immediately after ``create_server()``
+    returns — confirms the listening socket is bound and the asyncio
+    server has been created, all without sending a packet to it. The
+    SSE-first-open regression (#377) reproduced exclusively when the
+    first request to land on uvicorn was the SSE GET itself; any
+    prior request (including a /v1/health probe) warmed the pool /
+    connector init enough to mask the bug. This probe deliberately
+    avoids opening any TCP connection so the test's first
+    ``client.stream(...)`` is genuinely uvicorn's first request.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + deadline_s
+    while not server.started:
+        if loop.time() >= deadline:
+            raise TimeoutError(f"uvicorn did not finish startup within {deadline_s}s")
+        await asyncio.sleep(0.01)
+
+
+@contextlib.asynccontextmanager
+async def live_aios_server(
+    *,
+    defer_wake_patches: tuple[str, ...] = _DEFAULT_DEFER_WAKE_PATCHES,
+    pool_max_size: int = 4,
+) -> AsyncIterator[str]:
+    """Run uvicorn on a free port serving the aios app; yield base URL.
+
+    Used by e2e tests that need a real HTTP socket (SSE streaming,
+    chunked transfer, real-uvicorn behaviour) rather than the
+    ``ASGITransport`` shortcut. ``defer_wake_patches`` is mocked for
+    the context's lifetime — the tests drive session advancement
+    directly via the harness, so the production ``defer_wake`` would
+    queue jobs the test never executes. The default covers the three
+    production sites; SSE-only tests that never hit the connectors
+    router can pass a narrower tuple to keep the mock surface tight.
+
+    Uvicorn's ``should_exit`` is poll-based (500 ms tick); with an
+    open SSE stream the poll routinely loses the race and the test
+    eats the full ``wait_for`` timeout. ``server.shutdown()`` triggers
+    the graceful drain synchronously instead, then cancelling the
+    serve task frees the asyncio bookkeeping.
+    """
+    async with _live_aios_server_impl(
+        defer_wake_patches=defer_wake_patches,
+        pool_max_size=pool_max_size,
+        readiness=_readiness_via_health,
+    ) as url:
+        yield url
+
+
+@contextlib.asynccontextmanager
+async def live_aios_server_cold(
+    *,
+    defer_wake_patches: tuple[str, ...] = _DEFAULT_DEFER_WAKE_PATCHES,
+    pool_max_size: int = 4,
+) -> AsyncIterator[str]:
+    """Like :func:`live_aios_server` but yields BEFORE any HTTP request hits uvicorn.
+
+    The SSE first-open regression (#377) only manifests when the very
+    first request landing on uvicorn is the SSE GET itself; any prior
+    HTTP traffic — including a ``GET /v1/health`` readiness probe —
+    triggers uvicorn's first-request initialisation and masks the bug.
+    This variant waits on ``server.started`` (set at the end of
+    :meth:`uvicorn.Server.startup`, after the listening socket is
+    bound) instead of polling the health endpoint, so the test's first
+    ``client.stream(...)`` is observably uvicorn's first request.
+    """
+    async with _live_aios_server_impl(
+        defer_wake_patches=defer_wake_patches,
+        pool_max_size=pool_max_size,
+        readiness=_readiness_via_started_flag,
+    ) as url:
+        yield url
 
 
 async def wait_for_predicate(

--- a/tests/e2e/test_sse_first_open.py
+++ b/tests/e2e/test_sse_first_open.py
@@ -1,0 +1,207 @@
+"""Regression: SSE first-open against a cold uvicorn (#377).
+
+Before the preflight LISTEN fix (commit c774a35), the three connector
+SSE endpoints set up their ``asyncpg.connect`` + ``add_listener``
+INSIDE the ``EventSourceResponse`` generator body. When the SSE GET
+was the very first request to a freshly-bound uvicorn — i.e. before
+any pool slot had been warmed by a prior request — the LISTEN
+connection acquire raced uvicorn's first-request init and the
+chunked-response handshake half-aborted. The client saw a
+``RemoteProtocolError`` ("peer closed connection without sending
+complete message body") while the server logged "ASGI callable
+returned without completing response."
+
+The fix moved ``open_listen_for_*`` up into the route handler so it
+runs BEFORE ``EventSourceResponse`` is constructed; preflight failure
+now surfaces as a clean 503 with an aios error envelope and the
+chunked stream itself is only initialised once the LISTEN is live.
+
+These tests lock that in: a fresh uvicorn with pool ``min_size=1``,
+``max_size=4``, ``lifespan="off"``, no prior HTTP traffic, and an SSE
+GET as the FIRST request must complete the chunked handshake without
+the server teardown showing up on the wire as
+``RemoteProtocolError`` / ``ReadError``. The :func:`live_aios_server_cold`
+fixture polls ``server.started`` rather than ``GET /v1/health`` so the
+test's first ``client.stream(...)`` is genuinely uvicorn's first
+request — a health-GET would warm the path enough to mask the bug.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from aios.config import get_settings
+from aios.db.pool import create_pool
+from tests.conftest import needs_docker
+from tests.e2e.conftest import live_aios_server_cold
+from tests.helpers.connections import mint_runtime_token_via_db
+
+_SSE_ENDPOINTS: tuple[str, ...] = (
+    "/v1/connectors/connections",
+    "/v1/connectors/runtime/calls",
+    "/v1/connectors/runtime/management-calls",
+)
+
+
+async def _mint_echo_token_via_db() -> str:
+    """Open a short-lived pool, mint an ``echo`` runtime token, close it.
+
+    The pool is closed before the test enters :func:`live_aios_server_cold`
+    so the uvicorn it spawns starts with a genuinely cold state — no
+    lingering asyncpg connections, no warmed pool slots, nothing for
+    the SSE preflight to coast on.
+    """
+    settings = get_settings()
+    pool = await create_pool(settings.db_url, min_size=1, max_size=2)
+    try:
+        return await mint_runtime_token_via_db(pool, connector="echo")
+    finally:
+        await pool.close()
+
+
+async def _probe_chunked_stream_is_healthy(
+    response: httpx.Response, *, deadline_s: float = 2.0
+) -> None:
+    """Verify the chunked-transfer stream stayed open after the headers.
+
+    The regression we lock in is the server tearing down the chunked
+    response right after the 200 OK headers go out — the SSE
+    generator dies inside ``open_listen_for_*`` before yielding
+    anything, so the very first body read raises
+    :class:`httpx.RemoteProtocolError` ("peer closed connection
+    without sending complete message body").
+
+    Under the fixed code path, the generator parks waiting for a
+    NOTIFY; with an idle DB, the next keepalive ping (default 15 s)
+    is the first byte to land. We don't want a 15 s test, so we use
+    a short ``deadline_s`` and treat a clean timeout as the healthy
+    outcome.
+
+    Three outcomes:
+
+    * a chunk arrives (e.g. backfill event, ping, comment) → healthy.
+    * :class:`asyncio.TimeoutError` from :func:`asyncio.wait_for`
+      / :class:`httpx.ReadTimeout` → healthy (idle stream, no
+      teardown).
+    * :class:`httpx.RemoteProtocolError` / :class:`httpx.ReadError` →
+      the #377 regression bubbles up to the caller, which fails the
+      test with a clear message.
+    """
+
+    async def _read_one_chunk() -> None:
+        async for chunk in response.aiter_raw():
+            if chunk:
+                return
+
+    try:
+        await asyncio.wait_for(_read_one_chunk(), timeout=deadline_s)
+    except (TimeoutError, httpx.ReadTimeout):
+        # Idle stream — the chunked handshake completed and the
+        # generator is parked waiting for a NOTIFY. Exactly the
+        # post-fix steady state, so this is the success path.
+        return
+
+
+@needs_docker
+class TestSseFirstOpen:
+    @pytest.mark.parametrize("endpoint", _SSE_ENDPOINTS)
+    async def test_sse_first_open_succeeds_with_no_warmup_request(
+        self,
+        aios_env: dict[str, str],
+        endpoint: str,
+    ) -> None:
+        """A single SSE GET as uvicorn's first request must hand off cleanly.
+
+        The chunked-transfer handshake completes (200 + SSE
+        content-type) and the server does NOT tear the connection
+        down after the headers go out. Any
+        ``RemoteProtocolError`` / ``ReadError`` from probing the body
+        is the #377 regression — the preflight LISTEN didn't run
+        before ``EventSourceResponse`` and the stream died after
+        200 OK.
+        """
+        token = await _mint_echo_token_via_db()
+
+        async with live_aios_server_cold() as base_url:
+            try:
+                async with (
+                    httpx.AsyncClient(
+                        base_url=base_url,
+                        headers={"Authorization": f"Bearer {token}"},
+                        timeout=10.0,
+                    ) as client,
+                    client.stream(
+                        "GET", endpoint, headers={"Accept": "text/event-stream"}
+                    ) as response,
+                ):
+                    assert response.status_code == 200, (
+                        f"#377 regression: {endpoint} returned {response.status_code}, expected 200"
+                    )
+                    content_type = response.headers.get("content-type", "")
+                    assert content_type.startswith("text/event-stream"), (
+                        f"#377 regression: {endpoint} returned "
+                        f"content-type {content_type!r}, expected text/event-stream"
+                    )
+                    await _probe_chunked_stream_is_healthy(response)
+            except (httpx.RemoteProtocolError, httpx.ReadError) as exc:
+                pytest.fail(
+                    f"#377 regression: SSE first-open against cold uvicorn "
+                    f"flapped on {endpoint}: {type(exc).__name__}: {exc}"
+                )
+
+    async def test_three_concurrent_sse_first_opens_all_succeed(
+        self,
+        aios_env: dict[str, str],
+    ) -> None:
+        """All three connector SSE streams opened concurrently against a cold
+        uvicorn must each complete the chunked handshake.
+
+        Concurrent first-opens stress the pool harder than the
+        parametrized case — three preflight LISTEN acquires racing
+        uvicorn's first-request init at once. The preflight fix has
+        to hold up under that fan-out too, not just the single-stream
+        path.
+        """
+        token = await _mint_echo_token_via_db()
+
+        async with live_aios_server_cold() as base_url:
+
+            async def _open_one(endpoint: str) -> tuple[int, str]:
+                async with (
+                    httpx.AsyncClient(
+                        base_url=base_url,
+                        headers={"Authorization": f"Bearer {token}"},
+                        timeout=10.0,
+                    ) as client,
+                    client.stream(
+                        "GET", endpoint, headers={"Accept": "text/event-stream"}
+                    ) as response,
+                ):
+                    # Probe inside the stream context — RemoteProtocolError
+                    # surfaces here under the unfixed code path, which
+                    # is exactly what we want to detect.
+                    await _probe_chunked_stream_is_healthy(response)
+                    return (
+                        response.status_code,
+                        response.headers.get("content-type", ""),
+                    )
+
+            try:
+                results = await asyncio.gather(
+                    *(_open_one(endpoint) for endpoint in _SSE_ENDPOINTS),
+                )
+            except (httpx.RemoteProtocolError, httpx.ReadError) as exc:
+                pytest.fail(
+                    f"#377 regression: concurrent SSE first-opens flapped: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+
+            for endpoint, (status, content_type) in zip(_SSE_ENDPOINTS, results, strict=True):
+                assert status == 200, f"#377 regression: {endpoint} returned {status}, expected 200"
+                assert content_type.startswith("text/event-stream"), (
+                    f"#377 regression: {endpoint} returned content-type "
+                    f"{content_type!r}, expected text/event-stream"
+                )

--- a/tests/helpers/connections.py
+++ b/tests/helpers/connections.py
@@ -20,10 +20,13 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest import mock
 
 import httpx
+
+if TYPE_CHECKING:
+    import asyncpg
 
 
 def authed_client(base_url: str, token: str, **kwargs: Any) -> httpx.AsyncClient:
@@ -56,6 +59,31 @@ async def issue_runtime_token(api_key: str, base_url: str, connector: str) -> st
         r = await c.post("/v1/runtime-tokens", json={"connector": connector})
         r.raise_for_status()
         return str(r.json()["plaintext"])
+
+
+async def mint_runtime_token_via_db(
+    pool: asyncpg.Pool[Any],
+    *,
+    connector: str,
+    account_id: str = "acc_test_stub",
+    label: str | None = None,
+) -> str:
+    """Mint a runtime token by direct service call (not HTTP).
+
+    Use this in tests that must NOT hit uvicorn before the test's first
+    HTTP request — e.g. the SSE-first-open regression for #377. The
+    standard :func:`issue_runtime_token` POSTs to ``/v1/runtime-tokens``,
+    which itself warms up uvicorn (lazy lifespan + connection init) and
+    defeats the bug repro. This helper inserts the token row directly
+    against ``pool`` via the runtime-tokens service so the test's first
+    network request to the server is the SSE GET under examination.
+    """
+    from aios.services import runtime_tokens as runtime_tokens_service
+
+    _, plaintext = await runtime_tokens_service.issue(
+        pool, account_id=account_id, connector=connector, label=label
+    )
+    return plaintext
 
 
 async def create_connection(api_key: str, base_url: str, account: str) -> str:


### PR DESCRIPTION
## Summary

Adds the deterministic regression test called out as issue #377's suggested next step. The production fix landed in master via c774a35 (preflight `LISTEN` before sending 200 OK); this PR is **test-only — no `src/` changes**.

## What was added

- `tests/e2e/test_sse_first_open.py` — parametrized across the three connector SSE endpoints (discovery, tool, management); asserts SSE works as the literal first HTTP request against a fresh uvicorn. Includes `test_three_concurrent_sse_first_opens_all_succeed` covering the issue's "three near-simultaneous SSE requests" hypothesis.
- `tests/e2e/conftest.py` — extracted bring-up into `_live_aios_server_impl`; added `live_aios_server_cold` which polls `uvicorn.Server.started` instead of `GET /v1/health` (the health check warmed uvicorn and defeated the repro).
- `tests/helpers/connections.py` — added `mint_runtime_token_via_db`, which calls the runtime-tokens service directly so we don't warm uvicorn with a POST to `/v1/runtime-tokens`.

## Probe semantics

The assertion is on the chunked-stream handshake, not event arrival: a chunk OR a `ReadTimeout` = healthy; `RemoteProtocolError` / `ReadError` = regression. Connector SSE generators do no backfill on an empty DB and the next byte is a 15s keepalive ping, so the contract under test is "server doesn't tear down the chunked stream after sending headers" — exactly what the bug breaks.

## Sanity check

Temp-reverted the preflight to a forced `asyncpg.CannotConnectNowError` inside the generator body and confirmed the test fails with the exact `peer closed connection without sending complete message body (incomplete chunked read)` symptom from the issue. Production code was restored exactly (`git diff src/` is empty).

Closes #377.