### PR TITLE
feat(aios-sdk): publish wheels via tag-triggered GitHub Release

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -64,7 +64,7 @@ jobs:
           # ``bin/tool`` is a sandbox-image input (COPY-d by the Dockerfile)
           # and must invalidate the cheap-skip path alongside the source
           # tree even though it lives outside ``src/``.
-          if echo "$changed" | grep -qE '\.py$|^pyproject\.toml$|^uv\.lock$|^alembic\.ini$|^migrations/|^docker/|^connectors/[^/]+/Dockerfile$|^bin/tool$|^\.github/workflows/'; then
+          if echo "$changed" | grep -qE '\.py$|^pyproject\.toml$|^uv\.lock$|^alembic\.ini$|^migrations/|^docker/|^connectors/[^/]+/Dockerfile$|^bin/tool$|^\.github/workflows/|^packages/[^/]+/(pyproject\.toml|CHANGELOG\.md)$'; then
             echo "Build-affecting changes detected — running checks."
             echo "run_checks=true" >> "$GITHUB_OUTPUT"
           else
@@ -121,12 +121,19 @@ jobs:
         run: uv sync --dev
 
       - name: Lint (ruff)
+        # ``packages/aios-sdk/aios_sdk`` carries hand-written modules
+        # (``__init__.py``, ``config.py``, ``factory.py``, ``streaming.py``)
+        # alongside the generated ``_generated/`` tree.  Root
+        # ``pyproject.toml`` already excludes ``_generated/`` via
+        # ``extend-exclude`` and ``mypy.overrides``; including the package
+        # here lets ruff and mypy cover the hand-written surface so the
+        # release workflow's ``no re-gate'' assumption is honored.
         run: |
-          uv run ruff check src tests
-          uv run ruff format --check src tests
+          uv run ruff check src tests packages/aios-sdk/aios_sdk
+          uv run ruff format --check src tests packages/aios-sdk/aios_sdk
 
       - name: Type check (mypy)
-        run: uv run mypy src
+        run: uv run mypy src packages/aios-sdk/aios_sdk
 
   unit:
     needs: detect

--- a/.github/workflows/release-aios-sdk.yml
+++ b/.github/workflows/release-aios-sdk.yml
@@ -7,18 +7,26 @@ name: Release aios-sdk
 #   uv add "https://github.com/eumemic/aios/releases/download/aios-sdk-v0.1.0/aios_sdk-0.1.0-py3-none-any.whl"
 #   uv add "aios-sdk @ git+https://github.com/eumemic/aios.git@aios-sdk-v0.1.0#subdirectory=packages/aios-sdk"
 #
-# The release workflow is deliberately stateless: given a tag, build and
-# publish. The drift contract (FastAPI app ↔ openapi.json ↔
-# aios_sdk/_generated/) is already gated upstream by
-# ``code-validation.yml`` on every PR via the snapshot tests in
-# ``tests/unit/`` (openapi + SDK trees). Tags cut from master HEAD
-# therefore inherit drift coverage from master branch protection — no
-# re-gate inside this workflow.
+# The release workflow assumes the tagged commit has already passed the
+# CI checks that gate master.  An explicit ``git merge-base --is-ancestor``
+# step enforces that: tags pointing at non-master commits (feature branches,
+# force-pushes that bypass branch protection) fail the workflow before any
+# artifact is built.  The drift contract (FastAPI app ↔ openapi.json ↔
+# aios_sdk/_generated/) and the hand-written SDK surface
+# (``aios_sdk/{__init__,config,factory,streaming}.py``) are both covered
+# by ``code-validation.yml`` (lint + mypy + unit) on every PR.  Together
+# the two gates mean every released wheel was built from validated code.
 #
 # Coupling to runtime promotion is operator discipline, not workflow
 # enforcement: only cut SDK tags from commits that have been promoted to
 # ``:stable`` via ``promote-api.yml`` / ``promote-worker.yml``. See
 # ``packages/aios-sdk/README.md::Releasing`` for the procedure.
+#
+# Re-runs against an existing tag are idempotent: if a release with that
+# tag already exists, we update its notes and overwrite its assets via
+# ``gh release upload --clobber`` instead of failing.  Operators recover
+# from a flaky run by re-running the workflow from the Actions UI; no
+# UI-side delete dance is required.
 #
 # Security note: this workflow does not interpolate any ``${{ }}``
 # expression from untrusted sources (issue/PR titles, head_ref, commit
@@ -36,14 +44,45 @@ on:
   push:
     tags: ['aios-sdk-v*']
 
+# Serialize per-tag runs so that re-pushing a tag (or two rapid tag pushes)
+# can't race on the same release.  ``cancel-in-progress: false`` is load-
+# bearing: cancelling a release mid-upload would leave the release row in
+# a partial state on GitHub, defeating the idempotency the Create step
+# below provides.
+concurrency:
+  group: release-aios-sdk-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # for ``gh release create``
+      contents: write  # for ``gh release create`` / ``gh release upload``
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so ``git merge-base --is-ancestor`` below can see
+          # ``origin/master`` and so any future flow that consults annotated-
+          # tag bodies (e.g. ``gh release create --generate-notes``) has the
+          # refs it needs.  The aios tree is small enough that fetch-depth: 0
+          # is cheap.
+          fetch-depth: 0
+
+      - name: Verify tag points at a master-reachable commit
+        # The header comment claims tags inherit CI gating from master
+        # branch protection.  That claim is only true if the tagged commit
+        # is actually reachable from ``origin/master``.  Without this check
+        # an operator (or compromised collaborator) could ``git tag
+        # aios-sdk-vX.Y.Z <feature-branch-sha>`` and publish a wheel from
+        # un-reviewed code under the official release URL.
+        run: |
+          set -euo pipefail
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/master; then
+            echo "::error::Tag $GITHUB_REF points at $GITHUB_SHA which is not an ancestor of origin/master. Tags must be cut from a master-reachable commit; delete the tag and re-cut from master."
+            exit 1
+          fi
+          echo "Verified: $GITHUB_SHA is reachable from origin/master."
 
       - uses: astral-sh/setup-uv@v4
         with:
@@ -57,12 +96,20 @@ jobs:
         # compare against ``project.version`` in
         # ``packages/aios-sdk/pyproject.toml``. Fails hard on mismatch so
         # a forgotten version bump can't ship a wheel whose Metadata-Version
-        # disagrees with its release name.
+        # disagrees with its release name.  Also fails if the awk pattern
+        # finds no match (e.g. pyproject reformatted such that the
+        # ``version = "..."`` line no longer starts at column 0) — empty
+        # PROJECT_VERSION would otherwise produce a misleading error blaming
+        # the tag instead of the parser.
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#aios-sdk-v}"
           PROJECT_VERSION=$(awk -F'"' '/^version = "/{print $2; exit}' packages/aios-sdk/pyproject.toml)
+          if [[ -z "$PROJECT_VERSION" ]]; then
+            echo "::error::Could not extract project.version from packages/aios-sdk/pyproject.toml. Is the [project] table present and well-formed?"
+            exit 1
+          fi
           if [[ "$VERSION" != "$PROJECT_VERSION" ]]; then
             echo "::error::Tag version ($VERSION) does not match packages/aios-sdk/pyproject.toml::project.version ($PROJECT_VERSION). Bump the pyproject version to match the tag and re-tag, or delete the tag."
             exit 1
@@ -94,48 +141,60 @@ jobs:
       - name: Extract release notes from CHANGELOG
         # Pull just the ``## $VERSION — DATE`` block out of
         # ``packages/aios-sdk/CHANGELOG.md`` so the release page shows the
-        # curated changelog entry instead of the whole file. If no matching
-        # entry exists (forgotten changelog update), fall back to a static
-        # install snippet so the release page still tells consumers how to
-        # install the artifact.
+        # curated changelog entry instead of the whole file.  Hard-fail if
+        # the entry is missing — the README's documented Releasing
+        # procedure requires a CHANGELOG entry before tagging, and shipping
+        # a release with empty notes silently is the wrong default.
         #
-        # The literal-prefix match (``$0 == target`` or
+        # The literal-prefix start match (``$0 == target`` or
         # ``index($0, target " ") == 1``) avoids the regex-metachar trap
         # where ``^## 0.1.0`` would also match ``## 0X1X0`` or
         # ``## 0.10.0``.
+        #
+        # The exit predicate ``/^## [vV]?[0-9]/`` matches only
+        # *version-shaped* H2 headings, so markdown subsections inside an
+        # entry body (e.g. ``## Breaking changes``, ``## Migration``) do
+        # not prematurely truncate the notes.
         run: |
           set -euo pipefail
           awk -v target="## $VERSION" '
             $0 == target || index($0, target " ") == 1 {
               inblock = 1; print; next
             }
-            inblock && /^## / { exit }
+            inblock && /^## [vV]?[0-9]/ { exit }
             inblock { print }
           ' packages/aios-sdk/CHANGELOG.md > release-notes.md
 
           if [[ ! -s release-notes.md ]]; then
-            echo "::warning::No CHANGELOG.md entry for $VERSION — using fallback install snippet."
-            cat > release-notes.md <<EOF
-          \`\`\`bash
-          uv add "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/aios_sdk-${VERSION}-py3-none-any.whl"
-          \`\`\`
-
-          No CHANGELOG entry was present for this version at release time. See
-          [packages/aios-sdk/CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/${TAG}/packages/aios-sdk/CHANGELOG.md)
-          at this tag for the full history.
-          EOF
+            echo "::error::No CHANGELOG.md entry for $VERSION. Add a '## $VERSION — YYYY-MM-DD' section to packages/aios-sdk/CHANGELOG.md before tagging."
+            exit 1
           fi
 
           echo "--- release notes ---"
           cat release-notes.md
           echo "---"
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
+        # Idempotent: if a release at this tag already exists (re-pushed
+        # tag, prior workflow flake, manual rerun via the Actions UI),
+        # overwrite its assets with ``--clobber`` and update its title +
+        # notes via ``gh release edit`` instead of failing.  Operators
+        # recover from a flaky run by re-running the workflow; no UI-side
+        # release-delete dance is required.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          gh release create "$TAG" \
-            --title "aios-sdk v$VERSION" \
-            --notes-file release-notes.md \
-            packages/aios-sdk/dist/*
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — updating assets and notes."
+            gh release upload "$TAG" --clobber packages/aios-sdk/dist/*
+            gh release edit "$TAG" \
+              --title "aios-sdk v$VERSION" \
+              --notes-file release-notes.md
+          else
+            echo "Creating release $TAG."
+            gh release create "$TAG" \
+              --title "aios-sdk v$VERSION" \
+              --notes-file release-notes.md \
+              packages/aios-sdk/dist/*
+          fi

--- a/.github/workflows/release-aios-sdk.yml
+++ b/.github/workflows/release-aios-sdk.yml
@@ -1,0 +1,141 @@
+name: Release aios-sdk
+
+# Build and publish ``packages/aios-sdk/`` as a versioned GitHub Release
+# artifact whenever a tag matching ``aios-sdk-v*`` is pushed.
+#
+# Consumers install via the wheel asset URL or a git-tag source pin:
+#   uv add "https://github.com/eumemic/aios/releases/download/aios-sdk-v0.1.0/aios_sdk-0.1.0-py3-none-any.whl"
+#   uv add "aios-sdk @ git+https://github.com/eumemic/aios.git@aios-sdk-v0.1.0#subdirectory=packages/aios-sdk"
+#
+# The release workflow is deliberately stateless: given a tag, build and
+# publish. The drift contract (FastAPI app ↔ openapi.json ↔
+# aios_sdk/_generated/) is already gated upstream by
+# ``code-validation.yml`` on every PR via the snapshot tests in
+# ``tests/unit/`` (openapi + SDK trees). Tags cut from master HEAD
+# therefore inherit drift coverage from master branch protection — no
+# re-gate inside this workflow.
+#
+# Coupling to runtime promotion is operator discipline, not workflow
+# enforcement: only cut SDK tags from commits that have been promoted to
+# ``:stable`` via ``promote-api.yml`` / ``promote-worker.yml``. See
+# ``packages/aios-sdk/README.md::Releasing`` for the procedure.
+#
+# Security note: this workflow does not interpolate any ``${{ }}``
+# expression from untrusted sources (issue/PR titles, head_ref, commit
+# messages, etc.) into ``run:`` commands. Only trusted contexts —
+# ``secrets.GITHUB_TOKEN`` inside an ``env:`` block, plus shell-side
+# ``$GITHUB_REF`` / ``$GITHUB_REPOSITORY`` env vars — are referenced.
+# The tag name (``GITHUB_REF``) is operator-controlled (only repo
+# collaborators can push tags) and is used solely for string compare
+# against the pyproject version + as a ``gh release create`` argument
+# (quoted, not eval'd).
+#
+# Issue: eumemic/aios#707. Companion: eumemic/jarbot#42.
+
+on:
+  push:
+    tags: ['aios-sdk-v*']
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # for ``gh release create``
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Validate tag matches pyproject version
+        # Extract ``0.1.0`` from a tag like ``aios-sdk-v0.1.0`` and
+        # compare against ``project.version`` in
+        # ``packages/aios-sdk/pyproject.toml``. Fails hard on mismatch so
+        # a forgotten version bump can't ship a wheel whose Metadata-Version
+        # disagrees with its release name.
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#aios-sdk-v}"
+          PROJECT_VERSION=$(awk -F'"' '/^version = "/{print $2; exit}' packages/aios-sdk/pyproject.toml)
+          if [[ "$VERSION" != "$PROJECT_VERSION" ]]; then
+            echo "::error::Tag version ($VERSION) does not match packages/aios-sdk/pyproject.toml::project.version ($PROJECT_VERSION). Bump the pyproject version to match the tag and re-tag, or delete the tag."
+            exit 1
+          fi
+          {
+            echo "TAG=$TAG"
+            echo "VERSION=$VERSION"
+          } >> "$GITHUB_ENV"
+          echo "Validated: tag $TAG → version $VERSION matches pyproject."
+
+      - name: Build wheel + sdist
+        # ``uv build PATH`` builds the project at PATH as a standalone
+        # distribution. The SDK's pyproject lists only external PyPI
+        # deps (httpx, attrs, python-dateutil) — workspace
+        # ``tool.uv.sources`` overrides at the repo root affect
+        # ``uv sync`` / ``uv lock`` only and do not leak into wheel
+        # metadata.
+        #
+        # ``--out-dir`` is explicit because ``uv build PATH``'s default
+        # output directory is ``$PWD/dist/`` (the caller's cwd), not
+        # ``PATH/dist/``. Pin output to the package-local ``dist/`` so
+        # the ``gh release create`` glob below picks up exactly the SDK
+        # artifacts and nothing else.
+        run: |
+          set -euo pipefail
+          uv build --out-dir packages/aios-sdk/dist packages/aios-sdk/
+          ls -la packages/aios-sdk/dist/
+
+      - name: Extract release notes from CHANGELOG
+        # Pull just the ``## $VERSION — DATE`` block out of
+        # ``packages/aios-sdk/CHANGELOG.md`` so the release page shows the
+        # curated changelog entry instead of the whole file. If no matching
+        # entry exists (forgotten changelog update), fall back to a static
+        # install snippet so the release page still tells consumers how to
+        # install the artifact.
+        #
+        # The literal-prefix match (``$0 == target`` or
+        # ``index($0, target " ") == 1``) avoids the regex-metachar trap
+        # where ``^## 0.1.0`` would also match ``## 0X1X0`` or
+        # ``## 0.10.0``.
+        run: |
+          set -euo pipefail
+          awk -v target="## $VERSION" '
+            $0 == target || index($0, target " ") == 1 {
+              inblock = 1; print; next
+            }
+            inblock && /^## / { exit }
+            inblock { print }
+          ' packages/aios-sdk/CHANGELOG.md > release-notes.md
+
+          if [[ ! -s release-notes.md ]]; then
+            echo "::warning::No CHANGELOG.md entry for $VERSION — using fallback install snippet."
+            cat > release-notes.md <<EOF
+          \`\`\`bash
+          uv add "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/aios_sdk-${VERSION}-py3-none-any.whl"
+          \`\`\`
+
+          No CHANGELOG entry was present for this version at release time. See
+          [packages/aios-sdk/CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/${TAG}/packages/aios-sdk/CHANGELOG.md)
+          at this tag for the full history.
+          EOF
+          fi
+
+          echo "--- release notes ---"
+          cat release-notes.md
+          echo "---"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release create "$TAG" \
+            --title "aios-sdk v$VERSION" \
+            --notes-file release-notes.md \
+            packages/aios-sdk/dist/*

--- a/packages/aios-sdk/CHANGELOG.md
+++ b/packages/aios-sdk/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to `aios-sdk` are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project
+follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+While the SDK is in `0.x`, breaking changes may land at any minor bump.
+
+## 0.1.0 — 2026-05-24
+
+Initial public release.
+
+- Typed Python SDK for the aios management plane, generated from
+  `openapi.json` by `openapi-python-client`.
+- Curated public surface: `Client`, `client_from_env`, SSE streaming
+  helpers (`stream_session`, `stream_connector_calls`,
+  `stream_management_calls`, `stream_connection_discovery`),
+  `parse_sse_lines`, `UnexpectedStatus`.
+- Drift-guarded against the live FastAPI app via snapshot tests in the
+  aios repo's `tests/unit/`.

--- a/packages/aios-sdk/CHANGELOG.md
+++ b/packages/aios-sdk/CHANGELOG.md
@@ -12,9 +12,12 @@ Initial public release.
 
 - Typed Python SDK for the aios management plane, generated from
   `openapi.json` by `openapi-python-client`.
-- Curated public surface: `Client`, `client_from_env`, SSE streaming
-  helpers (`stream_session`, `stream_connector_calls`,
-  `stream_management_calls`, `stream_connection_discovery`),
-  `parse_sse_lines`, `UnexpectedStatus`.
-- Drift-guarded against the live FastAPI app via snapshot tests in the
-  aios repo's `tests/unit/`.
+- Curated public surface: `Client`, `client_from_env`, `SseMessage`,
+  `parse_sse_lines`, SSE streaming helpers (`stream_session`,
+  `stream_connector_calls`, `stream_management_calls`,
+  `stream_connection_discovery`), `UnexpectedStatus`. The full set is
+  enumerated in `aios_sdk.__all__`.
+- The bundled types match the FastAPI app at the commit this tag was
+  cut from. Consumers should pin a deployment-compatible version; the
+  SDK does not negotiate schema differences against an older runtime
+  at install or call time.

--- a/packages/aios-sdk/README.md
+++ b/packages/aios-sdk/README.md
@@ -8,6 +8,26 @@ generated client lives at `aios_sdk._generated`; this package's
 top-level re-exports the curated public surface plus hand-written
 helpers (SSE streaming, env-resolved client factory).
 
+## Install
+
+Releases are attached to [GitHub Releases](https://github.com/eumemic/aios/releases?q=aios-sdk)
+as built wheels. There is no PyPI package; pin to a tagged version:
+
+```bash
+uv add "https://github.com/eumemic/aios/releases/download/aios-sdk-v0.1.0/aios_sdk-0.1.0-py3-none-any.whl"
+```
+
+The git-tag form is available as a source-pin fallback:
+
+```bash
+uv add "aios-sdk @ git+https://github.com/eumemic/aios.git@aios-sdk-v0.1.0#subdirectory=packages/aios-sdk"
+```
+
+The SDK encodes whatever `openapi.json` said when its tag was cut, so the
+deployed aios runtime must be at least as recent as the SDK version on the
+caller side. In practice: tag SDK releases from commits that have already
+been promoted to `:stable` (see [Releasing](#releasing) below).
+
 ## Quick start
 
 ```python
@@ -33,3 +53,24 @@ Two snapshots guard the spec → client pipeline:
   `_generated/` tree matches what `openapi-python-client` produces
   from `openapi.json`. If the spec changes, re-run
   `scripts/regen-client.sh`.
+
+## Releasing
+
+1. After the aios runtime has been promoted to `:stable` via
+   `promote-api.yml` / `promote-worker.yml`, pick a new SDK version in
+   `packages/aios-sdk/pyproject.toml` (`project.version`). 0.x semver:
+   breaking changes are allowed at minor bumps.
+2. Add an entry to `packages/aios-sdk/CHANGELOG.md` under
+   `## X.Y.Z — YYYY-MM-DD`.
+3. Open a PR with both changes; merge to master.
+4. Tag the merge commit on master as `aios-sdk-vX.Y.Z` and push the tag:
+   ```bash
+   git tag aios-sdk-vX.Y.Z
+   git push origin aios-sdk-vX.Y.Z
+   ```
+5. The release workflow (`.github/workflows/release-aios-sdk.yml`)
+   builds the wheel + sdist and attaches them to a GitHub Release of
+   the same name.
+
+The version in `pyproject.toml` must match the tag suffix; the workflow
+asserts this and fails the release on mismatch.

--- a/packages/aios-sdk/README.md
+++ b/packages/aios-sdk/README.md
@@ -11,15 +11,15 @@ helpers (SSE streaming, env-resolved client factory).
 ## Install
 
 Releases are attached to [GitHub Releases](https://github.com/eumemic/aios/releases?q=aios-sdk)
-as built wheels. There is no PyPI package; pin to a tagged version:
+as built wheels — there is no PyPI package. Find the current version
+on the releases page above and substitute it into one of the install
+commands below. The examples use `v0.1.0`; replace with the latest tag.
 
 ```bash
+# Wheel asset (the recommended form):
 uv add "https://github.com/eumemic/aios/releases/download/aios-sdk-v0.1.0/aios_sdk-0.1.0-py3-none-any.whl"
-```
 
-The git-tag form is available as a source-pin fallback:
-
-```bash
+# Git tag + subdirectory (source-pin fallback):
 uv add "aios-sdk @ git+https://github.com/eumemic/aios.git@aios-sdk-v0.1.0#subdirectory=packages/aios-sdk"
 ```
 


### PR DESCRIPTION
## Summary

Closes #707.

Add `.github/workflows/release-aios-sdk.yml` — a tag-triggered workflow that builds `packages/aios-sdk/` (`uv build --out-dir`) and attaches the wheel + sdist to a GitHub Release whenever a tag matching `aios-sdk-v*` is pushed. After this lands, the SDK is installable from anywhere:

```bash
uv add "https://github.com/eumemic/aios/releases/download/aios-sdk-v0.1.0/aios_sdk-0.1.0-py3-none-any.whl"
```

or as a source pin:

```bash
uv add "aios-sdk @ git+https://github.com/eumemic/aios.git@aios-sdk-v0.1.0#subdirectory=packages/aios-sdk"
```

`packages/aios-sdk/CHANGELOG.md` (new) and the README's Install + Releasing sections (new) cover the consumer install path and the operator-discipline release procedure.

Companion: `eumemic/jarbot#42` will swap jarbot's vendored `_aios_client/` (309 files, 1.9 MB) for a wheel pin once a release tag exists.

## Design notes

- **No `:latest/:smoked/:stable` triplet for the SDK.** The image triplet exists because production needs a rollback-able rolling tag for a fanout-deployed binary. Versioned libraries solve that differently: consumers pin to immutable `aios-sdk-vX.Y.Z` tags. Operator discipline (documented in the README's `Releasing` section) keeps the SDK version aligned with what is currently deployed — cut tags only from commits that have been promoted to `:stable` via `promote-api.yml` / `promote-worker.yml`. A future enhancement could chain SDK release off `promote-api.yml`'s completion, but that is a separate issue.
- **No snapshot-test re-gate inside the release workflow.** The drift contract (FastAPI app ↔ `openapi.json` ↔ `aios_sdk/_generated/`) is already gated on every PR by `code-validation.yml` via the snapshot tests in `tests/unit/`. Tags cut from master HEAD inherit that coverage from branch protection — re-running the tests in the release workflow would add ~60–90 s for a check that is already passing on every commit master sees.
- **Tag-vs-pyproject version is hard-validated.** The workflow extracts `0.1.0` from `aios-sdk-v0.1.0` and compares to `project.version` in `packages/aios-sdk/pyproject.toml`. Mismatch → fail with a remediation message before any artifact is built. Prevents the failure mode where someone tags `aios-sdk-v0.2.0` but forgets to bump the pyproject — which would have shipped a wheel named `aios_sdk-0.1.0-py3-none-any.whl` attached to a `v0.2.0` release.
- **Release notes are extracted from `CHANGELOG.md` per version**, with a fallback static install snippet if the version's entry is missing (in case someone forgets to update the changelog before tagging). Literal-prefix awk match (not a regex) so `## 0.1.0` does not also match `## 0.10.0`.
- **Security**: no `${{ }}` template interpolation from untrusted sources (issue/PR titles, head_ref, commit messages, etc.) into `run:` blocks. Only `secrets.GITHUB_TOKEN` inside an `env:` block, plus shell-side `$GITHUB_REF` / `$GITHUB_REPOSITORY` env vars.

## Local verification

`uv build --out-dir packages/aios-sdk/dist packages/aios-sdk/` produces:
- `aios_sdk-0.1.0-py3-none-any.whl` (384 KB, 350 files including `aios_sdk/`, `aios_sdk/_generated/`, `py.typed`)
- `aios_sdk-0.1.0.tar.gz` (111 KB)

Wheel `Requires-Dist`: `attrs>=24.0`, `httpx>=0.27`, `python-dateutil>=2.9` — no workspace deps leaked.

Repo checks (`uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy src && uv run pytest tests/unit -q`) all pass on this branch (1620 tests).

Workflow run script syntax checked with `bash -n` after `yaml.safe_load`; awk-extract logic verified end-to-end against the CHANGELOG (happy path and fallback path).

## Test plan

- [x] `uv build --out-dir packages/aios-sdk/dist packages/aios-sdk/` succeeds locally and produces clean wheel metadata.
- [x] Wheel contents include `aios_sdk/`, `aios_sdk/_generated/`, `aios_sdk/py.typed`.
- [x] `Requires-Dist` is the three external PyPI deps only.
- [x] Repo checks: ruff, mypy, pytest unit all green.
- [x] Workflow YAML parses (`yaml.safe_load`) and run scripts pass `bash -n`.
- [x] Awk extraction returns the matching CHANGELOG section for the happy path.
- [x] Fallback static-snippet path triggers when no matching CHANGELOG entry exists.
- [ ] After merge: push tag `aios-sdk-v0.1.0` from master HEAD; confirm the workflow run starts, the tag↔pyproject version check passes, and a GitHub Release named "aios-sdk v0.1.0" appears with both artifacts attached.
- [ ] After release: `uv add "<wheel-asset-url>"` resolves and installs cleanly in a scratch directory outside the aios repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)