### PR TITLE
fix(services/connections): serialize archive+attach via row lock

### DIFF
--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -169,8 +169,19 @@ async def attach_connection(
     active ``bindings`` row.
 
     Returns the freshly-read connection with its derived
-    ``session_id`` populated.  Race-safe via the partial-unique index
-    on ``bindings (connection_id) WHERE archived_at IS NULL``.
+    ``session_id`` populated.  Race-safe along two axes:
+
+    * Attach-vs-attach: the partial-unique index on
+      ``bindings (connection_id) WHERE archived_at IS NULL`` rejects
+      a second concurrent attach on the same connection.
+    * Attach-vs-archive: a ``SELECT … FOR UPDATE`` on the
+      ``connections`` row serializes attach against concurrent
+      ``archive_connection``, and the archived-state re-check under
+      that lock refuses to bind to an archived connection. Without
+      the lock + re-check, archive could commit between a stale
+      ``get_active_binding`` read and the binding insert, leaving the
+      binding on an archived connection (the ``bindings.connection_id``
+      FK accepts archived rows).
 
     Refuses binding to an archived session — the FK constraint accepts
     archived rows (no partial ``WHERE archived_at IS NULL`` on the FK),
@@ -181,25 +192,45 @@ async def attach_connection(
     only point where the operator can correct the action that caused
     the misconfiguration.
     """
-    # pool.acquire() yields an autocommit connection; the INSERT commits
-    # before the NOTIFY fires.  Do NOT wrap these in
-    # ``async with conn.transaction()`` — see db/listen.py for why
-    # NOTIFY-after-commit is load-bearing for subscribers.
+    # The data ops run inside ``conn.transaction()`` with a ``SELECT
+    # FOR UPDATE`` row lock on ``connections``. This serializes attach
+    # against concurrent ``archive_connection``, which also takes the
+    # same lock — without it, archive can read 'no active binding',
+    # commit the archive, and the binding lands on an archived
+    # connection (the ``bindings.connection_id`` FK accepts archived
+    # rows). NOTIFY fires AFTER the transaction commits — see
+    # ``db/listen.py`` on why NOTIFY-after-commit is load-bearing.
     async with pool.acquire() as conn:
-        session = await queries.get_session(conn, session_id, account_id=account_id)
-        if session.archived_at is not None:
-            raise ConflictError(
-                f"session {session_id} is archived; cannot attach a connection to it",
-                detail={"id": connection_id, "session_id": session_id},
+        async with conn.transaction():
+            locked = await conn.fetchrow(
+                "SELECT archived_at FROM connections WHERE id = $1 AND account_id = $2 FOR UPDATE",
+                connection_id,
+                account_id,
             )
-        await queries.insert_binding(
-            conn,
-            connection_id=connection_id,
-            mode="single_session",
-            session_id=session_id,
-            account_id=account_id,
-        )
-        connection = await queries.get_connection(conn, connection_id, account_id=account_id)
+            if locked is None:
+                raise NotFoundError(
+                    f"connection {connection_id} not found",
+                    detail={"id": connection_id},
+                )
+            if locked["archived_at"] is not None:
+                raise ConflictError(
+                    f"connection {connection_id} is archived; cannot attach a session to it",
+                    detail={"id": connection_id},
+                )
+            session = await queries.get_session(conn, session_id, account_id=account_id)
+            if session.archived_at is not None:
+                raise ConflictError(
+                    f"session {session_id} is archived; cannot attach a connection to it",
+                    detail={"id": connection_id, "session_id": session_id},
+                )
+            await queries.insert_binding(
+                conn,
+                connection_id=connection_id,
+                mode="single_session",
+                session_id=session_id,
+                account_id=account_id,
+            )
+            connection = await queries.get_connection(conn, connection_id, account_id=account_id)
         await queries.notify_connection_change(
             conn,
             connector=connection.connector,
@@ -232,8 +263,30 @@ async def configure_per_chat(
 ) -> Connection:
     """Bind the connection in per_chat mode by inserting an active
     ``bindings`` row pointing at the session template.
+
+    Wraps the data ops in ``conn.transaction()`` with ``SELECT FOR
+    UPDATE`` on the connections row so a concurrent
+    ``archive_connection`` cannot complete between the archived-check
+    and the ``insert_binding`` — that race would otherwise leave an
+    archived connection with an active binding (the
+    ``bindings.connection_id`` FK accepts archived rows).
     """
-    async with pool.acquire() as conn:
+    async with pool.acquire() as conn, conn.transaction():
+        locked = await conn.fetchrow(
+            "SELECT archived_at FROM connections WHERE id = $1 AND account_id = $2 FOR UPDATE",
+            connection_id,
+            account_id,
+        )
+        if locked is None:
+            raise NotFoundError(
+                f"connection {connection_id} not found",
+                detail={"id": connection_id},
+            )
+        if locked["archived_at"] is not None:
+            raise ConflictError(
+                f"connection {connection_id} is archived; cannot configure",
+                detail={"id": connection_id},
+            )
         await queries.insert_binding(
             conn,
             connection_id=connection_id,
@@ -413,21 +466,48 @@ async def archive_connection(
     live single_session, or from stranding the template a per_chat
     binding spawns from.
     """
-    # pool.acquire() yields an autocommit connection; the archive UPDATE
-    # commits before the NOTIFY fires.  See ``attach_connection`` and
-    # ``services/management_calls.py`` for the same pattern + rationale.
+    # The data ops run inside ``conn.transaction()`` with a ``SELECT
+    # FOR UPDATE`` row lock on ``connections``. This serializes archive
+    # against concurrent ``attach_connection`` / ``configure_per_chat``,
+    # which both also take ``FOR UPDATE`` on the same row — without the
+    # lock, archive's ``get_active_binding`` could return None while a
+    # racing attach committed a binding, leaving the archive UPDATE to
+    # produce ``archived_at IS NOT NULL`` + active binding (the
+    # ``bindings.connection_id`` FK accepts archived rows).
+    # NOTIFY fires AFTER the transaction commits — see ``db/listen.py``
+    # on why NOTIFY-after-commit is load-bearing for subscribers. The
+    # nested ``with`` is required: the inner txn must exit BEFORE the
+    # NOTIFY runs, while the outer pool.acquire stays open.
     async with pool.acquire() as conn:
-        connection = await queries.get_connection(conn, connection_id, account_id=account_id)
-        if connection.archived_at is not None:
-            return await queries.archive_connection(conn, connection_id, account_id=account_id)
-        binding = await queries.get_active_binding(conn, connection_id, account_id=account_id)
-        if binding is not None:
-            raise ConflictError(
-                f"connection {connection_id} is in {binding.mode} mode; "
-                f"detach or unconfigure before archiving",
-                detail={"id": connection_id, "mode": binding.mode},
+        async with conn.transaction():
+            locked = await conn.fetchrow(
+                "SELECT id FROM connections WHERE id = $1 AND account_id = $2 FOR UPDATE",
+                connection_id,
+                account_id,
             )
-        archived = await queries.archive_connection(conn, connection_id, account_id=account_id)
+            if locked is None:
+                raise NotFoundError(
+                    f"connection {connection_id} not found",
+                    detail={"id": connection_id},
+                )
+            connection = await queries.get_connection(conn, connection_id, account_id=account_id)
+            if connection.archived_at is not None:
+                # Preserve pre-fix surface: double-archive raised
+                # ``NotFoundError`` (pre-fix called
+                # ``queries.archive_connection`` whose WHERE
+                # archived_at IS NULL did not match).
+                raise NotFoundError(
+                    f"connection {connection_id} not found or already archived",
+                    detail={"id": connection_id},
+                )
+            binding = await queries.get_active_binding(conn, connection_id, account_id=account_id)
+            if binding is not None:
+                raise ConflictError(
+                    f"connection {connection_id} is in {binding.mode} mode; "
+                    f"detach or unconfigure before archiving",
+                    detail={"id": connection_id, "mode": binding.mode},
+                )
+            archived = await queries.archive_connection(conn, connection_id, account_id=account_id)
         await queries.notify_connection_change(
             conn,
             connector=archived.connector,

--- a/tests/integration/test_archive_connection_attach_race.py
+++ b/tests/integration/test_archive_connection_attach_race.py
@@ -1,0 +1,196 @@
+"""Integration test: ``archive_connection`` and ``attach_connection``
+must not race into an invariant-violating end state (archived
+connection row + active binding row).
+
+Pre-fix, ``services.archive_connection`` ran three autocommit
+statements on a single pool connection — ``get_connection``,
+``get_active_binding``, ``queries.archive_connection`` — with no
+transaction or row lock. Concurrent ``attach_connection`` (also
+autocommit) could ``insert_binding`` between archive's
+``get_active_binding`` (returning ``None``) and the
+``archive_connection`` UPDATE. End state:
+``connections.archived_at IS NOT NULL`` AND an active row in
+``bindings``. The ``bindings.connection_id`` FK accepts archived rows
+(no partial ``WHERE archived_at IS NULL``), so the invariant violation
+persists silently until the resolver's DETACH safety net (#526/#541)
+fires on the next inbound.
+
+The test forces the race deterministically by patching
+``queries.get_active_binding`` with a wrapper that sleeps after the
+real query returns. Pre-fix the sleep happens between autocommit
+statements; concurrent ``attach_connection`` commits during the sleep
+window and the archive UPDATE then runs on stale state. Post-fix the
+sleep happens inside archive's transaction while it holds ``SELECT
+FOR UPDATE`` on the ``connections`` row, so the concurrent attach
+blocks behind the lock until archive commits, then re-reads
+``archived_at`` and raises :class:`ConflictError` — invariant
+preserved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import patch
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import ConflictError
+from aios.services import agents as agents_service
+from aios.services import connections as connections_service
+from aios.services import environments as environments_service
+
+pytestmark = pytest.mark.integration
+
+# Sleep duration inside the patched ``get_active_binding``. Long enough
+# that a concurrent autocommit ``insert_binding`` from
+# ``attach_connection`` reliably commits during the window pre-fix.
+# Post-fix the sleep is held inside archive's locked transaction and
+# attach blocks behind the row lock for the duration.
+_RACE_WINDOW_S = 0.2
+
+
+@pytest.fixture
+async def pool_acc_a_with_connection_and_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, connection_id, session_id)`` for acc_a."""
+    pool = await create_pool(migrated_db_url, min_size=2, max_size=8)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_root', NULL,       TRUE,  'tenant-root'),
+                       ('acc_a',    'acc_root', FALSE, 'tenant-a')
+                """
+            )
+
+        agent_a = await agents_service.create_agent(
+            pool,
+            account_id="acc_a",
+            name="a-agent",
+            model="openrouter/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env_a = await environments_service.create_environment(
+            pool, account_id="acc_a", name="a-env"
+        )
+        async with pool.acquire() as conn:
+            session = await queries.insert_session(
+                conn,
+                account_id="acc_a",
+                agent_id=agent_a.id,
+                environment_id=env_a.id,
+                agent_version=agent_a.version,
+                title=None,
+                metadata={},
+            )
+            connection = await queries.insert_connection(
+                conn,
+                account_id="acc_a",
+                connector="signal",
+                external_account_id="+15550001",
+                metadata={},
+            )
+        yield pool, connection.id, session.id
+    finally:
+        await pool.close()
+
+
+class TestArchiveConnectionAttachRace:
+    async def test_concurrent_archive_and_attach_preserves_invariant(
+        self,
+        pool_acc_a_with_connection_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """Concurrent ``archive_connection`` + ``attach_connection`` must
+        end in an invariant-preserving state.
+
+        Acceptable end states:
+
+        * attach wins → connection NOT archived, active binding exists;
+          archive raised ``ConflictError`` (saw the binding under lock).
+        * archive wins → connection archived, NO active binding;
+          attach raised ``ConflictError`` (saw archived under lock).
+
+        Both ``archived AND active binding`` is the bug — silent
+        invariant violation, reachable pre-fix because archive's reads
+        and write were unlocked autocommit statements.
+        """
+        pool, connection_id, session_id = pool_acc_a_with_connection_and_session
+
+        original_get_active_binding = queries.get_active_binding
+
+        async def slow_get_active_binding(
+            conn: asyncpg.Connection[Any], connection_id_arg: str, *, account_id: str
+        ) -> Any:
+            """Pause after the real query returns to widen archive's
+            race window. Pre-fix this just sleeps between autocommit
+            statements; post-fix it sleeps inside the locked txn."""
+            result = await original_get_active_binding(
+                conn, connection_id_arg, account_id=account_id
+            )
+            await asyncio.sleep(_RACE_WINDOW_S)
+            return result
+
+        archive_result: BaseException | None = None
+        attach_result: BaseException | None = None
+
+        async def _archive() -> None:
+            nonlocal archive_result
+            try:
+                await connections_service.archive_connection(
+                    pool, connection_id, account_id="acc_a"
+                )
+            except BaseException as exc:
+                archive_result = exc
+
+        async def _attach() -> None:
+            nonlocal attach_result
+            try:
+                await connections_service.attach_connection(
+                    pool, connection_id, account_id="acc_a", session_id=session_id
+                )
+            except BaseException as exc:
+                attach_result = exc
+
+        with patch.object(queries, "get_active_binding", slow_get_active_binding):
+            archive_task = asyncio.create_task(_archive())
+            # Give archive time to reach the slow get_active_binding
+            # — pre-fix it's into the race window; post-fix it has
+            # already acquired the FOR UPDATE lock.
+            await asyncio.sleep(_RACE_WINDOW_S / 4)
+            attach_task = asyncio.create_task(_attach())
+            await asyncio.wait_for(
+                asyncio.gather(archive_task, attach_task, return_exceptions=True),
+                timeout=_RACE_WINDOW_S * 10,
+            )
+
+        async with pool.acquire() as conn:
+            connection = await queries.get_connection(conn, connection_id, account_id="acc_a")
+            binding = await queries.get_active_binding(conn, connection_id, account_id="acc_a")
+
+        invariant_violated = connection.archived_at is not None and binding is not None
+        assert not invariant_violated, (
+            f"archive_connection + attach_connection race produced "
+            f"archived={connection.archived_at is not None} AND "
+            f"active_binding={binding is not None} — silent invariant "
+            f"violation. archive_result={archive_result!r} "
+            f"attach_result={attach_result!r}"
+        )
+        # Both operations must have either succeeded cleanly or raised
+        # ConflictError. Any other exception indicates the fix is
+        # malformed (e.g., deadlock, FK violation, etc.).
+        for label, result in (("archive", archive_result), ("attach", attach_result)):
+            assert result is None or isinstance(result, ConflictError), (
+                f"{label} raised an unexpected exception: {result!r}"
+            )


### PR DESCRIPTION
## Summary

- **Bug:** Silent invariant violation reachable via concurrent operator actions. `archive_connection`, `attach_connection`, and `configure_per_chat` ran reads-and-writes as separate autocommit statements with no transaction or row lock. A concurrent `attach_connection` (or `configure_per_chat`) could `insert_binding` between archive's `get_active_binding` (returning None) and the archive UPDATE → end state: `connections.archived_at IS NOT NULL` AND an active `bindings` row (the FK accepts archived rows). The resolver's DETACH safety net (#526/#541) eventually cleans up, but bind-time is where the operator should learn of the misconfiguration.
- **Fix:** Wrap data ops in `conn.transaction()` with `SELECT FOR UPDATE` on the `connections` row as the first statement in all three functions. `attach_connection` / `configure_per_chat` additionally re-check `archived_at` under the lock (pre-fix didn't even check this — relied on FK existence alone). NOTIFY stays OUTSIDE the transaction per the load-bearing NOTIFY-after-commit invariant (`db/listen.py`).
- **Test:** patches `queries.get_active_binding` with a wrapper that sleeps 200ms after returning, widening archive's race window. Starts archive and attach as concurrent tasks. Asserts the post-state invariant. Verified red pre-fix (via `git stash`, FAILED with `archived=True AND active_binding=True`), green post-fix.

## Follow-up flagged by code-review (deferred per "one bug per PR")

`bind_chat_to_session` (line 341, in this same file) has the **same race shape** against `archive_connection` — `get_connection` validates, then `insert_chat_session` (FK to connections accepts archived rows). Concurrent archive between read and write produces the analogous invariant violation. Same fix pattern applies. Reviewer recommended deferring to a follow-up; will file a separate issue.

## Test plan

- [x] mypy — clean (160 source files)
- [x] ruff check + format-check — clean
- [x] Unit suite — 1472 passed
- [x] Integration suite — 93 passed (one new race test)
- [x] TDD: verified the new test goes red without the fix (`git stash` cycle), green with
- [x] Code-reviewer agent independently verified: symmetric FOR UPDATE is sufficient, no deadlock cycles, NOTIFY semantics preserved, test fidelity good, found and flagged the `bind_chat_to_session` sibling site
- [ ] CI runs e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)