### PR TITLE
fix(harness/ghost-repair): branched recovery messages (#685)

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -817,10 +817,11 @@ async def _dispatch_confirmed_tools(
     # impatient user message that lifts the session out of
     # ``requires_action``).  Stopping at A2 would silently drop A1's
     # operator-confirmed dispatch — ghost-repair then papers over
-    # with the misleading ``"No result was received"`` synthetic
-    # error, even though the operator did allow the tool; the
-    # dispatch was lost.  Filtering by ``completed`` / ``in_flight``
-    # below correctly excludes anything already handled.
+    # with a synthetic "did not run" error (per the two-branch recovery
+    # in ``sweep.find_and_repair_ghosts``, see #685), even though the
+    # operator did allow the tool; the dispatch was lost.  Filtering by
+    # ``completed`` / ``in_flight`` below correctly excludes anything
+    # already handled.
     asst_tool_calls: list[dict[str, Any]] = []
     for e in message_events:
         if e.kind == "message" and e.data.get("role") == "assistant":

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -84,6 +84,24 @@ GHOST_LIFECYCLE_SQL = """
        AND e.data->>'result' = 'allow'
 """
 
+# Dispatch-marker spans: pre-invoke ``tool_execute_start`` events keyed by
+# tool_call_id.  Scope by both session set and tcid set so the seq-scan
+# stays bounded without a new index — the candidate counts are typically
+# single-digit per sweep.  Drives the two-branch recovery synthesis in
+# :func:`find_and_repair_ghosts` (#685).  If profiling under load shows
+# this as a hot spot, add a partial expression index following migration
+# 0024's pattern:
+#   CREATE INDEX events_tool_execute_start_idx ON events ((data->>'tool_call_id'))
+#       WHERE kind = 'span' AND data->>'event' = 'tool_execute_start';
+GHOST_SPAN_START_SQL = """
+    SELECT DISTINCT e.session_id, e.data->>'tool_call_id' AS tool_call_id
+      FROM events e
+     WHERE e.session_id = ANY($1::text[])
+       AND e.kind = 'span'
+       AND e.data->>'event' = 'tool_execute_start'
+       AND e.data->>'tool_call_id' = ANY($2::text[])
+"""
+
 CANDIDATE_ROWS_SQL = """
     WITH session_max_reacting AS (
         SELECT session_id,
@@ -262,14 +280,54 @@ async def find_and_repair_ghosts(
         if _was_dispatched(name, tcid, confirmed, agent_tools):
             ghosts.append((sid, tcid, name))
 
+    # ``tool_execute_start`` span presence per (session, tcid) — drives the
+    # two-branch recovery message below (#685).  Tcids missing from this set
+    # never reached the lifecycle body, so the tool definitely did not run;
+    # tcids present may have executed and committed side effects.  Scope to
+    # the post-``_was_dispatched`` ghost set (not the wider candidate set) so
+    # the seq-scan touches only the tcids the per-ghost loop will actually
+    # consult.
+    started: set[tuple[str, str]] = set()
+    if ghosts:
+        ghost_sids = list({sid for sid, _, _ in ghosts})
+        ghost_tcids = list({tcid for _, tcid, _ in ghosts})
+        async with pool.acquire() as conn:
+            span_rows = await conn.fetch(GHOST_SPAN_START_SQL, ghost_sids, ghost_tcids)
+        started = {(r["session_id"], r["tool_call_id"]) for r in span_rows}
+
     # Per-ghost isolation; see ``wake_sessions_needing_inference`` below
     # for the rationale.
     repaired: list[tuple[str, str]] = []
     for sid, tcid, name in ghosts:
-        content = json.dumps(
-            {"error": "No result was received for this tool call."},
-            ensure_ascii=False,
-        )
+        # Don't lie: distinguish "never dispatched" (safe to retry) from
+        # "may have executed" (verify before retrying).  The previous
+        # single fabricated "No result was received" message double-fired
+        # non-idempotent tools (bash mutations, http_request POST,
+        # connector send) on the model's retry — see #685.
+        #
+        # The "may have completed" branch is conservatively over-pessimistic:
+        # it also fires for crashes/cancels in the window between the span
+        # commit and the actual side-effectful invoke (MCP auth resolve,
+        # parameter validation, ``asyncio.CancelledError`` arriving inside
+        # the span ``await``).  Those produce false "verify the outcome"
+        # advice but never the dangerous false "safe to retry" that this
+        # design eliminates.  Tighter classification would require a second
+        # marker written immediately before each tool's side-effectful call
+        # — deferred until the over-pessimism is shown to matter.
+        if (sid, tcid) in started:
+            branch = "may_have_completed"
+            error_text = (
+                "Tool dispatch was interrupted after execution began. "
+                "The tool may have completed and side effects may have "
+                "committed. Verify the outcome before retrying."
+            )
+        else:
+            branch = "did_not_run"
+            error_text = (
+                "Tool dispatch was lost before execution began; "
+                "the tool did not run. You may retry."
+            )
+        content = json.dumps({"error": error_text}, ensure_ascii=False)
         # Load each ghost's session account_id individually so the
         # cross-session sweeper (session_id=None) doesn't stamp empty
         # account_id onto repair events for real tenants.
@@ -301,7 +359,16 @@ async def find_and_repair_ghosts(
             )
             continue
         repaired.append((sid, tcid))
-        log.info("sweep.ghost_repaired", session_id=sid, tool_call_id=tcid, tool_name=name)
+        # ``branch`` is the operational signal of #685: ops can grep this
+        # log for ``branch=may_have_completed`` after a crash to triage
+        # which recoveries carry side-effect risk vs which are safe-retry.
+        log.info(
+            "sweep.ghost_repaired",
+            session_id=sid,
+            tool_call_id=tcid,
+            tool_name=name,
+            branch=branch,
+        )
 
     return repaired
 

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -95,8 +95,22 @@ async def _tool_lifecycle(
     function = call.get("function") or {}
     name = function.get("name") or ""
     raw_args = function.get("arguments", "{}")
-    bound_log = log.bind(session_id=session_id, tool_call_id=call_id, tool_name=name)
-
+    # Load-bearing for ghost recovery (#685): the commit of this span is what
+    # ``sweep.find_and_repair_ghosts`` reads to distinguish "tool never
+    # dispatched" from "tool may have executed (outcome unknown)". Any
+    # side-effectful work added ABOVE this append could commit and then be
+    # lost to a crash before the span lands, surfacing as "never started"
+    # and double-firing on the model's retry. Keep the span as the very
+    # first action in this lifecycle — only pure-Python preamble (arg
+    # extraction, no I/O) is permitted above.
+    #
+    # The span is intentionally OUTSIDE the try/except below: an
+    # ``asyncio.CancelledError`` arriving mid-await leaves the span possibly
+    # committed and the body never entered, surfacing as "may have completed"
+    # — an over-pessimistic outcome that the recovery message acknowledges
+    # (see the branch comment in ``sweep.find_and_repair_ghosts``).  This is
+    # the conservatively-safe direction; the alternative (suppress the span
+    # on cancellation) would risk under-pessimism on real side effects.
     span_start = await sessions_service.append_event(
         pool,
         session_id,
@@ -108,6 +122,7 @@ async def _tool_lifecycle(
         },
         account_id=account_id,
     )
+    bound_log = log.bind(session_id=session_id, tool_call_id=call_id, tool_name=name)
     tc = _ToolCall(call_id=call_id, name=name, raw_args=raw_args, bound_log=bound_log)
     try:
         yield tc

--- a/tests/e2e/test_sweep.py
+++ b/tests/e2e/test_sweep.py
@@ -84,7 +84,10 @@ class TestGhostRecovery:
         assert len(tool_results) == 2
         for tr in tool_results:
             assert tr.data.get("is_error") is True
-            assert "No result was received" in tr.data.get("content", "")
+            # ``tool_execute_start`` spans committed inside ``_tool_lifecycle``
+            # before the handlers reached ``started.set()``, so this hits the
+            # "may have completed" branch of the recovery synthesis (#685).
+            assert "may have completed" in tr.data.get("content", "")
 
         # Session should now need inference.
         needs = await harness.sessions_needing_inference(session.id)
@@ -101,6 +104,116 @@ class TestGhostRecovery:
             and not e.data.get("tool_calls")
         )
         assert "failed" in last_asst.data.get("content", "").lower()
+
+    async def test_started_then_killed_single_tool(self, harness: Harness) -> None:
+        """SIGKILL after a single tool's lifecycle began — recovery surfaces
+        the "may have completed" branch (#685).
+
+        Distinct from ``test_all_tools_lost_after_sigkill`` (dual-tool batch
+        case): this isolates the marker logic on a single dispatched tool so
+        a regression that only flipped one of two messages still fails here.
+        """
+        tool_started = asyncio.Event()
+        tool_proceed = asyncio.Event()
+
+        async def handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+            tool_started.set()
+            await tool_proceed.wait()
+            return {"result": "done"}
+
+        harness.register_tool("slow_tool", handler)
+
+        harness.script_model(
+            [
+                assistant(tool_calls=[tool_call("slow_tool", {}, call_id="call_slow")]),
+                assistant("Tool dispatch interrupted — moving on."),
+            ]
+        )
+
+        session = await harness.start("run the slow tool", tools=[])
+
+        await harness.run_step(session.id)
+        await asyncio.wait_for(tool_started.wait(), timeout=5.0)
+
+        await harness.simulate_sigkill(session.id)
+
+        repaired = await harness.run_ghost_repair(session.id)
+        assert len(repaired) == 1
+        assert repaired[0] == (session.id, "call_slow")
+
+        events = await harness.events(session.id)
+        tool_results = [e for e in events if e.kind == "message" and e.data.get("role") == "tool"]
+        assert len(tool_results) == 1
+        assert tool_results[0].data.get("is_error") is True
+        assert "may have completed" in tool_results[0].data.get("content", "")
+
+        needs = await harness.sessions_needing_inference(session.id)
+        assert session.id in needs
+
+        # Model must actually react to the synthetic error.  Without this
+        # assertion, a regression where ghost-repair fails to bump
+        # reacting_to (or where the session status sticks in a state that
+        # short-circuits the next step) would still pop the scripted
+        # response without ever calling the model.
+        await harness.run_step(session.id)
+        events = await harness.events(session.id)
+        last_asst = next(
+            e
+            for e in reversed(events)
+            if e.kind == "message"
+            and e.data.get("role") == "assistant"
+            and not e.data.get("tool_calls")
+        )
+        assert "interrupted" in last_asst.data.get("content", "").lower()
+
+    async def test_cross_session_sweep_may_have_completed(self, harness: Harness) -> None:
+        """Cross-session ghost repair (``session_id=None`` — the
+        production startup-sweep + 30s periodic-sweep shape) correctly
+        classifies a span-present ghost as 'may have completed' (#685).
+
+        Production callers: ``worker_main`` startup sweep and
+        ``_periodic_sweep`` both call ``wake_sessions_needing_inference(
+        pool, registry)`` without a session_id.  The per-session e2e
+        tests cover the scoped query path; this one closes the gap on
+        the unscoped path so a refactor that mis-scopes
+        ``GHOST_SPAN_START_SQL`` only for cross-session sweeps would
+        surface here.
+        """
+        tool_started = asyncio.Event()
+        tool_proceed = asyncio.Event()
+
+        async def handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+            tool_started.set()
+            await tool_proceed.wait()
+            return {"result": "done"}
+
+        harness.register_tool("xs_tool", handler)
+
+        harness.script_model(
+            [
+                assistant(tool_calls=[tool_call("xs_tool", {}, call_id="call_xs")]),
+                assistant("Tool dispatch interrupted."),
+            ]
+        )
+
+        session = await harness.start("run xs_tool", tools=[])
+
+        await harness.run_step(session.id)
+        await asyncio.wait_for(tool_started.wait(), timeout=5.0)
+
+        await harness.simulate_sigkill(session.id)
+
+        # Cross-session sweep: no session_id arg — exercises the production
+        # startup-sweep code path that scoped tests never hit.
+        repaired = await harness.run_ghost_repair()
+        repaired_pairs = {(sid, tcid) for sid, tcid in repaired}
+        assert (session.id, "call_xs") in repaired_pairs
+
+        events = await harness.events(session.id)
+        tool_results = [e for e in events if e.kind == "message" and e.data.get("role") == "tool"]
+        assert len(tool_results) == 1
+        assert tool_results[0].data.get("is_error") is True
+        assert "may have completed" in tool_results[0].data.get("content", "")
 
     async def test_crash_before_tool_launch(self, harness: Harness) -> None:
         """Assistant message with tool_calls exists, but tools never dispatched.
@@ -138,6 +251,14 @@ class TestGhostRecovery:
         repaired = await harness.run_ghost_repair(session.id)
         assert len(repaired) == 1
         assert repaired[0] == (session.id, "call_x")
+
+        # ``launch_tool_calls`` never ran, so no ``tool_execute_start`` span
+        # exists — recovery hits the "never started" branch (#685).
+        events = await harness.events(session.id)
+        tool_results = [e for e in events if e.kind == "message" and e.data.get("role") == "tool"]
+        assert len(tool_results) == 1
+        assert tool_results[0].data.get("is_error") is True
+        assert "did not run" in tool_results[0].data.get("content", "")
 
         # Session should need inference.
         needs = await harness.sessions_needing_inference(session.id)
@@ -197,9 +318,10 @@ class TestGhostRecovery:
         # Two concurrent repairs. asyncio.gather starts both immediately;
         # they interleave at every ``await`` inside find_and_repair_ghosts
         # (pool.acquire, fetch result_rows, fetch lifecycle_rows, fetch
-        # agent_rows, load_session_account_id, append_event), so at least
-        # one scheduling order will leave both sweeps believing the ghost
-        # is unresolved when they reach the append.
+        # agent_rows, fetch span_rows, load_session_account_id,
+        # append_event), so at least one scheduling order will leave both
+        # sweeps believing the ghost is unresolved when they reach the
+        # append.
         await asyncio.gather(
             harness.run_ghost_repair(session.id),
             harness.run_ghost_repair(session.id),
@@ -219,6 +341,12 @@ class TestGhostRecovery:
             f"symptom: the unlocked read-then-append in find_and_repair_ghosts "
             f"admits both concurrent sweeps to write."
         )
+        # Branch assertion (#685): the assistant message was appended manually
+        # without ``launch_tool_calls``, so no ``tool_execute_start`` span
+        # exists — the surviving sweep MUST hit "did not run".  Locks the
+        # branch decision under concurrency so a race that flipped one
+        # sweep's classification would surface here.
+        assert "did not run" in tool_results_for_call_x[0].data.get("content", "")
 
     async def test_ghost_in_earlier_batch(self, harness: Harness) -> None:
         """Multi-batch conversation. Tool lost from first batch.
@@ -290,6 +418,20 @@ class TestGhostRecovery:
         assert len(repaired) == 1
         assert repaired[0] == (session.id, "call_slow")
 
+        # Branch assertion (#685): slow_tool's ``tool_execute_start`` span
+        # committed before simulate_sigkill (handler_a's await on the proceed
+        # event only fires inside ``_tool_lifecycle``'s yielded body), so the
+        # multi-batch ghost MUST hit "may have completed".
+        events = await harness.events(session.id)
+        slow_tool_result = next(
+            e
+            for e in events
+            if e.kind == "message"
+            and e.data.get("role") == "tool"
+            and e.data.get("tool_call_id") == "call_slow"
+        )
+        assert "may have completed" in slow_tool_result.data.get("content", "")
+
         # Session should need inference (ghost error is unreacted).
         needs = await harness.sessions_needing_inference(session.id)
         assert session.id in needs
@@ -347,6 +489,22 @@ class TestGhostRecovery:
         repaired = await harness.run_ghost_repair(session.id)
         assert len(repaired) == 1
         assert repaired[0] == (session.id, "call_g")
+
+        # Branch assertion (#685): the assistant message was appended via
+        # ``append_event`` directly without ``_tool_lifecycle`` ever running,
+        # so no ``tool_execute_start`` span exists for ``call_g`` — recovery
+        # MUST hit "did not run".  A regression that interpreted the
+        # ``tool_confirmed allow`` lifecycle event as a started-marker (in
+        # place of, or alongside, the span) would flip this assertion.
+        events = await harness.events(session.id)
+        glob_result = next(
+            e
+            for e in events
+            if e.kind == "message"
+            and e.data.get("role") == "tool"
+            and e.data.get("tool_call_id") == "call_g"
+        )
+        assert "did not run" in glob_result.data.get("content", "")
 
         # Session should need inference after ghost repair.
         needs = await harness.sessions_needing_inference(session.id)

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -28,7 +28,7 @@ from typing import Any
 import asyncpg
 import pytest
 
-from aios.harness.sweep import CANDIDATE_ROWS_SQL, UNREACTED_ROWS_SQL
+from aios.harness.sweep import CANDIDATE_ROWS_SQL, GHOST_SPAN_START_SQL, UNREACTED_ROWS_SQL
 from tests.conftest import needs_docker
 from tests.support import find_subplans_over_events
 
@@ -189,6 +189,23 @@ class TestNoCorrelatedSubplanOverEvents:
         assert not found, (
             f"N+1 regression in _filter_incomplete_batches unreacted query: "
             f"{len(found)} correlated subplan(s) over events. Same CTE fix applies."
+        )
+
+    async def test_span_start_rows_is_not_n_plus_1(self, seeded_pool: asyncpg.Pool[Any]) -> None:
+        """``GHOST_SPAN_START_SQL`` drives the two-branch ghost-recovery
+        synthesis (#685).  Lock its single-pass shape so a future
+        refactor that adds a correlated subquery (e.g., excluding
+        already-confirmed-but-redispatched tcids) fails here instead
+        of regressing sweep latency."""
+        session_ids = [f"sess_perf_{i:03d}" for i in range(_N_SESSIONS)]
+        # Arbitrary tcid set — the planner cares about the predicate shape,
+        # not the actual values.
+        tcids = [f"tc_{i}" for i in range(10)]
+        plan = await _explain(seeded_pool, GHOST_SPAN_START_SQL, session_ids, tcids)
+        found = find_subplans_over_events(plan)
+        assert not found, (
+            f"N+1 regression in find_and_repair_ghosts span-marker query: "
+            f"{len(found)} correlated subplan(s) over events. See #685."
         )
 
 

--- a/tests/unit/test_dispatch_confirmed_tools.py
+++ b/tests/unit/test_dispatch_confirmed_tools.py
@@ -99,9 +99,10 @@ class TestDispatchConfirmedTools:
         broke at the first assistant with non-empty tool_calls — A2's
         ``[Z]``.  The dispatch filter checked ``confirmed={X}`` against
         ``[Z]`` and returned ``[]``.  X is silently dropped; ghost-repair
-        eventually papers over with ``"No result was received"`` — a
-        misleading synthetic error, because the operator DID allow X;
-        only the dispatch was lost."""
+        eventually papers over with a synthetic "did not run" error (per
+        the two-branch recovery in ``sweep.find_and_repair_ghosts`` — see
+        #685), because the operator DID allow X; only the dispatch was
+        lost."""
         msg_events = [
             _assistant_with_tool_calls(["tc_X"]),  # older A1 with the confirmed tool
             SimpleNamespace(

--- a/tests/unit/test_sweep_isolation.py
+++ b/tests/unit/test_sweep_isolation.py
@@ -66,10 +66,14 @@ async def test_ghost_repair_failure_does_not_abort_batch(monkeypatch: Any) -> No
         {"session_id": "sess_a", "tools": "[]"},
         {"session_id": "sess_b", "tools": "[]"},
     ]
-    # find_and_repair_ghosts issues four ``conn.fetch`` calls in order:
-    # GHOST_ASST_SQL, ALL_RESULT_ROWS_SQL, GHOST_LIFECYCLE_SQL, agents.
+    # find_and_repair_ghosts issues five ``conn.fetch`` calls in order:
+    # GHOST_ASST_SQL, ALL_RESULT_ROWS_SQL, GHOST_LIFECYCLE_SQL, agents,
+    # GHOST_SPAN_START_SQL.  The empty span result means both ghosts hit
+    # the "never started" branch of the recovery synthesis (#685) — which
+    # is fine for this test, which only cares that per-ghost failures
+    # don't abort the batch.
     conn = MagicMock()
-    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], lifecycle_rows, agent_rows])
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], lifecycle_rows, agent_rows, []])
     pool = fake_pool_yielding_conn(conn)
 
     append_mock = AsyncMock(side_effect=[RuntimeError("first ghost db blip"), None])
@@ -88,3 +92,107 @@ async def test_ghost_repair_failure_does_not_abort_batch(monkeypatch: Any) -> No
     # The returned list reflects ghosts whose repair actually committed
     # (the second one); the first is logged-and-skipped.
     assert len(repaired) == 1
+
+
+async def test_ghost_repair_branch_may_have_completed(monkeypatch: Any) -> None:
+    """The 'may have completed' recovery branch fires when a
+    ``tool_execute_start`` span exists for the ghost tcid — model is
+    warned that side effects may have committed and to verify before
+    retrying (#685).
+
+    Closes the unit-level gap left by
+    ``test_ghost_repair_failure_does_not_abort_batch``, whose
+    ``span_rows`` mock is empty and so only exercises the 'did not run'
+    branch.  Without this test, a refactor that swapped the two
+    ``error_text`` strings, inverted the ``(sid, tcid) in started``
+    predicate, or constructed ``started`` with mismatched keys would
+    pass all unit tests and rely on Docker-gated e2e for coverage of
+    the side-effect-risk branch.
+    """
+    ghost_rows = [
+        {
+            "session_id": "sess_a",
+            "data": {
+                "role": "assistant",
+                "tool_calls": [{"id": "tc_a", "type": "function", "function": {"name": "bash"}}],
+            },
+        },
+    ]
+    # ``tool_confirmed allow`` for the always_ask bash builtin so the
+    # candidate passes ``_was_dispatched``.
+    lifecycle_rows = [
+        {"session_id": "sess_a", "tool_call_id": "tc_a"},
+    ]
+    agent_rows = [
+        {"session_id": "sess_a", "tools": "[]"},
+    ]
+    # The span EXISTS for tc_a → routes the synthesis to the
+    # "may have completed" branch.
+    span_rows = [
+        {"session_id": "sess_a", "tool_call_id": "tc_a"},
+    ]
+    # find_and_repair_ghosts now issues five ``conn.fetch`` calls in order:
+    # GHOST_ASST_SQL, ALL_RESULT_ROWS_SQL, GHOST_LIFECYCLE_SQL, agents,
+    # GHOST_SPAN_START_SQL.
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], lifecycle_rows, agent_rows, span_rows])
+    pool = fake_pool_yielding_conn(conn)
+
+    append_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "aios.harness.sweep.sessions_service.load_session_account_id",
+        AsyncMock(return_value="acc_test"),
+    )
+    monkeypatch.setattr("aios.harness.sweep.sessions_service.append_tool_result", append_mock)
+
+    repaired = await find_and_repair_ghosts(pool, TaskRegistry())
+
+    assert repaired == [("sess_a", "tc_a")]
+    assert append_mock.await_count == 1
+    content = append_mock.await_args_list[0].kwargs["content"]
+    assert "may have completed" in content
+    assert "Verify the outcome" in content
+
+
+async def test_ghost_repair_branch_did_not_run(monkeypatch: Any) -> None:
+    """The 'did not run' recovery branch fires when NO ``tool_execute_start``
+    span exists for the ghost tcid — model is told the tool did not run
+    and may be retried (#685).  Sibling of
+    ``test_ghost_repair_branch_may_have_completed`` for both-branch
+    explicit coverage at the unit level.
+    """
+    ghost_rows = [
+        {
+            "session_id": "sess_a",
+            "data": {
+                "role": "assistant",
+                "tool_calls": [{"id": "tc_a", "type": "function", "function": {"name": "bash"}}],
+            },
+        },
+    ]
+    lifecycle_rows = [
+        {"session_id": "sess_a", "tool_call_id": "tc_a"},
+    ]
+    agent_rows = [
+        {"session_id": "sess_a", "tools": "[]"},
+    ]
+    # NO span for tc_a → routes the synthesis to the "did not run" branch.
+    span_rows: list[dict[str, Any]] = []
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], lifecycle_rows, agent_rows, span_rows])
+    pool = fake_pool_yielding_conn(conn)
+
+    append_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "aios.harness.sweep.sessions_service.load_session_account_id",
+        AsyncMock(return_value="acc_test"),
+    )
+    monkeypatch.setattr("aios.harness.sweep.sessions_service.append_tool_result", append_mock)
+
+    repaired = await find_and_repair_ghosts(pool, TaskRegistry())
+
+    assert repaired == [("sess_a", "tc_a")]
+    assert append_mock.await_count == 1
+    content = append_mock.await_args_list[0].kwargs["content"]
+    assert "did not run" in content
+    assert "You may retry" in content


### PR DESCRIPTION
## Summary
- Replace the single fabricated `"No result was received for this tool call."` with two branched messages keyed on the existing `tool_execute_start` span: `"may have completed; verify before retrying"` when the span exists, `"did not run; you may retry"` when it doesn't.
- This stops the harness from *lying* about non-idempotent tool outcomes (bash mutations, http_request POST, connector send), which under the project's "model retries on error" philosophy was double-firing those operations on the model's retry.
- Add `branch=may_have_completed|did_not_run` kv to the `sweep.ghost_repaired` structlog line so ops can triage which recoveries carry side-effect risk.
- Producer side: move `bound_log = log.bind(...)` below the span append so the load-bearing "first action in this lifecycle" comment is literally true; comment now explicitly covers the `CancelledError`-during-await race.
- Consumer side: new `GHOST_SPAN_START_SQL` (scoped by both session and tcid lists, no new index — defer until profiling shows need), `find_and_repair_ghosts` restructured so spans are fetched only for the post-`_was_dispatched` ghost set.

## Test plan
- [x] `uv run mypy src` — clean (163 files)
- [x] `uv run ruff check src tests && uv run ruff format --check` — clean (408 files)
- [x] `uv run pytest tests/unit -q` — **1500 passed** (added 2 branch-coverage tests in `test_sweep_isolation.py`)
- [x] `uv run pytest tests/e2e/test_sweep.py::TestGhostRecovery ::TestGhostExclusions` — **10 passed** (added `test_started_then_killed_single_tool` + `test_cross_session_sweep_may_have_completed`, branch-content assertions on 4 existing tests)
- [x] `uv run pytest tests/e2e/test_sweep_perf.py::TestNoCorrelatedSubplanOverEvents` — **3 passed** (`GHOST_SPAN_START_SQL` registered)
- [x] Live SIGKILL-mid-`bash sleep 30` verification on an isolated runtime: worker dispatched bash, span committed, `kill -9` worker, restarted; startup sweep emitted `branch=may_have_completed` in structlog and synthesized the new content into the event log; model reacted with "sleep 30 command was interrupted before it could complete" — no blind retry.
- [x] Regression watch: `test_concurrent_ghost_repair_emits_single_result` (the invariant #4 dedup test) still passes unchanged; now also asserts the surviving branch under concurrency.

## Non-goals (deferred follow-ups)
- Re-dispatching the "never started" case automatically.
- Promoting side-effectful tools to durable jobs (direction 2 of #685).
- Per-tool idempotency keys.
- A partial expression index on `events ((data->>'tool_call_id')) WHERE kind='span' AND data->>'event'='tool_execute_start'` (defer until profiling shows need).

Pairs with the other two architecture findings from the same audit: #686 (context-builder poison-event brick) and #687 (events god-table retention).

Closes #685.

🤖 Generated with [Claude Code](https://claude.com/claude-code)