### PR TITLE
test(infra): fix structlog caplog blindness in test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,7 +278,7 @@ async def aios_env(aios_env_minimal: dict[str, str], _reset_db_state: Any) -> di
 
 
 @pytest.fixture(autouse=True)
-def _configure_structlog_for_tests():
+def _configure_structlog_for_tests() -> Iterator[None]:
     """Configure structlog before every test so caplog captures all messages.
 
     Two changes vs. structlog's bare default (which is what tests see when

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ from typing import Any
 from unittest import mock
 
 import pytest
+import structlog
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
@@ -274,3 +275,41 @@ async def aios_env(aios_env_minimal: dict[str, str], _reset_db_state: Any) -> di
         hash_key(plaintext),
     )
     return aios_env_minimal
+
+
+@pytest.fixture(autouse=True)
+def _configure_structlog_for_tests():
+    """Configure structlog before every test so caplog captures all messages.
+
+    Two changes vs. structlog's bare default (which is what tests see when
+    nothing calls aios.logging.configure_logging at process start):
+
+    1. logger_factory=structlog.stdlib.LoggerFactory() — routes log records
+       through Python's stdlib logging, which is what caplog hooks. The bare
+       default uses PrintLoggerFactory, which writes to stdout and is invisible
+       to caplog.
+
+    2. cache_logger_on_first_use=False — modules with module-level
+       log = structlog.get_logger() bind their config on first call. Caching
+       freezes that binding, so tests reconfiguring structlog (e.g., here)
+       cannot affect already-bound loggers. Disabling caching costs ~1us
+       per call to rebind — negligible at test-suite scale.
+
+    Function scope (not session) is deliberate: mid-suite code reconfigures
+    structlog and would otherwise leak across tests. ``aios.api.app.create_app``
+    calls ``aios.logging.configure_logging`` (which sets
+    cache_logger_on_first_use=True), and the ``capture_logs`` fixtures in
+    test_db_pool.py / test_worker_exit_diagnostics.py call
+    ``structlog.reset_defaults()`` in teardown. A once-per-session fixture
+    cannot defend against either — re-applying before each test does.
+    """
+    current = structlog.get_config()
+    structlog.configure(
+        **{
+            **current,
+            "logger_factory": structlog.stdlib.LoggerFactory(),
+            "cache_logger_on_first_use": False,
+        }
+    )
+    yield
+    structlog.configure(**current)

--- a/tests/unit/test_structlog_caplog.py
+++ b/tests/unit/test_structlog_caplog.py
@@ -1,0 +1,49 @@
+"""Tests verifying structlog is configured so caplog reliably captures log records.
+
+The bare-default structlog config (what tests inherit when nothing calls
+aios.logging.configure_logging at process start) uses PrintLoggerFactory, which
+writes to stdout and bypasses Python's stdlib logging — making caplog blind to
+structlog output. A separate trap is cache_logger_on_first_use=True (set in
+production), which freezes a module's bound-logger config at first call.
+
+The autouse fixture in tests/conftest.py neutralizes both: before every test it
+installs stdlib.LoggerFactory and disables caching, so caplog captures
+everything and reconfiguration (this fixture or any test-local override)
+actually takes effect.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import structlog
+
+
+def test_structlog_routed_through_stdlib_for_caplog() -> None:
+    """The conftest fixture must route structlog through stdlib.LoggerFactory."""
+    config = structlog.get_config()
+    assert isinstance(config["logger_factory"], structlog.stdlib.LoggerFactory)
+
+
+def test_cache_logger_on_first_use_disabled() -> None:
+    """The conftest fixture must disable structlog logger caching."""
+    assert structlog.get_config()["cache_logger_on_first_use"] is False
+
+
+def test_caplog_captures_module_level_structlog_logger(caplog) -> None:
+    """caplog must capture log records emitted via a module-level structlog logger.
+
+    Imports a module with module-level log binding (a class of modules that
+    would otherwise have their loggers frozen at first use). Verifies the
+    record reaches caplog through stdlib logging.
+    """
+    from aios.api.routers import connectors
+
+    marker = "caplog_capture_marker_644"
+    with caplog.at_level(logging.INFO):
+        connectors.log.info(marker)
+
+    assert any(marker in record.getMessage() for record in caplog.records), (
+        f"caplog did not capture structlog message containing {marker!r}. "
+        f"Records: {[r.getMessage() for r in caplog.records]}"
+    )

--- a/tests/unit/test_structlog_caplog.py
+++ b/tests/unit/test_structlog_caplog.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 
+import pytest
 import structlog
 
 
@@ -30,7 +31,9 @@ def test_cache_logger_on_first_use_disabled() -> None:
     assert structlog.get_config()["cache_logger_on_first_use"] is False
 
 
-def test_caplog_captures_module_level_structlog_logger(caplog) -> None:
+def test_caplog_captures_module_level_structlog_logger(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """caplog must capture log records emitted via a module-level structlog logger.
 
     Imports a module with module-level log binding (a class of modules that


### PR DESCRIPTION
`caplog` silently missed all structlog output in tests for two compounding reasons: structlog's default `PrintLoggerFactory` bypasses Python's stdlib `logging` entirely (so `caplog` never saw anything), and `cache_logger_on_first_use=True` — set by `configure_logging()` when tests call `create_app()` — froze module-level loggers mid-suite, making assertions order-dependent.

The fix is a function-scoped autouse fixture in `tests/conftest.py` that installs `structlog.stdlib.LoggerFactory()` and disables `cache_logger_on_first_use` before each test, restoring prior config on teardown. Function scope (not session) is required because `create_app()` calls `configure_logging()`, which re-runs `structlog.configure()` with caching re-enabled; a session-scoped fixture gets overwritten by the first app-creating test.

Three new tests in `tests/unit/test_structlog_caplog.py` pin the invariants: the stdlib factory is active, caching is disabled, and a module-level logger's output actually appears in `caplog`. The mutation checks confirm both fixture lines are load-bearing: removing the logger factory line makes the caplog end-to-end test fail; removing the cache line passes vacuously in isolation (structlog defaults to False) but fails at full-suite scale once `create_app()` has flipped the flag.

No production code changed.

Closes #644