### PR TITLE
docs: codegen invariants — regen-openapi + regen-client agent convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,21 @@ uv run aios skills create --dir path/to/my-skill --title "My Skill"
 
 Every resource has CRUD subcommands. See `aios <resource> --help` for specifics. Operator commands (`aios api`, `aios worker`, `aios migrate`) are also typer-backed but keep their original behavior.
 
+## Code generation invariants
+
+Two pre-commit invariants are checked in CI; both fail if the committed
+artifact drifts from its source-of-truth:
+
+- `openapi.json` is regenerated from FastAPI introspection.
+  Fix on drift: `./scripts/regen-openapi.sh && git add openapi.json`.
+- `packages/aios-sdk/aios_sdk/_generated/` is regenerated from `openapi.json`.
+  Fix on drift: `./scripts/regen-client.sh && git add packages/aios-sdk`
+  (also regenerates openapi.json as a prerequisite).
+
+Trigger: any API route, response model, error envelope, or pydantic schema
+change that flows through FastAPI introspection. **Run both before pushing**
+when you've touched API-layer code.
+
 ## Architecture
 
 aios is an event-driven agent runtime. The headline property: **every tool is implicitly async** — the model stays responsive to user messages even while tools are running.


### PR DESCRIPTION
## Summary

Adds a "Code generation invariants" section to `CLAUDE.md` documenting the two CI-enforced codegen snapshots and the scripts that fix them.

- Names the two pre-commit invariants checked in CI: `openapi.json` drift and `aios-sdk _generated/` drift.
- Points at the fix scripts: `scripts/regen-openapi.sh` and `scripts/regen-client.sh`.
- Spells out the trigger (any change to API routes, response models, error envelopes, or pydantic schemas that flow through FastAPI introspection) and instructs agents to run both scripts before pushing when touching API-layer code.

## Motivation

PR #642 (a docstring tweak on `/sessions/{id}/context`) tripped both snapshot tests in sequence, turning a green-once dispatch into a two-round CI debug. Local `uv run pytest tests/unit/` catches this, but agents that rely on CI to surface it pay the round-trip cost.

A pre-commit hook and CI auto-regen were considered (options B and C in the issue discussion) but are deliberately out of scope here — docs first, only escalate if agents keep missing this.

## Test plan

- [x] Docs-only change to `CLAUDE.md`; no code paths touched.
- [ ] Follow-up: revisit if the invariants continue to be missed in subsequent PRs.

Closes #643