### PR TITLE
fix(mcp/pool): don't close MCP sessions freshened mid-tick

### DIFF
--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -251,7 +251,7 @@ class McpSessionPool:
                 # and lock-acquire (the get() returning None handles
                 # that).
                 entry = self._entries.get(key)
-                if entry is None or time.monotonic() - entry.last_used <= idle_timeout:
+                if entry is None or now - entry.last_used <= idle_timeout:
                     continue
                 del self._entries[key]
                 log.info("mcp_pool.idle_close", url=key[0])

--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -239,11 +239,23 @@ class McpSessionPool:
         """
         stale = [k for k, e in self._entries.items() if now - e.last_used > idle_timeout]
         for key in stale:
-            entry = self._entries.pop(key, None)
-            if entry is None:
-                continue
-            log.info("mcp_pool.idle_close", url=key[0])
-            await entry.close()
+            async with self._lock_for(key):
+                # Re-check under the lock: a concurrent get_or_connect
+                # warm hit (pool.py:193-196) bumps entry.last_used
+                # synchronously without acquiring the lock, so a freshen
+                # can race between the scan above and this iteration.
+                # Without the re-check, the reaper would close a session
+                # actively held by a caller — same shape as the
+                # SandboxRegistry reaper TOCTOU fixed in #654. evict()
+                # is also lockless and can drop the entry between scan
+                # and lock-acquire (the get() returning None handles
+                # that).
+                entry = self._entries.get(key)
+                if entry is None or time.monotonic() - entry.last_used <= idle_timeout:
+                    continue
+                del self._entries[key]
+                log.info("mcp_pool.idle_close", url=key[0])
+                await entry.close()
 
     async def _reap_idle_loop(self, idle_timeout: float, interval: float = 60.0) -> None:
         """Background loop: close pooled sessions idle > idle_timeout.

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -6,6 +6,7 @@ All MCP SDK and httpx interactions are mocked. No network calls.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -264,6 +265,91 @@ class TestMcpSessionPool:
         )
         assert key_cold not in pool._entries
         assert key_warm in pool._entries
+
+    async def test_idle_reaper_skips_entry_freshened_during_close_of_another(self) -> None:
+        """The reaper must not close an entry whose ``last_used`` was
+        freshened by a concurrent ``get_or_connect`` between the scan
+        and the actual close.
+
+        Scenario: two pool entries (``vault_a``, ``vault_b``) both land
+        in the ``stale`` snapshot. While the reaper is awaiting
+        ``entry_a.close()``, a tool task warm-hits
+        ``get_or_connect(url, vault_b, ...)``, which bumps
+        ``entry_b.last_used`` to ``time.monotonic()``. The reaper must
+        NOT proceed to close ``entry_b`` — the entry is no longer idle.
+
+        Pre-fix, the reaper acted on the stale ``stale`` snapshot
+        without re-checking ``last_used`` under the per-key lock, so it
+        would close an entry actively held by a caller. Same failure
+        class as the SandboxRegistry reaper TOCTOU fixed in #654 — the
+        warm path (pool.py:193-196) takes no lock.
+        """
+        park_a = asyncio.Event()
+        continue_a = asyncio.Event()
+        closed: list[tuple[str, str | None]] = []
+
+        s_a, s_b = _make_mock_session(), _make_mock_session()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
+        ):
+            pool = McpSessionPool()
+            url = "https://m.example/"
+            await pool.get_or_connect(url, "vault_a", {"Authorization": "Bearer A"})
+            await pool.get_or_connect(url, "vault_b", {"Authorization": "Bearer B"})
+            assert len(pool._entries) == 2
+
+            key_a = next(k for k, e in pool._entries.items() if e.session is s_a)
+            key_b = next(k for k, e in pool._entries.items() if e.session is s_b)
+            entry_a = pool._entries[key_a]
+            entry_b = pool._entries[key_b]
+            orig_close_a = entry_a.close
+            orig_close_b = entry_b.close
+
+            async def _close_a() -> None:
+                closed.append(key_a)
+                park_a.set()
+                await continue_a.wait()
+                await orig_close_a()
+
+            async def _close_b() -> None:
+                closed.append(key_b)
+                await orig_close_b()
+
+            entry_a.close = _close_a  # type: ignore[method-assign]
+            entry_b.close = _close_b  # type: ignore[method-assign]
+
+            # Both deeply idle so they both land in ``stale`` on the scan.
+            entry_a.last_used = 1000.0
+            entry_b.last_used = 1000.0
+
+            # Insertion order pins key_a as the first iteration → reaper
+            # parks inside _close_a, yielding control to the test.
+            reap_task = asyncio.create_task(pool._reap_idle_once(idle_timeout=300.0, now=9100.0))
+            try:
+                await asyncio.wait_for(park_a.wait(), timeout=1.0)
+                # Reaper is parked inside entry_a.close(). Warm-hit
+                # vault_b — last_used is bumped to time.monotonic(), so
+                # the re-check at entry_b's iteration sees a fresh value.
+                returned_session, _ = await pool.get_or_connect(
+                    url, "vault_b", {"Authorization": "Bearer B"}
+                )
+                assert returned_session is s_b
+                continue_a.set()
+                await asyncio.wait_for(reap_task, timeout=1.0)
+            finally:
+                if not reap_task.done():
+                    reap_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await reap_task
+
+        assert key_b not in closed, (
+            f"reaper closed vault_b's session despite a concurrent "
+            f"get_or_connect freshening entry_b.last_used. The reaper "
+            f"must re-check idleness under the per-key lock before "
+            f"calling close(). closed={closed!r}"
+        )
+        assert key_b in pool._entries, "vault_b's entry must remain in the pool"
 
     async def test_oauth_refresh_does_not_orphan_entry(self) -> None:
         """A token rotation on the same vault must reuse the pool key.

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import time
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -319,13 +320,18 @@ class TestMcpSessionPool:
             entry_a.close = _close_a  # type: ignore[method-assign]
             entry_b.close = _close_b  # type: ignore[method-assign]
 
-            # Both deeply idle so they both land in ``stale`` on the scan.
-            entry_a.last_used = 1000.0
-            entry_b.last_used = 1000.0
+            # Use a single reference time so the reaper's ``now`` snapshot
+            # and ``get_or_connect``'s warm-hit (which bumps last_used to
+            # the real ``time.monotonic()``) live in the same clock frame.
+            # The fake-time pattern at line 256-261 only works because
+            # that test doesn't exercise a live warm-hit.
+            t0 = time.monotonic()
+            entry_a.last_used = t0 - 1000.0
+            entry_b.last_used = t0 - 1000.0
 
             # Insertion order pins key_a as the first iteration → reaper
             # parks inside _close_a, yielding control to the test.
-            reap_task = asyncio.create_task(pool._reap_idle_once(idle_timeout=300.0, now=9100.0))
+            reap_task = asyncio.create_task(pool._reap_idle_once(idle_timeout=300.0, now=t0))
             try:
                 await asyncio.wait_for(park_a.wait(), timeout=1.0)
                 # Reaper is parked inside entry_a.close(). Warm-hit


### PR DESCRIPTION
## Summary

- **Bug:** `McpSessionPool._reap_idle_once` (`src/aios/mcp/pool.py:231-246`) builds `stale = [k for k, e in self._entries.items() if now - e.last_used > idle_timeout]`, then iterates calling `entry = self._entries.pop(key)` + `await entry.close()`. The `await entry.close()` yields. During that yield, a concurrent `get_or_connect` warm-hit (`pool.py:193-196`) bumps `entry.last_used` on a **different** entry still in the snapshot — the reaper proceeds to pop+close it anyway, closing a `ClientSession` a caller just took out and is about to use. The subsequent `await session.call_tool(...)` fails with a transport error, model-visible.
- **Same archetype as #654:** the warm path takes no lock (`pool.py:193-196` mirrors `registry.py:100-103`), `evict()` is also lockless, the reaper trusts a stale snapshot. Different component, identical bug shape.
- **Fix:** wrap each iteration of `_reap_idle_once` in `async with self._lock_for(key)`, re-check `entry.last_used` against `idle_timeout` before `del`+close. Structural mirror of #654's `SandboxRegistry._reap_idle_once` fix (commit `803f9a0`).
- New regression test `test_idle_reaper_skips_entry_freshened_during_close_of_another`: parks reaper inside `entry_a.close()`, warm-hits `get_or_connect(url, vault_b, ...)`, releases the park, asserts `vault_b` was NOT closed AND remains in the pool. Mirrors the precedent test from #654.

## Test plan

- [x] mypy — clean (160 source files)
- [x] ruff check + format-check — clean
- [x] Unit suite — 1472 passed (one new test; 18 total in `test_mcp_pool.py`)
- [x] Code-reviewer independently verified discriminating power, confirmed the dict-insertion-order assumption is language-spec stable, validated the lock-held-during-close trade-off mirrors the established #654 pattern
- [ ] CI runs e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)