### PR TITLE
docs(CLAUDE.md): clarify AIOS_API_KEY auth + add BOOTSTRAP_TOKEN (#692)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,8 @@ They don't share connections; they share Postgres state.
 ## Environment variables
 
 All aios settings use the `AIOS_` prefix (Pydantic settings with `env_prefix="AIOS_"`):
-- `AIOS_API_KEY` — bearer auth key
+- `AIOS_API_KEY` — bearer auth key. Must hash to a row in `account_keys`; auth is no longer an env-var direct compare. On a fresh DB, mint one by POSTing to `/v1/accounts/bootstrap` (gated by `AIOS_BOOTSTRAP_TOKEN`) and store the returned `plaintext_key` as `AIOS_API_KEY` for both the API service and clients. A placeholder value (e.g. `test-aios-key-do-not-deploy`) will silently 401 against every request.
+- `AIOS_BOOTSTRAP_TOKEN` — bearer token that gates `POST /v1/accounts/bootstrap`; required to mint the root account's first API key on a fresh DB.
 - `AIOS_VAULT_KEY` — base64-encoded 32-byte libsodium key (do NOT regenerate if Postgres has encrypted data)
 - `AIOS_DB_URL` — Postgres connection string
 - `AIOS_API_PORT` — default 8080


### PR DESCRIPTION
Closes #692

- Replaces the misleading `AIOS_API_KEY` description ("bearer auth key") with an accurate one: the key must hash to a row in `account_keys`; on a fresh DB, mint via `POST /v1/accounts/bootstrap` (gated by `AIOS_BOOTSTRAP_TOKEN`) and store the returned `plaintext_key`; placeholder values silently 401.
- Adds a new bullet for `AIOS_BOOTSTRAP_TOKEN`, which was load-bearing for fresh-DB setup but completely absent from the env vars list.

**Deviation from spec**: the original issue suggested adding a note that `scripts/dev-bootstrap.sh` handles the bootstrap endpoint call. Verification showed that script only generates a key with `openssl rand -hex 32` and writes it to `.env` — it never calls the endpoint. That sentence was omitted to avoid re-introducing the same class of "docs imply something that doesn't happen" bug this PR is fixing.

Pure docs change; no production code, tests, or codegen artifacts touched.