### PR TITLE
refactor(api/sse): drop dead post-fetch allowlist re-check

### DIFF
--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -244,10 +244,6 @@ async def runtime_connector_calls_stream(
             for call in pending:
                 if call["tool_call_id"] in emitted:
                     continue
-                # Defensive post-fetch check — keeps the emit honest even
-                # if a future refactor changes the partition logic.
-                if allowlist is not None and connection_id not in allowlist:
-                    continue
                 emitted.add(call["tool_call_id"])
                 call["connection_id"] = connection_id
                 yield ServerSentEvent(data=json.dumps(call), event="call")


### PR DESCRIPTION
## Summary

- Delete a 4-line post-fetch defensive re-check in `runtime_connector_calls_stream` that evaluated the same boolean as the pre-fetch check 14 lines above with provably-identical inputs. `allowlist` is closed over from the generator argument and immutable; `connection_id` is loop-local and never reassigned between the two sites. The deleted check could never reject a call that the earlier check accepted.
- The inline comment self-identified the pattern as defending against hypothetical future refactors ("Defensive post-fetch check — keeps the emit honest even if a future refactor changes the partition logic") — the canonical "no belt-and-suspenders" anti-pattern called out in `CLAUDE.md`. Defend against a partition-logic change when it lands, not preemptively.
- Pure deletion (4 lines, no test changes); behavior preserved.

## Test plan

- [x] `uv run mypy src` — clean
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1472 passed
- [ ] CI e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)