### PR TITLE
fix(harness/context): surface non-focal attachments as text markers

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -323,6 +323,11 @@ def render_user_event(
     * Otherwise (focal is NULL, or focal differs from orig) →
       notification marker: a short, emoji-prefixed one-liner surfacing
       the origin channel, sender, and a truncated content preview.
+      Any attachments are appended as ``text_marker`` lines (images →
+      ``[image: … at <path>]``, others → ``[attachment: …]``) — never
+      inlined off-channel — so the model can ``read`` the in-sandbox
+      path now, or ``switch_channel`` to recover pixels via the
+      reorient recap.  Before #718 they were silently dropped here.
     """
     msg = {k: v for k, v in event_data.items() if k != "metadata"}
     metadata = event_data.get("metadata")
@@ -352,6 +357,10 @@ def render_user_event(
     if not isinstance(content, str):
         content = ""
     marker = _format_notification_marker(orig_channel, metadata, content)
+    attachments = metadata.get("attachments") if metadata else None
+    if isinstance(attachments, list) and attachments:
+        lines = [text_marker(r) for r in attachments if isinstance(r, dict)]
+        marker = "\n".join([marker, *lines])
     return {"role": "user", "content": marker}
 
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1387,6 +1387,40 @@ class TestFocalRendering:
         assert "from=Bob" in content
         assert "hey there" in content
 
+    def test_notification_with_attachment_appends_marker(self) -> None:
+        """#718: an attachment arriving on a non-focal channel surfaces a
+        ``read``-able marker appended to the notification — not silently
+        dropped.  Exercised through the real ``build_messages`` path with no
+        model threaded (how the append-time token counter calls it);
+        ``text_marker`` needs none, so the breadcrumb appears regardless."""
+        md = {
+            "channel": self._CHAN_B,
+            "sender_name": "Bob",
+            "attachments": [
+                {
+                    "filename": "shot.png",
+                    "content_type": "image/png",
+                    "size": 200_000,
+                    "in_sandbox_path": "/mnt/attachments/signal/evt-1-shot.png",
+                }
+            ],
+        }
+        events = [
+            _evt(
+                1,
+                "user",
+                content="eyeball this",
+                metadata=md,
+                focal_channel_at_arrival=self._CHAN_A,
+            )
+        ]
+        content = build_messages(events, system_prompt=None).messages[0]["content"]
+        assert isinstance(content, str)
+        assert content.startswith(f"🔔 channel_id={self._CHAN_B}")
+        assert "from=Bob" in content
+        assert "[image: shot.png" in content
+        assert "/mnt/attachments/signal/evt-1-shot.png" in content
+
     def test_notification_when_focal_null(self) -> None:
         """Phone-down state: all inbound renders as notifications."""
         md = {"channel": self._CHAN_B, "sender_name": "Bob"}

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -536,3 +536,96 @@ class TestVisionAwareRendering:
         assert "[attachment: b.pdf" in content[0]["text"]
         assert content[1]["type"] == "image_url"
         assert content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+class TestNonFocalAttachmentRendering:
+    """Issue #718: attachments on a NON-focal channel must surface a
+    ``read``-able ``text_marker`` — never inlined off-channel, never
+    silently dropped (the pre-#718 behavior).
+
+    Pixel recovery across a ``switch_channel`` is handled separately by
+    the reorient recap (#226); these pin the arrival-time breadcrumb.
+    The only contrast with :class:`TestVisionAwareRendering` is that
+    ``focal_channel_at_arrival`` differs from ``orig_channel``.
+    """
+
+    def test_nonfocal_attachment_emits_marker_not_dropped(self, temp_workspace_root: Path) -> None:
+        """A vision model + a present, inlinable image still renders as a
+        text marker off-channel: the non-focal branch never inlines, and
+        pre-#718 dropped the attachment entirely (no marker, no pixels)."""
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"jpegbytes"
+        )
+        event = _user_event(
+            content="check this",
+            attachments=[
+                {
+                    "filename": "photo.jpg",
+                    "content_type": "image/jpeg",
+                    "size": len(b"jpegbytes"),
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",  # orig_channel
+            "other/acct/chat-9",  # focal_channel_at_arrival differs → non-focal
+            model="model/vision",
+            session_id="sess-1",
+        )
+        content = msg["content"]
+        assert isinstance(content, str)
+        assert content.startswith("🔔 channel_id=echo/acct/chat-1")
+        assert "[image: photo.jpg" in content
+        assert "/mnt/attachments/echo/evt-1-photo.jpg" in content
+        # Off-channel is markers-only — no inlined pixels.
+        assert "image_url" not in content
+        assert "data:image" not in content
+
+    def test_nonfocal_non_image_attachment_emits_attachment_marker(self) -> None:
+        """Non-image attachments get the ``[attachment: …]`` marker
+        off-channel too.  No staging needed — ``text_marker`` reads only
+        the record dict, never the bytes."""
+        event = _user_event(
+            content="doc",
+            attachments=[
+                {
+                    "filename": "report.pdf",
+                    "content_type": "application/pdf",
+                    "size": 4,
+                    "in_sandbox_path": "/mnt/attachments/echo/evt-1-report.pdf",
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "other/acct/chat-9",
+            model="model/vision",
+            session_id="sess-1",
+        )
+        content = msg["content"]
+        assert isinstance(content, str)
+        assert content.startswith("🔔 channel_id=echo/acct/chat-1")
+        assert "[attachment: report.pdf" in content
+
+    def test_nonfocal_non_dict_attachment_skipped(self) -> None:
+        """A malformed (non-dict) record on the non-focal path is skipped,
+        not crashed on — the same brick-the-session guard as the focal
+        path's ``test_non_dict_attachment_record_is_skipped``."""
+        malformed: list[Any] = ["oops", None, 42]
+        event = _user_event(content="hi", attachments=malformed)
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "other/acct/chat-9",
+            model="model/vision",
+            session_id="sess-1",
+        )
+        content = msg["content"]
+        assert isinstance(content, str)
+        assert content.startswith("🔔 channel_id=echo/acct/chat-1")
+        # No attachment markers emitted for malformed records.
+        assert "[image:" not in content
+        assert "[attachment:" not in content


### PR DESCRIPTION
## Problem

Inbound attachments (images or any file) arriving on a **non-focal** channel were silently dropped from the agent's context. `render_user_event`'s notification-marker branch built a terse one-liner and never looked at `metadata["attachments"]` — so an image posted to a channel that wasn't focal at arrival left **no trace** in context. Because `focal_channel_at_arrival` is stamped at append time and immutable, switching to that channel afterward couldn't recover it either.

This broke cross-agent visual QA: when one agent posts a screenshot to a shared channel for another to eyeball, the screenshot was invisible to the recipient unless that channel happened to be their focal channel at the instant it landed. Confirmed firing in a live session (3 of the last 40 attachment-bearing inbounds dropped to markerless notifications).

## Fix

Append a `read`-able `text_marker` line per attachment on the non-focal branch:
- images → `[image: name (type, size) at <path>]`
- others → `[attachment: ...]`

The model can now `read` the in-sandbox path immediately, or `switch_channel` to recover inline pixels via the **existing** reorient recap (`render_reorient_block`, #226 — effectively the issue's "option 3", already shipped).

Off-channel stays **markers-only by design** — no inlining, no context bloat. The branch mirrors the focal branch's attachment-access idiom and preserves the monotonic-context invariant (rendering stays a pure function of the event's stamped fields). Re-inlining here would be redundant with the recap and would fight the terse-non-focal design.

This is the issue's recommended **option 1 (floor)**; #719 (magic-byte `read`) is already merged, so the marker's path is fully `read`-able even for extension-less connector files.

## Tests
- `test_nonfocal_attachment_emits_marker_not_dropped` — vision model + inlinable image still renders a string marker off-channel (not an `image_url` part).
- `test_nonfocal_non_image_attachment_emits_attachment_marker` — PDF → `[attachment:]`.
- `test_nonfocal_non_dict_attachment_skipped` — malformed (non-dict) record skipped without bricking the render.
- `test_notification_with_attachment_appends_marker` — `build_messages`-level integration guard.
- Focal inlining unchanged (existing `test_inlinable_image_emits_image_url_part` is the regression guard).

`mypy`, `ruff check`/`format`, and `pytest tests/unit` (1641 passed) all green via the pre-commit hook.

Closes #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
