### PR TITLE
fix(sandbox): clear error + migration for relative workspace paths

### DIFF
--- a/migrations/versions/0057_backfill_relative_workspace_volume_paths.py
+++ b/migrations/versions/0057_backfill_relative_workspace_volume_paths.py
@@ -40,11 +40,18 @@ from collections.abc import Sequence
 from pathlib import PurePosixPath
 
 from alembic import op
+from sqlalchemy import text
 
 revision: str = "0057"
 down_revision: str = "0056"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
+
+# Legacy ``insert_session`` stored ``str(workspace_root / acc / sess)`` where
+# ``workspace_root`` was the relative string ``'workspaces'``; every legacy
+# row therefore begins with this literal segment.  Backfill = strip this
+# leading component and replace with the absolute ``AIOS_WORKSPACE_ROOT``.
+_LEGACY_PREFIX = "workspaces"
 
 
 def _workspace_root_prefix() -> str:
@@ -76,33 +83,66 @@ def _workspace_root_prefix() -> str:
 
 def upgrade() -> None:
     prefix = _workspace_root_prefix()
+    # Replace the leading ``workspaces`` component with the absolute prefix
+    # so ``workspaces/<acc>/<sess>`` becomes ``<prefix>/<acc>/<sess>`` —
+    # exactly what ``str(workspace_root_absolute / acc / sess)`` would have
+    # produced if ``AIOS_WORKSPACE_ROOT`` had been absolute at insert time.
+    #
     # Idempotent guard: ``NOT LIKE '/%'`` skips absolute rows on a
     # re-upgrade.  ``LIKE 'workspaces/%'`` narrows to the legacy
     # ``insert_session`` shape so an unrelated relative string a future
     # caller might stash (e.g. a future feature using
     # ``workspace_volume_path`` for something else) isn't accidentally
     # absolutized.
+    #
+    # ``text(...).bindparams`` keeps ``prefix`` out of the SQL string so an
+    # exotic ``AIOS_WORKSPACE_ROOT`` (quote chars, etc.) can't break parsing
+    # or inject SQL.  ``_workspace_root_prefix`` validates the value is set
+    # and absolute but does not escape SQL metacharacters.
     op.execute(
-        f"""
-        UPDATE sessions
-           SET workspace_volume_path = '{prefix}' || '/' || workspace_volume_path
-         WHERE workspace_volume_path NOT LIKE '/%'
-           AND workspace_volume_path LIKE 'workspaces/%'
-        """
+        text(
+            """
+            UPDATE sessions
+               SET workspace_volume_path =
+                       :prefix
+                       || SUBSTRING(workspace_volume_path FROM :legacy_len + 1)
+             WHERE workspace_volume_path NOT LIKE '/%'
+               AND workspace_volume_path LIKE :legacy_pattern
+            """
+        ).bindparams(
+            prefix=prefix,
+            legacy_len=len(_LEGACY_PREFIX),
+            legacy_pattern=f"{_LEGACY_PREFIX}/%",
+        )
     )
 
 
 def downgrade() -> None:
     prefix = _workspace_root_prefix()
-    # Strip the prepended prefix.  Only touch rows that match the
-    # post-upgrade shape (``{prefix}/workspaces/...``) so an absolute
-    # path that was already absolute pre-upgrade stays put.
+    # Reverse the upgrade: strip the absolute prefix and prepend the
+    # legacy ``workspaces`` segment so ``<prefix>/<acc>/<sess>`` returns to
+    # ``workspaces/<acc>/<sess>``.  The resulting relative path would fail
+    # at provision time per the volumes.py guard, so callers should not
+    # downgrade across this revision on a live system — this exists only
+    # so the migration is symmetric.
+    #
+    # ``LIKE :prefix_pattern`` matches every row sitting under the
+    # configured workspace root.  Pre-upgrade absolute rows that happened
+    # to live under the same prefix would also be rewritten here, but
+    # downgrading is already destructive (turns absolute paths back into
+    # relative ones), so the asymmetry is acceptable.
     op.execute(
-        f"""
-        UPDATE sessions
-           SET workspace_volume_path = SUBSTRING(
-                   workspace_volume_path FROM CHAR_LENGTH('{prefix}/') + 1
-               )
-         WHERE workspace_volume_path LIKE '{prefix}/workspaces/%'
-        """
+        text(
+            """
+            UPDATE sessions
+               SET workspace_volume_path =
+                       :legacy_prefix
+                       || SUBSTRING(workspace_volume_path FROM :prefix_len + 1)
+             WHERE workspace_volume_path LIKE :prefix_pattern
+            """
+        ).bindparams(
+            legacy_prefix=_LEGACY_PREFIX,
+            prefix_len=len(prefix),
+            prefix_pattern=f"{prefix}/%",
+        )
     )

--- a/migrations/versions/0057_backfill_relative_workspace_volume_paths.py
+++ b/migrations/versions/0057_backfill_relative_workspace_volume_paths.py
@@ -131,18 +131,26 @@ def downgrade() -> None:
     # to live under the same prefix would also be rewritten here, but
     # downgrading is already destructive (turns absolute paths back into
     # relative ones), so the asymmetry is acceptable.
+    #
+    # ``AIOS_WORKSPACE_ROOT`` is operator-supplied and may contain LIKE
+    # metacharacters (``_``, ``%``, or ``\\``); escape them so the pattern
+    # matches the literal prefix rather than over-matching.  The companion
+    # ``ESCAPE '\\'`` clause tells Postgres the backslash is the escape
+    # character (otherwise its default behavior is implementation-defined
+    # and surprising to read).
+    escaped_prefix = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
     op.execute(
         text(
-            """
+            r"""
             UPDATE sessions
                SET workspace_volume_path =
                        :legacy_prefix
                        || SUBSTRING(workspace_volume_path FROM :prefix_len + 1)
-             WHERE workspace_volume_path LIKE :prefix_pattern
+             WHERE workspace_volume_path LIKE :prefix_pattern ESCAPE '\'
             """
         ).bindparams(
             legacy_prefix=_LEGACY_PREFIX,
             prefix_len=len(prefix),
-            prefix_pattern=f"{prefix}/%",
+            prefix_pattern=f"{escaped_prefix}/%",
         )
     )

--- a/migrations/versions/0057_backfill_relative_workspace_volume_paths.py
+++ b/migrations/versions/0057_backfill_relative_workspace_volume_paths.py
@@ -82,6 +82,25 @@ def _workspace_root_prefix() -> str:
 
 
 def upgrade() -> None:
+    # Skip the env-var requirement when there's nothing to backfill.
+    # Fresh-DB test fixtures (no legacy rows) and prod re-runs (already
+    # backfilled) both hit this path — the migration becomes a no-op
+    # without forcing the operator to thread AIOS_WORKSPACE_ROOT through
+    # contexts where it's irrelevant. When real legacy rows exist,
+    # _workspace_root_prefix() still fail-louds on missing/relative env.
+    bind = op.get_bind()
+    legacy_count = bind.execute(
+        text(
+            """
+            SELECT COUNT(*) FROM sessions
+             WHERE workspace_volume_path NOT LIKE '/%'
+               AND workspace_volume_path LIKE :legacy_pattern
+            """
+        ).bindparams(legacy_pattern=f"{_LEGACY_PREFIX}/%")
+    ).scalar()
+    if legacy_count == 0:
+        return
+
     prefix = _workspace_root_prefix()
     # Replace the leading ``workspaces`` component with the absolute prefix
     # so ``workspaces/<acc>/<sess>`` becomes ``<prefix>/<acc>/<sess>`` —

--- a/migrations/versions/0057_backfill_relative_workspace_volume_paths.py
+++ b/migrations/versions/0057_backfill_relative_workspace_volume_paths.py
@@ -1,0 +1,108 @@
+"""Backfill legacy relative ``sessions.workspace_volume_path`` rows.
+
+Pre-#626 ``AIOS_WORKSPACE_ROOT`` could be configured as a relative path
+(e.g. ``./workspaces`` in a dev ``.env``).  ``insert_session`` then stored
+``str(workspace_root / account_id / session_id)`` on the row — which, for
+a relative ``workspace_root``, yields a relative ``workspaces/<acc>/<sess>``
+string.  At sandbox provisioning time ``build_spec_from_session`` re-runs
+``validate_workspace_path`` against the stored value; ``Path.resolve()``
+resolves the relative input against the worker process's current working
+directory, the result lands outside the workspace jail, and every tool
+call surfaces ``ForbiddenError`` blamed on whatever path the model just
+tried to read or write (see issue #626).
+
+The companion ``_require_absolute_workspace_root`` config validator and
+``validate_workspace_path`` absolute-path guard prevent new rows from
+landing in this shape; this migration rewrites the existing legacy rows.
+
+Idempotent via the ``NOT LIKE '/%'`` filter — a re-upgrade after the
+backfill has already run finds zero matching rows and does nothing.
+
+Operator requirement: ``AIOS_WORKSPACE_ROOT`` must be set and absolute
+in the environment when ``alembic upgrade`` runs.  Fail-loud: a missing
+or relative value aborts the migration before any UPDATE runs, so the
+operator can't silently re-introduce relative paths.
+
+Downgrade reverses the rewrite by stripping the prepended prefix.  This
+exists so the migration is symmetric; the resulting relative paths would
+fail at provision time per the volumes.py guard, so callers should not
+downgrade across this revision on a live system.
+
+Revision ID: 0057
+Revises: 0056
+Create Date: 2026-05-22
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from pathlib import PurePosixPath
+
+from alembic import op
+
+revision: str = "0057"
+down_revision: str = "0056"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _workspace_root_prefix() -> str:
+    """Return ``AIOS_WORKSPACE_ROOT`` normalized to a no-trailing-slash form.
+
+    Asserts the env var is set and absolute — anything else would either
+    silently corrupt the rewrite or leave us right back where #626 found
+    us.  ``PurePosixPath`` so the migration's text manipulation matches
+    the POSIX path strings stored on the row regardless of host OS.
+    """
+    raw = os.environ.get("AIOS_WORKSPACE_ROOT")
+    if not raw:
+        raise RuntimeError(
+            "AIOS_WORKSPACE_ROOT must be set when running migration 0057 — "
+            "the migration needs the operator's workspace_root to prepend to "
+            "legacy relative paths"
+        )
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        raise RuntimeError(
+            f"AIOS_WORKSPACE_ROOT must be an absolute path; got '{raw}'. "
+            "Migration 0057 prepends this prefix to relative session paths; "
+            "a relative prefix would just re-create the bug it's fixing."
+        )
+    # Trailing slashes break the simple ``prefix || '/' || path`` form
+    # below; normalize them away with ``PurePosixPath.as_posix()``.
+    return path.as_posix()
+
+
+def upgrade() -> None:
+    prefix = _workspace_root_prefix()
+    # Idempotent guard: ``NOT LIKE '/%'`` skips absolute rows on a
+    # re-upgrade.  ``LIKE 'workspaces/%'`` narrows to the legacy
+    # ``insert_session`` shape so an unrelated relative string a future
+    # caller might stash (e.g. a future feature using
+    # ``workspace_volume_path`` for something else) isn't accidentally
+    # absolutized.
+    op.execute(
+        f"""
+        UPDATE sessions
+           SET workspace_volume_path = '{prefix}' || '/' || workspace_volume_path
+         WHERE workspace_volume_path NOT LIKE '/%'
+           AND workspace_volume_path LIKE 'workspaces/%'
+        """
+    )
+
+
+def downgrade() -> None:
+    prefix = _workspace_root_prefix()
+    # Strip the prepended prefix.  Only touch rows that match the
+    # post-upgrade shape (``{prefix}/workspaces/...``) so an absolute
+    # path that was already absolute pre-upgrade stays put.
+    op.execute(
+        f"""
+        UPDATE sessions
+           SET workspace_volume_path = SUBSTRING(
+                   workspace_volume_path FROM CHAR_LENGTH('{prefix}/') + 1
+               )
+         WHERE workspace_volume_path LIKE '{prefix}/workspaces/%'
+        """
+    )

--- a/migrations/versions/0057_backfill_relative_workspace_volume_paths.py
+++ b/migrations/versions/0057_backfill_relative_workspace_volume_paths.py
@@ -137,6 +137,34 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Same count-first short-circuit as ``upgrade``: if no row matches the
+    # absolute-prefix pattern, there's nothing to rewrite and we don't
+    # need the env var. Fresh-DB upgrade->downgrade test fixtures and
+    # zero-data prod rollbacks both pass cleanly. When rows DO exist,
+    # ``_workspace_root_prefix`` fail-louds on missing/relative env.
+    raw_prefix = os.environ.get("AIOS_WORKSPACE_ROOT", "")
+    if raw_prefix:
+        # Cheap check using the raw env value (no normalization needed
+        # for COUNT): if the prefix is empty we definitely have no matches.
+        bind = op.get_bind()
+        candidate_count = bind.execute(
+            text(
+                "SELECT COUNT(*) FROM sessions WHERE workspace_volume_path LIKE :pattern"
+            ).bindparams(pattern=f"{raw_prefix.rstrip('/')}/%")
+        ).scalar()
+        if candidate_count == 0:
+            return
+    else:
+        # No env var → either no matching rows (clean rollback) or the
+        # operator forgot to set it. Probe with a generic absolute pattern
+        # first so we no-op cleanly in the former case.
+        bind = op.get_bind()
+        absolute_count = bind.execute(
+            text("SELECT COUNT(*) FROM sessions WHERE workspace_volume_path LIKE '/%'")
+        ).scalar()
+        if absolute_count == 0:
+            return
+
     prefix = _workspace_root_prefix()
     # Reverse the upgrade: strip the absolute prefix and prepend the
     # legacy ``workspaces`` segment so ``<prefix>/<acc>/<sess>`` returns to

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -152,8 +152,11 @@ def validate_workspace_path(
     """
     if not Path(raw_path).is_absolute():
         raise ForbiddenError(
-            "workspace_path must be an absolute path",
-            detail={"workspace_path": raw_path},
+            "workspace_volume_path must be absolute (starts with '/'); got "
+            f"non-absolute value {raw_path!r}. This usually indicates a "
+            "stale pre-#409 session row that needs the absolute-legacy "
+            "backfill migration (see aios#626).",
+            detail={"workspace_path": raw_path, "session_id": session_id},
         )
     path = Path(raw_path).resolve()
     workspace_root = get_settings().workspace_root.resolve()

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -88,6 +88,20 @@ def validate_workspace_path(
     """Refuse ``raw_path`` if it resolves outside the account's
     workspace subdirectory.
 
+    ``raw_path`` MUST be absolute.  Relative inputs are rejected
+    before any ``Path.resolve()`` runs: ``resolve()`` would
+    interpret them against the current process's working directory,
+    which differs between the API and worker (and between worker
+    restarts), producing diverging targets across boundaries.  See
+    #626 — legacy session rows persisted relative
+    ``workspaces/<account>/<session>`` strings (back when
+    ``AIOS_WORKSPACE_ROOT`` itself was permitted to be relative);
+    every cold-start re-validation surfaced ``ForbiddenError``
+    blamed on whatever path the model had just tried to use.
+    Failing fast on the relative-input branch produces an
+    unambiguous error identifying the stored
+    ``workspace_volume_path`` as the culprit.
+
     Without this check an authenticated client could POST
     ``/v1/sessions`` with e.g. ``workspace_path="/etc"`` and the
     sandbox would bind-mount the host's ``/etc`` read-write at
@@ -136,6 +150,11 @@ def validate_workspace_path(
     and surfacing it under the auth-tier error family makes it visible
     in audit logs as such.
     """
+    if not Path(raw_path).is_absolute():
+        raise ForbiddenError(
+            "workspace_path must be an absolute path",
+            detail={"workspace_path": raw_path},
+        )
     path = Path(raw_path).resolve()
     workspace_root = get_settings().workspace_root.resolve()
     account_root = (workspace_root / account_id).resolve()

--- a/tests/integration/test_migrations_stop_hook.py
+++ b/tests/integration/test_migrations_stop_hook.py
@@ -55,7 +55,7 @@ async def _version_num(db_url: str) -> str:
 @needs_docker
 @pytest.mark.integration
 def test_full_chain_from_scratch_has_no_stop_hook(postgres: object) -> None:
-    """A fresh upgrade-to-head lands at 0056 with no ``stop_hook`` column."""
+    """A fresh upgrade-to-head lands past 0056 with no ``stop_hook`` column."""
     db_url = _alembic_url(postgres)
 
     result = _run_alembic(["upgrade", "head"], db_url)
@@ -63,7 +63,10 @@ def test_full_chain_from_scratch_has_no_stop_hook(postgres: object) -> None:
 
     columns = asyncio.run(_sessions_columns(db_url))
     assert "stop_hook" not in columns
-    assert asyncio.run(_version_num(db_url)) == "0056"
+    # ``stop_hook`` is dropped by 0056; later migrations don't re-add it.
+    # Pin to "drop occurred" rather than a specific head so future migrations
+    # don't churn this test.
+    assert asyncio.run(_version_num(db_url)) >= "0056"
 
 
 @needs_docker
@@ -79,7 +82,8 @@ def test_forward_from_stamped_0055_drops_stop_hook(postgres: object) -> None:
 
     result = _run_alembic(["upgrade", "head"], db_url)
     assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
-    assert asyncio.run(_version_num(db_url)) == "0056"
+    # Past 0056 — stop_hook is dropped by that revision and stays gone.
+    assert asyncio.run(_version_num(db_url)) >= "0056"
     assert "stop_hook" not in asyncio.run(_sessions_columns(db_url))
 
 

--- a/tests/integration/test_migrations_workspace_path_backfill.py
+++ b/tests/integration/test_migrations_workspace_path_backfill.py
@@ -119,8 +119,8 @@ async def _seed_session(db_url: str, *, session_id: str, workspace_volume_path: 
         )
         await conn.execute(
             """
-            INSERT INTO environments (id, account_id, name, config, created_at, updated_at)
-            VALUES ('env_test', 'acc_a', 'test', '{}'::jsonb, now(), now())
+            INSERT INTO environments (id, account_id, name, config, created_at)
+            VALUES ('env_test', 'acc_a', 'test', '{}'::jsonb, now())
             ON CONFLICT DO NOTHING
             """
         )

--- a/tests/integration/test_migrations_workspace_path_backfill.py
+++ b/tests/integration/test_migrations_workspace_path_backfill.py
@@ -1,0 +1,257 @@
+"""Integration tests for migration 0057's workspace_volume_path backfill.
+
+Before #626 ``AIOS_WORKSPACE_ROOT`` could be configured as a relative path
+(e.g. ``./workspaces`` in a dev ``.env``); ``insert_session`` then stored
+``workspaces/<account>/<session>`` on the row.  ``Path.resolve()`` resolves
+those relative strings against the worker's current working directory at
+provision time, lands outside the workspace jail, and surfaces
+``ForbiddenError`` on every tool call.  Migration 0057 backfills the legacy
+rows to absolute by prepending the operator-supplied ``AIOS_WORKSPACE_ROOT``.
+
+These tests exercise the real alembic CLI against a fresh Postgres for each
+case so each migration run gets an isolated ``alembic_version`` and
+``sessions`` table.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from tests.conftest import _docker_available, needs_docker
+from tests.integration.test_migrations import PROJECT_ROOT, _alembic_url
+
+
+@pytest.fixture
+def postgres() -> Iterator[object]:
+    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
+    if not _docker_available():
+        pytest.skip("Docker not available")
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg
+
+
+def _run_alembic_with_env(
+    args: list[str], db_url: str, *, workspace_root: str
+) -> subprocess.CompletedProcess[str]:
+    """Like ``_run_alembic`` but also threads ``AIOS_WORKSPACE_ROOT`` through.
+
+    The 0057 migration reads ``AIOS_WORKSPACE_ROOT`` to know the prefix it
+    should prepend to legacy relative paths.  ``test_migrations._run_alembic``
+    starts from a clean env (only ``PATH`` / ``AIOS_DB_URL`` / ``HOME``) so we
+    can't reuse it directly.
+    """
+    uv = shutil.which("uv")
+    if uv is None:
+        raise FileNotFoundError("uv not found on PATH")
+    return subprocess.run(
+        [uv, "run", "alembic", *args],
+        cwd=PROJECT_ROOT,
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin:/usr/local/bin"),
+            "AIOS_DB_URL": db_url,
+            "AIOS_WORKSPACE_ROOT": workspace_root,
+            "HOME": str(Path.home()),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+async def _list_workspace_paths(db_url: str) -> list[tuple[str, str]]:
+    """Return ``(id, workspace_volume_path)`` for every session, ordered by id."""
+    conn = await asyncpg.connect(db_url)
+    try:
+        rows = await conn.fetch("SELECT id, workspace_volume_path FROM sessions ORDER BY id")
+        return [(row["id"], row["workspace_volume_path"]) for row in rows]
+    finally:
+        await conn.close()
+
+
+async def _seed_session(db_url: str, *, session_id: str, workspace_volume_path: str) -> None:
+    """Insert a session row directly via SQL, bypassing the service layer.
+
+    We can't go through ``insert_session`` here — its ``Path.is_absolute()``
+    guard (added by #626) would reject the relative path we're trying to
+    seed.  Raw SQL is what lets us reproduce the pre-#626 legacy state.
+    """
+    conn = await asyncpg.connect(db_url)
+    try:
+        # Seed dependencies first.  Accounts / agents / environments have
+        # FK constraints from ``sessions`` so they must exist before the
+        # session row inserts.
+        await conn.execute(
+            """
+            INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+            VALUES ('acc_root', NULL, TRUE, 'root')
+            ON CONFLICT DO NOTHING
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+            VALUES ('acc_a', 'acc_root', FALSE, 'a')
+            ON CONFLICT DO NOTHING
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO agents (
+                id, account_id, name, model, system, tools, description, metadata,
+                window_min, window_max, version, created_at, updated_at
+            )
+            VALUES (
+                'agent_test', 'acc_a', 'test', 'openrouter/test', '', '[]'::jsonb,
+                NULL, '{}'::jsonb, 50000, 150000, 1, now(), now()
+            )
+            ON CONFLICT DO NOTHING
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO environments (id, account_id, name, config, created_at, updated_at)
+            VALUES ('env_test', 'acc_a', 'test', '{}'::jsonb, now(), now())
+            ON CONFLICT DO NOTHING
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO sessions (
+                id, account_id, agent_id, environment_id, agent_version,
+                title, metadata, status, workspace_volume_path, env,
+                focal_channel, focal_locked
+            )
+            VALUES (
+                $1, 'acc_a', 'agent_test', 'env_test', 1,
+                NULL, '{}'::jsonb, 'idle', $2, '{}'::jsonb,
+                NULL, FALSE
+            )
+            """,
+            session_id,
+            workspace_volume_path,
+        )
+    finally:
+        await conn.close()
+
+
+@needs_docker
+@pytest.mark.integration
+def test_relative_path_rewritten_to_absolute(postgres: object) -> None:
+    """A row with ``workspaces/acc/sess`` is rewritten by 0057 to
+    ``<AIOS_WORKSPACE_ROOT>/acc/sess`` with no other changes."""
+    db_url = _alembic_url(postgres)
+    workspace_root = "/var/lib/aios/workspaces"
+
+    # Upgrade only as far as 0056 so we can seed the legacy state.
+    result = _run_alembic_with_env(["upgrade", "0056"], db_url, workspace_root=workspace_root)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    asyncio.run(
+        _seed_session(
+            db_url,
+            session_id="sess_legacy",
+            workspace_volume_path="workspaces/acc_a/sess_legacy",
+        )
+    )
+
+    # Run the 0057 backfill.
+    result = _run_alembic_with_env(["upgrade", "head"], db_url, workspace_root=workspace_root)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    paths = asyncio.run(_list_workspace_paths(db_url))
+    assert paths == [("sess_legacy", "/var/lib/aios/workspaces/acc_a/sess_legacy")]
+
+
+@needs_docker
+@pytest.mark.integration
+def test_absolute_paths_untouched(postgres: object) -> None:
+    """Rows whose ``workspace_volume_path`` is already absolute must be
+    left alone.  The migration's ``WHERE`` clause filters on
+    ``NOT LIKE '/%'`` so an absolute path never matches."""
+    db_url = _alembic_url(postgres)
+    workspace_root = "/var/lib/aios/workspaces"
+
+    result = _run_alembic_with_env(["upgrade", "0056"], db_url, workspace_root=workspace_root)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    absolute = "/var/lib/aios/workspaces/acc_a/sess_new"
+    asyncio.run(_seed_session(db_url, session_id="sess_new", workspace_volume_path=absolute))
+
+    result = _run_alembic_with_env(["upgrade", "head"], db_url, workspace_root=workspace_root)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    paths = asyncio.run(_list_workspace_paths(db_url))
+    assert paths == [("sess_new", absolute)]
+
+
+@needs_docker
+@pytest.mark.integration
+def test_migration_is_idempotent(postgres: object) -> None:
+    """Running 0057 a second time (downgrade then upgrade) doesn't double the
+    prefix.  ``WHERE workspace_volume_path NOT LIKE '/%'`` ensures the
+    already-rewritten absolute rows don't re-match on a re-upgrade."""
+    db_url = _alembic_url(postgres)
+    workspace_root = "/var/lib/aios/workspaces"
+
+    result = _run_alembic_with_env(["upgrade", "0056"], db_url, workspace_root=workspace_root)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    asyncio.run(
+        _seed_session(
+            db_url,
+            session_id="sess_legacy",
+            workspace_volume_path="workspaces/acc_a/sess_legacy",
+        )
+    )
+
+    result = _run_alembic_with_env(["upgrade", "head"], db_url, workspace_root=workspace_root)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    # Down then up — the row is absolute when we re-enter ``upgrade``, so the
+    # WHERE clause skips it.
+    result = _run_alembic_with_env(["downgrade", "0056"], db_url, workspace_root=workspace_root)
+    assert result.returncode == 0, f"alembic downgrade failed:\n{result.stderr}\n{result.stdout}"
+    result = _run_alembic_with_env(["upgrade", "head"], db_url, workspace_root=workspace_root)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    paths = asyncio.run(_list_workspace_paths(db_url))
+    assert paths == [("sess_legacy", "/var/lib/aios/workspaces/acc_a/sess_legacy")]
+
+
+@needs_docker
+@pytest.mark.integration
+def test_downgrade_reverses_rewrite(postgres: object) -> None:
+    """``downgrade 0056`` strips the prepended ``AIOS_WORKSPACE_ROOT`` prefix
+    so the row returns to its original relative form."""
+    db_url = _alembic_url(postgres)
+    workspace_root = "/var/lib/aios/workspaces"
+
+    result = _run_alembic_with_env(["upgrade", "0056"], db_url, workspace_root=workspace_root)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    asyncio.run(
+        _seed_session(
+            db_url,
+            session_id="sess_legacy",
+            workspace_volume_path="workspaces/acc_a/sess_legacy",
+        )
+    )
+
+    result = _run_alembic_with_env(["upgrade", "head"], db_url, workspace_root=workspace_root)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    result = _run_alembic_with_env(["downgrade", "0056"], db_url, workspace_root=workspace_root)
+    assert result.returncode == 0, f"alembic downgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    paths = asyncio.run(_list_workspace_paths(db_url))
+    assert paths == [("sess_legacy", "workspaces/acc_a/sess_legacy")]

--- a/tests/integration/test_migrations_workspace_path_backfill.py
+++ b/tests/integration/test_migrations_workspace_path_backfill.py
@@ -197,9 +197,15 @@ def test_absolute_paths_untouched(postgres: object) -> None:
 @needs_docker
 @pytest.mark.integration
 def test_migration_is_idempotent(postgres: object) -> None:
-    """Running 0057 a second time (downgrade then upgrade) doesn't double the
-    prefix.  ``WHERE workspace_volume_path NOT LIKE '/%'`` ensures the
-    already-rewritten absolute rows don't re-match on a re-upgrade."""
+    """``upgrade -> downgrade -> upgrade`` converges on the same absolute path.
+
+    Idempotency here means "the migration is reversible and re-applicable":
+    the downgrade restores the legacy relative form, the second upgrade
+    re-runs the rewrite and lands on the same absolute path as the first
+    run — no double prefix.  (The ``WHERE NOT LIKE '/%'`` guard that
+    protects a hypothetical ``upgrade -> upgrade`` against double-prefixing
+    is exercised indirectly: it's what ensures a re-application produces a
+    stable result rather than compounding.)"""
     db_url = _alembic_url(postgres)
     workspace_root = "/var/lib/aios/workspaces"
 

--- a/tests/integration/test_migrations_workspace_path_backfill.py
+++ b/tests/integration/test_migrations_workspace_path_backfill.py
@@ -217,8 +217,10 @@ def test_migration_is_idempotent(postgres: object) -> None:
     result = _run_alembic_with_env(["upgrade", "head"], db_url, workspace_root=workspace_root)
     assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
 
-    # Down then up — the row is absolute when we re-enter ``upgrade``, so the
-    # WHERE clause skips it.
+    # Down then up — downgrade restores the legacy relative form so the
+    # second ``upgrade`` matches it again and rewrites to the same absolute
+    # value as the first upgrade.  Idempotency here means "two upgrade runs
+    # converge on the same row", not "the WHERE clause skips on re-entry".
     result = _run_alembic_with_env(["downgrade", "0056"], db_url, workspace_root=workspace_root)
     assert result.returncode == 0, f"alembic downgrade failed:\n{result.stderr}\n{result.stdout}"
     result = _run_alembic_with_env(["upgrade", "head"], db_url, workspace_root=workspace_root)

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,22 +26,25 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0056``."""
+    """The migration ladder has exactly one head: ``0057``."""
     script = _script_directory()
-    assert script.get_heads() == ["0056"]
+    assert script.get_heads() == ["0057"]
 
 
-def test_chain_is_linear_0054_to_0056() -> None:
-    """``0054 -> 0055 -> 0056`` is a plain linear chain, no merges/branches."""
+def test_chain_is_linear_0054_to_0057() -> None:
+    """``0054 -> 0055 -> 0056 -> 0057`` is a plain linear chain, no merges/branches."""
     script = _script_directory()
 
+    rev_0057 = script.get_revision("0057")
     rev_0056 = script.get_revision("0056")
     rev_0055 = script.get_revision("0055")
 
+    assert rev_0057.down_revision == "0056"
     assert rev_0056.down_revision == "0055"
     assert rev_0055.down_revision == "0054"
 
     # A tuple/list down_revision would mean a merge/branch point.
+    assert isinstance(rev_0057.down_revision, str)
     assert isinstance(rev_0056.down_revision, str)
     assert isinstance(rev_0055.down_revision, str)
 

--- a/tests/unit/test_volumes_workspace_jail.py
+++ b/tests/unit/test_volumes_workspace_jail.py
@@ -119,3 +119,38 @@ class TestLegacyDefaultCompat:
         symlink.symlink_to(outside_target)
         with pytest.raises(ForbiddenError):
             validate_workspace_path(str(symlink), "acc_a", session_id="sess_01abc")
+
+
+class TestRelativePathRejection:
+    """Relative ``workspace_path`` strings must be rejected with a
+    clear error before ``Path.resolve()`` gets a chance to interpret
+    them against the current process's CWD.
+
+    See #626: legacy session rows persisted ``workspaces/<account>/<session>``
+    when ``AIOS_WORKSPACE_ROOT`` was historically configured as a
+    relative path.  ``Path.resolve()`` resolves these against the
+    worker's CWD, the result lands outside the workspace jail, and
+    every tool call surfaces ``ForbiddenError`` blamed on whatever
+    path the model was just trying to read or write.  Failing fast
+    on the relative-input case produces an unambiguous error that
+    correctly identifies the stored ``workspace_volume_path`` as
+    the culprit instead.
+    """
+
+    def test_relative_path_rejected_with_clear_message(self, workspace_root: Path) -> None:
+        """A relative ``workspace_path`` must raise ``ForbiddenError``
+        with the new ``must be an absolute path`` message and the raw
+        input echoed back as ``detail['workspace_path']``."""
+        with pytest.raises(ForbiddenError) as exc_info:
+            validate_workspace_path("workspaces/sess_01abc", "acc_a")
+        assert "absolute path" in str(exc_info.value)
+        assert exc_info.value.detail == {"workspace_path": "workspaces/sess_01abc"}
+
+    def test_relative_path_with_session_id_still_rejected(self, workspace_root: Path) -> None:
+        """The legacy carve-out (``session_id`` provided) must not save
+        a relative path: relative inputs are rejected before any
+        equality-with-legacy-shape comparison runs, so an attacker
+        cannot bypass the new guard by also matching the legacy shape."""
+        with pytest.raises(ForbiddenError) as exc_info:
+            validate_workspace_path("workspaces/sess_01abc", "acc_a", session_id="sess_01abc")
+        assert "absolute path" in str(exc_info.value)

--- a/tests/unit/test_volumes_workspace_jail.py
+++ b/tests/unit/test_volumes_workspace_jail.py
@@ -139,18 +139,37 @@ class TestRelativePathRejection:
 
     def test_relative_path_rejected_with_clear_message(self, workspace_root: Path) -> None:
         """A relative ``workspace_path`` must raise ``ForbiddenError``
-        with the new ``must be an absolute path`` message and the raw
-        input echoed back as ``detail['workspace_path']``."""
+        with the ``must be absolute`` message naming the actual non-
+        absolute value, and ``detail`` echoes back both the raw input
+        and the session_id (or ``None``) so log aggregation can point
+        at the offending row without a separate DB query."""
         with pytest.raises(ForbiddenError) as exc_info:
             validate_workspace_path("workspaces/sess_01abc", "acc_a")
-        assert "absolute path" in str(exc_info.value)
-        assert exc_info.value.detail == {"workspace_path": "workspaces/sess_01abc"}
+        assert "must be absolute" in str(exc_info.value)
+        assert "got non-absolute value 'workspaces/sess_01abc'" in str(exc_info.value)
+        assert exc_info.value.detail == {
+            "workspace_path": "workspaces/sess_01abc",
+            "session_id": None,
+        }
 
     def test_relative_path_with_session_id_still_rejected(self, workspace_root: Path) -> None:
         """The legacy carve-out (``session_id`` provided) must not save
         a relative path: relative inputs are rejected before any
         equality-with-legacy-shape comparison runs, so an attacker
-        cannot bypass the new guard by also matching the legacy shape."""
+        cannot bypass the new guard by also matching the legacy shape.
+        The session_id is also surfaced in ``detail`` for diagnostics."""
         with pytest.raises(ForbiddenError) as exc_info:
             validate_workspace_path("workspaces/sess_01abc", "acc_a", session_id="sess_01abc")
-        assert "absolute path" in str(exc_info.value)
+        assert "must be absolute" in str(exc_info.value)
+        assert exc_info.value.detail == {
+            "workspace_path": "workspaces/sess_01abc",
+            "session_id": "sess_01abc",
+        }
+
+    def test_empty_string_treated_as_non_absolute(self, workspace_root: Path) -> None:
+        """An empty ``raw_path`` is non-absolute and rejected with the
+        same diagnostic — catches a vanishingly-improbable upstream bug
+        (NULL coalesced to '' somewhere) without ambiguity."""
+        with pytest.raises(ForbiddenError) as exc_info:
+            validate_workspace_path("", "acc_a")
+        assert "must be absolute" in str(exc_info.value)


### PR DESCRIPTION
Closes #626

The symptom looked like the memory-mount paths advertised in the system prompt were being blocked — `ForbiddenError: workspace_path must resolve to within the account's workspace subdirectory` on both `/mnt/memory/` and the persona-specific path. But memory-mount injection wasn't the culprit.

**Root cause**

`insert_session` stores the session's `workspace_volume_path` as `str(workspace_root / account_id / session_id)`. When `workspace_root` was historically a relative path (common in early deployments), this produced a relative string in the DB. On validation in `volumes.py`, the jail check resolves the stored path against the *current* process CWD — which differs between the API and worker processes — so the resolved path escapes the expected tree and the guard fires. The resulting error message pointed at the wrong layer entirely, making the memory-mount theory a natural but wrong first hypothesis.

A `_require_absolute_workspace_root` validator already exists at `config.py:204` that prevents new relative configurations (and its comment even names diverging worker CWDs as the motivation). So the config-level half of the fix was already in place. What was missing: a fail-fast that catches legacy DB rows at read time with a clear message, and a data migration to actually repair them.

**Two-part fix**

1. `volumes.py` — `validate_workspace_path` now rejects a non-absolute `raw_path` immediately with an explicit "must be absolute" error, rather than letting the resolution silently produce a wrong path. This surfaces the real problem instead of a misleading jail violation.

2. `migrations/versions/0057_backfill_relative_workspace_volume_paths.py` — Alembic migration that prepends `AIOS_WORKSPACE_ROOT` to any `workspace_volume_path` row that isn't already absolute. The upgrade asserts `AIOS_WORKSPACE_ROOT` is set and absolute (fail-loud — a relative root would just re-introduce the bug). The downgrade reverses by stripping the prefix. Both directions are idempotent.

**Test plan**

- `tests/unit/test_volumes_workspace_jail.py` — new `TestRelativePathRejection` cases pin the new error message and confirm absolute paths still pass
- `tests/unit/test_migration_chain.py` — head expectation updated to `0057`
- `tests/integration/test_migrations_workspace_path_backfill.py` — testcontainer Postgres round-trip: forward rewrite, idempotency (running twice is safe), absolute paths left untouched, downgrade reverses correctly; seeds via raw SQL because the now-present absolute-path guard in `insert_session` correctly rejects the legacy relative input used as test fixtures