### PR TITLE
fix(sandbox): per-clone timeout + graceful degradation in _materialize_github_clones

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -14,6 +14,16 @@ from typing import Literal
 from pydantic import Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+# Hardcoded mirror of ``aios.harness.loop._JOB_TIMEOUT_S`` (300.0). We
+# don't import it because ``aios.harness.loop`` itself imports config
+# at module load — a top-level import here would risk a cycle, and a
+# lazy one inside the validator is more noise than the constant is
+# worth. If ``_JOB_TIMEOUT_S`` ever moves, update this too; the failure
+# mode is a config validator that no longer matches reality, not a
+# crash. ``test_github_clone_session_timeout_below_step_budget``
+# cross-checks the two values stay aligned.
+_HARNESS_STEP_TIMEOUT_S: float = 300.0
+
 
 class Settings(BaseSettings):
     """All env-driven aios configuration.
@@ -255,6 +265,24 @@ class Settings(BaseSettings):
                 "API and worker processes resolve relative paths against their own CWD, "
                 "producing diverging session workspace_path values and ForbiddenError "
                 "on tool calls."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _github_clone_session_timeout_under_step_budget(self) -> Settings:
+        # The whole point of #697: per-session clone budget must fit
+        # strictly inside the harness step budget so a hung clone can't
+        # burn a whole user turn before the step-level cap fires. Reject
+        # misconfiguration loudly at startup rather than letting an
+        # operator silently defeat the fix.
+        if self.github_clone_session_timeout_seconds >= _HARNESS_STEP_TIMEOUT_S:
+            raise ValueError(
+                f"AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS="
+                f"{self.github_clone_session_timeout_seconds} must be strictly less than "
+                f"the harness step budget ({_HARNESS_STEP_TIMEOUT_S}s, "
+                f"aios.harness.loop._JOB_TIMEOUT_S); otherwise a hung clone "
+                f"burns a whole user turn before the step-level cap fires. "
+                f"See issue #697."
             )
         return self
 

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -130,6 +130,25 @@ class Settings(BaseSettings):
         "after the multipart body is drained so the client sees a clean "
         "response rather than a transport reset.",
     )
+    github_clone_session_timeout_seconds: float = Field(
+        default=30.0,
+        ge=1.0,
+        description="Wall-clock bound on each per-session "
+        "``git clone --reference --dissociate`` (and the short admin ops "
+        "around it: ``remote set-url``, ``config user.*``). Must stay "
+        "well below the 300s harness step timeout — otherwise a hung "
+        "clone burns a whole user turn before the step-level cap fires. "
+        "See issue #697.",
+    )
+    github_clone_cache_timeout_seconds: float = Field(
+        default=300.0,
+        ge=1.0,
+        description="Wall-clock bound on the bare-cache clone/fetch "
+        "(``<workspace_root>/_github_repos/<sha256(url)>``). Cold-case "
+        "clones of large repos can legitimately take minutes; failures "
+        "here only delay the cache, they don't block the per-session "
+        "working tree past the per-session budget. See issue #697.",
+    )
 
     # ── worker ─────────────────────────────────────────────────────────────
     worker_concurrency: int = Field(

--- a/src/aios/sandbox/github_clone.py
+++ b/src/aios/sandbox/github_clone.py
@@ -34,6 +34,7 @@ import hashlib
 import shutil
 from pathlib import Path
 
+from aios.config import get_settings
 from aios.logging import get_logger
 from aios.sandbox._subprocess import run_subprocess_with_timeout
 from aios.sandbox.volumes import (
@@ -45,11 +46,6 @@ from aios.sandbox.volumes import (
 )
 
 log = get_logger("aios.sandbox.github_clone")
-
-# Bound on each ``git`` invocation. Generous because clone over a slow
-# link can legitimately take a while; tighter values cause spurious
-# failures on CI runners.
-_GIT_TIMEOUT_S = 300.0
 
 
 class GithubCloneError(Exception):
@@ -85,22 +81,32 @@ def _build_auth_url(repo_url: str, token: str) -> str:
 
 
 async def _run_git(
-    argv: list[str], *, cwd: Path | None = None, op: str = "git"
+    argv: list[str],
+    *,
+    timeout_s: float,
+    cwd: Path | None = None,
+    op: str = "git",
 ) -> tuple[int, bytes, bytes]:
     """Launch ``git`` with the timeout and error semantics we rely on.
 
     ``op`` is a short label used in the timeout error message — never
     the raw argv, which carries the auth-embedded URL on clone/fetch
     paths and would leak the token into logs and the session event log.
+
+    ``timeout_s`` is required — it's the per-call wall-clock bound this
+    helper threads into :func:`run_subprocess_with_timeout`. Callers
+    resolve it from ``Settings.github_clone_session_timeout_seconds`` or
+    ``Settings.github_clone_cache_timeout_seconds`` depending on which
+    budget the call sits inside (issue #697).
     """
     full_argv = ["git", *argv]
     if cwd is not None:
         full_argv = ["git", "-C", str(cwd), *argv]
     rc, stdout, stderr, timed_out = await run_subprocess_with_timeout(
-        full_argv, timeout_s=_GIT_TIMEOUT_S
+        full_argv, timeout_s=timeout_s
     )
     if timed_out:
-        raise GithubCloneError(f"git {op} timed out after {_GIT_TIMEOUT_S}s")
+        raise GithubCloneError(f"git {op} timed out after {timeout_s}s")
     return rc, stdout, stderr
 
 
@@ -127,6 +133,7 @@ async def ensure_cache_clone(repo_url: str, token: str) -> Path:
     initial clone fails — the caller (provisioner) logs a session.error
     and continues.
     """
+    settings = get_settings()
     github_repos_cache_root().mkdir(parents=True, exist_ok=True)
     url_key = url_hash(repo_url)
     cache_dir = github_repo_cache_dir(url_key)
@@ -159,6 +166,7 @@ async def ensure_cache_clone(repo_url: str, token: str) -> Path:
             rc, _stdout, stderr = await _run_git(
                 ["clone", "--bare", auth_url, str(cache_dir)],
                 op="clone --bare",
+                timeout_s=settings.github_clone_cache_timeout_seconds,
             )
             if rc != 0:
                 # Drop any partial dir so the next attempt re-clones from scratch.
@@ -168,8 +176,14 @@ async def ensure_cache_clone(repo_url: str, token: str) -> Path:
                     stderr, message=f"git clone --bare failed for {repo_url!r}", token=token
                 )
             # Disable gc on the bare cache so it can't reap objects that
-            # per-session working trees alternate against.
-            await _run_git(["config", "gc.auto", "0"], cwd=cache_dir, op="config gc.auto")
+            # per-session working trees alternate against. Short admin op —
+            # bounded by the session budget, not the cache one.
+            await _run_git(
+                ["config", "gc.auto", "0"],
+                cwd=cache_dir,
+                op="config gc.auto",
+                timeout_s=settings.github_clone_session_timeout_seconds,
+            )
             log.info(
                 "github_clone.cache_created",
                 repo_url=repo_url,
@@ -187,6 +201,7 @@ async def _fetch_cache(cache_dir: Path, auth_url: str, repo_url: str) -> None:
     swallowed — a stale cache still works for read; the cost of a fresh
     push from the per-session clone is the same either way.
     """
+    settings = get_settings()
     # Use --quiet and a one-shot URL override (-c remote.origin.url=...)
     # so we don't have to mutate the cache's stored config.
     rc, _stdout, stderr = await _run_git(
@@ -200,6 +215,7 @@ async def _fetch_cache(cache_dir: Path, auth_url: str, repo_url: str) -> None:
         ],
         cwd=cache_dir,
         op="fetch",
+        timeout_s=settings.github_clone_cache_timeout_seconds,
     )
     if rc != 0:
         log.warning(
@@ -238,6 +254,9 @@ async def ensure_session_working_tree(
     you are" error (#207).  Both ``None`` means "no identity
     configured" — pre-#207 v1 behavior, preserved.
     """
+    settings = get_settings()
+    session_timeout_s = settings.github_clone_session_timeout_seconds
+
     work_dir = session_repo_working_tree_dir(session_id, resource_id)
     session_repos_root(session_id).mkdir(parents=True, exist_ok=True)
 
@@ -246,7 +265,9 @@ async def ensure_session_working_tree(
 
     auth_url = _build_auth_url(repo_url, token)
     # `--dissociate` copies needed objects into the working clone so cache
-    # GC can't break it later. We trade disk for safety.
+    # GC can't break it later. We trade disk for safety. This is the
+    # load-bearing per-session budget call (#697): tight enough that a
+    # hung clone can't burn a whole user turn.
     rc, _stdout, stderr = await _run_git(
         [
             "clone",
@@ -257,6 +278,7 @@ async def ensure_session_working_tree(
             str(work_dir),
         ],
         op="clone --reference",
+        timeout_s=session_timeout_s,
     )
     if rc != 0:
         if work_dir.exists():
@@ -270,11 +292,12 @@ async def ensure_session_working_tree(
     # Replace the auth-embedded origin URL with the proxy URL. The bind
     # mount is about to expose this .git/config inside the sandbox; if we
     # left the auth URL in place, the agent could read the PAT via
-    # `cat .git/config` or `git remote -v`.
+    # `cat .git/config` or `git remote -v`. Short local op.
     rc, _stdout, stderr = await _run_git(
         ["remote", "set-url", "origin", proxy_url],
         cwd=work_dir,
         op="remote set-url",
+        timeout_s=session_timeout_s,
     )
     if rc != 0:
         if work_dir.exists():
@@ -289,7 +312,10 @@ async def ensure_session_working_tree(
         if value is None:
             continue
         rc, _stdout, stderr = await _run_git(
-            ["config", key, value], cwd=work_dir, op=f"config {key}"
+            ["config", key, value],
+            cwd=work_dir,
+            op=f"config {key}",
+            timeout_s=session_timeout_s,
         )
         if rc != 0:
             raise GithubCloneError(

--- a/src/aios/sandbox/github_clone.py
+++ b/src/aios/sandbox/github_clone.py
@@ -176,13 +176,18 @@ async def ensure_cache_clone(repo_url: str, token: str) -> Path:
                     stderr, message=f"git clone --bare failed for {repo_url!r}", token=token
                 )
             # Disable gc on the bare cache so it can't reap objects that
-            # per-session working trees alternate against. Short admin op —
-            # bounded by the session budget, not the cache one.
+            # per-session working trees alternate against. Part of cache
+            # initialization — must share the cache budget so a timeout
+            # here doesn't leave a bare-clone dir behind with gc.auto
+            # still enabled (the next call's _exists() fast path would
+            # skip re-running this and the cache would silently reap
+            # objects referenced by --reference --dissociate working
+            # trees).
             await _run_git(
                 ["config", "gc.auto", "0"],
                 cwd=cache_dir,
                 op="config gc.auto",
-                timeout_s=settings.github_clone_session_timeout_seconds,
+                timeout_s=settings.github_clone_cache_timeout_seconds,
             )
             log.info(
                 "github_clone.cache_created",

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -172,7 +172,8 @@ async def _materialize_github_clones(
     Per-repo clone failures are non-fatal — they log + append a
     lifecycle event and drop the repo from the materialized list (its
     working tree won't be bind-mounted). The proxy stays alive for
-    sibling repos.
+    sibling repos. Per-clone wall-clock is bounded by
+    ``Settings.github_clone_session_timeout_seconds`` (issue #697).
     """
     from aios.sandbox.git_proxy import repo_key
     from aios.services import github_repositories as github_repo_service

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -144,3 +144,36 @@ def test_github_clone_session_timeout_env_override(
 
     s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
     assert s.github_clone_session_timeout_seconds == 7.0
+
+
+def test_github_clone_session_timeout_rejects_above_step_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A per-session clone budget >= the harness step budget would silently
+    defeat issue #697's fix (a hung clone would still burn a whole user
+    turn before the step-level cap fires). Settings construction must
+    reject the misconfiguration loudly at startup.
+    """
+    from pydantic import ValidationError
+
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.setenv("AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS", "400")
+
+    with pytest.raises(ValidationError, match="must be strictly less than"):
+        Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+
+
+def test_github_clone_session_timeout_mirror_matches_harness_constant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The config-module mirror of ``_JOB_TIMEOUT_S`` must stay in sync with
+    the harness's own constant — otherwise the validator above starts
+    rejecting (or admitting) misconfigurations using a stale bound.
+    """
+    from aios.config import _HARNESS_STEP_TIMEOUT_S
+    from aios.harness.loop import _JOB_TIMEOUT_S
+
+    assert _HARNESS_STEP_TIMEOUT_S == _JOB_TIMEOUT_S

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -78,3 +78,69 @@ def test_workspace_root_default_is_absolute(
 
     s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
     assert s.workspace_root.is_absolute()
+
+
+def test_github_clone_session_timeout_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Per-session ``git clone --reference --dissociate`` budget defaults to 30s.
+
+    Must be small enough that the harness step timeout (300s) is never the
+    instrument that fires on a hung clone — see issue #697.
+    """
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.delenv("AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS", raising=False)
+
+    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    assert s.github_clone_session_timeout_seconds == 30.0
+
+
+def test_github_clone_cache_timeout_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bare-cache clone/fetch budget defaults to 300s — cold-case clones
+    of large repos can legitimately take minutes, and the cache lives
+    off the per-session critical path."""
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.delenv("AIOS_GITHUB_CLONE_CACHE_TIMEOUT_SECONDS", raising=False)
+
+    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    assert s.github_clone_cache_timeout_seconds == 300.0
+
+
+def test_github_clone_session_timeout_below_step_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point of issue #697: the per-session clone budget must
+    fit strictly inside the harness step budget so a hung clone doesn't
+    burn the full 5-minute turn.
+    """
+    from aios.config import Settings
+    from aios.harness.loop import _JOB_TIMEOUT_S
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.delenv("AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS", raising=False)
+
+    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    assert s.github_clone_session_timeout_seconds < _JOB_TIMEOUT_S
+
+
+def test_github_clone_session_timeout_env_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS`` overrides the default."""
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.setenv("AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS", "7")
+
+    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    assert s.github_clone_session_timeout_seconds == 7.0

--- a/tests/unit/test_github_clone_helpers.py
+++ b/tests/unit/test_github_clone_helpers.py
@@ -7,6 +7,10 @@ covers only the logic-layer helpers: URL building, hashing, redaction.
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
 
 from aios.sandbox.github_clone import (
@@ -71,3 +75,117 @@ class TestRedactToken:
     def test_no_redaction_if_token_absent(self) -> None:
         msg = "fatal: not a git repository"
         assert _redact_token_from_message(msg, "ghp_secret") == msg
+
+
+# ─── per-call timeout wiring (#697) ────────────────────────────────────────────
+#
+# These tests pin that the per-session ``git clone --reference`` budget is
+# threaded from ``Settings.github_clone_session_timeout_seconds`` (not the
+# old module-level 300s constant) and that the cache helpers use a separate
+# ``github_clone_cache_timeout_seconds`` budget.
+
+
+def _settings_stub(*, session: float, cache: float) -> SimpleNamespace:
+    return SimpleNamespace(
+        github_clone_session_timeout_seconds=session,
+        github_clone_cache_timeout_seconds=cache,
+    )
+
+
+async def test_session_clone_passes_configured_session_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``ensure_session_working_tree``'s ``clone --reference`` invocation
+    must use ``Settings.github_clone_session_timeout_seconds`` — not the
+    300s harness step budget that issue #697 closes."""
+    from aios.config import get_settings
+    from aios.sandbox import github_clone
+
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    get_settings.cache_clear()
+
+    fake_run = AsyncMock(return_value=(0, b"", b"", False))
+    monkeypatch.setattr(github_clone, "run_subprocess_with_timeout", fake_run)
+    monkeypatch.setattr(
+        github_clone,
+        "get_settings",
+        lambda: _settings_stub(session=7.0, cache=99.0),
+    )
+
+    await github_clone.ensure_session_working_tree(
+        session_id="sess_test",
+        resource_id="ghr_test",
+        repo_url="https://github.com/acme/foo",
+        token="ghp_TOKEN",
+        cache_dir=tmp_path / "cache",
+        proxy_url="http://proxy/foo",
+    )
+
+    assert fake_run.await_count >= 1
+    first_call = fake_run.await_args_list[0]
+    assert first_call.kwargs["timeout_s"] == 7.0
+    argv = first_call.args[0]
+    assert "clone" in argv and "--reference" in argv
+
+
+async def test_session_clone_timeout_raises_github_clone_error_with_configured_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the ``clone --reference`` invocation times out, the
+    ``GithubCloneError`` message must reflect the configured budget — not
+    the old 300s constant."""
+    from aios.config import get_settings
+    from aios.sandbox import github_clone
+
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    get_settings.cache_clear()
+
+    fake_run = AsyncMock(return_value=(-1, b"", b"", True))
+    monkeypatch.setattr(github_clone, "run_subprocess_with_timeout", fake_run)
+    monkeypatch.setattr(
+        github_clone,
+        "get_settings",
+        lambda: _settings_stub(session=7.0, cache=99.0),
+    )
+
+    with pytest.raises(GithubCloneError) as excinfo:
+        await github_clone.ensure_session_working_tree(
+            session_id="sess_test",
+            resource_id="ghr_test",
+            repo_url="https://github.com/acme/foo",
+            token="ghp_TOKEN",
+            cache_dir=tmp_path / "cache",
+            proxy_url="http://proxy/foo",
+        )
+
+    msg = str(excinfo.value)
+    assert "7" in msg
+    assert "300" not in msg
+
+
+async def test_cache_clone_uses_cache_timeout_not_session_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``ensure_cache_clone`` cold-path runs ``git clone --bare`` against
+    the upstream — that's the cache budget, not the per-session one."""
+    from aios.config import get_settings
+    from aios.sandbox import github_clone
+
+    monkeypatch.setenv("AIOS_WORKSPACE_ROOT", str(tmp_path))
+    get_settings.cache_clear()
+
+    fake_run = AsyncMock(return_value=(0, b"", b"", False))
+    monkeypatch.setattr(github_clone, "run_subprocess_with_timeout", fake_run)
+    monkeypatch.setattr(
+        github_clone,
+        "get_settings",
+        lambda: _settings_stub(session=7.0, cache=99.0),
+    )
+
+    await github_clone.ensure_cache_clone("https://github.com/acme/foo", "ghp_TOKEN")
+
+    # First call is the bare clone — cache budget, not session.
+    bare_clone_call = fake_run.await_args_list[0]
+    argv = bare_clone_call.args[0]
+    assert "clone" in argv and "--bare" in argv
+    assert bare_clone_call.kwargs["timeout_s"] == 99.0

--- a/tests/unit/test_github_clone_helpers.py
+++ b/tests/unit/test_github_clone_helpers.py
@@ -167,7 +167,15 @@ async def test_cache_clone_uses_cache_timeout_not_session_timeout(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """``ensure_cache_clone`` cold-path runs ``git clone --bare`` against
-    the upstream — that's the cache budget, not the per-session one."""
+    the upstream — that's the cache budget, not the per-session one.
+
+    Asserts EVERY ``_run_git`` invocation inside ``ensure_cache_clone``
+    uses the cache budget. A regression that swaps either call's
+    constant (e.g. the post-clone ``config gc.auto`` admin op) would
+    otherwise pass undetected — and silently leave the cache with
+    ``gc.auto`` enabled, where it can reap objects still referenced
+    by per-session ``--reference --dissociate`` working trees.
+    """
     from aios.config import get_settings
     from aios.sandbox import github_clone
 
@@ -184,8 +192,14 @@ async def test_cache_clone_uses_cache_timeout_not_session_timeout(
 
     await github_clone.ensure_cache_clone("https://github.com/acme/foo", "ghp_TOKEN")
 
-    # First call is the bare clone — cache budget, not session.
-    bare_clone_call = fake_run.await_args_list[0]
-    argv = bare_clone_call.args[0]
-    assert "clone" in argv and "--bare" in argv
-    assert bare_clone_call.kwargs["timeout_s"] == 99.0
+    # Cold-path issues two git invocations: ``clone --bare`` then
+    # ``config gc.auto 0``. Both are cache initialization; both must
+    # use the cache budget.
+    assert fake_run.await_count == 2
+    argvs = [call.args[0] for call in fake_run.await_args_list]
+    assert any("clone" in argv and "--bare" in argv for argv in argvs)
+    assert any("config" in argv and "gc.auto" in argv for argv in argvs)
+    for call in fake_run.await_args_list:
+        assert call.kwargs["timeout_s"] == 99.0, (
+            f"expected cache budget (99.0) for {call.args[0]!r}, got {call.kwargs['timeout_s']}"
+        )

--- a/tests/unit/test_sandbox_spec.py
+++ b/tests/unit/test_sandbox_spec.py
@@ -49,6 +49,78 @@ def _make_pool_with_conn() -> MagicMock:
     return pool
 
 
+async def test_session_clone_timeout_does_not_abort_sibling_clones() -> None:
+    """A per-session ``git clone --reference`` timeout (now bounded by
+    ``Settings.github_clone_session_timeout_seconds`` — issue #697)
+    surfaces as a ``GithubCloneError``. The per-repo ``except
+    GithubCloneError`` branch must drop the failed echo and continue
+    cloning siblings, logging one ``github_clone_failed`` lifecycle
+    event. Without this branch, a single timed-out clone would skip
+    every later attached repo on the session.
+    """
+    mock_proxy = MagicMock()
+    mock_proxy.start = AsyncMock()
+    mock_proxy.stop = AsyncMock()
+    mock_proxy.proxy_url = MagicMock(return_value="http://stub/proxy")
+
+    from aios.sandbox.github_clone import GithubCloneError
+
+    failed_echo = _make_echo("ghr_failed")
+    ok_echo = _make_echo("ghr_ok")
+
+    append_event_mock = AsyncMock()
+
+    with (
+        patch("aios.sandbox.spec.GitProxy", return_value=mock_proxy),
+        patch(
+            "aios.sandbox.spec.queries.list_session_github_repo_echoes",
+            AsyncMock(return_value=[failed_echo, ok_echo]),
+        ),
+        patch(
+            "aios.services.github_repositories.get_session_token",
+            AsyncMock(return_value="ghp_TEST"),
+        ),
+        patch(
+            "aios.sandbox.spec.ensure_cache_clone",
+            AsyncMock(return_value=Path("/tmp/cache")),
+        ),
+        patch(
+            "aios.sandbox.spec.ensure_session_working_tree",
+            AsyncMock(
+                side_effect=[
+                    GithubCloneError("git clone --reference timed out after 30s"),
+                    None,
+                ]
+            ),
+        ),
+        patch(
+            "aios.sandbox.spec.runtime.require_pool",
+            return_value=_make_pool_with_conn(),
+        ),
+        patch(
+            "aios.sandbox.spec.runtime.require_crypto_box",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "aios.sandbox.spec.sessions_service.append_event",
+            append_event_mock,
+        ),
+    ):
+        materialized, returned_proxy = await _materialize_github_clones(
+            "sess_x", account_id="acct_x"
+        )
+
+    assert [e.id for e in materialized] == [ok_echo.id]
+    assert returned_proxy is mock_proxy
+    append_event_mock.assert_awaited_once()
+    call_args = append_event_mock.await_args
+    payload = call_args.args[3] if len(call_args.args) >= 4 else call_args.kwargs["payload"]
+    assert payload["event"] == "github_clone_failed"
+    assert payload["resource_id"] == failed_echo.id
+    # Sibling clone still ran and succeeded; proxy stays alive for the caller.
+    mock_proxy.stop.assert_not_called()
+
+
 async def test_materialize_github_clones_stops_proxy_on_non_clone_error() -> None:
     """If ``ensure_session_working_tree`` raises a non-``GithubCloneError``
     (``OSError`` from a full disk during mkdir/rmtree;


### PR DESCRIPTION
Closes #697

## What and why

On 2026-05-24, session `sess_01KQ8NQ3HP4XB9D0F4GW9JKYWF` (Ultron / Metals factchecker) demonstrated the failure mode: a single hung `git clone --reference` inside `_materialize_github_clones` held up the entire turn step for 300 s — the harness step-level cap — before the model got a chance to respond to the user message. The root cause was a single `_GIT_TIMEOUT_S = 300.0` module constant applied uniformly to every git call, conflating two very different operations:

- **Per-session working-tree clone** (`git clone --reference --dissociate`): this is on the critical path for every inbound user message attached to a GitHub repo. 300 s is indefensible here.
- **Bare cache clone/fetch** (cold path into `<workspace_root>/_github_repos/<sha256(url)>`): large repos legitimately take minutes; a generous budget is correct.

## Changes

**`src/aios/config.py`** — two new pydantic settings:
- `github_clone_session_timeout_seconds` (default **30 s**): per-session `clone --reference --dissociate` and the short admin ops after it (`remote set-url`, `config user.*`, `config gc.auto`). Chosen to be well below the 300 s step timeout so a hung clone fails fast and the graceful-degradation path in `_materialize_github_clones` (which already existed) takes over.
- `github_clone_cache_timeout_seconds` (default **300 s**): bare cache clone/fetch. Preserves existing behaviour for the cold path.

**`src/aios/sandbox/github_clone.py`** — deleted `_GIT_TIMEOUT_S`. `_run_git` now takes a required `timeout_s` parameter. Each call site resolves the appropriate budget from `get_settings()` at helper-entry (not globally), so the values are always live from the running config.

**`src/aios/sandbox/spec.py`** — docstring note in `_materialize_github_clones` pointing to the session-timeout setting and issue #697.

**Tests** — three new unit tests in `test_github_clone_helpers.py` asserting that `ensure_session_working_tree` uses the session budget, `ensure_cache_clone` uses the cache budget, and that the timeout error message carries the configured value. One regression-pin test in `test_sandbox_spec.py` locks the existing graceful-degradation invariant: a `GithubCloneError` on one repo echo must not abort sibling echoes. Coverage for both settings (defaults, env override, below-step-budget guard) in `test_config.py`.