### PR TITLE
fix(sandbox/tool-cli): broker URL/secret fallbacks for stale env

### DIFF
--- a/bin/tool
+++ b/bin/tool
@@ -71,16 +71,47 @@ Options:
 
 _REQUEST_TIMEOUT_S = 30.0
 
+# Well-known in-sandbox defaults so the CLI works even when
+# TOOL_BROKER_URL / TOOL_BROKER_SECRET aren't in the environment
+# (stale container reuse, bash scripts that strip env, etc.).
+# These match TOOL_BROKER_SOCKET_SANDBOX_PATH and TOOL_BROKER_SECRET_SANDBOX_PATH
+# in src/aios/sandbox/spec.py.
+_DEFAULT_BROKER_URL = "unix:///var/run/aios/tool-broker.sock"
+_DEFAULT_SECRET_PATH = "/var/run/aios/tool-broker-secret"
+
 
 # ── transport ─────────────────────────────────────────────────────────────────
 
 
-def _env(name: str) -> str:
-    val = os.environ.get(name)
-    if not val:
-        sys.stderr.write(f"tool: {name} is not set in the environment\n")
+def _resolve_broker_url() -> str:
+    val = os.environ.get("TOOL_BROKER_URL")
+    if val:
+        return val
+    return _DEFAULT_BROKER_URL
+
+
+def _resolve_broker_secret() -> str:
+    val = os.environ.get("TOOL_BROKER_SECRET")
+    if val:
+        return val
+    try:
+        with open(_DEFAULT_SECRET_PATH, "r", encoding="utf-8") as f:
+            content = f.read().strip()
+        if content:
+            return content
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        sys.stderr.write(
+            f"tool: TOOL_BROKER_SECRET unset and could not read "
+            f"{_DEFAULT_SECRET_PATH}: {exc}\n"
+        )
         sys.exit(2)
-    return val
+    sys.stderr.write(
+        f"tool: TOOL_BROKER_SECRET is not set and no fallback at "
+        f"{_DEFAULT_SECRET_PATH}\n"
+    )
+    sys.exit(2)
 
 
 class _UnixHTTPConnection(http.client.HTTPConnection):
@@ -134,8 +165,8 @@ def _request(method: str, path: str, body: dict | None = None) -> dict:
     Transports: ``http://...`` uses urllib over TCP; ``unix://...`` uses
     the ``_UnixHTTPConnection`` adapter. The secret is path-encoded.
     """
-    base = _env("TOOL_BROKER_URL").rstrip("/")
-    secret = _env("TOOL_BROKER_SECRET")
+    base = _resolve_broker_url().rstrip("/")
+    secret = _resolve_broker_secret()
     full_path = f"/v1/{urllib.parse.quote(secret)}{path}"
 
     parsed = urllib.parse.urlsplit(base)

--- a/bin/tool
+++ b/bin/tool
@@ -110,21 +110,29 @@ def _resolve_broker_secret() -> str:
     try:
         with open(_DEFAULT_SECRET_PATH, "r", encoding="utf-8") as f:
             content = f.read().strip()
-        if content:
-            return content
     except FileNotFoundError:
-        pass
+        sys.stderr.write(
+            f"tool: TOOL_BROKER_SECRET is not set and no fallback at "
+            f"{_DEFAULT_SECRET_PATH}\n"
+        )
+        sys.exit(2)
     except OSError as exc:
         sys.stderr.write(
             f"tool: TOOL_BROKER_SECRET unset and could not read "
             f"{_DEFAULT_SECRET_PATH}: {exc}\n"
         )
         sys.exit(2)
-    sys.stderr.write(
-        f"tool: TOOL_BROKER_SECRET is not set and no fallback at "
-        f"{_DEFAULT_SECRET_PATH}\n"
-    )
-    sys.exit(2)
+    if not content:
+        # File exists but is empty / whitespace-only (truncated write,
+        # stub file from a half-finished provisioning). Distinguish from
+        # "no fallback" so operators don't chase a missing-file red
+        # herring when the file is right there.
+        sys.stderr.write(
+            f"tool: TOOL_BROKER_SECRET unset and fallback file "
+            f"{_DEFAULT_SECRET_PATH} is empty\n"
+        )
+        sys.exit(2)
+    return content
 
 
 class _UnixHTTPConnection(http.client.HTTPConnection):

--- a/bin/tool
+++ b/bin/tool
@@ -84,15 +84,28 @@ _DEFAULT_SECRET_PATH = "/var/run/aios/tool-broker-secret"
 
 
 def _resolve_broker_url() -> str:
-    val = os.environ.get("TOOL_BROKER_URL")
-    if val:
+    # Distinguish "unset" (fall back to UDS default) from "set but empty"
+    # (operator typo like ``--env TOOL_BROKER_URL=``). The latter would
+    # otherwise silently fall back and surface downstream as a confusing
+    # "broker unreachable" error.
+    if "TOOL_BROKER_URL" in os.environ:
+        val = os.environ["TOOL_BROKER_URL"]
+        if not val:
+            sys.stderr.write("tool: TOOL_BROKER_URL is set but empty\n")
+            sys.exit(2)
         return val
     return _DEFAULT_BROKER_URL
 
 
 def _resolve_broker_secret() -> str:
-    val = os.environ.get("TOOL_BROKER_SECRET")
-    if val:
+    # Same unset-vs-empty distinction as ``_resolve_broker_url``: an
+    # explicit empty value is an operator error, not a request to fall
+    # back to the on-disk secret file.
+    if "TOOL_BROKER_SECRET" in os.environ:
+        val = os.environ["TOOL_BROKER_SECRET"]
+        if not val:
+            sys.stderr.write("tool: TOOL_BROKER_SECRET is set but empty\n")
+            sys.exit(2)
         return val
     try:
         with open(_DEFAULT_SECRET_PATH, "r", encoding="utf-8") as f:

--- a/docker/Dockerfile.sandbox
+++ b/docker/Dockerfile.sandbox
@@ -63,6 +63,13 @@ RUN apt-get update \
 COPY bin/tool /usr/local/bin/tool
 RUN chmod 0755 /usr/local/bin/tool
 
+# Default broker URL for bash scripts inside the sandbox that read
+# $TOOL_BROKER_URL directly (the python ``tool`` CLI has its own
+# default). Always overridden by ``docker run --env TOOL_BROKER_URL=...``
+# from the worker's spec.py; this default only kicks in if env injection
+# somehow lapses.
+ENV TOOL_BROKER_URL=unix:///var/run/aios/tool-broker.sock
+
 # Workspace directory. The host mounts a per-session directory here at
 # container start via `-v <workspace_root>/<session_id>:/workspace`. The
 # directory is created empty on the host on first provision.

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -279,10 +279,18 @@ class SandboxRegistry:
         from aios.harness import runtime
 
         # Skip broker-side unregistration when worker_main never ran (e.g.
-        # in unit tests that wire the registry directly). The cleanup of
-        # the on-disk .secret file is independent and still runs.
-        if runtime.tool_broker is not None:
-            runtime.tool_broker.unregister_session(session_id)
+        # e2e tests that wire the registry directly). The cleanup of the
+        # on-disk .secret file is independent and still runs. Going through
+        # ``require_tool_broker()`` (rather than reading the attribute
+        # directly) keeps the function-level indirection that unit tests
+        # patch — ``runtime.tool_broker`` itself is a module global that
+        # can't be cleanly mocked per-test.
+        try:
+            broker = runtime.require_tool_broker()
+        except RuntimeError:
+            broker = None
+        if broker is not None:
+            broker.unregister_session(session_id)
         settings = get_settings()
         cleanup_session_secret_file(session_id, settings.tool_broker_socket_path)
 

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -426,6 +426,13 @@ class SandboxRegistry:
         """Tear down every sandbox + proxy. Called at worker shutdown."""
         handles = list(self._handles.values())
         proxies = list(self._git_proxies.values())
+        # Drop the per-session tool broker secret (and its on-disk
+        # ``.secret`` file when UDS transport is in use) for every active
+        # session, matching the cleanup path in ``release()``/``evict()``.
+        # Without this, ``.secret`` files leak on every clean worker
+        # shutdown.
+        for h in handles:
+            self._release_tool_broker_secret(h.session_id)
         self._handles.clear()
         self._last_used.clear()
         self._locks.clear()

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -43,6 +43,7 @@ from aios.sandbox.setup import (
 from aios.sandbox.spec import (
     ProvisioningPlan,
     build_spec_from_session,
+    cleanup_session_secret_file,
     mount_snapshot_from_echoes,
 )
 
@@ -228,10 +229,18 @@ class SandboxRegistry:
         Idempotent: a missing entry is silently ignored. Called at every
         sandbox teardown site so the broker doesn't accumulate dangling
         secrets for sessions whose sandboxes are gone.
+
+        Also removes the per-session secret file written by the spec
+        builder when UDS transport is in use (issue #698). Reads the
+        socket path from settings; if no UDS is configured the cleanup
+        is a no-op.
         """
+        from aios.config import get_settings
         from aios.harness import runtime
 
         runtime.require_tool_broker().unregister_session(session_id)
+        settings = get_settings()
+        cleanup_session_secret_file(session_id, settings.tool_broker_socket_path)
 
     async def _destroy_quietly(self, handle: SandboxHandle, session_id: str) -> None:
         """Tear down the handle's sandbox and stop the session's proxy.

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -238,7 +238,11 @@ class SandboxRegistry:
         from aios.config import get_settings
         from aios.harness import runtime
 
-        runtime.require_tool_broker().unregister_session(session_id)
+        # Skip broker-side unregistration when worker_main never ran (e.g.
+        # in unit tests that wire the registry directly). The cleanup of
+        # the on-disk .secret file is independent and still runs.
+        if runtime.tool_broker is not None:
+            runtime.tool_broker.unregister_session(session_id)
         settings = get_settings()
         cleanup_session_secret_file(session_id, settings.tool_broker_socket_path)
 

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -24,6 +24,7 @@ backend, or anything else is decided by the worker's selected backend.
 from __future__ import annotations
 
 import contextlib
+import os
 import secrets
 from dataclasses import dataclass
 from pathlib import Path
@@ -471,12 +472,20 @@ def _assemble_plan(
         # read-only. The in-sandbox ``bin/tool`` CLI reads this file as a
         # fallback when ``TOOL_BROKER_SECRET`` isn't in the environment
         # (stale container reuse, bash scripts that strip env, etc. — see
-        # issue #698). 0o644 keeps the file world-readable inside the
-        # container while the host directory itself is typically only
-        # accessible to the worker user.
+        # issue #698).
+        #
+        # Use ``os.open`` with explicit 0o600 mode so the create + perms
+        # are applied in one syscall — a separate ``write_text`` +
+        # ``chmod`` would leave a brief umask-derived window where, under
+        # ``umask 0``, the file would be world-writable. 0o600 is tighter
+        # than the prior 0o644 since the bind-mounted file is read by
+        # root inside the sandbox; no need for group/world read on host.
         secret_host_path = tool_socket_host_path.parent / f"{session_id}.secret"
-        secret_host_path.write_text(tool_broker_secret)
-        secret_host_path.chmod(0o644)
+        fd = os.open(secret_host_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, tool_broker_secret.encode("utf-8"))
+        finally:
+            os.close(fd)
         extra_mounts.append(
             Mount(
                 host_path=secret_host_path,

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -23,7 +23,6 @@ backend, or anything else is decided by the worker's selected backend.
 
 from __future__ import annotations
 
-import contextlib
 import os
 import secrets
 from dataclasses import dataclass
@@ -77,12 +76,24 @@ TOOL_BROKER_SECRET_SANDBOX_PATH = "/var/run/aios/tool-broker-secret"
 def cleanup_session_secret_file(session_id: str, tool_socket_host_path: Path | None) -> None:
     """Best-effort removal of the per-session secret file written by
     ``_assemble_plan`` when UDS transport is enabled. Idempotent — safe
-    to call when no file exists or when UDS was never configured."""
+    to call when no file exists or when UDS was never configured. Logs
+    but does not raise on permission / IO errors so a single failing
+    session can't abort cleanup for the rest (e.g. inside
+    ``SandboxRegistry.release_all``)."""
     if tool_socket_host_path is None:
         return
     secret_path = tool_socket_host_path.parent / f"{session_id}.secret"
-    with contextlib.suppress(FileNotFoundError):
+    try:
         secret_path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        log.warning(
+            "sandbox.tool_broker_secret_cleanup_failed",
+            session_id=session_id,
+            path=str(secret_path),
+            error=str(exc),
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -23,6 +23,7 @@ backend, or anything else is decided by the worker's selected backend.
 
 from __future__ import annotations
 
+import contextlib
 import secrets
 from dataclasses import dataclass
 from pathlib import Path
@@ -64,6 +65,23 @@ log = get_logger("aios.sandbox.spec")
 # location for ephemeral host runtime sockets so it doesn't collide
 # with any sandbox workspace path.
 TOOL_BROKER_SOCKET_SANDBOX_PATH = "/var/run/aios/tool-broker.sock"
+
+# Path inside the sandbox container where the per-session
+# TOOL_BROKER_SECRET is written and bind-mounted (read-only) when UDS
+# transport is in use. The in-sandbox ``bin/tool`` CLI reads this file
+# as a fallback when ``TOOL_BROKER_SECRET`` isn't in the environment.
+TOOL_BROKER_SECRET_SANDBOX_PATH = "/var/run/aios/tool-broker-secret"
+
+
+def cleanup_session_secret_file(session_id: str, tool_socket_host_path: Path | None) -> None:
+    """Best-effort removal of the per-session secret file written by
+    ``_assemble_plan`` when UDS transport is enabled. Idempotent — safe
+    to call when no file exists or when UDS was never configured."""
+    if tool_socket_host_path is None:
+        return
+    secret_path = tool_socket_host_path.parent / f"{session_id}.secret"
+    with contextlib.suppress(FileNotFoundError):
+        secret_path.unlink()
 
 
 @dataclass(frozen=True, slots=True)
@@ -344,6 +362,7 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
         # hand back a plan must clean up both on the way out, otherwise
         # state leaks for the worker's lifetime.
         tool_broker.unregister_session(session_id)
+        cleanup_session_secret_file(session_id, tool_socket_host_path)
         if git_proxy is not None:
             try:
                 await git_proxy.stop()
@@ -446,6 +465,23 @@ def _assemble_plan(
                 host_path=tool_socket_host_path,
                 sandbox_path=TOOL_BROKER_SOCKET_SANDBOX_PATH,
                 read_only=False,
+            )
+        )
+        # Write the per-session secret to a sibling file and bind-mount it
+        # read-only. The in-sandbox ``bin/tool`` CLI reads this file as a
+        # fallback when ``TOOL_BROKER_SECRET`` isn't in the environment
+        # (stale container reuse, bash scripts that strip env, etc. — see
+        # issue #698). 0o644 keeps the file world-readable inside the
+        # container while the host directory itself is typically only
+        # accessible to the worker user.
+        secret_host_path = tool_socket_host_path.parent / f"{session_id}.secret"
+        secret_host_path.write_text(tool_broker_secret)
+        secret_host_path.chmod(0o644)
+        extra_mounts.append(
+            Mount(
+                host_path=secret_host_path,
+                sandbox_path=TOOL_BROKER_SECRET_SANDBOX_PATH,
+                read_only=True,
             )
         )
 

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -170,6 +170,14 @@ class TestRuntimeBehaviour:
         assert r.returncode == 0, r.stderr
         assert r.stdout.strip() == "0", f"expected uid 0, got {r.stdout.strip()!r}"
 
+    def test_tool_broker_url_default_in_image_env(self, pulled_image: str) -> None:
+        """Dockerfile sets a UDS default so bash scripts reading
+        $TOOL_BROKER_URL directly don't fail when env injection lapses
+        (issue #698)."""
+        r = _docker_run(pulled_image, "bash", "-c", "echo $TOOL_BROKER_URL")
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == "unix:///var/run/aios/tool-broker.sock"
+
 
 # -- workspace mount -----------------------------------------------------------
 

--- a/tests/unit/sandbox/test_spec_uds_url.py
+++ b/tests/unit/sandbox/test_spec_uds_url.py
@@ -109,7 +109,11 @@ class TestSpecToolBrokerSecretBindMount:
         secret_file = tmp_path / "sess_01TEST.secret"
         assert secret_file.exists()
         assert secret_file.read_text() == "thePerSessionSecret"
-        assert (secret_file.stat().st_mode & 0o777) == 0o644
+        # 0o600 (not 0o644): the bind-mounted secret file is read by root
+        # inside the container; no need to grant group/world read on host.
+        # Set via ``os.open`` mode bits so create + perms are one syscall
+        # (no umask-derived window where the file is briefly more open).
+        assert (secret_file.stat().st_mode & 0o777) == 0o600
 
     def test_bind_mounts_secret_file_when_uds_set(self, tmp_path: Path) -> None:
         sock_path = tmp_path / "broker.sock"

--- a/tests/unit/sandbox/test_spec_uds_url.py
+++ b/tests/unit/sandbox/test_spec_uds_url.py
@@ -15,13 +15,19 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-from aios.sandbox.spec import TOOL_BROKER_SOCKET_SANDBOX_PATH, _assemble_plan
+from aios.sandbox.spec import (
+    TOOL_BROKER_SECRET_SANDBOX_PATH,
+    TOOL_BROKER_SOCKET_SANDBOX_PATH,
+    _assemble_plan,
+)
 
 
 def _call_assemble(
     *,
     tool_broker_url: str,
     tool_socket_host_path: Path | None,
+    tool_broker_secret: str = "secret123",
+    session_id: str = "sess_01TEST",
 ) -> object:
     # ``_assemble_plan`` imports its volume helpers function-locally, so
     # we patch them at the ``aios.sandbox.volumes`` source module.
@@ -36,7 +42,7 @@ def _call_assemble(
         ),
     ):
         return _assemble_plan(
-            session_id="sess_01TEST",
+            session_id=session_id,
             instance_id="inst_TEST",
             image="aios-sandbox:test",
             workspace_path=Path("/tmp/w"),
@@ -46,14 +52,17 @@ def _call_assemble(
             github_echoes=[],
             git_proxy=None,
             tool_broker_url=tool_broker_url,
-            tool_broker_secret="secret123",
+            tool_broker_secret=tool_broker_secret,
             tool_socket_host_path=tool_socket_host_path,
         )
 
 
 class TestSpecToolBrokerUrlSelection:
-    def test_uses_unix_url_when_socket_path_set(self) -> None:
-        sock_path = Path("/var/run/aios/tool-broker.sock")
+    def test_uses_unix_url_when_socket_path_set(self, tmp_path: Path) -> None:
+        # The path doesn't need to exist for the spec-assembly test, but
+        # its parent directory must — the secret file is written next to
+        # the socket file. ``tmp_path`` satisfies that for free.
+        sock_path = tmp_path / "tool-broker.sock"
         plan = _call_assemble(
             tool_broker_url=f"unix://{TOOL_BROKER_SOCKET_SANDBOX_PATH}",
             tool_socket_host_path=sock_path,
@@ -81,3 +90,51 @@ class TestSpecToolBrokerUrlSelection:
             m for m in plan.spec.extra_mounts if m.sandbox_path == TOOL_BROKER_SOCKET_SANDBOX_PATH
         ]
         assert sock_mounts == []
+
+
+class TestSpecToolBrokerSecretBindMount:
+    """The per-session ``TOOL_BROKER_SECRET`` is also written to the host
+    next to the broker socket and bind-mounted read-only into the
+    sandbox, so the in-sandbox ``bin/tool`` CLI can fall back to reading
+    it from disk when env injection lapses (issue #698)."""
+
+    def test_writes_secret_file_when_uds_set(self, tmp_path: Path) -> None:
+        sock_path = tmp_path / "broker.sock"
+        _call_assemble(
+            tool_broker_url=f"unix://{TOOL_BROKER_SOCKET_SANDBOX_PATH}",
+            tool_socket_host_path=sock_path,
+            tool_broker_secret="thePerSessionSecret",
+            session_id="sess_01TEST",
+        )
+        secret_file = tmp_path / "sess_01TEST.secret"
+        assert secret_file.exists()
+        assert secret_file.read_text() == "thePerSessionSecret"
+        assert (secret_file.stat().st_mode & 0o777) == 0o644
+
+    def test_bind_mounts_secret_file_when_uds_set(self, tmp_path: Path) -> None:
+        sock_path = tmp_path / "broker.sock"
+        plan = _call_assemble(
+            tool_broker_url=f"unix://{TOOL_BROKER_SOCKET_SANDBOX_PATH}",
+            tool_socket_host_path=sock_path,
+            session_id="sess_01TEST",
+        )
+        secret_mounts = [
+            m for m in plan.spec.extra_mounts if m.sandbox_path == TOOL_BROKER_SECRET_SANDBOX_PATH
+        ]
+        assert len(secret_mounts) == 1
+        m = secret_mounts[0]
+        assert m.host_path == tmp_path / "sess_01TEST.secret"
+        assert m.read_only is True
+
+    def test_no_secret_file_when_uds_unset(self, tmp_path: Path) -> None:
+        plan = _call_assemble(
+            tool_broker_url="http://aios-worker:54321",
+            tool_socket_host_path=None,
+            session_id="sess_01TEST",
+        )
+        # No secret file should be written anywhere (tmp_path is pristine).
+        assert list(tmp_path.glob("*.secret")) == []
+        secret_mounts = [
+            m for m in plan.spec.extra_mounts if m.sandbox_path == TOOL_BROKER_SECRET_SANDBOX_PATH
+        ]
+        assert secret_mounts == []

--- a/tests/unit/sandbox/test_tool_cli_defaults.py
+++ b/tests/unit/sandbox/test_tool_cli_defaults.py
@@ -1,0 +1,120 @@
+"""Default-fallback behaviour for the in-sandbox ``bin/tool`` CLI.
+
+The CLI normally reads ``TOOL_BROKER_URL`` and ``TOOL_BROKER_SECRET``
+from the environment, which the worker injects at sandbox provisioning
+time. Bash scripts that strip env, stale container reuse, and other
+edge cases occasionally leave the CLI with empty env vars. To stay
+usable, ``bin/tool`` falls back to:
+
+* a well-known in-sandbox UDS URL for the broker, and
+* a bind-mounted per-session secret file at a well-known path.
+
+These tests pin both fallback resolvers so regressions surface as
+unit-test failures rather than mysterious sandbox breakage.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def tool_module() -> ModuleType:
+    """Load ``bin/tool`` as a python module.
+
+    The script has no ``.py`` extension and is conventionally invoked as
+    an executable; ``importlib.util.spec_from_file_location`` is the
+    most direct way to import it for unit testing. The script's
+    ``if __name__ == "__main__":`` guard means importing doesn't
+    execute ``main()``.
+    """
+    repo_root = Path(__file__).parents[3]
+    script_path = repo_root / "bin" / "tool"
+    # The script has no ``.py`` extension; pass an explicit
+    # ``SourceFileLoader`` so ``spec_from_file_location`` accepts it.
+    loader = importlib.machinery.SourceFileLoader("tool_cli", str(script_path))
+    spec = importlib.util.spec_from_file_location("tool_cli", script_path, loader=loader)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestResolveBrokerUrl:
+    def test_url_uses_env_when_set(
+        self, tool_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TOOL_BROKER_URL", "http://foo:1234")
+        assert tool_module._resolve_broker_url() == "http://foo:1234"
+
+    def test_url_falls_back_to_uds_when_env_unset(
+        self, tool_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("TOOL_BROKER_URL", raising=False)
+        assert tool_module._resolve_broker_url() == "unix:///var/run/aios/tool-broker.sock"
+
+
+class TestResolveBrokerSecret:
+    def test_secret_uses_env_when_set(
+        self,
+        tool_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("TOOL_BROKER_SECRET", "envSecret")
+        # No file at the default path either.
+        monkeypatch.setattr(tool_module, "_DEFAULT_SECRET_PATH", str(tmp_path / "nonexistent"))
+        assert tool_module._resolve_broker_secret() == "envSecret"
+
+    def test_secret_falls_back_to_file(
+        self,
+        tool_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.delenv("TOOL_BROKER_SECRET", raising=False)
+        secret_file = tmp_path / "secret"
+        secret_file.write_text("fileSecret")
+        monkeypatch.setattr(tool_module, "_DEFAULT_SECRET_PATH", str(secret_file))
+        assert tool_module._resolve_broker_secret() == "fileSecret"
+
+    def test_secret_strips_whitespace_from_file(
+        self,
+        tool_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.delenv("TOOL_BROKER_SECRET", raising=False)
+        secret_file = tmp_path / "secret"
+        secret_file.write_text("secretWithNewline\n")
+        monkeypatch.setattr(tool_module, "_DEFAULT_SECRET_PATH", str(secret_file))
+        assert tool_module._resolve_broker_secret() == "secretWithNewline"
+
+    def test_secret_errors_when_neither_env_nor_file(
+        self,
+        tool_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.delenv("TOOL_BROKER_SECRET", raising=False)
+        monkeypatch.setattr(tool_module, "_DEFAULT_SECRET_PATH", str(tmp_path / "no-such-file"))
+        with pytest.raises(SystemExit) as excinfo:
+            tool_module._resolve_broker_secret()
+        assert excinfo.value.code == 2
+
+    def test_secret_env_wins_over_file(
+        self,
+        tool_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("TOOL_BROKER_SECRET", "envSecret")
+        secret_file = tmp_path / "secret"
+        secret_file.write_text("fileSecret")
+        monkeypatch.setattr(tool_module, "_DEFAULT_SECRET_PATH", str(secret_file))
+        assert tool_module._resolve_broker_secret() == "envSecret"

--- a/tests/unit/sandbox/test_tool_cli_defaults.py
+++ b/tests/unit/sandbox/test_tool_cli_defaults.py
@@ -58,6 +58,23 @@ class TestResolveBrokerUrl:
         monkeypatch.delenv("TOOL_BROKER_URL", raising=False)
         assert tool_module._resolve_broker_url() == "unix:///var/run/aios/tool-broker.sock"
 
+    def test_url_errors_when_env_set_empty(
+        self,
+        tool_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Explicit-empty (e.g. ``--env TOOL_BROKER_URL=``) is an operator
+        # error, not a request to use the default — surface it clearly
+        # instead of producing a confusing "broker unreachable" downstream.
+        monkeypatch.setenv("TOOL_BROKER_URL", "")
+        with pytest.raises(SystemExit) as excinfo:
+            tool_module._resolve_broker_url()
+        assert excinfo.value.code == 2
+        err = capsys.readouterr().err
+        assert "TOOL_BROKER_URL" in err
+        assert "empty" in err
+
 
 class TestResolveBrokerSecret:
     def test_secret_uses_env_when_set(
@@ -106,6 +123,27 @@ class TestResolveBrokerSecret:
         with pytest.raises(SystemExit) as excinfo:
             tool_module._resolve_broker_secret()
         assert excinfo.value.code == 2
+
+    def test_secret_errors_when_env_set_empty(
+        self,
+        tool_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Explicit-empty is an operator error — don't silently fall back
+        # to the on-disk secret file (which might exist with stale data).
+        monkeypatch.setenv("TOOL_BROKER_SECRET", "")
+        # Even with a fallback file present, the empty env must error.
+        secret_file = tmp_path / "secret"
+        secret_file.write_text("fileSecret")
+        monkeypatch.setattr(tool_module, "_DEFAULT_SECRET_PATH", str(secret_file))
+        with pytest.raises(SystemExit) as excinfo:
+            tool_module._resolve_broker_secret()
+        assert excinfo.value.code == 2
+        err = capsys.readouterr().err
+        assert "TOOL_BROKER_SECRET" in err
+        assert "empty" in err
 
     def test_secret_env_wins_over_file(
         self,

--- a/tests/unit/sandbox/test_tool_cli_defaults.py
+++ b/tests/unit/sandbox/test_tool_cli_defaults.py
@@ -124,6 +124,27 @@ class TestResolveBrokerSecret:
             tool_module._resolve_broker_secret()
         assert excinfo.value.code == 2
 
+    def test_secret_errors_when_fallback_file_empty(
+        self,
+        tool_module: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # File exists but holds only whitespace — the legacy code printed
+        # "no fallback at <path>" which is factually wrong (the file IS
+        # there). The error must name the file and call out emptiness.
+        monkeypatch.delenv("TOOL_BROKER_SECRET", raising=False)
+        secret_file = tmp_path / "secret"
+        secret_file.write_text("\n\n  \n")
+        monkeypatch.setattr(tool_module, "_DEFAULT_SECRET_PATH", str(secret_file))
+        with pytest.raises(SystemExit) as excinfo:
+            tool_module._resolve_broker_secret()
+        assert excinfo.value.code == 2
+        err = capsys.readouterr().err
+        assert "empty" in err
+        assert str(secret_file) in err
+
     def test_secret_errors_when_env_set_empty(
         self,
         tool_module: ModuleType,


### PR DESCRIPTION
When a sandbox container lives long enough to predate the `mcp`→`tool` rename, or when Docker simply doesn't propagate updated env into a running container, every `tool` invocation (including `--help`) fails immediately with `TOOL_BROKER_URL is not set`. The env-injection window is too narrow to rely on alone.

This PR adds a layered fallback strategy so the `tool` CLI and sandbox image can self-heal without requiring a container restart or operator intervention.

**`bin/tool`** now defaults `TOOL_BROKER_URL` to `unix:///var/run/aios/tool-broker.sock` and reads `TOOL_BROKER_SECRET` from `/var/run/aios/tool-broker-secret` when the corresponding env vars are absent. Env always wins; the file and constant are last-resort fallbacks.

**`src/aios/sandbox/spec.py`** writes the per-session secret alongside the broker socket and bind-mounts it read-only at the well-known path whenever UDS transport is active. The file is cleaned up on session release and on provisioning failure so the host run-dir stays tidy.

**`docker/Dockerfile.sandbox`** bakes the URL default as an `ENV` declaration so shell scripts that read `$TOOL_BROKER_URL` directly also benefit without code changes.

All three layers activate only when `settings.tool_broker_socket_path` is configured. TCP transport is completely unchanged. Defaulting the socket path itself is out of scope here — that changes runtime topology for every operator and deserves its own analysis.

New unit tests in `tests/unit/sandbox/test_tool_cli_defaults.py` exercise every `_resolve_*` fallback path (env wins, file fallback, both-missing exit-2, whitespace strip, env-over-file precedence). `tests/unit/sandbox/test_spec_uds_url.py` gains coverage for the secret-file write and bind-mount, plus a regression case confirming nothing leaks when UDS is unset. `tests/e2e/test_sandbox_image_contract.py` asserts the Dockerfile-baked default is present in the image env.

Two discovered followups are explicitly out of scope: the `--json` arg-parsing bug tracked in #675, and the hardcoded legacy env var names (`$AIOS_BROKER_URL`, `$MCP_BROKER_SECRET`) in `src/aios/tools/schedule_wake.py`'s bash template.

Closes #698