### PR TITLE
fix(tools/read): detect images by magic bytes, not extension alone

### DIFF
--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -1,10 +1,13 @@
 """The read tool — read a file inside the session's sandbox.
 
 Text files return ``LINE_NUM<TAB>CONTENT`` windowed by ``offset`` /
-``limit`` via ``cat -n | sed``.  Image files (extensions in
-:data:`_EXT_TO_MIME`) return a content-parts list with an
-``image_url`` block when the bound model supports vision and the file
-fits the inline cap; otherwise an explanatory ``ToolResult``.
+``limit`` via ``cat -n | sed``.  Image files — detected by extension
+(:data:`_EXT_TO_MIME`) or, for paths whose extension is not a known
+image type (no extension, or a non-image extension such as a
+connector-staged chat attachment), by a magic-byte sniff of the leading
+bytes — return a content-parts list with an ``image_url`` block when the
+bound model supports vision and the file fits the inline cap; otherwise
+an explanatory ``ToolResult``.
 """
 
 from __future__ import annotations
@@ -29,6 +32,7 @@ from aios.sandbox.volumes import resolve_to_host_path
 from aios.services import sessions as sessions_service
 from aios.tools.memory_intercept import resolve_memory_target
 from aios.tools.registry import ToolResult, registry
+from aios_connector_http.mime import sniff_image_mime
 
 _EXT_TO_MIME = {
     ".png": "image/png",
@@ -99,8 +103,11 @@ async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     sandbox = runtime.require_sandbox_registry()
     handle = await sandbox.get_or_provision(session_id, pool=pool)
 
-    if _looks_like_image(path):
-        return await _read_image(session_id=session_id, path=path, handle=handle, pool=pool)
+    image_mime = await _detect_image_mime(session_id, path, handle=handle)
+    if image_mime is not None:
+        return await _read_image(
+            session_id=session_id, path=path, mime=image_mime, handle=handle, pool=pool
+        )
 
     target = resolve_memory_target(session_id, path)
 
@@ -152,19 +159,38 @@ async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     return {"path": path, "content": content}
 
 
-def _looks_like_image(path: str) -> bool:
-    return os.path.splitext(path)[1].lower() in _EXT_TO_MIME
+async def _detect_image_mime(session_id: str, path: str, *, handle: SandboxHandle) -> str | None:
+    """Return the image mime for ``path``, or ``None`` to read it as text.
+
+    The extension decides when it names a known image type — the common,
+    zero-IO case.  Otherwise (no extension, or a non-image extension:
+    connector-staged chat attachments arrive with arbitrary or no
+    extension) sniff the leading bytes.  The probe is read locally from the
+    bind mount when ``path`` resolves into one and falls back to one
+    docker-exec only for paths outside any mount.  The sniff decides routing
+    only — the final declared mime is reconciled against the bytes actually
+    inlined by :func:`make_image_url_part`, so a sniff/read race cannot ship
+    a PNG/JPEG/GIF mime that disagrees with the inlined bytes.
+    """
+    ext = os.path.splitext(path)[1].lower()
+    mime = _EXT_TO_MIME.get(ext)
+    if mime is not None:
+        return mime
+    head = await _read_probe_bytes(session_id, path, handle=handle, n=16)
+    if head is None:
+        return None
+    return sniff_image_mime(head)
 
 
 async def _read_image(
     *,
     session_id: str,
     path: str,
+    mime: str,
     handle: SandboxHandle,
     pool: Any,
 ) -> ToolResult:
     account_id = await sessions_service.load_session_account_id(pool, session_id)
-    mime = _EXT_TO_MIME[os.path.splitext(path)[1].lower()]
     model = await sessions_service.get_session_model(pool, session_id, account_id=account_id)
 
     host_path = resolve_to_host_path(session_id, path, workspace_path=handle.workspace_path)
@@ -239,6 +265,55 @@ async def _stat_and_read_via_exec(handle: SandboxHandle, path: str) -> tuple[byt
     except (ValueError, TypeError):
         return None
     return data, size
+
+
+async def _read_probe_bytes(
+    session_id: str, path: str, *, handle: SandboxHandle, n: int
+) -> bytes | None:
+    """First ``n`` bytes of ``path`` for magic-byte image detection.
+
+    Reads locally from the bind-mount source when ``path`` resolves into one
+    (no docker-exec — the full read in :func:`_read_image` uses the same host
+    fast path, so detection is free for the common ``/workspace`` and
+    ``/mnt/attachments`` cases).  Falls back to one docker-exec for paths
+    outside any mount.  Returns ``None`` when the file is unreadable — the
+    caller treats that as "not an image" and the text path surfaces the real
+    error.
+    """
+    host_path = resolve_to_host_path(session_id, path, workspace_path=handle.workspace_path)
+    if host_path is not None:
+        try:
+            with host_path.open("rb") as fh:
+                return fh.read(n)
+        except OSError:
+            return None
+    return await _read_head_bytes(handle, path, n=n)
+
+
+async def _read_head_bytes(handle: SandboxHandle, path: str, *, n: int) -> bytes | None:
+    """Read the first ``n`` bytes of ``path`` via one docker-exec, base64-framed
+    so binary survives the str stdout boundary.  Used as the out-of-mount
+    fallback for magic-byte image detection.  ``set -o pipefail`` makes a
+    failing ``head`` propagate (without it ``base64`` masks it with exit 0);
+    returns ``None`` on any failure — the caller treats that as "not an image"
+    and falls through to the text path.
+    """
+    settings = get_settings()
+    sandbox = runtime.require_sandbox_registry()
+    quoted = shlex.quote(path)
+    cmd = f"set -o pipefail; head -c {n} -- {quoted} | base64 -w0"
+    result = await sandbox.exec(
+        handle,
+        cmd,
+        timeout_seconds=settings.bash_default_timeout_seconds,
+        max_output_bytes=settings.bash_max_output_bytes,
+    )
+    if result.exit_code != 0:
+        return None
+    try:
+        return base64.b64decode(result.stdout.strip())
+    except (ValueError, TypeError):
+        return None
 
 
 def _register() -> None:

--- a/tests/e2e/test_extensionless_image_read.py
+++ b/tests/e2e/test_extensionless_image_read.py
@@ -1,0 +1,85 @@
+"""E2E regression for issue #715 — the read tool must inline images whose
+filenames carry no extension.
+
+Connector-staged chat attachments are saved at
+``/mnt/attachments/<connector>/<filename>`` where ``<filename>`` may have no
+extension (the reported Signal file was literally ``…-unnamed``).
+Extension-only detection routed these to the text path, so the tool result
+was raw image bytes decoded as UTF-8 mojibake and the model never saw an
+``image_url``.  The fix sniffs the leading bytes when the extension is not a
+known image type.
+
+This pins both probe paths in a live container.  Each case is written and read
+under ``/workspace`` AND ``/tmp``:
+
+* ``/workspace`` is a bind mount, so the 16-byte probe is read locally from the
+  host bind-mount source (the same fast path ``_read_image`` uses for the full
+  read) — no docker-exec.
+* ``/tmp`` is NOT a bind mount, so the probe exercises the real
+  ``set -o pipefail; head -c 16 -- <path> | base64 -w0`` docker-exec and the
+  full read goes through ``_stat_and_read_via_exec``.
+
+bash writes extension-less PNG/JPEG/GIF files and the read tool inlines each as
+an ``image_url`` with the correct mime.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from aios.harness import vision
+from aios.tools.bash import bash_handler
+from aios.tools.read import read_handler
+from aios.tools.registry import ToolResult
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness
+
+pytestmark = pytest.mark.docker
+
+# (extension-less filename, leading magic bytes, expected mime).
+_CASES = [
+    ("unnamed_png", b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR", "image/png"),
+    ("unnamed_jpg", b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00", "image/jpeg"),
+    ("unnamed_gif", b"GIF89a\x01\x00\x01\x00\x80\x00\x00", "image/gif"),
+]
+
+
+@needs_docker
+class TestExtensionlessImageRead:
+    async def test_extensionless_images_round_trip_through_read(
+        self,
+        docker_harness: Harness,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # The fake test model carries no LiteLLM metadata; pin vision on so
+        # ``_read_image`` doesn't bail on the "vision support: no" branch.
+        monkeypatch.setitem(vision._VISION_OVERRIDES, "fake/test", True)
+
+        session = await docker_harness.start("read extension-less images", tools=["bash", "read"])
+
+        # ``/workspace`` exercises the local bind-mount probe; ``/tmp`` is not a
+        # bind mount, so it exercises the real ``set -o pipefail; head -c 16 |
+        # base64`` exec probe + ``_stat_and_read_via_exec`` full read.
+        for parent in ("/workspace", "/tmp"):
+            for name, magic, expected_mime in _CASES:
+                payload = magic + f"-{parent}-{name}-sentinel".encode()
+                b64 = base64.b64encode(payload).decode("ascii")
+                write_cmd = f"printf '%s' {b64} | base64 -d > {parent}/{name}"
+                write_result = await bash_handler(session.id, {"command": write_cmd})
+                assert write_result["exit_code"] == 0, (parent, name, write_result)
+
+                read_result = await read_handler(session.id, {"path": f"{parent}/{name}"})
+
+                assert isinstance(read_result, ToolResult), (parent, name, read_result)
+                assert read_result.is_error is False, (parent, name, read_result)
+                assert isinstance(read_result.content, list), (
+                    f"{parent}/{name}: expected inlined image parts, got {read_result.content!r}"
+                )
+                image_part = read_result.content[1]
+                assert image_part["type"] == "image_url", (parent, name, image_part)
+                assert image_part["image_url"]["url"] == f"data:{expected_mime};base64,{b64}", (
+                    parent,
+                    name,
+                )

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -424,56 +424,40 @@ class TestExtensionlessImageDetection:
     count 0).  Only paths outside any mount fall back to a docker-exec probe.
     """
 
-    async def test_extensionless_png_inlines_via_magic_byte_sniff(
+    @pytest.mark.parametrize(
+        ("name", "payload", "mime"),
+        [
+            ("unnamed", b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDRrest-of-png-bytes", "image/png"),
+            (
+                "signal-abc-unnamed",
+                b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00rest",
+                "image/jpeg",
+            ),
+            ("img", b"GIF89a\x01\x00\x01\x00\x80\x00\x00rest-of-gif-bytes", "image/gif"),
+        ],
+    )
+    async def test_extensionless_image_inlines_via_magic_byte_sniff(
         self,
+        name: str,
+        payload: bytes,
+        mime: str,
         temp_workspace_root: Path,
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
+        """An extension-less PNG/JPEG/GIF is detected by a local magic-byte probe
+        (no docker-exec) and inlined as an ``image_url``."""
         stub_get_session_model.value = "model/vision"
-        payload = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDRrest-of-png-bytes"
-        _stage_workspace_image("sess_01TEST", "unnamed", payload)
-        result = await read_handler("sess_01TEST", {"path": "/workspace/unnamed"})
+        _stage_workspace_image("sess_01TEST", name, payload)
+        result = await read_handler("sess_01TEST", {"path": f"/workspace/{name}"})
         assert isinstance(result, ToolResult)
         assert isinstance(result.content, list)
         assert result.content[1] == {
             "type": "image_url",
-            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(payload).decode()}"},
+            "image_url": {"url": f"data:{mime};base64,{base64.b64encode(payload).decode()}"},
         }
         assert result.is_error is False
         assert stub_runtime.exec.call_count == 0  # bind-mounted: probe + full read are both local
-
-    async def test_extensionless_jpeg_inlines_via_magic_byte_sniff(
-        self,
-        temp_workspace_root: Path,
-        stub_runtime: Any,
-        stub_get_session_model: Any,
-    ) -> None:
-        stub_get_session_model.value = "model/vision"
-        payload = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00rest-of-jpeg"
-        _stage_workspace_image("sess_01TEST", "signal-abc-unnamed", payload)
-        result = await read_handler("sess_01TEST", {"path": "/workspace/signal-abc-unnamed"})
-        assert isinstance(result, ToolResult)
-        assert isinstance(result.content, list)
-        assert result.content[1]["image_url"]["url"] == (
-            f"data:image/jpeg;base64,{base64.b64encode(payload).decode()}"
-        )
-        assert stub_runtime.exec.call_count == 0
-
-    async def test_extensionless_gif_inlines_via_magic_byte_sniff(
-        self,
-        temp_workspace_root: Path,
-        stub_runtime: Any,
-        stub_get_session_model: Any,
-    ) -> None:
-        stub_get_session_model.value = "model/vision"
-        payload = b"GIF89a\x01\x00\x01\x00\x80\x00\x00rest-of-gif-bytes"
-        _stage_workspace_image("sess_01TEST", "img", payload)
-        result = await read_handler("sess_01TEST", {"path": "/workspace/img"})
-        assert isinstance(result, ToolResult)
-        assert isinstance(result.content, list)
-        assert result.content[1]["image_url"]["url"].startswith("data:image/gif;base64,")
-        assert stub_runtime.exec.call_count == 0
 
     async def test_wrong_extension_image_inlines_via_magic_byte_sniff(
         self,

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -407,3 +407,180 @@ class TestImagePathTraversalAttack:
         elif isinstance(result, dict):
             assert b64_secret not in str(result)
         assert stub_runtime.exec.call_count == 1  # type: ignore[attr-defined]
+
+
+class TestExtensionlessImageDetection:
+    """Issue #715 + the follow-up redesign: a file is routed to the image
+    path when its extension names a known image type OR — for any other
+    extension (none, or a non-image one like ``.dat``) — when a magic-byte
+    sniff of its leading bytes matches.  Connector-staged chat attachments
+    arrive at ``/mnt/attachments/<connector>/<filename>`` with arbitrary or
+    no extension, so an image among them still inlines as an ``image_url``
+    instead of being dumped down the text path as raw mojibake.
+
+    For bind-mounted paths (``/workspace``, ``/mnt/attachments``) the 16-byte
+    probe is read locally from the host bind-mount source — the same fast path
+    ``_read_image`` uses for the full read — so detection is free (``exec``
+    count 0).  Only paths outside any mount fall back to a docker-exec probe.
+    """
+
+    async def test_extensionless_png_inlines_via_magic_byte_sniff(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "model/vision"
+        payload = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDRrest-of-png-bytes"
+        _stage_workspace_image("sess_01TEST", "unnamed", payload)
+        result = await read_handler("sess_01TEST", {"path": "/workspace/unnamed"})
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[1] == {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(payload).decode()}"},
+        }
+        assert result.is_error is False
+        assert stub_runtime.exec.call_count == 0  # bind-mounted: probe + full read are both local
+
+    async def test_extensionless_jpeg_inlines_via_magic_byte_sniff(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "model/vision"
+        payload = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00rest-of-jpeg"
+        _stage_workspace_image("sess_01TEST", "signal-abc-unnamed", payload)
+        result = await read_handler("sess_01TEST", {"path": "/workspace/signal-abc-unnamed"})
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[1]["image_url"]["url"] == (
+            f"data:image/jpeg;base64,{base64.b64encode(payload).decode()}"
+        )
+        assert stub_runtime.exec.call_count == 0
+
+    async def test_extensionless_gif_inlines_via_magic_byte_sniff(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        stub_get_session_model.value = "model/vision"
+        payload = b"GIF89a\x01\x00\x01\x00\x80\x00\x00rest-of-gif-bytes"
+        _stage_workspace_image("sess_01TEST", "img", payload)
+        result = await read_handler("sess_01TEST", {"path": "/workspace/img"})
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[1]["image_url"]["url"].startswith("data:image/gif;base64,")
+        assert stub_runtime.exec.call_count == 0
+
+    async def test_wrong_extension_image_inlines_via_magic_byte_sniff(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """Finding 1: a NON-image extension whose bytes are a real image is detected by the sniff and inlined."""
+        stub_get_session_model.value = "model/vision"
+        payload = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00jpeg-mislabeled-as-dat"
+        _stage_workspace_image("sess_01TEST", "scan.dat", payload)
+        result = await read_handler("sess_01TEST", {"path": "/workspace/scan.dat"})
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[1]["image_url"]["url"] == (
+            f"data:image/jpeg;base64,{base64.b64encode(payload).decode()}"
+        )
+        assert stub_runtime.exec.call_count == 0
+
+    async def test_text_with_extension_does_not_sniff_as_image(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """A non-image-extension TEXT file reads as text: the local probe sniffs to None and the read falls through to the one-exec text path."""
+        stub_get_session_model.value = "model/vision"
+        _stage_workspace_image("sess_01TEST", "notes.dat", b"plain text, no magic header")
+        stub_runtime.exec = AsyncMock(  # type: ignore[method-assign]
+            return_value=CommandResult(
+                exit_code=0, stdout="     1\thello\n", stderr="", timed_out=False, truncated=False
+            )
+        )
+        result = await read_handler("sess_01TEST", {"path": "/workspace/notes.dat"})
+        assert result == {"path": "/workspace/notes.dat", "content": "     1\thello\n"}
+        assert stub_runtime.exec.call_count == 1  # only the cat-n; the probe was a local read
+
+    async def test_extensionless_text_falls_through_to_text_path(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """An extension-less non-image file must not false-positive into the image path."""
+        stub_get_session_model.value = "model/vision"
+        _stage_workspace_image(
+            "sess_01TEST", "random_name", b"just some text, definitely not an image"
+        )
+        stub_runtime.exec = AsyncMock(  # type: ignore[method-assign]
+            return_value=CommandResult(
+                exit_code=0, stdout="     1\thello\n", stderr="", timed_out=False, truncated=False
+            )
+        )
+        result = await read_handler("sess_01TEST", {"path": "/workspace/random_name"})
+        assert result == {"path": "/workspace/random_name", "content": "     1\thello\n"}
+        assert stub_runtime.exec.call_count == 1
+
+    async def test_extension_path_skips_probe(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """An image extension resolves the mime from the extension alone — no probe read."""
+        stub_get_session_model.value = "model/vision"
+        _stage_workspace_image("sess_01TEST", "screenshot.png", b"PNGbytes")
+        result = await read_handler("sess_01TEST", {"path": "/workspace/screenshot.png"})
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+        assert stub_runtime.exec.call_count == 0
+
+    async def test_non_bind_mount_extensionless_image_sniffs_via_exec(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """Outside any bind mount the probe falls back to one docker-exec (with set -o pipefail), then the full read is a second exec."""
+        stub_get_session_model.value = "model/vision"
+        png_head = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+        full = png_head + b"-more-png-bytes"
+        stub_runtime.exec = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[
+                CommandResult(
+                    exit_code=0,
+                    stdout=base64.b64encode(png_head).decode(),
+                    stderr="",
+                    timed_out=False,
+                    truncated=False,
+                ),
+                CommandResult(
+                    exit_code=0,
+                    stdout=f"{len(full)}\n{base64.b64encode(full).decode()}",
+                    stderr="",
+                    timed_out=False,
+                    truncated=False,
+                ),
+            ]
+        )
+        result = await read_handler("sess_01TEST", {"path": "/etc/unnamed"})
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[1]["image_url"]["url"] == (
+            f"data:image/png;base64,{base64.b64encode(full).decode()}"
+        )
+        assert stub_runtime.exec.call_count == 2
+        probe_cmd = stub_runtime.exec.call_args_list[0].args[1]
+        assert "head -c 16" in probe_cmd
+        assert "set -o pipefail" in probe_cmd


### PR DESCRIPTION
## Problem

Inbound chat attachments (Signal, Telegram) are staged at `/mnt/attachments/<connector>/<filename>` with **arbitrary or no extension** (the reported Signal file was literally named `…-unnamed`). `tools/read` detected images by file **extension only**, so an extension-less image fell through to the text-read path and the tool result was raw image bytes decoded as UTF-8 mojibake. The model never received an `image_url` block — in the captured #715 miss, the agent read a 311 KB JPEG, saw ICC-profile garbage, and silently dropped the user's question.

## Fix

Detect images by extension when it names a known image type; otherwise sniff the leading bytes for PNG/JPEG/GIF magic, reusing `aios_connector_http.mime.sniff_image_mime` (already used at the SDK boundary and the renderer — a third call site, not new infrastructure).

- **`_looks_like_image` (bool) → `_detect_image_mime` (str | None)** — one place decides "is this an image, and what mime," removing the duplicated `_EXT_TO_MIME` lookup; `_read_image` now takes `mime` as a parameter.
- The 16-byte probe is **read locally from the bind-mount source** for `/workspace` and `/mnt/attachments` (the same host fast path `_read_image` uses for the full read), so detection costs **no extra docker-exec** in the common case. Paths outside any mount fall back to one `set -o pipefail; head -c 16 -- <path> | base64 -w0` exec.

## Review-driven hardening

A max-effort review of the initial extension-less-only fix surfaced five issues, all addressed here:

1. **Broadened the gate** to sniff whenever the extension is not a known image type (no extension *or* a non-image extension like `.dat`), so a *mislabeled* image is detected too — the "arbitrary extension" half of the issue, not just "no extension."
4. **Closed the sniff/read TOCTOU** for PNG/JPEG/GIF by routing the probe through the same `resolve_to_host_path` source as the full read, with `make_image_url_part` → `correct_image_mime_b64` reconciling the declared mime against the actually-inlined bytes.
5/6. **No redundant docker-exec** — the probe is a local read for bind-mounted paths, so bind-mounted text reads stay at one exec.
7. **`set -o pipefail`** in the exec-probe fallback so a failing `head` isn't masked by `base64`'s exit 0.

## Testing

- **Unit** (`tests/unit/test_read_image.py`): extension-less and mislabeled PNG/JPEG/GIF inline via the local probe (0 exec); extension-less / wrong-extension text falls through to the text path (1 exec, no false-positive routing); non-bind-mount exec-probe fallback (asserts `set -o pipefail`).
- **E2E** (`tests/e2e/test_extensionless_image_read.py`): real-container round-trip writing+reading extension-less PNG/JPEG/GIF under **both** `/workspace` (local probe) and `/tmp` (real `head -c 16 | base64` exec probe).
- Full gate green: `mypy` clean, `ruff` clean, **1628 unit tests pass**, e2e passes.

## Notes

- **Companion bug #714** (stale litellm catalog → `supports_vision=False` for new Claude models) must also land for end-to-end vision on opus-4-8: this PR fixes path routing, #714 fixes the model-capability lookup.
- **One accepted tradeoff:** broadening the gate means a *text* file whose literal first bytes are `GIF89a`/`GIF87a` (printable ASCII) would now route to the image path. It's the only such false-positive (PNG/JPEG magics are non-ASCII so text can't trigger them), it's recoverable (the model sees a malformed image part and re-reads), and there's no security impact. Left as-is rather than adding a special-case guard; happy to tighten if preferred.
- **Out of scope** (per the issue): extension-less WebP/HEIC (the sniffer's magic table is PNG/JPEG/GIF only) and the pre-existing `_stat_and_read_via_exec` truncation behavior for >cap images on non-bind-mount paths.

Closes #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
