### PR TITLE
fix(harness/context): guard timestamp_ms render against session brick

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -119,8 +119,18 @@ def _format_channel_header(metadata: dict[str, Any]) -> str:
         parts.append(f"sender_id={sender_id}")
     timestamp_ms = metadata.get("timestamp_ms")
     if isinstance(timestamp_ms, int):
-        iso = datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).isoformat(timespec="milliseconds")
-        parts.append(f"timestamp_ms={timestamp_ms} ({iso})")
+        try:
+            iso = datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).isoformat(
+                timespec="milliseconds"
+            )
+            parts.append(f"timestamp_ms={timestamp_ms} ({iso})")
+        except (ValueError, OverflowError, OSError):
+            # An int outside the valid Unix-millisecond range (a connector
+            # sending micro/nanoseconds, say) makes datetime.fromtimestamp
+            # raise. The renderer runs on every wake, so an unguarded raise
+            # bricks the session permanently — same failure class as #446.
+            # The raw int still goes to the model; only the ISO is dropped.
+            parts.append(f"timestamp_ms={timestamp_ms}")
     message_id = metadata.get("message_id")
     if isinstance(message_id, int):
         parts.append(f"message_id={message_id}")

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1124,6 +1124,24 @@ class TestFocalRendering:
         assert "timestamp_ms=1776401210703" in content
         assert "(2026-04-17T" in content
 
+    def test_focal_match_timestamp_ms_out_of_range_does_not_brick_session(self) -> None:
+        """An int ``timestamp_ms`` outside the valid millisecond-Unix
+        range (a connector sending micro/nanoseconds, say) makes
+        ``datetime.fromtimestamp`` raise. ``_format_channel_header`` runs
+        on every wake, so an unguarded raise bricks the session
+        permanently (same failure class as #446)."""
+        # 1776401210703 ms is a sane 2026 timestamp; 1000x larger
+        # (microseconds mistaken for milliseconds) lands the divided
+        # value past datetime's MAXYEAR.
+        md = {"channel": self._CHAN_A, "timestamp_ms": 1_776_401_210_703_000}
+        events = [_evt(1, "user", content="hi", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        # The raw int is still surfaced — connector tools need it as an
+        # argument — but the unconvertible value yields no ISO
+        # parenthetical (the success path appends " (<iso>)").
+        assert "timestamp_ms=1776401210703000" in content
+        assert "timestamp_ms=1776401210703000 (" not in content
+
     def test_focal_match_message_id_inlined(self) -> None:
         """The ``message_id`` lets the model react/edit/delete the user
         message via the connector tools — without it, the model has to


### PR DESCRIPTION
## Summary

- **Bug:** `_format_channel_header` reads `metadata["timestamp_ms"]` from a connector inbound payload, guards it with `isinstance(timestamp_ms, int)`, then calls `datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC)`. The `isinstance` check is *structural* — it does not establish the *semantic* precondition that the int is a valid millisecond Unix timestamp. A connector sending a microsecond- or nanosecond-magnitude integer passes the guard, then `fromtimestamp` raises `ValueError`/`OverflowError`/`OSError`.
- **Impact:** `build_messages` → `render_user_event` → `_format_channel_header` runs on **every session wake**. A single poisoned event in the context window means the session can never assemble context again — a permanent, unrecoverable brick.
- **Fix:** wrap the conversion in `try/except (ValueError, OverflowError, OSError)` — the documented failure set of `datetime.fromtimestamp`. On failure, still surface the raw `timestamp_ms` integer (connector tools need it as an argument) and drop only the human-readable ISO parenthetical.
- **Precedent:** same failure class and remedy as the `#446` attachment-record guard and the `reply_to.text` non-string guard — both already in `harness/context.py` for malformed connector metadata. This patches the unguarded sibling.
- Adds `test_focal_match_timestamp_ms_out_of_range_does_not_brick_session`, mirroring the `#446` precedent test; it fails pre-fix with `ValueError: year 58261 is out of range`.

## Test plan

- [x] mypy — clean (160 source files)
- [x] ruff check + format-check — clean
- [x] Unit suite — 1465 passed (new regression test red pre-fix, green post-fix)
- [ ] CI runs e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)