### PR TITLE
fix(mime): detect WebP magic bytes in the shared image sniffer

### DIFF
--- a/packages/aios-connector-http/aios_connector_http/mime.py
+++ b/packages/aios-connector-http/aios_connector_http/mime.py
@@ -21,4 +21,9 @@ def sniff_image_mime(data: bytes) -> str | None:
     for sig, mime in _IMAGE_MAGIC:
         if data.startswith(sig):
             return mime
+    # WebP is a RIFF container — ``RIFF<4-byte size>WEBP`` — so its form-type tag
+    # sits at offset 8 and can't join the prefix table above.  A truncated or
+    # non-WebP RIFF payload (WAV, AVI) fails the offset-8 check and falls through.
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
     return None

--- a/packages/aios-connector-http/tests/test_mime.py
+++ b/packages/aios-connector-http/tests/test_mime.py
@@ -16,6 +16,8 @@ PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 JPEG_MAGIC = b"\xff\xd8\xff\xe0"
 GIF87_MAGIC = b"GIF87a"
 GIF89_MAGIC = b"GIF89a"
+# RIFF chunk id + a 4-byte size + the WEBP form type at offset 8.
+WEBP_MAGIC = b"RIFF\x24\x58\x00\x00WEBP"
 
 
 class TestSniffImageMime:
@@ -30,6 +32,18 @@ class TestSniffImageMime:
 
     def test_gif89a(self) -> None:
         assert sniff_image_mime(GIF89_MAGIC + b"trailing-bytes") == "image/gif"
+
+    def test_webp(self) -> None:
+        assert sniff_image_mime(WEBP_MAGIC + b"VP8 trailing") == "image/webp"
+
+    def test_riff_non_webp_returns_none(self) -> None:
+        # A RIFF container that isn't WebP (e.g. WAV audio, AVI video) carries a
+        # different form type at offset 8 and must not sniff as an image.
+        assert sniff_image_mime(b"RIFF\x24\x58\x00\x00WAVEfmt ") is None
+
+    def test_truncated_riff_returns_none(self) -> None:
+        # RIFF chunk id present but the form type at offset 8 is missing.
+        assert sniff_image_mime(b"RIFF\x24\x58\x00\x00") is None
 
     def test_short_bytes_returns_none(self) -> None:
         assert sniff_image_mime(b"") is None

--- a/packages/aios-connector-http/tests/test_sandbox.py
+++ b/packages/aios-connector-http/tests/test_sandbox.py
@@ -196,7 +196,7 @@ class TestAttachmentParams:
         assert att.as_params()["content_type"] == "image/png"
 
     def test_mime_unchanged_for_unsniffable_bytes(self, tmp_path: Path) -> None:
-        """Sniffer recognises PNG/JPEG/GIF only; non-image attachments
+        """Sniffer recognises PNG/JPEG/GIF/WebP only; non-image attachments
         (PDFs, audio, etc.) keep their declared content_type."""
         path = tmp_path / "doc.pdf"
         path.write_bytes(b"%PDF-1.4\n%trailer")

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -124,11 +124,11 @@ def make_image_url_part(*, content_type: str, data_b64: str) -> dict[str, Any]:
 
     Also strips RFC-7231 parameters (anything after ``;``) from the mime
     before building the data URI. A connector posting an attachment with
-    ``Content-Type: image/webp; charset=utf-8`` would otherwise produce
-    ``data:image/webp; charset=utf-8;base64,...``, which Anthropic and
+    ``Content-Type: image/svg+xml; charset=utf-8`` would otherwise produce
+    ``data:image/svg+xml; charset=utf-8;base64,...``, which Anthropic and
     most providers reject as malformed — bricking every wake of any
     session whose context now includes that part. ``correct_image_mime_b64``
-    only rewrites for PNG/JPEG/GIF magic, so WEBP/SVG/HEIC/AVIF/BMP
+    only rewrites for PNG/JPEG/GIF/WebP magic, so SVG/HEIC/AVIF/BMP
     declared values flow through unchanged unless stripped here.
     """
     content_type = correct_image_mime_b64(content_type, data_b64)

--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -170,7 +170,7 @@ async def _detect_image_mime(session_id: str, path: str, *, handle: SandboxHandl
     docker-exec only for paths outside any mount.  The sniff decides routing
     only — the final declared mime is reconciled against the bytes actually
     inlined by :func:`make_image_url_part`, so a sniff/read race cannot ship
-    a PNG/JPEG/GIF mime that disagrees with the inlined bytes.
+    a PNG/JPEG/GIF/WebP mime that disagrees with the inlined bytes.
     """
     ext = os.path.splitext(path)[1].lower()
     mime = _EXT_TO_MIME.get(ext)

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -434,6 +434,9 @@ class TestExtensionlessImageDetection:
                 "image/jpeg",
             ),
             ("img", b"GIF89a\x01\x00\x01\x00\x80\x00\x00rest-of-gif-bytes", "image/gif"),
+            # WebP is a RIFF container — ``RIFF<4-byte size>WEBP`` — so the
+            # discriminating tag sits at offset 8.  The 16-byte probe covers it.
+            ("photo", b"RIFF\x24\x58\x00\x00WEBPVP8 \x18\x00\x00\x00webp-body", "image/webp"),
         ],
     )
     async def test_extensionless_image_inlines_via_magic_byte_sniff(
@@ -445,8 +448,8 @@ class TestExtensionlessImageDetection:
         stub_runtime: Any,
         stub_get_session_model: Any,
     ) -> None:
-        """An extension-less PNG/JPEG/GIF is detected by a local magic-byte probe
-        (no docker-exec) and inlined as an ``image_url``."""
+        """An extension-less PNG/JPEG/GIF/WebP is detected by a local magic-byte
+        probe (no docker-exec) and inlined as an ``image_url``."""
         stub_get_session_model.value = "model/vision"
         _stage_workspace_image("sess_01TEST", name, payload)
         result = await read_handler("sess_01TEST", {"path": f"/workspace/{name}"})

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -169,6 +169,17 @@ class TestMakeImageUrlPart:
         part = vision.make_image_url_part(content_type="image/png", data_b64=jpeg_b64)
         assert part["image_url"]["url"] == f"data:image/jpeg;base64,{jpeg_b64}"
 
+    def test_self_corrects_to_webp(self) -> None:
+        """WebP joined the sniffer's magic table (``RIFF<size>WEBP``), so a WebP
+        body mislabeled as another image type now reconciles to ``image/webp``
+        instead of surviving as a wrong declared mime that triggers a provider 400.
+        """
+        import base64 as _b64
+
+        webp_b64 = _b64.b64encode(b"RIFF\x24\x58\x00\x00WEBPVP8 " + b"\x00" * 16).decode("ascii")
+        part = vision.make_image_url_part(content_type="image/png", data_b64=webp_b64)
+        assert part["image_url"]["url"] == f"data:image/webp;base64,{webp_b64}"
+
     def test_keeps_declared_mime_when_unrecognized(self) -> None:
         """Sniff returns None on random/unknown bytes — declared mime wins."""
         part = vision.make_image_url_part(content_type="image/png", data_b64="ZmFrZQ==")
@@ -180,10 +191,11 @@ class TestMakeImageUrlPart:
         connector POSTs an inbound attachment whose multipart
         ``Content-Type`` header includes parameters, the staging layer
         persists the value verbatim into ``metadata.attachments[i]
-        .content_type``. The renderer then calls ``make_image_url_part``
-        which only sniff-corrects for PNG/JPEG/GIF magic bytes — for
-        WEBP/SVG/HEIC/AVIF/BMP (and ANY other non-sniffable image type)
-        the declared value flows through unchanged into
+        .content_type``. The renderer then calls ``make_image_url_part``,
+        which sniff-corrects only when the bytes carry a recognized magic
+        (PNG/JPEG/GIF/WebP); when they don't — a declared image type whose
+        bytes match no magic (here), or a non-sniffable format like
+        SVG/HEIC/AVIF/BMP — the declared value flows through unchanged into
         ``data:image/webp; charset=utf-8;base64,...``.
 
         Anthropic's ``/v1/messages`` and most other providers reject
@@ -196,12 +208,14 @@ class TestMakeImageUrlPart:
         (after sniff correction). Cheapest correct-by-construction
         guard at the renderer boundary.
         """
+        # Non-magic bytes so the sniff returns ``None`` and the declared
+        # parametered mime survives to the strip — the path this test guards.
         part = vision.make_image_url_part(
             content_type="image/webp; charset=utf-8",
-            data_b64="UklGRg==",
+            data_b64="ZmFrZQ==",
         )
         url = part["image_url"]["url"]
-        assert url == "data:image/webp;base64,UklGRg==", (
+        assert url == "data:image/webp;base64,ZmFrZQ==", (
             f"data URI must carry only the bare mime (no RFC-7231 parameters); "
             f"got {url!r}. Pre-fix the renderer would build "
             f"``data:image/webp; charset=utf-8;base64,...`` which Anthropic "


### PR DESCRIPTION
## Summary

`tools/read` now detects images by magic bytes (PR #719, closing #715) — but the shared sniffer it reuses, `aios_connector_http.mime.sniff_image_mime`, recognizes **PNG/JPEG/GIF only**. So an **extension-less or mislabeled WebP** attachment still falls through to the text path and dumps raw bytes as mojibake — the exact #715 failure mode, for the one format #715/#719 explicitly scoped out.

`.webp` is already in `read.py`'s `_EXT_TO_MIME`, so WebP-*by-extension* inlines fine. Only the byte-sniff couldn't see it — an asymmetry for a format the vision API accepts. Connector-staged chat attachments (Signal/Telegram) arrive with arbitrary or no extension, and plenty of web images are WebP.

## Fix

Add WebP to the **shared** sniffer (one entry, not a parallel detector):

```python
if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
    return "image/webp"
```

WebP is a RIFF container — `RIFF<4-byte size>WEBP` — so its form-type tag sits at **offset 8**, past four variable size bytes, and can't join the `startswith()` prefix table. `data[8:12]` is shorter than four bytes on a truncated header and compares unequal, so short input and a non-WebP RIFF payload (WAV, AVI) both still return `None`.

Because the sniffer has **four** consumers, this fixes mislabeled/extension-less WebP at every layer at once:

| Call site | Effect |
|---|---|
| `Attachment.as_params` (SDK boundary) | mislabeled WebP → corrected `content_type` persisted |
| `make_image_url_part` → `correct_image_mime_b64` (renderer) | declared-vs-bytes reconciliation now covers WebP |
| `tools/read._detect_image_mime` (#715 path) | extension-less WebP routes to `_read_image` |
| `harness/vision` reconciliation | same |

Correctly-declared WebP is unchanged everywhere; only the previously-broken mislabeled/extension-less cases change.

## Tests

- **Sniffer unit** (`test_mime`): WebP positive; non-WebP RIFF (`RIFF…WAVE`) and truncated-RIFF negatives.
- **Enforced #715-path regression** (`tests/unit/test_read_image`): an extension-less WebP inlines as an `image_url` via the local probe (0 docker-exec).
- **Renderer reconcile** (`tests/unit/test_vision`): a WebP body mislabeled as `image/png` is corrected to `image/webp`.

Also refreshes the comments that enumerated the sniffer's coverage (`read.py`, `vision.py`, `test_sandbox`) so they don't rot, and decouples the param-strip test from WebP-sniffability — it now uses non-magic bytes, proving the strip path it actually guards.

Full gate green: `ruff` + `mypy src` clean, **1639 unit tests pass**; the `aios-connector-http` package's own ruff/mypy/**96 tests** pass too.

## Relationship to #716

This supersedes the WebP *intent* of #716 (now closed): #716 added a **parallel** `_sniff_image_mime` (against #715's explicit "re-use `sniff_image_mime`, don't fork" acceptance criterion) that `open()`s the path on the worker host — wrong for sandbox-container paths like `/mnt/attachments/…`. This PR captures the same goal in the shared sniffer, so all four call sites benefit and the sandbox path model is respected.

## Note (not addressed here)

`packages/aios-connector-http/tests/` (96 fast, green, self-contained tests, incl. `test_mime`) isn't collected by `run-checks.sh` or any CI step — only `mypy src` reaches `mime.py`, transitively. That's why the enforced WebP regressions above live in `tests/unit` (CI-run) rather than relying on `test_mime`. Wiring the workspace packages' unit suites into the CI gate is a separate, broader change worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
