### PR TITLE
fix(harness): assume Claude vision+thinking despite stale catalog

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -784,7 +784,15 @@ def build_messages(
     # exit before this point or run under tests that never reach it.
     import litellm
 
-    target_supports_thinking = bool(model) and litellm.supports_reasoning(model)
+    # Same stale-catalog short-circuit as ``supports_vision`` (see its docstring
+    # for the full rationale): a Claude newer than this worker's catalog
+    # snapshot — or a proxy-routed one litellm under-reports even when fresh —
+    # must keep its ``thinking_blocks``, or stripping them across turns violates
+    # Anthropic's preservation contract.  Extended thinking is Claude 4.x+;
+    # over-broad for <= 3.5 (no thinking), which aios doesn't run.
+    target_supports_thinking = bool(
+        model and ("claude" in model.lower() or litellm.supports_reasoning(model))
+    )
     return ContextResult(
         messages=[
             _strip_to_spec(m, target_supports_thinking=target_supports_thinking) for m in messages

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -49,21 +49,38 @@ INLINE_MAX_DIMENSION = 2000
 # (uploaded TIFFs, multi-100MP camera RAWs, etc.).
 PRE_RESIZE_CEILING_BYTES = 50 * 1024 * 1024
 
+# Explicit per-model vision escape hatch (force True/False).  Empty in
+# production — Claude is matched by name in ``supports_vision`` and everything
+# else defers to litellm — but kept as the stub point for tests.
 _VISION_OVERRIDES: dict[str, bool] = {}
 
 
 def supports_vision(model: str) -> bool:
     """True when ``model`` accepts ``image_url`` content parts.
 
-    Consults :data:`_VISION_OVERRIDES` first for cases LiteLLM is wrong
-    or behind on (empty initially; populated as we hit them), then
-    falls back to ``litellm.get_model_info``.
+    Resolution order:
+
+    1. :data:`_VISION_OVERRIDES` — explicit per-model escape hatch (force
+       ``True`` or ``False``).
+    2. Any Claude family is assumed vision-capable (3.x onward; aios targets
+       4.x).  A long-running worker fetches litellm's catalog once at startup,
+       so a Claude model released afterwards makes ``litellm.get_model_info``
+       raise "isn't mapped yet" and we would otherwise collapse to "no vision"
+       — silently degrading image reads to a text marker.  Asserting the family
+       by name needs no edit when the next Claude lands.  The match is a
+       substring rather than an ``anthropic/`` prefix because aios routes Claude
+       through several providers whose strings all still contain ``claude`` (the
+       routes ``_supports_anthropic_cache_control`` enumerates in
+       :mod:`aios.harness.completion`).
+    3. ``litellm.get_model_info`` for every other provider/model.
     """
     if model in _VISION_OVERRIDES:
         return _VISION_OVERRIDES[model]
+    if "claude" in model.lower():
+        return True
     # Defer the heavy ``litellm`` import: every harness consumer of this
     # module pays ~1.18s of bootstrap otherwise, and most call sites never
-    # reach this branch.
+    # reach this branch (Claude short-circuits above).
     import litellm
 
     try:

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -9,6 +9,8 @@ import json
 from datetime import UTC, datetime
 from typing import Any
 
+import pytest
+
 from aios.harness.channels import build_channels_tail_block
 from aios.harness.context import (
     build_messages,
@@ -832,6 +834,49 @@ class TestThinkingBlockPreservation:
         assert "reasoning" not in msgs[1]
         assert "reasoning_details" not in msgs[1]
         assert "reacting_to" not in msgs[1]
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic/claude-opus-4-8",  # stale catalog on a long-running worker
+            "openrouter/anthropic/claude-opus-4-8",  # litellm under-reports proxy routes
+        ],
+    )
+    def test_thinking_blocks_preserved_for_claude_despite_stale_catalog(
+        self, monkeypatch: pytest.MonkeyPatch, model: str
+    ) -> None:
+        """``litellm.supports_reasoning`` returns False for Claude models a
+        long-running worker's catalog predates — and for proxy-routed Claude
+        even when fresh.  Stripping ``thinking_blocks`` then violates
+        Anthropic's cross-turn preservation contract; the Claude short-circuit
+        keeps them regardless of the catalog.
+        """
+        monkeypatch.setattr("litellm.supports_reasoning", lambda *a, **k: False)
+        events = [
+            _evt(1, "user", content="hi"),
+            _evt(2, "assistant", content="hey"),
+        ]
+        events[1].data["thinking_blocks"] = [
+            {"type": "thinking", "thinking": "user said hi", "signature": "abc"}
+        ]
+        msgs = build_messages(events, system_prompt=None, model=model).messages
+        assert msgs[1]["thinking_blocks"] == [
+            {"type": "thinking", "thinking": "user said hi", "signature": "abc"}
+        ]
+
+    def test_thinking_blocks_stripped_for_non_claude_when_catalog_says_no(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-Claude models still defer to litellm: a False there strips,
+        confirming the Claude rule didn't over-broaden to every model."""
+        monkeypatch.setattr("litellm.supports_reasoning", lambda *a, **k: False)
+        events = [
+            _evt(1, "user", content="hi"),
+            _evt(2, "assistant", content="hey"),
+        ]
+        events[1].data["thinking_blocks"] = [{"type": "thinking", "thinking": "x"}]
+        msgs = build_messages(events, system_prompt=None, model="deepseek/deepseek-chat").messages
+        assert "thinking_blocks" not in msgs[1]
 
 
 class TestToolCallSanitization:

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -73,6 +73,40 @@ class TestSupportsVision:
         vision._VISION_OVERRIDES["foo/vision"] = False
         assert vision.supports_vision("foo/vision") is False
 
+    @pytest.mark.parametrize(
+        "model",
+        [
+            # The predicate is a bare substring, so family/tier/version add no
+            # coverage; the cases that matter are the distinct provider-route
+            # shapes (a regression to an ``anthropic/`` prefix breaks these).
+            "anthropic/claude-opus-4-8",  # current primary, plain anthropic route
+            "anthropic/claude-opus-5",  # unreleased shape: must not need a code edit
+            "openrouter/anthropic/claude-opus-4-8",  # provider-prefixed route
+            "bedrock/anthropic.claude-3-5-sonnet",  # bedrock dot-SKU
+            "vertex_ai/claude-opus-4-8",  # vertex bare-claude SKU
+        ],
+    )
+    def test_claude_assumed_vision_capable_despite_stale_litellm(
+        self, monkeypatch: pytest.MonkeyPatch, model: str
+    ) -> None:
+        """A long-running worker pins litellm's catalog at startup, so a Claude
+        model released afterwards makes ``get_model_info`` raise "isn't mapped
+        yet" and ``supports_vision`` would collapse to False — silently
+        degrading image reads to a text marker.  All Claude families support
+        vision, so we assert it by name and never consult litellm for them,
+        across every provider route aios uses.  Returning True under a *raising*
+        patch proves litellm is never reached (so no lookup-failed warning).
+        """
+        _patch_get_model_info(monkeypatch, {})  # stale catalog: every lookup raises
+        assert vision.supports_vision(model) is True
+
+    def test_explicit_override_can_force_claude_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The override dict is consulted before the Claude-family rule, so an
+        explicit ``False`` still forces a Claude model off."""
+        _patch_get_model_info(monkeypatch, {})
+        vision._VISION_OVERRIDES["anthropic/claude-opus-4-8"] = False
+        assert vision.supports_vision("anthropic/claude-opus-4-8") is False
+
 
 class TestCanInlineImage:
     def test_image_under_cap_with_vision_mind(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

A long-running aios-worker fetches litellm's capability catalog **once** at process start and never refreshes it. A Claude model released after that snapshot — or one routed via `openrouter/`/`bedrock/`/`vertex_ai/`, which litellm under-reports *even when fresh* — silently loses a capability:

- **`supports_vision()`** collapsed to `False` → image reads degraded to a `"vision support: no"` text marker. This is the reported #714 symptom on the live `anthropic/claude-opus-4-8` worker.
- **`build_messages()` → `target_supports_thinking`** stripped `thinking_blocks`/`reasoning_content` from assistant turns → violates Anthropic's cross-turn preservation contract. (Sibling bug surfaced while fixing #714.)

Both now short-circuit by **model-family name** (`"claude" in model.lower()`, which covers every provider route) before consulting litellm — so the next Claude release needs no edit. Vision is exact for all Claude 3+; the thinking rule is deliberately over-broad for Claude ≤3.5 (which lack extended thinking, and which aios doesn't run — documented in-code).

The issue proposed hardcoding 4 model strings into `_VISION_OVERRIDES`; this generalizes to a family rule instead, so there's no per-model list to maintain.

## Why not fix the root cause (catalog refresh)?

Deliberately out of scope per #714 — and *insufficient* for reasoning anyway: litellm's `supports_reasoning` data is structurally incomplete for proxy routes (`openrouter/anthropic/claude-opus-4-8` → `False` even with a fresh catalog), so a refresh wouldn't close the thinking gap.

## Test plan

- [x] mypy — clean (171 files)
- [x] ruff check + format — clean
- [x] unit suite — 1629 passed
- [ ] CI runs e2e / integration

New regression tests (each fails if the short-circuit is reverted):
- `test_vision.py` — parametrized over 5 provider-route shapes; `supports_vision` returns `True` even when litellm `get_model_info` raises; plus override-can-force-off.
- `test_context.py` — `thinking_blocks` preserved for Claude (direct + proxy route) when `supports_reasoning` is monkeypatched `False`; non-Claude contrast stays stripped.

## Known follow-up (not this PR)

Non-Claude vision models released mid-uptime (a future `gpt-5o`/`gemini-3`) still silently degrade — only the deferred catalog-refresh closes that. Flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #714