### PR TITLE
fix: regression test + prose update for mcp→tool rename (#675)

### DIFF
--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -63,7 +63,7 @@ _MCP_CLI_HINT = (
     "Permitted MCP tools are also callable from inside the sandbox via the "
     "`tool` binary, so you can invoke them programmatically from `bash` "
     "without paying an inference cycle per call:\n\n"
-    "    tool                              list available MCP servers\n"
+    "    tool                              list reachable tools (built-ins + MCP servers)\n"
     "    tool <server>                     list methods on a server\n"
     "    tool <server> <method> --help     show description + JSON schema\n"
     "    tool <server> <method> '{...}'    invoke with JSON arguments\n\n"

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -63,7 +63,7 @@ _MCP_CLI_HINT = (
     "Permitted MCP tools are also callable from inside the sandbox via the "
     "`tool` binary, so you can invoke them programmatically from `bash` "
     "without paying an inference cycle per call:\n\n"
-    "    tool                              list available built-ins + MCP servers\n"
+    "    tool                              list available MCP servers\n"
     "    tool <server>                     list methods on a server\n"
     "    tool <server> <method> --help     show description + JSON schema\n"
     "    tool <server> <method> '{...}'    invoke with JSON arguments\n\n"

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -52,19 +52,21 @@ if TYPE_CHECKING:
     from aios.models.skills import SkillVersion
 
 
-# Generic affordance prose explaining the in-sandbox ``mcp`` CLI. Rendered
+# Generic affordance prose explaining the in-sandbox ``tool`` CLI. Rendered
 # into the system prompt whenever the agent has at least one
 # ``always_allow`` MCP toolset entry. Worded in stable runtime terms — no
 # dev-world references — so it remains agent-actionable across releases.
+# ``<method>`` is used as the placeholder for the MCP method name so the
+# binary name (``tool``) and the meta-variable don't collide visually.
 _MCP_CLI_HINT = (
-    "## Sandbox MCP CLI\n\n"
+    "## Sandbox tool CLI\n\n"
     "Permitted MCP tools are also callable from inside the sandbox via the "
-    "`mcp` binary, so you can invoke them programmatically from `bash` "
+    "`tool` binary, so you can invoke them programmatically from `bash` "
     "without paying an inference cycle per call:\n\n"
-    "    mcp                          list available MCP servers\n"
-    "    mcp <server>                 list tools on a server\n"
-    "    mcp <server> <tool> --help   show description + JSON schema\n"
-    "    mcp <server> <tool> '{...}'  invoke with JSON arguments\n\n"
+    "    tool                              list available built-ins + MCP servers\n"
+    "    tool <server>                     list methods on a server\n"
+    "    tool <server> <method> --help     show description + JSON schema\n"
+    "    tool <server> <method> '{...}'    invoke with JSON arguments\n\n"
     "Use the CLI when you want scriptable invocation (composition with `jq`, "
     "`xargs`, redirection, scheduled wakes). The model-tool invocation path "
     "remains available for the same tools."

--- a/tests/unit/sandbox/conftest.py
+++ b/tests/unit/sandbox/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures for the in-sandbox ``bin/tool`` CLI tests.
+
+The CLI script has no ``.py`` extension and is conventionally invoked
+as an executable; ``importlib.util.spec_from_file_location`` is the
+most direct way to import it for unit testing. The script's
+``if __name__ == "__main__":`` guard means importing doesn't execute
+``main()``. Centralised here so test files don't reproduce the loader
+incantation.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def tool_module() -> ModuleType:
+    repo_root = Path(__file__).parents[3]
+    script_path = repo_root / "bin" / "tool"
+    loader = importlib.machinery.SourceFileLoader("tool_cli", str(script_path))
+    spec = importlib.util.spec_from_file_location("tool_cli", script_path, loader=loader)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/unit/sandbox/test_tool_cli_defaults.py
+++ b/tests/unit/sandbox/test_tool_cli_defaults.py
@@ -15,34 +15,10 @@ unit-test failures rather than mysterious sandbox breakage.
 
 from __future__ import annotations
 
-import importlib.machinery
-import importlib.util
 from pathlib import Path
 from types import ModuleType
 
 import pytest
-
-
-@pytest.fixture(scope="module")
-def tool_module() -> ModuleType:
-    """Load ``bin/tool`` as a python module.
-
-    The script has no ``.py`` extension and is conventionally invoked as
-    an executable; ``importlib.util.spec_from_file_location`` is the
-    most direct way to import it for unit testing. The script's
-    ``if __name__ == "__main__":`` guard means importing doesn't
-    execute ``main()``.
-    """
-    repo_root = Path(__file__).parents[3]
-    script_path = repo_root / "bin" / "tool"
-    # The script has no ``.py`` extension; pass an explicit
-    # ``SourceFileLoader`` so ``spec_from_file_location`` accepts it.
-    loader = importlib.machinery.SourceFileLoader("tool_cli", str(script_path))
-    spec = importlib.util.spec_from_file_location("tool_cli", script_path, loader=loader)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 class TestResolveBrokerUrl:

--- a/tests/unit/sandbox/test_tool_cli_help.py
+++ b/tests/unit/sandbox/test_tool_cli_help.py
@@ -11,26 +11,9 @@ documentation and parser. These tests lock in the positional form.
 
 from __future__ import annotations
 
-import importlib.machinery
-import importlib.util
-from pathlib import Path
 from types import ModuleType
 
 import pytest
-
-
-@pytest.fixture(scope="module")
-def tool_module() -> ModuleType:
-    """Load ``bin/tool`` as a python module (same pattern as
-    ``test_tool_cli_defaults.py`` — script has no ``.py`` extension)."""
-    repo_root = Path(__file__).parents[3]
-    script_path = repo_root / "bin" / "tool"
-    loader = importlib.machinery.SourceFileLoader("tool_cli", str(script_path))
-    spec = importlib.util.spec_from_file_location("tool_cli", script_path, loader=loader)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 class TestBuiltinHelpInvokeLine:

--- a/tests/unit/sandbox/test_tool_cli_help.py
+++ b/tests/unit/sandbox/test_tool_cli_help.py
@@ -1,0 +1,79 @@
+"""Pinned wording for ``bin/tool``'s per-tool ``--help`` INVOKE line.
+
+Issue #675: the legacy ``mcp`` CLI's per-tool ``--help`` once printed
+``mcp <server> <tool> --json '{...}'`` even though ``--json`` was never
+a real flag — pasting the printed example failed with ``unknown option:
+--json``. The flag was dropped (commit f8aefa3) and the binary later
+renamed to ``tool`` (commit 57a0747), but no test pinned the wording,
+so a future copy-edit could resurrect the same divergence between
+documentation and parser. These tests lock in the positional form.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def tool_module() -> ModuleType:
+    """Load ``bin/tool`` as a python module (same pattern as
+    ``test_tool_cli_defaults.py`` — script has no ``.py`` extension)."""
+    repo_root = Path(__file__).parents[3]
+    script_path = repo_root / "bin" / "tool"
+    loader = importlib.machinery.SourceFileLoader("tool_cli", str(script_path))
+    spec = importlib.util.spec_from_file_location("tool_cli", script_path, loader=loader)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestBuiltinHelpInvokeLine:
+    def test_invoke_line_uses_positional_form(
+        self, tool_module: ModuleType, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tool_module._print_help_builtin(
+            "web_fetch", {"description": "Fetch a URL.", "input_schema": {"type": "object"}}
+        )
+        out = capsys.readouterr().out
+        assert "INVOKE:" in out
+        assert "tool web_fetch '{...}'" in out
+
+    def test_invoke_line_does_not_advertise_json_flag(
+        self, tool_module: ModuleType, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tool_module._print_help_builtin(
+            "web_fetch", {"description": "Fetch a URL.", "input_schema": {"type": "object"}}
+        )
+        out = capsys.readouterr().out
+        assert "--json" not in out
+
+
+class TestMcpHelpInvokeLine:
+    def test_invoke_line_uses_positional_form(
+        self, tool_module: ModuleType, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tool_module._print_help_mcp(
+            "github",
+            "get_me",
+            {"description": "Get the authenticated user.", "input_schema": {"type": "object"}},
+        )
+        out = capsys.readouterr().out
+        assert "INVOKE:" in out
+        assert "tool github get_me '{...}'" in out
+
+    def test_invoke_line_does_not_advertise_json_flag(
+        self, tool_module: ModuleType, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tool_module._print_help_mcp(
+            "github",
+            "get_me",
+            {"description": "Get the authenticated user.", "input_schema": {"type": "object"}},
+        )
+        out = capsys.readouterr().out
+        assert "--json" not in out

--- a/tests/unit/test_step_context_mcp_hint.py
+++ b/tests/unit/test_step_context_mcp_hint.py
@@ -107,3 +107,11 @@ class TestMcpCliHintWording:
         # only thing the binary supports.
         assert "tool <server> <method> '{...}'" in _MCP_CLI_HINT
         assert "--json" not in _MCP_CLI_HINT
+
+    def test_listing_line_acknowledges_both_builtins_and_mcp_servers(self) -> None:
+        # ``bin/tool`` with no args prints both a ``Built-ins:`` and an
+        # ``MCP servers:`` section (see ``_list_surface``). Narrowing
+        # the hint's description back to MCP-only would surprise an
+        # agent that sees built-ins listed and has no anchor for them.
+        assert "built-ins" in _MCP_CLI_HINT
+        assert "MCP servers" in _MCP_CLI_HINT

--- a/tests/unit/test_step_context_mcp_hint.py
+++ b/tests/unit/test_step_context_mcp_hint.py
@@ -1,15 +1,19 @@
-"""Tests for the ``mcp`` CLI system-prompt hint predicate.
+"""Tests for the ``tool`` CLI system-prompt hint.
 
 The hint is rendered into the system prompt whenever the agent has at
 least one ``always_allow`` MCP toolset entry. Emitting it for an agent
 whose toolset has only ``always_ask`` policies would lie to the model
 (every CLI call would 403), so the predicate has to walk both
 ``default_config`` and per-tool ``configs`` overrides.
+
+Wording assertions (issue #675) pin the binary name and INVOKE form so
+the prose can't drift from the parser again — the original bug was a
+``--json`` flag mentioned in the help text that the CLI never accepted.
 """
 
 from __future__ import annotations
 
-from aios.harness.step_context import _has_always_allow_mcp_tool
+from aios.harness.step_context import _MCP_CLI_HINT, _has_always_allow_mcp_tool
 from aios.models.agents import (
     McpPermissionPolicy,
     McpToolConfig,
@@ -77,3 +81,29 @@ class TestHasAlwaysAllowMcpTool:
             ],
         )
         assert _has_always_allow_mcp_tool([spec]) is False
+
+
+class TestMcpCliHintWording:
+    """Pinned wording for the in-sandbox CLI hint (issue #675).
+
+    The hint went stale twice already: ``--json`` was dropped from the
+    binary in commit f8aefa3 and the binary was renamed ``mcp`` →
+    ``tool`` in commit 57a0747, but this prose wasn't updated either
+    time. These assertions lock the binary name and INVOKE form so the
+    same drift can't recur silently.
+    """
+
+    def test_hint_names_tool_binary_not_legacy_mcp(self) -> None:
+        # The binary is invoked as ``tool`` post-rename.
+        assert "`tool`" in _MCP_CLI_HINT
+        # And the legacy ``mcp`` binary name must not reappear as a
+        # callable. Match the backticked form to avoid false positives
+        # on prose like "MCP tools" / "MCP server".
+        assert "`mcp`" not in _MCP_CLI_HINT
+
+    def test_hint_shows_positional_invoke_form_without_json_flag(self) -> None:
+        # The original #675 symptom: prose advertising ``--json`` for a
+        # flag the parser never accepted. The positional form is the
+        # only thing the binary supports.
+        assert "tool <server> <method> '{...}'" in _MCP_CLI_HINT
+        assert "--json" not in _MCP_CLI_HINT


### PR DESCRIPTION
Closes #675

## Background

Issue #675 reported that the sandbox CLI's per-tool `--help` printed an INVOKE example with a `--json` flag the CLI never accepted (`mcp <server> <tool> --json '{...}'`). Pasting that example failed immediately with "unknown option: --json".

A follow-up comment noted the bug still reproduced after the `mcp → tool` binary rename, and flagged that the Ultron persona's system prompt contained a `Sandbox MCP CLI` section still documenting the old `mcp` invocation style — stale doc drift to fix alongside the help template.

## What we found

By the time this PR was written, the production `--json` bug had already been resolved as a side-effect of two earlier commits: f8aefa3 (dropped `--json`, May 14) and 57a0747 (renamed `mcp → tool`, May 23). The per-tool help output was already printing the correct positional form. There was nothing to "fix" in the help template itself.

What remained unfixed was the stale `_MCP_CLI_HINT` string in `src/aios/harness/step_context.py`, which still referenced `mcp` throughout its heading, body prose, and grammar lines — exactly what Tom called out as in-scope.

## What changed

**`src/aios/harness/step_context.py`** — rewrites `_MCP_CLI_HINT` so all references use `tool` instead of `mcp`. The per-tool positional placeholder was changed from `<tool>` to `<method>` to avoid the confusing collision between the binary name and the placeholder name that a naive rename would have produced (`tool <server> <tool> '{...}'`). The `<method>` form matches `bin/tool`'s own USAGE convention.

**`tests/unit/sandbox/test_tool_cli_help.py`** (new) — pins the output of `_print_help_builtin` and `_print_help_mcp`. Both assertions verify the positional invocation form is present and that `--json` is absent. Mutation-checked: re-introducing the `--json` form causes these tests to fail.

**`tests/unit/test_step_context_mcp_hint.py`** (extended) — adds `TestMcpCliHintWording` with two assertions: the hint must not contain the backtick-quoted string `` `mcp` ``, and the hint must contain `tool <server> <method> '{...}'` without `--json`. Also mutation-checked.

## Validation

`uv run mypy src` — clean (171 source files). `uv run ruff check src tests && uv run ruff format --check src tests` — clean. `uv run pytest tests/unit -q` — 1619 passed.