### PR TITLE
fix(whatsapp): COPY README.md so wheel build succeeds

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -64,7 +64,7 @@ jobs:
           # ``bin/tool`` is a sandbox-image input (COPY-d by the Dockerfile)
           # and must invalidate the cheap-skip path alongside the source
           # tree even though it lives outside ``src/``.
-          if echo "$changed" | grep -qE '\.py$|^pyproject\.toml$|^uv\.lock$|^alembic\.ini$|^migrations/|^docker/|^bin/tool$|^\.github/workflows/'; then
+          if echo "$changed" | grep -qE '\.py$|^pyproject\.toml$|^uv\.lock$|^alembic\.ini$|^migrations/|^docker/|^connectors/[^/]+/Dockerfile$|^bin/tool$|^\.github/workflows/'; then
             echo "Build-affecting changes detected — running checks."
             echo "run_checks=true" >> "$GITHUB_OUTPUT"
           else

--- a/connectors/whatsapp/Dockerfile
+++ b/connectors/whatsapp/Dockerfile
@@ -61,6 +61,7 @@ WORKDIR /app
 COPY packages/aios-sdk /app/packages/aios-sdk
 COPY packages/aios-connector-http /app/packages/aios-connector-http
 COPY connectors/whatsapp/pyproject.toml /app/connectors/whatsapp/pyproject.toml
+COPY connectors/whatsapp/README.md /app/connectors/whatsapp/README.md
 COPY connectors/whatsapp/src /app/connectors/whatsapp/src
 
 # ``--no-sources`` ignores ``[tool.uv.sources]`` workspace-deps which


### PR DESCRIPTION
Hatchling fails during `uv pip install` in the WhatsApp connector image build because `pyproject.toml` declares `readme = "README.md"` but the Dockerfile only copies `pyproject.toml` and `src/` — leaving `README.md` absent from the build context.

**Fix:** add one `COPY` line for `README.md` between the existing `pyproject.toml` and `src/` copies.

**Verification:** reproduced the exact `OSError: Readme file does not exist: README.md` by reverting the line; re-applying it makes `docker build` pass the wheel step cleanly. The Signal connector is unaffected — its Dockerfile copies the whole directory.

Closes #680