### PR TITLE
fix(sandbox/registry): liveness-probe cached handles to detect --rm death (#691)

### DIFF
--- a/src/aios/sandbox/backends/base.py
+++ b/src/aios/sandbox/backends/base.py
@@ -233,6 +233,23 @@ class SandboxBackend(Protocol):
         """
         ...
 
+    async def is_alive(self, handle: SandboxHandle) -> bool:
+        """Return True iff ``handle``'s sandbox is still running.
+
+        Used by the registry's warm path (issue #691) to detect
+        sandboxes that the underlying execution layer removed without
+        the registry's knowledge. For Docker that is the ``--rm`` path
+        after any entrypoint exit (OOM kill, internal crash, signal) —
+        the container is gone but the registry's cached handle survives
+        until the next command-run fails with "No such container".
+
+        Implementations should be cheap (single round-trip) and total:
+        a transient probe failure (daemon hiccup, timeout) should
+        return False so the caller re-provisions rather than risk
+        returning a possibly-dead handle.
+        """
+        ...
+
 
 # ── Standard labels every backend SHOULD set on managed sandboxes ───────────
 #

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -263,6 +263,50 @@ class DockerBackend:
                 stderr=stderr_bytes.decode("utf-8", errors="replace").strip(),
             )
 
+    async def is_alive(self, handle: SandboxHandle) -> bool:
+        """``docker inspect`` the container; True iff State.Running is true.
+
+        Probe failures (daemon hiccup, launch error, timeout) return
+        False — better to take the cost of a re-provision than hand
+        back a possibly-dead handle. Per #691, ``--rm`` containers that
+        die between provision and the next call appear here as a
+        nonzero ``rc`` (Docker's "No such container").
+        """
+        argv = [
+            "docker",
+            "inspect",
+            "--format",
+            "{{.State.Running}}",
+            handle.sandbox_id,
+        ]
+        try:
+            rc, stdout_bytes, _ = await run_docker_cli(argv)
+        except Exception as err:
+            # Total by contract (see Protocol docstring): ANY probe failure
+            # — daemon hiccup, CLI launch error, 30s timeout — means we
+            # couldn't confirm liveness, so report dead and let the caller
+            # re-provision rather than hand back a possibly-dead handle.
+            # ``CancelledError`` (BaseException, not Exception) is NOT caught,
+            # so worker shutdown / job-timeout cancellation still propagates.
+            log.warning(
+                "sandbox.is_alive_probe_failed",
+                session_id=handle.session_id,
+                container_id=handle.sandbox_id[:12],
+                error=str(err),
+            )
+            return False
+        if rc != 0:
+            # Most common case: container was removed (--rm after exit), which
+            # Docker reports as a nonzero exit + "No such container" on stderr.
+            log.info(
+                "sandbox.is_alive_inspect_nonzero",
+                session_id=handle.session_id,
+                container_id=handle.sandbox_id[:12],
+                exit_code=rc,
+            )
+            return False
+        return stdout_bytes.decode("utf-8", errors="replace").strip() == "true"
+
 
 def _is_registry_image(image: str) -> bool:
     """Return True if *image* refers to a remote registry (not a bare local tag).

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -94,19 +94,59 @@ class SandboxRegistry:
         """Return the cached handle, or provision a new sandbox.
 
         Passing ``pool`` emits a ``sandbox_provision_*`` span pair on
-        the cold-start path only (issue #78) — warm hits stay
-        zero-observable-cost.
+        the cold-start path only (issue #78).
+
+        Every warm hit probes ``backend.is_alive(handle)`` before
+        returning. Issue #691: ``--rm`` containers that died between
+        provisions (entrypoint exit, OOM kill, daemon-side cleanup)
+        leave the cached handle dangling — the registry can't observe
+        the loss until the next backend call fails. The probe costs one
+        round-trip per warm hit and closes the common case: a not-alive
+        answer is treated as a cache miss; the dead container's host-side
+        resources are recycled and a fresh sandbox provisioned under the
+        per-session lock.
+
+        Best-effort, not a hard guarantee. The probe runs lock-free, so a
+        container can still die between the probe and the caller's use,
+        and a concurrent ``release``/reaper (which DO hold the per-session
+        lock) can tear down a handle this warm probe just validated. Those
+        callers cold-fail one backend call and self-correct on the next
+        step — same as before this fix. The probe removes the *steady-
+        state* staleness (a container that died turns sweeps earlier),
+        not every TOCTOU window.
         """
         handle = self._handles.get(session_id)
-        if handle is not None:
+        if handle is not None and await self._backend.is_alive(handle):
             self._last_used[session_id] = time.monotonic()
             return handle
 
+        # ``handle`` is the dead reference we just probed (or None on a cold
+        # miss). Capture it: under the lock, a *different* cached handle means
+        # a concurrent caller already recycled+reprovisioned while we waited,
+        # and we trust theirs without a second probe (they validated it micro-
+        # seconds ago via backend.create). Only when the cached handle is still
+        # the same dead one do we recycle it.
+        stale = handle
         async with self._lock_for(session_id):
-            handle = self._handles.get(session_id)
-            if handle is not None:
+            current = self._handles.get(session_id)
+            if current is not None and current is not stale:
                 self._last_used[session_id] = time.monotonic()
-                return handle
+                return current
+            if current is not None:
+                log.warning(
+                    "sandbox.stale_handle_recycling",
+                    session_id=session_id,
+                    container_id=current.sandbox_id[:12],
+                )
+                # Recycle the dead container's host-side resources (proxy,
+                # broker secret) but DELIBERATELY keep the session-level
+                # runtime caches: we're mid-step and about to hand a fresh
+                # sandbox back to the same step. ``_session_memory_mounts``
+                # in particular is consumed by the bash memory-reconcile that
+                # runs right after this returns (bash.py snapshots it *after*
+                # get_or_provision); clearing it here would make the before/
+                # after diff empty and silently drop the step's memory writes.
+                self.evict(session_id, unload_session_caches=False)
             handle = await self._provision_with_span(session_id, pool=pool)
             self._handles[session_id] = handle
             self._last_used[session_id] = time.monotonic()
@@ -364,7 +404,7 @@ class SandboxRegistry:
         """Return the cached handle without provisioning. ``None`` if not cached."""
         return self._handles.get(session_id)
 
-    def evict(self, session_id: str) -> None:
+    def evict(self, session_id: str, *, unload_session_caches: bool = True) -> None:
         """Drop the cache entry without backend teardown (sandbox is dead).
 
         Used by tool_dispatch when it detects a sandbox-side failure that
@@ -377,6 +417,17 @@ class SandboxRegistry:
         uvicorn server, httpx client and bound TCP port — ``release_all``
         only sees ``_git_proxies`` (which we've popped here), so without
         the background stop the proxy leaks for the worker's lifetime.
+
+        ``unload_session_caches`` (default True) clears the per-session
+        runtime caches (``_session_memory_mounts``, ``_session_read_shas``).
+        That is correct when the session is being unloaded or its sandbox
+        recycled *between* steps (the next step repopulates). The stale-
+        handle recycle inside :meth:`get_or_provision` passes False: it
+        happens *mid-step* and immediately re-provisions the same session,
+        so the caches are still valid and — for ``_session_memory_mounts``
+        — load-bearing for the bash memory-reconcile that runs right after
+        provisioning. Clearing them there would silently drop the step's
+        memory-store writes (the before/after diff would see no mounts).
         """
         from aios.harness import runtime
 
@@ -405,13 +456,14 @@ class SandboxRegistry:
         # Same story for the tool broker secret: drop it immediately; a
         # fresh sandbox will get a fresh secret from the next provision.
         self._release_tool_broker_secret(session_id)
-        # Drop the runtime read-sha cache so a fresh sandbox doesn't
-        # serve a stale precondition match against a different
-        # container's file state. Memory mounts are re-populated at the
-        # top of every step (loop.py:87) so leaving them is harmless,
-        # but symmetry argues for clearing both.
-        runtime.clear_session_memory_mounts(session_id)
-        runtime.clear_session_read_shas(session_id)
+        # Drop the runtime caches so a fresh sandbox doesn't serve a stale
+        # read-sha precondition match against a different container's file
+        # state. Skipped on the mid-step recycle path (see the
+        # ``unload_session_caches`` note in the docstring) where the same
+        # session keeps running and the caches remain valid.
+        if unload_session_caches:
+            runtime.clear_session_memory_mounts(session_id)
+            runtime.clear_session_read_shas(session_id)
 
     async def release_all(self) -> None:
         """Tear down every sandbox + proxy. Called at worker shutdown."""
@@ -504,13 +556,13 @@ class SandboxRegistry:
             async with self._lock_for(sid):
                 # Re-check under the lock: a concurrent get_or_provision
                 # warm hit could have freshened _last_used[sid] between
-                # the scan above and now. The warm path takes no lock
-                # (it's the fast path — "zero-observable-cost"), so this
-                # re-check is the only place we serialize against it.
-                # #566 added the lock, which closes the cold-path race;
-                # the missing piece was that the reaper trusted its
-                # stale to_release snapshot. ``evict`` can also pop
-                # _last_used out from under us, so absence means skip.
+                # the scan above and now. The warm path takes no lock (it
+                # only does a liveness probe, not the per-session lock —
+                # see get_or_provision), so this re-check is the only place
+                # we serialize against it. #566 added the lock, which closes
+                # the cold-path race; the missing piece was that the reaper
+                # trusted its stale to_release snapshot. ``evict`` can also
+                # pop _last_used out from under us, so absence means skip.
                 current = self._last_used.get(sid)
                 if current is not None and time.monotonic() - current > idle_timeout:
                     log.info("sandbox.idle_release", session_id=sid)

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -61,6 +61,10 @@ class FakeBackend:
     next_result: CommandResult | None = None
     managed: list[ManagedSandboxRef] = field(default_factory=list)
     calls: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+    # Sandbox ids the backend should report as dead via ``is_alive``.
+    # Default-empty so existing tests behave as before; tests covering
+    # the stale-handle path (#691) populate this.
+    dead_sandbox_ids: set[str] = field(default_factory=set)
 
     async def create(self, spec: SandboxSpec) -> SandboxHandle:
         self.calls.append(("create", {"session_id": spec.session_id}))
@@ -70,6 +74,12 @@ class FakeBackend:
             workspace_path=spec.workspace.host_path,
             mount_snapshot=spec.mount_snapshot,
         )
+
+    async def is_alive(self, handle: SandboxHandle) -> bool:
+        self.calls.append(
+            ("is_alive", {"session_id": handle.session_id, "sandbox_id": handle.sandbox_id})
+        )
+        return handle.sandbox_id not in self.dead_sandbox_ids
 
     async def exec(
         self,

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -16,6 +17,7 @@ from aios.models.environments import (
 from aios.sandbox.backends.base import (
     Limited,
     Mount,
+    SandboxBackendError,
     SandboxSpec,
     Unrestricted,
 )
@@ -182,6 +184,80 @@ class TestDockerBackendArgs:
     async def test_unrestricted_no_cap_net_admin(self) -> None:
         argv = await _capture_docker_argv(_make_spec(Unrestricted()))
         assert "--cap-add" not in argv
+
+
+class TestDockerBackendIsAlive:
+    """DockerBackend.is_alive maps ``docker inspect`` outcomes to a bool (#691).
+
+    The registry's warm path depends on this method being total: any
+    failure mode must resolve to ``True`` (running) or ``False`` (re-
+    provision), never an exception that escapes into the tool call.
+    These tests patch ``run_docker_cli`` so no real daemon is needed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_running_true_returns_alive(self) -> None:
+        async def fake(argv: list[str]) -> tuple[int, bytes, bytes]:
+            # Sanity: we inspect the right container with the State.Running format.
+            assert argv[:3] == ["docker", "inspect", "--format"]
+            assert make_handle().sandbox_id in argv
+            return 0, b"true\n", b""
+
+        with patch("aios.sandbox.backends.docker.run_docker_cli", fake):
+            assert await DockerBackend().is_alive(make_handle()) is True
+
+    @pytest.mark.asyncio
+    async def test_running_false_string_returns_dead(self) -> None:
+        """A stopped (but not yet removed) container inspects as 'false'."""
+
+        async def fake(argv: list[str]) -> tuple[int, bytes, bytes]:
+            return 0, b"false\n", b""
+
+        with patch("aios.sandbox.backends.docker.run_docker_cli", fake):
+            assert await DockerBackend().is_alive(make_handle()) is False
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_returns_dead(self) -> None:
+        """`--rm` removed the container → inspect exits nonzero ('No such container')."""
+
+        async def fake(argv: list[str]) -> tuple[int, bytes, bytes]:
+            return 1, b"", b"Error: No such container: abc123\n"
+
+        with patch("aios.sandbox.backends.docker.run_docker_cli", fake):
+            assert await DockerBackend().is_alive(make_handle()) is False
+
+    @pytest.mark.asyncio
+    async def test_probe_launch_failure_returns_dead_not_raises(self) -> None:
+        """A daemon hiccup / timeout (SandboxBackendError) must not escape."""
+
+        async def fake(argv: list[str]) -> tuple[int, bytes, bytes]:
+            raise SandboxBackendError("docker cli timed out after 30.0s")
+
+        with patch("aios.sandbox.backends.docker.run_docker_cli", fake):
+            assert await DockerBackend().is_alive(make_handle()) is False
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_returns_dead_not_raises(self) -> None:
+        """Totality contract: ANY non-cancellation error resolves to dead."""
+
+        async def fake(argv: list[str]) -> tuple[int, bytes, bytes]:
+            raise RuntimeError("unexpected boom")
+
+        with patch("aios.sandbox.backends.docker.run_docker_cli", fake):
+            assert await DockerBackend().is_alive(make_handle()) is False
+
+    @pytest.mark.asyncio
+    async def test_cancellation_propagates(self) -> None:
+        """CancelledError (worker shutdown) must NOT be swallowed as 'dead'."""
+
+        async def fake(argv: list[str]) -> tuple[int, bytes, bytes]:
+            raise asyncio.CancelledError
+
+        with (
+            patch("aios.sandbox.backends.docker.run_docker_cli", fake),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await DockerBackend().is_alive(make_handle())
 
 
 # ── network lockdown helper applies the right script via the backend ──────────

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -5,19 +5,27 @@ recycles a cached sandbox when the session's attached memory stores
 have changed since provisioning (issue #198). ``TestEvictReclamation``
 covers the ``evict`` fast path used by ``tool_dispatch`` when a
 sandbox-side failure suggests the sandbox itself is unhealthy.
+``TestStaleHandleDetection`` covers the liveness probe inserted into
+``get_or_provision`` so a container that Docker auto-removed (``--rm``
+after entrypoint exit / OOM / daemon-side cleanup) doesn't poison the
+next exec with "No such container" (issue #691).
 """
 
 from __future__ import annotations
 
 import asyncio
 import gc
+from pathlib import Path
 from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aios.harness import runtime
 from aios.models.memory_stores import Access, MemoryStoreResourceEcho
-from aios.sandbox.backends.base import SandboxHandle
+from aios.sandbox.backends.base import Mount, SandboxHandle, SandboxSpec, Unrestricted
 from aios.sandbox.registry import SandboxRegistry
+from aios.sandbox.spec import ProvisioningPlan
 from tests.helpers.sandbox import FakeBackend, make_handle
 
 
@@ -116,10 +124,6 @@ class TestReleaseIfMountsChanged:
         """The per-session lock must serialize release_if_mounts_changed against
         a concurrent get_or_provision so the registry never returns a handle
         that's about to be torn down."""
-        from unittest.mock import AsyncMock
-
-        from aios.sandbox.spec import ProvisioningPlan
-
         backend = FakeBackend()
         registry = SandboxRegistry(backend=backend)
         old_snapshot = frozenset([("memstore", "memstore_a", "a", "read_write")])
@@ -132,8 +136,6 @@ class TestReleaseIfMountsChanged:
         async def slow_build_spec(_session_id: str) -> ProvisioningPlan:
             provision_started.set()
             await let_provision_continue.wait()
-            from aios.sandbox.backends.base import Mount, SandboxSpec, Unrestricted
-
             spec = SandboxSpec(
                 session_id="sess_X",
                 instance_id="inst_T",
@@ -156,8 +158,6 @@ class TestReleaseIfMountsChanged:
 
         # Force a cache miss so get_or_provision contends for the lock.
         registry._handles.pop("sess_X")
-
-        from unittest.mock import patch
 
         with (
             patch("aios.sandbox.registry.build_spec_from_session", slow_build_spec),
@@ -325,3 +325,253 @@ class TestEvictReclamation:
         gc.collect()
 
         await asyncio.wait_for(proxy_stopped.wait(), timeout=1.0)
+
+
+def _provisioning_plan(session_id: str) -> ProvisioningPlan:
+    """Build a minimal :class:`ProvisioningPlan` for stale-handle tests.
+
+    The plan is returned by a patched ``build_spec_from_session`` so the
+    registry's cold path runs without touching the DB. The fresh handle's
+    sandbox_id is controlled by the caller via ``FakeBackend.next_handle_id``;
+    the spec itself doesn't carry one.
+    """
+    spec = SandboxSpec(
+        session_id=session_id,
+        instance_id="inst_TEST",
+        workspace=Mount(host_path=Path("/tmp/w"), sandbox_path="/workspace"),
+        extra_mounts=(),
+        environment={},
+        labels={},
+        network_policy=Unrestricted(),
+        host_gateway_alias=None,
+        image="aios-sandbox:test",
+    )
+    return ProvisioningPlan(
+        spec=spec,
+        env_config=None,
+        memory_echoes=[],
+        github_echoes=[],
+        git_proxy=None,
+    )
+
+
+class TestStaleHandleDetection:
+    """``get_or_provision`` validates handle liveness on every warm hit.
+
+    Issue #691: containers spawned with ``--rm`` auto-remove on any exit
+    (entrypoint exit, OOM, daemon-side cleanup). The registry's cached
+    handle outlives the dead container, so the next ``exec`` against the
+    cached handle fails with Docker's "No such container". The fix is to
+    probe the backend (``is_alive``) on the warm path and treat a
+    not-alive answer the same as a cache miss — evict the dead cache
+    entry and re-provision under the per-session lock.
+
+    All tests patch the registry's provisioning helpers so the cold
+    path runs without DB or Docker; they assert behavior via the
+    :class:`FakeBackend` call log.
+    """
+
+    async def test_live_handle_returned_without_reprovision(self) -> None:
+        """Default warm path: ``is_alive`` returns True ⇒ cached handle returned."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        cached = _seed(registry, "sess_X")
+
+        result = await registry.get_or_provision("sess_X")
+
+        assert result is cached
+        assert any(c[0] == "is_alive" for c in backend.calls)
+        assert not any(c[0] == "create" for c in backend.calls), (
+            "live handle must not trigger re-provision"
+        )
+
+    async def test_dead_handle_triggers_reprovision(self) -> None:
+        """Stale cached handle ⇒ evict + provision; caller gets the new handle."""
+        backend = FakeBackend(next_handle_id="fresh_sandbox_id")
+        registry = SandboxRegistry(backend=backend)
+        stale = _seed(registry, "sess_X")
+        backend.dead_sandbox_ids.add(stale.sandbox_id)
+
+        with (
+            patch(
+                "aios.sandbox.registry.build_spec_from_session",
+                AsyncMock(return_value=_provisioning_plan("sess_X")),
+            ),
+            patch("aios.sandbox.registry.ensure_workspace_runtime_dirs", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+            patch("aios.sandbox.registry.apply_network_lockdown", AsyncMock()),
+        ):
+            result = await registry.get_or_provision("sess_X")
+
+        assert result is not stale
+        assert result.sandbox_id == "fresh_sandbox_id"
+        assert registry.peek("sess_X") is result
+        create_calls = [c for c in backend.calls if c[0] == "create"]
+        assert len(create_calls) == 1, (
+            "stale-handle path must re-provision exactly once via backend.create"
+        )
+
+    async def test_cold_start_skips_liveness_check(self) -> None:
+        """Empty cache ⇒ no ``is_alive`` (nothing to check)."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+
+        with (
+            patch(
+                "aios.sandbox.registry.build_spec_from_session",
+                AsyncMock(return_value=_provisioning_plan("sess_X")),
+            ),
+            patch("aios.sandbox.registry.ensure_workspace_runtime_dirs", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+            patch("aios.sandbox.registry.apply_network_lockdown", AsyncMock()),
+        ):
+            await registry.get_or_provision("sess_X")
+
+        assert not any(c[0] == "is_alive" for c in backend.calls), (
+            "cold start has no cached handle to probe — is_alive must not fire"
+        )
+
+    async def test_dead_handle_eviction_clears_proxy_and_broker_secret(self) -> None:
+        """The evict-before-reprovision must release the proxy and broker secret.
+
+        Without this, the new sandbox would inherit the dead handle's proxy
+        (its uvicorn server and TCP port) and the broker would still serve
+        the dead session's secret to the new container. ``evict()`` is the
+        method that bundles these; verify the stale-handle path delegates
+        through it.
+        """
+        backend = FakeBackend(next_handle_id="fresh_sandbox_id")
+        registry = SandboxRegistry(backend=backend)
+        stale = _seed(registry, "sess_X")
+        backend.dead_sandbox_ids.add(stale.sandbox_id)
+
+        proxy_stopped = asyncio.Event()
+
+        class _StubProxy:
+            async def stop(self) -> None:
+                proxy_stopped.set()
+
+        registry._git_proxies["sess_X"] = cast(Any, _StubProxy())
+
+        broker = MagicMock()
+        broker.port = 0
+
+        with (
+            patch(
+                "aios.harness.runtime.require_tool_broker",
+                lambda: broker,
+            ),
+            patch(
+                "aios.sandbox.registry.build_spec_from_session",
+                AsyncMock(return_value=_provisioning_plan("sess_X")),
+            ),
+            patch("aios.sandbox.registry.ensure_workspace_runtime_dirs", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+            patch("aios.sandbox.registry.apply_network_lockdown", AsyncMock()),
+        ):
+            await registry.get_or_provision("sess_X")
+
+        # Proxy stop is fire-and-forget — give the loop a chance to run it.
+        await asyncio.wait_for(proxy_stopped.wait(), timeout=1.0)
+        # Broker secret is unregistered immediately (synchronous part of evict).
+        broker.unregister_session.assert_called_with("sess_X")
+
+    async def test_recycle_preserves_session_runtime_caches(self) -> None:
+        """The mid-step recycle must NOT clear ``_session_memory_mounts``/
+        ``_session_read_shas`` (issue #691 follow-up — data-loss guard).
+
+        Ordering that makes this load-bearing: ``bash_handler`` calls
+        ``get_or_provision`` and only THEN snapshots the memory mounts for
+        its post-exec reconcile. The mounts cache is populated once at step
+        start (``loop.py``) and is NOT repopulated by provisioning. If the
+        stale-handle recycle cleared it, the bash reconcile's before/after
+        diff would see no mounts and silently drop every memory-store write
+        the command made. So a recycle inside get_or_provision must leave
+        the session caches intact (the fresh sandbox re-mounts the same
+        host dirs).
+        """
+        runtime._session_memory_mounts.clear()
+        runtime._session_read_shas.clear()
+        try:
+            backend = FakeBackend(next_handle_id="fresh_sandbox_id")
+            registry = SandboxRegistry(backend=backend)
+            stale = _seed(registry, "sess_X")
+            backend.dead_sandbox_ids.add(stale.sandbox_id)
+
+            echo = _echo("memstore_a", "a")
+            runtime.set_session_memory_mounts("sess_X", [echo])
+            runtime.set_read_sha("sess_X", "memstore_a", "/notes.md", "sha_before")
+
+            broker = MagicMock()
+            broker.port = 0
+            with (
+                patch("aios.harness.runtime.require_tool_broker", lambda: broker),
+                patch(
+                    "aios.sandbox.registry.build_spec_from_session",
+                    AsyncMock(return_value=_provisioning_plan("sess_X")),
+                ),
+                patch("aios.sandbox.registry.ensure_workspace_runtime_dirs", AsyncMock()),
+                patch("aios.sandbox.registry.install_packages", AsyncMock()),
+                patch("aios.sandbox.registry.apply_network_lockdown", AsyncMock()),
+            ):
+                await registry.get_or_provision("sess_X")
+
+            assert runtime.get_session_memory_mounts("sess_X") == [echo], (
+                "recycle cleared the memory-mounts cache mid-step → bash reconcile "
+                "would see no mounts and lose the step's memory writes"
+            )
+            assert runtime.get_read_sha("sess_X", "memstore_a", "/notes.md") == "sha_before", (
+                "recycle cleared the read-sha cache mid-step → spurious precondition misses"
+            )
+        finally:
+            runtime._session_memory_mounts.clear()
+            runtime._session_read_shas.clear()
+
+    async def test_concurrent_stale_handle_reprovisions_once(self) -> None:
+        """Two concurrent ``get_or_provision`` calls both seeing the same
+        stale handle must re-provision exactly once.
+
+        This exercises both arms of the under-lock identity check: the
+        winner (task_a) finds its captured stale handle still cached and
+        recycles it; the loser (task_b) acquires the lock after task_a
+        installed a *different* fresh handle and trusts it via identity
+        rather than recycling+reprovisioning a third container. Without
+        the identity guard the loser would churn another container.
+        """
+        backend = FakeBackend(next_handle_id="fresh_sandbox_id")
+        registry = SandboxRegistry(backend=backend)
+        stale = _seed(registry, "sess_X")
+        backend.dead_sandbox_ids.add(stale.sandbox_id)
+
+        # Gate the cold-path provision so the second task piles up on the lock.
+        let_provision_continue = asyncio.Event()
+        first_provision_started = asyncio.Event()
+
+        async def slow_build_spec(_session_id: str) -> ProvisioningPlan:
+            first_provision_started.set()
+            await let_provision_continue.wait()
+            return _provisioning_plan("sess_X")
+
+        with (
+            patch("aios.sandbox.registry.build_spec_from_session", slow_build_spec),
+            patch("aios.sandbox.registry.ensure_workspace_runtime_dirs", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+            patch("aios.sandbox.registry.apply_network_lockdown", AsyncMock()),
+        ):
+            task_a = asyncio.create_task(registry.get_or_provision("sess_X"))
+            # Wait until task_a is inside _provision (lock held).
+            await first_provision_started.wait()
+            task_b = asyncio.create_task(registry.get_or_provision("sess_X"))
+            # task_b is now contending for the lock. Let task_a finish.
+            await asyncio.sleep(0)
+            let_provision_continue.set()
+            result_a, result_b = await asyncio.gather(task_a, task_b)
+
+        # Both callers see the fresh handle.
+        assert result_a.sandbox_id == "fresh_sandbox_id"
+        assert result_b.sandbox_id == "fresh_sandbox_id"
+        # Exactly one create call across the two callers.
+        create_calls = [c for c in backend.calls if c[0] == "create"]
+        assert len(create_calls) == 1, (
+            f"expected exactly one re-provision; got {len(create_calls)} (calls={backend.calls})"
+        )


### PR DESCRIPTION
## Summary

Containers spawned with `--rm` (`backends/docker.py:66`) auto-remove on any entrypoint exit — OOM kill, internal crash, signal, normal exit. The registry's cached `SandboxHandle` outlives the dead container, so the next backend call surfaces Docker's "No such container" and the caller fails. For scheduled-task fires (one-shot, delete-before-curl per #688) the wake is then **lost**: no stuck-recovery re-fire, no retry. Surfaced during verification of the #688 stack.

## Fix

Add `is_alive(handle) -> bool` to the `SandboxBackend` Protocol and probe it on every warm hit in `SandboxRegistry.get_or_provision`. A not-alive answer is treated as a cache miss: under the per-session lock, the dead container's host-side resources are recycled and a fresh sandbox provisioned. Cost: one `docker inspect` round-trip per warm hit. Best-effort, not a hard guarantee — see the `get_or_provision` docstring for what the lock-free probe does and doesn't cover.

Two correctness details worth flagging:

1. **The recycle preserves session-level runtime caches.** `evict()` originally cleared `_session_memory_mounts` / `_session_read_shas` on the (only) failure-path caller. Reusing it for the warm path would silently drop the step's memory-store writes: `bash.py:126→128` calls `get_or_provision` *before* snapshotting the mounts cache, and the cache is only repopulated at step start (`loop.py:91`). New `unload_session_caches` flag (default `True`) keeps tool_dispatch's session-unload semantics unchanged; the warm path passes `False`.

2. **Under the lock, identity check instead of a second probe.** The warm-path probe is captured; under the lock, a *different* cached handle means a concurrent caller already recycled+reprovisioned — we trust theirs without a second `docker inspect`. Only when the cached handle is still the same dead reference do we recycle.

`DockerBackend.is_alive` is total: `except Exception` resolves to `False` so any probe failure (daemon hiccup, timeout, unexpected error) falls through to re-provision rather than escaping into the tool call. `CancelledError` (BaseException) still propagates so worker shutdown isn't masked.

## Test plan
- [x] `uv run mypy src` — clean (170 files)
- [x] `uv run ruff check src tests && uv run ruff format --check` — clean (416 files)
- [x] `uv run pytest tests/unit -q` — **1569 passed** (+7 new)
- [x] New `TestStaleHandleDetection` (6 tests): live-handle pass-through, dead-handle recycle, cold-start skips probe, eviction clears proxy + broker secret, runtime caches preserved across recycle, concurrent contention re-provisions exactly once.
- [x] New `TestDockerBackendIsAlive` (6 tests) covers `State.Running` `true`/`false`, nonzero exit ("No such container"), `SandboxBackendError`, generic exception (totality), and that `CancelledError` propagates.
- [ ] Live verification on a real sandbox (deferred — the unit suite pins the contract and the failure mode requires a `--rm` exit between two `get_or_provision` calls on the same session, which is awkward to stage deterministically).

## Non-goals (deferred)
- **`evict()` by session_id vs handle identity** (`tool_dispatch._evict_session_container`). Pre-existing race; this PR doesn't widen the `get_or_provision` side (the identity check guards it). Fixing the tool_dispatch path requires threading the handle through `_tool_lifecycle`'s `on_exception` plumbing — invasive and out of scope for #691.
- **Probe single-flighting / shorter timeout under daemon stress.** The 30s `DOCKER_CLI_TIMEOUT_S` is the established budget; the spec accepted "one round-trip per warm hit". Reduce only if measured impact warrants it.

Closes #691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)