### PR TITLE
fix(sandbox/registry): don't release sessions freshened mid-tick

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -488,6 +488,34 @@ class SandboxRegistry:
 
     # ── idle-TTL reaper ──────────────────────────────────────────────────
 
+    async def _reap_idle_once(self, idle_timeout: float) -> None:
+        """One reap pass: release every session idle past ``idle_timeout``.
+
+        Extracted from :meth:`_reap_idle_loop` for deterministic testing.
+        Driven once per tick by the loop; never called directly in
+        production.
+        """
+        now = time.monotonic()
+        to_release: list[str] = []
+        for sid, last in list(self._last_used.items()):
+            if now - last > idle_timeout:
+                to_release.append(sid)
+        for sid in to_release:
+            async with self._lock_for(sid):
+                # Re-check under the lock: a concurrent get_or_provision
+                # warm hit could have freshened _last_used[sid] between
+                # the scan above and now. The warm path takes no lock
+                # (it's the fast path — "zero-observable-cost"), so this
+                # re-check is the only place we serialize against it.
+                # #566 added the lock, which closes the cold-path race;
+                # the missing piece was that the reaper trusted its
+                # stale to_release snapshot. ``evict`` can also pop
+                # _last_used out from under us, so absence means skip.
+                current = self._last_used.get(sid)
+                if current is not None and time.monotonic() - current > idle_timeout:
+                    log.info("sandbox.idle_release", session_id=sid)
+                    await self.release(sid)
+
     async def _reap_idle_loop(self, idle_timeout: float, interval: float = 60.0) -> None:
         """Background loop: release sandboxes idle > idle_timeout seconds.
 
@@ -503,15 +531,7 @@ class SandboxRegistry:
         while True:
             try:
                 await asyncio.sleep(interval)
-                now = time.monotonic()
-                to_release: list[str] = []
-                for sid, last in list(self._last_used.items()):
-                    if now - last > idle_timeout:
-                        to_release.append(sid)
-                for sid in to_release:
-                    log.info("sandbox.idle_release", session_id=sid)
-                    async with self._lock_for(sid):
-                        await self.release(sid)
+                await self._reap_idle_once(idle_timeout)
             except Exception:
                 log.exception("sandbox.reap_idle_loop_failed")
 

--- a/tests/unit/test_sandbox_reaper.py
+++ b/tests/unit/test_sandbox_reaper.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -223,3 +224,70 @@ async def test_idle_release_holds_per_session_lock() -> None:
         reaper.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await reaper
+
+
+async def test_reaper_skips_session_freshened_during_destroy_of_another() -> None:
+    """The reaper must not release a session whose ``_last_used`` was
+    freshened by a concurrent ``get_or_provision`` between the scan and
+    the actual release.
+
+    Scenario: two idle sessions ``sess_a`` and ``sess_b`` land in
+    ``to_release`` during the scan. While the reaper is awaiting
+    ``backend.destroy(handle_a)``, a tool task warm-hits
+    ``get_or_provision("sess_b")``, bumping ``_last_used["sess_b"]`` to
+    "now". The reaper must NOT proceed to destroy ``handle_b`` — the
+    session is no longer idle.
+
+    Pre-fix, the reaper acted on the stale ``to_release`` snapshot and
+    skipped a re-check of ``_last_used`` under the per-session lock, so
+    it destroyed a sandbox still in active use. The #566 lock fix did
+    not cover this residual race: ``get_or_provision``'s warm path
+    takes no lock, so it can freshen ``_last_used`` between the scan
+    and the release without ever serializing against the reaper.
+    """
+    destroy_a_started = asyncio.Event()
+    destroy_a_continue = asyncio.Event()
+    destroy_b_calls: list[SandboxHandle] = []
+
+    async def destroy(handle: SandboxHandle) -> None:
+        if handle.session_id == "sess_a":
+            destroy_a_started.set()
+            await destroy_a_continue.wait()
+        elif handle.session_id == "sess_b":
+            destroy_b_calls.append(handle)
+
+    registry = SandboxRegistry(_backend_with_destroy(AsyncMock(side_effect=destroy)))
+    # Insertion order is significant: _reap_idle_once iterates
+    # _last_used in dict-insertion order, so sess_a is processed first.
+    handle_a = _handle("sess_a")
+    handle_b = _handle("sess_b")
+    registry._handles["sess_a"] = handle_a
+    registry._handles["sess_b"] = handle_b
+    # Both sessions are deeply idle: _last_used set 1000s in the past,
+    # idle_timeout=300s — both land in to_release on the scan.
+    long_ago = time.monotonic() - 1000.0
+    registry._last_used["sess_a"] = long_ago
+    registry._last_used["sess_b"] = long_ago
+
+    reap_task = asyncio.create_task(registry._reap_idle_once(idle_timeout=300.0))
+    try:
+        await asyncio.wait_for(destroy_a_started.wait(), timeout=1.0)
+        # Reaper is now parked inside backend.destroy(handle_a). Warm-hit
+        # sess_b — _last_used["sess_b"] is bumped to "now", so sess_b is
+        # no longer idle by the time the reaper processes it.
+        returned = await registry.get_or_provision("sess_b")
+        assert returned is handle_b
+        destroy_a_continue.set()
+        await asyncio.wait_for(reap_task, timeout=1.0)
+    finally:
+        if not reap_task.done():
+            reap_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await reap_task
+
+    assert destroy_b_calls == [], (
+        "reaper destroyed sess_b's container despite a concurrent "
+        'get_or_provision freshening _last_used["sess_b"]. The reaper '
+        "must re-check idleness under the per-session lock before "
+        "calling release()."
+    )


### PR DESCRIPTION
## Summary

- **Bug:** The idle-TTL reaper's `_reap_idle_loop` builds a list of stale sessions (scan), then iterates calling `release()` under the per-session lock. But `get_or_provision`'s **warm path** (`registry.py:100-103`) takes no lock — it just bumps `_last_used[sid]` synchronously and returns the cached handle. A tool task that warm-hits a session between the scan and that session's release freshens `_last_used[sid]`, but the reaper acts on its **stale `to_release` snapshot** and destroys the container anyway. The reaper yields during `backend.destroy(handle_a)` for *earlier* sessions in the list, giving a real-time window for the warm-hit interleaving.
- **Impact:** A sandbox container can be destroyed mid-`exec` for an actively-used session. Same symptom class as `#566` ("No such container" on the first call after idle), but a residual race the `#566` lock fix could not cover — the lock serializes the cold path only; the warm path's freshening was invisible to the reaper.
- **Fix:** Re-check `_last_used[sid]` under the per-session lock before calling `release()`. Skip when the value is fresh (warm-hit happened during the reaper tick) or missing (`evict()` is lockless by design and may have popped it). Move the `idle_release` log inside the re-check so it reflects actual releases, not intentions.
- **Testability:** Extract `_reap_idle_once` from the `while True` loop body — a single-pass method the new test can `await` directly. Avoids timeout-based assertions on the negative outcome; the new test runs in ~370ms and is fully deterministic.
- Adds `test_reaper_skips_session_freshened_during_destroy_of_another`: parks the reaper inside `destroy(handle_a)` via an event, warm-hits `get_or_provision(\"sess_b\")`, releases the park, asserts `destroy_b_calls == []`. Pre-fix the assertion fails (handle_b destroyed); post-fix it passes.

## Test plan

- [x] mypy — clean (160 source files)
- [x] ruff check + format-check — clean
- [x] Unit suite — 1466 passed (one new test; existing 4 reaper tests untouched and still pass)
- [x] Code-reviewer agent independently verified discriminating power by removing the re-check and observing only the new test flip red
- [ ] CI runs e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)