### PR TITLE
fix(sandbox/volumes): fail-fast on relative workspace_volume_path

### DIFF
--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -136,6 +136,14 @@ def validate_workspace_path(
     and surfacing it under the auth-tier error family makes it visible
     in audit logs as such.
     """
+    if not raw_path.startswith("/"):
+        raise ForbiddenError(
+            "workspace_volume_path must be absolute (starts with '/'); got "
+            f"non-absolute value {raw_path!r}. This usually indicates a "
+            "stale pre-#409 session row that needs the absolute-legacy "
+            "backfill migration (see aios#626).",
+            detail={"workspace_path": raw_path, "session_id": session_id},
+        )
     path = Path(raw_path).resolve()
     workspace_root = get_settings().workspace_root.resolve()
     account_root = (workspace_root / account_id).resolve()

--- a/tests/unit/test_volumes_workspace_jail.py
+++ b/tests/unit/test_volumes_workspace_jail.py
@@ -119,3 +119,57 @@ class TestLegacyDefaultCompat:
         symlink.symlink_to(outside_target)
         with pytest.raises(ForbiddenError):
             validate_workspace_path(str(symlink), "acc_a", session_id="sess_01abc")
+
+
+class TestNonAbsoluteGuard:
+    """Fail-fast guard: any non-absolute ``raw_path`` is rejected with a
+    diagnostic message before ``Path.resolve()`` runs.
+
+    Without this guard a stale pre-#409 session row whose
+    ``workspace_volume_path`` was persisted as a relative path (e.g.
+    ``workspaces/sess_X``) would be silently resolved against the
+    worker's CWD by ``Path.resolve()``, yielding a confusing
+    "must resolve to within the account's workspace subdirectory" error
+    that hides the real cause — a row that needs the absolute-legacy
+    backfill migration. See aios#668 (and #626 for the broader
+    legacy-row story)."""
+
+    def test_relative_path_raises_with_diagnostic_message(self, workspace_root: Path) -> None:
+        with pytest.raises(ForbiddenError) as excinfo:
+            validate_workspace_path("workspaces/sess_X", "acc_Y")
+        assert "must be absolute" in excinfo.value.message
+        assert "got non-absolute value 'workspaces/sess_X'" in excinfo.value.message
+
+    def test_relative_path_detail_includes_session_id_and_raw_path(
+        self, workspace_root: Path
+    ) -> None:
+        with pytest.raises(ForbiddenError) as excinfo:
+            validate_workspace_path("relative/path", "acc_Y", session_id="sess_ABC")
+        assert excinfo.value.detail == {
+            "workspace_path": "relative/path",
+            "session_id": "sess_ABC",
+        }
+
+    def test_relative_path_detail_with_no_session_id_is_none(self, workspace_root: Path) -> None:
+        with pytest.raises(ForbiddenError) as excinfo:
+            validate_workspace_path("relative/path", "acc_Y")
+        assert excinfo.value.detail == {
+            "workspace_path": "relative/path",
+            "session_id": None,
+        }
+
+    def test_empty_string_treated_as_non_absolute(self, workspace_root: Path) -> None:
+        with pytest.raises(ForbiddenError) as excinfo:
+            validate_workspace_path("", "acc_Y")
+        assert "must be absolute" in excinfo.value.message
+
+    def test_guard_fires_before_other_checks(self, workspace_root: Path) -> None:
+        """The non-absolute guard short-circuits — the caller sees the
+        "must be absolute" diagnostic, not the generic
+        "must resolve to within..." message produced by the downstream
+        jail check. This documents the ordering invariant: a relative
+        ``raw_path`` is never silently resolved against CWD."""
+        with pytest.raises(ForbiddenError) as excinfo:
+            validate_workspace_path("some/relative/path", "acc_Y")
+        assert "must be absolute" in excinfo.value.message
+        assert "must resolve to within" not in excinfo.value.message


### PR DESCRIPTION
Closes #668

Before this fix, a relative `workspace_volume_path` in the session row (as produced by the 47 pre-#409 sessions identified in #626) would silently resolve against the container's cwd via `Path.resolve()`, then fail the account-subtree check with a generic `ForbiddenError("workspace_path must resolve to within the account's workspace subdirectory")`. That message pointed at the wrong problem, and the adjacent fixes in #628 and #637 looked superficially applicable, making the root cause hours to isolate.

The fix is a 7-line guard at the top of `validate_workspace_path` that rejects non-absolute paths immediately with a message that names the offending value, identifies the session, and points to the #626 backfill migration. Uses `startswith("/")` rather than `Path.is_absolute()` since aios is Linux-only and the explicit string check is unambiguous.

Five new tests cover: diagnostic message content, `detail` dict with and without `session_id`, empty-string input, and the ordering invariant (guard fires before the account-subtree check). Mutation testing confirmed the tests aren't vacuous — removing the `not` from the guard condition causes them to fail.

No API surface change, no migration, no codegen.