### PR TITLE
ci: parallelize jobs + shard e2e + xdist on docker shard

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -271,7 +271,13 @@ jobs:
         # (e.g. ``bin/tool`` advanced on master between this PR's base
         # and the last ``build-sandbox.yml`` publish) would silently
         # produce a misroute later in the E2E run.
+        #
+        # ``continue-on-error`` lets the next step fall back to a local
+        # build when this fails — GHCR outage, ``:smoked`` not yet
+        # published, fork-PR token cannot read a private package.
+        id: pull_sandbox
         if: matrix.shard == 'docker' && needs.detect.outputs.sandbox_changed == 'false'
+        continue-on-error: true
         run: |
           docker pull ghcr.io/eumemic/aios-sandbox:smoked
           docker tag ghcr.io/eumemic/aios-sandbox:smoked aios-sandbox:ci
@@ -297,8 +303,18 @@ jobs:
         # later. ``set -euo pipefail`` is the workflow default but
         # the explicit ``|| exit 1`` after the ``docker run`` makes
         # the failure mode obvious in the log.
-        if: matrix.shard == 'docker' && needs.detect.outputs.sandbox_changed == 'true'
+        #
+        # Fires when the Dockerfile/bin/tool inputs changed (so the pull
+        # path was skipped) OR when the pull path attempted and failed.
+        if: |
+          matrix.shard == 'docker' && (
+            needs.detect.outputs.sandbox_changed == 'true' ||
+            steps.pull_sandbox.outcome == 'failure'
+          )
         run: |
+          if [[ "${{ steps.pull_sandbox.outcome }}" == "failure" ]]; then
+            echo "::warning::GHCR pull failed; falling back to local sandbox build"
+          fi
           docker build -t aios-sandbox:ci -f docker/Dockerfile.sandbox .
           docker image inspect aios-sandbox:ci --format 'image registered: {{.Id}}'
           docker run --rm aios-sandbox:ci which tool || {

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_checks: ${{ steps.filter.outputs.run_checks }}
+      sandbox_changed: ${{ steps.filter.outputs.sandbox_changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,10 +44,12 @@ jobs:
 
           # First push to a new branch, force-push from a non-fast-forward,
           # or any case where `before` is the all-zeros SHA: be conservative
-          # and run the full pipeline.
+          # and run the full pipeline AND rebuild the sandbox image (since
+          # we cannot tell whether its inputs changed).
           if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
-            echo "No usable base ref — running checks."
+            echo "No usable base ref — running checks and rebuilding sandbox."
             echo "run_checks=true" >> "$GITHUB_OUTPUT"
+            echo "sandbox_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -64,6 +67,19 @@ jobs:
           else
             echo "Docs/config-only changes — skipping checks."
             echo "run_checks=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Sandbox image inputs: the Dockerfile itself and the ``bin/tool``
+          # binary it COPYs in.  When neither changed, the ``e2e`` job can
+          # pull ``ghcr.io/eumemic/aios-sandbox:smoked`` (published by
+          # ``build-sandbox.yml`` after its smoke test passes) instead of
+          # rebuilding from scratch — saves ~29 s per run.
+          if echo "$changed" | grep -qE '^docker/Dockerfile\.sandbox$|^bin/tool$'; then
+            echo "Sandbox inputs changed — rebuilding image."
+            echo "sandbox_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Sandbox inputs unchanged — will pull pre-built image."
+            echo "sandbox_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
   # The four check jobs below run in parallel.  Splitting them off the
@@ -179,6 +195,13 @@ jobs:
     if: needs.detect.outputs.run_checks == 'true'
     runs-on: ubuntu-latest
 
+    # Required to ``docker pull`` the sandbox image from GHCR when its
+    # inputs are unchanged.  Read-only; the ``build-sandbox.yml`` workflow
+    # is the only writer.
+    permissions:
+      contents: read
+      packages: read
+
     services:
       postgres:
         image: postgres:17
@@ -212,6 +235,41 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
+      - name: Log in to GHCR
+        # Needed only for the ``docker pull`` path below.  When the sandbox
+        # is being rebuilt locally this login is unused but harmless.
+        if: needs.detect.outputs.sandbox_changed == 'false'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull sandbox image from GHCR
+        # ``:smoked`` is set by ``build-sandbox.yml``'s smoke job after the
+        # contract test passes, so PRs never get an unverified image.
+        # Retag under the CI-local ``aios-sandbox:ci`` name the E2E step's
+        # ``AIOS_DOCKER_IMAGE`` env points at — see the build step below
+        # for why a non-GHCR-prefixed tag matters (the
+        # ``test_sandbox_image_contract`` silent-fallback footgun from
+        # PR #670).
+        #
+        # The sanity probes (``image inspect`` + ``which tool``) mirror
+        # the build step's probes: the pulled image must satisfy the
+        # same contract the built one does, otherwise a stale ``:smoked``
+        # (e.g. ``bin/tool`` advanced on master between this PR's base
+        # and the last ``build-sandbox.yml`` publish) would silently
+        # produce a misroute later in the E2E run.
+        if: needs.detect.outputs.sandbox_changed == 'false'
+        run: |
+          docker pull ghcr.io/eumemic/aios-sandbox:smoked
+          docker tag ghcr.io/eumemic/aios-sandbox:smoked aios-sandbox:ci
+          docker image inspect aios-sandbox:ci --format 'image registered: {{.Id}}'
+          docker run --rm aios-sandbox:ci which tool || {
+            echo "::error::bin/tool not found in pulled image — :smoked tag is stale relative to HEAD"
+            exit 1
+          }
+
       - name: Build sandbox image
         # CI-local tag (no registry prefix) — pairs with the
         # ``AIOS_DOCKER_IMAGE`` env on the E2E step. The
@@ -228,6 +286,7 @@ jobs:
         # later. ``set -euo pipefail`` is the workflow default but
         # the explicit ``|| exit 1`` after the ``docker run`` makes
         # the failure mode obvious in the log.
+        if: needs.detect.outputs.sandbox_changed == 'true'
         run: |
           docker build -t aios-sandbox:ci -f docker/Dockerfile.sandbox .
           docker image inspect aios-sandbox:ci --format 'image registered: {{.Id}}'

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -61,7 +61,10 @@ jobs:
           # Anything that can affect lint / types / tests / sandbox
           # build / the workflow itself counts as build-affecting.
           # Everything else (READMEs, LICENSE, prose docs) skips.
-          if echo "$changed" | grep -qE '\.py$|^pyproject\.toml$|^uv\.lock$|^alembic\.ini$|^migrations/|^docker/|^\.github/workflows/'; then
+          # ``bin/tool`` is a sandbox-image input (COPY-d by the Dockerfile)
+          # and must invalidate the cheap-skip path alongside the source
+          # tree even though it lives outside ``src/``.
+          if echo "$changed" | grep -qE '\.py$|^pyproject\.toml$|^uv\.lock$|^alembic\.ini$|^migrations/|^docker/|^bin/tool$|^\.github/workflows/'; then
             echo "Build-affecting changes detected — running checks."
             echo "run_checks=true" >> "$GITHUB_OUTPUT"
           else
@@ -69,12 +72,14 @@ jobs:
             echo "run_checks=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Sandbox image inputs: the Dockerfile itself and the ``bin/tool``
-          # binary it COPYs in.  When neither changed, the ``e2e`` job can
+          # Sandbox image inputs: anything under ``docker/`` (currently
+          # only ``Dockerfile.sandbox``, but future COPY-source files
+          # added here would also count) plus the ``bin/tool`` binary the
+          # Dockerfile COPYs in.  When none changed, the ``e2e`` job can
           # pull ``ghcr.io/eumemic/aios-sandbox:smoked`` (published by
           # ``build-sandbox.yml`` after its smoke test passes) instead of
           # rebuilding from scratch — saves ~29 s per run.
-          if echo "$changed" | grep -qE '^docker/Dockerfile\.sandbox$|^bin/tool$'; then
+          if echo "$changed" | grep -qE '^docker/|^bin/tool$'; then
             echo "Sandbox inputs changed — rebuilding image."
             echo "sandbox_changed=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -66,31 +66,23 @@ jobs:
             echo "run_checks=false" >> "$GITHUB_OUTPUT"
           fi
 
-  validate:
+  # The four check jobs below run in parallel.  Splitting them off the
+  # previous monolithic ``validate`` job collapses the critical path from
+  # ``sum(lint, mypy, unit, integration, sandbox build, e2e)`` to
+  # ``max(...)`` — in practice ~max(e2e) ≈ 7 min instead of ~9.5 min.  Each
+  # job pays its own checkout + uv-setup overhead (~10-15 s), but they pay
+  # in parallel.  The setup-uv cache is shared across jobs by the action.
+  lint:
     needs: detect
     if: needs.detect.outputs.run_checks == 'true'
     runs-on: ubuntu-latest
 
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: aios
-          POSTGRES_PASSWORD: aios
-          POSTGRES_DB: aios_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 5
-
     env:
+      # ``get_settings()`` is called at module import by code that ruff/mypy
+      # also import (``aios.harness.worker`` → ``procrastinate_app``).  The
+      # URL is never reached — these are static analysis steps — but it
+      # must parse as a valid Postgres DSN for the import to succeed.
       AIOS_DB_URL: postgresql://aios:aios@localhost:5432/aios_test
-      # Dummy values so import-time get_settings() doesn't fail in tests
-      # that import aios.harness.worker (and transitively procrastinate_app)
-      # at collection time. Real production keys are set in Coolify.
       AIOS_API_KEY: test-key-for-ci
       AIOS_VAULT_KEY: 5Uvx6pICqEEpPDl+1f5SrKyXOoQA5j0XcYD590hZH/Y=
 
@@ -115,11 +107,110 @@ jobs:
       - name: Type check (mypy)
         run: uv run mypy src
 
+  unit:
+    needs: detect
+    if: needs.detect.outputs.run_checks == 'true'
+    runs-on: ubuntu-latest
+
+    env:
+      AIOS_DB_URL: postgresql://aios:aios@localhost:5432/aios_test
+      AIOS_API_KEY: test-key-for-ci
+      AIOS_VAULT_KEY: 5Uvx6pICqEEpPDl+1f5SrKyXOoQA5j0XcYD590hZH/Y=
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --dev
+
       - name: Unit tests
         run: uv run pytest tests/unit -q
 
+  integration:
+    needs: detect
+    if: needs.detect.outputs.run_checks == 'true'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: aios
+          POSTGRES_PASSWORD: aios
+          POSTGRES_DB: aios_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      AIOS_DB_URL: postgresql://aios:aios@localhost:5432/aios_test
+      AIOS_API_KEY: test-key-for-ci
+      AIOS_VAULT_KEY: 5Uvx6pICqEEpPDl+1f5SrKyXOoQA5j0XcYD590hZH/Y=
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --dev
+
       - name: Integration tests
         run: uv run pytest tests/integration -q
+
+  e2e:
+    needs: detect
+    if: needs.detect.outputs.run_checks == 'true'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: aios
+          POSTGRES_PASSWORD: aios
+          POSTGRES_DB: aios_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      AIOS_DB_URL: postgresql://aios:aios@localhost:5432/aios_test
+      AIOS_API_KEY: test-key-for-ci
+      AIOS_VAULT_KEY: 5Uvx6pICqEEpPDl+1f5SrKyXOoQA5j0XcYD590hZH/Y=
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --dev
 
       - name: Build sandbox image
         # CI-local tag (no registry prefix) — pairs with the

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -330,9 +330,11 @@ jobs:
       - name: E2E tests (non-docker shard)
         # signal_connector / signal_registration / telegram_connector need
         # external daemon RPC infrastructure (signal-cli, a live telegram
-        # bot) that GitHub Actions doesn't supply; they live in the docker
-        # shard but the ignore list is repeated so a misclassified test
-        # doesn't accidentally run here.
+        # bot) that GitHub Actions does not supply.  Those files carry
+        # the ``docker`` marker, so ``-m "not docker"`` excludes them
+        # here naturally — the explicit ``--ignore`` list on the docker
+        # shard below remains the source of truth for "needs daemon
+        # infrastructure, skip in CI."
         if: matrix.shard == 'non-docker'
         run: |
           uv run pytest tests/e2e -q -m "not docker"

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -317,11 +317,21 @@ jobs:
           uv run pytest tests/e2e -q -m "not docker"
 
       - name: E2E tests (docker shard)
+        # ``-n 2 --dist=loadfile`` runs the docker shard in two parallel
+        # xdist workers, one whole-file at a time.  ``loadfile`` is load-
+        # bearing: ``test_memory_cross_session_sync.py`` uses a module-
+        # scoped ``shared_docker_harness`` fixture which would be torn
+        # down + rebuilt per test under the default ``load`` dist.  Two
+        # workers matches the GHA standard runner's 2 cores; ``auto``
+        # over-subscribes on this hardware.  Local measurement: 84 s with
+        # ``-n 2`` vs. ~280 s serial — 3.3× speedup on the docker shard,
+        # amortizing the per-worker testcontainer-Postgres + Docker setup
+        # over ~100 tests each.
         if: matrix.shard == 'docker'
         env:
           AIOS_DOCKER_IMAGE: aios-sandbox:ci
         run: |
-          uv run pytest tests/e2e -q -m docker \
+          uv run pytest tests/e2e -q -m docker -n 2 --dist=loadfile \
             --ignore=tests/e2e/test_signal_connector.py \
             --ignore=tests/e2e/test_signal_registration.py \
             --ignore=tests/e2e/test_telegram_connector.py

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -190,14 +190,25 @@ jobs:
       - name: Integration tests
         run: uv run pytest tests/integration -q
 
+  # E2E runs as a two-shard matrix.  Tests carrying ``pytest.mark.docker``
+  # (added at module scope on the 31 files that use the sandbox image)
+  # run in the ``docker`` shard; everything else in ``non-docker``.  The
+  # non-docker shard skips the sandbox-image step entirely (~30 s saved).
+  # ``fail-fast: false`` so one shard's failure doesn't abort the other.
   e2e:
     needs: detect
     if: needs.detect.outputs.run_checks == 'true'
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [non-docker, docker]
+
     # Required to ``docker pull`` the sandbox image from GHCR when its
     # inputs are unchanged.  Read-only; the ``build-sandbox.yml`` workflow
-    # is the only writer.
+    # is the only writer.  Only the docker shard actually uses it, but
+    # GHA does not support per-matrix-leg permissions.
     permissions:
       contents: read
       packages: read
@@ -238,7 +249,7 @@ jobs:
       - name: Log in to GHCR
         # Needed only for the ``docker pull`` path below.  When the sandbox
         # is being rebuilt locally this login is unused but harmless.
-        if: needs.detect.outputs.sandbox_changed == 'false'
+        if: matrix.shard == 'docker' && needs.detect.outputs.sandbox_changed == 'false'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -260,7 +271,7 @@ jobs:
         # (e.g. ``bin/tool`` advanced on master between this PR's base
         # and the last ``build-sandbox.yml`` publish) would silently
         # produce a misroute later in the E2E run.
-        if: needs.detect.outputs.sandbox_changed == 'false'
+        if: matrix.shard == 'docker' && needs.detect.outputs.sandbox_changed == 'false'
         run: |
           docker pull ghcr.io/eumemic/aios-sandbox:smoked
           docker tag ghcr.io/eumemic/aios-sandbox:smoked aios-sandbox:ci
@@ -286,7 +297,7 @@ jobs:
         # later. ``set -euo pipefail`` is the workflow default but
         # the explicit ``|| exit 1`` after the ``docker run`` makes
         # the failure mode obvious in the log.
-        if: needs.detect.outputs.sandbox_changed == 'true'
+        if: matrix.shard == 'docker' && needs.detect.outputs.sandbox_changed == 'true'
         run: |
           docker build -t aios-sandbox:ci -f docker/Dockerfile.sandbox .
           docker image inspect aios-sandbox:ci --format 'image registered: {{.Id}}'
@@ -295,16 +306,22 @@ jobs:
             exit 1
           }
 
-      - name: E2E tests
-        # The signal_connector / signal_registration / telegram_connector
-        # tests need external daemon RPC infrastructure (signal-cli, a live
-        # telegram bot) that GitHub Actions doesn't supply; they are
-        # consistently failing in CI even when nothing about their code
-        # path has changed. Run them locally with the daemons up.
+      - name: E2E tests (non-docker shard)
+        # signal_connector / signal_registration / telegram_connector need
+        # external daemon RPC infrastructure (signal-cli, a live telegram
+        # bot) that GitHub Actions doesn't supply; they live in the docker
+        # shard but the ignore list is repeated so a misclassified test
+        # doesn't accidentally run here.
+        if: matrix.shard == 'non-docker'
+        run: |
+          uv run pytest tests/e2e -q -m "not docker"
+
+      - name: E2E tests (docker shard)
+        if: matrix.shard == 'docker'
         env:
           AIOS_DOCKER_IMAGE: aios-sandbox:ci
         run: |
-          uv run pytest tests/e2e -q \
+          uv run pytest tests/e2e -q -m docker \
             --ignore=tests/e2e/test_signal_connector.py \
             --ignore=tests/e2e/test_signal_registration.py \
             --ignore=tests/e2e/test_telegram_connector.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,4 +186,5 @@ markers = [
     "integration: tests requiring a Postgres testcontainer",
     "e2e: end-to-end tests requiring Docker + a real or recorded model",
     "slow: heavy tests (benchmarks, large fixtures) — skipped on PR CI, run nightly",
+    "docker: e2e tests that need the sandbox image (selected by CI's docker shard)",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,11 @@ addopts = [
     "-ra",
     "--strict-markers",
     "--strict-config",
+    # Surface slow tests in every CI log so regressions don't accumulate
+    # silently.  ``--durations-min=0.5`` filters out the noise floor so
+    # the report stays a sentence, not a screenful.
+    "--durations=20",
+    "--durations-min=0.5",
 ]
 markers = [
     "integration: tests requiring a Postgres testcontainer",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
     "pytest-mock>=3.14",
+    "pytest-xdist>=3.6",          # parallel test execution on docker e2e shard
     "httpx>=0.27",                # FastAPI TestClient backend
     "testcontainers[postgres]>=4.8",
     "ruff>=0.8",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,21 @@ os.environ.setdefault(
 )
 os.environ.setdefault("AIOS_DB_URL", "postgresql://x:x@localhost:5432/x")
 
+# Scope ``AIOS_INSTANCE_ID`` per pytest-xdist worker so that
+# ``SandboxRegistry.reap_orphans`` (which lists containers by the
+# ``aios.instance_id`` label) only ever sees this worker's containers.
+# ``Settings.instance_id`` defaults to the literal ``"default"`` —
+# without this override, two xdist workers in the same CI job would
+# share an instance_id and a hypothetical future test that triggers
+# the orphan-reaper path would ``docker rm -f`` the sibling worker's
+# live sandbox.  Today no test exercises that path, but pre-empting
+# the footgun is cheap and keeps ``-n 2`` safe for future test growth.
+# ``PYTEST_XDIST_WORKER`` is set by xdist to ``gw0`` / ``gw1`` / ...
+# per worker and is absent in single-process runs.
+_xdist_worker = os.environ.get("PYTEST_XDIST_WORKER")
+if _xdist_worker:
+    os.environ.setdefault("AIOS_INSTANCE_ID", f"test_{_xdist_worker}")
+
 
 def _docker_available() -> bool:
     """Check if Docker is available, ensuring ``DOCKER_HOST`` is set.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -315,7 +315,19 @@ async def harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
 
 @pytest.fixture
 async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
-    """Like ``harness`` but with a real SandboxRegistry for Docker tests."""
+    """Like ``harness`` but with a real SandboxRegistry for Docker tests.
+
+    pytest-xdist note: ``SANDBOX_NETWORK_NAME`` is a hardcoded host-global
+    name (``aios-sandbox``).  Under ``-n 2``, both xdist workers' sandbox
+    containers join the same bridge.  This is safe for the current test
+    set — assertions are per-container (iptables rules, broker
+    reachability) and don't depend on bridge composition or
+    inter-container reachability.  If you add a test that asserts "this
+    container is the only/first/last thing on aios-sandbox" or relies on
+    cross-container DNS resolution, you'll need to either run it
+    serially (``--dist=no``) or thread a per-worker network name through
+    ``aios.sandbox.network``.
+    """
     import aios.tools  # noqa: F401
     from aios.config import get_settings
     from aios.crypto.vault import CryptoBox

--- a/tests/e2e/test_connection_discovery_sse.py
+++ b/tests/e2e/test_connection_discovery_sse.py
@@ -28,6 +28,8 @@ from tests.conftest import needs_docker
 from tests.e2e.conftest import live_aios_server
 from tests.helpers.connections import authed_client, create_connection
 
+pytestmark = pytest.mark.docker
+
 
 @pytest.fixture
 async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:

--- a/tests/e2e/test_connection_tools.py
+++ b/tests/e2e/test_connection_tools.py
@@ -21,11 +21,14 @@ This file pins the contract end-to-end with the real harness:
 from __future__ import annotations
 
 import httpx
+import pytest
 
 from aios.crypto.vault import CryptoBox
 from aios.db import queries as db_queries
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness, assistant, last_assistant_content, tool_call
+
+pytestmark = pytest.mark.docker
 
 
 @needs_docker

--- a/tests/e2e/test_connector_secrets.py
+++ b/tests/e2e/test_connector_secrets.py
@@ -17,10 +17,13 @@ across ``CryptoBox`` + queries + service + routes.
 from __future__ import annotations
 
 import httpx
+import pytest
 
 from tests.conftest import needs_docker
 from tests.e2e.test_echo_http_connector import live_server  # noqa: F401  fixture re-export
 from tests.helpers.connections import authed_client, issue_runtime_token
+
+pytestmark = pytest.mark.docker
 
 
 async def _create_with_secrets(

--- a/tests/e2e/test_echo_http_connector.py
+++ b/tests/e2e/test_echo_http_connector.py
@@ -30,6 +30,8 @@ from tests.e2e.conftest import live_aios_server
 from tests.e2e.harness import Harness, assistant, last_assistant_content, tool_call
 from tests.helpers.connections import create_connection, issue_runtime_token
 
+pytestmark = pytest.mark.docker
+
 
 @pytest.fixture
 async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:

--- a/tests/e2e/test_errored_session_sweep.py
+++ b/tests/e2e/test_errored_session_sweep.py
@@ -23,6 +23,8 @@ from aios.models.sessions import SessionStatus
 from aios.services import sessions as sessions_service
 from tests.conftest import needs_docker
 
+pytestmark = pytest.mark.docker
+
 
 async def _ensure_agent_and_env(pool: asyncpg.Pool[Any]) -> tuple[str, str]:
     """Idempotently seed the FK targets ``create_session`` needs."""

--- a/tests/e2e/test_focal_channel.py
+++ b/tests/e2e/test_focal_channel.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.harness.channels import (
@@ -36,6 +38,8 @@ from aios.harness.channels import (
 from aios.services import sessions as sessions_service
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness, assistant, msg_text, tool_call
+
+pytestmark = pytest.mark.docker
 
 _TAIL_HEADER = "━━━ Channels ━━━"
 _PARADIGM_HEADER = "## Channels & focal attention"

--- a/tests/e2e/test_github_repositories.py
+++ b/tests/e2e/test_github_repositories.py
@@ -38,6 +38,8 @@ from aios.services import github_repositories as github_service
 from aios.services import sessions as sessions_service
 from tests.helpers.connections import authed_client
 
+pytestmark = pytest.mark.docker
+
 _OCTOCAT_REPO = "https://github.com/octocat/Hello-World"
 
 

--- a/tests/e2e/test_inbound_attachment.py
+++ b/tests/e2e/test_inbound_attachment.py
@@ -20,11 +20,14 @@ covered by the manual smoke documented in PR 1's verification section.
 from __future__ import annotations
 
 import httpx
+import pytest
 
 from aios.ids import EVENT, make_id, split_id
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness
 from tests.helpers.connections import bearer
+
+pytestmark = pytest.mark.docker
 
 
 def _new_event_id() -> str:

--- a/tests/e2e/test_litellm_502_recovery.py
+++ b/tests/e2e/test_litellm_502_recovery.py
@@ -12,9 +12,12 @@ from typing import Any
 from unittest import mock
 
 import litellm
+import pytest
 
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness, assistant, last_assistant_content
+
+pytestmark = pytest.mark.docker
 
 
 def _make_bad_gateway() -> litellm.exceptions.BadGatewayError:

--- a/tests/e2e/test_memory_cross_session_sync.py
+++ b/tests/e2e/test_memory_cross_session_sync.py
@@ -36,7 +36,7 @@ from tests.e2e.harness import Harness
 # pytest-asyncio's default function-scoped loops cause "another
 # operation in progress" errors when a pool created on the module
 # setup loop is acquired from on a test-body loop.
-pytestmark = pytest.mark.asyncio(loop_scope="module")
+pytestmark = [pytest.mark.asyncio(loop_scope="module"), pytest.mark.docker]
 
 # Tables this file's tests mutate.  Truncating just these between tests
 # (instead of every public-schema table from conftest's ``_reset_db_state``)

--- a/tests/e2e/test_networking.py
+++ b/tests/e2e/test_networking.py
@@ -6,9 +6,13 @@ rules actually block/allow outbound traffic.
 
 from __future__ import annotations
 
+import pytest
+
 from aios.models.environments import EnvironmentConfig, LimitedNetworking, UnrestrictedNetworking
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness, assistant, bash
+
+pytestmark = pytest.mark.docker
 
 
 @needs_docker

--- a/tests/e2e/test_orphan_stuck.py
+++ b/tests/e2e/test_orphan_stuck.py
@@ -16,9 +16,13 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import pytest
+
 from tests.conftest import needs_docker
 from tests.e2e.conftest import wait_for_predicate
 from tests.e2e.harness import Harness, assistant, tool_call
+
+pytestmark = pytest.mark.docker
 
 
 @needs_docker

--- a/tests/e2e/test_reap_stalled_jobs.py
+++ b/tests/e2e/test_reap_stalled_jobs.py
@@ -23,6 +23,8 @@ from procrastinate.manager import JobManager
 from aios.harness.sweep import reap_stalled_jobs
 from tests.conftest import needs_docker
 
+pytestmark = pytest.mark.docker
+
 
 @pytest.fixture
 async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:

--- a/tests/e2e/test_runtime_token_connection_scope.py
+++ b/tests/e2e/test_runtime_token_connection_scope.py
@@ -24,6 +24,8 @@ from tests.conftest import needs_docker
 from tests.e2e.conftest import live_aios_server
 from tests.helpers.connections import authed_client, bearer, create_connection
 
+pytestmark = pytest.mark.docker
+
 
 @pytest.fixture
 async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:

--- a/tests/e2e/test_runtime_tokens.py
+++ b/tests/e2e/test_runtime_tokens.py
@@ -8,8 +8,12 @@ authenticate.
 
 from __future__ import annotations
 
+import pytest
+
 from tests.conftest import needs_docker
 from tests.helpers.connections import bearer
+
+pytestmark = pytest.mark.docker
 
 
 async def _issue_runtime_token(http_client: object, connector: str) -> tuple[str, str]:

--- a/tests/e2e/test_sandbox_broker_reachability.py
+++ b/tests/e2e/test_sandbox_broker_reachability.py
@@ -34,7 +34,7 @@ from aios.sandbox.network import (
 )
 from tests.conftest import needs_docker
 
-pytestmark = needs_docker
+pytestmark = [needs_docker, pytest.mark.docker]
 
 IMAGE = os.environ.get("AIOS_DOCKER_IMAGE", "ghcr.io/eumemic/aios-sandbox:latest")
 SIDECAR_PORT = 7777

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -21,7 +21,7 @@ import pytest
 
 from tests.conftest import needs_docker
 
-pytestmark = needs_docker
+pytestmark = [needs_docker, pytest.mark.docker]
 
 # Read directly from env to keep this file free of aios package imports.
 # The env var name is stable -- derived from env_prefix="AIOS_" + field "docker_image"

--- a/tests/e2e/test_search_events.py
+++ b/tests/e2e/test_search_events.py
@@ -17,6 +17,8 @@ from aios.tools.search_events import search_events_handler
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness, assistant
 
+pytestmark = pytest.mark.docker
+
 
 @needs_docker
 class TestSearchEvents:

--- a/tests/e2e/test_session_files_api.py
+++ b/tests/e2e/test_session_files_api.py
@@ -20,6 +20,8 @@ from aios.config import get_settings
 from aios.sandbox.volumes import session_uploads_dir
 from tests.e2e.harness import Harness
 
+pytestmark = pytest.mark.docker
+
 
 async def _make_session(harness: Harness) -> str:
     account_id = "acc_test_stub"  # PR 3 scaffolding

--- a/tests/e2e/test_signal_connector.py
+++ b/tests/e2e/test_signal_connector.py
@@ -29,6 +29,8 @@ from tests.e2e.conftest import live_aios_server
 from tests.e2e.harness import Harness, assistant, last_assistant_content, tool_call
 from tests.helpers.connections import authed_client, issue_runtime_token
 
+pytestmark = pytest.mark.docker
+
 # Two phones, two connections — the demux subjects.
 PHONE_A = "+15550000111"
 PHONE_B = "+15550000222"

--- a/tests/e2e/test_signal_registration.py
+++ b/tests/e2e/test_signal_registration.py
@@ -17,6 +17,8 @@ from tests.conftest import needs_docker
 from tests.e2e.conftest import live_aios_server
 from tests.helpers.connections import authed_client, issue_runtime_token
 
+pytestmark = pytest.mark.docker
+
 
 class _FakeSignalConnector(HttpConnector):
     """Real SDK, scripted management handlers.

--- a/tests/e2e/test_sse_conn_leak_on_disconnect.py
+++ b/tests/e2e/test_sse_conn_leak_on_disconnect.py
@@ -36,6 +36,8 @@ from tests.e2e.conftest import live_aios_server, wait_for_predicate
 from tests.helpers.db import count_active_backends
 from tests.integration.conftest import seed_agent_env_session
 
+pytestmark = pytest.mark.docker
+
 
 @pytest.fixture
 async def live_server(aios_env: dict[str, str]) -> AsyncIterator[str]:

--- a/tests/e2e/test_sse_first_open.py
+++ b/tests/e2e/test_sse_first_open.py
@@ -39,6 +39,8 @@ from tests.conftest import needs_docker
 from tests.e2e.conftest import live_aios_server_cold
 from tests.helpers.connections import mint_runtime_token_via_db
 
+pytestmark = pytest.mark.docker
+
 _SSE_ENDPOINTS: tuple[str, ...] = (
     "/v1/connectors/connections",
     "/v1/connectors/runtime/calls",

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -26,6 +26,8 @@ from tests.e2e.harness import (
     tool_results,
 )
 
+pytestmark = pytest.mark.docker
+
 # ─── fast tier (no Docker) ───────────────────────────────────────────────────
 
 

--- a/tests/e2e/test_step_separator.py
+++ b/tests/e2e/test_step_separator.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import pytest
+
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness, assistant, msg_text
+
+pytestmark = pytest.mark.docker
 
 _TAIL_HEADER = "━━━ Channels ━━━"
 

--- a/tests/e2e/test_sweep.py
+++ b/tests/e2e/test_sweep.py
@@ -10,10 +10,14 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import pytest
+
 from aios.services import sessions as sessions_service
 from tests.conftest import needs_docker
 from tests.e2e.conftest import wait_for_predicate
 from tests.e2e.harness import Harness, assistant, tool_call
+
+pytestmark = pytest.mark.docker
 
 # ─── ghost recovery ──────────────────────────────────────────────────────────
 

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -32,6 +32,8 @@ from aios.harness.sweep import CANDIDATE_ROWS_SQL, UNREACTED_ROWS_SQL
 from tests.conftest import needs_docker
 from tests.support import find_subplans_over_events
 
+pytestmark = pytest.mark.docker
+
 # ─── fixture: pathological session ───────────────────────────────────────────
 
 

--- a/tests/e2e/test_telegram_connector.py
+++ b/tests/e2e/test_telegram_connector.py
@@ -29,6 +29,8 @@ from tests.e2e.conftest import live_aios_server
 from tests.e2e.harness import Harness, assistant, last_assistant_content, tool_call
 from tests.helpers.connections import authed_client, issue_runtime_token
 
+pytestmark = pytest.mark.docker
+
 BOT_TOKEN_A = "11111:tokenA"
 BOT_TOKEN_B = "22222:tokenB"
 BOT_ID_A = 111

--- a/tests/e2e/test_wake_lock_release_latency.py
+++ b/tests/e2e/test_wake_lock_release_latency.py
@@ -17,6 +17,8 @@ from aios.services import sessions as sessions_service
 from tests.conftest import needs_docker
 from tests.e2e.conftest import wait_for_predicate
 
+pytestmark = pytest.mark.docker
+
 
 @needs_docker
 class TestWakeLockReleaseLatencyE2E:

--- a/tests/e2e/test_worker_concurrency.py
+++ b/tests/e2e/test_worker_concurrency.py
@@ -20,6 +20,7 @@ from typing import Any
 from unittest import mock
 
 import asyncpg
+import pytest
 from procrastinate import PsycopgConnector
 
 from aios.models.agents import ToolSpec
@@ -27,6 +28,8 @@ from aios.services import agents as agents_service
 from aios.services import environments as environments_service
 from aios.services import sessions as sessions_service
 from tests.conftest import needs_docker
+
+pytestmark = pytest.mark.docker
 
 
 async def _create_session(pool: asyncpg.Pool[Any], agent_id: str, env_id: str) -> str:

--- a/tests/e2e/test_workspace_image_read.py
+++ b/tests/e2e/test_workspace_image_read.py
@@ -27,6 +27,8 @@ from aios.tools.registry import ToolResult
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness
 
+pytestmark = pytest.mark.docker
+
 
 @needs_docker
 class TestWorkspaceImageRead:

--- a/uv.lock
+++ b/uv.lock
@@ -145,6 +145,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "testcontainers" },
 ]
@@ -186,6 +187,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-mock", specifier = ">=3.14" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.8" },
     { name = "testcontainers", extras = ["postgres"], specifier = ">=4.8" },
 ]
@@ -685,6 +687,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1891,6 +1902,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

PR CI on master was taking a median of ~562 s (9.4 min) per run, with e2e dominating at 72% of total. Profiling 9 recent runs showed the slowdown was **systemic** (no single pathological test — slowest was 8.4 s) and concentrated in 31 Docker-bound e2e files. The fix is structural, in four layers:

1. **Parallel jobs** (`5449b27`) — split the single `validate` job into `lint` / `unit` / `integration` / `e2e`, all gated on the existing `detect` job. Critical path becomes `max(...)` instead of `sum(...)`.
2. **Pull pre-built sandbox image from GHCR** (`178918c`) — when `docker/Dockerfile.sandbox` and `bin/mcp` are unchanged (the common case), pull `ghcr.io/eumemic/aios-sandbox:smoked` instead of rebuilding. Saves ~29 s per run on the e2e job.
3. **Shard e2e by Docker-dependence** (`e0b0440`) — `pytest.mark.docker` at module scope on the 31 files that need the sandbox image; workflow matrix `[non-docker, docker]`. The non-docker shard skips the GHCR/build step entirely.
4. **pytest-xdist on the docker shard** (`0a755c1`) — `-n 2 --dist=loadfile` on the docker shard only. 3.3× speedup locally (84 s vs. ~280 s serial). `--dist=loadfile` is load-bearing: keeps `test_memory_cross_session_sync.py`'s module-scoped `shared_docker_harness` on one worker. `McpBroker` already uses ephemeral ports, so no port-collision blocker materialised.

Plus a free tooling addition (`fae61ac`): `--durations=20 --durations-min=0.5` in `pyproject.toml` so future regressions in test wall-clock surface in every CI log without re-instrumenting.

## Expected wall-clock

| | Before | After (est.) |
|---|---:|---:|
| Setup overhead | ~22 s | ~22 s per job, in parallel |
| Lint + mypy | 23 s | ~30 s parallel |
| Unit | 35 s | ~50 s parallel |
| Integration | 51 s | ~65 s parallel |
| Sandbox image | 29 s | ~5 s (GHCR pull) / fallback ~29 s |
| E2E non-docker shard | (n/a) | ~170 s |
| E2E docker shard | ~400 s serial | **~150 s** (xdist `-n 2`) |
| **Critical path** | **~562 s** | **~210–240 s** |

That's ~60% reduction. Will refine the estimate against the first run of this PR.

## Review fixes folded in

After a `/code-review high` pass, four `fix(ci):` commits and one `docs(tests):` commit address findings from the review:

- `7b743d2 fix(ci): fall back to local sandbox build when GHCR pull fails` — pull/build were mutually exclusive on `sandbox_changed`; pull failures (registry outage, `:smoked` missing on a fresh master state, fork-PR token without packages:read) had no recovery path. `continue-on-error: true` on pull plus a widened build gate restores the original build path as a fallback.
- `e380cf9 fix(ci): close two gaps in the detect-step regexes` — `run_checks` regex now includes `bin/mcp` (was inconsistent with the new `sandbox_changed` regex). `sandbox_changed` widened from `^docker/Dockerfile\.sandbox$` to `^docker/` to catch future Dockerfile-input additions.
- `01224b9 fix(ci): scope test instance_id per xdist worker` — `Settings.instance_id` defaults to `"default"` and flows into the `aios.instance_id` Docker label; two xdist workers in the same CI job share it, so any future test triggering the orphan-reaper would `docker rm -f` the sibling worker's containers. Conftest now seeds `AIOS_INSTANCE_ID=test_gw0` (etc.) per xdist worker.
- `114407b fix(ci): correct misleading non-docker shard comment` — the previous comment claimed `--ignore` was repeated on the non-docker shard; it wasn't. Rewrote to state what actually keeps signal/telegram tests off this shard (the `docker` marker).
- `0cc9956 docs(tests): warn future authors about shared sandbox bridge under xdist` — the `aios-sandbox` Docker network is host-global and shared between xdist workers. Safe for the current test set (per-container assertions only); docstring on `docker_harness` warns future authors not to assert on bridge composition without per-worker scoping.

## Test plan

- [ ] Confirm all four parallel jobs run concurrently in the GHA UI (not waiting on each other beyond `detect`)
- [ ] Confirm GHCR pull succeeds on this PR (no `docker/` or `bin/mcp` change → `sandbox_changed=false`)
- [ ] Confirm GHCR pull-fallback path: open a follow-up PR with a no-op whitespace change to `docker/Dockerfile.sandbox` to force `sandbox_changed=true` and verify the local-build path
- [ ] Confirm pytest-xdist `-n 2 --dist=loadfile` passes all docker e2e tests in CI; cross-check pass count matches serial (199 in the docker shard, 227 in non-docker)
- [ ] Verify wall-clock against the table above; refine the docs if real numbers differ materially
- [ ] Check the `--durations=20` block appears in every pytest step's log