### PR TITLE
fix(api/sse): clean up subscription when response never invoked

### DIFF
--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -36,6 +36,7 @@ from aios.api.deps import (
 from aios.api.sse import (
     SSE_PREFLIGHT_EXCEPTIONS,
     connection_discovery_stream,
+    make_sse_response,
     management_calls_stream,
     runtime_connector_calls_stream,
 )
@@ -331,7 +332,8 @@ async def get_connection_discovery(
             "could not establish LISTEN connection for connection-discovery stream",
             detail={"stream": "connection_discovery"},
         ) from exc
-    return EventSourceResponse(
+    return make_sse_response(
+        subscription,
         connection_discovery_stream(
             subscription,
             pool,
@@ -339,7 +341,6 @@ async def get_connection_discovery(
             account_id=account_id,
             connection_ids=auth_connection_ids,
         ),
-        ping=15,
     )
 
 
@@ -525,7 +526,8 @@ async def get_runtime_calls(
             "could not establish LISTEN connection for runtime-calls stream",
             detail={"stream": "runtime_calls"},
         ) from exc
-    return EventSourceResponse(
+    return make_sse_response(
+        subscription,
         runtime_connector_calls_stream(
             subscription,
             pool,
@@ -533,7 +535,6 @@ async def get_runtime_calls(
             account_id=account_id,
             connection_ids=auth_connection_ids,
         ),
-        ping=15,
     )
 
 
@@ -567,9 +568,9 @@ async def get_runtime_management_calls(
             "could not establish LISTEN connection for management-calls stream",
             detail={"stream": "management_calls"},
         ) from exc
-    return EventSourceResponse(
+    return make_sse_response(
+        subscription,
         management_calls_stream(subscription, pool, connector, account_id=account_id),
-        ping=15,
     )
 
 

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -24,7 +24,7 @@ from aios.api.deps import (
     PoolDep,
     ProcrastinateDep,
 )
-from aios.api.sse import SSE_PREFLIGHT_EXCEPTIONS, sse_event_stream
+from aios.api.sse import SSE_PREFLIGHT_EXCEPTIONS, make_sse_response, sse_event_stream
 from aios.db import queries
 from aios.db.listen import (
     SESSION_INTERRUPT_CHANNEL,
@@ -615,9 +615,9 @@ async def stream_events(
             "could not establish LISTEN connection for session events stream",
             detail={"stream": "session_events"},
         ) from exc
-    return EventSourceResponse(
+    return make_sse_response(
+        subscription,
         sse_event_stream(subscription, pool, session_id, after_seq=after_seq),
-        ping=15,
     )
 
 

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -28,10 +28,11 @@ let it propagate.
 from __future__ import annotations
 
 import json
+import weakref
 from typing import TYPE_CHECKING, Any
 
 import asyncpg
-from sse_starlette import ServerSentEvent
+from sse_starlette import EventSourceResponse, ServerSentEvent
 
 from aios.db import queries
 from aios.logging import get_logger
@@ -47,6 +48,43 @@ log = get_logger("aios.api.sse")
 # socket churn — these surface as a clean 503 from the SSE route handlers
 # (issue #376). Anything else bubbles as an unhandled 500.
 SSE_PREFLIGHT_EXCEPTIONS = (asyncpg.PostgresError, OSError)
+
+
+def make_sse_response(
+    subscription: ListenSubscription,
+    content: AsyncIterator[ServerSentEvent],
+    *,
+    ping: int = 15,
+) -> EventSourceResponse:
+    """Build an ``EventSourceResponse`` whose ``ListenSubscription`` is
+    cleaned up even on paths that never iterate the wrapped generator.
+
+    Normal lifecycle: ``__call__`` runs, the generator iterates, its
+    ``finally: subscription.terminate()`` fires on consumer disconnect
+    or stream end.
+
+    Pathological lifecycle (the bug this exists to close): the request
+    task is cancelled between FastAPI's ``response = await handler()``
+    and the subsequent ``await response(scope, receive, send)`` (e.g.
+    server shutdown striking mid-dispatch, or a fast client disconnect).
+    ``__call__`` never runs, the async generator is never started — and
+    Python's async-generator semantics guarantee that an
+    *unstarted* generator's ``finally`` block does NOT execute on
+    ``aclose`` or GC. Without a backup, the dedicated asyncpg
+    connection, its ``LISTEN``, and the SSE subscriber advisory lock
+    leak until TCP keepalive reaps the backend (~2h).
+
+    A ``weakref.finalize`` registers ``subscription.terminate`` to fire
+    when the response is GC'd, catching the un-invoked path. In the
+    normal path it fires *after* the generator's own ``finally`` has
+    already terminated the connection — ``terminate`` is idempotent at
+    asyncpg's transport layer (``transport.abort`` and the protocol's
+    ``_state`` transition both tolerate repeated calls), so the second
+    call is a no-op.
+    """
+    response = EventSourceResponse(content, ping=ping)
+    weakref.finalize(response, subscription.terminate)
+    return response
 
 
 def _event_to_sse(event_dict: dict[str, Any]) -> ServerSentEvent:

--- a/tests/unit/test_sse_response_cleanup.py
+++ b/tests/unit/test_sse_response_cleanup.py
@@ -1,0 +1,78 @@
+"""Unit coverage for SSE response cleanup on un-invoked dispatch.
+
+The four SSE route handlers in ``aios.api.routers`` open a dedicated
+asyncpg connection via ``open_listen_for_*`` BEFORE constructing
+``EventSourceResponse`` (issue #376 — preflight failures must surface
+as 503 before 200 OK lands on the wire). The wrapped generator owns
+``subscription.terminate()`` in ``finally`` for the normal path.
+
+That ``finally`` does NOT run if the wrapped async generator never
+starts. Python's async-generator semantics: ``aclose()`` and GC on an
+unstarted generator skip the body entirely — no ``finally``, no
+cleanup. The route handler creates the subscription before
+constructing the response, so if the request task is cancelled in
+FastAPI's dispatch gap (between ``response = await handler(request)``
+and the subsequent ``await response(scope, receive, send)``), the
+asyncpg connection, its ``LISTEN``, and the SSE subscriber advisory
+lock leak until TCP keepalive reaps the backend (~2h).
+
+``make_sse_response`` is the cleanup-aware response builder these
+routes use; this test pins the contract that it terminates the
+subscription on the un-invoked path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock
+
+import asyncpg
+from sse_starlette import ServerSentEvent
+
+from aios.api.sse import make_sse_response
+from aios.db.listen import ListenSubscription
+
+
+async def _unstarted_generator() -> AsyncIterator[ServerSentEvent]:
+    """An async generator that the test never iterates.
+
+    Mirrors the shape ``EventSourceResponse`` receives in production
+    (the various ``sse_*_stream`` generators from ``aios.api.sse``).
+    The ``finally`` clause is the production cleanup hook whose
+    absence-of-execution this test is about: an unstarted generator
+    skips it entirely.
+    """
+    try:
+        yield ServerSentEvent(data="unreachable", event="event")
+    finally:  # pragma: no cover — unreachable in the dispatch-gap path
+        pass
+
+
+def test_make_sse_response_terminates_subscription_when_response_uninvoked() -> None:
+    """If the EventSourceResponse is dropped without ``__call__`` ever
+    running (the FastAPI dispatch-gap cancellation case), the wrapped
+    generator never starts and its ``finally:
+    subscription.terminate()`` never runs. ``make_sse_response`` must
+    register a cleanup hook that terminates the subscription's asyncpg
+    connection when the response is GC'd on this path.
+    """
+    conn = MagicMock(spec=asyncpg.Connection)
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    subscription = ListenSubscription(queue=queue, _conn=conn)
+
+    # Build the response exactly as a route handler would, then drop it
+    # without invoking ``__call__``. Refcount → 0 → response is GC'd →
+    # the cleanup hook (if registered) fires.
+    response = make_sse_response(subscription, _unstarted_generator())
+    del response
+    gc.collect()
+
+    assert conn.terminate.called, (
+        "asyncpg connection leaked: EventSourceResponse was constructed "
+        "but never invoked, so the wrapped generator's finally never ran. "
+        "make_sse_response must register a finalizer that terminates "
+        "the subscription on the no-call path (otherwise the Postgres "
+        "backend lingers ~2h until TCP keepalive reaps it)."
+    )


### PR DESCRIPTION
## Summary

- **Bug:** The four SSE route handlers open a dedicated asyncpg connection via `open_listen_for_*` BEFORE constructing `EventSourceResponse` (preserves #376 — preflight failures must surface as 503 before 200 OK). The wrapped generator owns `subscription.terminate()` in `finally`. But if the request task is cancelled in FastAPI's dispatch gap — between `response = await handler(request)` and the subsequent `await response(scope, receive, send)` — the async generator is **never started**, and Python's async-generator semantics guarantee that an unstarted generator's `finally` block does NOT execute on `aclose` or GC. The asyncpg connection, its `LISTEN`, and the SSE subscriber advisory lock leak until TCP keepalive reaps the backend (~2h). Server restart with N concurrent in-flight SSE setups leaks up to N postgres backends.
- **Reachability:** narrow (server shutdown / fast client disconnect striking the µs-scale dispatch window) but real and persistent.
- **Fix:** `make_sse_response(subscription, content, *, ping=15)` in `api/sse.py` constructs the `EventSourceResponse` and registers `weakref.finalize(response, subscription.terminate)`. The finalizer fires on response GC — including the un-invoked path. Migrated the 4 SSE route sites to use the helper.
- **Idempotency:** `terminate()` is synchronous (see `db/listen.py` docstring) and idempotent at asyncpg's transport layer, so the duplicate call in the normal path (generator `finally` + finalizer) is a no-op.
- **Design alternative considered:** FastAPI `Depends`-with-yield (one mechanism via `AsyncExitStack`). Rejected after code review: (a) `Depends` teardown's cancellation guarantee only stabilized in [fastapi#14099](https://github.com/fastapi/fastapi/pull/14099) (Sep 2024), vs `weakref.finalize`'s stdlib-since-3.4 stability; (b) the refactor would scatter `SSE_PREFLIGHT_EXCEPTIONS` handling and per-stream `detail` payloads across 4 dependency functions; (c) the two cleanup hooks here operate on **disjoint object-graph states** (started-then-disconnect vs never-started), not duplicating a single guard.

## Test plan

- [x] mypy — clean (160 source files)
- [x] ruff check + format — clean
- [x] Unit suite — 1470 passed (new `test_make_sse_response_terminates_subscription_when_response_uninvoked` is red without the finalize, green with — confirmed)
- [x] Code-reviewer independently re-verified discriminating power (removed `weakref.finalize`, observed test failure on the right assertion) plus `Depends(yield)` cancellation behavior
- [ ] CI runs e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)