### PR TITLE
fix(migrations): repair broken alembic chain at orphaned 0055 stamp

### DIFF
--- a/migrations/versions/0055_sessions_stop_hook.py
+++ b/migrations/versions/0055_sessions_stop_hook.py
@@ -1,0 +1,36 @@
+"""Add nullable ``stop_hook jsonb`` to ``sessions`` (#374).
+
+A pluggable Stop hook decides when a session may transition to ``idle``
+at the harness's would-stop branch.  Three v1 hook types share this
+column via a discriminated union:
+
+* ``self_check`` — agent self-evaluates a condition each end-of-turn.
+* ``task_call``  — only the ``task_complete`` tool may terminate.
+* ``always_continue`` — never honor end-of-turn; only external interrupts pause.
+
+``NULL`` (default) preserves the long-standing conversational default —
+no behavioral change for sessions that don't opt in.
+
+Revision ID: 0055
+Revises: 0054
+Create Date: 2026-05-21
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0055"
+down_revision: str = "0054"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE sessions ADD COLUMN stop_hook jsonb")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS stop_hook")

--- a/migrations/versions/0056_drop_stop_hook.py
+++ b/migrations/versions/0056_drop_stop_hook.py
@@ -1,0 +1,29 @@
+"""Drop the orphaned ``stop_hook`` column left by the #603 stop-hook revert.
+
+#603 added ``sessions.stop_hook`` (migration 0055). #613/#615 reverted the
+stop-hook feature in code but the production DB kept the column and the 0055
+stamp. This migration brings the schema back in line with the reverted code.
+
+Revision ID: 0056
+Revises: 0055
+Create Date: 2026-05-22
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0056"
+down_revision: str = "0055"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS stop_hook")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE sessions ADD COLUMN stop_hook jsonb")

--- a/tests/integration/test_migrations_stop_hook.py
+++ b/tests/integration/test_migrations_stop_hook.py
@@ -1,0 +1,103 @@
+"""Integration tests for the 0055/0056 stop-hook migration repair.
+
+Production aios DBs are stamped ``alembic_version = 0055`` with a physical
+``sessions.stop_hook`` column (added by #603, code-reverted by #613/#615).
+Migration ``0055`` was re-added verbatim so the stamp resolves, and ``0056``
+drops the orphaned column. These tests exercise the real alembic CLI against
+a fresh Postgres for each case — each stamps/mutates ``alembic_version``, so
+a shared container would leak state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import asyncpg
+import pytest
+
+from tests.conftest import _docker_available, needs_docker
+from tests.integration.test_migrations import _alembic_url, _run_alembic
+
+
+@pytest.fixture
+def postgres() -> Iterator[object]:
+    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
+    if not _docker_available():
+        pytest.skip("Docker not available")
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg
+
+
+async def _sessions_columns(db_url: str) -> set[str]:
+    """Return the set of column names on the ``sessions`` table."""
+    conn = await asyncpg.connect(db_url)
+    try:
+        rows = await conn.fetch(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema='public' AND table_name='sessions'"
+        )
+        return {row["column_name"] for row in rows}
+    finally:
+        await conn.close()
+
+
+async def _version_num(db_url: str) -> str:
+    conn = await asyncpg.connect(db_url)
+    try:
+        return await conn.fetchval("SELECT version_num FROM alembic_version")
+    finally:
+        await conn.close()
+
+
+@needs_docker
+@pytest.mark.integration
+def test_full_chain_from_scratch_has_no_stop_hook(postgres: object) -> None:
+    """A fresh upgrade-to-head lands at 0056 with no ``stop_hook`` column."""
+    db_url = _alembic_url(postgres)
+
+    result = _run_alembic(["upgrade", "head"], db_url)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    columns = asyncio.run(_sessions_columns(db_url))
+    assert "stop_hook" not in columns
+    assert asyncio.run(_version_num(db_url)) == "0056"
+
+
+@needs_docker
+@pytest.mark.integration
+def test_forward_from_stamped_0055_drops_stop_hook(postgres: object) -> None:
+    """Reproduce prod (stamped 0055 with the column), then upgrade clears it."""
+    db_url = _alembic_url(postgres)
+
+    result = _run_alembic(["upgrade", "0055"], db_url)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+    assert "stop_hook" in asyncio.run(_sessions_columns(db_url))
+    assert asyncio.run(_version_num(db_url)) == "0055"
+
+    result = _run_alembic(["upgrade", "head"], db_url)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+    assert asyncio.run(_version_num(db_url)) == "0056"
+    assert "stop_hook" not in asyncio.run(_sessions_columns(db_url))
+
+
+@needs_docker
+@pytest.mark.integration
+def test_downgrade_0056_to_0054_runs_clean(postgres: object) -> None:
+    """Downgrading 0056 -> 0055 -> 0054 restores and then drops ``stop_hook``."""
+    db_url = _alembic_url(postgres)
+
+    result = _run_alembic(["upgrade", "head"], db_url)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    result = _run_alembic(["downgrade", "0055"], db_url)
+    assert result.returncode == 0, f"alembic downgrade failed:\n{result.stderr}\n{result.stdout}"
+    assert asyncio.run(_version_num(db_url)) == "0055"
+    assert "stop_hook" in asyncio.run(_sessions_columns(db_url))
+
+    result = _run_alembic(["downgrade", "0054"], db_url)
+    assert result.returncode == 0, f"alembic downgrade failed:\n{result.stderr}\n{result.stdout}"
+    assert asyncio.run(_version_num(db_url)) == "0054"
+    assert "stop_hook" not in asyncio.run(_sessions_columns(db_url))

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -1,0 +1,57 @@
+"""Verify the on-disk alembic migration chain is linear with a single head.
+
+These tests guard against the production failure where the DB is stamped
+``alembic_version = 0055`` but the codebase lacked a resolvable ``0055``
+revision (added by #603, removed by the #613/#615 stop-hook revert). With
+``0055`` missing, ``aios migrate`` cannot resolve the stamped revision and
+every deploy fails.
+
+Pure-Python: reads ``migrations/`` via ``ScriptDirectory``; no DB, no Docker.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+_MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "migrations"
+
+
+def _script_directory() -> ScriptDirectory:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    return ScriptDirectory.from_config(cfg)
+
+
+def test_single_head() -> None:
+    """The migration ladder has exactly one head: ``0056``."""
+    script = _script_directory()
+    assert script.get_heads() == ["0056"]
+
+
+def test_chain_is_linear_0054_to_0056() -> None:
+    """``0054 -> 0055 -> 0056`` is a plain linear chain, no merges/branches."""
+    script = _script_directory()
+
+    rev_0056 = script.get_revision("0056")
+    rev_0055 = script.get_revision("0055")
+
+    assert rev_0056.down_revision == "0055"
+    assert rev_0055.down_revision == "0054"
+
+    # A tuple/list down_revision would mean a merge/branch point.
+    assert isinstance(rev_0056.down_revision, str)
+    assert isinstance(rev_0055.down_revision, str)
+
+
+def test_revision_0055_resolvable() -> None:
+    """``0055`` resolves — the precise assertion reproducing the prod failure.
+
+    Production DBs are stamped ``alembic_version = 0055``; if the revision is
+    missing, ``alembic upgrade`` raises and every deploy fails.
+    """
+    script = _script_directory()
+    revision = script.get_revision("0055")
+    assert revision is not None


### PR DESCRIPTION
## Incident

Production aios DB is stamped `alembic_version = 0055` with a physical `stop_hook jsonb` column on `sessions`, but the codebase only carried migrations through `0054`. Migration `0055` was introduced in `ace47d4` (#603, pluggable Stop hooks) and later removed by the stop-hook revert (#613/#615) — without unwinding the DB stamp.

As a result, `aios migrate` (aios-api's pre-deploy command) reads `version_num=0055`, fails to resolve that revision in `migrations/versions/`, and aborts inside alembic. **Every aios-api deploy fails.**

Confirmed 2026-05-22: the aios-api deploy of `6b5dfa25` failed at the migrate step and rolled back, leaving aios-api stuck on an older revision while sibling services advanced — service lockstep broken.

## Fix

Two new migration files:

1. **`migrations/versions/0055_sessions_stop_hook.py`** — restored verbatim from `ace47d4`. Gives alembic a revision object named `0055` so it can *recognize* the DB's current stamp and anchor the revision chain.
2. **`migrations/versions/0056_drop_stop_hook.py`** — new; drops the orphaned `stop_hook` column, bringing the schema in line with the reverted code.

After this lands and aios-api deploys, `aios migrate` sees the DB at `0055`, applies `0056`, and drops the column. DB and codebase head both land at `0056`.

### Why restore-then-drop rather than deleting the stamp

Alembic needs a revision object named `0055` in its script directory to compute "what comes after 0055". Restoring the file provides that anchor; `0056` provides the forward path. This keeps the fix fully migration-driven and reviewable — no manual `UPDATE alembic_version` on production.

## Tests (TDD)

**`tests/unit/test_migration_chain.py`** (3 cases, no Docker):
- single head is `0056`
- chain `0054 -> 0055 -> 0056` is linear with no branches
- revision `0055` is resolvable — the precise assertion reproducing the production failure

**`tests/integration/test_migrations_stop_hook.py`** (3 cases, Docker):
- full chain from scratch ends with no `stop_hook` column at `0056`
- forward path from a DB stamped at `0055` (reproducing prod) drops the column
- downgrade `0056 -> 0055 -> 0054` runs clean

## Notes for reviewers

- The restored `0055` file was verified byte-identical against `git show ace47d4:migrations/versions/0055_sessions_stop_hook.py`.
- The `sessions` table also has a pre-existing, unrelated `stop_reason` column — not touched.
- `stop_hook` is NULL for all rows in practice (feature reverted before general use), so dropping the column is non-destructive.
- This is a deploy-blocking incident fix and should merge/deploy ahead of other queued work.

Closes #650