### PR TITLE
chore(skills/aios-smoke-setup): fix cold-start bugs + headless mode

### DIFF
--- a/.claude/skills/aios-smoke-setup/SKILL.md
+++ b/.claude/skills/aios-smoke-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aios-smoke-setup
-description: This skill should be used when the user asks to "smoke test the connector", "DM the bot in this worktree", "set up a fresh aios runtime", "spin up aios", "prep a smoke session", "bring up aios on this branch", or otherwise wants to point a real Telegram, Signal, or WhatsApp bot at the code in the current worktree.  Bundles the pre-flight checks (bot getUpdates conflict, sibling worktree non-interference, free port), the isolated `.env` overrides (separate DB + port + ``AIOS_DEFAULT_MCP_PERMISSION_POLICY=always_allow``), the right migration command (``aios migrate``, not ``alembic upgrade head``), and the env/agent/connection/session/attach resource chain in one ``setup.sh`` so the first DM round-trips in seconds instead of forty-five minutes.  For WhatsApp specifically the pair flow differs (QR scan, no bot-token) — once this skill brings up the runtime, hand off to ``aios-whatsapp-pair`` to actually link the account, then ``aios-live-monitor`` for narration.
+description: This skill should be used when the user asks to "smoke test the connector", "DM the bot in this worktree", "set up a fresh aios runtime", "spin up aios", "prep a smoke session", "bring up aios on this branch", "bring up aios headless", "spin up aios without a bot", "no-connector runtime", or needs a running aios runtime to "verify a harness change" / repro a sweep/loop/context/tool_dispatch issue — whether pointed at a real Telegram/Signal/WhatsApp bot OR headless (api+worker only, driven via the CLI).  Bundles the pre-flight checks (bot getUpdates conflict, sibling worktree non-interference, free port), the isolated `.env` overrides (separate DB + port + ``AIOS_URL`` + absolute ``AIOS_WORKSPACE_ROOT`` + ``AIOS_DEFAULT_MCP_PERMISSION_POLICY=always_allow``), the right migration command (``aios migrate``, not ``alembic upgrade head``), the fresh-DB ``bootstrap_root`` step (a new DB 401s every call until an account key is minted), and the env/agent/(connection)/session resource chain in one ``setup.sh`` so the first DM (or first CLI round-trip) works in seconds instead of forty-five minutes.  Use ``--no-connector`` for harness verification; for WhatsApp the pair flow differs (QR scan, no bot-token) — hand off to ``aios-whatsapp-pair`` then ``aios-live-monitor``.
 ---
 
 # aios smoke session setup
@@ -24,7 +24,29 @@ Skip this skill if you're just running unit / e2e tests — `uv run pytest` is t
   [--system-prompt-file <path>]
 ```
 
-Reads source `.env` from `~/code/aios/.env`, writes a worktree-scoped `.env` with overrides, creates a fresh `aios_smoke_<branch_short>` Postgres database, runs migrations, starts api + worker, builds the env/agent/connection/session resource chain, and prints `session_id` + the focal-channel address on stdout.
+Reads source `.env` from `~/code/aios/.env`, writes a worktree-scoped `.env` with overrides, creates a fresh `aios_smoke_<branch_short>` Postgres database, runs migrations, bootstraps the root account, starts api + worker, builds the env/agent/connection/session resource chain, and prints `session_id` + the focal-channel address on stdout.
+
+## Headless bring-up (no connector — for `/verify` of harness changes)
+
+When verifying a change to the harness core (sweep / loop / context / tool_dispatch / completion), a connector is dead weight — you just need a running runtime you can drive via the CLI. Use `--no-connector`: it skips the bot-token requirement and the connector-readiness wait, and builds env+agent+session **without** the connection/attach steps.
+
+```bash
+.claude/skills/aios-smoke-setup/scripts/setup.sh --no-connector [--port <num>]
+# → prints a session_id; drive it with:
+uv run aios sessions send <sess_id> "run sleep 30"
+uv run aios sessions events <sess_id> --kind message
+```
+
+### When Claude is driving (not a human terminal)
+
+`setup.sh`'s api/worker are spawned with `nohup … &`. That survives a **human** running the script in a terminal, but **not** Claude running it via the Bash tool — the harness reaps the call's process group on completion (`nohup` only ignores SIGHUP). The runtime dies before you can drive it. Use the three-step `--phase` split so the processes are owned by `run_in_background` calls that persist across tool calls:
+
+1. `setup.sh --no-connector --phase prep` — writes `.env`, creates+migrates the DB, bootstraps the root account. No long-lived processes.
+2. Start **api and worker as two separate `run_in_background` Bash calls**:
+   `( set -a; source .env; set +a; uv run python -m aios api )` and `… -m aios worker`.
+3. `setup.sh --no-connector --phase fixtures` — builds env+agent+session once the runtime is up.
+
+Then SIGKILL/restart the worker (`kill -9 <pid>` → restart via `run_in_background`) to exercise crash-recovery paths, and read the event log with `aios sessions events` or `docker exec <pg> psql`. See `references/gotchas.md` #9–13 for the cold-start failure modes this sequence avoids.
 
 ## Pre-flight rules (every smoke run)
 

--- a/.claude/skills/aios-smoke-setup/references/gotchas.md
+++ b/.claude/skills/aios-smoke-setup/references/gotchas.md
@@ -13,6 +13,21 @@ The eight failure modes that cost ~5–15 min each during the openclaw-parity PR
 | 7 | `connections attach` returns `connector 'X' is None; snapshot unavailable` even though `aios connectors list` shows status=running | Pre-existing bug in `_assert_account_in_snapshot` reading the wrong envelope key (singular `connector` instead of plural `connectors`). | Fixed in #242.  If you hit this on a branch off pre-`bff6660` master, cherry-pick the fix or use `--phase post-attach` to skip the validation. |
 | 8 | `aios sessions create` rejects with "either provide --agent and --environment-id" | Subcommand needs **both** flags; `--agent` alone isn't enough. | `aios sessions create --agent <agent_id> --environment-id <env_id>`.  See also: `envs` (plural) not `environments`; `--session-id` not `--session` on connections attach.  See `references/missing-affordances.md` for the wishlist of CLI naming consistency. |
 
+## Fresh-DB & headless bring-up (added after the #685 verify session)
+
+These bite a **cold start** — a brand-new per-branch DB and/or a
+no-connector runtime for `/verify`-ing a harness change.  `setup.sh` now
+handles all five, but they're documented here because a manual bring-up
+(or a future refactor of the script) will re-hit them.
+
+| # | Symptom | Root cause | Fix |
+|---|---------|------------|-----|
+| 9 | `aios migrate` dies with `pydantic … AIOS_WORKSPACE_ROOT must be an absolute path; got 'workspaces'` | Source `.env` ships `AIOS_WORKSPACE_ROOT=./workspaces` (relative).  Pydantic rejects it regardless of CWD; api and worker would also resolve a relative path against diverging CWDs. | `setup.sh` `write_env` now overrides it to `$WORKTREE/workspaces` (absolute).  Manual: set an absolute path. |
+| 10 | Every CLI/API call returns `401 invalid api key` on a fresh DB, even with the `.env` `AIOS_API_KEY` | Auth is **DB-backed** (`account_keys` table via `lookup_account_by_key_hash`); the `.env` `AIOS_API_KEY` is *not* what the server validates.  A fresh DB has zero keys. | `setup.sh` now runs `bootstrap_root` after migrate and writes the minted plaintext key back into `.env`.  Manual: `uv run python -c "...bootstrap_root(pool, display_name='x')..."` then use the returned key.  (The HTTP `/v1/accounts/bootstrap` route also works but is gated on `AIOS_BOOTSTRAP_TOKEN`.) |
+| 11 | Fixtures land on the wrong runtime / `connection refused` from the CLI during `build_fixtures` | `write_env` overrode `AIOS_API_PORT` but not `AIOS_URL`; the CLI targets `AIOS_URL`, so it hit whatever the source `.env` pointed at (often `:8090` — a sibling worktree's runtime). | `setup.sh` now also pins `AIOS_URL=http://127.0.0.1:$PORT`.  Manual: export `AIOS_URL` to match the chosen port. |
+| 12 | `docker exec aios-pg …: No such container` | `ensure_db` hardcoded `aios-pg`; compose now names it `aios-postgres-1`. | `setup.sh` `pg_container()` auto-detects the container publishing `:5433`, falling back to `aios-postgres-1`. |
+| 13 | api/worker spawned by `setup.sh` (or by `nohup … &` in a Bash tool call) die the moment the call returns — runtime gone before you can drive it | When **Claude** runs a command via the Bash tool, the harness reaps the call's process group on completion; `nohup` only ignores SIGHUP, not the SIGTERM/SIGKILL that reaping sends.  (A human running `setup.sh` in a real terminal is fine — children reparent to init.) | For Claude-driven sessions: `setup.sh --phase prep`, then start **api and worker as two separate `run_in_background` Bash calls**, then `setup.sh --phase fixtures`.  See SKILL.md "Headless bring-up when Claude is driving". |
+
 ## Less-frequent pitfalls
 
 - **Pre-commit hook gates on the whole working tree**, not just staged files.  Splitting two logical changes into separate commits requires `git stash` of the file you don't want gated.

--- a/.claude/skills/aios-smoke-setup/scripts/setup.sh
+++ b/.claude/skills/aios-smoke-setup/scripts/setup.sh
@@ -1,46 +1,64 @@
 #!/usr/bin/env bash
-# Bring up an isolated aios smoke runtime in this worktree, ready to
-# receive real Telegram messages and respond.
+# Bring up an isolated aios runtime in this worktree.
 #
-# Idempotent.  Re-running with the same flags refreshes the DB + fixtures.
-# Use --restart to reload api/worker on the new HEAD without rebuilding the
-# DB (the smoke-branch commit-cycle pattern).
+# Two shapes:
+#   * connector mode (default) — pointed at a real Telegram/Signal bot,
+#     ready to receive DMs.  Needs --bot-token for telegram.
+#   * headless mode (--no-connector) — api+worker only, no connector,
+#     driven via the CLI.  For /verify of harness changes (sweep, loop,
+#     context, tool_dispatch) where a connector is irrelevant.
+#
+# Idempotent.  Re-running refreshes the DB + fixtures.  --restart reloads
+# api/worker on the new HEAD without rebuilding the DB.
 #
 # Usage:
 #   setup.sh --bot-token <token> [--connector telegram] \
 #            [--agent-name smoke] [--system-prompt-file <path>] \
 #            [--source-env ~/code/aios/.env] [--port <num>] \
 #            [--db <name>] [--restart]
+#   setup.sh --no-connector [--agent-name verify] [--port <num>] [--db <name>]
 #
 # Output (last line):
 #   smoke_session_id=sess_01...
+#
+# NOTE for Claude-driven sessions: a plain `bash setup.sh` started via the
+# Bash tool spawns api/worker that are reaped when the tool call returns.
+# If you need the runtime to outlive the call, start api+worker yourself via
+# two `run_in_background` Bash calls and use `--phase fixtures` here.  See
+# SKILL.md "Headless bring-up when Claude is driving".
 
 set -euo pipefail
 
 # ── arg parsing ───────────────────────────────────────────────────────
 BOT_TOKEN=""
 CONNECTOR="telegram"
-AGENT_NAME="smoke"
+NO_CONNECTOR=false
+AGENT_NAME=""
 SYSTEM_PROMPT_FILE=""
 SOURCE_ENV="${HOME}/code/aios/.env"
 PORT=""
 DB=""
 RESTART_ONLY=false
+PHASE="all"   # all | prep | fixtures
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --bot-token) BOT_TOKEN="$2"; shift 2;;
     --connector) CONNECTOR="$2"; shift 2;;
+    --no-connector) NO_CONNECTOR=true; CONNECTOR=""; shift;;
     --agent-name) AGENT_NAME="$2"; shift 2;;
     --system-prompt-file) SYSTEM_PROMPT_FILE="$2"; shift 2;;
     --source-env) SOURCE_ENV="$2"; shift 2;;
     --port) PORT="$2"; shift 2;;
     --db) DB="$2"; shift 2;;
     --restart) RESTART_ONLY=true; shift;;
-    -h|--help) sed -n '2,15p' "$0"; exit 0;;
+    --phase) PHASE="$2"; shift 2;;
+    -h|--help) sed -n '2,24p' "$0"; exit 0;;
     *) echo "unknown flag: $1" >&2; exit 2;;
   esac
 done
+
+[[ -z "$AGENT_NAME" ]] && { $NO_CONNECTOR && AGENT_NAME="verify" || AGENT_NAME="smoke"; }
 
 WORKTREE="$(pwd)"
 BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo nobranch)"
@@ -53,11 +71,23 @@ warn()  { printf "\033[33m⚠\033[0m %s\n" "$*"; }
 fail()  { printf "\033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
 ok()    { printf "\033[32m✓\033[0m %s\n" "$*"; }
 
+export DOCKER_HOST="${DOCKER_HOST:-unix:///Users/tom/.docker/run/docker.sock}"
+
+# Resolve the aios Postgres container by the port it publishes (5433),
+# falling back to the conventional compose name.  The hardcoded `aios-pg`
+# this replaced silently broke once compose started naming it
+# `aios-postgres-1`.
+pg_container() {
+  local c
+  c="$(docker ps --filter "publish=5433" --format '{{.Names}}' 2>/dev/null | head -1)"
+  echo "${c:-aios-postgres-1}"
+}
+
 # ── 1. preflight ──────────────────────────────────────────────────────
 preflight() {
   say "preflight"
 
-  # 1a. Bot token uncontested
+  # 1a. Bot token uncontested (telegram connector only)
   if [[ "$CONNECTOR" == "telegram" && -n "$BOT_TOKEN" ]]; then
     local resp
     resp="$(curl -sS "https://api.telegram.org/bot${BOT_TOKEN}/getUpdates?timeout=2&limit=1" 2>&1 || echo '{"ok":false}')"
@@ -80,13 +110,13 @@ preflight() {
 
   # 1c. Pick a free port if not provided
   if [[ -z "$PORT" ]]; then
-    for candidate in 8091 8092 8093 8094 8095; do
+    for candidate in 8091 8092 8093 8094 8095 8096 8097; do
       if ! lsof -iTCP:"$candidate" -sTCP:LISTEN >/dev/null 2>&1; then
         PORT="$candidate"
         break
       fi
     done
-    [[ -z "$PORT" ]] && fail "no free port in 8091..8095"
+    [[ -z "$PORT" ]] && fail "no free port in 8091..8097"
   elif lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
     fail "port $PORT already in use"
   fi
@@ -95,21 +125,29 @@ preflight() {
 
 # ── 2. write .env with overrides ──────────────────────────────────────
 write_env() {
-  say "writing .env (db=$DB port=$PORT)"
+  say "writing .env (db=$DB port=$PORT connector=${CONNECTOR:-none})"
   [[ -e "$SOURCE_ENV" ]] || fail "source env $SOURCE_ENV missing"
 
-  # Start from source env, then override the four critical lines.  Any
-  # existing .env is overwritten — this script owns it on smoke runtimes.
+  # Start from source env, then override the critical lines.  Any existing
+  # .env is overwritten — this script owns it on smoke runtimes.
   cp "$SOURCE_ENV" "$WORKTREE/.env"
 
-  python3 - "$WORKTREE/.env" "$DB" "$PORT" "$CONNECTOR" "$BOT_TOKEN" <<'PY'
+  python3 - "$WORKTREE/.env" "$DB" "$PORT" "$CONNECTOR" "$BOT_TOKEN" "$WORKTREE" <<'PY'
 import sys, pathlib
-path, db, port, connector, token = sys.argv[1:6]
+path, db, port, connector, token, worktree = sys.argv[1:7]
 overrides = {
     "AIOS_DB_URL": f"postgresql://aios:aios@localhost:5433/{db}",
     "AIOS_API_PORT": port,
+    # The CLI targets AIOS_URL; without pinning it to THIS runtime's port a
+    # port-overridden smoke runtime would have its fixtures created against
+    # whatever the source .env points at (often :8090 — a sibling worktree).
+    "AIOS_URL": f"http://127.0.0.1:{port}",
     "AIOS_CONNECTORS_ENABLED": connector,
     "AIOS_DEFAULT_MCP_PERMISSION_POLICY": "always_allow",
+    # Pydantic rejects a relative workspace root ("must be an absolute
+    # path"); the source .env ships `./workspaces`.  Resolve it under the
+    # worktree so api + worker agree on the same absolute path.
+    "AIOS_WORKSPACE_ROOT": f"{worktree}/workspaces",
 }
 if connector == "telegram" and token:
     overrides["AIOS_TELEGRAM_BOT_TOKEN"] = token
@@ -129,20 +167,61 @@ for key, val in overrides.items():
         out.append(f"{key}={val}")
 pathlib.Path(path).write_text("\n".join(out) + "\n")
 PY
+  mkdir -p "$WORKTREE/workspaces"
   ok ".env written"
 }
 
 # ── 3. fresh DB + migrate ─────────────────────────────────────────────
 ensure_db() {
-  say "creating database $DB"
-  DOCKER_HOST="${DOCKER_HOST:-unix:///Users/tom/.docker/run/docker.sock}" \
-    docker exec aios-pg psql -U aios -d postgres -c "DROP DATABASE IF EXISTS \"$DB\"" >/dev/null
-  DOCKER_HOST="${DOCKER_HOST:-unix:///Users/tom/.docker/run/docker.sock}" \
-    docker exec aios-pg psql -U aios -d postgres -c "CREATE DATABASE \"$DB\" OWNER aios" >/dev/null
+  local pg
+  pg="$(pg_container)"
+  say "creating database $DB (container=$pg)"
+  docker exec "$pg" psql -U aios -d postgres -c "DROP DATABASE IF EXISTS \"$DB\"" >/dev/null
+  docker exec "$pg" psql -U aios -d postgres -c "CREATE DATABASE \"$DB\" OWNER aios" >/dev/null
 
   say "applying schemas (alembic + procrastinate via 'aios migrate')"
   ( set -a; source "$WORKTREE/.env"; set +a; uv run aios migrate >/dev/null )
   ok "schemas applied"
+}
+
+# ── 3b. bootstrap root account ────────────────────────────────────────
+# A fresh DB has no account_keys rows, so every CLI/API call 401s with
+# "invalid api key" — the .env's AIOS_API_KEY is NOT what the server
+# validates (auth is DB-backed via account_keys).  Mint the root account
+# and write its plaintext key back into .env so the CLI authenticates.
+bootstrap_account() {
+  say "bootstrapping root account"
+  local key
+  key="$( set -a; source "$WORKTREE/.env"; set +a
+    uv run python -c "
+import asyncio, os
+from aios.db.pool import create_pool
+from aios.services.accounts import bootstrap_root
+async def main():
+    pool = await create_pool(os.environ['AIOS_DB_URL'], max_size=2)
+    try:
+        r = await bootstrap_root(pool, display_name='smoke-root')
+        print(r.plaintext_key)
+    finally:
+        await pool.close()
+asyncio.run(main())
+" 2>/dev/null )"
+  [[ -z "$key" ]] && fail "bootstrap_root produced no key — see migrate/env"
+  python3 - "$WORKTREE/.env" "$key" <<'PY'
+import sys, pathlib
+path, key = sys.argv[1:3]
+lines = pathlib.Path(path).read_text().splitlines()
+out, seen = [], False
+for line in lines:
+    if line.startswith("AIOS_API_KEY="):
+        out.append(f"AIOS_API_KEY={key}"); seen = True
+    else:
+        out.append(line)
+if not seen:
+    out.append(f"AIOS_API_KEY={key}")
+pathlib.Path(path).write_text("\n".join(out) + "\n")
+PY
+  ok "root account bootstrapped; AIOS_API_KEY written to .env"
 }
 
 # ── 4. start api + worker ─────────────────────────────────────────────
@@ -156,30 +235,41 @@ start_runtime() {
   say "starting api + worker"
   # Unlink rather than truncate: the previous worker's still-open stdout
   # fd keeps appending to the inode it opened, which is now anonymous,
-  # so its shutdown traceback can't bleed into the new log file. The
-  # new processes open a fresh inode at the same path. See #298.
+  # so its shutdown traceback can't bleed into the new log file.  See #298.
   rm -f "$WORKTREE/.logs/api.log" "$WORKTREE/.logs/worker.log"
   ( set -a; source "$WORKTREE/.env"; set +a
     nohup uv run python -m aios api > "$WORKTREE/.logs/api.log" 2>&1 &
     nohup uv run python -m aios worker > "$WORKTREE/.logs/worker.log" 2>&1 & )
 
-  # Wait for bot identification or fatal
   local deadline=$((SECONDS + 60))
   while (( SECONDS < deadline )); do
-    if grep -q "telegram\.bot\.identified\|signal\.account\.ready" "$WORKTREE/.logs/worker.log" 2>/dev/null; then
-      ok "connector running"
-      return 0
-    fi
-    if grep -qE "RuntimeError|Conflict|Errno 48|duplicate_instance" "$WORKTREE/.logs/worker.log" "$WORKTREE/.logs/api.log" 2>/dev/null; then
-      tail -20 "$WORKTREE/.logs/worker.log"
+    # Fatal-error short-circuit (covers both modes).  ValidationError
+    # catches the relative-workspace-root class early.
+    if grep -qE "RuntimeError|Conflict|Errno 48|duplicate_instance|ValidationError" \
+         "$WORKTREE/.logs/worker.log" "$WORKTREE/.logs/api.log" 2>/dev/null; then
+      tail -20 "$WORKTREE/.logs/worker.log" "$WORKTREE/.logs/api.log"
       fail "runtime startup failed — see .logs/"
+    fi
+    if $NO_CONNECTOR; then
+      # Headless readiness: api port listening + worker booted.  There's no
+      # connector to identify, so the connector-log grep would never fire.
+      if lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1 \
+         && grep -q "worker.startup" "$WORKTREE/.logs/worker.log" 2>/dev/null; then
+        ok "runtime up (headless, no connector)"
+        return 0
+      fi
+    else
+      if grep -q "telegram\.bot\.identified\|signal\.account\.ready" "$WORKTREE/.logs/worker.log" 2>/dev/null; then
+        ok "connector running"
+        return 0
+      fi
     fi
     sleep 0.5
   done
-  fail "runtime didn't identify within 60s — see .logs/"
+  fail "runtime didn't become ready within 60s — see .logs/"
 }
 
-# ── 5. fixtures: env + agent + connection + session + attach ──────────
+# ── 5. fixtures ───────────────────────────────────────────────────────
 build_fixtures() {
   ( set -a; source "$WORKTREE/.env"; set +a
 
@@ -187,7 +277,7 @@ build_fixtures() {
     local env_id
     env_id="$(uv run aios -f json envs create --data '{"name":"smoke"}' 2>/dev/null \
               | python3 -c "import json,sys;print(json.load(sys.stdin)['id'])")"
-    [[ -z "$env_id" ]] && fail "env create failed"
+    [[ -z "$env_id" ]] && fail "env create failed (auth? run bootstrap_account; is the runtime up on \$AIOS_URL?)"
 
     say "creating agent"
     local agent_json
@@ -195,6 +285,8 @@ build_fixtures() {
     local sysprompt
     if [[ -n "$SYSTEM_PROMPT_FILE" && -e "$SYSTEM_PROMPT_FILE" ]]; then
       sysprompt="$(cat "$SYSTEM_PROMPT_FILE")"
+    elif $NO_CONNECTOR; then
+      sysprompt="You are a verification assistant. Run tools as asked; keep replies brief."
     else
       sysprompt="You are a smoke-test assistant on Telegram. Speak in your own voice; never claim to be Claude Code. Keep replies brief and conversational."
     fi
@@ -218,6 +310,30 @@ PY
     rm -f "$agent_json"
     [[ -z "$agent_id" ]] && fail "agent create failed"
 
+    say "creating session"
+    local sess_id
+    sess_id="$(uv run aios -f json sessions create --agent "$agent_id" --environment-id "$env_id" 2>/dev/null \
+               | python3 -c "import json,sys;print(json.load(sys.stdin)['id'])")"
+    [[ -z "$sess_id" ]] && fail "session create failed"
+
+    if $NO_CONNECTOR; then
+      cat <<EOF
+
+✓ headless runtime ready (no connector)
+  session:   $sess_id
+  agent:     $agent_id
+  api:       http://127.0.0.1:$PORT
+  db:        $DB
+
+Drive it via the CLI (AIOS_URL/AIOS_API_KEY are in .env):
+  uv run aios sessions send $sess_id "run sleep 30"
+  uv run aios sessions events $sess_id --kind message
+
+smoke_session_id=$sess_id
+EOF
+      return 0
+    fi
+
     say "fetching bot account id"
     local bot_id
     bot_id="$(uv run aios -f json connectors list 2>/dev/null \
@@ -232,11 +348,6 @@ for c in data['connectors']:
     say "creating connection"
     local conn_id
     conn_id="$(uv run aios -f json connections create --connector="$CONNECTOR" --account="$bot_id" 2>/dev/null \
-               | python3 -c "import json,sys;print(json.load(sys.stdin)['id'])")"
-
-    say "creating session"
-    local sess_id
-    sess_id="$(uv run aios -f json sessions create --agent "$agent_id" --environment-id "$env_id" 2>/dev/null \
                | python3 -c "import json,sys;print(json.load(sys.stdin)['id'])")"
 
     say "attaching connection → session"
@@ -264,12 +375,34 @@ if $RESTART_ONLY; then
   exit 0
 fi
 
+if [[ "$PHASE" == "fixtures" ]]; then
+  # Processes already started elsewhere (e.g. Claude's run_in_background).
+  build_fixtures
+  exit 0
+fi
+
 if [[ -z "$BOT_TOKEN" && "$CONNECTOR" == "telegram" ]]; then
-  fail "--bot-token is required for connector=telegram"
+  fail "--bot-token is required for connector=telegram (or pass --no-connector for headless)"
 fi
 
 preflight
 write_env
 ensure_db
+bootstrap_account
+
+if [[ "$PHASE" == "prep" ]]; then
+  cat <<EOF
+
+✓ prep complete (db + .env + root account)
+  Start the runtime yourself (persists across tool calls), then build fixtures:
+    # two run_in_background Bash calls:
+    ( set -a; source .env; set +a; uv run python -m aios api )
+    ( set -a; source .env; set +a; uv run python -m aios worker )
+    # then:
+    $0 ${NO_CONNECTOR:+--no-connector }--phase fixtures --port $PORT --db $DB
+EOF
+  exit 0
+fi
+
 start_runtime
 build_fixtures


### PR DESCRIPTION
## Summary
Surfaced while verifying #685 (PR #690) via a headless aios runtime — `setup.sh` had several latent breakages on a fresh-DB / no-connector bring-up, plus no headless mode. Skill-tooling only; no product code.

- **Container name**: `ensure_db` hardcoded `docker exec aios-pg`; compose renamed it to `aios-postgres-1`. Now auto-detected by the container publishing `:5433`, with that name as fallback.
- **Workspace root**: `write_env` inherited the source `.env`'s relative `AIOS_WORKSPACE_ROOT=./workspaces`, which Pydantic rejects at migrate ("must be an absolute path"). Now overridden to `$WORKTREE/workspaces`.
- **Bootstrap**: a fresh DB has no `account_keys` rows, so every CLI call 401s (auth is DB-backed; the `.env` `AIOS_API_KEY` is not the validated credential). Added a `bootstrap_root` step that writes the minted key back into `.env`.
- **`AIOS_URL`**: `write_env` pinned `AIOS_API_PORT` but not `AIOS_URL`, so `build_fixtures`' CLI calls targeted whatever the source `.env` pointed at (a sibling worktree on `:8090`). Now pinned to the chosen port.
- **`--no-connector` headless mode**: brings up api+worker only (no connector/bot-token), builds env+agent+session without connection/attach — for `/verify` of harness changes (sweep/loop/context/tool_dispatch). A `--phase prep|fixtures` split lets a Claude-driven session own api+worker via `run_in_background` (a plain `nohup &` inside a Bash tool call is reaped when the call returns).
- `gotchas.md` gains entries #9–13 for these cold-start failure modes; `SKILL.md` description broadened to trigger on headless/verify phrasing + a "Headless bring-up" section.

## Test plan
- [x] `bash -n setup.sh` — syntax clean
- [x] Ran the real headless path end-to-end against a fresh DB: `--phase prep` (container auto-detect ✓, migrate ✓, bootstrap ✓) → api+worker via `run_in_background` → `--phase fixtures` → session created, CLI authenticated, **no 401**.
- [x] Diff vs master is exactly the 3 skill files (no product-code change).

Follow-on from the #690 retro; the original learnings came out of `/verify`-ing the ghost-repair fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)