### PR TITLE
refactor(db/queries): promote session-lock SQL into queries module

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -894,6 +894,34 @@ async def list_sessions(
     return [_row_to_session(r) for r in rows]
 
 
+async def lock_active_session_for_update(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+) -> None:
+    """Enforce the active-session precondition: ``SELECT FOR UPDATE`` the
+    session row, raise :class:`NotFoundError` on miss / wrong account,
+    :class:`ConflictError` when status is ``errored`` (a user message is
+    required to resume).
+
+    Must be called inside an outer ``conn.transaction()`` block — the
+    row lock is what serialises concurrent retries on the same session.
+    """
+    row = await conn.fetchrow(
+        "SELECT status FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
+        session_id,
+        account_id,
+    )
+    if row is None:
+        raise NotFoundError(
+            f"session {session_id} not found",
+            detail={"session_id": session_id},
+        )
+    if row["status"] == "errored":
+        raise ConflictError(
+            f"session {session_id} is errored; post a user message to resume",
+            detail={"session_id": session_id, "status": "errored"},
+        )
+
+
 async def set_session_status(
     conn: asyncpg.Connection[Any],
     session_id: str,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -396,34 +396,6 @@ async def append_event(
         )
 
 
-async def _lock_active_session_or_raise(
-    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
-) -> None:
-    """Enforce the active-session precondition: ``SELECT FOR UPDATE``
-    the session row, raise NotFoundError on miss / wrong account,
-    ConflictError when status is ``errored`` (a user message is
-    required to resume).
-
-    Must be called inside an outer ``conn.transaction()`` block — the
-    row lock is what serialises concurrent retries on the same session.
-    """
-    row = await conn.fetchrow(
-        "SELECT status FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
-        session_id,
-        account_id,
-    )
-    if row is None:
-        raise NotFoundError(
-            f"session {session_id} not found",
-            detail={"session_id": session_id},
-        )
-    if row["status"] == "errored":
-        raise ConflictError(
-            f"session {session_id} is errored; post a user message to resume",
-            detail={"session_id": session_id, "status": "errored"},
-        )
-
-
 async def append_tool_result(
     conn: asyncpg.Connection[Any],
     *,
@@ -453,7 +425,7 @@ async def append_tool_result(
     deferring the wake afterwards.
     """
     async with conn.transaction():
-        await _lock_active_session_or_raise(conn, session_id, account_id=account_id)
+        await queries.lock_active_session_for_update(conn, session_id, account_id=account_id)
         existing = await queries.find_tool_result_event(
             conn, session_id, tool_call_id, account_id=account_id
         )
@@ -734,7 +706,7 @@ async def confirm_tool_allow(
     silently accept impossible inputs.
     """
     async with pool.acquire() as conn, conn.transaction():
-        await _lock_active_session_or_raise(conn, session_id, account_id=account_id)
+        await queries.lock_active_session_for_update(conn, session_id, account_id=account_id)
         existing = await queries.find_tool_confirmed_event(
             conn, session_id, tool_call_id, account_id=account_id
         )


### PR DESCRIPTION
## Summary

- The `_lock_active_session_or_raise` helper in `services/sessions.py` spelled out a raw `SELECT ... FOR UPDATE` directly in a service module, violating the project convention from `CLAUDE.md`: **"Every query lives in `db/queries.py`"**.
- Promoted the SQL to `queries.lock_active_session_for_update`, placed next to `set_session_status` where the other session-state queries live. Deleted the redundant wrapper.
- The two callers (`append_tool_result`, `confirm_tool_allow`) now invoke `queries.lock_active_session_for_update` directly inside their existing `conn.transaction()` blocks.
- **No behavior change**: identical SQL, identical exceptions (`NotFoundError`, `ConflictError`), identical messages. Net diff: +30 / −30 LOC.

## Test plan

- [x] `uv run mypy src` — clean (162 files)
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] `uv run pytest tests/unit -q` — 1495 passed
- [ ] CI e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)