### PR TITLE
fix(sandbox/spec): stop GitProxy on non-clone errors in materialize

### DIFF
--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -200,50 +200,69 @@ async def _materialize_github_clones(
     proxy = GitProxy(repos_map)
     await proxy.start()
 
-    materialized: list[GithubRepositoryResourceEcho] = []
-    failures: list[tuple[GithubRepositoryResourceEcho, GithubCloneError]] = []
-    for echo, token in echo_tokens:
-        try:
-            cache_dir = await ensure_cache_clone(echo.url, token)
-            await ensure_session_working_tree(
-                session_id=session_id,
-                resource_id=echo.id,
-                repo_url=echo.url,
-                token=token,
-                cache_dir=cache_dir,
-                proxy_url=proxy.proxy_url(echo.url, host=WORKER_NETWORK_ALIAS),
-                git_user_name=echo.git_user_name,
-                git_user_email=echo.git_user_email,
-            )
-        except GithubCloneError as err:
-            failures.append((echo, err))
-            continue
-        materialized.append(echo)
+    # The per-repo except below catches only GithubCloneError. Anything
+    # else (OSError from a full disk during mkdir/rmtree in
+    # ensure_session_working_tree, CancelledError on step interrupt,
+    # asyncpg failure during the failure-event append) escapes — and
+    # the proxy is already running. Without this outer guard the
+    # uvicorn server, httpx client, bound TCP port, and in-memory
+    # token map leak for the worker's lifetime. Mirrors the cleanup
+    # pattern at build_spec_from_session below.
+    try:
+        materialized: list[GithubRepositoryResourceEcho] = []
+        failures: list[tuple[GithubRepositoryResourceEcho, GithubCloneError]] = []
+        for echo, token in echo_tokens:
+            try:
+                cache_dir = await ensure_cache_clone(echo.url, token)
+                await ensure_session_working_tree(
+                    session_id=session_id,
+                    resource_id=echo.id,
+                    repo_url=echo.url,
+                    token=token,
+                    cache_dir=cache_dir,
+                    proxy_url=proxy.proxy_url(echo.url, host=WORKER_NETWORK_ALIAS),
+                    git_user_name=echo.git_user_name,
+                    git_user_email=echo.git_user_email,
+                )
+            except GithubCloneError as err:
+                failures.append((echo, err))
+                continue
+            materialized.append(echo)
 
-    # Log + append failure events outside the conn block so we don't
-    # hold one connection while acquiring a second from the same pool.
-    if failures:
-        for failed_echo, failure in failures:
+        # Log + append failure events outside the conn block so we don't
+        # hold one connection while acquiring a second from the same pool.
+        if failures:
+            for failed_echo, failure in failures:
+                log.warning(
+                    "sandbox.github_clone_failed",
+                    session_id=session_id,
+                    resource_id=failed_echo.id,
+                    repo_url=failed_echo.url,
+                    error=str(failure),
+                )
+                await sessions_service.append_event(
+                    pool,
+                    session_id,
+                    "lifecycle",
+                    {
+                        "event": "github_clone_failed",
+                        "resource_id": failed_echo.id,
+                        "repo_url": failed_echo.url,
+                        "message": str(failure),
+                    },
+                    account_id=account_id,
+                )
+        return materialized, proxy
+    except BaseException:
+        try:
+            await proxy.stop()
+        except Exception as cleanup_err:
             log.warning(
-                "sandbox.github_clone_failed",
+                "sandbox.git_proxy_cleanup_after_materialize_failure",
                 session_id=session_id,
-                resource_id=failed_echo.id,
-                repo_url=failed_echo.url,
-                error=str(failure),
+                error=str(cleanup_err),
             )
-            await sessions_service.append_event(
-                pool,
-                session_id,
-                "lifecycle",
-                {
-                    "event": "github_clone_failed",
-                    "resource_id": failed_echo.id,
-                    "repo_url": failed_echo.url,
-                    "message": str(failure),
-                },
-                account_id=account_id,
-            )
-    return materialized, proxy
+        raise
 
 
 def _network_policy_from_config(env_config: EnvironmentConfig | None) -> NetworkPolicy:

--- a/tests/unit/test_sandbox_spec.py
+++ b/tests/unit/test_sandbox_spec.py
@@ -1,0 +1,98 @@
+"""Unit coverage for sandbox spec assembly cleanup paths.
+
+``_materialize_github_clones`` starts a :class:`GitProxy` at the top of
+the function (uvicorn server + httpx client + bound TCP port +
+in-memory token map). It then iterates the session's github echoes
+calling ``ensure_session_working_tree`` for each. The per-repo
+``except`` catches only :class:`GithubCloneError` — any other exception
+(``OSError`` from a full disk during ``mkdir``/``rmtree``;
+``asyncio.CancelledError`` on step interrupt; asyncpg failure during
+the failure-event append) escapes without ``proxy.stop()``, leaking
+the proxy for the worker's lifetime.
+
+The outer ``try/except BaseException`` in ``build_spec_from_session``
+wraps ``_assemble_plan`` (``spec.py:307-337``), not
+``_materialize_github_clones`` — it cannot catch a proxy already
+orphaned upstream of the plan-assembly call.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.models.github_repositories import GithubRepositoryResourceEcho
+from aios.sandbox.spec import _materialize_github_clones
+
+
+def _make_echo(repo_id: str = "ghr_test") -> GithubRepositoryResourceEcho:
+    now = datetime.now(tz=UTC)
+    return GithubRepositoryResourceEcho(
+        id=repo_id,
+        url="https://github.com/acme/foo.git",
+        mount_path="/workspace/foo",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_pool_with_conn() -> MagicMock:
+    """Build a pool whose ``acquire()`` yields a stub connection."""
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acquire_cm)
+    return pool
+
+
+async def test_materialize_github_clones_stops_proxy_on_non_clone_error() -> None:
+    """If ``ensure_session_working_tree`` raises a non-``GithubCloneError``
+    (``OSError`` from a full disk during mkdir/rmtree;
+    ``CancelledError`` on step interrupt), the :class:`GitProxy` started
+    at the top of ``_materialize_github_clones`` must be stopped before
+    the exception propagates. Otherwise the uvicorn server, httpx
+    client, bound TCP port, and in-memory token map leak for the
+    worker's lifetime — and every subsequent provision for this session
+    would orphan another one.
+    """
+    mock_proxy = MagicMock()
+    mock_proxy.start = AsyncMock()
+    mock_proxy.stop = AsyncMock()
+    mock_proxy.proxy_url = MagicMock(return_value="http://stub/proxy")
+
+    with (
+        patch("aios.sandbox.spec.GitProxy", return_value=mock_proxy),
+        patch(
+            "aios.sandbox.spec.queries.list_session_github_repo_echoes",
+            AsyncMock(return_value=[_make_echo()]),
+        ),
+        patch(
+            "aios.services.github_repositories.get_session_token",
+            AsyncMock(return_value="ghp_TEST"),
+        ),
+        patch(
+            "aios.sandbox.spec.ensure_cache_clone",
+            AsyncMock(return_value=Path("/tmp/cache")),
+        ),
+        patch(
+            "aios.sandbox.spec.ensure_session_working_tree",
+            AsyncMock(side_effect=OSError("disk full")),
+        ),
+        patch(
+            "aios.sandbox.spec.runtime.require_pool",
+            return_value=_make_pool_with_conn(),
+        ),
+        patch(
+            "aios.sandbox.spec.runtime.require_crypto_box",
+            return_value=MagicMock(),
+        ),
+        pytest.raises(OSError),
+    ):
+        await _materialize_github_clones("sess_x", account_id="acct_x")
+
+    mock_proxy.start.assert_awaited_once()
+    mock_proxy.stop.assert_awaited_once()


### PR DESCRIPTION
## Summary

- **Bug:** `_materialize_github_clones` (`src/aios/sandbox/spec.py:159-246`) starts a `GitProxy` at line 200-201 — a uvicorn server + httpx client + bound TCP port + in-memory token map — then iterates session github echoes calling `ensure_session_working_tree`. The per-repo `except` at line 218 catches **only** `GithubCloneError`. But `ensure_session_working_tree`'s `mkdir(parents=True, exist_ok=True)` (`github_clone.py:242`) and `shutil.rmtree(work_dir)` (`github_clone.py:245`) are unguarded — `OSError` (`ENOSPC`, `EPERM`) and `asyncio.CancelledError` escape as themselves, bypassing the catch. The outer `try/except BaseException` in `build_spec_from_session` wraps `_assemble_plan` only (`spec.py:307-337`), not `_materialize_github_clones` (called at line 292, upstream of the try block). The proxy is orphaned upstream of any cleanup.
- **Impact:** worker-lifetime leak per session-with-clone-failure: a bound TCP port, an in-memory token map, a uvicorn server, and an httpx client. Every retry orphans another set. Disk pressure or interrupted steps trigger the bug; both are realistic in production.
- **Fix:** wrap the post-`proxy.start()` body in `try/except BaseException` with `await proxy.stop()` cleanup, mirroring the existing pattern at `build_spec_from_session` (spec.py:307-337). The outer `BaseException` catches `CancelledError`/`KeyboardInterrupt` so cleanup runs on those paths too; the inner cleanup catches the narrower `Exception` so a `CancelledError` arriving during `proxy.stop` propagates rather than masking the original error.
- New regression test `test_materialize_github_clones_stops_proxy_on_non_clone_error`: patches `ensure_session_working_tree` to raise `OSError`, calls `_materialize_github_clones`, asserts `proxy.start` was awaited once AND `proxy.stop` was awaited once. Red without the fix (stop never called); green with.

## Test plan

- [x] mypy — clean (160 source files)
- [x] ruff check + format-check — clean
- [x] Unit suite — 1471 passed (one new test)
- [x] Code-reviewer independently verified discriminating power, confirmed exception scope (`BaseException` outer + `Exception` inner) is correct for preserving cancellation propagation, confirmed pattern mirrors the established cleanup idiom in the same file
- [ ] CI runs e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)