### PR TITLE
feat(tools): add `wake_self` primitive for scheduled tasks

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -12804,6 +12804,7 @@
                   "cancel",
                   "schedule_wake",
                   "wake_session",
+                  "wake_self",
                   "http_request",
                   "schedule_task_add",
                   "schedule_task_remove",

--- a/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
@@ -14,6 +14,7 @@ class ToolSpecTypeType0(str, Enum):
     SCHEDULE_TASK_UPDATE = "schedule_task_update"
     SCHEDULE_WAKE = "schedule_wake"
     SEARCH_EVENTS = "search_events"
+    WAKE_SELF = "wake_self"
     WAKE_SESSION = "wake_session"
     WEB_FETCH = "web_fetch"
     WEB_SEARCH = "web_search"

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -29,6 +29,7 @@ BuiltinToolType = Literal[
     "cancel",
     "schedule_wake",
     "wake_session",
+    "wake_self",
     "http_request",
     "schedule_task_add",
     "schedule_task_remove",

--- a/src/aios/tools/__init__.py
+++ b/src/aios/tools/__init__.py
@@ -32,6 +32,7 @@ from aios.tools import schedule_task_update as _schedule_task_update  # noqa: F4
 from aios.tools import schedule_wake as _schedule_wake  # noqa: F401
 from aios.tools import search_events as _search_events  # noqa: F401
 from aios.tools import switch_channel as _switch_channel  # noqa: F401
+from aios.tools import wake_self as _wake_self  # noqa: F401
 from aios.tools import wake_session as _wake_session  # noqa: F401
 from aios.tools import web_fetch as _web_fetch  # noqa: F401
 from aios.tools import web_search as _web_search  # noqa: F401

--- a/src/aios/tools/schedule_task_add.py
+++ b/src/aios/tools/schedule_task_add.py
@@ -4,9 +4,9 @@ Hand-written precursor to the autogen'd self-state tools envisaged in
 #652. Per #270 we deliberately expose granular ops only — no whole-list
 ``set``. Each entry is identified by ``name`` (unique per session).
 
-Fires run in the session's sandbox without waking the model; bash must
-explicitly escalate via the broker's ``sessions/messages`` endpoint to
-deliver a user-role event back to the session.
+Fires run in the session's sandbox without waking the model; to deliver
+a user-role event back to the session, bash invokes the ``wake_self``
+tool (or, for scripted/advanced callers, POSTs to the broker directly).
 """
 
 from __future__ import annotations
@@ -30,13 +30,14 @@ SCHEDULE_TASK_ADD_DESCRIPTION = (
     "Add a cron-fired bash task to this session. The task runs at the "
     "specified schedule in the session's sandbox WITHOUT waking the "
     "model. To escalate (wake the model with a user-role message), the "
-    "bash command must POST to the broker. The canonical invocation, "
-    "which works in both TCP and Unix-socket broker transports (the "
-    "broker exposes ``unix://`` or ``http://`` via TOOL_BROKER_URL), is:\n"
+    "canonical bash invocation is:\n"
     "\n"
-    '  curl -fsS "$TOOL_BROKER_URL/v1/$TOOL_BROKER_SECRET/sessions/messages" \\\n'
-    "       -X POST -H 'Content-Type: application/json' \\\n"
-    '       -d \'{"content":"<message to deliver to yourself>"}\'\n'
+    '  tool wake_self \'{"content":"<message to deliver to yourself>"}\'\n'
+    "\n"
+    "This keeps the broker secret out of the command string. Advanced "
+    "or scripted callers may still POST to "
+    "``$TOOL_BROKER_URL/v1/$TOOL_BROKER_SECRET/sessions/messages`` "
+    "directly.\n"
     "\n"
     "Use this primitive for deterministic polling (file watchers, API "
     "checks, periodic state syncs) without burning model tokens per "

--- a/src/aios/tools/schedule_wake.py
+++ b/src/aios/tools/schedule_wake.py
@@ -210,7 +210,7 @@ async def schedule_wake_handler(session_id: str, arguments: dict[str, Any]) -> d
         name=_make_task_name(),
         fire_at=fire_at,
         command=_build_wake_bash(reason),
-        # Curl finishes in seconds; tight bound keeps stuck fires from
+        # `tool wake_self` finishes in seconds; tight bound keeps stuck fires from
         # tying up worker slots.
         timeout_seconds=30,
         # Tag for human-friendly rendering in the CLI's

--- a/src/aios/tools/schedule_wake.py
+++ b/src/aios/tools/schedule_wake.py
@@ -170,24 +170,17 @@ def _resolve_fire_at(arguments: dict[str, Any]) -> datetime:
 def _build_wake_bash(reason: str) -> str:
     """Generate the bash one-liner the scheduled fire will execute.
 
-    The command POSTs ``{"content": "<wake marker>"}`` to the broker's
-    ``sessions/messages`` endpoint via the canonical idiom (works under
-    both TCP and Unix-socket broker transports). The reason is embedded
-    as a JSON-encoded payload, then shell-escaped into the curl
-    invocation so arbitrary characters in the reason can't break out of
-    the body argument.
+    Invokes the in-sandbox ``tool wake_self`` CLI with a JSON-encoded
+    ``content`` argument. This keeps the broker secret out of the
+    command string and uses the canonical self-wake primitive (#703).
+    The JSON payload is shell-escaped so arbitrary characters in the
+    reason can't break out of the argument.
     """
     payload = json.dumps(
         {"content": f"[Your scheduled wake fired. Reason: {reason}]"},
         ensure_ascii=False,
     )
-    quoted_payload = shlex.quote(payload)
-    return (
-        'curl -fsS ${AIOS_BROKER_SOCKET:+--unix-socket "$AIOS_BROKER_SOCKET"} '
-        '"$AIOS_BROKER_URL/v1/$MCP_BROKER_SECRET/sessions/messages" '
-        "-X POST -H 'Content-Type: application/json' "
-        f"-d {quoted_payload}"
-    )
+    return f"tool wake_self {shlex.quote(payload)}"
 
 
 def _make_task_name() -> str:

--- a/src/aios/tools/schedule_wake.py
+++ b/src/aios/tools/schedule_wake.py
@@ -1,10 +1,12 @@
 """The schedule_wake tool — ask the harness to wake this session at a future time.
 
 Thin wrapper over :mod:`aios.services.scheduled_tasks`: creates a one-shot
-``scheduled_tasks`` row whose bash command POSTs a user-role marker back
-to the session via the broker's ``sessions/messages`` endpoint. At the
-configured time, the scheduler claims the row, the runner fires the bash,
-the broker appends the marker, and the model wakes naturally.
+``scheduled_tasks`` row whose bash command invokes the ``tool wake_self``
+CLI, which delivers a user-role message to the session via the broker
+(authenticating through the sandbox's ``TOOL_BROKER_URL`` /
+``TOOL_BROKER_SECRET`` env vars, so no secret lands in the command string).
+At the configured time, the scheduler claims the row, the runner fires the
+bash, the broker appends the marker, and the model wakes naturally.
 
 Accepts either ``delay_seconds`` (relative) or ``at`` (absolute, ISO 8601
 or natural language via ``dateparser``). Hard-fails unparseable strings —
@@ -180,6 +182,8 @@ def _build_wake_bash(reason: str) -> str:
         {"content": f"[Your scheduled wake fired. Reason: {reason}]"},
         ensure_ascii=False,
     )
+    # Requires `wake_self` to be declared on the agent; an undeclared tool
+    # yields a fire-time 404 surfaced through the scheduled-task runner.
     return f"tool wake_self {shlex.quote(payload)}"
 
 

--- a/src/aios/tools/wake_self.py
+++ b/src/aios/tools/wake_self.py
@@ -23,7 +23,7 @@ class WakeSelfArgumentError(AiosError):
 
 
 WAKE_SELF_DESCRIPTION = (
-    "Append CONTENT as a user-role message to your own session and "
+    "Append content as a user-role message to your own session and "
     "schedule the next step. This is the canonical self-wake primitive "
     "from inside scheduled-task cron commands or any sandbox bash "
     "command — it replaces the older "

--- a/src/aios/tools/wake_self.py
+++ b/src/aios/tools/wake_self.py
@@ -1,0 +1,78 @@
+"""The ``wake_self`` tool — append a user-role message to *this* session.
+
+Canonical self-wake primitive for cron-fired bash commands (and any
+other sandbox-side caller). Replaces the older curl-the-broker idiom
+so the broker secret never has to be interpolated into the command
+string.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.errors import AiosError
+from aios.harness import runtime
+from aios.services import sessions as sessions_service
+from aios.services.wake import defer_wake
+from aios.tools.registry import registry
+
+
+class WakeSelfArgumentError(AiosError):
+    error_type = "wake_self_argument_error"
+    status_code = 400
+
+
+WAKE_SELF_DESCRIPTION = (
+    "Append CONTENT as a user-role message to your own session and "
+    "schedule the next step. This is the canonical self-wake primitive "
+    "from inside scheduled-task cron commands or any sandbox bash "
+    "command — it replaces the older "
+    "``curl $TOOL_BROKER_URL/v1/$TOOL_BROKER_SECRET/sessions/messages`` "
+    "idiom and keeps the broker secret out of the command string. The "
+    "appended message is delivered to your next model call as a normal "
+    "user-role event. Available on both the model-tool surface and as "
+    '``tool wake_self \'{"content":"..."}\'`` from inside the sandbox.'
+)
+
+WAKE_SELF_PARAMETERS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "content": {
+            "type": "string",
+            "minLength": 1,
+        },
+    },
+    "required": ["content"],
+    "additionalProperties": False,
+}
+
+
+async def wake_self_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    content = arguments.get("content")
+    if not isinstance(content, str) or not content:
+        raise WakeSelfArgumentError("content must be a non-empty string")
+
+    pool = runtime.require_pool()
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
+    event = await sessions_service.append_user_message(
+        pool, session_id, content, account_id=account_id
+    )
+    await defer_wake(pool, session_id, cause="message", account_id=account_id)
+    return {
+        "woken": True,
+        "session_id": session_id,
+        "event_id": event.id,
+    }
+
+
+def _register() -> None:
+    registry.register(
+        name="wake_self",
+        description=WAKE_SELF_DESCRIPTION,
+        parameters_schema=WAKE_SELF_PARAMETERS_SCHEMA,
+        handler=wake_self_handler,
+        transport="both",
+    )
+
+
+_register()

--- a/src/aios/tools/wake_session.py
+++ b/src/aios/tools/wake_session.py
@@ -186,11 +186,12 @@ async def wake_session_handler(session_id: str, arguments: dict[str, Any]) -> di
         )
 
     if target_session_id == session_id:
-        # Self-wake has a dedicated tool (schedule_wake) — reject so an
-        # agent can't accidentally bypass that surface and the depth
-        # tracking doesn't conflate self-reentry with cross-session loops.
+        # Self-wake has dedicated tools — reject so an agent can't
+        # accidentally bypass those surfaces and the depth tracking
+        # doesn't conflate self-reentry with cross-session loops.
         raise WakeSessionArgumentError(
-            "cannot wake your own session; use schedule_wake for self-reentry"
+            "cannot wake your own session; use wake_self for immediate "
+            "self-delivery, or schedule_wake for a delayed self-wake"
         )
 
     pool = runtime.require_pool()

--- a/tests/unit/test_schedule_wake_handler.py
+++ b/tests/unit/test_schedule_wake_handler.py
@@ -128,21 +128,24 @@ class TestResolveFireAt:
 
 class TestBuildWakeBash:
     def test_contains_canonical_idiom(self) -> None:
+        # The bash command invokes the in-sandbox ``tool wake_self`` CLI
+        # so the broker secret never has to be interpolated and the env
+        # vars in the sandbox (TOOL_BROKER_URL / TOOL_BROKER_SECRET) are
+        # used implicitly by the CLI (#703).
         bash = _build_wake_bash("hello")
-        assert "AIOS_BROKER_URL" in bash
-        assert "MCP_BROKER_SECRET" in bash
-        assert "AIOS_BROKER_SOCKET" in bash
-        assert "/sessions/messages" in bash
+        assert bash.startswith("tool wake_self ")
+        # The legacy broker idiom must be gone — the prior implementation
+        # referenced env vars that the sandbox never sets, so the curl
+        # would have silently failed.
+        assert "AIOS_BROKER_URL" not in bash
+        assert "MCP_BROKER_SECRET" not in bash
+        assert "AIOS_BROKER_SOCKET" not in bash
+        assert "curl" not in bash
 
     def test_embeds_reason_safely(self) -> None:
         # Embedded single quotes + dollar signs in the reason must not
         # break out of the shell-escaped argument.
         bash = _build_wake_bash("it's $weird")
-        # The JSON-encoded payload appears inside a shlex-quoted block,
-        # so single quotes are escaped via shell's '"'"' or "'\''" form
-        # (or the whole arg is wrapped in single quotes with escapes).
-        # We don't pin the exact escape style, just that the reason text
-        # is recoverable.
         assert "it" in bash
         assert "weird" in bash
 
@@ -151,6 +154,23 @@ class TestBuildWakeBash:
         bash = _build_wake_bash("line1\nline2")
         assert "line1" in bash
         assert "line2" in bash
+
+    def test_payload_is_recoverable_json(self) -> None:
+        # The reason should arrive at wake_self as the ``content`` field
+        # of a JSON object. Verify by stripping the leading ``tool
+        # wake_self `` prefix and shlex-splitting the rest to recover
+        # the exact JSON argument the CLI will see.
+        import json
+        import shlex as _shlex
+
+        reason = 'it\'s $weird with "quotes" and a\nnewline'
+        bash = _build_wake_bash(reason)
+        prefix = "tool wake_self "
+        assert bash.startswith(prefix)
+        args = _shlex.split(bash[len(prefix) :])
+        assert len(args) == 1
+        payload = json.loads(args[0])
+        assert reason in payload["content"]
 
 
 class TestScheduleWakeHandler:
@@ -168,7 +188,7 @@ class TestScheduleWakeHandler:
         assert spec.metadata == {"kind": "wake", "reason": "check back later"}
         assert spec.timeout_seconds == 30
         assert spec.name.startswith("wake-")
-        assert "MCP_BROKER_SECRET" in spec.command
+        assert spec.command.startswith("tool wake_self ")
         assert result["scheduled"] is True
         assert result["reason"] == "check back later"
         assert "fire_at" in result

--- a/tests/unit/test_wake_session_handler.py
+++ b/tests/unit/test_wake_session_handler.py
@@ -96,10 +96,15 @@ class TestWakeSessionHandlerArguments:
             await wake_session_handler("sess_01SOURCE", {"target_session_id": "", "prompt": "hi"})
 
     async def test_self_wake_rejects(self) -> None:
-        with pytest.raises(WakeSessionArgumentError, match="schedule_wake"):
+        # The error must recommend wake_self for immediate self-delivery
+        # and mention schedule_wake for the delayed case (issue #703 #704).
+        with pytest.raises(WakeSessionArgumentError) as exc_info:
             await wake_session_handler(
                 "sess_01SAME", {"target_session_id": "sess_01SAME", "prompt": "hi"}
             )
+        message = str(exc_info.value)
+        assert "wake_self" in message
+        assert "schedule_wake" in message
 
 
 class TestWakeSessionHandlerPermission:

--- a/tests/unit/tools/test_wake_self.py
+++ b/tests/unit/tools/test_wake_self.py
@@ -122,3 +122,24 @@ class TestWakeSelfRegistration:
         assert tool.transport == "both"
         assert tool.parameters_schema == WAKE_SELF_PARAMETERS_SCHEMA
         assert tool.description
+
+
+class TestWakeSelfToolSpec:
+    """Regression: ``wake_self`` must be declarable on an agent.
+
+    Without ``"wake_self"`` in ``BuiltinToolType``, Pydantic rejects
+    ``ToolSpec(type="wake_self")``, agents cannot list the tool, and
+    the broker's ``_find_builtin_spec`` 404s every CLI invocation —
+    defeating the entire purpose of the tool.
+    """
+
+    def test_toolspec_accepts_wake_self(self) -> None:
+        from aios.models.agents import ToolSpec
+
+        spec = ToolSpec(type="wake_self")
+        assert spec.type == "wake_self"
+
+    def test_wake_self_in_builtin_names(self) -> None:
+        from aios.models.agents import _BUILTIN_NAMES
+
+        assert "wake_self" in _BUILTIN_NAMES

--- a/tests/unit/tools/test_wake_self.py
+++ b/tests/unit/tools/test_wake_self.py
@@ -1,0 +1,124 @@
+"""Unit tests for the ``wake_self`` tool handler.
+
+The handler appends a user-role message to the *same* session that
+invoked it and defers a wake. It exists so cron-fired bash commands
+(and any other sandbox-side caller) can hand a user-role prompt to
+their own next model step without curling the broker.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from jsonschema import ValidationError, validate
+
+from aios.tools.wake_self import (
+    WAKE_SELF_PARAMETERS_SCHEMA,
+    WakeSelfArgumentError,
+    wake_self_handler,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_runtime_pool(monkeypatch: Any) -> MagicMock:
+    """Stub the worker-only runtime pool so the handler can resolve
+    ``runtime.require_pool()`` without a live worker_main context.
+    """
+    pool = MagicMock()
+    monkeypatch.setattr("aios.tools.wake_self.runtime.require_pool", lambda: pool)
+    return pool
+
+
+@pytest.fixture
+def mock_services(monkeypatch: Any) -> dict[str, AsyncMock]:
+    """Replace the session/wake service calls with AsyncMocks so the
+    handler runs without Postgres.
+
+    Returns the mocks keyed by name for per-test assertions.
+    """
+    load_account = AsyncMock(return_value="acct_TEST")
+    event = MagicMock(id="evt_TEST")
+    append = AsyncMock(return_value=event)
+    defer = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "aios.tools.wake_self.sessions_service.load_session_account_id",
+        load_account,
+    )
+    monkeypatch.setattr(
+        "aios.tools.wake_self.sessions_service.append_user_message",
+        append,
+    )
+    monkeypatch.setattr("aios.tools.wake_self.defer_wake", defer)
+    return {
+        "load_account": load_account,
+        "append": append,
+        "defer": defer,
+    }
+
+
+class TestWakeSelfHandler:
+    async def test_handler_appends_user_message_and_defers_wake(
+        self,
+        mock_runtime_pool: MagicMock,
+        mock_services: dict[str, AsyncMock],
+    ) -> None:
+        result = await wake_self_handler("sess_TEST", {"content": "ping"})
+
+        mock_services["load_account"].assert_awaited_once_with(mock_runtime_pool, "sess_TEST")
+        mock_services["append"].assert_awaited_once_with(
+            mock_runtime_pool, "sess_TEST", "ping", account_id="acct_TEST"
+        )
+        mock_services["defer"].assert_awaited_once_with(
+            mock_runtime_pool, "sess_TEST", cause="message", account_id="acct_TEST"
+        )
+        assert result == {
+            "woken": True,
+            "session_id": "sess_TEST",
+            "event_id": "evt_TEST",
+        }
+
+    async def test_empty_content_rejected(self, mock_services: dict[str, AsyncMock]) -> None:
+        with pytest.raises(WakeSelfArgumentError):
+            await wake_self_handler("sess_TEST", {"content": ""})
+        mock_services["append"].assert_not_awaited()
+        mock_services["defer"].assert_not_awaited()
+
+    @pytest.mark.parametrize("bad_content", [None, 42, ["a"], {"k": "v"}])
+    async def test_non_string_content_rejected(
+        self,
+        mock_services: dict[str, AsyncMock],
+        bad_content: Any,
+    ) -> None:
+        with pytest.raises(WakeSelfArgumentError):
+            await wake_self_handler("sess_TEST", {"content": bad_content})
+        mock_services["append"].assert_not_awaited()
+        mock_services["defer"].assert_not_awaited()
+
+    async def test_missing_content_rejected(self, mock_services: dict[str, AsyncMock]) -> None:
+        with pytest.raises(WakeSelfArgumentError):
+            await wake_self_handler("sess_TEST", {})
+        mock_services["append"].assert_not_awaited()
+        mock_services["defer"].assert_not_awaited()
+
+
+class TestWakeSelfSchema:
+    def test_additional_properties_rejected_by_schema(self) -> None:
+        with pytest.raises(ValidationError):
+            validate(
+                {"content": "x", "metadata": {}},
+                WAKE_SELF_PARAMETERS_SCHEMA,
+            )
+
+
+class TestWakeSelfRegistration:
+    def test_registered_with_correct_metadata(self) -> None:
+        # Importing the tools package triggers all _register() side-effects.
+        import aios.tools  # noqa: F401
+        from aios.tools.registry import registry
+
+        tool = registry.get("wake_self")
+        assert tool.transport == "both"
+        assert tool.parameters_schema == WAKE_SELF_PARAMETERS_SCHEMA
+        assert tool.description


### PR DESCRIPTION
Adds a `wake_self(content: str)` tool so scheduled tasks can wake the model without embedding `$TOOL_BROKER_SECRET` in the command string.

**Motivation:** The current pattern requires a raw `curl` POST with the broker secret in the command line, exposing it in process listings, cron logs, and `schedule_task_add` payloads.

**Changes:**
- `src/aios/tools/wake_self.py` — new tool registered with `transport="both"`, serving both model tool calls and `tool wake_self '{"content":"..."}'` CLI dispatch via the broker's existing `/v1/{secret}/builtins/{name}` route. Validates non-empty content, appends a user message, defers a `cause="message"` wake.
- `src/aios/tools/__init__.py` — side-effect import for the new module.
- `src/aios/tools/schedule_task_add.py` — description updated to recommend `wake_self` as canonical; raw `curl` POST demoted to fallback for advanced/scripted callers.
- `tests/unit/tools/test_wake_self.py` — unit tests covering happy path, content validation, schema rejection of extra properties, and registry metadata.

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)